### PR TITLE
[Update] MSstatsConverter (TMT)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -92,8 +92,8 @@ namespace OpenMS
 
 
         /*
-         *  @brief: Class to aggregate intermediate information from ConsensusFeature and ConsusneMap,
-         *  such as filenames, intensities, retention times, labes and features (for futher processing)
+         *  @brief: Struct to aggregate intermediate information from ConsensusFeature and ConsensusMap,
+         *  such as filenames, intensities, retention times, labes and features (for further processing)
          */
         struct AggregatedConsensusInfo
         {
@@ -301,7 +301,7 @@ namespace OpenMS
       };
 
         /*
-         *  @brief Constructs the lines and add them to the TextFile
+         *  @brief Constructs the lines and adds them to the TextFile
          */
         template <class LineTemplate>
         void constructFile(const String& retention_time_summarization_method,

--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -82,7 +82,7 @@ namespace OpenMS
                       const String& condition,
                       const String& mixture,
                       const String& retention_time_summarization_method);
-    
+
     private:
 
         typedef OpenMS::Peak2D::IntensityType Intensity;
@@ -90,21 +90,26 @@ namespace OpenMS
 
         const String na_string = "NA";
 
+
+        /*
+         *  @brief: Class to aggregate intermediate information from ConsensusFeature and ConsusneMap,
+         *  such as filenames, intensities, retention times, labes and features (for futher processing)
+         */
         struct AggregatedConsensusInfo
         {
           std::vector< std::vector< String > > consensus_feature_filenames;           // Filenames of ConsensusFeature
-          std::vector< std::vector< Intensity > > consensus_feature_intensites;       // Intensites of ConsensusFeature
+          std::vector< std::vector< Intensity > > consensus_feature_intensities;       // Intensities of ConsensusFeature
           std::vector< std::vector< Coordinate > > consensus_feature_retention_times; // Retention times of ConsensusFeature
           std::vector< std::vector< unsigned > > consensus_feature_labels;          // Labels of ConsensusFeature
+          std::vector<BaseFeature> features;                                        // Features of ConsensusMap
         };
 
-        MSstatsFile::AggregatedConsensusInfo aggregateInfo(ConsensusMap const &consensus_map,
-                                                           std::vector<BaseFeature> &features,
-                                                           std::vector<String> const &spectra_paths);
+        MSstatsFile::AggregatedConsensusInfo aggregateInfo(const ConsensusMap& consensus_map,
+                                                           const std::vector<String>& spectra_paths);
 
         /*
-        *  @brief: Internal function to check if MSstats_BioReplicate and MSstats_Condition in Experimental Design
-        */
+         *  @brief: Internal function to check if MSstats_BioReplicate and MSstats_Condition in Experimental Design
+         */
         static void checkConditionLFQ_(const ExperimentalDesign::SampleSection& sampleSection, const String& bioreplicate, const String& condition);
 
         /*
@@ -115,7 +120,6 @@ namespace OpenMS
         /*
          *  @brief MSstats treats runs differently than OpenMS. In MSstats, runs are an enumeration of (SpectraFilePath, Fraction)
          *  In OpenMS, a run is split into multiple fractions.
-         *
          */
         static void assembleRunMap(
                 std::map< std::pair< String, unsigned>, unsigned> &run_map,
@@ -159,142 +163,154 @@ namespace OpenMS
         }
 
         class MSstatsLine
