### PR TITLE
Improve handling of precursor m/z when reading/writing mzML

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -369,7 +369,7 @@ protected:
                                       const Internal::MzMLValidator& validator);
 
       /// Writes user terms
-      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator) const;
+      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude = {}) const;
 
       /// Helper method that writes a software
       void writeSoftware_(std::ostream& os, const String& id, const Software& software, const Internal::MzMLValidator& validator);

--- a/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
+++ b/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
@@ -221,6 +221,12 @@ public:
     void setMaxDataPoolSize(Size size);
     //@}
 
+    /// [mzML only!] Whether to use the "selected ion m/z" value as the precursor m/z value (alternative: use the "isolation window target m/z" value)
+    bool getPrecursorMZSelectedIon() const;
+
+    /// [mzML only!] Set whether to use the "selected ion m/z" value as the precursor m/z value (alternative: use the "isolation window target m/z" value)
+    void setPrecursorMZSelectedIon(bool choice);
+
     /// do these options skip spectra or chromatograms due to RT or MSLevel filters?
     bool hasFilters();
 
@@ -249,7 +255,7 @@ private:
     MSNumpressCoder::NumpressConfig np_config_int_;
     MSNumpressCoder::NumpressConfig np_config_fda_;
     Size maximal_data_pool_size_;
-
+    bool precursor_mz_selected_ion_;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
+++ b/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
@@ -60,7 +60,7 @@ public:
     void setMetadataOnly(bool only);
     ///returns whether or not to load only meta data
     bool getMetadataOnly() const;
-    
+
     /// [mzXML only!] Whether to write a scan-index and meta data to indicate a Thermo FTMS/ITMS instrument (required to have parameter control in MQ)
     void setForceMQCompatability(bool forceMQ);
     /// [mzXML only!] Whether to write a scan-index and meta data to indicate a Thermo FTMS/ITMS instrument (required to have parameter control in MQ)
@@ -223,7 +223,7 @@ public:
 
     /// do these options skip spectra or chromatograms due to RT or MSLevel filters?
     bool hasFilters();
-    
+
 private:
     bool metadata_only_;
     bool force_maxquant_compatibility_; ///< for mzXML-writing only: set a fixed vendor (Thermo Scientific), mass analyzer (FTMS)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3852,7 +3852,9 @@ namespace OpenMS
       {
         os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000044\" name=\"dissociation method\" />\n";
       }
