### PR TITLE
[FEATURE] some memory fixes for ProteomicsLFQ

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -363,18 +363,20 @@ namespace OpenMS
     OPENMS_LOG_INFO << "Extracting chromatograms..." << endl;
     ChromatogramExtractor extractor;
     // extractor.setLogType(ProgressLogger::NONE);
-    vector<OpenSwath::ChromatogramPtr> chrom_temp;
-    vector<ChromatogramExtractor::ExtractionCoordinates> coords;
-    extractor.prepare_coordinates(chrom_temp, coords, library_,
-                                  numeric_limits<double>::quiet_NaN(), false);
+    {
+      vector<OpenSwath::ChromatogramPtr> chrom_temp;
+      vector<ChromatogramExtractor::ExtractionCoordinates> coords;
+      extractor.prepare_coordinates(chrom_temp, coords, library_,
+          numeric_limits<double>::quiet_NaN(), false);
 
-    boost::shared_ptr<PeakMap> shared = boost::make_shared<PeakMap>(ms_data_);
-    OpenSwath::SpectrumAccessPtr spec_temp =
-      SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(shared);
-    extractor.extractChromatograms(spec_temp, chrom_temp, coords, mz_window_,
-                                   mz_window_ppm_, "tophat");
-    extractor.return_chromatogram(chrom_temp, coords, library_, (*shared)[0],
-                                  chrom_data_.getChromatograms(), false);
+      boost::shared_ptr<PeakMap> shared = boost::make_shared<PeakMap>(ms_data_);
+      OpenSwath::SpectrumAccessPtr spec_temp =
+        SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(shared);
+      extractor.extractChromatograms(spec_temp, chrom_temp, coords, mz_window_,
+          mz_window_ppm_, "tophat");
+      extractor.return_chromatogram(chrom_temp, coords, library_, (*shared)[0],
+          chrom_data_.getChromatograms(), false);
+    }
 
     OPENMS_LOG_DEBUG << "Extracted " << chrom_data_.getNrChromatograms()
               << " chromatogram(s)." << endl;

--- a/src/utils/ProteomicsLFQ.cpp
+++ b/src/utils/ProteomicsLFQ.cpp
@@ -884,7 +884,6 @@ protected:
       StringList feature_msfile_ref;
       feature_msfile_ref.push_back(mz_file);
       fm.setPrimaryMSRunPath(feature_msfile_ref);
-      feature_maps.push_back(fm);
 
       FeatureFinderIdentificationAlgorithm ffi;
       ffi.getMSData().swap(ms_centroided);
@@ -899,12 +898,21 @@ protected:
       ffi.setParameters(ffi_param);
       writeDebug_("Parameters passed to FeatureFinderIdentification algorithm", ffi_param, 3);
 
+      FeatureMap tmp = fm;
       ffi.run(peptide_ids, 
         protein_ids, 
         ext_peptide_ids, 
         ext_protein_ids, 
-        feature_maps.back(), 
+        tmp,
         seeds);
+
+      for (auto & f : tmp)
+      {
+        f.clearMetaInfo();
+        f.setSubordinates({});
+        f.setConvexHulls({});
+      }
+      feature_maps.push_back(tmp);
       
       if (debug_level_ > 666)
       {


### PR DESCRIPTION
this reduces the featureXML produced (debug output) by about 10x, from > 250 MB to less than 25 MB and allows me to run iPRG 2015 study with about 2GB of system memory (measurement currently ongoing). 