### PR TITLE
Feature/visual fix

### DIFF
--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -54,6 +54,7 @@ namespace OpenMS
 
     for (Size i = 0; i < float_data_arrays_.size(); ++i)
     {
+      if (float_data_arrays_[i].empty()) continue;
       if (float_data_arrays_[i].size() != peaks_old)
       {
         throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "FloatDataArray[" + String(i) + "] size (" +
@@ -71,6 +72,7 @@ namespace OpenMS
 
     for (Size i = 0; i < string_data_arrays_.size(); ++i)
     {
+      if (string_data_arrays_[i].empty()) continue;
       if (string_data_arrays_[i].size() != peaks_old)
       {
         throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "StringDataArray[" + String(i) + "] size (" +
@@ -87,6 +89,7 @@ namespace OpenMS
 
     for (Size i = 0; i < integer_data_arrays_.size(); ++i)
     {
+      if (integer_data_arrays_[i].empty()) continue;
       if (integer_data_arrays_[i].size() != peaks_old)
       {
         throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IntegerDataArray[" + String(i) + "] size (" +

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1239,13 +1239,15 @@ namespace OpenMS
         bool parsing_success = false;
         if (type == FileTypes::MZML)
         {
-          MzMLFile f;
-          on_disc_peaks->openFile(filename);
 
+          // Load index only and check success (is it indexed?)
+          MzMLFile f;
           Internal::IndexedMzMLHandler indexed_mzml_file_;
           indexed_mzml_file_.openFile(filename);
           if ( indexed_mzml_file_.getParsingSuccess() && cache_ms2_on_disc)
           {
+            // If it has an index, now load index and meta data
+            on_disc_peaks->openFile(filename, false);
             OPENMS_LOG_INFO << "INFO: will use cached MS2 spectra" << std::endl;
             if (cache_ms1_on_disc)
             {

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -72,6 +72,10 @@ namespace OpenMS
       spectrum.push_back(peak1d);
     }
 
+    spectrum.getFloatDataArrays() = current_chrom.getFloatDataArrays();
+    spectrum.getIntegerDataArrays() = current_chrom.getIntegerDataArrays();
+    spectrum.getStringDataArrays() = current_chrom.getStringDataArrays();
+
     // Add at least one data point to the chromatogram, otherwise
     // "addLayer" will fail and a segfault occurs later
     if (current_chrom.empty()) 


### PR DESCRIPTION
fixes two bugs encountered in the wild

- chromatogams now also display meta data
- filtering does not crash if meta data arrays are empty
- substantially speeds up loading of data if no index is present in TOPPView