### PR TITLE
Feature/osw speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,11 @@ option(HAS_XSERVER "Indicates if an X server is available. If set to Off it will
 option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
 option(ENABLE_TUTORIALS "Indicates whether tutorials should be build. Note that this also depends on the availability of (pdf)latex." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
+if(MSVC)
+  option(MT_ENABLE_NESTED_OPENMP "Enable nested parallelism." OFF)
+else()
+  option(MT_ENABLE_NESTED_OPENMP "Enable nested parallelism." ON)
+endif()
 
 #------------------------------------------------------------------------------
 # Extend module path with our modules

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -300,6 +300,10 @@ private:
     double uis_threshold_sn_;
     double uis_threshold_peak_area_;
 
+    double sn_win_len_;
+    unsigned int sn_bin_count_;
+    bool write_log_messages_;
+
     // members
     std::map<OpenMS::String, const PeptideType*> PeptideRefMap_;
     OpenSwath_Scores_Usage su_;

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
@@ -149,13 +149,13 @@ protected:
      * @param ms1only If true, will only score on MS1 level and ignore MS2 level
      *
     */
-    void MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps,
+    void MS1Extraction_(const OpenSwath::SpectrumAccessPtr ms1_map,
+                        const std::vector< OpenSwath::SwathMap > & swath_maps,
                         std::vector< MSChromatogram >& ms1_chromatograms,
                         Interfaces::IMSDataConsumer * chromConsumer,
                         const ChromExtractParams & cp,
                         const OpenSwath::LightTargetedExperiment& transition_exp,
                         const TransformationDescription& trafo_inverse,
-                        bool load_into_memory,
                         bool ms1only = false,
                         int ms1_isotopes = 0);
 

--- a/src/openms/include/OpenMS/KERNEL/MRMFeature.h
+++ b/src/openms/include/OpenMS/KERNEL/MRMFeature.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <OpenMS/KERNEL/Feature.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathScores.h>
 
 namespace OpenMS
 {
@@ -55,8 +56,6 @@ public:
     //@{
     /// Feature list type
     typedef std::vector<Feature> FeatureListType;
-    /// Peak group score type
-    typedef std::map<String, double> PGScoresType;
     //@}
 
     ///@name Constructors and Destructor
@@ -76,11 +75,12 @@ public:
 
     ///@name Accessors
     //@{
-    /// get all peakgroup scores
-    const PGScoresType & getScores() const;
 
-    /// get a single peakgroup score
-    double getScore(const String & score_name);
+    /// get all peakgroup scores
+    const OpenSwath_Scores & getScores() const;
+
+    /// get all peakgroup scores
+    OpenSwath_Scores & getScores();
 
     /// get a specified feature
     Feature & getFeature(const String& key);
@@ -89,7 +89,7 @@ public:
     const Feature & getFeature(const String& key) const;
 
     /// set all peakgroup scores
-    void setScores(const PGScoresType & scores);
+    void setScores(const OpenSwath_Scores & scores);
 
     /// set a single peakgroup score
     void addScore(const String & score_name, double score);
@@ -124,7 +124,7 @@ protected:
     FeatureListType precursor_features_;
 
     /// peak group scores
-    PGScoresType pg_scores_;
+    OpenSwath_Scores pg_scores_;
 
     /// map native ids to the features
     std::map<String, int> feature_map_;

--- a/src/openms/include/OpenMS/config.h.in
+++ b/src/openms/include/OpenMS/config.h.in
@@ -145,6 +145,8 @@
   #define IF_MASTERTHREAD
 #endif
 
+#cmakedefine MT_ENABLE_NESTED_OPENMP 1
+
 #cmakedefine WITH_CRAWDAD 1
 
 // NOTE: This is a temporary hack. The aim is that OpenMS should not care

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -570,7 +570,7 @@ namespace OpenMS
         // Call the scoring for MS1 only
         ///////////////////////////////////
 
-        OpenSwath_Scores scores;
+        OpenSwath_Scores& scores = mrmfeature->getScores();
         precursor_mz = mrmfeature->getMZ();
 
         // S/N scores
@@ -663,7 +663,7 @@ namespace OpenMS
           precursor_ids.push_back(precursor_id);
         }
 
-        OpenSwath_Scores scores;
+        OpenSwath_Scores& scores = mrmfeature->getScores();
         scorer.calculateChromatographicScores(imrmfeature, native_ids_detection, precursor_ids, normalized_library_intensity,
                                               signal_noise_estimators, scores);
 
@@ -935,7 +935,7 @@ namespace OpenMS
       pep_hit_.setScore(xx_lda_prescore);
       if (swath_present)
       {
-        pep_hit_.setScore(mrmfeature->getScore("xx_swath_prelim_score"));
+        // pep_hit_.setScore(mrmfeature->getMetaValue("xx_swath_prelim_score"));
       }
 
       if (pep->isPeptide())
@@ -994,6 +994,7 @@ namespace OpenMS
       mrmfeature->setMetaValue("peak_apices_sum", total_peak_apices);
       mrmfeature->setMetaValue("ms1_area_intensity", ms1_total_intensity);
       mrmfeature->setMetaValue("ms1_apex_intensity", ms1_total_peak_apices);
+      mrmfeature->setMetaValue("xx_swath_prelim_score", 0.0);
       feature_list.push_back((*mrmfeature));
 
       delete imrmfeature;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -312,7 +312,7 @@ namespace OpenMS
                                                                  const unsigned int sn_bin_count_,
                                                                  const double det_intensity_ratio_score,
                                                                  const double det_mi_ratio_score,
-                                                                 bool write_log_messages,
+                                                                 bool write_log_messages_,
                                                                  const std::vector<OpenSwath::SwathMap>& swath_maps)
   {
     MRMFeature idmrmfeature = trgr_ident.getFeaturesMuteable()[feature_idx];
@@ -342,7 +342,7 @@ namespace OpenMS
     {
       OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< MSChromatogram >(
             trgr_ident.getChromatogram(trgr_ident.getTransitions()[i].getNativeID()),
-            sn_win_len_, sn_bin_count_, write_log_messages));
+            sn_win_len_, sn_bin_count_, write_log_messages_));
       if (  (snptr->getValueAtRT(idmrmfeature.getRT()) > uis_threshold_sn_) 
             && (idmrmfeature.getFeature(trgr_ident.getTransitions()[i].getNativeID()).getIntensity() > uis_threshold_peak_area_))
       {
@@ -502,14 +502,11 @@ namespace OpenMS
       drift_upper = prec.getDriftTime() + prec.getDriftTimeWindowUpperOffset();
     }
 
-    double sn_win_len_ = (double)param_.getValue("TransitionGroupPicker:PeakPickerMRM:sn_win_len");
-    unsigned int sn_bin_count_ = (unsigned int)param_.getValue("TransitionGroupPicker:PeakPickerMRM:sn_bin_count");
-    bool write_log_messages = (bool)param_.getValue("TransitionGroupPicker:PeakPickerMRM:write_sn_log_messages").toBool();
     // currently we cannot do much about the log messages and they mostly occur in decoy transition signals
     for (Size k = 0; k < transition_group_detection.getChromatograms().size(); k++)
     {
       OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< MSChromatogram >(
-            transition_group_detection.getChromatograms()[k], sn_win_len_, sn_bin_count_, write_log_messages));
+            transition_group_detection.getChromatograms()[k], sn_win_len_, sn_bin_count_, write_log_messages_));
       signal_noise_estimators.push_back(snptr);
     }
 
@@ -520,7 +517,7 @@ namespace OpenMS
       for (Size k = 0; k < transition_group_detection.getPrecursorChromatograms().size(); k++)
       {
         OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< MSChromatogram >(
-              transition_group_detection.getPrecursorChromatograms()[k], sn_win_len_, sn_bin_count_, write_log_messages));
+              transition_group_detection.getPrecursorChromatograms()[k], sn_win_len_, sn_bin_count_, write_log_messages_));
         ms1_signal_noise_estimators.push_back(snptr);
       }
     }
@@ -706,7 +703,7 @@ namespace OpenMS
                                                            sn_bin_count_,
                                                            det_intensity_ratio_score,
                                                            det_mi_ratio_score,
-                                                           write_log_messages,
+                                                           write_log_messages_,
                                                            swath_maps);
 
           mrmfeature->setMetaValue("id_target_transition_names", idscores.ind_transition_names);
@@ -738,7 +735,7 @@ namespace OpenMS
                                                            sn_bin_count_,
                                                            det_intensity_ratio_score,
                                                            det_mi_ratio_score,
-                                                           write_log_messages,
+                                                           write_log_messages_,
                                                            swath_maps);
 
           mrmfeature->setMetaValue("id_decoy_transition_names", idscores.ind_transition_names);
@@ -1026,6 +1023,10 @@ namespace OpenMS
     uis_threshold_sn_ = param_.getValue("uis_threshold_sn");
     uis_threshold_peak_area_ = param_.getValue("uis_threshold_peak_area");
     scoring_model_ = param_.getValue("scoring_model");
+
+    sn_win_len_ = (double)param_.getValue("TransitionGroupPicker:PeakPickerMRM:sn_win_len");
+    sn_bin_count_ = (unsigned int)param_.getValue("TransitionGroupPicker:PeakPickerMRM:sn_bin_count");
+    write_log_messages_ = (bool)param_.getValue("TransitionGroupPicker:PeakPickerMRM:write_sn_log_messages").toBool();
 
     // set SONAR values
     Param p = sonarscoring_.getDefaults();

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -930,9 +930,9 @@ namespace OpenMS
         pep_hit_.setCharge(pep->getChargeState());
       }
       pep_hit_.setScore(xx_lda_prescore);
-      if (swath_present)
+      if (swath_present && mrmfeature->metaValueExists("xx_swath_prelim_score"))
       {
-        // pep_hit_.setScore(mrmfeature->getMetaValue("xx_swath_prelim_score"));
+        pep_hit_.setScore(mrmfeature->getMetaValue("xx_swath_prelim_score"));
       }
 
       if (pep->isPeptide())

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -40,6 +40,28 @@
 namespace OpenMS
 {
 
+  OpenSwath::SpectrumAccessPtr loadMS1Map(const std::vector< OpenSwath::SwathMap > & swath_maps, bool load_into_memory)
+  {
+    OpenSwath::SpectrumAccessPtr ms1_map;
+    // store reference to MS1 map for later -> note that this is *not* threadsafe!
+    for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_maps.size()); ++i)
+    {
+      // if (swath_maps[i].ms1 && use_ms1_traces_)
+      if (swath_maps[i].ms1)
+      {
+        ms1_map = swath_maps[i].sptr;
+      }
+    }
+    if (load_into_memory)
+    {
+      // This creates an InMemory object that keeps all data in memory
+      // but provides the same access functionality to the raw data as
+      // any object implementing ISpectrumAccess
+      ms1_map = boost::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*ms1_map) );
+    }
+    return ms1_map;
+  }
+
   TransformationDescription OpenSwathCalibrationWorkflow::performRTNormalization(
     const OpenSwath::LightTargetedExperiment& irt_transitions,
     std::vector< OpenSwath::SwathMap > & swath_maps,
@@ -438,14 +460,11 @@ namespace OpenMS
     this->startProgress(0, swath_maps.size(), "Extracting and scoring transitions");
 
     // (i) Obtain precursor chromatograms (MS1) if precursor extraction is enabled
-    std::vector< MSChromatogram > ms1_chromatograms;
     ChromExtractParams ms1_cp(cp_ms1);
     if (!use_ms1_ion_mobility_)
     {
       ms1_cp.im_extraction_window = -1;
     }
-    MS1Extraction_(swath_maps, ms1_chromatograms, chromConsumer, ms1_cp,
-                   transition_exp, trafo_inverse, load_into_memory, ms1_only, ms1_isotopes);
 
     if (ms1_only && !use_ms1_traces_)
     {
@@ -453,9 +472,15 @@ namespace OpenMS
           "Error, you need to enable use_ms1_traces when run in MS1 mode." );
     }
 
+    if (use_ms1_traces_) ms1_map_ = loadMS1Map(swath_maps, load_into_memory);
+
     // (ii) Precursor extraction only
     if (ms1_only)
     {
+      std::vector< MSChromatogram > ms1_chromatograms;
+      MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, chromConsumer, ms1_cp,
+                     transition_exp, trafo_inverse, ms1_only, ms1_isotopes);
+
       FeatureMap featureFile;
       boost::shared_ptr<MSExperiment> empty_exp = boost::shared_ptr<MSExperiment>(new MSExperiment);
 
@@ -637,9 +662,19 @@ namespace OpenMS
               "from SWATH " << i << " (batch " << pep_idx << " out of " << nr_batches << ")" << std::endl;
             }
 
+
             // Create the new, batch-size transition experiment
             OpenSwath::LightTargetedExperiment transition_exp_used;
             selectCompoundsForBatch_(transition_exp_used_all, transition_exp_used, batch_size, pep_idx);
+
+            // Extract MS1 chromatograms for this batch
+            std::vector< MSChromatogram > ms1_chromatograms;
+            if (ms1_map_ != nullptr) 
+            {
+              OpenSwath::SpectrumAccessPtr threadsafe_ms1 = ms1_map_->lightClone();
+              MS1Extraction_(threadsafe_ms1, swath_maps, ms1_chromatograms, chromConsumer, ms1_cp,
+                  transition_exp_used, trafo_inverse, ms1_only, ms1_isotopes);
+            }
 
             // Step 2.1: extract these transitions
             ChromatogramExtractor extractor;
