### PR TITLE
Q: Why are we sorting all spectra in TOPPView?

### DIFF
--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -264,6 +264,8 @@ namespace OpenMS
 
   void MSSpectrum::sortByPosition()
   {
+    if (std::is_sorted(ContainerType::begin(), ContainerType::end(), PeakType::PositionLess())) return;
+
     if (float_data_arrays_.empty() && string_data_arrays_.empty() && integer_data_arrays_.empty())
     {
       std::stable_sort(ContainerType::begin(), ContainerType::end(), PeakType::PositionLess());
@@ -292,6 +294,9 @@ namespace OpenMS
 
   void MSSpectrum::sortByIntensity(bool reverse)
   {
+    if (reverse && std::is_sorted(ContainerType::begin(), ContainerType::end(), reverseComparator(PeakType::IntensityLess()))) return;
+    else if (!reverse && std::is_sorted(ContainerType::begin(), ContainerType::end(), PeakType::IntensityLess())) return;
+
     if (float_data_arrays_.empty() && string_data_arrays_.empty() && integer_data_arrays_.empty())
     {
       if (reverse)

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -264,7 +264,7 @@ namespace OpenMS
 
   void MSSpectrum::sortByPosition()
   {
-    if (std::is_sorted(ContainerType::begin(), ContainerType::end(), PeakType::PositionLess())) return;
+    if (isSorted()) return;
 
     if (float_data_arrays_.empty() && string_data_arrays_.empty() && integer_data_arrays_.empty())
     {
@@ -340,13 +340,7 @@ namespace OpenMS
 
   bool MSSpectrum::isSorted() const
   {
-    if (this->size() < 2) return true;
-
-    for (Size i = 1; i < this->size(); ++i)
-    {
-      if (this->operator[](i - 1).getMZ() > this->operator[](i).getMZ()) return false;
-    }
-    return true;
+    return std::is_sorted(ContainerType::begin(), ContainerType::end(), PeakType::PositionLess());
   }
 
   bool MSSpectrum::operator==(const MSSpectrum &rhs) const

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1199,6 +1199,10 @@ namespace OpenMS
     }
 
     // sort spectra in ascending order of position (ensure that we sort all spectra as well as the currently
+    for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
+    {
+      (*getCurrentLayer_().getPeakDataMuteable())[i].sortByPosition();
+    }
     getCurrentLayer_().sortCurrentSpectrumByPosition();
 
     getCurrentLayer_().annotations_1d.resize(getCurrentLayer_().getPeakData()->size());

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1199,10 +1199,6 @@ namespace OpenMS
     }
 
     // sort spectra in ascending order of position (ensure that we sort all spectra as well as the currently
-    for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
-    {
-      (*getCurrentLayer_().getPeakDataMuteable())[i].sortByPosition();
-    }
     getCurrentLayer_().sortCurrentSpectrumByPosition();
 
     getCurrentLayer_().annotations_1d.resize(getCurrentLayer_().getPeakData()->size());

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1199,6 +1199,7 @@ namespace OpenMS
     }
 
     // sort spectra in ascending order of position (ensure that we sort all spectra as well as the currently
+    // TODO: check why this is need since we load data already sorted! 
     for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
     {
       (*getCurrentLayer_().getPeakDataMuteable())[i].sortByPosition();


### PR DESCRIPTION
I noticed a significant delay with my data when loading them in TOPPView and then opening the 1D view, I found that we are sorting all spectra when adding a new layer. This seems like redundant work and adds a noticeable delay. I wonder

- can we sort the spectra while reading them from mzML (using parallel OpenMP here)?
- can we sort them before display, so only sort those we need (instead of all)?
- can we sort them only once instead of each time they are used for a new layer (maybe keep a flag)?

PS: do not merge this