### PR TITLE
[FIX] Temporarily opt-out from dark mode feature (MacOS)

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS-resources/TOPPAS.plist.in
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS-resources/TOPPAS.plist.in
@@ -52,5 +52,7 @@
 	</dict>  
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSRequiresAquaSystemAppearance</key>
+    <string>true</string>  
 </dict>
 </plist>

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView-resources/TOPPView.plist.in
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView-resources/TOPPView.plist.in
@@ -148,5 +148,7 @@
 	</dict>  
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSRequiresAquaSystemAppearance</key>
+    <string>true</string>  
 </dict>
 </plist>


### PR DESCRIPTION
Apps TOPPView and TOPPAS will be started in "aqua/light" mode instead of dark mode independent of system settings (MacOS).

I think if we want to support dark more work has to go into optimization - see #3785