-      //as "precursor" has no own user param its userParam is stored here
+      // as "precursor" has no own user param its userParam is stored here;
+      // don't write out parameters that are used internally to distinguish
+      // between precursor m/z values from different sources:
       writeUserParam_(os, precursor, 7, "/mzML/run/spectrumList/spectrum/precursorList/precursor/activation/cvParam/@accession", validator, {"isolation window target m/z", "selected ion m/z"});
       os << "\t\t\t\t\t\t</activation>\n";
       os << "\t\t\t\t\t</precursor>\n";

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1649,7 +1649,6 @@ namespace OpenMS
 
         if (accession == "MS:1000744") //selected ion m/z
         {
-          // @TODO: what if "isolationWindow" was missing (which is allowed)?
           double this_mz = value.toDouble();
           Precursor& precursor = in_spectrum_list_ ?
             spec_.getPrecursors().back() : chromatogram_.getPrecursor();
@@ -3712,13 +3711,13 @@ namespace OpenMS
       //isolation window (optional)
       //--------------------------------------------------------------------------------------------
 
+      double mz = precursor.metaValueExists("isolation window target m/z") ?
+        double(precursor.getMetaValue("isolation window target m/z")) :
+        precursor.getMZ(); // precursor m/z may come from "selected ion"
       // Note that TPP parsers break when the isolation window is written out
       // in mzML files and the precursorMZ gets set to zero.
-      if (precursor.getMZ() > 0.0 && !options_.getForceTPPCompatability() )
+      if (mz > 0.0 && !options_.getForceTPPCompatability())
       {
-        double mz = precursor.metaValueExists("isolation window target m/z") ?
-          double(precursor.getMetaValue("isolation window target m/z")) :
-          precursor.getMZ(); // precursor m/z may come from "selected ion"
         os << "\t\t\t\t\t\t<isolationWindow>\n";
         os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000827\" name=\"isolation window target m/z\" value=\"" << mz << "\" unitAccession=\"MS:1000040\" unitName=\"m/z\" unitCvRef=\"MS\" />\n";
         if (precursor.getIsolationWindowLowerOffset() > 0.0)
@@ -3743,7 +3742,7 @@ namespace OpenMS
           precursor.getDriftTime() >= 0.0 ||
           precursor.getPossibleChargeStates().size() > 0)
       {
-        double mz = precursor.metaValueExists("selected ion m/z") ?
+        mz = precursor.metaValueExists("selected ion m/z") ?
           double(precursor.getMetaValue("selected ion m/z")) :
           precursor.getMZ(); // precursor m/z may come from "isolation window"
         os << "\t\t\t\t\t\t<selectedIonList count=\"1\">\n";

--- a/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
+++ b/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
@@ -107,12 +107,12 @@ namespace OpenMS
   {
     return metadata_only_;
   }
-  
+
   void PeakFileOptions::setForceMQCompatability(bool forceMQ)
   {
     force_maxquant_compatibility_ = forceMQ;
   }
-  
+
   bool PeakFileOptions::getForceMQCompatability() const
   {
     return force_maxquant_compatibility_;
@@ -122,7 +122,7 @@ namespace OpenMS
   {
     force_tpp_compatibility_ = forceTPP;
   }
-  
+
   bool PeakFileOptions::getForceTPPCompatability() const
   {
     return force_tpp_compatibility_;
@@ -225,7 +225,7 @@ namespace OpenMS
   {
     return zlib_compression_;
   }
-  
+
   bool PeakFileOptions::getAlwaysAppendData() const
   {
     return always_append_data_;

--- a/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
+++ b/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
@@ -62,7 +62,8 @@ namespace OpenMS
     np_config_mz_(),
     np_config_int_(),
     np_config_fda_(),
-    maximal_data_pool_size_(100)
+    maximal_data_pool_size_(100),
+    precursor_mz_selected_ion_(true)
   {
   }
 
@@ -90,7 +91,8 @@ namespace OpenMS
     np_config_mz_(options.np_config_mz_),
     np_config_int_(options.np_config_int_),
     np_config_fda_(options.np_config_fda_),
-    maximal_data_pool_size_(options.maximal_data_pool_size_)
+    maximal_data_pool_size_(options.maximal_data_pool_size_),
+    precursor_mz_selected_ion_(options.precursor_mz_selected_ion_)
   {
   }
 
@@ -348,6 +350,16 @@ namespace OpenMS
   void PeakFileOptions::setMaxDataPoolSize(Size size)
   {
     maximal_data_pool_size_ = size;
+  }
+
+  bool PeakFileOptions::getPrecursorMZSelectedIon() const
+  {
+    return precursor_mz_selected_ion_;
+  }
+
+  void PeakFileOptions::setPrecursorMZSelectedIon(bool choice)
+  {
+    precursor_mz_selected_ion_ = choice;
   }
 
   bool PeakFileOptions::hasFilters()

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -827,8 +827,10 @@ namespace OpenMS
       for (vector<Precursor>::const_iterator it = pcs.begin(); it != pcs.end(); ++it)
       {
         // determine start and stop of isolation window
-        double isolation_window_lower_mz = it->getMZ() - it->getIsolationWindowLowerOffset();
-        double isolation_window_upper_mz = it->getMZ() + it->getIsolationWindowUpperOffset();
+        double center_mz = it->metaValueExists("isolation window target m/z") ?
+          double(it->getMetaValue("isolation window target m/z")) : it->getMZ();
+        double isolation_window_lower_mz = center_mz - it->getIsolationWindowLowerOffset();
+        double isolation_window_upper_mz = center_mz + it->getIsolationWindowUpperOffset();
 
         // determine maximum peak intensity in isolation window
         SpectrumType::const_iterator vbegin = spectrum.MZBegin(isolation_window_lower_mz);

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -990,27 +990,28 @@ START_SECTION((template <typename MapType> void store(const String& filename, co
   {
     //load map
     PeakMap exp_original;
-    file.load(OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML"),exp_original);
+    file.load(OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML"), exp_original);
     //store map
     std::string tmp_filename;
     NEW_TMP_FILE(tmp_filename);
-    file.store(tmp_filename,exp_original);
+    file.store(tmp_filename, exp_original);
+    file.store(OPENMS_GET_TEST_DATA_PATH("MzMLFile_1_test.tmp"), exp_original);
     //load written map
     PeakMap exp;
-    file.load(tmp_filename,exp);
+    file.load(tmp_filename, exp);
     //test if everything worked
-    TEST_EQUAL(exp==exp_original,true)
+    TEST_EQUAL(exp == exp_original, true)
     //NOTE: If it does not work, use this code to find out where the difference is
-    TEST_EQUAL(exp.size()==exp_original.size(),true)
-    TEST_EQUAL(exp.ExperimentalSettings::operator==(exp_original),true)
-    TEST_EQUAL(exp[0].SpectrumSettings::operator==(exp_original[0]),true)
-    TEST_EQUAL(exp[0]==exp_original[0],true)
-    TEST_EQUAL(exp[1].SpectrumSettings::operator==(exp_original[1]),true)
-    TEST_EQUAL(exp[1]==exp_original[1],true)
-    TEST_EQUAL(exp[2].SpectrumSettings::operator==(exp_original[2]),true)
-    TEST_EQUAL(exp[2]==exp_original[2],true)
-    TEST_EQUAL(exp[3].SpectrumSettings::operator==(exp_original[3]),true)
-    TEST_EQUAL(exp[3]==exp_original[3],true)
+    TEST_EQUAL(exp.size() == exp_original.size(), true)
+    TEST_EQUAL(exp.ExperimentalSettings::operator==(exp_original), true)
+    TEST_EQUAL(exp[0].SpectrumSettings::operator==(exp_original[0]), true)
+    TEST_EQUAL(exp[0] == exp_original[0], true)
+    TEST_EQUAL(exp[1].SpectrumSettings::operator==(exp_original[1]), true)
+    TEST_EQUAL(exp[1] == exp_original[1], true)
+    TEST_EQUAL(exp[2].SpectrumSettings::operator==(exp_original[2]), true)
+    TEST_EQUAL(exp[2] == exp_original[2], true)
+    TEST_EQUAL(exp[3].SpectrumSettings::operator==(exp_original[3]), true)
+    TEST_EQUAL(exp[3] == exp_original[3], true)
     TEST_EQUAL(exp.getChromatograms().size(), exp_original.getChromatograms().size());
     TEST_EQUAL(exp.getChromatograms() == exp_original.getChromatograms(), true);
   }
@@ -1087,9 +1088,9 @@ START_SECTION((void storeBuffer(std::string & output, const PeakMap& map) const)
     // store map in our output buffer
     std::string out;
     file.storeBuffer(out, exp_original);
-    TEST_EQUAL(out.size(), 36584)
+    TEST_EQUAL(out.size(), 36582)
     TEST_EQUAL(out.substr(0, 100), "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<indexedmzML xmlns=\"http://psi.hupo.org/ms/mzml\" xmlns:x")
-    TEST_EQUAL(out.substr(36584 -99, 36584-1), "</indexList>\n<indexListOffset>36136</indexListOffset>\n<fileChecksum>0</fileChecksum>\n</indexedmzML>")
+    TEST_EQUAL(out.substr(36582 - 99, 36582 - 1), "</indexList>\n<indexListOffset>36134</indexListOffset>\n<fileChecksum>0</fileChecksum>\n</indexedmzML>")
 
     TEST_EQUAL(String(out).hasSubstring("<spectrumList count=\"4\" defaultDataProcessingRef=\"dp_sp_0\">"), true)
     TEST_EQUAL(String(out).hasSubstring("<chromatogramList count=\"2\" defaultDataProcessingRef=\"dp_sp_0\">"), true)

--- a/src/tests/topp/FileConverter_8_output.mzData
+++ b/src/tests/topp/FileConverter_8_output.mzData
@@ -127,6 +127,7 @@
 							<userParam name="source_file_name" value="pr.dta"/>
 							<userParam name="source_file_path" value="file:///F:/data/Exp03"/>
 							<userParam name="iwname" value="isolationwindow1"/>
+							<userParam name="isolation window target m/z" value="5.55"/>
 							<userParam name="siname" value="selectedion1"/>
 							<userParam name="buffer gas" value="Krypton"/>
 							<userParam name="collision gas" value="Argon"/>

--- a/src/tests/topp/FileMerger_10_output.mzML
+++ b/src/tests/topp/FileMerger_10_output.mzML
@@ -142,9 +142,6 @@
 				</scanList>
 				<precursorList count="1">
 					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
 						<selectedIonList count="1">
 							<selectedIon>
 								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
@@ -213,9 +210,6 @@
 				</scanList>
 				<precursorList count="1">
 					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
 						<selectedIonList count="1">
 							<selectedIon>
 								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
@@ -263,10 +257,10 @@
 </mzML>
 <indexList count="1">
 	<index name="spectrum">
-		<offset idRef="spectrum=0">8036</offset>
-		<offset idRef="spectrum=1">12007</offset>
-		<offset idRef="spectrum=2">12788</offset>
-		<offset idRef="spectrum=3">16838</offset>
+		<offset idRef="spectrum=0">8046</offset>
+		<offset idRef="spectrum=1">11847</offset>
+		<offset idRef="spectrum=2">12628</offset>
+		<offset idRef="spectrum=3">16509</offset>
 	</index>
 </indexList>
 <indexListOffset>17756</indexListOffset>

--- a/src/tests/topp/FileMerger_6_output.mzML
+++ b/src/tests/topp/FileMerger_6_output.mzML
@@ -199,9 +199,6 @@
 				</scanList>
 				<precursorList count="1">
 					<precursor>
-						<isolationWindow>
-							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-						</isolationWindow>
 						<selectedIonList count="1">
 							<selectedIon>
 								<cvParam cvRef="MS" accession="MS:1000744" name="selected ion m/z" value="445.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
@@ -248,11 +245,11 @@
 </mzML>
 <indexList count="1">
 	<index name="spectrum">
-		<offset idRef="spectrum=0">8817</offset>
-		<offset idRef="spectrum=1">11987</offset>
-		<offset idRef="spectrum=2">15958</offset>
+		<offset idRef="spectrum=0">8815</offset>
+		<offset idRef="spectrum=1">12024</offset>
+		<offset idRef="spectrum=2">15825</offset>
 	</index>
 </indexList>
-<indexListOffset>16797</indexListOffset>
+<indexListOffset>16664</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>


### PR DESCRIPTION
This addresses issue #4168 using the approach mentioned here: https://github.com/OpenMS/OpenMS/issues/4168#issuecomment-508520131

What remains is checking for the meta value "isolation window target m/z" in the isolation window visualisation code for TOPPView. Can anyone point me to where this should be changed?