+      {
+      public :
+        MSstatsLine(
+            bool _has_fraction,
+            const String& _accession,
+            const String& _sequence,
+            const String& _precursor_charge,
+            const String& _fragment_ion,
+            const String& _frag_charge,
+            const String& _isotope_label_type,
+            const String& _condition,
+            const String& _bioreplicate,
+            const String& _run,
+            const String& _fraction
+        ): has_fraction_(_has_fraction),
+           accession_(_accession),
+           sequence_(_sequence),
+           precursor_charge_(_precursor_charge),
+           fragment_ion_(_fragment_ion),
+           frag_charge_(_frag_charge),
+           isotope_label_type_(_isotope_label_type),
+           condition_(_condition),
+           bioreplicate_(_bioreplicate),
+           run_(_run),
+           fraction_(_fraction) {}
+
+        const String& accession() const {return this->accession_;}
+        const String& sequence() const {return this->sequence_;}
+        const String& precursor_charge() const {return this->precursor_charge_;}
+        const String& run() const {return this->run_;}
+
+        String toString() const
         {
-        public :
-            MSstatsLine(
-                    bool _has_fraction,
-                    const String& _accession,
-                    const String& _sequence,
-                    const String& _precursor_charge,
-                    const String& _fragment_ion,
-                    const String& _frag_charge,
-                    const String& _isotope_label_type,
-                    const String& _condition,
-                    const String& _bioreplicate,
-                    const String& _run,
-                    const String& _fraction
-            ): has_fraction_(_has_fraction),
-               accession_(_accession),
-               sequence_(_sequence),
-               precursor_charge_(_precursor_charge),
-               fragment_ion_(_fragment_ion),
-               frag_charge_(_frag_charge),
-               isotope_label_type_(_isotope_label_type),
-               condition_(_condition),
-               bioreplicate_(_bioreplicate),
-               run_(_run),
-               fraction_(_fraction) {}
-            
-            const String& accession() const {return this->accession_;}
-            const String& sequence() const {return this->sequence_;}
-            const String& precursor_charge() const {return this->precursor_charge_;}
-            const String& run() const {return this->run_;}
+          const String delim(",");
+          return  accession_
+                  + delim + sequence_
+                  + delim + precursor_charge_
+                  + delim + fragment_ion_
+                  + delim + frag_charge_
+                  + delim + isotope_label_type_
+                  + delim + condition_
+                  + delim + bioreplicate_
+                  + delim + run_
+                  + (this->has_fraction_ ? delim + String(fraction_) : "");
+        }
 
-            String toString() const
-            {
-              const String delim(",");
-              return  accession_
-                      + delim + sequence_
-                      + delim + precursor_charge_
-                      + delim + fragment_ion_
-                      + delim + frag_charge_
-                      + delim + isotope_label_type_
-                      + delim + condition_
-                      + delim + bioreplicate_
-                      + delim + run_
-                      + (this->has_fraction_ ? delim + String(fraction_) : "");
-            }
+        friend bool operator<(const MSstatsLine &l,
+                              const MSstatsLine &r) {
 
-            friend bool operator<(const MSstatsLine &l,
-                                  const MSstatsLine &r) {
-
-              return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.precursor_charge_, l.sequence_) <
-                     std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.precursor_charge_, r.sequence_);
-            }
+          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.precursor_charge_, l.sequence_) <
+                 std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.precursor_charge_, r.sequence_);
+        }
 
 
-        private:
-            bool has_fraction_;
-            String accession_;
-            String sequence_;
-            String precursor_charge_;
-            String fragment_ion_;
-            String frag_charge_;
-            String isotope_label_type_;
-            String condition_;
-            String bioreplicate_;
-            String run_;
-            String fraction_;
-        };
- 
+      private:
+        bool has_fraction_;
+        String accession_;
+        String sequence_;
+        String precursor_charge_;
+        String fragment_ion_;
+        String frag_charge_;
+        String isotope_label_type_;
+        String condition_;
+        String bioreplicate_;
+        String run_;
+        String fraction_;
+      };
+
         class MSstatsTMTLine
+      {
+      public :
+        MSstatsTMTLine(
+            bool _has_fraction,
+            const String& _accession,
+            const String& _sequence,
+            const String& _precursor_charge,
+            const String& _channel,
+            const String& _condition,
+            const String& _bioreplicate,
+            const String& _run,
+            const String& _mixture,
+            const String& _techrepmixture,
+            const String& _fraction
+        ): has_fraction_(_has_fraction),
+           accession_(_accession),
+           sequence_(_sequence),
+           precursor_charge_(_precursor_charge),
+           channel_(_channel),
+           condition_(_condition),
+           bioreplicate_(_bioreplicate),
+           run_(_run),
+           mixture_(_mixture),
+           techrepmixture_(_techrepmixture),
+           fraction_(_fraction) {}
+
+        const String& accession() const {return this->accession_;}
+        const String& sequence() const {return this->sequence_;}
+        const String& precursor_charge() const {return this->precursor_charge_;}
+        const String& run() const {return this->run_;}
+
+        String toString() const
         {
-        public :
-            MSstatsTMTLine(
-                    bool _has_fraction,
-                    const String& _accession,
-                    const String& _sequence,
-                    const String& _precursor_charge,
-                    const String& _channel,
-                    const String& _condition,
-                    const String& _bioreplicate,
-                    const String& _run,
-                    const String& _mixture,
-                    const String& _techrepmixture,
-                    const String& _fraction
-            ): has_fraction_(_has_fraction),
-               accession_(_accession),
-               sequence_(_sequence),
-               precursor_charge_(_precursor_charge),
-               channel_(_channel),
-               condition_(_condition),
-               bioreplicate_(_bioreplicate),
-               run_(_run),
-               mixture_(_mixture),
-               techrepmixture_(_techrepmixture),
-               fraction_(_fraction) {}
+          const String delim(",");
+          return  accession_
+                  + delim + sequence_
+                  + delim + precursor_charge_
+                  + delim + channel_
+                  + delim + condition_
+                  + delim + bioreplicate_
+                  + delim + run_
+                  + delim + mixture_
+                  + delim + techrepmixture_
+                  + (this->has_fraction_ ? delim + String(fraction_) : "");
+        }
 
-            const String& accession() const {return this->accession_;}
-            const String& sequence() const {return this->sequence_;}
-            const String& precursor_charge() const {return this->precursor_charge_;}
-            const String& run() const {return this->run_;}
+        friend bool operator<(const MSstatsTMTLine &l,
+                              const MSstatsTMTLine &r) {
 
-            String toString() const
-            {
-              const String delim(",");
-              return  accession_
-                      + delim + sequence_
-                      + delim + precursor_charge_
-                      + delim + channel_
-                      + delim + condition_
-                      + delim + bioreplicate_
-                      + delim + run_
-                      + delim + mixture_
-                      + delim + techrepmixture_
-                      + (this->has_fraction_ ? delim + String(fraction_) : "");
-            }
-
-            friend bool operator<(const MSstatsTMTLine &l,
-                                  const MSstatsTMTLine &r) {
-
-              return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_) <
-                     std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_);
-            }
+          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_) <
+                 std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_);
+        }
 
 
-        private:
-            bool has_fraction_;
-            String accession_;
-            String sequence_;
-            String precursor_charge_;
-            String channel_;
-            String condition_;
-            String bioreplicate_;
-            String run_;
-            String mixture_;
-            String techrepmixture_;
-            String fraction_;
-        };
-        
-     }; 
+      private:
+        bool has_fraction_;
+        String accession_;
+        String sequence_;
+        String precursor_charge_;
+        String channel_;
+        String condition_;
+        String bioreplicate_;
+        String run_;
+        String mixture_;
+        String techrepmixture_;
+        String fraction_;
+      };
+
+        /*
+         *  @brief Constructs the lines and add them to the TextFile
+         */
+        template <class LineTemplate>
+        void constructFile(const String& retention_time_summarization_method,
+                           const bool rt_summarization_manual,
+                           TextFile& csv_out,
+                           const String& delim,
+                           const std::map<String, std::set<String> >& peptideseq_to_accessions,
+                           LineTemplate & peptideseq_to_prefix_to_intensities);
+
+
+    };
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -63,6 +63,21 @@ namespace OpenMS
         ///Destructor
         ~MSstatsFile();
 
