### PR TITLE
Fixes bugs encountered in a full TMT pipeline:

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -983,6 +983,7 @@ public:
     static MzTab exportConsensusMapToMzTab(
       const ConsensusMap & consensus_map,
       const String & filename,
+      const bool first_run_inference_only,
       const bool export_unidentified_features,
       const bool export_unassigned_ids,
       const bool export_subfeatures,

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2838,9 +2838,10 @@ namespace OpenMS
 
   void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
   {
-  if (!FileHandler::hasValidExtension(filename, FileTypes::MZTAB))
+  if (!(FileHandler::hasValidExtension(filename, FileTypes::MZTAB) || FileHandler::hasValidExtension(filename, FileTypes::TSV)))
   {
-    throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "invalid file extension, expected '" + FileTypes::typeToName(FileTypes::MZTAB) + "'");
+    throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "invalid file extension, expected '"
+    + FileTypes::typeToName(FileTypes::MZTAB) + "' or '" + FileTypes::typeToName(FileTypes::TSV) + "'");
   }
 
   StringList out;

--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -117,9 +117,9 @@ protected:
       setValidFormats_("in", ListUtils::create<String>("featureXML,consensusXML,idXML,mzid"));
       registerOutputFile_("out", "<file>", "", "Output file (mzTab)", true);
       setValidFormats_("out", ListUtils::create<String>("mzTab"));
-      registerFlag_("first_run_inference_only", "(idXML/mzid only): Does the first IdentificationRun in the file "
-                                                "only represent inference results? Read peptide information only "
-                                                "from second to last runs.");
+      registerFlag_("first_run_inference_only", "Does the first IdentificationRun in the file "
+                                                "only represent (protein) inference results? If so, read peptide information only "
+                                                "from second to last runs.", true);
       registerStringList_("opt_columns", "<mods>", {"subfeatures"}, "Add optional columns which are not part of the mzTab standard.", false);
       setValidStrings_("opt_columns", {"subfeatures"});
     }
@@ -205,7 +205,7 @@ protected:
         ConsensusMap consensus_map;
         ConsensusXMLFile c;
         c.load(in, consensus_map);
-        mztab = MzTab::exportConsensusMapToMzTab(consensus_map, in, true, true, export_subfeatures);
+        mztab = MzTab::exportConsensusMapToMzTab(consensus_map, in, getFlag_("first_run_inference_only"), true, true, export_subfeatures);
       }
 
       MzTabFile().store(out, mztab);

--- a/src/topp/ProteinQuantifier.cpp
+++ b/src/topp/ProteinQuantifier.cpp
@@ -370,7 +370,7 @@ protected:
     setValidFormats_("peptide_out", ListUtils::create<String>("csv"));
 
     registerOutputFile_("mztab", "<file>", "", "Output file (mzTab)", false);
-    setValidFormats_("mztab", ListUtils::create<String>("tsv"));
+    setValidFormats_("mztab", ListUtils::create<String>("mzTab"));
 
     // algorithm parameters:
     addEmptyLine_();
@@ -843,7 +843,7 @@ protected:
         const bool report_unmapped(true);
         const bool report_unidentified_features(false);
         const bool report_subfeatures(false);
-        MzTab m = MzTab::exportConsensusMapToMzTab(consensus, in, report_unidentified_features, report_unmapped, report_subfeatures);
+        MzTab m = MzTab::exportConsensusMapToMzTab(consensus, in, true, report_unidentified_features, report_unmapped, report_subfeatures);
         MzTabFile().store(mztab, m);
       }
     }

--- a/src/utils/ProteomicsLFQ.cpp
+++ b/src/utils/ProteomicsLFQ.cpp
@@ -1540,7 +1540,8 @@ protected:
 
     MzTab m = MzTab::exportConsensusMapToMzTab(
       consensus, 
-      String("null"),   
+      String("null"),
+      true,
       report_unidentified_features, 
       report_unmapped,
       "Export from ProteomicsLFQ workflow in OpenMS.");


### PR DESCRIPTION
- When consensusXML is merged rowwise instead of colwise, files in the
ID structures might not exist in the quant structures anymore. Throw
better error.
- Allow first_run_inference_only also for consensusID and make it an
advanced flag for the manual export in MzTabExporter
- Make mzTab the default file suffix in ProteinQuantifier mzTab output.
Nonetheless allow tsv when storing mzTab files.

Signed-off-by: Julianus Pfeuffer <jpfeuffer@fu-berlin.de>