### PR TITLE
fix: rename mz_extraction_window to mz_extract_window in DiaHelper

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
@@ -51,7 +51,7 @@ namespace OpenMS
     /**
       @brief Adjust left/right window based on window and whether its ppm or not
     */
-    OPENMS_DLLAPI void adjustExtractionWindow(double& right, double& left, const double& mz_extraction_window, const bool& mz_extraction_ppm);
+    OPENMS_DLLAPI void adjustExtractionWindow(double& right, double& left, const double& mz_extract_window, const bool& mz_extraction_ppm);
 
     /// compute the b and y series masses for a given AASequence
     OPENMS_DLLAPI void getBYSeries(const AASequence& a,

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
@@ -52,7 +52,7 @@ namespace OpenMS
 
     void adjustExtractionWindow(double& right, double& left, const double& mz_extract_window, const bool& mz_extraction_ppm)
     {
-      OPENMS_PRECONDITION(mz_extraction_window > 0, "MZ extraction window needst to be larger than zero.");
+      OPENMS_PRECONDITION(mz_extract_window > 0, "MZ extraction window needst to be larger than zero.");
 
       if (mz_extraction_ppm)
       {


### PR DESCRIPTION
Small inconsistency found in the last few changes to the class.

I guess `Release` builds succeed because those do not include `OPENMS_PRECONDITION()` calls.

But once I tried building `develop` as `Debug`, I had compile errors.