### PR TITLE
NucleicAcidSearchEngine improvements

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 730
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - critical
+  - major
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
+++ b/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
@@ -19,6 +19,7 @@
 				<UserParam type="float" name="q-value" value="0.0"/>
 			</PeptideHit>
 			<UserParam type="int" name="scan_index" value="0"/>
+			<UserParam type="float" name="precursor_intensity" value="3.688524e06"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/utils/FeatureFinderMetaboIdent.cpp
+++ b/src/utils/FeatureFinderMetaboIdent.cpp
@@ -272,22 +272,24 @@ protected:
       vector<String> parts = ListUtils::create<String>(line, '\t'); // split
       if (parts.size() < 7)
       {
-        OPENMS_LOG_ERROR << "Error: Expected 7 tab-separated fields, found only "
-                  << parts.size() << " in line " << line_count
-                  << " - skipping this line." << endl;
+        OPENMS_LOG_ERROR
+          << "Error: Expected 7 tab-separated fields, found only "
+          << parts.size() << " in line " << line_count
+          << " - skipping this line." << endl;
         continue;
       }
       String name = parts[0];
       if (name.empty())
       {
-        OPENMS_LOG_ERROR << "Error: Empty name field in input line " << line_count
-                  << " - skipping this line." << endl;
+        OPENMS_LOG_ERROR << "Error: Empty name field in input line "
+                         << line_count << " - skipping this line." << endl;
         continue;
       }
       if (!names.insert(name).second) // @TODO: is this check necessary?
       {
-        OPENMS_LOG_ERROR << "Error: Duplicate name '" << name << "' in input line "
-                  << line_count << " - skipping this line." << endl;
+        OPENMS_LOG_ERROR << "Error: Duplicate name '" << name
+                         << "' in input line " << line_count
+                         << " - skipping this line." << endl;
         continue;
       }
       String formula = parts[1];
@@ -316,14 +318,14 @@ protected:
   {
     if ((mass <= 0) && formula.empty())
     {
-      OPENMS_LOG_ERROR << "Error: No mass or sum formula given for target '" << name
-                << "' - skipping this target." << endl;
+      OPENMS_LOG_ERROR << "Error: No mass or sum formula given for target '"
+                       << name << "' - skipping this target." << endl;
       return;
     }
     if (rts.empty())
     {
-      OPENMS_LOG_ERROR << "Error: No retention time (RT) given for target '" << name
-                << "' - skipping this target." << endl;
+      OPENMS_LOG_ERROR << "Error: No retention time (RT) given for target '"
+                       << name << "' - skipping this target." << endl;
       return;
     }
     // @TODO: detect entries with same RT and m/z ("collisions")
@@ -344,8 +346,8 @@ protected:
       if (formula.empty())
       {
         OPENMS_LOG_ERROR << "Error: No sum formula given for target '" << name
-                  << "'; cannot calculate isotope distribution"
-                  << " - using estimation method for peptides." << endl;
+                         << "'; cannot calculate isotope distribution"
+                         << " - using estimation method for peptides." << endl;
         iso_dist = iso_gen_.estimateFromPeptideWeight(mass);
       }
       else
@@ -378,7 +380,7 @@ protected:
       if (*z_it == 0)
       {
         OPENMS_LOG_ERROR << "Error: Invalid charge 0 for target '" << name
-                  << "' - skipping this charge." << endl;
+                         << "' - skipping this charge." << endl;
         continue;
       }
       target.setChargeState(*z_it);
@@ -621,7 +623,8 @@ protected:
            ++it)
       {
         if (it != group.begin()) msg += ", ";
-        msg += String((*it)->getMetaValue("PeptideRef")) + " (RT " + String(float((*it)->getRT())) + ")";
+        msg += String((*it)->getMetaValue("PeptideRef")) + " (RT " +
+          String(float((*it)->getRT())) + ")";
       }
       OPENMS_LOG_DEBUG << msg << endl;
     }
