### PR TITLE
[FIX] OpenSWATH: Patch to prevent NaN from spectral angle score

### DIFF
--- a/src/openswathalgo/source/OPENSWATHALGO/ALGO/MRMScoring.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/ALGO/MRMScoring.cpp
@@ -593,6 +593,11 @@ namespace OpenSwath
 
     spectral_angle = Scoring::SpectralAngle(&experimental_intensity[0], &library_intensity[0], boost::numeric_cast<unsigned int>(transitions.size()));
 
+    if (boost::math::isnan(spectral_angle))
+    {
+      spectral_angle = 0.0;
+    }
+
     Scoring::normalize_sum(&experimental_intensity[0], boost::numeric_cast<unsigned int>(transitions.size()));
     Scoring::normalize_sum(&library_intensity[0], boost::numeric_cast<unsigned int>(transitions.size()));
 


### PR DESCRIPTION
In very rare cases (e.g. with ultra-short gradients), the spectral angle score of OpenSWATH results in NaN values. This patch ensures that always numerical values are reported.