### PR TITLE
Fix broken PDF creation

### DIFF
--- a/doc/OpenMS_tutorial/refman_overwrite.tex.in
+++ b/doc/OpenMS_tutorial/refman_overwrite.tex.in
@@ -1,4 +1,5 @@
 \documentclass[a4paper]{article}
+\usepackage{ifthen}
 \usepackage{geometry}
 \geometry{
   includeheadfoot,

--- a/doc/TOPP_tutorial/TOPP_scripting.doxygen
+++ b/doc/TOPP_tutorial/TOPP_scripting.doxygen
@@ -70,9 +70,9 @@
         <TABLE border=1>
 
         <TR>
-            <TH colspan="2">
+            <TH>
                 <b><br>Contaminants</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
             <TD>
@@ -110,9 +110,9 @@
         </TR>
 
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>FragmentMassError</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
              <TD>
@@ -144,9 +144,9 @@
              </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>MissedCleavages</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>
@@ -178,9 +178,9 @@
               </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>MS2IdentificationRate</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>
@@ -211,9 +211,9 @@
               </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>MzCalibration</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>
@@ -246,9 +246,9 @@
               </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>RTAlignment</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>
@@ -278,9 +278,9 @@
               </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>TIC</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>
@@ -308,9 +308,9 @@
               </TD>
         </TR>
         <TR>
-            <TH colspan="2">
+            <TH>
                 <br><b>TopNoverRT</b>
-            </TH>
+            </TH><TH></TH>
         </TR>
         <TR>
               <TD>

--- a/doc/TOPP_tutorial/TOPP_scripting.doxygen
+++ b/doc/TOPP_tutorial/TOPP_scripting.doxygen
@@ -72,7 +72,7 @@
         <TR>
             <TH colspan="2">
                 <b><br>Contaminants</b>
-                </TH>
+            </TH>
         </TR>
         <TR>
             <TD>
@@ -334,18 +334,20 @@
                    <b> Changes in files:</b> <br>
                    Metavalues: <br>
                    <ul>
-                   <li>'ScanEventNumber' set to the calculated value</li>
-                   <li>'identified' set to '+' or '-'</li>
+                    <li>'ScanEventNumber' set to the calculated value</li>
+                    <li>'identified' set to '+' or '-'</li>
+                   </ul>
                    If provided:
-                   <li>'FWHM' set to RT peak width for all assigned PIs</li>
-                   <li>'ion_injection_time'set to injection time from MS2 spectrum</li>
-                   <li>'activation_method'set to activation method from MS2 spectrum</li>
-                   <li>'total_ion_count'set to summed intensity from MS2 spectrum</li>
-                   <li>'base_peak_intensity'set to highest intensity from MS2 spectrum</li>
+                   <ul>
+                     <li>'FWHM' set to RT peak width for all assigned PIs</li>
+                     <li>'ion_injection_time'set to injection time from MS2 spectrum</li>
+                     <li>'activation_method'set to activation method from MS2 spectrum</li>
+                     <li>'total_ion_count'set to summed intensity from MS2 spectrum</li>
+                     <li>'base_peak_intensity'set to highest intensity from MS2 spectrum</li>
                    </ul>
                    Additionally: <br>
                    <ul>
-                   <li>Adds empty PeptideIdentifications</li>
+                    <li>Adds empty PeptideIdentifications</li>
                    </ul>
                    <b> Other Output:</b> <br>
                    No additional output.

--- a/doc/TOPP_tutorial/refman_overwrite.tex.in
+++ b/doc/TOPP_tutorial/refman_overwrite.tex.in
@@ -1,4 +1,5 @@
 \documentclass[a4paper]{article}
+\usepackage{ifthen}
 \usepackage{geometry}
 \geometry{
   includeheadfoot,


### PR DESCRIPTION
fixes a bug in doxygen 1.8.13 which
when using 'colspan' in HTML. 
E.g.
`<TH colspan="2"> ...` will yield

```
l.173 \end{longtabu}
                             
         ? 
         ! Emergency stop.
         \multispan ->\omit 
                            \@multispan 
         l.173 \end{longtabu}
```

Doxygen 1.8.16 does not seem to have this problem but break at another point:
```
! Undefined control sequence.
\DoxyCode ...}{0ex plus 0ex minus 0ex}\ifthenelse 
                                                  {\equal {#1}{0}} { {\lccod...
l.411 \begin{DoxyCodeInclude}{0}
```

fixed in 55e2ccc 