@@ -664,11 +667,12 @@ protected:
           }
           else
           {
-            OPENMS_LOG_WARN << "Warning: cannot decide between equally good feature candidates; picking the first one of "
-                     << best_feature->getMetaValue("PeptideRef") << " (RT "
-                     << float(best_feature->getRT()) << ") and "
-                     << (*it)->getMetaValue("PeptideRef") << " (RT "
-                     << float((*it)->getRT()) << ")." << endl;
+            OPENMS_LOG_WARN
+              << "Warning: cannot decide between equally good feature candidates; picking the first one of "
+              << best_feature->getMetaValue("PeptideRef") << " (RT "
+              << float(best_feature->getRT()) << ") and "
+              << (*it)->getMetaValue("PeptideRef") << " (RT "
+              << float((*it)->getRT()) << ")." << endl;
           }
         }
       }
@@ -785,8 +789,9 @@ protected:
       {
         if (best_rt_dist <= 0.0)
         {
-          OPENMS_LOG_WARN << "Warning: overlapping feature candidates for assay '"
-                   << ref << "'" << endl;
+          OPENMS_LOG_WARN
+            << "Warning: overlapping feature candidates for assay '" << ref
+            << "'" << endl;
         }
         rt_dist = 0.0;
       }
@@ -901,8 +906,8 @@ protected:
     {
       // calculate RT window based on other parameters:
       rt_window_ = 4 * peak_width;
-      OPENMS_LOG_INFO << "RT window size calculated as " << rt_window_ << " seconds."
-               << endl;
+      OPENMS_LOG_INFO << "RT window size calculated as " << rt_window_
+                      << " seconds." << endl;
     }
 
     //-------------------------------------------------------------
@@ -968,8 +973,8 @@ protected:
     feat_finder_.pickExperiment(chrom_data_, features, library_,
                                 TransformationDescription(), ms_data_);
     OpenMS_Log_info.insert(cout);
-    OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."
-             << endl;
+    OPENMS_LOG_INFO << "Found " << features.size()
+                    << " feature candidates in total." << endl;
     ms_data_.reset(); // not needed anymore, free up the memory
 
     // complete feature annotation:

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -850,7 +850,9 @@ protected:
     {
       IDFilter::filterQueryMatchesByScore(id_data, fdr_ref, fdr_cutoff);
       OPENMS_LOG_INFO << "Search hits after FDR filtering: "
-               << id_data.getMoleculeQueryMatches().size() << endl;
+                      << id_data.getMoleculeQueryMatches().size()
+                      << "\nIdentified spectra after FDR filtering: "
+                      << id_data.getDataQueries().size() << endl;
     }
   }
 
@@ -1297,10 +1299,11 @@ protected:
     }
     progresslogger.endProgress();
 
-    OPENMS_LOG_INFO << "Undigested nucleic acids: " << fasta_db.size() << endl;
-    OPENMS_LOG_INFO << "Oligonucleotides: " << id_data.getIdentifiedOligos().size()
-             << endl;
-    OPENMS_LOG_INFO << "Search hits: " << hit_counter << endl;
+    OPENMS_LOG_INFO << "Undigested nucleic acids: " << fasta_db.size()
+                    << "\nOligonucleotides: "
+                    << id_data.getIdentifiedOligos().size()
+                    << "\nSearch hits (spectrum matches): " << hit_counter
+                    << endl;
 
     if (!exp_ms2_out.empty())
     {
@@ -1314,6 +1317,8 @@ protected:
     progresslogger.startProgress(0, 1, "post-processing search hits...");
     postProcessHits_(spectra, annotated_hits, id_data, negative_mode);
     progresslogger.endProgress();
+    OPENMS_LOG_INFO << "Identified spectra: " << id_data.getDataQueries().size()
+                    << endl;
 
     // FDR:
     if (!decoy_pattern.empty())

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -653,7 +653,7 @@ protected:
   }
 
 
