### PR TITLE
[FIX] only write protein ids once in assay generation. remove decoys

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -350,7 +350,12 @@ namespace OpenMS
     OPENMS_LOG_INFO << "Creating assay library..." << endl;
     PeptideRefRTMap ref_rt_map;
     createAssayLibrary_(peptide_map_, ref_rt_map);
-    // TraMLFile().store("debug.traml", library_);
+
+    if (debug_level_ >= 666)
+    {
+      cout << "Writing debug.traml file." << endl; 
+      TraMLFile().store("debug.traml", library_);
+    }
 
     //-------------------------------------------------------------
     // run feature detection
@@ -627,6 +632,7 @@ namespace OpenMS
       {
         current_accessions.insert("not_available");
       }
+
       peptide.protein_refs = vector<String>(current_accessions.begin(),
                                             current_accessions.end());
 
@@ -753,14 +759,13 @@ namespace OpenMS
           }
         }
       }
-
-      // add proteins to library:
-      for (String const &acc : protein_accessions)
-      {
-        TargetedExperiment::Protein protein;
-        protein.id = acc;
-        library_.addProtein(protein);
-      }
+    }
+    // add proteins to library:
+    for (String const &acc : protein_accessions)
+    {
+      TargetedExperiment::Protein protein;
+      protein.id = acc;
+      library_.addProtein(protein);
     }
   }
 
@@ -1147,6 +1152,7 @@ namespace OpenMS
     if (peptide.getHits().empty()) return;
     peptide.sort();
     PeptideHit& hit = peptide.getHits()[0];
+    if (hit.metaValueExists("target_decoy") && hit.getMetaValue("target_decoy") == "decoy") { return; }
     peptide.getHits().resize(1);
     Int charge = hit.getCharge();
     double rt = peptide.getRT();

--- a/src/utils/ProteomicsLFQ.cpp
+++ b/src/utils/ProteomicsLFQ.cpp
@@ -723,6 +723,17 @@ protected:
       const String& id_file_abs_path = File::absolutePath(mzfile2idfile.at(mz_file_abs_path));
       IdXMLFile().load(id_file_abs_path, protein_ids, peptide_ids);
 
+      if (protein_ids.size() != 1)
+      {
+        OPENMS_LOG_FATAL_ERROR << "Exactly one protein identification run must be annotated in " << id_file_abs_path << endl;
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
+
+      IDFilter::removeDecoyHits(peptide_ids);
+      IDFilter::removeDecoyHits(protein_ids);
+      IDFilter::removeEmptyIdentifications(peptide_ids);
+      IDFilter::removeUnreferencedProteins(protein_ids, peptide_ids);
+
       // add to the (global) set of fixed and variable modifications
       for (auto & p : protein_ids)
       {
@@ -742,12 +753,6 @@ protected:
         {
           ph.clearMetaInfo();
         }
-      }
-
-      if (protein_ids.size() != 1)
-      {
-        OPENMS_LOG_FATAL_ERROR << "Exactly one protein identification run must be annotated in " << id_file_abs_path << endl;
-        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
       }
 
       // annotate experimental design


### PR DESCRIPTION
from targeted extraction