+        typedef OpenMS::Peak2D::IntensityType Intensity;
+        typedef OpenMS::Peak2D::CoordinateType Coordinate;
+
+        struct AggregatedConsensusInfo
+        {
+          std::vector< std::vector< String > > consensus_feature_filenames;           // Filenames of ConsensusFeature
+          std::vector< std::vector< Intensity > > consensus_feature_intensites;       // Intensites of ConsensusFeature
+          std::vector< std::vector< Coordinate > > consensus_feature_retention_times; // Retention times of ConsensusFeature
+          std::vector< std::vector< unsigned > > consensus_feature_labels;          // Labels of ConsensusFeature
+        };
+
+        MSstatsFile::AggregatedConsensusInfo aggregateInfo(ConsensusMap const &consensus_map,
+                                                           std::vector<BaseFeature> &features,
+                                                           std::vector<String> const &spectra_paths);
+
         /// store label free experiment (MSstats)
         void storeLFQ(const String& filename, 
                       const ConsensusMap &consensus_map,

--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -63,21 +63,6 @@ namespace OpenMS
         ///Destructor
         ~MSstatsFile();
 
-        typedef OpenMS::Peak2D::IntensityType Intensity;
-        typedef OpenMS::Peak2D::CoordinateType Coordinate;
-
-        struct AggregatedConsensusInfo
-        {
-          std::vector< std::vector< String > > consensus_feature_filenames;           // Filenames of ConsensusFeature
-          std::vector< std::vector< Intensity > > consensus_feature_intensites;       // Intensites of ConsensusFeature
-          std::vector< std::vector< Coordinate > > consensus_feature_retention_times; // Retention times of ConsensusFeature
-          std::vector< std::vector< unsigned > > consensus_feature_labels;          // Labels of ConsensusFeature
-        };
-
-        MSstatsFile::AggregatedConsensusInfo aggregateInfo(ConsensusMap const &consensus_map,
-                                                           std::vector<BaseFeature> &features,
-                                                           std::vector<String> const &spectra_paths);
-
         /// store label free experiment (MSstats)
         void storeLFQ(const String& filename, 
                       const ConsensusMap &consensus_map,
@@ -99,8 +84,23 @@ namespace OpenMS
                       const String& retention_time_summarization_method);
     
     private:
-     
+
+        typedef OpenMS::Peak2D::IntensityType Intensity;
+        typedef OpenMS::Peak2D::CoordinateType Coordinate;
+
         const String na_string = "NA";
+
+        struct AggregatedConsensusInfo
+        {
+          std::vector< std::vector< String > > consensus_feature_filenames;           // Filenames of ConsensusFeature
+          std::vector< std::vector< Intensity > > consensus_feature_intensites;       // Intensites of ConsensusFeature
+          std::vector< std::vector< Coordinate > > consensus_feature_retention_times; // Retention times of ConsensusFeature
+          std::vector< std::vector< unsigned > > consensus_feature_labels;          // Labels of ConsensusFeature
+        };
+
+        MSstatsFile::AggregatedConsensusInfo aggregateInfo(ConsensusMap const &consensus_map,
+                                                           std::vector<BaseFeature> &features,
+                                                           std::vector<String> const &spectra_paths);
 
         /*
         *  @brief: Internal function to check if MSstats_BioReplicate and MSstats_Condition in Experimental Design

--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -225,7 +225,7 @@ namespace OpenMS
                     const String& _bioreplicate,
                     const String& _run,
                     const String& _mixture,
-                    const String& _techmixture,
+                    const String& _techrepmixture,
                     const String& _fraction
             ): has_fraction_(_has_fraction),
                accession_(_accession),
@@ -236,7 +236,7 @@ namespace OpenMS
                bioreplicate_(_bioreplicate),
                run_(_run),
                mixture_(_mixture),
-               techmixture_(_techmixture),
+               techrepmixture_(_techrepmixture),
                fraction_(_fraction) {}
 
             const String& accession() const {return this->accession_;}
@@ -255,7 +255,7 @@ namespace OpenMS
                       + delim + bioreplicate_
                       + delim + run_
                       + delim + mixture_
-                      + delim + techmixture_
+                      + delim + techrepmixture_
                       + (this->has_fraction_ ? delim + String(fraction_) : "");
             }
 
@@ -277,7 +277,7 @@ namespace OpenMS
             String bioreplicate_;
             String run_;
             String mixture_;
-            String techmixture_;
+            String techrepmixture_;
             String fraction_;
         };
         

--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -93,22 +93,27 @@ namespace OpenMS
 
         /*
          *  @brief: Struct to aggregate intermediate information from ConsensusFeature and ConsensusMap,
-         *  such as filenames, intensities, retention times, labes and features (for further processing)
+         *  such as filenames, intensities, retention times, labels and features (for further processing)
          */
         struct AggregatedConsensusInfo
         {
-          std::vector< std::vector< String > > consensus_feature_filenames;           // Filenames of ConsensusFeature
-          std::vector< std::vector< Intensity > > consensus_feature_intensities;       // Intensities of ConsensusFeature
-          std::vector< std::vector< Coordinate > > consensus_feature_retention_times; // Retention times of ConsensusFeature
-          std::vector< std::vector< unsigned > > consensus_feature_labels;          // Labels of ConsensusFeature
-          std::vector<BaseFeature> features;                                        // Features of ConsensusMap
+          std::vector< std::vector< String > > consensus_feature_filenames;           //< Filenames of ConsensusFeature
+          std::vector< std::vector< Intensity > > consensus_feature_intensities;       //< Intensities of ConsensusFeature
+          std::vector< std::vector< Coordinate > > consensus_feature_retention_times; //< Retention times of ConsensusFeature
+          std::vector< std::vector< unsigned > > consensus_feature_labels;          //< Labels of ConsensusFeature
+          std::vector<BaseFeature> features;                                        //<s Features of ConsensusMap
         };
 
-        MSstatsFile::AggregatedConsensusInfo aggregateInfo(const ConsensusMap& consensus_map,
+        /*
+         *  @brief: Aggregates information from ConsensusFeature and ConsensusMap,
+         *  such as filenames, intensities, retention times, labels and features.
+         *  Stores them in AggregatedConsensusInfo for later processing
+         */
+        MSstatsFile::AggregatedConsensusInfo aggregateInfo_(const ConsensusMap& consensus_map,
                                                            const std::vector<String>& spectra_paths);
 
         /*
-         *  @brief: Internal function to check if MSstats_BioReplicate and MSstats_Condition in Experimental Design
+         *  @brief: Internal function to check if MSstats_BioReplicate and MSstats_Condition exists in Experimental Design
          */
         static void checkConditionLFQ_(const ExperimentalDesign::SampleSection& sampleSection, const String& bioreplicate, const String& condition);
 
@@ -121,7 +126,7 @@ namespace OpenMS
          *  @brief MSstats treats runs differently than OpenMS. In MSstats, runs are an enumeration of (SpectraFilePath, Fraction)
          *  In OpenMS, a run is split into multiple fractions.
          */
-        static void assembleRunMap(
+        static void assembleRunMap_(
                 std::map< std::pair< String, unsigned>, unsigned> &run_map,
                 const ExperimentalDesign &design)
         {
@@ -147,7 +152,7 @@ namespace OpenMS
                  && std::equal(lhs.begin(), lhs.end(), rhs.begin());
         }
 
-        OpenMS::Peak2D::IntensityType sumIntensity(const std::set< OpenMS::Peak2D::IntensityType > &intensities)
+        OpenMS::Peak2D::IntensityType sumIntensity_(const std::set< OpenMS::Peak2D::IntensityType > &intensities)
         {
           OpenMS::Peak2D::IntensityType result = 0;
           for (const OpenMS::Peak2D::IntensityType &intensity : intensities)
@@ -157,159 +162,159 @@ namespace OpenMS
           return result;
         }
 
-        OpenMS::Peak2D::IntensityType meanIntensity(const std::set< OpenMS::Peak2D::IntensityType > &intensities)
+        OpenMS::Peak2D::IntensityType meanIntensity_(const std::set< OpenMS::Peak2D::IntensityType > &intensities)
         {
-          return sumIntensity(intensities) / intensities.size();
+          return sumIntensity_(intensities) / intensities.size();
         }
 
-        class MSstatsLine
-      {
-      public :
-        MSstatsLine(
-            bool _has_fraction,
-            const String& _accession,
-            const String& _sequence,
-            const String& _precursor_charge,
-            const String& _fragment_ion,
-            const String& _frag_charge,
-            const String& _isotope_label_type,
-            const String& _condition,
-            const String& _bioreplicate,
-            const String& _run,
-            const String& _fraction
-        ): has_fraction_(_has_fraction),
-           accession_(_accession),
-           sequence_(_sequence),
-           precursor_charge_(_precursor_charge),
-           fragment_ion_(_fragment_ion),
-           frag_charge_(_frag_charge),
-           isotope_label_type_(_isotope_label_type),
-           condition_(_condition),
-           bioreplicate_(_bioreplicate),
-           run_(_run),
-           fraction_(_fraction) {}
-
-        const String& accession() const {return this->accession_;}
-        const String& sequence() const {return this->sequence_;}
-        const String& precursor_charge() const {return this->precursor_charge_;}
-        const String& run() const {return this->run_;}
-
-        String toString() const
+        class MSstatsLine_
         {
-          const String delim(",");
-          return  accession_
-                  + delim + sequence_
-                  + delim + precursor_charge_
-                  + delim + fragment_ion_
-                  + delim + frag_charge_
-                  + delim + isotope_label_type_
-                  + delim + condition_
-                  + delim + bioreplicate_
-                  + delim + run_
-                  + (this->has_fraction_ ? delim + String(fraction_) : "");
-        }
+        public :
+          MSstatsLine_(
+              bool _has_fraction,
+              const String& _accession,
+              const String& _sequence,
+              const String& _precursor_charge,
+              const String& _fragment_ion,
+              const String& _frag_charge,
+              const String& _isotope_label_type,
+              const String& _condition,
+              const String& _bioreplicate,
+              const String& _run,
+              const String& _fraction
+          ): has_fraction_(_has_fraction),
+             accession_(_accession),
+             sequence_(_sequence),
+             precursor_charge_(_precursor_charge),
+             fragment_ion_(_fragment_ion),
+             frag_charge_(_frag_charge),
+             isotope_label_type_(_isotope_label_type),
+             condition_(_condition),
+             bioreplicate_(_bioreplicate),
+             run_(_run),
+             fraction_(_fraction) {}
 
-        friend bool operator<(const MSstatsLine &l,
-                              const MSstatsLine &r) {
+          const String& accession() const {return this->accession_;}
+          const String& sequence() const {return this->sequence_;}
+          const String& precursor_charge() const {return this->precursor_charge_;}
+          const String& run() const {return this->run_;}
 
-          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.precursor_charge_, l.sequence_) <
-                 std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.precursor_charge_, r.sequence_);
-        }
+          String toString() const
+          {
+            const String delim(",");
+            return  accession_
+                    + delim + sequence_
+                    + delim + precursor_charge_
+                    + delim + fragment_ion_
+                    + delim + frag_charge_
+                    + delim + isotope_label_type_
+                    + delim + condition_
+                    + delim + bioreplicate_
+                    + delim + run_
+                    + (this->has_fraction_ ? delim + String(fraction_) : "");
+          }
+
+          friend bool operator<(const MSstatsLine_ &l,
+                                const MSstatsLine_ &r) {
+
+            return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.precursor_charge_, l.sequence_) <
+                   std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.precursor_charge_, r.sequence_);
+          }
 
 
-      private:
-        bool has_fraction_;
-        String accession_;
-        String sequence_;
-        String precursor_charge_;
-        String fragment_ion_;
-        String frag_charge_;
-        String isotope_label_type_;
-        String condition_;
-        String bioreplicate_;
-        String run_;
-        String fraction_;
-      };
+        private:
+          bool has_fraction_;
+          String accession_;
+          String sequence_;
+          String precursor_charge_;
+          String fragment_ion_;
+          String frag_charge_;
+          String isotope_label_type_;
+          String condition_;
+          String bioreplicate_;
+          String run_;
+          String fraction_;
+        };
 