-  double calculatePrecursorMass_(double mz, Int charge, Size isotope,
+  double calculatePrecursorMass_(double mz, Int charge, Int isotope,
                                  double adduct_mass, bool negative_mode)
   {
     // we want to calculate the unadducted (!) precursor mass at neutral charge:
@@ -668,10 +668,7 @@ protected:
       mass -= Constants::PROTON_MASS_U * charge;
     }
     // correct for precursor not being the monoisotopic peak:
-    if (isotope > 0)
-    {
-      mass -= isotope * Constants::C13C12_MASSDIFF_U;
-    }
+    mass -= isotope * Constants::C13C12_MASSDIFF_U;
 
     return mass;
   }

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -600,12 +600,17 @@ protected:
           }
           if (inferred_charge == 0)
           {
-            OPENMS_LOG_ERROR << "Error: unable to determine charge state for spectrum '" << spec.getNativeID() << "' based on precursor m/z values " << mz1 << " and " << mz2 << endl;
+            OPENMS_LOG_ERROR
+              << "Error: unable to determine charge state for spectrum '"
+              << spec.getNativeID() << "' based on precursor m/z values "
+              << mz1 << " and " << mz2 << endl;
           }
           else
           {
             ++n_inferred_charge;
-            OPENMS_LOG_DEBUG << "Inferred charge state " << inferred_charge << " for spectrum '" << spec.getNativeID() << "'" << endl;
+            OPENMS_LOG_DEBUG << "Inferred charge state " << inferred_charge
+                             << " for spectrum '" << spec.getNativeID() << "'"
+                             << endl;
             // keep only precursor with highest charge, set inferred charge:
             Precursor prec = spec.getPrecursors()[precursors.begin()->second];
             prec.setCharge(abs(inferred_charge));
@@ -629,14 +634,20 @@ protected:
 
     if (n_zero_charge)
     {
-      OPENMS_LOG_WARN << "Warning: no charge state information available for " << n_zero_charge << " out of " << exp.size() << " spectra." << endl;
+      OPENMS_LOG_WARN << "Warning: no charge state information available for "
+                      << n_zero_charge << " out of " << exp.size()
+                      << " spectra." << endl;
       if (n_inferred_charge)
       {
-        OPENMS_LOG_INFO << "Inferred charge states for " << n_inferred_charge << " spectra." << endl;
+        OPENMS_LOG_INFO << "Inferred charge states for " << n_inferred_charge
+                        << " spectra." << endl;
       }
       if (n_zero_charge - n_inferred_charge > 0)
       {
-        OPENMS_LOG_INFO << "Spectra without charge information will be " << (include_unknown_charge ? "included in the processing" : "skipped") << " (see parameter 'precursor:include_unknown_charge')" << endl;
+        OPENMS_LOG_INFO
+          << "Spectra without charge information will be "
+          << (include_unknown_charge ? "included in the processing" : "skipped")
+          << " (see parameter 'precursor:include_unknown_charge')" << endl;
       }
     }
   }
@@ -990,7 +1001,8 @@ protected:
         EmpiricalFormula ef = parseAdduct_(adduct);
         double mass = use_avg_mass ? ef.getAverageWeight() : ef.getMonoWeight();
         adduct_masses[mass] = adduct;
-        OPENMS_LOG_DEBUG << "Added adduct: " << adduct << ", mass: " << mass << endl;
+        OPENMS_LOG_DEBUG << "Added adduct: " << adduct << ", mass: " << mass
+                         << endl;
       }
     }
 
@@ -1013,7 +1025,8 @@ protected:
                        single_charge_spectra, negative_mode, min_charge,
                        max_charge, include_unknown_charge);
     progresslogger.endProgress();
-    OPENMS_LOG_DEBUG << "preprocessed spectra: " << spectra.getNrSpectra() << endl;
+    OPENMS_LOG_DEBUG << "preprocessed spectra: " << spectra.getNrSpectra()
+                     << endl;
 
     // build multimap of precursor mass to scan index (and other information):
     multimap<double, PrecursorInfo> precursor_mass_map;
