### PR TITLE
[FEATURE/FIX] ChromeleonFile handles raw data header

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
@@ -51,7 +51,7 @@ namespace OpenMS
     /**
       @brief Adjust left/right window based on window and whether its ppm or not
     */
-    OPENMS_DLLAPI void adjustExtractionWindow(double& right, double& left, const double& mz_extraction_window, const bool& mz_extraction_ppm);
+    OPENMS_DLLAPI void adjustExtractionWindow(double& right, double& left, const double& mz_extract_window, const bool& mz_extraction_ppm);
 
     /// compute the b and y series masses for a given AASequence
     OPENMS_DLLAPI void getBYSeries(const AASequence& a,

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
@@ -52,7 +52,7 @@ namespace OpenMS
 
     void adjustExtractionWindow(double& right, double& left, const double& mz_extract_window, const bool& mz_extraction_ppm)
     {
-      OPENMS_PRECONDITION(mz_extraction_window > 0, "MZ extraction window needst to be larger than zero.");
+      OPENMS_PRECONDITION(mz_extract_window > 0, "MZ extraction window needst to be larger than zero.");
 
       if (mz_extraction_ppm)
       {

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -59,6 +59,7 @@ namespace OpenMS
     boost::regex re_signal_unit("^Signal Unit\t(.+)", boost::regex::no_mod_s);
     boost::regex re_signal_info("^Signal Info\t(.+)", boost::regex::no_mod_s);
     boost::regex re_raw_data("^Raw Data:", boost::regex::no_mod_s);
+    boost::regex re_chromatogram_data("^Chromatogram Data:", boost::regex::no_mod_s);
     while (!ifs.eof())
     {
       ifs.getline(line, BUFSIZE);
@@ -102,7 +103,8 @@ namespace OpenMS
       {
         experiment.setMetaValue("signal_info", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_raw_data))
+      else if (boost::regex_search(line, m, re_raw_data) ||
+               boost::regex_search(line, m, re_chromatogram_data))
       {
         ifs.getline(line, BUFSIZE); // remove the subsequent line, right before the raw data
         break;
@@ -112,7 +114,7 @@ namespace OpenMS
     {
       ifs.getline(line, BUFSIZE);
       double rt, intensity;
-      int ret = std::sscanf(line, "%lf\t%*f\t%lf", &rt, &intensity);
+      int ret = std::sscanf(line, "%lf\t%*s\t%lf", &rt, &intensity);
       if (ret == 2)
       {
         chromatogram.push_back(ChromatogramPeak(rt, intensity));

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -38,94 +38,93 @@ namespace OpenMS
 {
   void ChromeleonFile::load(const String& filename, MSExperiment& experiment) const
   {
+    experiment.clear(true);
     std::ifstream ifs(filename, std::ifstream::in);
     if (!ifs.is_open())
     {
       throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
-    const Size BUFSIZE = 65536;
-    char line[BUFSIZE];
-    experiment.clear(true);
+    String line;
     MSChromatogram chromatogram;
-    boost::cmatch m;
-    boost::regex re_channel("^Channel\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection("^Injection\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_processing_method("^Processing Method\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_instrument_method("^Instrument Method\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection_date("^Injection Date\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection_time("^Injection Time\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_detector("^Detector\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_quantity("^Signal Quantity\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_unit("^Signal Unit\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_info("^Signal Info\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_raw_data("^Raw Data:", boost::regex::no_mod_s);
-    boost::regex re_chromatogram_data("^Chromatogram Data:", boost::regex::no_mod_s);
+    boost::smatch m;
+    boost::regex re_channel("^Channel\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_injection("^Injection\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_processing_method("^Processing Method\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_instrument_method("^Instrument Method\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_injection_date("^Injection Date\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_injection_time("^Injection Time\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_detector("^Detector\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_signal_quantity("^Signal Quantity\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_signal_unit("^Signal Unit\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_signal_info("^Signal Info\t(.*)\r?", boost::regex::no_mod_s);
+    boost::regex re_raw_data("^Raw Data:\r?", boost::regex::no_mod_s);
+    boost::regex re_chromatogram_data("^Chromatogram Data:\r?", boost::regex::no_mod_s);
     while (!ifs.eof())
     {
-      ifs.getline(line, BUFSIZE);
-      if (boost::regex_search(line, m, re_injection))
+      std::getline(ifs, line);
+      if (boost::regex_match(line, m, re_injection))
       {
-        experiment.setMetaValue("mzml_id", std::string(m[1]));
+        experiment.setMetaValue("mzml_id", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_channel))
+      else if (boost::regex_match(line, m, re_channel))
       {
-        experiment.setMetaValue("acq_method_name", std::string(m[1]));
+        experiment.setMetaValue("acq_method_name", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_processing_method))
+      else if (boost::regex_match(line, m, re_processing_method))
       {
-        experiment.getExperimentalSettings().getInstrument().getSoftware().setName(String(m[1]));
+        experiment.getExperimentalSettings().getInstrument().getSoftware().setName(m.str(1));
       }
-      else if (boost::regex_search(line, m, re_instrument_method))
+      else if (boost::regex_match(line, m, re_instrument_method))
       {
-        experiment.getExperimentalSettings().getInstrument().setName(String(m[1]));
+        experiment.getExperimentalSettings().getInstrument().setName(m.str(1));
       }
-      else if (boost::regex_search(line, m, re_injection_date))
+      else if (boost::regex_match(line, m, re_injection_date))
       {
-        experiment.setMetaValue("injection_date", std::string(m[1]));
+        experiment.setMetaValue("injection_date", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_injection_time))
+      else if (boost::regex_match(line, m, re_injection_time))
       {
-        experiment.setMetaValue("injection_time", std::string(m[1]));
+        experiment.setMetaValue("injection_time", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_detector))
+      else if (boost::regex_match(line, m, re_detector))
       {
-        experiment.setMetaValue("detector", std::string(m[1]));
+        experiment.setMetaValue("detector", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_signal_quantity))
+      else if (boost::regex_match(line, m, re_signal_quantity))
       {
-        experiment.setMetaValue("signal_quantity", std::string(m[1]));
+        experiment.setMetaValue("signal_quantity", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_signal_unit))
+      else if (boost::regex_match(line, m, re_signal_unit))
       {
-        experiment.setMetaValue("signal_unit", std::string(m[1]));
+        experiment.setMetaValue("signal_unit", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_signal_info))
+      else if (boost::regex_match(line, m, re_signal_info))
       {
-        experiment.setMetaValue("signal_info", std::string(m[1]));
+        experiment.setMetaValue("signal_info", m.str(1));
       }
-      else if (boost::regex_search(line, m, re_raw_data) ||
-               boost::regex_search(line, m, re_chromatogram_data))
+      else if (boost::regex_match(line, m, re_raw_data) ||
+               boost::regex_match(line, m, re_chromatogram_data))
       {
-        ifs.getline(line, BUFSIZE); // remove the subsequent line, right before the raw data
+        std::getline(ifs, line); // remove the subsequent line, right before the raw data
         break;
       }
     }
     while (!ifs.eof())
     {
-      ifs.getline(line, BUFSIZE);
+      std::getline(ifs, line);
       double rt, intensity;
-      int ret = std::sscanf(line, "%lf\t%*s\t%lf", &rt, &intensity);
+      int ret = std::sscanf(line.c_str(), "%lf\t%*s\t%lf", &rt, &intensity);
       if (ret == 2)
       {
         chromatogram.push_back(ChromatogramPeak(rt, intensity));
       }
-      else if (!strcmp(line, "\r") || !strcmp(line, ""))
+      else if (line == "\r" || line == "")
       {
         continue; // skips eventual empty lines, eg. the last before EOF
       }
       else
       {
-        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, std::string(line), "Couldn't parse the raw data.");
+        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, line, "Couldn't parse the raw data.");
       }
     }
     ifs.close();

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/ChromeleonFile.h>
+#include <OpenMS/FORMAT/TextFile.h>
 
 namespace OpenMS
 {
@@ -47,21 +48,21 @@ namespace OpenMS
     String line;
     MSChromatogram chromatogram;
     boost::smatch m;
-    boost::regex re_channel("^Channel\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_injection("^Injection\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_processing_method("^Processing Method\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_instrument_method("^Instrument Method\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_injection_date("^Injection Date\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_injection_time("^Injection Time\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_detector("^Detector\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_signal_quantity("^Signal Quantity\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_signal_unit("^Signal Unit\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_signal_info("^Signal Info\t(.*)\r?", boost::regex::no_mod_s);
-    boost::regex re_raw_data("^Raw Data:\r?", boost::regex::no_mod_s);
-    boost::regex re_chromatogram_data("^Chromatogram Data:\r?", boost::regex::no_mod_s);
+    boost::regex re_channel("^Channel\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_injection("^Injection\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_processing_method("^Processing Method\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_instrument_method("^Instrument Method\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_injection_date("^Injection Date\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_injection_time("^Injection Time\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_detector("^Detector\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_signal_quantity("^Signal Quantity\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_signal_unit("^Signal Unit\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_signal_info("^Signal Info\t(.*)", boost::regex::no_mod_s);
+    boost::regex re_raw_data("^Raw Data:", boost::regex::no_mod_s);
+    boost::regex re_chromatogram_data("^Chromatogram Data:", boost::regex::no_mod_s);
     while (!ifs.eof())
     {
-      std::getline(ifs, line);
+      TextFile::getLine(ifs, line);
       if (boost::regex_match(line, m, re_injection))
       {
         experiment.setMetaValue("mzml_id", m.str(1));
@@ -105,20 +106,20 @@ namespace OpenMS
       else if (boost::regex_match(line, m, re_raw_data) ||
                boost::regex_match(line, m, re_chromatogram_data))
       {
-        std::getline(ifs, line); // remove the subsequent line, right before the raw data
+        TextFile::getLine(ifs, line); // remove the subsequent line, right before the raw data
         break;
       }
     }
     while (!ifs.eof())
     {
-      std::getline(ifs, line);
+      TextFile::getLine(ifs, line);
       double rt, intensity;
       int ret = std::sscanf(line.c_str(), "%lf\t%*s\t%lf", &rt, &intensity);
       if (ret == 2)
       {
         chromatogram.push_back(ChromatogramPeak(rt, intensity));
       }
-      else if (line == "\r" || line == "")
+      else if (line.empty())
       {
         continue; // skips eventual empty lines, eg. the last before EOF
       }

--- a/src/tests/class_tests/openms/data/ChromeleonFile_new_header.txt
+++ b/src/tests/class_tests/openms/data/ChromeleonFile_new_header.txt
@@ -1,0 +1,53 @@
+﻿File Path	chrom://aibn-gh359r2/ChromeleonLocal/Instrument Data/HPLC_2/SUG_190605_AXA_REINJ FOR ROBIN_MP.seq/629.smp/RID_Signal.channel/RID_Signal.chm
+Channel	RID_Signal
+
+Injection Information:
+Data Vault	ChromeleonLocal
+Injection	S1
+Injection Number	14
+Position	Vial:8
+Comment	
+Processing Method	SUGARS_CAL
+Instrument Method	SUGARS_MP.M
+Type	Calibration Standard
+Status	Finished
+Injection Date	13/06/2019
+Injection Time	12:11:41 AM
+Injection Volume (µL)	10.00
+Dilution Factor	1.0000
+Weight	1.0000
+
+Chromatogram Data Information:
+Time Min. (min)	0.000000
+Time Max. (min)	21.002886
+Data Points	2912
+Detector	LCSystem
+Generating Data System	Chromeleon 7.2.9.11323
+Exporting Data System	Chromeleon 7.2.9.0
+Operator	Instrument Controller
+Signal Quantity	
+Signal Unit	nRIU
+Signal Min.	-202.620000
+Signal Max.	65,603.370000
+Channel	RID_Signal
+Driver Name	ICF.dll
+Channel Type	Evaluation
+Min. Step (s)	0.43290043
+Max. Step (s)	0.43290043
+Average Step (s)	0.43290043
+
+Signal Parameter Information:
+Signal Info	
+
+Chromatogram Data:
+Time (min)	Step (s)	Value (nRIU)
+0.000000	n.a.	5.060000
+0.007215	0.43290043	5.320000
+0.014430	0.43290043	5.450000
+0.021645	0.43290043	5.510000
+0.028860	0.43290043	5.580000
+0.036075	0.43290043	5.510000
+0.043290	0.43290043	5.380000
+0.050505	0.43290043	5.190000
+0.057720	0.43290043	5.060000
+0.064935	0.43290043	4.930000

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -123,7 +123,7 @@ END_SECTION
 
 START_SECTION(load_with_new_raw_data_header)
 {
-  String input_filepath = OPENMS_GET_TEST_DATA_PATH("ChromeleonFile_test_new_header.txt");
+  String input_filepath = OPENMS_GET_TEST_DATA_PATH("ChromeleonFile_new_header.txt");
   MSExperiment experiment;
   ChromeleonFile cf;
   cf.load(input_filepath, experiment);
@@ -134,9 +134,9 @@ START_SECTION(load_with_new_raw_data_header)
   TEST_EQUAL(experiment.getMetaValue("injection_date"), "13/06/2019")
   TEST_EQUAL(experiment.getMetaValue("injection_time"), "12:11:41 AM")
   TEST_EQUAL(experiment.getMetaValue("detector"), "LCSystem")
-  TEST_EQUAL(experiment.getMetaValue("signal_quantity").toString(), "")
+  TEST_EQUAL(experiment.getMetaValue("signal_quantity"), "")
   TEST_EQUAL(experiment.getMetaValue("signal_unit"), "nRIU")
-  TEST_EQUAL(experiment.getMetaValue("signal_info").toString(), "")
+  TEST_EQUAL(experiment.getMetaValue("signal_info"), "")
   const vector<MSChromatogram> chromatograms = experiment.getChromatograms();
   TEST_EQUAL(chromatograms.size(), 1);
   TEST_EQUAL(chromatograms[0].size(), 10);

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -50,7 +50,6 @@ START_TEST(ChromeleonFile, "$Id$")
 
 ChromeleonFile* ptr = 0;
 ChromeleonFile* null_ptr = 0;
-const String input_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.txt");
 
 START_SECTION(ChromeleonFile())
 {
@@ -65,12 +64,12 @@ START_SECTION(~ChromeleonFile())
 }
 END_SECTION
 
-ptr = new ChromeleonFile();
-
 START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
 {
+  String input_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.txt");
   MSExperiment experiment;
-  ptr->load(input_filepath, experiment);
+  ChromeleonFile cf;
+  cf.load(input_filepath, experiment);
   TEST_EQUAL(experiment.getMetaValue("acq_method_name"), "UV_VIS_2")
   TEST_EQUAL(experiment.getMetaValue("mzml_id"), "20171013_C61_ISO_P1_GA1")
   TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getName(), "HM_metode_ZorBax_0,02%_Acetic_acid_ver6")
@@ -122,7 +121,58 @@ START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
 }
 END_SECTION
 
-delete ptr;
+START_SECTION(load_with_new_raw_data_header)
+{
+  String input_filepath = OPENMS_GET_TEST_DATA_PATH("ChromeleonFile_test_new_header.txt");
+  MSExperiment experiment;
+  ChromeleonFile cf;
+  cf.load(input_filepath, experiment);
+  TEST_EQUAL(experiment.getMetaValue("acq_method_name"), "RID_Signal")
+  TEST_EQUAL(experiment.getMetaValue("mzml_id"), "S1")
+  TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getName(), "SUGARS_MP.M")
+  TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getSoftware().getName(), "SUGARS_CAL")
+  TEST_EQUAL(experiment.getMetaValue("injection_date"), "13/06/2019")
+  TEST_EQUAL(experiment.getMetaValue("injection_time"), "12:11:41 AM")
+  TEST_EQUAL(experiment.getMetaValue("detector"), "LCSystem")
+  TEST_EQUAL(experiment.getMetaValue("signal_quantity").toString(), "")
+  TEST_EQUAL(experiment.getMetaValue("signal_unit"), "nRIU")
+  TEST_EQUAL(experiment.getMetaValue("signal_info").toString(), "")
+  const vector<MSChromatogram> chromatograms = experiment.getChromatograms();
+  TEST_EQUAL(chromatograms.size(), 1);
+  TEST_EQUAL(chromatograms[0].size(), 10);
+  const MSChromatogram& c = chromatograms[0];
+  TEST_REAL_SIMILAR(c[0].getRT(), 0.0)
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 5.060000)
+  TEST_REAL_SIMILAR(c[2].getRT(), 0.014430)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), 5.450000)
+  TEST_REAL_SIMILAR(c[4].getRT(), 0.028860)
+  TEST_REAL_SIMILAR(c[4].getIntensity(), 5.580000)
+  TEST_REAL_SIMILAR(c[6].getRT(), 0.043290)
+  TEST_REAL_SIMILAR(c[6].getIntensity(), 5.380000)
+  TEST_REAL_SIMILAR(c[9].getRT(), 0.064935)
+  TEST_REAL_SIMILAR(c[9].getIntensity(), 4.930000)
+
+  MzMLFile mzml;
+  const String output_filepath = File::getTemporaryFile();
+  mzml.store(output_filepath, experiment);
+  MSExperiment read_exp;
+  mzml.load(output_filepath, read_exp);
+  TEST_EQUAL(read_exp.getChromatograms().size(), 1);
+  const MSChromatogram& c1 = experiment.getChromatograms()[0];
+  const MSChromatogram& c2 = read_exp.getChromatograms()[0];
+  TEST_EQUAL(c1.size(), c2.size())
+  TEST_REAL_SIMILAR(c1[0].getRT(), c2[0].getRT())
+  TEST_REAL_SIMILAR(c1[0].getIntensity(), c2[0].getIntensity())
+  TEST_REAL_SIMILAR(c1[2].getRT(), c2[2].getRT())
+  TEST_REAL_SIMILAR(c1[2].getIntensity(), c2[2].getIntensity())
+  TEST_REAL_SIMILAR(c1[4].getRT(), c2[4].getRT())
+  TEST_REAL_SIMILAR(c1[4].getIntensity(), c2[4].getIntensity())
+  TEST_REAL_SIMILAR(c1[6].getRT(), c2[6].getRT())
+  TEST_REAL_SIMILAR(c1[6].getIntensity(), c2[6].getIntensity())
+  TEST_REAL_SIMILAR(c1[9].getRT(), c2[9].getRT())
+  TEST_REAL_SIMILAR(c1[9].getIntensity(), c2[9].getIntensity())
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Additions
- handle new `Chromatogram Data:` raw data header (tests included)
- handle possible string `n.a.` in the `Step` column
- `line` is now a dynamically allocated string instead of a fixed-size array
- using `regex_match` instead of `regex_search`
- do not include character `\r` in sub-match

Note: the first commit is part of another PR: https://github.com/OpenMS/OpenMS/pull/4191 I branched out of that otherwise I could not compile and test this PR's code locally.