-        class MSstatsTMTLine
-      {
-      public :
-        MSstatsTMTLine(
-            bool _has_fraction,
-            const String& _accession,
-            const String& _sequence,
-            const String& _precursor_charge,
-            const String& _channel,
-            const String& _condition,
-            const String& _bioreplicate,
-            const String& _run,
-            const String& _mixture,
-            const String& _techrepmixture,
-            const String& _fraction
-        ): has_fraction_(_has_fraction),
-           accession_(_accession),
-           sequence_(_sequence),
-           precursor_charge_(_precursor_charge),
-           channel_(_channel),
-           condition_(_condition),
-           bioreplicate_(_bioreplicate),
-           run_(_run),
-           mixture_(_mixture),
-           techrepmixture_(_techrepmixture),
-           fraction_(_fraction) {}
-
-        const String& accession() const {return this->accession_;}
-        const String& sequence() const {return this->sequence_;}
-        const String& precursor_charge() const {return this->precursor_charge_;}
-        const String& run() const {return this->run_;}
-
-        String toString() const
+          class MSstatsTMTLine_
         {
-          const String delim(",");
-          return  accession_
-                  + delim + sequence_
-                  + delim + precursor_charge_
-                  + delim + channel_
-                  + delim + condition_
-                  + delim + bioreplicate_
-                  + delim + run_
-                  + delim + mixture_
-                  + delim + techrepmixture_
-                  + (this->has_fraction_ ? delim + String(fraction_) : "");
-        }
+        public :
+          MSstatsTMTLine_(
+              bool _has_fraction,
+              const String& _accession,
+              const String& _sequence,
+              const String& _precursor_charge,
+              const String& _channel,
+              const String& _condition,
+              const String& _bioreplicate,
+              const String& _run,
+              const String& _mixture,
+              const String& _techrepmixture,
+              const String& _fraction
+          ): has_fraction_(_has_fraction),
+             accession_(_accession),
+             sequence_(_sequence),
+             precursor_charge_(_precursor_charge),
+             channel_(_channel),
+             condition_(_condition),
+             bioreplicate_(_bioreplicate),
+             run_(_run),
+             mixture_(_mixture),
+             techrepmixture_(_techrepmixture),
+             fraction_(_fraction) {}
 
-        friend bool operator<(const MSstatsTMTLine &l,
-                              const MSstatsTMTLine &r) {
+          const String& accession() const {return this->accession_;}
+          const String& sequence() const {return this->sequence_;}
+          const String& precursor_charge() const {return this->precursor_charge_;}
+          const String& run() const {return this->run_;}
 
-          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_) <
-                 std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_);
-        }
+          String toString() const
+          {
+            const String delim(",");
+            return  accession_
+                    + delim + sequence_
+                    + delim + precursor_charge_
+                    + delim + channel_
+                    + delim + condition_
+                    + delim + bioreplicate_
+                    + delim + run_
+                    + delim + mixture_
+                    + delim + techrepmixture_
+                    + (this->has_fraction_ ? delim + String(fraction_) : "");
+          }
+
+          friend bool operator<(const MSstatsTMTLine_ &l,
+                                const MSstatsTMTLine_ &r) {
+
+            return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_) <
+                   std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_);
+          }
 
 
-      private:
-        bool has_fraction_;
-        String accession_;
-        String sequence_;
-        String precursor_charge_;
-        String channel_;
-        String condition_;
-        String bioreplicate_;
-        String run_;
-        String mixture_;
-        String techrepmixture_;
-        String fraction_;
-      };
+        private:
+          bool has_fraction_;
+          String accession_;
+          String sequence_;
+          String precursor_charge_;
+          String channel_;
+          String condition_;
+          String bioreplicate_;
+          String run_;
+          String mixture_;
+          String techrepmixture_;
+          String fraction_;
+        };
 
         /*
          *  @brief Constructs the lines and adds them to the TextFile
          */