@@ -1212,7 +1225,7 @@ protected:
         {
           const NASequence& candidate = *seq_ptr;
           OPENMS_LOG_DEBUG << "Candidate: " << candidate.toString() << " ("
-                    << float(candidate_mass) << " Da)" << endl;
+                           << float(candidate_mass) << " Da)" << endl;
 
           // pre-generate spectra:
           map<Int, MSSpectrum> theo_spectra_by_charge;
@@ -1222,8 +1235,8 @@ protected:
 
           for (auto prec_it = low_it; prec_it != up_it; ++prec_it) // OMS_CODING_TEST_EXCLUDE
           {
-            OPENMS_LOG_DEBUG << "Matching precursor mass: " << float(prec_it->first)
-                      << endl;
+            OPENMS_LOG_DEBUG << "Matching precursor mass: "
+                             << float(prec_it->first) << endl;
 
             Size charge = prec_it->second.charge;
             // look up theoretical spectrum for this charge:
@@ -1331,11 +1344,11 @@ protected:
     // store results
     MzTab results = IdentificationDataConverter::exportMzTab(id_data);
     OPENMS_LOG_DEBUG << "Nucleic acid rows: "
-              << results.getNucleicAcidSectionRows().size()
-              << "\nOligonucleotide rows: "
-              << results.getOligonucleotideSectionRows().size()
-              << "\nOligo-spectrum match rows: "
-              << results.getOSMSectionRows().size() << endl;
+                     << results.getNucleicAcidSectionRows().size()
+                     << "\nOligonucleotide rows: "
+                     << results.getOligonucleotideSectionRows().size()
+                     << "\nOligo-spectrum match rows: "
+                     << results.getOSMSectionRows().size() << endl;
 
     MzTabFile().store(out, results);
 

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -867,9 +867,11 @@ protected:
 
   void generateLFQInput_(IdentificationData& id_data, const String& out_file)
   {
-    // mapping: (oligo, adduct) -> charge -> (precursor intensity, RT)
-    map<pair<NASequence, String>,
-        map<Int, vector<pair<double, double>>>> rt_info;
+    using AdductedOligo = pair<NASequence, String>; // oligo, adduct
+    using PrecursorPair = pair<double, double>; // precursor intensity, RT
+    // mapping: charge -> list of precursors
+    using PrecursorsByCharge = map<Int, vector<PrecursorPair>>;
+    map<AdductedOligo, PrecursorsByCharge> rt_info;
     for (const IdentificationData::MoleculeQueryMatch& match :
            id_data.getMoleculeQueryMatches())
     {
@@ -894,8 +896,6 @@ protected:
         name += "+[" + entry.first.second + "]";
         ef += parseAdduct_(entry.first.second);
       }
-      // strategy for selecting RT (should be near the top of the elution peak):
-      // get highest-intensity precursor per charge, use median RT of those
       // @TODO: use charge-specific RTs?
       vector<Int> charges;
       vector<double> rts;

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -902,13 +902,17 @@ protected:
       for (const auto& charge_pair : entry.second)
       {
         charges.push_back(charge_pair.first);
-        // get RT of precursor with max. intensity per charge:
-        auto best_it = max_element(charge_pair.second.begin(),
-                                   charge_pair.second.end());
-        rts.push_back(best_it->second);
+        // use intensity-weighted mean of precursor RTs as "apex" RT:
+        double weighted_rt = 0.0, total_weight = 0.0;
+        for (const auto& rt_pair : charge_pair.second)
+        {
+          weighted_rt += rt_pair.first * rt_pair.second;
+          total_weight += rt_pair.first;
+        }
+        rts.push_back(weighted_rt / total_weight);
       }
       tsv << name << ef << 0 << ListUtils::concatenate(charges, ",");
-      // @TODO: do something more sophisticated for the RT?
+      // overall target RT is median over all charge states:
       tsv << Math::median(rts.begin(), rts.end(), false) << 0 << 0 << endl;
     }
   }


### PR DESCRIPTION
- Allow negative values for parameter "precursor:isotopes" (see issue #4168)
- Take precursor intensities into account when estimating target RTs for label-free quantification (see parameter "lfq_out") - this improves feature detection using FeatureFinderMetaboIdent
- Add log messages with number of identified spectra (before/after FDR filtering)