@@ -727,30 +762,18 @@ namespace OpenMS
     }
   }
 
-  void OpenSwathWorkflowBase::MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps,
+  void OpenSwathWorkflowBase::MS1Extraction_(const OpenSwath::SpectrumAccessPtr ms1_map,
+                                             const std::vector< OpenSwath::SwathMap > & swath_maps,
                                              std::vector< MSChromatogram >& ms1_chromatograms,
                                              Interfaces::IMSDataConsumer* chromConsumer,
                                              const ChromExtractParams& cp,
                                              const OpenSwath::LightTargetedExperiment& transition_exp,
                                              const TransformationDescription& trafo_inverse,
-                                             bool load_into_memory, 
                                              bool ms1_only,
                                              int ms1_isotopes)
   {
-    for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_maps.size()); ++i)
     {
-      if (swath_maps[i].ms1 && use_ms1_traces_)
       {
-        // store reference to MS1 map for later -> note that this is *not* threadsafe!
-        ms1_map_ = swath_maps[i].sptr;
-
-        if (load_into_memory)
-        {
-          // This creates an InMemory object that keeps all data in memory
-          // but provides the same access functionality to the raw data as
-          // any object implementing ISpectrumAccess
-          ms1_map_ = boost::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*ms1_map_) );
-        }
 
         std::vector< OpenSwath::ChromatogramPtr > chrom_list;
         std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
@@ -759,7 +782,7 @@ namespace OpenMS
 
         // prepare the extraction coordinates and extract chromatogram
         prepareExtractionCoordinates_(chrom_list, coordinates, transition_exp_used, trafo_inverse, cp, true, ms1_isotopes);
-        extractor.extractChromatograms(ms1_map_, chrom_list, coordinates, cp.mz_extraction_window,
+        extractor.extractChromatograms(ms1_map, chrom_list, coordinates, cp.mz_extraction_window,
             cp.ppm, cp.im_extraction_window, cp.extraction_function);
 
         extractor.return_chromatogram(chrom_list, coordinates, transition_exp_used,
@@ -781,12 +804,17 @@ namespace OpenMS
                   swath_maps[i].lower < coordinates[j].mz && swath_maps[i].upper > coordinates[j].mz)
                 )
             {
-              // write MS1 chromatograms to disk
-              chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
+#ifdef _OPENMP
+#pragma omp critical (osw_write_out)
+#endif
+              {
+                // write MS1 chromatograms to disk
+                chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
+              }
             }
           }
+        } // end of for coordinates
 
-        }
       }
     }
   }
@@ -1087,10 +1115,15 @@ namespace OpenMS
           String("No swath maps provided"));
       }
 
+      if (use_ms1_traces_) ms1_map_ = loadMS1Map(swath_maps, load_into_memory);
+
       // (i) Obtain precursor chromatograms (MS1) if precursor extraction is enabled
       std::vector< MSChromatogram > ms1_chromatograms;
-      MS1Extraction_(swath_maps, ms1_chromatograms, chromConsumer, cp_ms1,
-                     transition_exp, trafo_inverse, load_into_memory);
+      if (ms1_map_ != nullptr)
+      {
+        MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, chromConsumer, cp_ms1,
+            transition_exp, trafo_inverse);
+      }
 
       ///////////////////////////////////////////////////////////////////////////
       // (ii) Compute SONAR window sizes and upper/lower limit

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -34,8 +34,6 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h>
 