-        template <class LineTemplate>
-        void constructFile(const String& retention_time_summarization_method,
+        template <class LineType>
+        void constructFile_(const String& retention_time_summarization_method,
                            const bool rt_summarization_manual,
                            TextFile& csv_out,
                            const String& delim,
                            const std::map<String, std::set<String> >& peptideseq_to_accessions,
-                           LineTemplate & peptideseq_to_prefix_to_intensities);
+                           LineType & peptideseq_to_prefix_to_intensities);
 
 
     };

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -244,6 +244,8 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, const Consens
   // intensities, such that we combine intensities over multiple retention times.
   map< String, map< MSstatsLine, set< pair<Intensity, Coordinate> > > > peptideseq_to_prefix_to_intensities;
 
+
+  // TODO: how to deal with that in AggregatedInfo
   for (Size i = 0; i < features.size(); ++i)
   {
     const OpenMS::BaseFeature &base_feature = features[i];
@@ -267,6 +269,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, const Consens
         // Have to combine all fragment annotations with all peptide evidences
         for (const OpenMS::PeptideHit::PeakAnnotation & frag_ann : fragment_annotations)
         {
+
           String fragment_ion = na_string;
 
           // Determine if the FragmentIon field can be assigned

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -46,7 +46,9 @@ OpenMS::MSstatsFile::~MSstatsFile()
 
 }
 
-void OpenMS::MSstatsFile::checkConditionLFQ_(const ExperimentalDesign::SampleSection& sampleSection, const String& bioreplicate, const String& condition)
+void OpenMS::MSstatsFile::checkConditionLFQ_(const ExperimentalDesign::SampleSection& sampleSection,
+                                             const String& bioreplicate,
+                                             const String& condition)
 {
   // Sample Section must contain the column that contains the condition used for MSstats
   if (!sampleSection.hasFactor(condition))
@@ -61,7 +63,10 @@ void OpenMS::MSstatsFile::checkConditionLFQ_(const ExperimentalDesign::SampleSec
   } 
 }
 
-void OpenMS::MSstatsFile::checkConditionISO_(const ExperimentalDesign::SampleSection& sampleSection, const String& bioreplicate, const String& condition, const String& mixture)
+void OpenMS::MSstatsFile::checkConditionISO_(const ExperimentalDesign::SampleSection& sampleSection,
+                                             const String& bioreplicate,
+                                             const String& condition,
+                                             const String& mixture)
 {
   checkConditionLFQ_(sampleSection, bioreplicate, condition);
   
@@ -73,9 +78,9 @@ void OpenMS::MSstatsFile::checkConditionISO_(const ExperimentalDesign::SampleSec
 }
 
 void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, const ConsensusMap &consensus_map,
-                                const OpenMS::ExperimentalDesign& design, const StringList& reannotate_filenames,
-                                const bool is_isotope_label_type, const String& bioreplicate, const String& condition,
-                                const String& retention_time_summarization_method)
+                                   const OpenMS::ExperimentalDesign& design, const StringList& reannotate_filenames,
+                                   const bool is_isotope_label_type, const String& bioreplicate, const String& condition,
+                                   const String& retention_time_summarization_method)
 {
   // Experimental Design file
   ExperimentalDesign::SampleSection sampleSection = design.getSampleSection();
@@ -530,7 +535,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
 
   // The output file of the MSstats converter (TODO Change to CSV file once store for CSV files has been implemented)
   TextFile csv_out;
-  csv_out.addLine(String(rt_summarization_manual ? "RetentionTime,": "") + "ProteinName,PeptideSequence,Charge,Channel,Condition,BioReplicate,Run,Mixture,TechMixture," + String(has_fraction ? "Fraction,": "") + "Intensity");
+  csv_out.addLine(String(rt_summarization_manual ? "RetentionTime,": "") + "ProteinName,PeptideSequence,Charge,Channel,Condition,BioReplicate,Run,Mixture,TechRepMixture," + String(has_fraction ? "Fraction,": "") + "Intensity");
 
   // These are placeholder peptide evidences in case the original ones are empty
   PeptideEvidence new_pep_ev;
@@ -584,10 +589,10 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
               const unsigned sample = path_label_to_sample[tpl1];
               const unsigned fraction = path_label_to_fraction[tpl1];
 
-              // Resolve techmixture, run
+              // Resolve techrepmixture, run
               const unsigned openms_fractiongroup = path_label_to_fractiongroup[tpl1];
-              String techmixture = String(sampleSection.getFactorValue(sample, mixture)) + "_" + String(openms_fractiongroup);
-              String run = techmixture + (has_fraction ? String("_" + String(fraction)) : "");  
+              String techrepmixture = String(sampleSection.getFactorValue(sample, mixture)) + "_" + String(openms_fractiongroup);
+              String run = techrepmixture + (has_fraction ? String("_" + String(fraction)) : "");
                           
               // Assemble MSstats line
               MSstatsTMTLine prefix(
@@ -600,7 +605,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
                       sampleSection.getFactorValue(sample, bioreplicate),
                       String(run),
                       sampleSection.getFactorValue(sample, mixture),
-                      String(techmixture),
+                      String(techrepmixture),
                       (has_fraction ? String(fraction) : "")
               );
               pair<Intensity, Coordinate> intensity_retention_time = make_pair(intensity, retention_time);
@@ -615,7 +620,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
   for (const auto& run_mapping : msstats_run_to_openms_fractiongroup)
   {
     cout << "MSstats run " << String(run_mapping.first)
-         << " corresponds to OpenMS TechMixture " << String(run_mapping.second) << endl;
+         << " corresponds to OpenMS TechRepMixture " << String(run_mapping.second) << endl;
   }
 
   // sanity check that the triples (peptide_sequence, precursor_charge, run) only appears once

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -73,8 +73,8 @@ void OpenMS::MSstatsFile::checkConditionISO_(const ExperimentalDesign::SampleSec
   } 
 }
 
-OpenMS::MSstatsFile::AggregatedConsensusInfo OpenMS::MSstatsFile::aggregateInfo(const ConsensusMap& consensus_map,
-                                                                                const std::vector<String>& spectra_paths)
+OpenMS::MSstatsFile::AggregatedConsensusInfo OpenMS::MSstatsFile::aggregateInfo_(const ConsensusMap& consensus_map,
+                                                                                 const std::vector<String>& spectra_paths)
 {
   OpenMS::MSstatsFile::AggregatedConsensusInfo AggregatedInfo;
   const auto &column_headers = consensus_map.getColumnHeaders(); // needed for label_id
@@ -118,13 +118,13 @@ OpenMS::MSstatsFile::AggregatedConsensusInfo OpenMS::MSstatsFile::aggregateInfo(
   return AggregatedInfo;
 }
 
-template <class LineTemplate>
-void OpenMS::MSstatsFile::constructFile(const String& retention_time_summarization_method,
-                                        const bool rt_summarization_manual,
-                                        TextFile& csv_out,
-                                        const String& delim,
-                                        const std::map<String, std::set<String> >& peptideseq_to_accessions,
-                                        LineTemplate & peptideseq_to_prefix_to_intensities)
+template <class LineType>
+void OpenMS::MSstatsFile::constructFile_(const String& retention_time_summarization_method,
+                                         const bool rt_summarization_manual,
+                                         TextFile& csv_out,
+                                         const String& delim,
+                                         const std::map<String, std::set<String> >& peptideseq_to_accessions,
+                                         LineType & peptideseq_to_prefix_to_intensities)
 
 {
   // sanity check that the triples (peptide_sequence, precursor_charge, run) only appears once
@@ -187,11 +187,11 @@ void OpenMS::MSstatsFile::constructFile(const String& retention_time_summarizati
           }
           else if (retention_time_summarization_method == "mean")
           {
-            intensity = this->meanIntensity(intensities);
+            intensity = this->meanIntensity_(intensities);
           }
           else if (retention_time_summarization_method == "sum")
           {
-            intensity = this->sumIntensity(intensities);
+            intensity = this->sumIntensity_(intensities);
           }
           csv_out.addLine(line.first.toString() + delim + OpenMS::String(intensity));
         }
@@ -222,7 +222,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename,
 
   // assemble lookup table for run (each combination of pathname and fraction is a run)
   std::map< pair< String, unsigned>, unsigned > run_map;
-  assembleRunMap(run_map, design);
+  assembleRunMap_(run_map, design);
 
   // Maps run in MSstats input to run for OpenMS
   map< unsigned, unsigned > msstats_run_to_openms_fractiongroup;
@@ -290,7 +290,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename,
   }
 
   // Extract information from the consensus features.