-// #define ENABLE_OPENMS_NESTED_PARALLELISM
-
 // OpenSwathCalibrationWorkflow
 namespace OpenMS
 {
@@ -534,7 +532,7 @@ namespace OpenMS
     // in which they were given to the program / acquired. This gives much
     // better load balancing than static allocation.
 #ifdef _OPENMP
-#ifdef ENABLE_OPENMS_NESTED_PARALLELISM
+#ifdef MT_ENABLE_NESTED_OPENMP
     int total_nr_threads = omp_get_max_threads(); // store total number of threads we are allowed to use
     if (threads_outer_loop_ > -1)
     {
@@ -616,7 +614,7 @@ namespace OpenMS
           SignedSize nr_batches = (transition_exp_used_all.getCompounds().size() / batch_size);
 
 #ifdef _OPENMP
-#ifdef ENABLE_OPENMS_NESTED_PARALLELISM
+#ifdef MT_ENABLE_NESTED_OPENMP
           // If we have a multiple of threads_outer_loop_ here, then use nested
           // parallelization here. E.g. if we use 8 threads for the outer loop,
           // but we have a total of 24 cores available, each of the 8 threads
@@ -635,7 +633,7 @@ namespace OpenMS
             OpenSwath::SpectrumAccessPtr current_swath_map_inner = current_swath_map;
 
 #ifdef _OPENMP
-#ifdef ENABLE_OPENMS_NESTED_PARALLELISM
+#ifdef MT_ENABLE_NESTED_OPENMP
             // To ensure multi-threading safe access to the individual spectra, we
             // need to use a light clone of the spectrum access (if multiple threads
             // share a single filestream and call seek on it, chaos will ensue).
@@ -649,7 +647,7 @@ namespace OpenMS
             {
               std::cout << "Thread " <<
 #ifdef _OPENMP
-#ifdef ENABLE_OPENMS_NESTED_PARALLELISM
+#ifdef MT_ENABLE_NESTED_OPENMP
               outer_thread_nr << "_" << omp_get_thread_num() << " " <<
 #else
               omp_get_thread_num() << "_0 " <<
@@ -719,7 +717,7 @@ namespace OpenMS
     this->endProgress();
     
 #ifdef _OPENMP
-#ifdef ENABLE_OPENMS_NESTED_PARALLELISM
+#ifdef MT_ENABLE_NESTED_OPENMP
     if (threads_outer_loop_ > -1)
     {
       omp_set_num_threads(total_nr_threads); // set number of available threads back to initial value

--- a/src/openms/source/KERNEL/MRMFeature.cpp
+++ b/src/openms/source/KERNEL/MRMFeature.cpp
@@ -74,29 +74,24 @@ namespace OpenMS
   {
   }
 
-  const MRMFeature::PGScoresType & MRMFeature::getScores() const
+  const OpenSwath_Scores & MRMFeature::getScores() const
   {
     return pg_scores_;
   }
 
-  double MRMFeature::getScore(const String & score_name)
+  OpenSwath_Scores & MRMFeature::getScores()
   {
-    return pg_scores_[score_name];
+    return pg_scores_;
   }
 
-  void MRMFeature::setScores(const PGScoresType & scores)
+  void MRMFeature::setScores(const OpenSwath_Scores & scores)
   {
-
-    for (MRMFeature::PGScoresType::const_iterator score = scores.begin();
-         score != scores.end(); ++score)
-    {
-      addScore(score->first, score->second);
-    }
+    pg_scores_ = scores;
   }
 
   void MRMFeature::addScore(const String & score_name, double score)
   {
-    pg_scores_[score_name] = score;
+    // pg_scores_[score_name] = score;
     setMetaValue(score_name, score);
   }
 

--- a/src/openms/source/KERNEL/MRMFeature.cpp
+++ b/src/openms/source/KERNEL/MRMFeature.cpp
@@ -91,7 +91,6 @@ namespace OpenMS
 
   void MRMFeature::addScore(const String & score_name, double score)
   {
-    // pg_scores_[score_name] = score;
     setMetaValue(score_name, score);
   }
 

--- a/src/pyOpenMS/pxds/MRMFeature.pxd
+++ b/src/pyOpenMS/pxds/MRMFeature.pxd
@@ -2,6 +2,7 @@ from libcpp.vector cimport vector as libcpp_vector
 from libcpp.map cimport map as libcpp_map
 from String cimport *
 from Feature cimport *
+from OpenSwathScoring cimport *
 
 cdef extern from "<OpenMS/KERNEL/MRMFeature.h>" namespace "OpenMS":
 
@@ -13,10 +14,8 @@ cdef extern from "<OpenMS/KERNEL/MRMFeature.h>" namespace "OpenMS":
         MRMFeature() nogil except +
         MRMFeature(MRMFeature &) nogil except +
 
-        # TODO STL map with wrapped key
-        # libcpp_map[String, double] getScores() nogil except +
-        double getScore(String name) nogil except +
-        void addScore(String name, double score) nogil except +
+        OpenSwath_Scores getScores() nogil except +
+        void setScores(OpenSwath_Scores s) nogil except +
 
         Feature getFeature(String key) nogil except +
         void addFeature(Feature & f, String key) nogil except +

--- a/src/pyOpenMS/pxds/OpenSwathScoring.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathScoring.pxd
@@ -133,5 +133,3 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
 
         double dotprod_score_dia
         double manhatt_score_dia
-
-

--- a/src/pyOpenMS/pxds/OpenSwathScoring.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathScoring.pxd
@@ -55,7 +55,6 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         bool use_total_mi_score_
         bool use_nr_peaks_score_
         bool use_sn_score_
-        bool use_sn_score_sub_
         bool use_mi_score_
         bool use_dia_scores_
         bool use_sonar_scores
@@ -134,7 +133,5 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
 
         double dotprod_score_dia
         double manhatt_score_dia
-
-        libcpp_vector[double] masserror_ppm
 
 

--- a/src/pyOpenMS/pxds/OpenSwathScoring.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathScoring.pxd
@@ -52,16 +52,17 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         bool use_elution_model_score_
         bool use_intensity_score_
         bool use_total_xic_score_
+        bool use_total_mi_score_
         bool use_nr_peaks_score_
         bool use_sn_score_
+        bool use_sn_score_sub_
+        bool use_mi_score_
         bool use_dia_scores_
+        bool use_sonar_scores
         bool use_ms1_correlation
         bool use_ms1_fullscan
-        bool use_sonar_scores
-        bool use_uis_scores
-        bool use_total_mi_score_
-        bool use_mi_score_
         bool use_ms1_mi
+        bool use_uis_scores
 
     cdef cppclass OpenSwath_Scores:
 
@@ -83,11 +84,13 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         double library_rootmeansquare
         double library_sangle
         double norm_rt_score
+
         double isotope_correlation
         double isotope_overlap
         double massdev_score
         double xcorr_coelution_score
         double xcorr_shape_score
+
         double yseries_score
         double bseries_score
         double log_sn_score
@@ -97,10 +100,24 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         double weighted_massdev_score
        
         double ms1_xcorr_coelution_score
+        double ms1_xcorr_coelution_contrast_score
+        double ms1_xcorr_coelution_combined_score
         double ms1_xcorr_shape_score
+        double ms1_xcorr_shape_contrast_score
+        double ms1_xcorr_shape_combined_score
         double ms1_ppm_score
         double ms1_isotope_correlation
         double ms1_isotope_overlap
+        double ms1_mi_score
+        double ms1_mi_contrast_score
+        double ms1_mi_combined_score
+
+        double sonar_sn 
+        double sonar_diff
+        double sonar_trend
+        double sonar_rsq
+        double sonar_shape
+        double sonar_lag
 
         double library_manhattan
         double library_dotprod
@@ -108,6 +125,8 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         double total_xic
         double nr_peaks
         double sn_ratio
+        double mi_score 
+        double weighted_mi_score
 
         double rt_difference
         double normalized_experimental_rt
@@ -115,3 +134,7 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
 
         double dotprod_score_dia
         double manhatt_score_dia
+
+        libcpp_vector[double] masserror_ppm
+
+

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3338,11 +3338,31 @@ def testMRMFeature():
       MRMFeature.getScore
      """
     mrmfeature = pyopenms.MRMFeature()
+    f = pyopenms.Feature()
 
-    mrmfeature.addScore("testscore", 6)
-    assert mrmfeature.getScore("testscore") == 6.0
-    mrmfeature.addScore("testscore", 7)
-    assert mrmfeature.getScore("testscore") == 7.0
+    fs = mrmfeature.getFeatures()
+    assert len(fs) == 0
+
+    mrmfeature.addFeature(f, "myFeature")
+    fs = mrmfeature.getFeatures()
+    assert len(fs) == 1
+    assert mrmfeature.getFeature("myFeature") is not None
+    slist = []
+    mrmfeature.getFeatureIDs(slist)
+    assert len(slist) == 1
+
+    mrmfeature.addPrecursorFeature(f, "myFeature_Pr0")
+    slist = []
+    mrmfeature.getPrecursorFeatureIDs(slist)
+    assert len(slist) == 1
+    assert mrmfeature.getPrecursorFeature("myFeature_Pr0") is not None
+
+    s = mrmfeature.getScores()
+    assert abs(s.yseries_score - 0.0) < 1e-4
+    s.yseries_score = 4.0
+    mrmfeature.setScores(s)
+    s2 = mrmfeature.getScores()
+    assert abs(s2.yseries_score - 4.0) < 1e-4
 
 @report
 def testConfidenceScoring():

--- a/src/tests/class_tests/openms/source/MRMFeature_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeature_test.cpp
@@ -72,7 +72,7 @@ START_SECTION(MRMFeature(const MRMFeature &rhs))
 
   MRMFeature tmp2 (tmp);
 
-  TEST_EQUAL(tmp2.getScore("testscore"), 200)
+  TEST_REAL_SIMILAR(tmp2.getMetaValue("testscore"), 200)
   TEST_REAL_SIMILAR(tmp2.getIntensity(), 100.0)
 }
 END_SECTION
@@ -86,7 +86,7 @@ START_SECTION(MRMFeature& operator=(const MRMFeature &rhs))
   MRMFeature tmp2;
   tmp2 = tmp;
 
-  TEST_EQUAL(tmp2.getScore("testscore"), 200)
+  TEST_REAL_SIMILAR(tmp2.getMetaValue("testscore"), 200)
   TEST_REAL_SIMILAR(tmp2.getIntensity(), 100.0)
 }
 END_SECTION
@@ -120,15 +120,11 @@ END_SECTION
 START_SECTION (void setScores(const PGScoresType & scores))
 {
   MRMFeature mrmfeature;
-  MRMFeature::PGScoresType scores;
-  scores["score1"] = 1;
-  scores["score2"] = 2;
+  OpenSwath_Scores scores;
+  scores.library_sangle = 99;
   mrmfeature.setScores(scores);
-  scores = mrmfeature.getScores();
-  TEST_EQUAL(mrmfeature.getScore("score1"), 1)
-  TEST_EQUAL(mrmfeature.getScore("score2"), 2)
-  TEST_EQUAL(scores[String("score1")], 1)
-  TEST_EQUAL(scores[String("score2")], 2)
+
+  TEST_REAL_SIMILAR(scores.library_sangle, mrmfeature.getScores().library_sangle)
 }
 END_SECTION
 
@@ -137,11 +133,8 @@ START_SECTION (void addScore(const String & score_name, double score))
   MRMFeature mrmfeature;
   mrmfeature.addScore("score1",1);
   mrmfeature.addScore("score2",2);
-  MRMFeature::PGScoresType scores = mrmfeature.getScores();
-  TEST_EQUAL(mrmfeature.getScore("score1"), 1)
-  TEST_EQUAL(mrmfeature.getScore("score2"), 2)
-  TEST_EQUAL(scores[String("score1")], 1)
-  TEST_EQUAL(scores[String("score2")], 2)
+  TEST_REAL_SIMILAR(mrmfeature.getMetaValue("score1"), 1)
+  TEST_REAL_SIMILAR(mrmfeature.getMetaValue("score2"), 2)
 }
 END_SECTION
 

--- a/src/tests/topp/OpenSwathAnalyzer_10_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_10_output.featureXML
@@ -15,47 +15,47 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
 			<overallquality>6.92259</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="total_mi" value="2.73422729278948"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="total_mi" value="2.734227292789477"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
 					<UserParam type="float" name="total_mi" value="3.586033627559"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -64,14 +64,14 @@
 				<PeptideHit score="6.92258985582744" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
-			<UserParam type="float" name="total_mi" value="3.16013046017424"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
+			<UserParam type="float" name="total_mi" value="3.160130460174239"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -80,87 +80,88 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="119.091968219875"/>
-			<UserParam type="float" name="assay_rt" value="3000"/>
+			<UserParam type="float" name="delta_rt" value="119.091968219875071"/>
+			<UserParam type="float" name="assay_rt" value="3000.000000000001819"/>
 			<UserParam type="float" name="norm_RT" value="0.46858207237277"/>
-			<UserParam type="float" name="rt_score" value="0.0285820723727704"/>
-			<UserParam type="float" name="var_norm_rt_score" value="0.0285820723727704"/>
+			<UserParam type="float" name="rt_score" value="0.02858207237277"/>
+			<UserParam type="float" name="var_norm_rt_score" value="0.02858207237277"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
-			<UserParam type="float" name="var_mi_score" value="3.8073549220576"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.8073549220576"/>
-			<UserParam type="float" name="var_mi_ratio_score" value="1.20480941215562"/>
+			<UserParam type="float" name="var_mi_score" value="3.807354922057603"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.807354922057603"/>
+			<UserParam type="float" name="var_mi_ratio_score" value="1.204809412155623"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.92258985582744"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.92258985582744"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.922589855827443"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.922589855827443"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.95351</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.953507</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -168,103 +169,104 @@
 				<PeptideHit score="1.95350659622369" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="1055.58448187053"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1055.584481870530453"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.453340275648928"/>
 			<UserParam type="float" name="rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
-			<UserParam type="float" name="var_mi_score" value="1.75162916738782"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="2.20105644479131"/>
+			<UserParam type="float" name="var_mi_score" value="1.751629167387823"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="2.201056444791313"/>
 			<UserParam type="float" name="var_mi_ratio_score" value="0.455194183085335"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
 			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="float" name="xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.2483</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.248305</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -272,41 +274,42 @@
 				<PeptideHit score="1.2483045614906" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="1119.06301053107"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1119.063010531066993"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.468575122527456"/>
 			<UserParam type="float" name="rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
-			<UserParam type="float" name="var_mi_score" value="3.66449777920046"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.56432195667905"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
+			<UserParam type="float" name="var_mi_score" value="3.664497779200461"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.564321956679047"/>
 			<UserParam type="float" name="var_mi_ratio_score" value="0.952289505151783"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.2483045614906"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="1.2483045614906"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.248304561490597"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="1.248304561490597"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_11_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_11_output.featureXML
@@ -15,47 +15,47 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
 			<overallquality>6.92259</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="total_mi" value="2.73422729278948"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="total_mi" value="2.734227292789477"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
 					<UserParam type="float" name="total_mi" value="3.586033627559"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -64,14 +64,14 @@
 				<PeptideHit score="6.92258985582744" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
-			<UserParam type="float" name="total_mi" value="3.16013046017424"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
+			<UserParam type="float" name="total_mi" value="3.160130460174239"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -80,84 +80,85 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="119.091968219875"/>
-			<UserParam type="float" name="assay_rt" value="3000"/>
+			<UserParam type="float" name="delta_rt" value="119.091968219875071"/>
+			<UserParam type="float" name="assay_rt" value="3000.000000000001819"/>
 			<UserParam type="float" name="norm_RT" value="0.46858207237277"/>
-			<UserParam type="float" name="rt_score" value="0.0285820723727704"/>
-			<UserParam type="float" name="var_norm_rt_score" value="0.0285820723727704"/>
+			<UserParam type="float" name="rt_score" value="0.02858207237277"/>
+			<UserParam type="float" name="var_norm_rt_score" value="0.02858207237277"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.92258985582744"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.92258985582744"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.922589855827443"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.922589855827443"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.95351</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.953507</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -165,100 +166,101 @@
 				<PeptideHit score="1.95350659622369" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="1055.58448187053"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1055.584481870530453"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.453340275648928"/>
 			<UserParam type="float" name="rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
 			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="float" name="xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.2483</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.248305</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -266,38 +268,39 @@
 				<PeptideHit score="1.2483045614906" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="1119.06301053107"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1119.063010531066993"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.468575122527456"/>
 			<UserParam type="float" name="rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.2483045614906"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="1.2483045614906"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.248304561490597"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="1.248304561490597"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_1_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_1_output.featureXML
@@ -15,45 +15,45 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
 			<overallquality>6.92259</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -62,13 +62,13 @@
 				<PeptideHit score="6.92258985582744" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -77,81 +77,82 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="119.091968219875"/>
-			<UserParam type="float" name="assay_rt" value="3000"/>
+			<UserParam type="float" name="delta_rt" value="119.091968219875071"/>
+			<UserParam type="float" name="assay_rt" value="3000.000000000001819"/>
 			<UserParam type="float" name="norm_RT" value="0.46858207237277"/>
-			<UserParam type="float" name="rt_score" value="0.0285820723727704"/>
-			<UserParam type="float" name="var_norm_rt_score" value="0.0285820723727704"/>
+			<UserParam type="float" name="rt_score" value="0.02858207237277"/>
+			<UserParam type="float" name="var_norm_rt_score" value="0.02858207237277"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.92258985582744"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.92258985582744"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.922589855827443"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.922589855827443"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.95351</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.953507</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -159,96 +160,97 @@
 				<PeptideHit score="1.95350659622369" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="1055.58448187053"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1055.584481870530453"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.453340275648928"/>
 			<UserParam type="float" name="rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
 			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="float" name="xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.2483</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.248305</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -256,37 +258,38 @@
 				<PeptideHit score="1.2483045614906" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="1119.06301053107"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1119.063010531066993"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.468575122527456"/>
 			<UserParam type="float" name="rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.2483045614906"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="1.2483045614906"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.248304561490597"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="1.248304561490597"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_2_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_2_output.featureXML
@@ -15,61 +15,61 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17581.9</overallquality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17581.892578</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEA" charge="0">
+				<PeptideHit score="-21994.8526299932" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[628.435, 0.795655307308668, 654.38, 0.601388001638662]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[628.434999999999945, 0.795655307308668, 654.379999999999995, 0.601388001638662]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -78,245 +78,245 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="3118.65196821988"/>
+			<UserParam type="float" name="delta_rt" value="3118.651968219876835"/>
 			<UserParam type="float" name="assay_rt" value="0.44"/>
-			<UserParam type="float" name="norm_RT" value="3119.09196821988"/>
-			<UserParam type="float" name="rt_score" value="3118.65196821988"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.65196821988"/>
+			<UserParam type="float" name="norm_RT" value="3119.09196821987689"/>
+			<UserParam type="float" name="rt_score" value="3118.651968219876835"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.651968219876835"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.8526299932"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406217887"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.852629993172741"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406266041"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
 			<UserParam type="float" name="var_massdev_score" value="0.698521654473665"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="0.666143770195331"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.748534661694761"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.790882639429274"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.8917975033"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.748534665439434"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.790882631508097"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.891797503001726"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17227.6</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17227.595703</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-21551.8862238136" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.284853767623738, 651.3, 3.83577941240474]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.284853767623738, 651.299999999999955, 3.835779412404737]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="3055.38448187053"/>
+			<UserParam type="float" name="delta_rt" value="3055.384481870531999"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3055.58448187053"/>
-			<UserParam type="float" name="rt_score" value="3055.38448187053"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3055.38448187053"/>
+			<UserParam type="float" name="norm_RT" value="3055.584481870531818"/>
+			<UserParam type="float" name="rt_score" value="3055.384481870531999"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3055.384481870531999"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.8862238136"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666510130199"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="1.37354439334283"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.886223813598917"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666511858478"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
+			<UserParam type="float" name="var_massdev_score" value="1.373544393342825"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="1.18664964107839"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.819948909662397"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.655571510832033"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.5960779472"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.819948911009368"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.655571508089016"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.596077946120204"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17585.7</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17585.660156</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-22000.322668871" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.172578584832479, 628.435, 0.795655307308668, 651.3, 3.35491881386111]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.172578584832479, 628.434999999999945, 0.795655307308668, 651.299999999999955, 3.354918813861108]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="3118.86301053107"/>
+			<UserParam type="float" name="delta_rt" value="3118.863010531068539"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3119.06301053107"/>
-			<UserParam type="float" name="rt_score" value="3118.86301053107"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.86301053107"/>
+			<UserParam type="float" name="norm_RT" value="3119.063010531068358"/>
+			<UserParam type="float" name="rt_score" value="3118.863010531068539"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.863010531068539"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668871"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549841450573"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.0754514560103416"/>
-			<UserParam type="float" name="var_massdev_score" value="1.44105090200075"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.08854278297821"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.648134861655366"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.880571523870264"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.6606327116"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668870983762"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549840856606"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.075451456010342"/>
+			<UserParam type="float" name="var_massdev_score" value="1.441050902000751"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.088542782978214"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.648134857979065"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.880571529027551"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.660632711937069"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_5_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_5_output.featureXML
@@ -15,61 +15,61 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17581.9</overallquality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17581.892578</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEA" charge="0">
+				<PeptideHit score="-21994.8526299932" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[628.435, 0.795655307308668, 654.38, 0.601388001638662]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[628.434999999999945, 0.795655307308668, 654.379999999999995, 0.601388001638662]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -78,245 +78,245 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="3118.65196821988"/>
+			<UserParam type="float" name="delta_rt" value="3118.651968219876835"/>
 			<UserParam type="float" name="assay_rt" value="0.44"/>
-			<UserParam type="float" name="norm_RT" value="3119.09196821988"/>
-			<UserParam type="float" name="rt_score" value="3118.65196821988"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.65196821988"/>
+			<UserParam type="float" name="norm_RT" value="3119.09196821987689"/>
+			<UserParam type="float" name="rt_score" value="3118.651968219876835"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.651968219876835"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.8526299932"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406217887"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.852629993172741"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406266041"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
 			<UserParam type="float" name="var_massdev_score" value="0.698521654473665"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="0.666143770195331"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.748534661694761"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.790882639429274"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.8917975033"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.748534665439434"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.790882631508097"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.891797503001726"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17227.6</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17227.595703</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-21551.8862238136" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.284853767623738, 651.3, 3.83577941240474]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.284853767623738, 651.299999999999955, 3.835779412404737]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="3055.38448187053"/>
+			<UserParam type="float" name="delta_rt" value="3055.384481870531999"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3055.58448187053"/>
-			<UserParam type="float" name="rt_score" value="3055.38448187053"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3055.38448187053"/>
+			<UserParam type="float" name="norm_RT" value="3055.584481870531818"/>
+			<UserParam type="float" name="rt_score" value="3055.384481870531999"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3055.384481870531999"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.8862238136"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666510130199"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="1.37354439334283"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.886223813598917"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666511858478"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
+			<UserParam type="float" name="var_massdev_score" value="1.373544393342825"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="1.18664964107839"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.819948909662397"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.655571510832033"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.5960779472"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.819948911009368"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.655571508089016"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.596077946120204"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17585.7</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17585.660156</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-22000.322668871" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.172578584832479, 628.435, 0.795655307308668, 651.3, 3.35491881386111]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.172578584832479, 628.434999999999945, 0.795655307308668, 651.299999999999955, 3.354918813861108]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="3118.86301053107"/>
+			<UserParam type="float" name="delta_rt" value="3118.863010531068539"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3119.06301053107"/>
-			<UserParam type="float" name="rt_score" value="3118.86301053107"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.86301053107"/>
+			<UserParam type="float" name="norm_RT" value="3119.063010531068358"/>
+			<UserParam type="float" name="rt_score" value="3118.863010531068539"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.863010531068539"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668871"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549841450573"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.0754514560103416"/>
-			<UserParam type="float" name="var_massdev_score" value="1.44105090200075"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.08854278297821"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.648134861655366"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.880571523870264"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.6606327116"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668870983762"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549840856606"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.075451456010342"/>
+			<UserParam type="float" name="var_massdev_score" value="1.441050902000751"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.088542782978214"/>
+			<UserParam type="float" name="var_bseries_score" value="1.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.648134857979065"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.880571529027551"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.660632711937069"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_6_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_6_output.featureXML
@@ -15,61 +15,61 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17581.7</overallquality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17581.699219</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEA" charge="0">
+				<PeptideHit score="-21994.8526299932" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[628.435, 0.795655307308668, 654.38, 0.601388001638662]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[628.434999999999945, 0.795655307308668, 654.379999999999995, 0.601388001638662]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -78,245 +78,245 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="3118.65196821988"/>
+			<UserParam type="float" name="delta_rt" value="3118.651968219876835"/>
 			<UserParam type="float" name="assay_rt" value="0.44"/>
-			<UserParam type="float" name="norm_RT" value="3119.09196821988"/>
-			<UserParam type="float" name="rt_score" value="3118.65196821988"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.65196821988"/>
+			<UserParam type="float" name="norm_RT" value="3119.09196821987689"/>
+			<UserParam type="float" name="rt_score" value="3118.651968219876835"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.651968219876835"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.8526299932"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406217887"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.852629993172741"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.99809406266041"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
 			<UserParam type="float" name="var_massdev_score" value="0.698521654473665"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="0.666143770195331"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="1"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.748534661694761"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.790882639429274"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.6991193733"/>
+			<UserParam type="float" name="var_bseries_score" value="1.0"/>
+			<UserParam type="float" name="var_yseries_score" value="1.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.748534665439434"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.790882631508097"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17581.699119373002759"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17227.6</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17227.595703</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-21551.8862238136" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.284853767623738, 651.3, 3.83577941240474]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.284853767623738, 651.299999999999955, 3.835779412404737]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="3055.38448187053"/>
+			<UserParam type="float" name="delta_rt" value="3055.384481870531999"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3055.58448187053"/>
-			<UserParam type="float" name="rt_score" value="3055.38448187053"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3055.38448187053"/>
+			<UserParam type="float" name="norm_RT" value="3055.584481870531818"/>
+			<UserParam type="float" name="rt_score" value="3055.384481870531999"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3055.384481870531999"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.8862238136"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666510130199"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="1.37354439334283"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.886223813598917"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.972666511858478"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0"/>
+			<UserParam type="float" name="var_massdev_score" value="1.373544393342825"/>
 			<UserParam type="float" name="var_massdev_score_weighted" value="1.18664964107839"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.819948909662397"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.655571510832033"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.5960779472"/>
+			<UserParam type="float" name="var_bseries_score" value="0.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.819948911009368"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.655571508089016"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17227.596077946120204"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-17585.7</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-17585.660156</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="0" >
-				<PeptideHit score="0" sequence="PEPTIDEB" charge="0">
+				<PeptideHit score="-22000.322668871" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="floatList" name="masserror_ppm" value="[618.31, 0.172578584832479, 628.435, 0.795655307308668, 651.3, 3.35491881386111]"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="floatList" name="masserror_ppm" value="[618.309999999999945, 0.172578584832479, 628.434999999999945, 0.795655307308668, 651.299999999999955, 3.354918813861108]"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="3118.86301053107"/>
+			<UserParam type="float" name="delta_rt" value="3118.863010531068539"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3119.06301053107"/>
-			<UserParam type="float" name="rt_score" value="3118.86301053107"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.86301053107"/>
+			<UserParam type="float" name="norm_RT" value="3119.063010531068358"/>
+			<UserParam type="float" name="rt_score" value="3118.863010531068539"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.863010531068539"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668871"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549841450573"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.0754514560103416"/>
-			<UserParam type="float" name="var_massdev_score" value="1.44105090200075"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.08854278297821"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.648134861655366"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.880571523870264"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.6606327116"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.322668870983762"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.907549840856606"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.075451456010342"/>
+			<UserParam type="float" name="var_massdev_score" value="1.441050902000751"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.088542782978214"/>
+			<UserParam type="float" name="var_bseries_score" value="1.0"/>
+			<UserParam type="float" name="var_yseries_score" value="0.0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.648134857979065"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.880571529027551"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="-17585.660632711937069"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_7_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_7_output.featureXML
@@ -15,49 +15,49 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3298.3</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-21994.9</overallquality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3298.299561</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-21994.855469</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>737.553</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>737.553162</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
-					<UserParam type="float" name="area_background_level" value="65.4700031280518"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
+					<UserParam type="float" name="area_background_level" value="65.470003128051758"/>
 					<UserParam type="float" name="noise_background_level" value="4.67642879486084"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="165.115731239319"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="165.115731239318848"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2560.75</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2560.746338</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
-					<UserParam type="float" name="area_background_level" value="210.462914466858"/>
-					<UserParam type="float" name="noise_background_level" value="15.0330653190613"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
+					<UserParam type="float" name="area_background_level" value="210.46291446685791"/>
+					<UserParam type="float" name="noise_background_level" value="15.033065319061279"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
-					<UserParam type="float" name="peak_apex_int" value="562.293350696564"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="peak_apex_int" value="562.293350696563721"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -66,102 +66,103 @@
 				<PeptideHit score="-21994.8557780273" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="727.409081935883"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="727.409081935882568"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_corr" value="1.0"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.109717145133844"/>
 			<UserParam type="float" name="var_library_sangle" value="0.183215027960453"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.109717145133844"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.129936391282398"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992454548410864"/>
-			<UserParam type="float" name="delta_rt" value="3118.65196821988"/>
+			<UserParam type="float" name="delta_rt" value="3118.651968219876835"/>
 			<UserParam type="float" name="assay_rt" value="0.44"/>
-			<UserParam type="float" name="norm_RT" value="3119.09196821988"/>
-			<UserParam type="float" name="rt_score" value="3118.65196821988"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.65196821988"/>
+			<UserParam type="float" name="norm_RT" value="3119.09196821987689"/>
+			<UserParam type="float" name="rt_score" value="3118.651968219876835"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.651968219876835"/>
 			<UserParam type="float" name="var_intensity_score" value="0.896237934360355"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-21994.8557780273"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.8557780273"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-21994.855778027300403"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21994.855778027300403"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>79.9008</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-21551.9</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>79.900803</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-21551.882813</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>59.4001</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>59.400093</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
-					<UserParam type="float" name="area_background_level" value="61.2187056541443"/>
-					<UserParam type="float" name="noise_background_level" value="10.203117609024"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
+					<UserParam type="float" name="area_background_level" value="61.218705654144287"/>
+					<UserParam type="float" name="noise_background_level" value="10.203117609024048"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="25.3897016048431"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="25.38970160484314"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
-					<intensity>0</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>0.0</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="float" name="area_background_level" value="0.708549812436104"/>
 					<UserParam type="float" name="noise_background_level" value="0.118091635406017"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.118091635406017"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>20.5007</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>20.500708</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
-					<UserParam type="float" name="area_background_level" value="54.0623531341553"/>
-					<UserParam type="float" name="noise_background_level" value="9.01039218902588"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
+					<UserParam type="float" name="area_background_level" value="54.062353134155273"/>
+					<UserParam type="float" name="noise_background_level" value="9.010392189025879"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="11.9154462814331"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="11.915446281433106"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -169,102 +170,103 @@
 				<PeptideHit score="-21551.88209474" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="37.4232395216823"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="37.423239521682262"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.997974315498601"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0866173792920827"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.086617379292083"/>
 			<UserParam type="float" name="var_library_sangle" value="0.195957498999165"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.103260427684827"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.425318730001056"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.935507925463858"/>
-			<UserParam type="float" name="delta_rt" value="3055.38448187053"/>
+			<UserParam type="float" name="delta_rt" value="3055.384481870531999"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3055.58448187053"/>
-			<UserParam type="float" name="rt_score" value="3055.38448187053"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3055.38448187053"/>
-			<UserParam type="float" name="var_intensity_score" value="0.0496193842175974"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="norm_RT" value="3055.584481870531818"/>
+			<UserParam type="float" name="rt_score" value="3055.384481870531999"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3055.384481870531999"/>
+			<UserParam type="float" name="var_intensity_score" value="0.049619384217597"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-21551.88209474"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.88209474"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-21551.88209473995812"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-21551.88209473995812"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>817.454</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>-22000.6</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>817.45398</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>-22000.574219</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>0</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>0.0</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
-					<UserParam type="float" name="area_background_level" value="100.850258827209"/>
-					<UserParam type="float" name="noise_background_level" value="7.20358991622925"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
+					<UserParam type="float" name="area_background_level" value="100.850258827209473"/>
+					<UserParam type="float" name="noise_background_level" value="7.203589916229248"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="1.20453500747681"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="1.204535007476807"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>737.553</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>737.553162</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
-					<UserParam type="float" name="area_background_level" value="65.4700031280518"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
+					<UserParam type="float" name="area_background_level" value="65.470003128051758"/>
 					<UserParam type="float" name="noise_background_level" value="4.67642879486084"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="165.115731239319"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="165.115731239318848"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>79.9008</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>79.90081</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
-					<UserParam type="float" name="area_background_level" value="73.5710880756378"/>
-					<UserParam type="float" name="noise_background_level" value="5.25507771968842"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
+					<UserParam type="float" name="area_background_level" value="73.571088075637817"/>
+					<UserParam type="float" name="noise_background_level" value="5.255077719688416"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="19.0481811761856"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="27.4099999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="19.048181176185608"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="27.409999999999855"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -272,37 +274,38 @@
 				<PeptideHit score="-22000.5745695042" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="185.368447422981"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="185.368447422981262"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.786700268533966"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.519704744008913"/>
-			<UserParam type="float" name="var_library_sangle" value="1.34744114813701"/>
+			<UserParam type="float" name="var_library_sangle" value="1.347441148137014"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.580707547702574"/>
-			<UserParam type="float" name="var_library_manhattan" value="1.07941514422893"/>
+			<UserParam type="float" name="var_library_manhattan" value="1.079415144228927"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.49330296995263"/>
-			<UserParam type="float" name="delta_rt" value="3118.86301053107"/>
+			<UserParam type="float" name="delta_rt" value="3118.863010531068539"/>
 			<UserParam type="float" name="assay_rt" value="0.2"/>
-			<UserParam type="float" name="norm_RT" value="3119.06301053107"/>
-			<UserParam type="float" name="rt_score" value="3118.86301053107"/>
-			<UserParam type="float" name="var_norm_rt_score" value="3118.86301053107"/>
+			<UserParam type="float" name="norm_RT" value="3119.063010531068358"/>
+			<UserParam type="float" name="rt_score" value="3118.863010531068539"/>
+			<UserParam type="float" name="var_norm_rt_score" value="3118.863010531068539"/>
 			<UserParam type="float" name="var_intensity_score" value="0.507649006799594"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-22000.5745695042"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.5745695042"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="-22000.574569504158717"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="-22000.574569504158717"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_8_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_8_output.featureXML
@@ -15,47 +15,47 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
 			<overallquality>6.92259</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="total_mi" value="2.73422729278948"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="total_mi" value="2.734227292789477"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
 					<UserParam type="float" name="total_mi" value="3.586033627559"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -64,14 +64,14 @@
 				<PeptideHit score="6.92258985582744" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
-			<UserParam type="float" name="total_mi" value="3.16013046017424"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
+			<UserParam type="float" name="total_mi" value="3.160130460174239"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -80,87 +80,88 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="119.091968219875"/>
-			<UserParam type="float" name="assay_rt" value="3000"/>
+			<UserParam type="float" name="delta_rt" value="119.091968219875071"/>
+			<UserParam type="float" name="assay_rt" value="3000.000000000001819"/>
 			<UserParam type="float" name="norm_RT" value="0.46858207237277"/>
-			<UserParam type="float" name="rt_score" value="0.0285820723727704"/>
-			<UserParam type="float" name="var_norm_rt_score" value="0.0285820723727704"/>
+			<UserParam type="float" name="rt_score" value="0.02858207237277"/>
+			<UserParam type="float" name="var_norm_rt_score" value="0.02858207237277"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
-			<UserParam type="float" name="var_mi_score" value="3.8073549220576"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.8073549220576"/>
-			<UserParam type="float" name="var_mi_ratio_score" value="1.20480941215562"/>
+			<UserParam type="float" name="var_mi_score" value="3.807354922057603"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.807354922057603"/>
+			<UserParam type="float" name="var_mi_ratio_score" value="1.204809412155623"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.92258985582744"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.92258985582744"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.922589855827443"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.922589855827443"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.95351</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.953507</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -168,103 +169,104 @@
 				<PeptideHit score="1.95350659622369" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="1055.58448187053"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1055.584481870530453"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.453340275648928"/>
 			<UserParam type="float" name="rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
-			<UserParam type="float" name="var_mi_score" value="1.75162916738782"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="2.20105644479131"/>
+			<UserParam type="float" name="var_mi_score" value="1.751629167387823"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="2.201056444791313"/>
 			<UserParam type="float" name="var_mi_ratio_score" value="0.455194183085335"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
 			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="float" name="xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.2483</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.248305</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="total_mi" value="4.42794793968087"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="total_mi" value="4.427947939680868"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
 					<UserParam type="float" name="total_mi" value="2.78992957612118"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="total_mi" value="4.32639896538122"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="total_mi" value="4.326398965381223"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -272,41 +274,42 @@
 				<PeptideHit score="1.2483045614906" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
-			<UserParam type="float" name="total_mi" value="3.84809216039442"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
+			<UserParam type="float" name="total_mi" value="3.848092160394424"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="1119.06301053107"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1119.063010531066993"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.468575122527456"/>
 			<UserParam type="float" name="rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
-			<UserParam type="float" name="var_mi_score" value="3.66449777920046"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.56432195667905"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
+			<UserParam type="float" name="var_mi_score" value="3.664497779200461"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.564321956679047"/>
 			<UserParam type="float" name="var_mi_ratio_score" value="0.952289505151783"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.2483045614906"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="1.2483045614906"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.248304561490597"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="1.248304561490597"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathAnalyzer_9_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_9_output.featureXML
@@ -15,45 +15,45 @@
 	</IdentificationRun>
 	<featureList count="3">
 		<feature id="f_5233264595117471314">
-			<position dim="0">3119.09196821988</position>
-			<position dim="1">0</position>
-			<intensity>3574.23</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
+			<position dim="0">3119.09196821987689</position>
+			<position dim="1">0.0</position>
+			<intensity>3574.232422</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
 			<overallquality>6.92259</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr1"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">3119.09196821988</position>
-					<position dim="1">654.38</position>
-					<intensity>2771.21</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.09196821987689</position>
+					<position dim="1">654.379999999999995</position>
+					<intensity>2771.209229</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="654.38"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="654.379999999999995"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr2"/>
 					<UserParam type="float" name="peak_apex_int" value="577.326416015625"/>
-					<UserParam type="float" name="total_xic" value="2867.66653496027"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
+					<UserParam type="float" name="total_xic" value="2867.666534960269928"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
 					<UserParam type="float" name="logSN" value="4.45007591150298"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
@@ -62,13 +62,13 @@
 				<PeptideHit score="6.92258985582744" sequence="PEPTIDEA" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="3680.16062933207"/>
+			<UserParam type="float" name="total_xic" value="3680.160629332065582"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr1"/>
-			<UserParam type="float" name="leftWidth" value="3096.28002929688"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="747.118576049805"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="leftWidth" value="3096.280029296875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="747.118576049804688"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0.0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.998183460545928"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997577947394571"/>
 			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
@@ -77,83 +77,84 @@
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.108663236021716"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.128558411767946"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.992608693580346"/>
-			<UserParam type="float" name="delta_rt" value="119.091968219875"/>
-			<UserParam type="float" name="assay_rt" value="3000"/>
+			<UserParam type="float" name="delta_rt" value="119.091968219875071"/>
+			<UserParam type="float" name="assay_rt" value="3000.000000000001819"/>
 			<UserParam type="float" name="norm_RT" value="0.46858207237277"/>
-			<UserParam type="float" name="rt_score" value="0.0285820723727704"/>
-			<UserParam type="float" name="var_norm_rt_score" value="0.0285820723727704"/>
+			<UserParam type="float" name="rt_score" value="0.02858207237277"/>
+			<UserParam type="float" name="var_norm_rt_score" value="0.02858207237277"/>
 			<UserParam type="float" name="var_intensity_score" value="0.971216417399615"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="86.0041379995282"/>
+			<UserParam type="float" name="nr_peaks" value="2.0"/>
+			<UserParam type="float" name="sn_ratio" value="86.004137999528155"/>
 			<UserParam type="float" name="var_log_sn_score" value="4.45439541136954"/>
-			<UserParam type="float" name="var_mi_score" value="3.8073549220576"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.8073549220576"/>
+			<UserParam type="float" name="var_mi_score" value="3.807354922057603"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.807354922057603"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.985403120517731"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.92258985582744"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.92258985582744"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="6.922589855827443"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.922589855827443"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="500"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="500.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_15004869347769368353">
-			<position dim="0">3055.58448187053</position>
-			<position dim="1">0</position>
-			<intensity>195.654</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.95351</overallquality>
+			<position dim="0">3055.584481870531818</position>
+			<position dim="1">0.0</position>
+			<intensity>195.654221</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.953507</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_15004869347769368353_15157403601844400700">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">618.31</position>
-					<intensity>120.619</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>120.618797</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3055.16"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3055.159999999999854"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="35.5928192138672"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
+					<UserParam type="float" name="peak_apex_int" value="35.592819213867188"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
 					<UserParam type="float" name="logSN" value="1.86739581779823"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">628.435</position>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">628.434999999999945</position>
 					<intensity>0.472367</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3048.31"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3048.309999999999945"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
 					<UserParam type="float" name="peak_apex_int" value="0.236183270812035"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1399999999999"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.139999999999873"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">3055.58448187053</position>
-					<position dim="1">651.3</position>
-					<intensity>74.5631</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3055.584481870531818</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>74.563057</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3058.59"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3058.590000000000146"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="20.925838470459"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="13.71"/>
-					<UserParam type="float" name="logSN" value="1.33498168074371"/>
+					<UserParam type="float" name="peak_apex_int" value="20.925838470458984"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="13.710000000000036"/>
+					<UserParam type="float" name="logSN" value="1.334981680743709"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -161,98 +162,99 @@
 				<PeptideHit score="1.95350659622369" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
 			<UserParam type="float" name="leftWidth" value="3044.8798828125"/>
 			<UserParam type="float" name="rightWidth" value="3065.43994140625"/>
-			<UserParam type="float" name="peak_apices_sum" value="56.7548409551382"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.69946222565531"/>
+			<UserParam type="float" name="peak_apices_sum" value="56.754840955138207"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.699462225655311"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.430576988219353"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.801773648038466"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.827432023818302"/>
 			<UserParam type="float" name="var_library_corr" value="0.930678748454332"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0801900625876904"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.08019006258769"/>
 			<UserParam type="float" name="var_library_sangle" value="0.230979581576551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0970136886035403"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.09701368860354"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.357621970266554"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.949274692722253"/>
-			<UserParam type="float" name="delta_rt" value="1055.58448187053"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1055.584481870530453"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.453340275648928"/>
 			<UserParam type="float" name="rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.253340275648928"/>
 			<UserParam type="float" name="var_intensity_score" value="0.121503684911807"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="3.42378266973528"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="3.423782669735276"/>
 			<UserParam type="float" name="var_log_sn_score" value="1.23074598364098"/>
-			<UserParam type="float" name="var_mi_score" value="1.75162916738782"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="2.20105644479131"/>
+			<UserParam type="float" name="var_mi_score" value="1.751629167387823"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="2.201056444791313"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.88344943523407"/>
 			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="float" name="xx_lda_prelim_score" value="1.95350659622369"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 		<feature id="f_7804704400743266335">
-			<position dim="0">3119.06301053107</position>
-			<position dim="1">0</position>
-			<intensity>1034.55</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1.2483</overallquality>
+			<position dim="0">3119.063010531068358</position>
+			<position dim="1">0.0</position>
+			<intensity>1034.553589</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>1.248305</overallquality>
 			<charge>0</charge>
 			<subordinate>
 				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">618.31</position>
-					<intensity>78.0586</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">618.309999999999945</position>
+					<intensity>78.058571</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="618.31"/>
-					<UserParam type="float" name="peak_apex_position" value="3123.69"/>
+					<UserParam type="float" name="MZ" value="618.309999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3123.690000000000055"/>
 					<UserParam type="string" name="native_id" value="tr3"/>
-					<UserParam type="float" name="peak_apex_int" value="8.40812492370605"/>
-					<UserParam type="float" name="total_xic" value="412.092581033707"/>
-					<UserParam type="float" name="width_at_50" value="44.5500000000002"/>
-					<UserParam type="float" name="logSN" value="0"/>
+					<UserParam type="float" name="peak_apex_int" value="8.408124923706055"/>
+					<UserParam type="float" name="total_xic" value="412.092581033706665"/>
+					<UserParam type="float" name="width_at_50" value="44.550000000000182"/>
+					<UserParam type="float" name="logSN" value="0.0"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">628.435</position>
-					<intensity>803.023</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">628.434999999999945</position>
+					<intensity>803.023132</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="628.435"/>
-					<UserParam type="float" name="peak_apex_position" value="3120.26"/>
+					<UserParam type="float" name="MZ" value="628.434999999999945"/>
+					<UserParam type="float" name="peak_apex_position" value="3120.260000000000218"/>
 					<UserParam type="string" name="native_id" value="tr4"/>
-					<UserParam type="float" name="peak_apex_int" value="169.79216003418"/>
-					<UserParam type="float" name="total_xic" value="812.494094371796"/>
-					<UserParam type="float" name="width_at_50" value="17.1300000000001"/>
-					<UserParam type="float" name="logSN" value="4.45869633337531"/>
+					<UserParam type="float" name="peak_apex_int" value="169.792160034179688"/>
+					<UserParam type="float" name="total_xic" value="812.494094371795654"/>
+					<UserParam type="float" name="width_at_50" value="17.130000000000109"/>
+					<UserParam type="float" name="logSN" value="4.458696333375309"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 				<feature id="f_7804704400743266335_15916652588957785155">
-					<position dim="0">3119.06301053107</position>
-					<position dim="1">651.3</position>
-					<intensity>153.472</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
+					<position dim="0">3119.063010531068358</position>
+					<position dim="1">651.299999999999955</position>
+					<intensity>153.471893</intensity>
+					<quality dim="0">0.0</quality>
+					<quality dim="1">0.0</quality>
+					<overallquality>0.0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="651.3"/>
-					<UserParam type="float" name="peak_apex_position" value="3127.11"/>
+					<UserParam type="float" name="MZ" value="651.299999999999955"/>
+					<UserParam type="float" name="peak_apex_position" value="3127.110000000000127"/>
 					<UserParam type="string" name="native_id" value="tr5"/>
-					<UserParam type="float" name="peak_apex_int" value="24.303258895874"/>
-					<UserParam type="float" name="total_xic" value="385.687290549278"/>
-					<UserParam type="float" name="width_at_50" value="20.5599999999999"/>
-					<UserParam type="float" name="logSN" value="1.16692266163571"/>
+					<UserParam type="float" name="peak_apex_int" value="24.303258895874023"/>
+					<UserParam type="float" name="total_xic" value="385.687290549278259"/>
+					<UserParam type="float" name="width_at_50" value="20.559999999999945"/>
+					<UserParam type="float" name="logSN" value="1.166922661635712"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 				</feature>
 			</subordinate>
@@ -260,39 +262,40 @@
 				<PeptideHit score="1.2483045614906" sequence="PEPTIDEB" charge="0">
 				</PeptideHit>
 			</PeptideIdentification>
-			<UserParam type="float" name="total_xic" value="1610.27396595478"/>
+			<UserParam type="float" name="total_xic" value="1610.273965954780579"/>
 			<UserParam type="string" name="PeptideRef" value="tr_gr2"/>
-			<UserParam type="float" name="leftWidth" value="3099.69995117188"/>
-			<UserParam type="float" name="rightWidth" value="3147.67993164063"/>
-			<UserParam type="float" name="peak_apices_sum" value="202.50354385376"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="2.26491106406735"/>
+			<UserParam type="float" name="leftWidth" value="3099.699951171875"/>
+			<UserParam type="float" name="rightWidth" value="3147.679931640625"/>
+			<UserParam type="float" name="peak_apices_sum" value="202.503543853759766"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="2.264911064067352"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.904813880838571"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.724571355831169"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.643242628379923"/>
 			<UserParam type="float" name="var_library_corr" value="-0.78414843390081"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.435668770903728"/>
-			<UserParam type="float" name="var_library_sangle" value="1.22900596185022"/>
+			<UserParam type="float" name="var_library_sangle" value="1.229005961850221"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.493251048154143"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.718225439410146"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.718225439410147"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.721582143955776"/>
-			<UserParam type="float" name="delta_rt" value="1119.06301053107"/>
-			<UserParam type="float" name="assay_rt" value="2000"/>
+			<UserParam type="float" name="delta_rt" value="1119.063010531066993"/>
+			<UserParam type="float" name="assay_rt" value="2000.000000000001364"/>
 			<UserParam type="float" name="norm_RT" value="0.468575122527456"/>
 			<UserParam type="float" name="rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_norm_rt_score" value="0.268575122527456"/>
 			<UserParam type="float" name="var_intensity_score" value="0.642470542740079"/>
-			<UserParam type="float" name="nr_peaks" value="3"/>
-			<UserParam type="float" name="sn_ratio" value="30.180081980405"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.40718216971789"/>
-			<UserParam type="float" name="var_mi_score" value="3.66449777920046"/>
-			<UserParam type="float" name="var_mi_weighted_score" value="3.56432195667905"/>
+			<UserParam type="float" name="nr_peaks" value="3.0"/>
+			<UserParam type="float" name="sn_ratio" value="30.180081980405049"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.407182169717891"/>
+			<UserParam type="float" name="var_mi_score" value="3.664497779200461"/>
+			<UserParam type="float" name="var_mi_weighted_score" value="3.564321956679047"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.902114371458689"/>
-			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.2483045614906"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="1.2483045614906"/>
+			<UserParam type="float" name="main_var_xx_lda_prelim_score" value="1.248304561490597"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="1.248304561490597"/>
 			<UserParam type="int" name="missedCleavages" value="0"/>
-			<UserParam type="float" name="PrecursorMZ" value="501"/>
-			<UserParam type="float" name="ms1_area_intensity" value="0"/>
-			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.0"/>
+			<UserParam type="float" name="ms1_area_intensity" value="0.0"/>
+			<UserParam type="float" name="ms1_apex_intensity" value="0.0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0.0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathWorkflow_11_output.featureXML
+++ b/src/tests/topp/OpenSwathWorkflow_11_output.featureXML
@@ -88,6 +88,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="412.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="0"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="tr1"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[100.01, 7.94922416102196, 101.01, 32.6000601512688, 102.02, -41.0343641330559]"/>
@@ -111,7 +112,6 @@
 			<UserParam type="float" name="var_sonar_log_diff" value="0"/>
 			<UserParam type="float" name="var_sonar_log_trend" value="0"/>
 			<UserParam type="float" name="var_sonar_rsq" value="1"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_2927519776102075938">
 			<position dim="0">9.99999952316284</position>
@@ -195,6 +195,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="462.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="0"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="0"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="7"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[300.01, 24.5361359309146, 301.01, 0.243383210139807, 302.01, -24.2904376531646]"/>
@@ -218,7 +219,6 @@
 			<UserParam type="float" name="var_sonar_log_diff" value="0"/>
 			<UserParam type="float" name="var_sonar_log_trend" value="0"/>
 			<UserParam type="float" name="var_sonar_rsq" value="0"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathWorkflow_13_output.chrom.mzML
+++ b/src/tests/topp/OpenSwathWorkflow_13_output.chrom.mzML
@@ -136,192 +136,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2_Precursor_i0" index="1" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="3_Precursor_i0" index="2" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="4_Precursor_i0" index="3" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="6_Precursor_i0" index="4" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="5_Precursor_i0" index="5" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="0" index="6" defaultArrayLength="19">
+			<chromatogram id="0" index="1" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -358,7 +173,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="1" index="7" defaultArrayLength="19">
+			<chromatogram id="1" index="2" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -395,7 +210,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2" index="8" defaultArrayLength="19">
+			<chromatogram id="2" index="3" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -432,7 +247,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="3" index="9" defaultArrayLength="19">
+			<chromatogram id="2_Precursor_i0" index="4" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3" index="5" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -469,7 +321,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="4" index="10" defaultArrayLength="19">
+			<chromatogram id="4" index="6" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -506,7 +358,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="5" index="11" defaultArrayLength="19">
+			<chromatogram id="5" index="7" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -543,7 +395,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="6" index="12" defaultArrayLength="19">
+			<chromatogram id="3_Precursor_i0" index="8" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6" index="9" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -580,7 +469,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="7" index="13" defaultArrayLength="19">
+			<chromatogram id="7" index="10" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -617,7 +506,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="8" index="14" defaultArrayLength="19">
+			<chromatogram id="8" index="11" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -654,7 +543,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="9" index="15" defaultArrayLength="19">
+			<chromatogram id="4_Precursor_i0" index="12" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9" index="13" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -691,7 +617,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="10" index="16" defaultArrayLength="19">
+			<chromatogram id="10" index="14" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -728,7 +654,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="11" index="17" defaultArrayLength="19">
+			<chromatogram id="11" index="15" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -762,6 +688,80 @@
 						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
 						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
 						<binary>eJwBLgDR/0DEu4AAAAAAcEy7ZjyAAZiXrcrAgdGu30zrVvTN+q7++f+u/s36VvRM667fgdEo+Bve</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6_Precursor_i0" index="16" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="5_Precursor_i0" index="17" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
@@ -993,23 +993,23 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="0_Precursor_i0">6874</offset>
-		<offset idRef="2_Precursor_i0">9034</offset>
-		<offset idRef="3_Precursor_i0">11194</offset>
-		<offset idRef="4_Precursor_i0">13354</offset>
-		<offset idRef="6_Precursor_i0">15514</offset>
-		<offset idRef="5_Precursor_i0">17732</offset>
-		<offset idRef="0">19950</offset>
-		<offset idRef="1">22178</offset>
-		<offset idRef="2">24406</offset>
-		<offset idRef="3">26634</offset>
-		<offset idRef="4">28862</offset>
-		<offset idRef="5">31087</offset>
-		<offset idRef="6">33316</offset>
-		<offset idRef="7">35545</offset>
-		<offset idRef="8">37770</offset>
-		<offset idRef="9">39999</offset>
-		<offset idRef="10">42228</offset>
-		<offset idRef="11">44454</offset>
+		<offset idRef="0">9034</offset>
+		<offset idRef="1">11262</offset>
+		<offset idRef="2">13490</offset>
+		<offset idRef="2_Precursor_i0">15718</offset>
+		<offset idRef="3">17878</offset>
+		<offset idRef="4">20106</offset>
+		<offset idRef="5">22330</offset>
+		<offset idRef="3_Precursor_i0">24558</offset>
+		<offset idRef="6">26718</offset>
+		<offset idRef="7">28946</offset>
+		<offset idRef="8">31171</offset>
+		<offset idRef="4_Precursor_i0">33400</offset>
+		<offset idRef="9">35561</offset>
+		<offset idRef="10">37790</offset>
+		<offset idRef="11">40016</offset>
+		<offset idRef="6_Precursor_i0">42246</offset>
+		<offset idRef="5_Precursor_i0">44465</offset>
 		<offset idRef="15">46684</offset>
 		<offset idRef="12">48916</offset>
 		<offset idRef="16">51148</offset>

--- a/src/tests/topp/OpenSwathWorkflow_14_output.chrom.mzML
+++ b/src/tests/topp/OpenSwathWorkflow_14_output.chrom.mzML
@@ -81,192 +81,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2_Precursor_i0" index="1" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="204">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="104">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="3_Precursor_i0" index="2" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="204">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="104">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="4_Precursor_i0" index="3" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="204">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="104">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="6_Precursor_i0" index="4" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="204">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="104">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>pm2+Qjz4IUMzbIFDf0TCQ8v6CETafDVELdhhRMoEhETE/pBEc5qVRMT+kETKBIRELdhhRNp8NUTL+ghEf0TCQzNsgUM8+CFDpm2+Qg==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="5_Precursor_i0" index="5" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="204">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="104">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-						<binary>pm2+Qjz4IUMzbIFDf0TCQ8v6CETafDVELdhhRMoEhETE/pBEc5qVRMT+kETKBIRELdhhRNp8NUTL+ghEf0TCQzNsgUM8+CFDpm2+Qg==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="0" index="6" defaultArrayLength="19">
+			<chromatogram id="0" index="1" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -303,7 +118,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="1" index="7" defaultArrayLength="19">
+			<chromatogram id="1" index="2" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -340,7 +155,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2" index="8" defaultArrayLength="19">
+			<chromatogram id="2" index="3" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -377,7 +192,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="3" index="9" defaultArrayLength="19">
+			<chromatogram id="2_Precursor_i0" index="4" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="204">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="104">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3" index="5" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -414,7 +266,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="4" index="10" defaultArrayLength="19">
+			<chromatogram id="4" index="6" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -451,7 +303,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="5" index="11" defaultArrayLength="19">
+			<chromatogram id="5" index="7" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -488,7 +340,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="6" index="12" defaultArrayLength="19">
+			<chromatogram id="3_Precursor_i0" index="8" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="204">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="104">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6" index="9" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -525,7 +414,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="7" index="13" defaultArrayLength="19">
+			<chromatogram id="7" index="10" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -562,7 +451,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="8" index="14" defaultArrayLength="19">
+			<chromatogram id="8" index="11" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -599,7 +488,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="9" index="15" defaultArrayLength="19">
+			<chromatogram id="4_Precursor_i0" index="12" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="204">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="104">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9" index="13" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -636,7 +562,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="10" index="16" defaultArrayLength="19">
+			<chromatogram id="10" index="14" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -673,7 +599,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="11" index="17" defaultArrayLength="19">
+			<chromatogram id="11" index="15" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -707,6 +633,80 @@
 						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
 						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
 						<binary>bC6qQNiWLkFzRqhBgFsYQlmTgUKEDs9Ca2wbQ+EtW0MDMJFDiKy0Q/s900OIAehDyl7vQ4gB6EP7PdNDiKy0QwMwkUPhLVtDa2wbQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6_Precursor_i0" index="16" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="204">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="104">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>pm2+Qjz4IUMzbIFDf0TCQ8v6CETafDVELdhhRMoEhETE/pBEc5qVRMT+kETKBIRELdhhRNp8NUTL+ghEf0TCQzNsgUM8+CFDpm2+Qg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="5_Precursor_i0" index="17" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000810" name="mass chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="204">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAJEAAAAAAAAA0QAAAAAAAAD5AAAAAAAAAREAAAAAAAABJQAAAAAAAAE5AAAAAAACAUUAAAAAAAABUQAAAAAAAgFZAAAAAAAAAWUAAAAAAAIBbQAAAAAAAAF5AAAAAAABAYEAAAAAAAIBhQAAAAAAAwGJAAAAAAAAAZEAAAAAAAEBlQAAAAAAAgGZAAAAAAADAZ0A=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="104">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>pm2+Qjz4IUMzbIFDf0TCQ8v6CETafDVELdhhRMoEhETE/pBEc5qVRMT+kETKBIRELdhhRNp8NUTL+ghEf0TCQzNsgUM8+CFDpm2+Qg==</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
@@ -938,23 +938,23 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="0_Precursor_i0">3033</offset>
-		<offset idRef="2_Precursor_i0">5338</offset>
-		<offset idRef="3_Precursor_i0">7643</offset>
-		<offset idRef="4_Precursor_i0">9948</offset>
-		<offset idRef="6_Precursor_i0">12253</offset>
-		<offset idRef="5_Precursor_i0">14560</offset>
-		<offset idRef="0">16867</offset>
-		<offset idRef="1">19164</offset>
-		<offset idRef="2">21461</offset>
-		<offset idRef="3">23758</offset>
-		<offset idRef="4">26055</offset>
-		<offset idRef="5">28353</offset>
-		<offset idRef="6">30651</offset>
-		<offset idRef="7">32949</offset>
-		<offset idRef="8">35247</offset>
-		<offset idRef="9">37545</offset>
-		<offset idRef="10">39843</offset>
-		<offset idRef="11">42142</offset>
+		<offset idRef="0">5338</offset>
+		<offset idRef="1">7635</offset>
+		<offset idRef="2">9932</offset>
+		<offset idRef="2_Precursor_i0">12229</offset>
+		<offset idRef="3">14534</offset>
+		<offset idRef="4">16831</offset>
+		<offset idRef="5">19128</offset>
+		<offset idRef="3_Precursor_i0">21425</offset>
+		<offset idRef="6">23730</offset>
+		<offset idRef="7">26027</offset>
+		<offset idRef="8">28325</offset>
+		<offset idRef="4_Precursor_i0">30623</offset>
+		<offset idRef="9">32929</offset>
+		<offset idRef="10">35227</offset>
+		<offset idRef="11">37526</offset>
+		<offset idRef="6_Precursor_i0">39825</offset>
+		<offset idRef="5_Precursor_i0">42133</offset>
 		<offset idRef="15">44441</offset>
 		<offset idRef="12">46742</offset>
 		<offset idRef="16">49043</offset>

--- a/src/tests/topp/OpenSwathWorkflow_16_output.chrom.mzML
+++ b/src/tests/topp/OpenSwathWorkflow_16_output.chrom.mzML
@@ -159,562 +159,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i0" index="3" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i1" index="4" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="438.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="438.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i2" index="5" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="439.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="439.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEC_Precursor_i0" index="6" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEC_Precursor_i1" index="7" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="463.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="463.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEC_Precursor_i2" index="8" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="464.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="464.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDED_Precursor_i0" index="9" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDED_Precursor_i1" index="10" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="488.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="488.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDED_Precursor_i2" index="11" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="489.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="489.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEF_Precursor_i0" index="12" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8rIatfO4/Ht1fV4+9r++//a/nj71fXx7c7jatfKyPK36qSoFyDn</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEF_Precursor_i1" index="13" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="501.0133548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="501.0133548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzOLK7gQEEZkxfe+pA48V1931eh38582vtv5//1/478yv8i8/rdfcbL546MH0twwwAY+0cqA==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEF_Precursor_i2" index="14" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="502.0167096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="502.0167096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEE_Precursor_i0" index="15" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8rIatfO4/Ht1fV4+9r++//a/nj71fXx7c7jatfKyPK36qSoFyDn</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEE_Precursor_i1" index="16" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="511.0533548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="511.0533548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzOLWFAQQ21r6dfmr9xSMnr018KvMx/mfIvz//Q/7F/5T5OPHpyWsXj5xa/3b6xloAXGcc0g==</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEE_Precursor_i2" index="17" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="512.0567096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="512.0567096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="1" index="18" defaultArrayLength="19">
+			<chromatogram id="1" index="3" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -751,7 +196,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2" index="19" defaultArrayLength="19">
+			<chromatogram id="2" index="4" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -788,7 +233,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="3" index="20" defaultArrayLength="19">
+			<chromatogram id="3" index="5" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -825,7 +270,118 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="4" index="21" defaultArrayLength="19">
+			<chromatogram id="PEPTIDEB_Precursor_i0" index="6" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEB_Precursor_i1" index="7" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="438.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="438.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEB_Precursor_i2" index="8" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="439.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="439.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4" index="9" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -862,7 +418,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="5" index="22" defaultArrayLength="19">
+			<chromatogram id="5" index="10" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -899,7 +455,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="6" index="23" defaultArrayLength="19">
+			<chromatogram id="6" index="11" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -936,7 +492,118 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="7" index="24" defaultArrayLength="19">
+			<chromatogram id="PEPTIDEC_Precursor_i0" index="12" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEC_Precursor_i1" index="13" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="463.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="463.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEC_Precursor_i2" index="14" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="464.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="464.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7" index="15" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -973,7 +640,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="8" index="25" defaultArrayLength="19">
+			<chromatogram id="8" index="16" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -1010,7 +677,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="9" index="26" defaultArrayLength="19">
+			<chromatogram id="9" index="17" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -1047,7 +714,118 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="10" index="27" defaultArrayLength="19">
+			<chromatogram id="PEPTIDED_Precursor_i0" index="18" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDED_Precursor_i1" index="19" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="488.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="488.5033548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDED_Precursor_i2" index="20" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="489.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="489.5067096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10" index="21" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -1084,7 +862,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="11" index="28" defaultArrayLength="19">
+			<chromatogram id="11" index="22" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -1121,7 +899,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="12" index="29" defaultArrayLength="19">
+			<chromatogram id="12" index="23" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -1155,6 +933,228 @@
 						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
 						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
 						<binary>eJwBLgDR/0DEu4AAAAAAcEy8ZjyAAZiXrcvAgdGu30zrV/TN+q7++P+u/s36V/RM667fgdEpRhvh</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEF_Precursor_i0" index="24" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8rIatfO4/Ht1fV4+9r++//a/nj71fXx7c7jatfKyPK36qSoFyDn</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEF_Precursor_i1" index="25" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="501.0133548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="501.0133548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzOLK7gQEEZkxfe+pA48V1931eh38582vtv5//1/478yv8i8/rdfcbL546MH0twwwAY+0cqA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEF_Precursor_i2" index="26" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="502.0167096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="502.0167096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEE_Precursor_i0" index="27" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8rIatfO4/Ht1fV4+9r++//a/nj71fXx7c7jatfKyPK36qSoFyDn</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEE_Precursor_i1" index="28" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="511.0533548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="511.0533548378" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzOLWFAQQ21r6dfmr9xSMnr018KvMx/mfIvz//Q/7F/5T5OPHpyWsXj5xa/3b6xloAXGcc0g==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEE_Precursor_i2" index="29" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="512.0567096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="512.0567096756" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
@@ -1388,33 +1388,33 @@
 		<offset idRef="PEPTIDEA_Precursor_i0">3268</offset>
 		<offset idRef="PEPTIDEA_Precursor_i1">5435</offset>
 		<offset idRef="PEPTIDEA_Precursor_i2">7620</offset>
-		<offset idRef="PEPTIDEB_Precursor_i0">9805</offset>
-		<offset idRef="PEPTIDEB_Precursor_i1">11972</offset>
-		<offset idRef="PEPTIDEB_Precursor_i2">14157</offset>
-		<offset idRef="PEPTIDEC_Precursor_i0">16342</offset>
-		<offset idRef="PEPTIDEC_Precursor_i1">18509</offset>
-		<offset idRef="PEPTIDEC_Precursor_i2">20694</offset>
-		<offset idRef="PEPTIDED_Precursor_i0">22879</offset>
-		<offset idRef="PEPTIDED_Precursor_i1">25046</offset>
-		<offset idRef="PEPTIDED_Precursor_i2">27232</offset>
-		<offset idRef="PEPTIDEF_Precursor_i0">29418</offset>
-		<offset idRef="PEPTIDEF_Precursor_i1">31644</offset>
-		<offset idRef="PEPTIDEF_Precursor_i2">33886</offset>
-		<offset idRef="PEPTIDEE_Precursor_i0">36072</offset>
-		<offset idRef="PEPTIDEE_Precursor_i1">38298</offset>
-		<offset idRef="PEPTIDEE_Precursor_i2">40540</offset>
-		<offset idRef="1">42726</offset>
-		<offset idRef="2">44955</offset>
-		<offset idRef="3">47184</offset>
-		<offset idRef="4">49413</offset>
-		<offset idRef="5">51642</offset>
-		<offset idRef="6">53867</offset>
-		<offset idRef="7">56096</offset>
-		<offset idRef="8">58325</offset>
-		<offset idRef="9">60550</offset>
-		<offset idRef="10">62779</offset>
-		<offset idRef="11">65009</offset>
-		<offset idRef="12">67235</offset>
+		<offset idRef="1">9805</offset>
+		<offset idRef="2">12033</offset>
+		<offset idRef="3">14261</offset>
+		<offset idRef="PEPTIDEB_Precursor_i0">16489</offset>
+		<offset idRef="PEPTIDEB_Precursor_i1">18656</offset>
+		<offset idRef="PEPTIDEB_Precursor_i2">20841</offset>
+		<offset idRef="4">23026</offset>
+		<offset idRef="5">25254</offset>
+		<offset idRef="6">27479</offset>
+		<offset idRef="PEPTIDEC_Precursor_i0">29708</offset>
+		<offset idRef="PEPTIDEC_Precursor_i1">31876</offset>
+		<offset idRef="PEPTIDEC_Precursor_i2">34062</offset>
+		<offset idRef="7">36248</offset>
+		<offset idRef="8">38477</offset>
+		<offset idRef="9">40702</offset>
+		<offset idRef="PEPTIDED_Precursor_i0">42931</offset>
+		<offset idRef="PEPTIDED_Precursor_i1">45099</offset>
+		<offset idRef="PEPTIDED_Precursor_i2">47285</offset>
+		<offset idRef="10">49471</offset>
+		<offset idRef="11">51701</offset>
+		<offset idRef="12">53927</offset>
+		<offset idRef="PEPTIDEF_Precursor_i0">56157</offset>
+		<offset idRef="PEPTIDEF_Precursor_i1">58383</offset>
+		<offset idRef="PEPTIDEF_Precursor_i2">60625</offset>
+		<offset idRef="PEPTIDEE_Precursor_i0">62811</offset>
+		<offset idRef="PEPTIDEE_Precursor_i1">65037</offset>
+		<offset idRef="PEPTIDEE_Precursor_i2">67279</offset>
 		<offset idRef="13">69465</offset>
 		<offset idRef="16">71697</offset>
 		<offset idRef="14">73929</offset>

--- a/src/tests/topp/OpenSwathWorkflow_21_output.featureXML
+++ b/src/tests/topp/OpenSwathWorkflow_21_output.featureXML
@@ -124,6 +124,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="410"/>
 			<UserParam type="float" name="ms1_area_intensity" value="5995"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[100, 0, 200, 0, 300, 0, 400, 0]"/>
@@ -148,7 +149,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.488040389673534"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.28253858091952"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_3823858840059792698">
 			<position dim="0">209</position>
@@ -268,6 +268,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="417"/>
 			<UserParam type="float" name="ms1_area_intensity" value="8229"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="11"/>
 			<UserParam type="float" name="initialPeakQuality" value="0.974974762227991"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[360, 0, 460, 0, 560, 0, 570, 0]"/>
@@ -292,7 +293,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.904998371593326"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.79955528773135"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_11275867043381640475">
 			<position dim="0">25</position>
@@ -412,6 +412,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="412"/>
 			<UserParam type="float" name="ms1_area_intensity" value="7225"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[350, 0, 450, 0, 550, 0, 650, 0]"/>
@@ -436,7 +437,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.905481747652519"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.65133864719984"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_17569764383250687096">
 			<position dim="0">92</position>
@@ -556,6 +556,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="419.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9962"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[380, 0, 480, 0, 580, 0, 680, 0]"/>
@@ -580,7 +581,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.904756241889379"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.76"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.19449741343877"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_13113514917555180171">
 			<position dim="0">32.404443581899</position>
@@ -700,6 +700,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="430"/>
 			<UserParam type="float" name="ms1_area_intensity" value="15459"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="197"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[110, 0, 210, 0, 310, 0, 410, 0]"/>
@@ -724,7 +725,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.630052461006068"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.37940283411016"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_17287849381738438716">
 			<position dim="0">210.333333333333</position>
@@ -844,6 +844,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="435"/>
 			<UserParam type="float" name="ms1_area_intensity" value="8125.33349609375"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.24657613052264"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[370, 0, 470, 0, 570, 0, 670, 0]"/>
@@ -868,7 +869,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.894919451095711"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.11705527393418"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_11399299100673837381">
 			<position dim="0">130.333333333333</position>
@@ -988,6 +988,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="445.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="14608"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="44"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[380, 0, 480, 0, 580, 0, 680, 0]"/>
@@ -1012,7 +1013,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.347221911470927"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.79025484467146"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_4021463513649428920">
 			<position dim="0">30.3333333333333</position>
@@ -1132,6 +1132,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="445.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="12374.6669921875"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="100"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[381, 0, 481, 0, 581, 0, 681, 0]"/>
@@ -1156,7 +1157,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.742735019216397"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.27975091654281"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_575144564576995072">
 			<position dim="0">80.3333333333333</position>
@@ -1276,6 +1276,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="446.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9774.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[382, 0, 482, 0, 582, 0, 682, 0]"/>
@@ -1300,7 +1301,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.66937362167774"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="1"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.2769082827398"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_11630589982317102322">
 			<position dim="0">120.333333333333</position>
@@ -1420,6 +1420,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="447.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9979.6669921875"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="56"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[383, 0, 483, 0, 583, 0, 683, 0]"/>
@@ -1444,7 +1445,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.634564823097929"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.6"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.99268716084505"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_17078574238716611972">
 			<position dim="0">160.333333333333</position>
@@ -1564,6 +1564,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="448.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9920.6669921875"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[384, 0, 484, 0, 584, 0, 684, 0]"/>
@@ -1588,7 +1589,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.665304775115317"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.6"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.48643697187333"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_7344192187426184761">
 			<position dim="0">190.333333333333</position>
@@ -1708,6 +1708,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="449.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9141"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[385, 0, 485, 0, 585, 0, 685, 0]"/>
@@ -1732,7 +1733,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.792552490277728"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.7"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.32580851264761"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_16616557306000669869">
 			<position dim="0">12.3333328564961</position>
@@ -1852,6 +1852,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="439"/>
 			<UserParam type="float" name="ms1_area_intensity" value="6054.33349609375"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[100, 0, 200, 0, 300, 0, 400, 0]"/>
@@ -1876,7 +1877,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.894513399165362"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.2981768490076"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_12520536430934325912">
 			<position dim="0">32.404443581899</position>
@@ -1996,6 +1996,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="430"/>
 			<UserParam type="float" name="ms1_area_intensity" value="15459"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="197"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[110, 0, 210, 0, 310, 0, 410, 0]"/>
@@ -2020,7 +2021,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.630052461006068"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.37940283411016"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_16603831684342283009">
 			<position dim="0">27.3333333333333</position>
@@ -2140,6 +2140,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="432"/>
 			<UserParam type="float" name="ms1_area_intensity" value="7274.33349609375"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[350, 0, 450, 0, 550, 0, 650, 0]"/>
@@ -2164,7 +2165,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.898600758052808"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.88"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.77913782042676"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_3279626156608649238">
 			<position dim="0">15.3333328564961</position>
@@ -2284,6 +2284,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="431"/>
 			<UserParam type="float" name="ms1_area_intensity" value="6316.33349609375"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.24839812897918"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[360, 0, 460, 0, 560, 0, 570, 0]"/>
@@ -2308,7 +2309,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.578847947732441"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="1.63"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.93066881223862"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_15568981923429820128">
 			<position dim="0">15.6666661898295</position>
@@ -2428,6 +2428,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="460"/>
 			<UserParam type="float" name="ms1_area_intensity" value="6287.66650390625"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[100, 0, 200, 0, 300, 0, 400, 0]"/>
@@ -2452,7 +2453,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.883804145346413"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.09674990431294"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_16262506217367104038">
 			<position dim="0">131.666666666667</position>
@@ -2572,6 +2572,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="467"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9982.6669921875"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="76"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[350, 0, 450, 0, 550, 0, 650, 0]"/>
@@ -2596,7 +2597,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.878654990536721"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.29631788230775"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_7273255783824449336">
 			<position dim="0">122.588430563609</position>
@@ -2716,6 +2716,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="451"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9987.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="83"/>
 			<UserParam type="float" name="initialPeakQuality" value="-0.10610670029955"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[360, 0, 460, 0, 560, 0, 570, 0]"/>
@@ -2740,7 +2741,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.889061140510244"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.00824742280330855"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.355239716397114"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_4804931408721345291">
 			<position dim="0">90.6666666666667</position>
@@ -2860,6 +2860,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="465.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9930.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[380, 0, 480, 0, 580, 0, 680, 0]"/>
@@ -2884,7 +2885,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.617657140274255"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.92660310035698"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_435931305321438914">
 			<position dim="0">30.6666666666667</position>
@@ -3004,6 +3004,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="455.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="7467.66650390625"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[381, 0, 481, 0, 581, 0, 681, 0]"/>
@@ -3028,7 +3029,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.733173437716837"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.28991998537712"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_12175240310315893095">
 			<position dim="0">99.666667143504</position>
@@ -3148,6 +3148,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="456.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9982.6669921875"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[382, 0, 482, 0, 582, 0, 682, 0]"/>
@@ -3172,7 +3173,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.433698199006495"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.303030303030303"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.67058765558843"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_13986717998338703682">
 			<position dim="0">100.66666618983</position>
@@ -3292,6 +3292,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="457.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9987.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.6666666666766"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[383, 0, 483, 0, 583, 0, 683, 0]"/>
@@ -3316,7 +3317,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.757049367112445"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.98989898989899"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.96488906687134"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_15490049804574065229">
 			<position dim="0">170.666666666667</position>
@@ -3436,6 +3436,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="458.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9781.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="none"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[384, 0, 484, 0, 584, 0, 684, 0]"/>
@@ -3460,7 +3461,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.533975900234372"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.292929292929293"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="1.96897070285388"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 		<feature id="f_3109052061041085863">
 			<position dim="0">176.666666666667</position>
@@ -3580,6 +3580,7 @@
 			<UserParam type="float" name="PrecursorMZ" value="459.5"/>
 			<UserParam type="float" name="ms1_area_intensity" value="9640.3330078125"/>
 			<UserParam type="float" name="ms1_apex_intensity" value="99.666666666667"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="string" name="potentialOutlier" value="108"/>
 			<UserParam type="float" name="initialPeakQuality" value="1.25"/>
 			<UserParam type="floatList" name="masserror_ppm" value="[385, 0, 485, 0, 585, 0, 685, 0]"/>
@@ -3604,7 +3605,6 @@
 			<UserParam type="float" name="var_ms1_isotope_correlation" value="0.883857175151856"/>
 			<UserParam type="float" name="var_ms1_isotope_overlap" value="0.939393939393939"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.08818603644809"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/OpenSwathWorkflow_22_output.chrom.mzML
+++ b/src/tests/topp/OpenSwathWorkflow_22_output.chrom.mzML
@@ -122,81 +122,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i0" index="2" defaultArrayLength="50">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="24">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGGAAy4g7sABALAcDS8=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="152">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzOL27gQEI7q7o3HRk1/uD7id+nlW+fOe62R37B0xPOp7fePXj7bsPez9nfvv2I+33nr+//u/5m/b724/Mb3s/v/vw4+2NVx3PmZ7YPzC7c+e68uWfZ91PvD94ZFfnprsrVOe69N2rTExGQABqQ0bf</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i0" index="3" defaultArrayLength="50">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="24">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGGAAy4g7sABALAcDS8=</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="152">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzOL27gQEI7q7o3HRk1/uD7id+nlW+fOe62R37B0xPOp7fePXj7bsPez9nfvv2I+33nr+//u/5m/b724/Mb3s/v/vw4+2NVx3PmZ7YPzC7c+e68uWfZ91PvD94ZFfnprsrVOe69N2rTExGQABqQ0bf</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="tr1" index="4" defaultArrayLength="50">
+			<chromatogram id="tr1" index="2" defaultArrayLength="50">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -233,7 +159,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="tr2" index="5" defaultArrayLength="50">
+			<chromatogram id="tr2" index="3" defaultArrayLength="50">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -270,7 +196,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="3" index="6" defaultArrayLength="50">
+			<chromatogram id="3" index="4" defaultArrayLength="50">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -304,6 +230,80 @@
 						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
 						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
 						<binary>eJwBbACT/0DGbQAAAAAAAAALc1+Q9aGOrmG4b8BDxy/NatIZ11fbN9/I4hXmKekK7L/uTPG28wD2LvhC+j/8Jv75/yb+P/xC+i74APa280zxv+4K7CnpFebI4jffV9sZ12rSL81Dx2/AYbiOrvWhX5ALc8IiO1w=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEB_Precursor_i0" index="5" defaultArrayLength="50">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGGAAy4g7sABALAcDS8=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="152">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzOL27gQEI7q7o3HRk1/uD7id+nlW+fOe62R37B0xPOp7fePXj7bsPez9nfvv2I+33nr+//u/5m/b724/Mb3s/v/vw4+2NVx3PmZ7YPzC7c+e68uWfZ91PvD94ZFfnprsrVOe69N2rTExGQABqQ0bf</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEB_Precursor_i0" index="6" defaultArrayLength="50">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="417.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGGAAy4g7sABALAcDS8=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="152">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzOL27gQEI7q7o3HRk1/uD7id+nlW+fOe62R37B0xPOp7fePXj7bsPez9nfvv2I+33nr+//u/5m/b724/Mb3s/v/vw4+2NVx3PmZ7YPzC7c+e68uWfZ91PvD94ZFfnprsrVOe69N2rTExGQABqQ0bf</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
@@ -425,11 +425,11 @@
 	<index name="chromatogram">
 		<offset idRef="PEPTIDEA_Precursor_i0">3268</offset>
 		<offset idRef="PEPTIDEA_Precursor_i0">5564</offset>
-		<offset idRef="PEPTIDEB_Precursor_i0">7860</offset>
-		<offset idRef="PEPTIDEB_Precursor_i0">10156</offset>
-		<offset idRef="tr1">12452</offset>
-		<offset idRef="tr2">14767</offset>
-		<offset idRef="3">17082</offset>
+		<offset idRef="tr1">7860</offset>
+		<offset idRef="tr2">10175</offset>
+		<offset idRef="3">12490</offset>
+		<offset idRef="PEPTIDEB_Precursor_i0">14803</offset>
+		<offset idRef="PEPTIDEB_Precursor_i0">17099</offset>
 		<offset idRef="4">19395</offset>
 		<offset idRef="5">21708</offset>
 		<offset idRef="6">24021</offset>

--- a/src/tests/topp/OpenSwathWorkflow_3_output.chrom.mzML
+++ b/src/tests/topp/OpenSwathWorkflow_3_output.chrom.mzML
@@ -136,192 +136,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="PEPTIDEB_Precursor_i0" index="1" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEC_Precursor_i0" index="2" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDED_Precursor_i0" index="3" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="20">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJxzeP//AAPRAACBxQLv</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEF_Precursor_i0" index="4" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="PEPTIDEE_Precursor_i0" index="5" defaultArrayLength="19">
-				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
-					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-						<selectedIonList count="1">
-							<selectedIon>
-								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
-							</selectedIon>
-						</selectedIonList>
-						<activation>
-							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
-						</activation>
-					</precursor>
-					<product>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
-					</product>
-				<binaryDataArrayList count="2">
-					<binaryDataArray encodedLength="28">
-						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
-						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
-					</binaryDataArray>
-					<binaryDataArray encodedLength="76">
-						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
-						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
-					</binaryDataArray>
-				</binaryDataArrayList>
-			</chromatogram>
-			<chromatogram id="1" index="6" defaultArrayLength="19">
+			<chromatogram id="1" index="1" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -358,7 +173,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="2" index="7" defaultArrayLength="19">
+			<chromatogram id="2" index="2" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -395,7 +210,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="3" index="8" defaultArrayLength="19">
+			<chromatogram id="3" index="3" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -432,7 +247,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="4" index="9" defaultArrayLength="19">
+			<chromatogram id="PEPTIDEB_Precursor_i0" index="4" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="437.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEB"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4" index="5" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -469,7 +321,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="5" index="10" defaultArrayLength="19">
+			<chromatogram id="5" index="6" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -506,7 +358,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="6" index="11" defaultArrayLength="19">
+			<chromatogram id="6" index="7" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -543,7 +395,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="7" index="12" defaultArrayLength="19">
+			<chromatogram id="PEPTIDEC_Precursor_i0" index="8" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="462.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEC"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7" index="9" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -580,7 +469,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="8" index="13" defaultArrayLength="19">
+			<chromatogram id="8" index="10" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -617,7 +506,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="9" index="14" defaultArrayLength="19">
+			<chromatogram id="9" index="11" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -654,7 +543,44 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="10" index="15" defaultArrayLength="19">
+			<chromatogram id="PEPTIDED_Precursor_i0" index="12" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="487.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDED"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJxzeP//AAPRAACBxQLv</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10" index="13" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -691,7 +617,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="11" index="16" defaultArrayLength="19">
+			<chromatogram id="11" index="14" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -728,7 +654,7 @@
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
-			<chromatogram id="12" index="17" defaultArrayLength="19">
+			<chromatogram id="12" index="15" defaultArrayLength="19">
 				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
 					<precursor>
 						<isolationWindow>
@@ -762,6 +688,80 @@
 						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
 						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
 						<binary>eJwBLgDR/0DEu4AAAAAAcEy7ZjyAAZiXrcrAgdGu30zrVvTN+q7++f+u/s36VvRM667fgdEo+Bve</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEF_Precursor_i0" index="16" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="500.01" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEF"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="PEPTIDEE_Precursor_i0" index="17" defaultArrayLength="19">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<selectedIonList count="1">
+							<selectedIon>
+								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="510.05" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2" />
+							</selectedIon>
+						</selectedIonList>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="PEPTIDEE"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002746" name="MS-Numpress linear prediction compression followed by zlib compression" />
+						<binary>eJxzUGEAgxQgPgHEHVDQAAAyZQZR</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="76">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002748" name="MS-Numpress short logged float compression followed by zlib compression" />
+						<binary>eJwBLgDR/0DCDoAAAAAA6qTyt8vIatfN4/Lt1fV4+9r++//a/nj71fXy7c3jatfLyPK36qSoPyDp</binary>
 					</binaryDataArray>
 				</binaryDataArrayList>
 			</chromatogram>
@@ -993,23 +993,23 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="PEPTIDEA_Precursor_i0">6874</offset>
-		<offset idRef="PEPTIDEB_Precursor_i0">9041</offset>
-		<offset idRef="PEPTIDEC_Precursor_i0">11208</offset>
-		<offset idRef="PEPTIDED_Precursor_i0">13375</offset>
-		<offset idRef="PEPTIDEF_Precursor_i0">15542</offset>
-		<offset idRef="PEPTIDEE_Precursor_i0">17767</offset>
-		<offset idRef="1">19992</offset>
-		<offset idRef="2">22220</offset>
-		<offset idRef="3">24448</offset>
-		<offset idRef="4">26676</offset>
-		<offset idRef="5">28904</offset>
-		<offset idRef="6">31129</offset>
-		<offset idRef="7">33358</offset>
-		<offset idRef="8">35587</offset>
-		<offset idRef="9">37812</offset>
-		<offset idRef="10">40041</offset>
-		<offset idRef="11">42271</offset>
-		<offset idRef="12">44497</offset>
+		<offset idRef="1">9041</offset>
+		<offset idRef="2">11269</offset>
+		<offset idRef="3">13497</offset>
+		<offset idRef="PEPTIDEB_Precursor_i0">15725</offset>
+		<offset idRef="4">17892</offset>
+		<offset idRef="5">20120</offset>
+		<offset idRef="6">22344</offset>
+		<offset idRef="PEPTIDEC_Precursor_i0">24572</offset>
+		<offset idRef="7">26739</offset>
+		<offset idRef="8">28967</offset>
+		<offset idRef="9">31192</offset>
+		<offset idRef="PEPTIDED_Precursor_i0">33421</offset>
+		<offset idRef="10">35589</offset>
+		<offset idRef="11">37819</offset>
+		<offset idRef="12">40045</offset>
+		<offset idRef="PEPTIDEF_Precursor_i0">42275</offset>
+		<offset idRef="PEPTIDEE_Precursor_i0">44501</offset>
 		<offset idRef="13">46727</offset>
 		<offset idRef="16">48959</offset>
 		<offset idRef="14">51191</offset>


### PR DESCRIPTION
several improvements for OpenSwath under highly parallel loads

- memory improvements: instead of loading all MS1 chromatograms into memory, only load those of the current batch
- speed improvements: store scores in MRMFeature not in a map any more but as meta-values
- speed improvements: store paramters as members (e.g. `sn_win_len_`)
- allow compilation option `MT_ENABLE_NESTED_OPENMP` to utilize nested parallelism in OpenSWATH

speed improvements on a heavy parallel load with 40 threads:

before:

```
 OpenSwathWorkflow took 19:14 m (wall), 07:52:12 h (CPU), 02:39 m (system), 07:49:32 h (user).
 28172.61user 160.30system 19:19.99elapsed 2442%CPU (0avgtext+0avgdata 11329876maxresident)k
 0inputs+0outputs (0major+36875216minor)pagefaults 0swaps
```

after:

```
OpenSwathWorkflow took 05:38 m (wall), 02:03:15 h (CPU), 02:14 m (system), 02:01:00 h (user).
7260.90user 135.00system 5:44.10elapsed 2149%CPU (0avgtext+0avgdata 6870080maxresident)k
0inputs+0outputs (0major+21793570minor)pagefaults 0swaps
```

* speed is improved 3-fold
* memory requirements are reduced by 60%