-  OpenMS::MSstatsFile::AggregatedConsensusInfo AggregatedInfo = OpenMS::MSstatsFile::aggregateInfo(consensus_map, spectra_paths);
+  OpenMS::MSstatsFile::AggregatedConsensusInfo AggregatedInfo = OpenMS::MSstatsFile::aggregateInfo_(consensus_map, spectra_paths);
 
   // The output file of the MSstats converter
   TextFile csv_out;
@@ -328,7 +328,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename,
   // We need to map peptide sequences to full features, because then we can ignore peptides
   // that are mapped to multiple proteins. We also need to map to the
   // intensities, such that we combine intensities over multiple retention times.
-  map< String, map< MSstatsLine, set< pair<Intensity, Coordinate> > > > peptideseq_to_prefix_to_intensities;
+  map< String, map< MSstatsLine_, set< pair<Intensity, Coordinate> > > > peptideseq_to_prefix_to_intensities;
 
   for (Size i = 0; i < AggregatedInfo.features.size(); ++i)
   {
@@ -398,7 +398,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename,
               msstats_run_to_openms_fractiongroup[run] = openms_fractiongroup;
 
               // Assemble MSstats line
-              MSstatsLine prefix(
+              MSstatsLine_ prefix(
                       has_fraction,
                       accession,
                       sequence,
@@ -427,12 +427,12 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename,
          << " corresponds to OpenMS fraction group " << String(run_mapping.second) << endl;
   }
 
-  MSstatsFile::constructFile(retention_time_summarization_method,
-                             rt_summarization_manual,
-                             csv_out,
-                             delim,
-                             peptideseq_to_accessions,
-                             peptideseq_to_prefix_to_intensities);
+  MSstatsFile::constructFile_(retention_time_summarization_method,
+                              rt_summarization_manual,
+                              csv_out,
+                              delim,
+                              peptideseq_to_accessions,
+                              peptideseq_to_prefix_to_intensities);
 
   // Store the final assembled CSV file
   csv_out.store(filename);
@@ -519,7 +519,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename,
   }
 
   // Extract information from the consensus features.
-  OpenMS::MSstatsFile::AggregatedConsensusInfo AggregatedInfo = OpenMS::MSstatsFile::aggregateInfo(consensus_map, spectra_paths);
+  OpenMS::MSstatsFile::AggregatedConsensusInfo AggregatedInfo = OpenMS::MSstatsFile::aggregateInfo_(consensus_map, spectra_paths);
 
   // The output file of the MSstats converter
   TextFile csv_out;
@@ -539,7 +539,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename,
   // We need to map peptide sequences to full features, because then we can ignore peptides
   // that are mapped to multiple proteins. We also need to map to the
   // intensities, such that we combine intensities over multiple retention times.
-  map< String, map< MSstatsTMTLine, set< pair<Intensity, Coordinate> > > > peptideseq_to_prefix_to_intensities;
+  map< String, map< MSstatsTMTLine_, set< pair<Intensity, Coordinate> > > > peptideseq_to_prefix_to_intensities;
 
   for (Size i = 0; i < AggregatedInfo.features.size(); ++i)
   {
@@ -582,7 +582,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename,
               String run = techrepmixture + (has_fraction ? String("_" + String(fraction)) : "");
                           
               // Assemble MSstats line
-              MSstatsTMTLine prefix(
+              MSstatsTMTLine_ prefix(
                       has_fraction,
                       accession,
                       sequence,
@@ -610,7 +610,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename,
          << " corresponds to OpenMS TechRepMixture " << String(run_mapping.second) << endl;
   }
 
-  MSstatsFile::constructFile(retention_time_summarization_method,
+  MSstatsFile::constructFile_(retention_time_summarization_method,
                              rt_summarization_manual,
                              csv_out,
                              delim,

--- a/src/tests/topp/MSstatsConverter_2_out.csv
+++ b/src/tests/topp/MSstatsConverter_2_out.csv
@@ -1,4 +1,4 @@
-ProteinName,PeptideSequence,Charge,Channel,Condition,BioReplicate,Run,Mixture,TechMixture,Fraction,Intensity
+ProteinName,PeptideSequence,Charge,Channel,Condition,BioReplicate,Run,Mixture,TechRepMixture,Fraction,Intensity
 sp|Q14980|NUMA1_HUMAN,.(TMT6plex)AALM(Oxidation)ESQGQQQEER,3,1,1,1,1_1_1,1,1_1,1,38015.398438
 sp|Q14980|NUMA1_HUMAN,.(TMT6plex)AALM(Oxidation)ESQGQQQEER,3,2,1,2,1_1_1,1,1_1,1,44224.601563
 sp|Q14980|NUMA1_HUMAN,.(TMT6plex)AALM(Oxidation)ESQGQQQEER,3,3,1,3,1_1_1,1,1_1,1,29487.900391


### PR DESCRIPTION
Some minor updates for the MSstatsConverter, due to changes in the next R package version (MSstatsTMT). 

Question: 
The class MSstatsFile, due to the addition of the TMT-method has a lot of code duplication, or at least code overlap, with small changes e.g. MSstatsFile::MSstatsLine and MSstatsFile::MSstatsTMTLine; storeLFQ and storeISO.

Here, I tried to do some refactoring, but I am a little bit lost - where do I start and what would be best to make the code a bit cleaner and more functional. 

I would be very happy if you could give me some pointers! 
This will then probably go to a new PR. 
