### PR TITLE
[FIX] Add map_index for Unassigned PeptideIdentifications for linking

### DIFF
--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -50,6 +50,8 @@ macro(find_boost)
 
   # help boost finding it's packages
   set(Boost_ADDITIONAL_VERSIONS
+    "1.71.1" "1.71.0" "1.71"
+    "1.70.1" "1.70.0" "1.70"
     "1.69.1" "1.69.0" "1.69"
     "1.68.1" "1.68.0" "1.68"
     "1.67.1" "1.67.0" "1.67"

--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -47,6 +47,14 @@ macro(find_boost)
   set(Boost_USE_STATIC_RUNTIME OFF)
   add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
   set(Boost_COMPILER "")
+  ## since boost 1.70 they provide CMake config files which only define imported targets and do not fill
+  ## Boost_LIBRARIES anymore
+  ## Try to avoid that until we changed our build system to use imported targets
+  set(Boost_NO_BOOST_CMAKE ON)
+  ## since boost 1.66 they add an architecture tag if you build with layout=versioned and since 1.69 even when you
+  ## build with layout=tagged (which we do in the contrib)
+  set(Boost_ARCHITECTURE "-x64")
+
 
   # help boost finding it's packages
   set(Boost_ADDITIONAL_VERSIONS

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.h
@@ -70,11 +70,56 @@ public:
     /// Register all derived classes in this method
     static void registerChildren();
 
+protected:
+
+    /// after grouping by the subclasses, postprocess unassigned IDs, protein IDs and sort results in a
+    /// consistent way
+    template<class MapType>
+    void postprocess_(const std::vector<MapType>& maps, ConsensusMap& out)
+    {
+      // add protein IDs and unassigned peptide IDs to the result map here,
+      // to keep the same order as the input maps (useful for output later):
+      auto& newIDs = out.getUnassignedPeptideIdentifications();
+      Size map_idx = 0;
+
+      for (typename std::vector<MapType>::const_iterator map_it = maps.begin();
+           map_it != maps.end(); ++map_it)
+      {
+        // add protein identifications to result map:
+        out.getProteinIdentifications().insert(
+            out.getProteinIdentifications().end(),
+            map_it->getProteinIdentifications().begin(),
+            map_it->getProteinIdentifications().end());
+
+        // assign the map_index to unassigned PepIDs as well.
+        // for the assigned ones, this has to be done in the subclass.
+        for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
+        {
+          auto newPepID = pepID;
+          // Note: during linking of _consensus_Maps we have the problem that old identifications
+          // should already have a map_index associated. Since we group the consensusFeatures only anyway
+          // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
+          // Subfeatures have to be transferred in postprocessing if required
+          // (see FeatureGroupingAlgorithm::transferSubelements as used in the TOPP tools, i.e. FeatureLinkerBase),
+          // which also takes care of a re-re-indexing if the old map_index of the IDs was saved.
+          newPepID.setMetaValue("map_index", map_idx);
+          newIDs.push_back(newPepID);
+        }
+        map_idx++;
+      }
+
+      // canonical ordering for checking the results:
+      out.sortByQuality();
+      out.sortByMaps();
+      out.sortBySize();
+    }
 private:
     ///Copy constructor is not implemented -> private
     FeatureGroupingAlgorithm(const FeatureGroupingAlgorithm &);
     ///Assignment operator is not implemented -> private
     FeatureGroupingAlgorithm & operator=(const FeatureGroupingAlgorithm &);
+
+
 
   };
 

--- a/src/openms/include/OpenMS/KERNEL/BaseFeature.h
+++ b/src/openms/include/OpenMS/KERNEL/BaseFeature.h
@@ -88,6 +88,9 @@ public:
     /// Copy constructor
     BaseFeature(const BaseFeature& feature);
 
+    /// Copy constructor with a new map_index
+    BaseFeature(const BaseFeature& rhs, UInt64 map_index);
+
     /// Constructor from raw data point
     explicit BaseFeature(const Peak2D& point);
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
@@ -81,7 +81,7 @@ namespace OpenMS
     // accumulate file descriptions from the input maps:
     // cout << "Updating file descriptions..." << endl;
     out.getColumnHeaders().clear();
-    // mapping: (map index, original id) -> new id
+    // mapping: (input file index / map index assigned by the linkers, old map index) -> new map index
     map<pair<Size, UInt64>, Size> mapid_table;
     for (Size i = 0; i < maps.size(); ++i)
     {
@@ -129,6 +129,27 @@ namespace OpenMS
         }
       }
       *cons_it = adjusted;
+
+      for (auto& id : cons_it->getPeptideIdentifications())
+      {
+        Size file_index = id.getMetaValue("map_index");
+        // TODO check for existence, since the actual saving of the old map_index
+        //  happens in the FeatureLinkerBase class, not here.
+        Size old_map_index = id.getMetaValue("old_map_index");
+        Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
+        id.setMetaValue("map_index", new_idx);
+        id.removeMetaValue("old_map_index");
+      }
+    }
+    for (auto& id : out.getUnassignedPeptideIdentifications())
+    {
+      Size file_index = id.getMetaValue("map_index");
+      // TODO check for existence, since the actual saving of the old map_index
+      //  happens in the FeatureLinkerBase class, not here.
+      Size old_map_index = id.getMetaValue("old_map_index");
+      Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
+      id.setMetaValue("map_index", new_idx);
+      id.removeMetaValue("old_map_index");
     }
   }
 
@@ -136,4 +157,4 @@ namespace OpenMS
   {
   }
 
-}
+} //namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
@@ -132,24 +132,40 @@ namespace OpenMS
 
       for (auto& id : cons_it->getPeptideIdentifications())
       {
-        Size file_index = id.getMetaValue("map_index");
-        // TODO check for existence, since the actual saving of the old map_index
-        //  happens in the FeatureLinkerBase class, not here.
-        Size old_map_index = id.getMetaValue("old_map_index");
-        Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
-        id.setMetaValue("map_index", new_idx);
-        id.removeMetaValue("old_map_index");
+        // if old_map_index is not present, there was no map_index in the beginning,
+        // therefore the newly assigned map_index cannot be "corrected"
+        // -> remove the MetaValue to be consistent.
+        if (id.metaValueExists("old_map_index"))
+        {
+          Size old_map_index = id.getMetaValue("old_map_index");
+          Size file_index = id.getMetaValue("map_index");
+          Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
+          id.setMetaValue("map_index", new_idx);
+          id.removeMetaValue("old_map_index");
+        }
+        else
+        {
+          id.removeMetaValue("map_index");
+        }
       }
     }
     for (auto& id : out.getUnassignedPeptideIdentifications())
     {
-      Size file_index = id.getMetaValue("map_index");
-      // TODO check for existence, since the actual saving of the old map_index
-      //  happens in the FeatureLinkerBase class, not here.
-      Size old_map_index = id.getMetaValue("old_map_index");
-      Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
-      id.setMetaValue("map_index", new_idx);
-      id.removeMetaValue("old_map_index");
+      // if old_map_index is not present, there was no map_index in the beginning,
+      // therefore the newly assigned map_index cannot be "corrected"
+      // -> remove the MetaValue to be consistent.
+      if (id.metaValueExists("old_map_index"))
+      {
+        Size old_map_index = id.getMetaValue("old_map_index");
+        Size file_index = id.getMetaValue("map_index");
+        Size new_idx = mapid_table[make_pair(file_index, old_map_index)];
+        id.setMetaValue("map_index", new_idx);
+        id.removeMetaValue("old_map_index");
+      }
+      else
+      {
+        id.removeMetaValue("map_index");
+      }
     }
   }
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
@@ -276,6 +276,9 @@ namespace OpenMS
 
     // add protein IDs and unassigned peptide IDs to the result map here,
     // to keep the same order as the input maps (useful for output later):
+    auto& newIDs = out.getUnassignedPeptideIdentifications();
+    Size map_idx = 0;
+    
     for (typename vector<MapType>::const_iterator map_it = input_maps.begin();
          map_it != input_maps.end(); ++map_it)
     {
@@ -285,11 +288,19 @@ namespace OpenMS
         map_it->getProteinIdentifications().begin(),
         map_it->getProteinIdentifications().end());
 
-      // add unassigned peptide identifications to result map:
-      out.getUnassignedPeptideIdentifications().insert(
-        out.getUnassignedPeptideIdentifications().end(),
-        map_it->getUnassignedPeptideIdentifications().begin(),
-        map_it->getUnassignedPeptideIdentifications().end());
+      for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
+      {
+        auto newPepID = pepID;
+        // Note: during linking of _consensus_Maps we have the problem that old identifications
+        // should already have a map_index associated. Since we group the consensusFeatures only anyway
+        // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
+        // Subfeatures have to be transferred in postprocessing if required
+        // (see FeatureGroupingAlgorithm::transferSubelements), which also takes care of a re-re-indexing
+        // if the old map_index of the IDs was saved.
+        newPepID.setMetaValue("map_index", map_idx);
+        newIDs.push_back(newPepID);
+      }
+      map_idx++;
     }
 
     // canonical ordering for checking the results:

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
@@ -274,44 +274,7 @@ namespace OpenMS
     }
     endProgress();
 
-    // add protein IDs and unassigned peptide IDs to the result map here,
-    // to keep the same order as the input maps (useful for output later):
-    auto& newIDs = out.getUnassignedPeptideIdentifications();
-    Size map_idx = 0;
-    
-    for (typename vector<MapType>::const_iterator map_it = input_maps.begin();
-         map_it != input_maps.end(); ++map_it)
-    {
-      // add protein identifications to result map:
-      out.getProteinIdentifications().insert(
-        out.getProteinIdentifications().end(),
-        map_it->getProteinIdentifications().begin(),
-        map_it->getProteinIdentifications().end());
-
-      for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
-      {
-        auto newPepID = pepID;
-        // Note: during linking of _consensus_Maps we have the problem that old identifications
-        // should already have a map_index associated. Since we group the consensusFeatures only anyway
-        // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
-        // Subfeatures have to be transferred in postprocessing if required
-        // (see FeatureGroupingAlgorithm::transferSubelements), which also takes care of a re-re-indexing
-        // if the old map_index of the IDs was saved.
-        newPepID.setMetaValue("map_index", map_idx);
-        newIDs.push_back(newPepID);
-      }
-      map_idx++;
-    }
-
-    // canonical ordering for checking the results:
-    startProgress(0, 3, String("sorting results"));
-    out.sortByQuality();
-    setProgress(1);
-    out.sortByMaps();
-    setProgress(2);
-    out.sortBySize();
-    endProgress();
-    return;
+    postprocess_(input_maps, out);
   }
 
   void FeatureGroupingAlgorithmKD::group(const std::vector<FeatureMap>& maps,

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.cpp
@@ -70,41 +70,7 @@ namespace OpenMS
 
     cluster_finder.run(maps, out);
 
-    StringList ms_run_locations;
-
-    // add protein IDs and unassigned peptide IDs to the result map here,
-    // to keep the same order as the input maps (useful for output later):
-    auto& newIDs = out.getUnassignedPeptideIdentifications();
-    Size map_idx = 0;
-
-    for (typename vector<MapType>::const_iterator map_it = maps.begin();
-         map_it != maps.end(); ++map_it)
-    {      
-      // add protein identifications to result map:
-      out.getProteinIdentifications().insert(
-        out.getProteinIdentifications().end(),
-        map_it->getProteinIdentifications().begin(),
-        map_it->getProteinIdentifications().end());
-
-      for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
-      {
-        auto newPepID = pepID;
-        // Note: during linking of _consensus_Maps we have the problem that old identifications
-        // should already have a map_index associated. Since we group the consensusFeatures only anyway
-        // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
-        // Subfeatures have to be transferred in postprocessing if required
-        // (see FeatureGroupingAlgorithm::transferSubelements), which also takes care of a re-re-indexing
-        // if the old map_index of the IDs was saved.
-        newPepID.setMetaValue("map_index", map_idx);
-        newIDs.push_back(newPepID);
-      }
-      map_idx++;
-    }
-
-    // canonical ordering for checking the results:
-    out.sortByQuality();
-    out.sortByMaps();
-    out.sortBySize();
+    postprocess_(maps, out);
   }
 
   void FeatureGroupingAlgorithmQT::group(const std::vector<FeatureMap>& maps,

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.cpp
@@ -74,6 +74,9 @@ namespace OpenMS
 
     // add protein IDs and unassigned peptide IDs to the result map here,
     // to keep the same order as the input maps (useful for output later):
+    auto& newIDs = out.getUnassignedPeptideIdentifications();
+    Size map_idx = 0;
+
     for (typename vector<MapType>::const_iterator map_it = maps.begin();
          map_it != maps.end(); ++map_it)
     {      
@@ -83,18 +86,25 @@ namespace OpenMS
         map_it->getProteinIdentifications().begin(),
         map_it->getProteinIdentifications().end());
 
-      // add unassigned peptide identifications to result map:
-      out.getUnassignedPeptideIdentifications().insert(
-        out.getUnassignedPeptideIdentifications().end(),
-        map_it->getUnassignedPeptideIdentifications().begin(),
-        map_it->getUnassignedPeptideIdentifications().end());
+      for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
+      {
+        auto newPepID = pepID;
+        // Note: during linking of _consensus_Maps we have the problem that old identifications
+        // should already have a map_index associated. Since we group the consensusFeatures only anyway
+        // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
+        // Subfeatures have to be transferred in postprocessing if required
+        // (see FeatureGroupingAlgorithm::transferSubelements), which also takes care of a re-re-indexing
+        // if the old map_index of the IDs was saved.
+        newPepID.setMetaValue("map_index", map_idx);
+        newIDs.push_back(newPepID);
+      }
+      map_idx++;
     }
 
     // canonical ordering for checking the results:
     out.sortByQuality();
     out.sortByMaps();
     out.sortBySize();
-    return;
   }
 
   void FeatureGroupingAlgorithmQT::group(const std::vector<FeatureMap>& maps,

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmUnlabeled.cpp
@@ -99,45 +99,7 @@ namespace OpenMS
     // copy back the input maps (they have been deleted while swapping)
     out.getColumnHeaders() = input[0].getColumnHeaders();
 
-    // add protein IDs and unassigned peptide IDs to the result map here,
-    // to keep the same order as the input maps (useful for output later)
-    auto& newIDs = out.getUnassignedPeptideIdentifications();
-    Size map_idx = 0;
-
-    for (std::vector<FeatureMap>::const_iterator map_it = maps.begin();
-         map_it != maps.end(); ++map_it)
-    {
-      // add protein identifications to result map
-      out.getProteinIdentifications().insert(
-        out.getProteinIdentifications().end(),
-        map_it->getProteinIdentifications().begin(),
-        map_it->getProteinIdentifications().end());
-
-      for (const PeptideIdentification& pepID : map_it->getUnassignedPeptideIdentifications())
-      {
-        auto newPepID = pepID;
-        // Note: during linking of _consensus_Maps we have the problem that old identifications
-        // should already have a map_index associated. Since we group the consensusFeatures only anyway
-        // (without keeping the subfeatures) the method for now is to "re"-index based on the input file/map index.
-        // Subfeatures have to be transferred in postprocessing if required
-        // (see FeatureGroupingAlgorithm::transferSubelements), which also takes care of a re-re-indexing
-        // if the old map_index of the IDs was saved.
-        newPepID.setMetaValue("map_index", map_idx);
-        newIDs.push_back(newPepID);
-      }
-      map_idx++;
-    }
-
-    // canonical ordering for checking the results, and the ids have no real meaning anyway
-#if 1 // the way this was done in DelaunayPairFinder and StablePairFinder
-    out.sortByMZ();
-#else
-    out.sortByQuality();
-    out.sortByMaps();
-    out.sortBySize();
-#endif
-
-    return;
+    postprocess_(maps, out);
   }
 
   void FeatureGroupingAlgorithmUnlabeled::addToGroup(int map_id, const FeatureMap& feature_map)

--- a/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
@@ -201,14 +201,7 @@ namespace OpenMS
           ConsensusFeature& f = result_map.back();
 
           f.insert(input_maps[0][fi0]);
-          f.getPeptideIdentifications().insert(f.getPeptideIdentifications().end(),
-                                               input_maps[0][fi0].getPeptideIdentifications().begin(),
-                                               input_maps[0][fi0].getPeptideIdentifications().end());
-
           f.insert(input_maps[1][fi1]);
-          f.getPeptideIdentifications().insert(f.getPeptideIdentifications().end(),
-                                               input_maps[1][fi1].getPeptideIdentifications().begin(),
-                                               input_maps[1][fi1].getPeptideIdentifications().end());
 
           f.computeConsensus();
           double quality = 1.0 - nn_distance_0[fi0].first;

--- a/src/openms/source/KERNEL/BaseFeature.cpp
+++ b/src/openms/source/KERNEL/BaseFeature.cpp
@@ -53,6 +53,16 @@ namespace OpenMS
   {
   }
 
+  BaseFeature::BaseFeature(const BaseFeature& rhs, UInt64 map_index) :
+      RichPeak2D(rhs), quality_(rhs.quality_), charge_(rhs.charge_), width_(rhs.width_),
+      peptides_(rhs.peptides_)
+  {
+    for (auto& pep : this->peptides_)
+    {
+      pep.setMetaValue("map_index", map_index);
+    }
+  }
+
   BaseFeature::BaseFeature(const RichPeak2D& point) :
     RichPeak2D(point), quality_(0.0), charge_(0), width_(0), peptides_()
   {

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -65,7 +65,7 @@ namespace OpenMS
   }
 
   ConsensusFeature::ConsensusFeature(UInt64 map_index, const BaseFeature& element) :
-    BaseFeature(element), handles_(), ratios_()
+    BaseFeature(element, map_index), handles_(), ratios_()
   {
     insert(FeatureHandle(map_index, element));
   }
@@ -88,6 +88,7 @@ namespace OpenMS
   void ConsensusFeature::insert(const ConsensusFeature& cf)
   {
     handles_.insert(cf.handles_.begin(), cf.handles_.end());
+    peptides_.insert(peptides_.end(), cf.getPeptideIdentifications().begin(), cf.getPeptideIdentifications().end());
   }
 
   void ConsensusFeature::insert(const FeatureHandle& handle)

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_1_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_1_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////Users/veit/Code/OpenMS-development/git-openms/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_7804704400743266335" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledKD" version="version_string" />
 		<processingAction name="Feature grouping" />
@@ -39,93 +39,96 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="3">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="0" charge="1">
-			<centroid rt="1004.22566666667" mz="1014.61" it="3.16178e+08"/>
+		<consensusElement id="e_15004869347769368353" quality="0.0" charge="1">
+			<centroid rt="1004.225666666666598" mz="1014.610000000000014" it="3.161777e08"/>
 			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927" mz="1014.61" it="3.71373e+08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.49" mz="1014.61" it="2.35017e+08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.26" mz="1014.61" it="3.42143e+08" charge="1"/>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="0" charge="1">
-			<centroid rt="1267.61666666667" mz="1725.81" it="3.19362e+08"/>
+		<consensusElement id="e_3332699010107892018" quality="0.0" charge="1">
+			<centroid rt="1267.616666666666561" mz="1725.810000000000173" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.54" mz="1725.81" it="2.45958e+08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.04" mz="1725.81" it="3.674e+08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.27" mz="1725.81" it="3.44727e+08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0" charge="1">
-			<centroid rt="1211.96333333333" mz="1399.69" it="2.24143e+08"/>
+		<consensusElement id="e_13440783915218733453" quality="0.0" charge="1">
+			<centroid rt="1211.963333333333367" mz="1399.689999999999827" it="2.241427e08"/>
 			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.52" mz="1399.69" it="2.3497e+08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.42" mz="1399.69" it="3.17631e+08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.95" mz="1399.69" it="1.19827e+08" charge="1"/>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0" charge="2">
-			<centroid rt="824.473333333333" mz="789.372" it="2.19646e+08"/>
+		<consensusElement id="e_15916652588957785155" quality="0.0" charge="2">
+			<centroid rt="824.473333333333358" mz="789.371999999999957" it="2.19646e08"/>
 			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.972" mz="789.372" it="2.23649e+08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.435" mz="789.372" it="2.36463e+08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013" mz="789.372" it="1.98826e+08" charge="2"/>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0" charge="1">
-			<centroid rt="1081.58" mz="1955.95" it="2.33178e+08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.0" charge="1">
+			<centroid rt="1081.580000000000155" mz="1955.950000000000046" it="2.331777e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.19" mz="1955.95" it="2.84147e+08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.74" mz="1955.95" it="1.78653e+08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.81" mz="1955.95" it="2.36733e+08" charge="1"/>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0" charge="1">
-			<centroid rt="822.757333333333" mz="1749.67" it="3.02481e+08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.0" charge="1">
+			<centroid rt="822.757333333333349" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
-				<element map="0" id="11259143081880763675" rt="806.443" mz="1749.67" it="3.57962e+08" charge="1"/>
-				<element map="1" id="8781789908765837138" rt="818.552" mz="1749.67" it="3.67003e+08" charge="1"/>
-				<element map="2" id="5572181956708182284" rt="843.277" mz="1749.67" it="1.82478e+08" charge="1"/>
+				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
+				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
+				<element map="2" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0" charge="1">
-			<centroid rt="838.689333333333" mz="1504.57" it="2.57013e+08"/>
+		<consensusElement id="e_474525871221756682" quality="0.0" charge="1">
+			<centroid rt="838.689333333333366" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797" mz="1504.57" it="2.60293e+08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.924" mz="1504.57" it="1.45679e+08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.347" mz="1504.57" it="3.65068e+08" charge="1"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0" charge="2">
-			<centroid rt="924.713" mz="941.449" it="2.06357e+08"/>
+		<consensusElement id="e_12999979801269632061" quality="0.0" charge="2">
+			<centroid rt="924.713000000000079" mz="941.448999999999955" it="2.063567e08"/>
 			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.64" mz="941.449" it="2.15944e+08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.712" mz="941.449" it="1.25569e+08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787" mz="941.449" it="2.77557e+08" charge="2"/>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0" charge="1">
-			<centroid rt="761.192" mz="1444.62" it="3.48902e+08"/>
+		<consensusElement id="e_17413765565443951891" quality="0.0" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.489015e08"/>
 			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768" mz="1444.62" it="3.03992e+08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.616" mz="1444.62" it="3.93811e+08" charge="1"/>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
@@ -133,25 +136,25 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0" charge="2">
-			<centroid rt="561.762" mz="733.275" it="2.08168e+08"/>
+		<consensusElement id="e_2927519776102075938" quality="0.0" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.639" mz="733.275" it="1.6889e+08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.885" mz="733.275" it="2.47446e+08" charge="2"/>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0" charge="1">
-			<centroid rt="921.7225" mz="1511.84" it="1.8723e+08"/>
+		<consensusElement id="e_16907355690727166316" quality="0.0" charge="1">
+			<centroid rt="921.722500000000082" mz="1511.839999999999918" it="1.872305e08"/>
 			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197" mz="1511.84" it="1.08185e+08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248" mz="1511.84" it="2.66276e+08" charge="1"/>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0" charge="1">
-			<centroid rt="1035.53" mz="1163.62" it="2.14078e+08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.0" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
 			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.54" mz="1163.62" it="1.34898e+08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.52" mz="1163.62" it="2.93257e+08" charge="1"/>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
@@ -159,84 +162,84 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_2927519776102075938" quality="0" charge="1">
-			<centroid rt="1454.51" mz="2493.24" it="2.11806e+08"/>
+		<consensusElement id="e_12524258085768770586" quality="0.0" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
 			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.23" mz="2493.24" it="1.55069e+08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.79" mz="2493.24" it="2.68544e+08" charge="1"/>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0" charge="1">
-			<centroid rt="1049.535" mz="1420.67" it="2.27286e+08"/>
+		<consensusElement id="e_1755235105885170967" quality="0.0" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.54" mz="1420.67" it="2.58532e+08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.53" mz="1420.67" it="1.96041e+08" charge="1"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0" charge="2">
-			<centroid rt="785.3975" mz="778.315" it="3.35197e+08"/>
+		<consensusElement id="e_14811341817612382122" quality="0.0" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
 			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.996" mz="778.315" it="2.97395e+08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.799" mz="778.315" it="3.72998e+08" charge="2"/>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0" charge="2">
-			<centroid rt="1300.965" mz="944.96" it="2.75438e+08"/>
+		<consensusElement id="e_2684106197423007927" quality="0.0" charge="2">
+			<centroid rt="1300.965000000000146" mz="944.960000000000036" it="2.754385e08"/>
 			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.92" mz="944.96" it="3.20176e+08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.01" mz="944.96" it="2.30701e+08" charge="2"/>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0" charge="2">
-			<centroid rt="1241.715" mz="954.949" it="2.3003e+08"/>
+		<consensusElement id="e_8119044117483804262" quality="0.0" charge="2">
+			<centroid rt="1241.715000000000146" mz="954.948999999999955" it="2.3003e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.41" mz="954.949" it="1.93777e+08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.02" mz="954.949" it="2.66283e+08" charge="2"/>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0" charge="1">
-			<centroid rt="854.844" mz="1752.61" it="1.68751e+08"/>
+		<consensusElement id="e_17314619952666245179" quality="0.0" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
 			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.342" mz="1752.61" it="1.54686e+08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346" mz="1752.61" it="1.82817e+08" charge="1"/>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0" charge="2">
-			<centroid rt="875.638" mz="653.354" it="2.67572e+08"/>
+		<consensusElement id="e_3023658190814908261" quality="0.0" charge="2">
+			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
-				<element map="1" id="9947115975316200578" rt="856.941" mz="653.354" it="1.52129e+08" charge="2"/>
-				<element map="2" id="1045454825286354924" rt="894.335" mz="653.354" it="3.83015e+08" charge="2"/>
+				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
+				<element map="2" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0" charge="1">
-			<centroid rt="1197.24" mz="1479.79" it="3.46508e+08"/>
+		<consensusElement id="e_7898004582401008768" quality="0.0" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
 			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.36" mz="1479.79" it="3.762e+08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.12" mz="1479.79" it="3.16815e+08" charge="1"/>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0" charge="1">
-			<centroid rt="1304.43" mz="1567.74" it="3.00518e+08"/>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
+			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
 			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.43" mz="1567.74" it="3.00518e+08" charge="1"/>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0" charge="1">
-			<centroid rt="1196.8" mz="1908.9" it="2.00984e+08"/>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.8" mz="1908.9" it="2.00984e+08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0" charge="1">
-			<centroid rt="979.852" mz="1283.7" it="3.13719e+08"/>
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
 			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.852" mz="1283.7" it="3.13719e+08" charge="1"/>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0" charge="1">
-			<centroid rt="786.15" mz="1555.63" it="1.86424e+08"/>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="1">
+			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
 			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.15" mz="1555.63" it="1.86424e+08" charge="1"/>
+				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
@@ -244,10 +247,10 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0" charge="1">
-			<centroid rt="638.468" mz="537.243" it="2.10227e+08"/>
+		<consensusElement id="e_7276556891837796968" quality="0.0" charge="1">
+			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
-				<element map="0" id="12975660629189576601" rt="638.468" mz="537.243" it="2.10227e+08" charge="1"/>
+				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_0">
@@ -255,22 +258,22 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0" charge="1">
-			<centroid rt="875.319" mz="1305.71" it="2.96944e+08"/>
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
+			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.319" mz="1305.71" it="2.96944e+08" charge="1"/>
+				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0" charge="2">
-			<centroid rt="836.541" mz="876.804" it="4.39745e+08"/>
+		<consensusElement id="e_11115414975438642789" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
 			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541" mz="876.804" it="4.39745e+08" charge="2"/>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0" charge="2">
-			<centroid rt="640.822" mz="537.243" it="3.46578e+08"/>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
 			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822" mz="537.243" it="3.46578e+08" charge="2"/>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
@@ -278,22 +281,22 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0" charge="3">
-			<centroid rt="1006.93" mz="642.352" it="2.64687e+08"/>
+		<consensusElement id="e_13424404046998308790" quality="0.0" charge="3">
+			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.93" mz="642.352" it="2.64687e+08" charge="3"/>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0" charge="1">
-			<centroid rt="542.407" mz="1465.55" it="2.43214e+08"/>
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
 			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407" mz="1465.55" it="2.43214e+08" charge="1"/>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0" charge="3">
-			<centroid rt="656.405" mz="537.243" it="1.32679e+08"/>
+		<consensusElement id="e_17092894204355333314" quality="0.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
 			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.405" mz="537.243" it="1.32679e+08" charge="3"/>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
@@ -301,40 +304,40 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0" charge="1">
-			<centroid rt="796.474" mz="1108.49" it="6.83877e+07"/>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
+			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
-				<element map="2" id="6004004326366812857" rt="796.474" mz="1108.49" it="6.83877e+07" charge="1"/>
+				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0" charge="2">
-			<centroid rt="1531.86" mz="1247.12" it="2.34128e+08"/>
+		<consensusElement id="e_10627069796380146481" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
 			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.86" mz="1247.12" it="2.34128e+08" charge="2"/>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0" charge="2">
-			<centroid rt="1114.9" mz="710.835" it="2.71023e+08"/>
+		<consensusElement id="e_10052793688680741109" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
 			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.9" mz="710.835" it="2.71023e+08" charge="2"/>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0" charge="1">
-			<centroid rt="1415.83" mz="1567.74" it="2.20417e+08"/>
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
 			<groupedElementList>
-				<element map="2" id="10053481325799554694" rt="1415.83" mz="1567.74" it="2.20417e+08" charge="1"/>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="0" charge="2">
-			<centroid rt="1011.47" mz="642.352" it="2.21253e+08"/>
+		<consensusElement id="e_14768204679546465715" quality="0.0" charge="2">
+			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
 			<groupedElementList>
-				<element map="2" id="15743766982953332227" rt="1011.47" mz="642.352" it="2.21253e+08" charge="2"/>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10052793688680741109" quality="0" charge="1">
-			<centroid rt="817.266" mz="922.481" it="2.63046e+08"/>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
+			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
 			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.266" mz="922.481" it="2.63046e+08" charge="1"/>
+				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_2_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_2_output.consensusXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:///C:/dev/openmsqt5/share/OpenMS/XSL/ConsensusXML.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
 <consensusXML version="1.7" id="cm_13440783915218733453" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledKD" version="version_string" />
@@ -69,68 +69,94 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_3" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_7">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="3"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_9">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="4"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_5" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_11">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="5"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
-		<map id="3" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="3" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="4" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="4" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="5" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="5" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_15916652588957785155" quality="0.0" charge="2">
-			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
+		<consensusElement id="e_15916652588957785155" quality="0.0" charge="1">
+			<centroid rt="838.689333333333252" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
-				<element map="3" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
-				<element map="5" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999865" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
+				<element map="3" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="4" id="510828531039388399" rt="821.923999999999865" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="5" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0.0" charge="3">
-			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.0" charge="1">
+			<centroid rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
-				<element map="4" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="0" id="13635893658662189107" rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
+				<element map="3" id="13635893658662189107" rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0.0" charge="2">
-			<centroid rt="1241.714999999999918" mz="954.948999999999955" it="2.3003e08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.0" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
-				<element map="4" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
-				<element map="5" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
+				<element map="3" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="4" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_474525871221756682" quality="0.0" charge="2">
+			<centroid rt="1300.964999999999918" mz="944.960000000000036" it="2.754385e08"/>
+			<groupedElementList>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.010000000000218" mz="944.960000000000036" it="2.30701e08" charge="2"/>
+				<element map="4" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="5" id="6916883853867664495" rt="1304.010000000000218" mz="944.960000000000036" it="2.30701e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12999979801269632061" quality="0.0" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999864" it="2.08168e08"/>
+			<groupedElementList>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999864" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999864" it="2.47446e08" charge="2"/>
+				<element map="3" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999864" it="1.6889e08" charge="2"/>
+				<element map="5" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999864" it="2.47446e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17413765565443951891" quality="0.0" charge="2">
 			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
 				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
@@ -139,178 +165,26 @@
 				<element map="5" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0.0" charge="1">
-			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.11806e08"/>
-			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
-				<element map="3" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
-				<element map="4" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.0" charge="1">
-			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
-			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
-				<element map="3" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
 		<consensusElement id="e_2927519776102075938" quality="0.0" charge="1">
-			<centroid rt="1081.579999999999927" mz="1955.950000000000046" it="2.33178e08"/>
+			<centroid rt="1267.616666666666561" mz="1725.809999999999945" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
-				<element map="3" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
-				<element map="4" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
-				<element map="5" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
+				<element map="3" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="4" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="5" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_16907355690727166316" quality="0.0" charge="1">
-			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
-			<groupedElementList>
-				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
-				<element map="5" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.0" charge="1">
-			<centroid rt="1004.225666666670008" mz="1014.610000000000014" it="3.16178e08"/>
-			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
-				<element map="3" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
-				<element map="4" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
-				<element map="5" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0.0" charge="1">
-			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.48902e08"/>
-			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
-				<element map="3" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
-				<element map="5" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_10">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0.0" charge="2">
-			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
-			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
-				<element map="4" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_8">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0.0" charge="1">
-			<centroid rt="1211.963333333329956" mz="1399.690000000000055" it="2.24143e08"/>
-			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
-				<element map="3" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
-				<element map="4" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
-				<element map="5" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0.0" charge="1">
-			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
-			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
-				<element map="3" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0.0" charge="1">
-			<centroid rt="1197.240000000000009" mz="1479.789999999999964" it="3.46508e08"/>
-			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
-				<element map="4" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
-				<element map="5" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0.0" charge="1">
-			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
-			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
-				<element map="5" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0.0" charge="2">
-			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.35197e08"/>
-			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
-				<element map="4" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
-				<element map="5" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0.0" charge="2">
-			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
-			<groupedElementList>
-				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
-				<element map="5" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
-			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
-			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
-				<element map="4" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0.0" charge="2">
-			<centroid rt="1300.964999999999918" mz="944.960000000000036" it="2.75438e08"/>
-			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
-				<element map="4" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
-				<element map="5" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0.0" charge="2">
-			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
-			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
-				<element map="5" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0.0" charge="1">
-			<centroid rt="921.722499999999968" mz="1511.839999999999918" it="1.8723e08"/>
-			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
-				<element map="3" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
-				<element map="5" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0.0" charge="1">
 			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
 				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 				<element map="5" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
-			<centroid rt="822.757333333333008" mz="1749.670000000000073" it="3.02481e08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.0" charge="1">
+			<centroid rt="822.757333333333236" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
 				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
 				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
@@ -320,139 +194,7 @@
 				<element map="5" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0.0" charge="3">
-			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
-			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
-				<element map="5" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_10">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0.0" charge="1">
-			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.68751e08"/>
-			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
-				<element map="4" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
-				<element map="5" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0.0" charge="2">
-			<centroid rt="824.473333333333017" mz="789.371999999999957" it="2.19646e08"/>
-			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
-				<element map="3" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
-				<element map="4" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
-				<element map="5" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
-			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
-			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
-				<element map="3" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_6">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0.0" charge="2">
-			<centroid rt="924.712999999999966" mz="941.448999999999955" it="2.06357e08"/>
-			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
-				<element map="3" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
-				<element map="4" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
-				<element map="5" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
-			<centroid rt="838.689333333333025" mz="1504.569999999999936" it="2.57013e08"/>
-			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
-				<element map="3" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
-				<element map="4" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
-				<element map="5" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="0.0" charge="2">
-			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
-			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
-				<element map="3" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10052793688680741109" quality="0.0" charge="1">
-			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
-			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
-				<element map="3" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
-			<centroid rt="1049.535000000000082" mz="1420.670000000000073" it="2.27286e08"/>
-			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
-				<element map="3" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
-				<element map="4" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_14768204679546465715" quality="0.0" charge="2">
-			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
-			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
-				<element map="5" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
-			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
-			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
-				<element map="3" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15885522598119108466" quality="0.0" charge="1">
-			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.14078e08"/>
-			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
-				<element map="3" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
-				<element map="4" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_8">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_3823858840059792698" quality="0.0" charge="1">
+		<consensusElement id="e_12524258085768770586" quality="0.0" charge="1">
 			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
 				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
@@ -466,18 +208,282 @@
 			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_6">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="3"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_1755235105885170967" quality="0.0" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
+			<groupedElementList>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
+				<element map="4" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="5" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14811341817612382122" quality="0.0" charge="2">
+			<centroid rt="1241.714999999999918" mz="954.948999999999955" it="2.3003e08"/>
+			<groupedElementList>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+				<element map="4" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="5" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_2684106197423007927" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
+			<groupedElementList>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
+				<element map="5" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_8119044117483804262" quality="0.0" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
+			<groupedElementList>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
+				<element map="3" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="4" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
+				</PeptideHit>
 				<UserParam type="int" name="map_index" value="1"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_8">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="4"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_17314619952666245179" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
+			<groupedElementList>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
+				<element map="5" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3023658190814908261" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08"/>
+			<groupedElementList>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08" charge="2"/>
+				<element map="3" id="15776542383322853081" rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_7898004582401008768" quality="0.0" charge="1">
+			<centroid rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08"/>
+			<groupedElementList>
+				<element map="2" id="17198512653051715988" rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08" charge="1"/>
+				<element map="5" id="17198512653051715988" rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
+			<groupedElementList>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
+				<element map="3" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="4" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
+			<groupedElementList>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
+				<element map="4" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="2">
+			<centroid rt="924.712999999999966" mz="941.448999999999955" it="2.063567e08"/>
+			<groupedElementList>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
+				<element map="3" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="4" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="5" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="3">
+			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
+			<groupedElementList>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="4" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_7276556891837796968" quality="0.0" charge="1">
+			<centroid rt="1211.963333333332912" mz="1399.689999999999827" it="2.241427e08"/>
+			<groupedElementList>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
+				<element map="3" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="4" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="5" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
+			<groupedElementList>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
+				<element map="4" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_8">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="4"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_11115414975438642789" quality="0.0" charge="2">
+			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
+			<groupedElementList>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
+				<element map="5" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
+			<groupedElementList>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999865" mz="778.315000000000055" it="3.72998e08" charge="2"/>
+				<element map="4" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="5" id="9588482092062192060" rt="781.798999999999865" mz="778.315000000000055" it="3.72998e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_13424404046998308790" quality="0.0" charge="1">
+			<centroid rt="1004.225666666666484" mz="1014.610000000000014" it="3.161777e08"/>
+			<groupedElementList>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.260000000000218" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
+				<element map="3" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="4" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="5" id="836885712912035377" rt="1043.260000000000218" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
+			<groupedElementList>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+				<element map="3" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17092894204355333314" quality="0.0" charge="1">
+			<centroid rt="1081.579999999999927" mz="1955.950000000000046" it="2.331777e08"/>
+			<groupedElementList>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+				<element map="3" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="4" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="5" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
+			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
+			<groupedElementList>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
+				<element map="5" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_10627069796380146481" quality="0.0" charge="2">
+			<centroid rt="824.473333333333244" mz="789.371999999999844" it="2.19646e08"/>
+			<groupedElementList>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999844" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999832" mz="789.371999999999844" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999844" it="1.98826e08" charge="2"/>
+				<element map="3" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999844" it="2.23649e08" charge="2"/>
+				<element map="4" id="9891393289043950297" rt="820.434999999999832" mz="789.371999999999844" it="2.36463e08" charge="2"/>
+				<element map="5" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999844" it="1.98826e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_10052793688680741109" quality="0.0" charge="1">
+			<centroid rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08"/>
+			<groupedElementList>
+				<element map="0" id="9201749952666825017" rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
+				<element map="3" id="9201749952666825017" rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_6">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="3"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
+			<groupedElementList>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
+				<element map="3" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14768204679546465715" quality="0.0" charge="1">
+			<centroid rt="921.722499999999968" mz="1511.839999999999918" it="1.872305e08"/>
+			<groupedElementList>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
+				<element map="3" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="5" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
+			<groupedElementList>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
+				<element map="5" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_10">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="5"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_15885522598119108466" quality="0.0" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
+			<groupedElementList>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
+				<element map="4" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="5" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3823858840059792698" quality="0.0" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999664" it="3.489015e08"/>
+			<groupedElementList>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999664" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999664" it="3.93811e08" charge="1"/>
+				<element map="3" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999664" it="3.03992e08" charge="1"/>
+				<element map="5" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999664" it="3.93811e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_10">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="5"/>
 			</PeptideIdentification>
 		</consensusElement>
 		<consensusElement id="e_893904610286969204" quality="0.0" charge="1">
-			<centroid rt="1267.616666666669971" mz="1725.809999999999945" it="3.19362e08"/>
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
-				<element map="3" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
-				<element map="4" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
-				<element map="5" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
+				<element map="3" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_3_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_3_output.consensusXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:///C:/dev/openmsqt5/share/OpenMS/XSL/ConsensusXML.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
 <consensusXML version="1.7" id="cm_17749660155506638460" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledKD" version="version_string" />
@@ -50,21 +50,25 @@
 		<PeptideHit score="0.00238" sequence="CHARLES" charge="2" aa_before="K K" aa_after="L L" start="143 143" end="153 153" protein_refs="PH_0 PH_1">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="412.89" RT="3001.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=4429" >
 		<PeptideHit score="0.002935" sequence="DAISY" charge="3" aa_before="R" aa_after="L" start="6" end="16" protein_refs="PH_2">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.327" RT="3000.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=4428" >
 		<PeptideHit score="0.00238" sequence="TWHIMALAYA" charge="2" aa_before="K K" aa_after="L L" start="143 143" end="153 153" protein_refs="PH_3 PH_4">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="412.89" RT="3001.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=4429" >
 		<PeptideHit score="0.002935" sequence="TWRCKYMUNTAIN" charge="3" aa_before="R" aa_after="L" start="6" end="16" protein_refs="PH_5">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="2">
 		<map id="0" name="raw_file1.mzML" unique_id="8706403922746272921" label="" size="470">

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_1_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_1_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_7804704400743266335" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledQT" version="version_string" />
 		<processingAction name="Feature grouping" />
@@ -39,93 +39,96 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="3">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="0.801668" charge="1">
-			<centroid rt="1004.22566666667" mz="1014.61" it="3.16178e+08"/>
+		<consensusElement id="e_15004869347769368353" quality="0.801668" charge="1">
+			<centroid rt="1004.225666666666598" mz="1014.610000000000014" it="3.161777e08"/>
 			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927" mz="1014.61" it="3.71373e+08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.49" mz="1014.61" it="2.35017e+08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.26" mz="1014.61" it="3.42143e+08" charge="1"/>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="0.895675" charge="1">
-			<centroid rt="1267.61666666667" mz="1725.81" it="3.19362e+08"/>
+		<consensusElement id="e_3332699010107892018" quality="0.895675" charge="1">
+			<centroid rt="1267.616666666666561" mz="1725.810000000000173" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.54" mz="1725.81" it="2.45958e+08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.04" mz="1725.81" it="3.674e+08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.27" mz="1725.81" it="3.44727e+08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0.913675" charge="1">
-			<centroid rt="1211.96333333333" mz="1399.69" it="2.24143e+08"/>
+		<consensusElement id="e_13440783915218733453" quality="0.913675" charge="1">
+			<centroid rt="1211.963333333333367" mz="1399.689999999999827" it="2.241427e08"/>
 			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.52" mz="1399.69" it="2.3497e+08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.42" mz="1399.69" it="3.17631e+08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.95" mz="1399.69" it="1.19827e+08" charge="1"/>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0.932397" charge="2">
-			<centroid rt="824.473333333333" mz="789.372" it="2.19646e+08"/>
+		<consensusElement id="e_15916652588957785155" quality="0.932398" charge="2">
+			<centroid rt="824.473333333333358" mz="789.371999999999957" it="2.19646e08"/>
 			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.972" mz="789.372" it="2.23649e+08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.435" mz="789.372" it="2.36463e+08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013" mz="789.372" it="1.98826e+08" charge="2"/>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0.86095" charge="1">
-			<centroid rt="1081.58" mz="1955.95" it="2.33178e+08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.86095" charge="1">
+			<centroid rt="1081.580000000000155" mz="1955.950000000000046" it="2.331777e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.19" mz="1955.95" it="2.84147e+08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.74" mz="1955.95" it="1.78653e+08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.81" mz="1955.95" it="2.36733e+08" charge="1"/>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0.907915" charge="1">
-			<centroid rt="822.757333333333" mz="1749.67" it="3.02481e+08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.907915" charge="1">
+			<centroid rt="822.757333333333349" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
-				<element map="0" id="11259143081880763675" rt="806.443" mz="1749.67" it="3.57962e+08" charge="1"/>
-				<element map="1" id="8781789908765837138" rt="818.552" mz="1749.67" it="3.67003e+08" charge="1"/>
-				<element map="2" id="5572181956708182284" rt="843.277" mz="1749.67" it="1.82478e+08" charge="1"/>
+				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
+				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
+				<element map="2" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0.798625" charge="1">
-			<centroid rt="838.689333333333" mz="1504.57" it="2.57013e+08"/>
+		<consensusElement id="e_474525871221756682" quality="0.798625" charge="1">
+			<centroid rt="838.689333333333366" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797" mz="1504.57" it="2.60293e+08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.924" mz="1504.57" it="1.45679e+08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.347" mz="1504.57" it="3.65068e+08" charge="1"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0.914813" charge="2">
-			<centroid rt="924.713" mz="941.449" it="2.06357e+08"/>
+		<consensusElement id="e_12999979801269632061" quality="0.914813" charge="2">
+			<centroid rt="924.713000000000079" mz="941.448999999999955" it="2.063567e08"/>
 			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.64" mz="941.449" it="2.15944e+08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.712" mz="941.449" it="1.25569e+08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787" mz="941.449" it="2.77557e+08" charge="2"/>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0.44788" charge="1">
-			<centroid rt="761.192" mz="1444.62" it="3.48902e+08"/>
+		<consensusElement id="e_17413765565443951891" quality="0.44788" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.489015e08"/>
 			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768" mz="1444.62" it="3.03992e+08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.616" mz="1444.62" it="3.93811e+08" charge="1"/>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
@@ -133,25 +136,25 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0.475615" charge="2">
-			<centroid rt="561.762" mz="733.275" it="2.08168e+08"/>
+		<consensusElement id="e_2927519776102075938" quality="0.475615" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.639" mz="733.275" it="1.6889e+08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.885" mz="733.275" it="2.47446e+08" charge="2"/>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0.332372" charge="1">
-			<centroid rt="921.7225" mz="1511.84" it="1.8723e+08"/>
+		<consensusElement id="e_16907355690727166316" quality="0.332373" charge="1">
+			<centroid rt="921.722500000000082" mz="1511.839999999999918" it="1.872305e08"/>
 			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197" mz="1511.84" it="1.08185e+08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248" mz="1511.84" it="2.66276e+08" charge="1"/>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.48995" charge="1">
-			<centroid rt="1035.53" mz="1163.62" it="2.14078e+08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.48995" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
 			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.54" mz="1163.62" it="1.34898e+08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.52" mz="1163.62" it="2.93257e+08" charge="1"/>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
@@ -159,84 +162,84 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_2927519776102075938" quality="0.4286" charge="1">
-			<centroid rt="1454.51" mz="2493.24" it="2.11806e+08"/>
+		<consensusElement id="e_12524258085768770586" quality="0.4286" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
 			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.23" mz="2493.24" it="1.55069e+08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.79" mz="2493.24" it="2.68544e+08" charge="1"/>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0.434975" charge="1">
-			<centroid rt="1049.535" mz="1420.67" it="2.27286e+08"/>
+		<consensusElement id="e_1755235105885170967" quality="0.434975" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.54" mz="1420.67" it="2.58532e+08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.53" mz="1420.67" it="1.96041e+08" charge="1"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.482008" charge="2">
-			<centroid rt="785.3975" mz="778.315" it="3.35197e+08"/>
+		<consensusElement id="e_14811341817612382122" quality="0.482008" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
 			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.996" mz="778.315" it="2.97395e+08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.799" mz="778.315" it="3.72998e+08" charge="2"/>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0.484775" charge="2">
-			<centroid rt="1300.965" mz="944.96" it="2.75438e+08"/>
+		<consensusElement id="e_2684106197423007927" quality="0.484775" charge="2">
+			<centroid rt="1300.965000000000146" mz="944.960000000000036" it="2.754385e08"/>
 			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.92" mz="944.96" it="3.20176e+08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.01" mz="944.96" it="2.30701e+08" charge="2"/>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0.253475" charge="2">
-			<centroid rt="1241.715" mz="954.949" it="2.3003e+08"/>
+		<consensusElement id="e_8119044117483804262" quality="0.253475" charge="2">
+			<centroid rt="1241.715000000000146" mz="954.948999999999955" it="2.3003e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.41" mz="954.949" it="1.93777e+08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.02" mz="954.949" it="2.66283e+08" charge="2"/>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0.45749" charge="1">
-			<centroid rt="854.844" mz="1752.61" it="1.68751e+08"/>
+		<consensusElement id="e_17314619952666245179" quality="0.45749" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
 			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.342" mz="1752.61" it="1.54686e+08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346" mz="1752.61" it="1.82817e+08" charge="1"/>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0.406515" charge="2">
-			<centroid rt="875.638" mz="653.354" it="2.67572e+08"/>
+		<consensusElement id="e_3023658190814908261" quality="0.406515" charge="2">
+			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
-				<element map="1" id="9947115975316200578" rt="856.941" mz="653.354" it="1.52129e+08" charge="2"/>
-				<element map="2" id="1045454825286354924" rt="894.335" mz="653.354" it="3.83015e+08" charge="2"/>
+				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
+				<element map="2" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0.3056" charge="1">
-			<centroid rt="1197.24" mz="1479.79" it="3.46508e+08"/>
+		<consensusElement id="e_7898004582401008768" quality="0.3056" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
 			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.36" mz="1479.79" it="3.762e+08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.12" mz="1479.79" it="3.16815e+08" charge="1"/>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0" charge="1">
-			<centroid rt="1304.43" mz="1567.74" it="3.00518e+08"/>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
+			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
 			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.43" mz="1567.74" it="3.00518e+08" charge="1"/>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0" charge="1">
-			<centroid rt="1196.8" mz="1908.9" it="2.00984e+08"/>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.8" mz="1908.9" it="2.00984e+08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0" charge="1">
-			<centroid rt="979.852" mz="1283.7" it="3.13719e+08"/>
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
 			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.852" mz="1283.7" it="3.13719e+08" charge="1"/>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0" charge="1">
-			<centroid rt="786.15" mz="1555.63" it="1.86424e+08"/>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="1">
+			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
 			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.15" mz="1555.63" it="1.86424e+08" charge="1"/>
+				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
@@ -244,10 +247,10 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0" charge="1">
-			<centroid rt="638.468" mz="537.243" it="2.10227e+08"/>
+		<consensusElement id="e_7276556891837796968" quality="0.0" charge="1">
+			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
-				<element map="0" id="12975660629189576601" rt="638.468" mz="537.243" it="2.10227e+08" charge="1"/>
+				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_0">
@@ -255,22 +258,22 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0" charge="1">
-			<centroid rt="875.319" mz="1305.71" it="2.96944e+08"/>
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
+			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.319" mz="1305.71" it="2.96944e+08" charge="1"/>
+				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0" charge="2">
-			<centroid rt="836.541" mz="876.804" it="4.39745e+08"/>
+		<consensusElement id="e_11115414975438642789" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
 			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541" mz="876.804" it="4.39745e+08" charge="2"/>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0" charge="2">
-			<centroid rt="640.822" mz="537.243" it="3.46578e+08"/>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
 			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822" mz="537.243" it="3.46578e+08" charge="2"/>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
@@ -278,22 +281,22 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0" charge="3">
-			<centroid rt="1006.93" mz="642.352" it="2.64687e+08"/>
+		<consensusElement id="e_13424404046998308790" quality="0.0" charge="3">
+			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.93" mz="642.352" it="2.64687e+08" charge="3"/>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0" charge="1">
-			<centroid rt="542.407" mz="1465.55" it="2.43214e+08"/>
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
 			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407" mz="1465.55" it="2.43214e+08" charge="1"/>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0" charge="3">
-			<centroid rt="656.405" mz="537.243" it="1.32679e+08"/>
+		<consensusElement id="e_17092894204355333314" quality="0.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
 			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.405" mz="537.243" it="1.32679e+08" charge="3"/>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
@@ -301,40 +304,40 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0" charge="1">
-			<centroid rt="796.474" mz="1108.49" it="6.83877e+07"/>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
+			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
-				<element map="2" id="6004004326366812857" rt="796.474" mz="1108.49" it="6.83877e+07" charge="1"/>
+				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0" charge="2">
-			<centroid rt="1531.86" mz="1247.12" it="2.34128e+08"/>
+		<consensusElement id="e_10627069796380146481" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
 			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.86" mz="1247.12" it="2.34128e+08" charge="2"/>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0" charge="2">
-			<centroid rt="1114.9" mz="710.835" it="2.71023e+08"/>
+		<consensusElement id="e_10052793688680741109" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
 			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.9" mz="710.835" it="2.71023e+08" charge="2"/>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0" charge="1">
-			<centroid rt="1415.83" mz="1567.74" it="2.20417e+08"/>
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
 			<groupedElementList>
-				<element map="2" id="10053481325799554694" rt="1415.83" mz="1567.74" it="2.20417e+08" charge="1"/>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="0" charge="2">
-			<centroid rt="1011.47" mz="642.352" it="2.21253e+08"/>
+		<consensusElement id="e_14768204679546465715" quality="0.0" charge="2">
+			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
 			<groupedElementList>
-				<element map="2" id="15743766982953332227" rt="1011.47" mz="642.352" it="2.21253e+08" charge="2"/>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10052793688680741109" quality="0" charge="1">
-			<centroid rt="817.266" mz="922.481" it="2.63046e+08"/>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
+			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
 			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.266" mz="922.481" it="2.63046e+08" charge="1"/>
+				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_2_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_2_output.consensusXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:///C:/dev/openmsqt5/share/OpenMS/XSL/ConsensusXML.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
 <consensusXML version="1.7" id="cm_13440783915218733453" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledQT" version="version_string" />
@@ -69,68 +69,94 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_3" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_7">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="3"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_9">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="4"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_5" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_11">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="5"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
-		<map id="3" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="3" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="4" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="4" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="5" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="5" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_15916652588957785155" quality="1.0" charge="2">
-			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
+		<consensusElement id="e_15916652588957785155" quality="1.0" charge="1">
+			<centroid rt="838.689333333333252" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
-				<element map="3" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
-				<element map="5" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999865" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
+				<element map="3" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="4" id="510828531039388399" rt="821.923999999999865" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="5" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="1.0" charge="3">
-			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
+		<consensusElement id="e_15157403601844400700" quality="1.0" charge="1">
+			<centroid rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
-				<element map="4" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="0" id="13635893658662189107" rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
+				<element map="3" id="13635893658662189107" rt="875.318999999999846" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="1.0" charge="2">
-			<centroid rt="1241.714999999999918" mz="954.948999999999955" it="2.3003e08"/>
+		<consensusElement id="e_6408859317243173796" quality="1.0" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
-				<element map="4" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
-				<element map="5" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
+				<element map="3" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="4" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_474525871221756682" quality="1.0" charge="2">
+			<centroid rt="1300.964999999999918" mz="944.960000000000036" it="2.754385e08"/>
+			<groupedElementList>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.010000000000218" mz="944.960000000000036" it="2.30701e08" charge="2"/>
+				<element map="4" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="5" id="6916883853867664495" rt="1304.010000000000218" mz="944.960000000000036" it="2.30701e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12999979801269632061" quality="1.0" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999864" it="2.08168e08"/>
+			<groupedElementList>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999864" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999864" it="2.47446e08" charge="2"/>
+				<element map="3" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999864" it="1.6889e08" charge="2"/>
+				<element map="5" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999864" it="2.47446e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17413765565443951891" quality="1.0" charge="2">
 			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
 				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
@@ -139,178 +165,26 @@
 				<element map="5" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="1.0" charge="1">
-			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.11806e08"/>
-			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
-				<element map="3" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
-				<element map="4" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="1.0" charge="1">
-			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
-			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
-				<element map="3" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
 		<consensusElement id="e_2927519776102075938" quality="1.0" charge="1">
-			<centroid rt="1081.579999999999927" mz="1955.950000000000046" it="2.33178e08"/>
+			<centroid rt="1267.616666666666561" mz="1725.809999999999945" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
-				<element map="3" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
-				<element map="4" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
-				<element map="5" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
+				<element map="3" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="4" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="5" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_16907355690727166316" quality="1.0" charge="1">
-			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
-			<groupedElementList>
-				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
-				<element map="5" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="1.0" charge="1">
-			<centroid rt="1004.225666666670008" mz="1014.610000000000014" it="3.16178e08"/>
-			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
-				<element map="3" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
-				<element map="4" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
-				<element map="5" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="1.0" charge="1">
-			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.48902e08"/>
-			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
-				<element map="3" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
-				<element map="5" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_10">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="1.0" charge="2">
-			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
-			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
-				<element map="4" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_8">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="1.0" charge="1">
-			<centroid rt="1211.963333333329956" mz="1399.690000000000055" it="2.24143e08"/>
-			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
-				<element map="3" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
-				<element map="4" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
-				<element map="5" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="1.0" charge="1">
-			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
-			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
-				<element map="3" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="1.0" charge="1">
-			<centroid rt="1197.240000000000009" mz="1479.789999999999964" it="3.46508e08"/>
-			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
-				<element map="4" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
-				<element map="5" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="1.0" charge="1">
-			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
-			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
-				<element map="5" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="1.0" charge="2">
-			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.35197e08"/>
-			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
-				<element map="4" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
-				<element map="5" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="1.0" charge="2">
-			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
-			<groupedElementList>
-				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
-				<element map="5" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="1.0" charge="1">
-			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
-			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
-				<element map="4" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="1.0" charge="2">
-			<centroid rt="1300.964999999999918" mz="944.960000000000036" it="2.75438e08"/>
-			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
-				<element map="4" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
-				<element map="5" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="1.0" charge="2">
-			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
-			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
-				<element map="5" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="1.0" charge="1">
-			<centroid rt="921.722499999999968" mz="1511.839999999999918" it="1.8723e08"/>
-			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
-				<element map="3" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
-				<element map="5" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="1.0" charge="1">
 			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
 				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 				<element map="5" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="1.0" charge="1">
-			<centroid rt="822.757333333333008" mz="1749.670000000000073" it="3.02481e08"/>
+		<consensusElement id="e_10306100746905639127" quality="1.0" charge="1">
+			<centroid rt="822.757333333333236" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
 				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
 				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
@@ -320,139 +194,7 @@
 				<element map="5" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="1.0" charge="3">
-			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
-			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
-				<element map="5" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_10">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="1.0" charge="1">
-			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.68751e08"/>
-			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
-				<element map="4" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
-				<element map="5" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="1.0" charge="2">
-			<centroid rt="824.473333333333017" mz="789.371999999999957" it="2.19646e08"/>
-			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
-				<element map="3" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
-				<element map="4" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
-				<element map="5" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="1.0" charge="1">
-			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
-			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
-				<element map="3" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_6">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="1.0" charge="2">
-			<centroid rt="924.712999999999966" mz="941.448999999999955" it="2.06357e08"/>
-			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
-				<element map="3" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
-				<element map="4" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
-				<element map="5" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="1.0" charge="1">
-			<centroid rt="838.689333333333025" mz="1504.569999999999936" it="2.57013e08"/>
-			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
-				<element map="3" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
-				<element map="4" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
-				<element map="5" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="1.0" charge="2">
-			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
-			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
-				<element map="3" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_10052793688680741109" quality="1.0" charge="1">
-			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
-			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
-				<element map="3" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15166508592180818156" quality="1.0" charge="1">
-			<centroid rt="1049.535000000000082" mz="1420.670000000000073" it="2.27286e08"/>
-			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
-				<element map="3" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
-				<element map="4" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_14768204679546465715" quality="1.0" charge="2">
-			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
-			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
-				<element map="5" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_12156709473159629610" quality="1.0" charge="1">
-			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
-			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
-				<element map="3" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_15885522598119108466" quality="1.0" charge="1">
-			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.14078e08"/>
-			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
-				<element map="3" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
-				<element map="4" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
-			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="0"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
-				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_8">
-				</PeptideHit>
-				<UserParam type="int" name="map_index" value="1"/>
-			</PeptideIdentification>
-		</consensusElement>
-		<consensusElement id="e_3823858840059792698" quality="1.0" charge="1">
+		<consensusElement id="e_12524258085768770586" quality="1.0" charge="1">
 			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
 				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
@@ -466,18 +208,282 @@
 			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_6">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="3"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_1755235105885170967" quality="1.0" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
+			<groupedElementList>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
+				<element map="4" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="5" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14811341817612382122" quality="1.0" charge="2">
+			<centroid rt="1241.714999999999918" mz="954.948999999999955" it="2.3003e08"/>
+			<groupedElementList>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+				<element map="4" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="5" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_2684106197423007927" quality="1.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
+			<groupedElementList>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
+				<element map="5" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_8119044117483804262" quality="1.0" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
+			<groupedElementList>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
+				<element map="3" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="4" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
+				</PeptideHit>
 				<UserParam type="int" name="map_index" value="1"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_8">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="4"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_17314619952666245179" quality="1.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
+			<groupedElementList>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
+				<element map="5" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3023658190814908261" quality="1.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08"/>
+			<groupedElementList>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08" charge="2"/>
+				<element map="3" id="15776542383322853081" rt="836.541000000000054" mz="876.80399999999986" it="4.39745e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_7898004582401008768" quality="1.0" charge="1">
+			<centroid rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08"/>
+			<groupedElementList>
+				<element map="2" id="17198512653051715988" rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08" charge="1"/>
+				<element map="5" id="17198512653051715988" rt="817.265999999999849" mz="922.481000000000108" it="2.63046e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_15050004366391181853" quality="1.0" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
+			<groupedElementList>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
+				<element map="3" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="4" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17716858074023296841" quality="1.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
+			<groupedElementList>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
+				<element map="4" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_16250062551099875712" quality="1.0" charge="2">
+			<centroid rt="924.712999999999966" mz="941.448999999999955" it="2.063567e08"/>
+			<groupedElementList>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
+				<element map="3" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="4" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="5" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_16177748921272733768" quality="1.0" charge="3">
+			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
+			<groupedElementList>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="4" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_7276556891837796968" quality="1.0" charge="1">
+			<centroid rt="1211.963333333332912" mz="1399.689999999999827" it="2.241427e08"/>
+			<groupedElementList>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
+				<element map="3" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="4" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="5" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_1147219038608936718" quality="1.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
+			<groupedElementList>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
+				<element map="4" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_4" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_8">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="4"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_11115414975438642789" quality="1.0" charge="2">
+			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
+			<groupedElementList>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
+				<element map="5" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14509930621887606273" quality="1.0" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
+			<groupedElementList>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999865" mz="778.315000000000055" it="3.72998e08" charge="2"/>
+				<element map="4" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="5" id="9588482092062192060" rt="781.798999999999865" mz="778.315000000000055" it="3.72998e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_13424404046998308790" quality="1.0" charge="1">
+			<centroid rt="1004.225666666666484" mz="1014.610000000000014" it="3.161777e08"/>
+			<groupedElementList>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.260000000000218" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
+				<element map="3" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="4" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="5" id="836885712912035377" rt="1043.260000000000218" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12665713047548007769" quality="1.0" charge="1">
+			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
+			<groupedElementList>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+				<element map="3" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17092894204355333314" quality="1.0" charge="1">
+			<centroid rt="1081.579999999999927" mz="1955.950000000000046" it="2.331777e08"/>
+			<groupedElementList>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+				<element map="3" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="4" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="5" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3491056946625602141" quality="1.0" charge="1">
+			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
+			<groupedElementList>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
+				<element map="5" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_10627069796380146481" quality="1.0" charge="2">
+			<centroid rt="824.473333333333244" mz="789.371999999999844" it="2.19646e08"/>
+			<groupedElementList>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999844" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999832" mz="789.371999999999844" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999844" it="1.98826e08" charge="2"/>
+				<element map="3" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999844" it="2.23649e08" charge="2"/>
+				<element map="4" id="9891393289043950297" rt="820.434999999999832" mz="789.371999999999844" it="2.36463e08" charge="2"/>
+				<element map="5" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999844" it="1.98826e08" charge="2"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_10052793688680741109" quality="1.0" charge="1">
+			<centroid rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08"/>
+			<groupedElementList>
+				<element map="0" id="9201749952666825017" rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
+				<element map="3" id="9201749952666825017" rt="786.149999999999864" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_3" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_6">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="3"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_15166508592180818156" quality="1.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
+			<groupedElementList>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
+				<element map="3" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_14768204679546465715" quality="1.0" charge="1">
+			<centroid rt="921.722499999999968" mz="1511.839999999999918" it="1.872305e08"/>
+			<groupedElementList>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
+				<element map="3" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="5" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_12156709473159629610" quality="1.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
+			<groupedElementList>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
+				<element map="5" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_10">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="5"/>
+			</PeptideIdentification>
+		</consensusElement>
+		<consensusElement id="e_15885522598119108466" quality="1.0" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
+			<groupedElementList>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
+				<element map="4" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="5" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_3823858840059792698" quality="1.0" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999664" it="3.489015e08"/>
+			<groupedElementList>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999664" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999664" it="3.93811e08" charge="1"/>
+				<element map="3" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999664" it="3.03992e08" charge="1"/>
+				<element map="5" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999664" it="3.93811e08" charge="1"/>
+			</groupedElementList>
+			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_5" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
+				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_10">
+				</PeptideHit>
+				<UserParam type="int" name="map_index" value="5"/>
 			</PeptideIdentification>
 		</consensusElement>
 		<consensusElement id="e_893904610286969204" quality="1.0" charge="1">
-			<centroid rt="1267.616666666669971" mz="1725.809999999999945" it="3.19362e08"/>
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
-				<element map="3" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
-				<element map="4" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
-				<element map="5" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
+				<element map="3" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_3_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_3_output.consensusXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:///C:/dev/openmsqt5/share/OpenMS/XSL/ConsensusXML.xsl"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
 <consensusXML version="1.7" id="cm_17749660155506638460" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledQT" version="version_string" />
@@ -50,21 +50,25 @@
 		<PeptideHit score="0.00238" sequence="CHARLES" charge="2" aa_before="K K" aa_after="L L" start="143 143" end="153 153" protein_refs="PH_0 PH_1">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="412.89" RT="3001.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=4429" >
 		<PeptideHit score="0.002935" sequence="DAISY" charge="3" aa_before="R" aa_after="L" start="6" end="16" protein_refs="PH_2">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.327" RT="3000.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=4428" >
 		<PeptideHit score="0.00238" sequence="TWHIMALAYA" charge="2" aa_before="K K" aa_after="L L" start="143 143" end="153 153" protein_refs="PH_3 PH_4">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="412.89" RT="3001.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=4429" >
 		<PeptideHit score="0.002935" sequence="TWRCKYMUNTAIN" charge="3" aa_before="R" aa_after="L" start="6" end="16" protein_refs="PH_5">
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="2">
 		<map id="0" name="raw_file1.mzML" unique_id="8706403922746272921" label="" size="470">

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_4_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_4_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_7804704400743266335" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeledQT" version="version_string" />
 		<processingAction name="Feature grouping" />
@@ -39,93 +39,96 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="3">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="0.801668" charge="1">
-			<centroid rt="1004.22566666667" mz="1014.61" it="3.16178e+08"/>
+		<consensusElement id="e_15004869347769368353" quality="0.801668" charge="1">
+			<centroid rt="1004.225666666666598" mz="1014.610000000000014" it="3.161777e08"/>
 			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927" mz="1014.61" it="3.71373e+08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.49" mz="1014.61" it="2.35017e+08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.26" mz="1014.61" it="3.42143e+08" charge="1"/>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="0.895675" charge="1">
-			<centroid rt="1267.61666666667" mz="1725.81" it="3.19362e+08"/>
+		<consensusElement id="e_3332699010107892018" quality="0.895675" charge="1">
+			<centroid rt="1267.616666666666561" mz="1725.810000000000173" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.54" mz="1725.81" it="2.45958e+08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.04" mz="1725.81" it="3.674e+08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.27" mz="1725.81" it="3.44727e+08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0.913675" charge="1">
-			<centroid rt="1211.96333333333" mz="1399.69" it="2.24143e+08"/>
+		<consensusElement id="e_13440783915218733453" quality="0.913675" charge="1">
+			<centroid rt="1211.963333333333367" mz="1399.689999999999827" it="2.241427e08"/>
 			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.52" mz="1399.69" it="2.3497e+08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.42" mz="1399.69" it="3.17631e+08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.95" mz="1399.69" it="1.19827e+08" charge="1"/>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0.932397" charge="2">
-			<centroid rt="824.473333333333" mz="789.372" it="2.19646e+08"/>
+		<consensusElement id="e_15916652588957785155" quality="0.932398" charge="2">
+			<centroid rt="824.473333333333358" mz="789.371999999999957" it="2.19646e08"/>
 			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.972" mz="789.372" it="2.23649e+08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.435" mz="789.372" it="2.36463e+08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013" mz="789.372" it="1.98826e+08" charge="2"/>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0.86095" charge="1">
-			<centroid rt="1081.58" mz="1955.95" it="2.33178e+08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.86095" charge="1">
+			<centroid rt="1081.580000000000155" mz="1955.950000000000046" it="2.331777e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.19" mz="1955.95" it="2.84147e+08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.74" mz="1955.95" it="1.78653e+08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.81" mz="1955.95" it="2.36733e+08" charge="1"/>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0.907915" charge="1">
-			<centroid rt="822.757333333333" mz="1749.67" it="3.02481e+08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.907915" charge="1">
+			<centroid rt="822.757333333333349" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
-				<element map="0" id="11259143081880763675" rt="806.443" mz="1749.67" it="3.57962e+08" charge="1"/>
-				<element map="1" id="8781789908765837138" rt="818.552" mz="1749.67" it="3.67003e+08" charge="1"/>
-				<element map="2" id="5572181956708182284" rt="843.277" mz="1749.67" it="1.82478e+08" charge="1"/>
+				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
+				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
+				<element map="2" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0.798625" charge="1">
-			<centroid rt="838.689333333333" mz="1504.57" it="2.57013e+08"/>
+		<consensusElement id="e_474525871221756682" quality="0.798625" charge="1">
+			<centroid rt="838.689333333333366" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797" mz="1504.57" it="2.60293e+08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.924" mz="1504.57" it="1.45679e+08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.347" mz="1504.57" it="3.65068e+08" charge="1"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0.914813" charge="2">
-			<centroid rt="924.713" mz="941.449" it="2.06357e+08"/>
+		<consensusElement id="e_12999979801269632061" quality="0.914813" charge="2">
+			<centroid rt="924.713000000000079" mz="941.448999999999955" it="2.063567e08"/>
 			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.64" mz="941.449" it="2.15944e+08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.712" mz="941.449" it="1.25569e+08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787" mz="941.449" it="2.77557e+08" charge="2"/>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0.44788" charge="1">
-			<centroid rt="761.192" mz="1444.62" it="3.48902e+08"/>
+		<consensusElement id="e_17413765565443951891" quality="0.44788" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.489015e08"/>
 			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768" mz="1444.62" it="3.03992e+08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.616" mz="1444.62" it="3.93811e+08" charge="1"/>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
@@ -133,25 +136,25 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0.475615" charge="2">
-			<centroid rt="561.762" mz="733.275" it="2.08168e+08"/>
+		<consensusElement id="e_2927519776102075938" quality="0.475615" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.639" mz="733.275" it="1.6889e+08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.885" mz="733.275" it="2.47446e+08" charge="2"/>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0.332372" charge="1">
-			<centroid rt="921.7225" mz="1511.84" it="1.8723e+08"/>
+		<consensusElement id="e_16907355690727166316" quality="0.332373" charge="1">
+			<centroid rt="921.722500000000082" mz="1511.839999999999918" it="1.872305e08"/>
 			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197" mz="1511.84" it="1.08185e+08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248" mz="1511.84" it="2.66276e+08" charge="1"/>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.48995" charge="1">
-			<centroid rt="1035.53" mz="1163.62" it="2.14078e+08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.48995" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
 			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.54" mz="1163.62" it="1.34898e+08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.52" mz="1163.62" it="2.93257e+08" charge="1"/>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
@@ -159,84 +162,84 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_2927519776102075938" quality="0.4286" charge="1">
-			<centroid rt="1454.51" mz="2493.24" it="2.11806e+08"/>
+		<consensusElement id="e_12524258085768770586" quality="0.4286" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
 			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.23" mz="2493.24" it="1.55069e+08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.79" mz="2493.24" it="2.68544e+08" charge="1"/>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0.434975" charge="1">
-			<centroid rt="1049.535" mz="1420.67" it="2.27286e+08"/>
+		<consensusElement id="e_1755235105885170967" quality="0.434975" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.54" mz="1420.67" it="2.58532e+08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.53" mz="1420.67" it="1.96041e+08" charge="1"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.482008" charge="2">
-			<centroid rt="785.3975" mz="778.315" it="3.35197e+08"/>
+		<consensusElement id="e_14811341817612382122" quality="0.482008" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
 			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.996" mz="778.315" it="2.97395e+08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.799" mz="778.315" it="3.72998e+08" charge="2"/>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0.484775" charge="2">
-			<centroid rt="1300.965" mz="944.96" it="2.75438e+08"/>
+		<consensusElement id="e_2684106197423007927" quality="0.484775" charge="2">
+			<centroid rt="1300.965000000000146" mz="944.960000000000036" it="2.754385e08"/>
 			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.92" mz="944.96" it="3.20176e+08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.01" mz="944.96" it="2.30701e+08" charge="2"/>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0.253475" charge="2">
-			<centroid rt="1241.715" mz="954.949" it="2.3003e+08"/>
+		<consensusElement id="e_8119044117483804262" quality="0.253475" charge="2">
+			<centroid rt="1241.715000000000146" mz="954.948999999999955" it="2.3003e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.41" mz="954.949" it="1.93777e+08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.02" mz="954.949" it="2.66283e+08" charge="2"/>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0.45749" charge="1">
-			<centroid rt="854.844" mz="1752.61" it="1.68751e+08"/>
+		<consensusElement id="e_17314619952666245179" quality="0.45749" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
 			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.342" mz="1752.61" it="1.54686e+08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346" mz="1752.61" it="1.82817e+08" charge="1"/>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0.406515" charge="2">
-			<centroid rt="875.638" mz="653.354" it="2.67572e+08"/>
+		<consensusElement id="e_3023658190814908261" quality="0.406515" charge="2">
+			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
-				<element map="1" id="9947115975316200578" rt="856.941" mz="653.354" it="1.52129e+08" charge="2"/>
-				<element map="2" id="1045454825286354924" rt="894.335" mz="653.354" it="3.83015e+08" charge="2"/>
+				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
+				<element map="2" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0.3056" charge="1">
-			<centroid rt="1197.24" mz="1479.79" it="3.46508e+08"/>
+		<consensusElement id="e_7898004582401008768" quality="0.3056" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
 			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.36" mz="1479.79" it="3.762e+08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.12" mz="1479.79" it="3.16815e+08" charge="1"/>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0" charge="1">
-			<centroid rt="1304.43" mz="1567.74" it="3.00518e+08"/>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
+			<centroid rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08"/>
 			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.43" mz="1567.74" it="3.00518e+08" charge="1"/>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0" charge="1">
-			<centroid rt="1196.8" mz="1908.9" it="2.00984e+08"/>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.8" mz="1908.9" it="2.00984e+08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0" charge="1">
-			<centroid rt="979.852" mz="1283.7" it="3.13719e+08"/>
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
 			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.852" mz="1283.7" it="3.13719e+08" charge="1"/>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0" charge="1">
-			<centroid rt="786.15" mz="1555.63" it="1.86424e+08"/>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="1">
+			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
 			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.15" mz="1555.63" it="1.86424e+08" charge="1"/>
+				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
@@ -244,10 +247,10 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0" charge="1">
-			<centroid rt="638.468" mz="537.243" it="2.10227e+08"/>
+		<consensusElement id="e_7276556891837796968" quality="0.0" charge="1">
+			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
-				<element map="0" id="12975660629189576601" rt="638.468" mz="537.243" it="2.10227e+08" charge="1"/>
+				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_0">
@@ -255,22 +258,22 @@
 				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0" charge="1">
-			<centroid rt="875.319" mz="1305.71" it="2.96944e+08"/>
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
+			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.319" mz="1305.71" it="2.96944e+08" charge="1"/>
+				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0" charge="2">
-			<centroid rt="836.541" mz="876.804" it="4.39745e+08"/>
+		<consensusElement id="e_11115414975438642789" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
 			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541" mz="876.804" it="4.39745e+08" charge="2"/>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0" charge="2">
-			<centroid rt="640.822" mz="537.243" it="3.46578e+08"/>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
 			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822" mz="537.243" it="3.46578e+08" charge="2"/>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
@@ -278,22 +281,22 @@
 				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0" charge="3">
-			<centroid rt="1006.93" mz="642.352" it="2.64687e+08"/>
+		<consensusElement id="e_13424404046998308790" quality="0.0" charge="3">
+			<centroid rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.93" mz="642.352" it="2.64687e+08" charge="3"/>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0" charge="1">
-			<centroid rt="542.407" mz="1465.55" it="2.43214e+08"/>
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
 			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407" mz="1465.55" it="2.43214e+08" charge="1"/>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0" charge="3">
-			<centroid rt="656.405" mz="537.243" it="1.32679e+08"/>
+		<consensusElement id="e_17092894204355333314" quality="0.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
 			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.405" mz="537.243" it="1.32679e+08" charge="3"/>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
@@ -301,40 +304,40 @@
 				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0" charge="1">
-			<centroid rt="796.474" mz="1108.49" it="6.83877e+07"/>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
+			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
-				<element map="2" id="6004004326366812857" rt="796.474" mz="1108.49" it="6.83877e+07" charge="1"/>
+				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0" charge="2">
-			<centroid rt="1531.86" mz="1247.12" it="2.34128e+08"/>
+		<consensusElement id="e_10627069796380146481" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
 			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.86" mz="1247.12" it="2.34128e+08" charge="2"/>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0" charge="2">
-			<centroid rt="1114.9" mz="710.835" it="2.71023e+08"/>
+		<consensusElement id="e_10052793688680741109" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
 			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.9" mz="710.835" it="2.71023e+08" charge="2"/>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0" charge="1">
-			<centroid rt="1415.83" mz="1567.74" it="2.20417e+08"/>
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+			<centroid rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08"/>
 			<groupedElementList>
-				<element map="2" id="10053481325799554694" rt="1415.83" mz="1567.74" it="2.20417e+08" charge="1"/>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="0" charge="2">
-			<centroid rt="1011.47" mz="642.352" it="2.21253e+08"/>
+		<consensusElement id="e_14768204679546465715" quality="0.0" charge="2">
+			<centroid rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08"/>
 			<groupedElementList>
-				<element map="2" id="15743766982953332227" rt="1011.47" mz="642.352" it="2.21253e+08" charge="2"/>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10052793688680741109" quality="0" charge="1">
-			<centroid rt="817.266" mz="922.481" it="2.63046e+08"/>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
+			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
 			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.266" mz="922.481" it="2.63046e+08" charge="1"/>
+				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeled_1_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeled_1_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_15916652588957785155" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeled" version="version_string" />
 		<processingAction name="Feature grouping" />
@@ -39,286 +39,295 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="3">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="0.968431" charge="1">
-			<centroid rt="645.231666666667" mz="537.243" it="2.29828e+08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.968431" charge="1">
+			<centroid rt="645.231666666666683" mz="537.243000000000052" it="2.29828e08"/>
 			<groupedElementList>
-				<element map="0" id="12975660629189576601" rt="638.468" mz="537.243" it="2.10227e+08" charge="1"/>
-				<element map="1" id="757269036628510515" rt="640.822" mz="537.243" it="3.46578e+08" charge="2"/>
-				<element map="2" id="1966557505224183820" rt="656.405" mz="537.243" it="1.32679e+08" charge="3"/>
+				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="0.986587" charge="2">
-			<centroid rt="1009.2" mz="642.352" it="2.4297e+08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.986587" charge="2">
+			<centroid rt="1009.200000000000045" mz="642.351999999999975" it="2.4297e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.93" mz="642.352" it="2.64687e+08" charge="3"/>
-				<element map="2" id="15743766982953332227" rt="1011.47" mz="642.352" it="2.21253e+08" charge="2"/>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0.888626" charge="2">
-			<centroid rt="875.638" mz="653.354" it="2.67572e+08"/>
+		<consensusElement id="e_474525871221756682" quality="0.888626" charge="2">
+			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
-				<element map="1" id="9947115975316200578" rt="856.941" mz="653.354" it="1.52129e+08" charge="2"/>
-				<element map="2" id="1045454825286354924" rt="894.335" mz="653.354" it="3.83015e+08" charge="2"/>
+				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
+				<element map="2" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0" charge="2">
-			<centroid rt="1114.9" mz="710.835" it="2.71023e+08"/>
+		<consensusElement id="e_12999979801269632061" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
 			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.9" mz="710.835" it="2.71023e+08" charge="2"/>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="SLHTLFGDELCK"/>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0.97278" charge="2">
-			<centroid rt="561.762" mz="733.275" it="2.08168e+08"/>
+		<consensusElement id="e_17413765565443951891" quality="0.97278" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.639" mz="733.275" it="1.6889e+08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.885" mz="733.275" it="2.47446e+08" charge="2"/>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0.97568" charge="2">
-			<centroid rt="785.3975" mz="778.315" it="3.35197e+08"/>
+		<consensusElement id="e_2927519776102075938" quality="0.97568" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
 			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.996" mz="778.315" it="2.97395e+08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.799" mz="778.315" it="3.72998e+08" charge="2"/>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0.957139" charge="2">
-			<centroid rt="824.473333333333" mz="789.372" it="2.19646e+08"/>
+		<consensusElement id="e_16907355690727166316" quality="0.957139" charge="2">
+			<centroid rt="824.473333333333358" mz="789.371999999999957" it="2.19646e08"/>
 			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.972" mz="789.372" it="2.23649e+08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.435" mz="789.372" it="2.36463e+08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013" mz="789.372" it="1.98826e+08" charge="2"/>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0" charge="2">
-			<centroid rt="836.541" mz="876.804" it="4.39745e+08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
 			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541" mz="876.804" it="4.39745e+08" charge="2"/>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="ECCHGDLLECADDR"/>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0" charge="1">
-			<centroid rt="817.266" mz="922.481" it="2.63046e+08"/>
+		<consensusElement id="e_12524258085768770586" quality="0.0" charge="1">
+			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
 			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.266" mz="922.481" it="2.63046e+08" charge="1"/>
+				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="AEFVEVTK"/>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0.908517" charge="2">
-			<centroid rt="924.713" mz="941.449" it="2.06357e+08"/>
+		<consensusElement id="e_1755235105885170967" quality="0.908517" charge="2">
+			<centroid rt="924.713000000000079" mz="941.448999999999955" it="2.063567e08"/>
 			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.64" mz="941.449" it="2.15944e+08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.712" mz="941.449" it="1.25569e+08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787" mz="941.449" it="2.77557e+08" charge="2"/>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0.981759" charge="2">
-			<centroid rt="1300.965" mz="944.96" it="2.75438e+08"/>
+		<consensusElement id="e_14811341817612382122" quality="0.981759" charge="2">
+			<centroid rt="1300.965000000000146" mz="944.960000000000036" it="2.754385e08"/>
 			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.92" mz="944.96" it="3.20176e+08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.01" mz="944.96" it="2.30701e+08" charge="2"/>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.710475" charge="2">
-			<centroid rt="1241.715" mz="954.949" it="2.3003e+08"/>
+		<consensusElement id="e_2684106197423007927" quality="0.710475" charge="2">
+			<centroid rt="1241.715000000000146" mz="954.948999999999955" it="2.3003e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.41" mz="954.949" it="1.93777e+08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.02" mz="954.949" it="2.66283e+08" charge="2"/>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2927519776102075938" quality="0.894646" charge="1">
-			<centroid rt="1004.22566666667" mz="1014.61" it="3.16178e+08"/>
+		<consensusElement id="e_8119044117483804262" quality="0.894646" charge="1">
+			<centroid rt="1004.225666666666598" mz="1014.610000000000014" it="3.161777e08"/>
 			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927" mz="1014.61" it="3.71373e+08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.49" mz="1014.61" it="2.35017e+08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.26" mz="1014.61" it="3.42143e+08" charge="1"/>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0" charge="1">
-			<centroid rt="796.474" mz="1108.49" it="6.83877e+07"/>
+		<consensusElement id="e_17314619952666245179" quality="0.0" charge="1">
+			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
-				<element map="2" id="6004004326366812857" rt="796.474" mz="1108.49" it="6.83877e+07" charge="1"/>
+				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="EACFAVEGPK"/>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.98962" charge="1">
-			<centroid rt="1035.53" mz="1163.62" it="2.14078e+08"/>
+		<consensusElement id="e_3023658190814908261" quality="0.98962" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
 			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.54" mz="1163.62" it="1.34898e+08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.52" mz="1163.62" it="2.93257e+08" charge="1"/>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0" charge="2">
-			<centroid rt="1531.86" mz="1247.12" it="2.34128e+08"/>
+		<consensusElement id="e_7898004582401008768" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
 			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.86" mz="1247.12" it="2.34128e+08" charge="2"/>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="GLVLIAFSQYLQQCPFDEHVK"/>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0" charge="1">
-			<centroid rt="979.852" mz="1283.7" it="3.13719e+08"/>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
 			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.852" mz="1283.7" it="3.13719e+08" charge="1"/>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="HPEYAVSVLLR"/>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0" charge="1">
-			<centroid rt="875.319" mz="1305.71" it="2.96944e+08"/>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.319" mz="1305.71" it="2.96944e+08" charge="1"/>
+				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="HLVDEPQNLIK"/>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0.934053" charge="1">
-			<centroid rt="1211.96333333333" mz="1399.69" it="2.24143e+08"/>
+		<consensusElement id="e_16250062551099875712" quality="0.934053" charge="1">
+			<centroid rt="1211.963333333333367" mz="1399.689999999999827" it="2.241427e08"/>
 			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.52" mz="1399.69" it="2.3497e+08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.42" mz="1399.69" it="3.17631e+08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.95" mz="1399.69" it="1.19827e+08" charge="1"/>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0.924367" charge="1">
-			<centroid rt="1049.535" mz="1420.67" it="2.27286e+08"/>
+		<consensusElement id="e_16177748921272733768" quality="0.924367" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.54" mz="1420.67" it="2.58532e+08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.53" mz="1420.67" it="1.96041e+08" charge="1"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0.941172" charge="1">
-			<centroid rt="761.192" mz="1444.62" it="3.48902e+08"/>
+		<consensusElement id="e_7276556891837796968" quality="0.941172" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.489015e08"/>
 			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768" mz="1444.62" it="3.03992e+08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.616" mz="1444.62" it="3.93811e+08" charge="1"/>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0" charge="1">
-			<centroid rt="542.407" mz="1465.55" it="2.43214e+08"/>
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
 			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407" mz="1465.55" it="2.43214e+08" charge="1"/>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="TCVADESHAGCEK"/>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0.789499" charge="1">
-			<centroid rt="1197.24" mz="1479.79" it="3.46508e+08"/>
+		<consensusElement id="e_11115414975438642789" quality="0.789499" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
 			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.36" mz="1479.79" it="3.762e+08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.12" mz="1479.79" it="3.16815e+08" charge="1"/>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0.815779" charge="1">
-			<centroid rt="838.689333333333" mz="1504.57" it="2.57013e+08"/>
+		<consensusElement id="e_14509930621887606273" quality="0.815779" charge="1">
+			<centroid rt="838.689333333333366" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797" mz="1504.57" it="2.60293e+08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.924" mz="1504.57" it="1.45679e+08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.347" mz="1504.57" it="3.65068e+08" charge="1"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0.81903" charge="1">
-			<centroid rt="921.7225" mz="1511.84" it="1.8723e+08"/>
+		<consensusElement id="e_13424404046998308790" quality="0.81903" charge="1">
+			<centroid rt="921.722500000000082" mz="1511.839999999999918" it="1.872305e08"/>
 			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197" mz="1511.84" it="1.08185e+08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248" mz="1511.84" it="2.66276e+08" charge="1"/>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0" charge="1">
-			<centroid rt="786.15" mz="1555.63" it="1.86424e+08"/>
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
 			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.15" mz="1555.63" it="1.86424e+08" charge="1"/>
+				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="sequence" value="DDPHACYSTVFDK"/>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0.719815" charge="1">
-			<centroid rt="1360.13" mz="1567.74" it="2.60468e+08"/>
+		<consensusElement id="e_17092894204355333314" quality="0.719815" charge="1">
+			<centroid rt="1360.130000000000109" mz="1567.740000000000009" it="2.604675e08"/>
 			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.43" mz="1567.74" it="3.00518e+08" charge="1"/>
-				<element map="2" id="10053481325799554694" rt="1415.83" mz="1567.74" it="2.20417e+08" charge="1"/>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0.931309" charge="1">
-			<centroid rt="1267.61666666667" mz="1725.81" it="3.19362e+08"/>
+		<consensusElement id="e_3491056946625602141" quality="0.931309" charge="1">
+			<centroid rt="1267.616666666666561" mz="1725.810000000000173" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.54" mz="1725.81" it="2.45958e+08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.04" mz="1725.81" it="3.674e+08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.27" mz="1725.81" it="3.44727e+08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0.905571" charge="1">
-			<centroid rt="822.757333333333" mz="1749.67" it="3.02481e+08"/>
+		<consensusElement id="e_10627069796380146481" quality="0.905571" charge="1">
+			<centroid rt="822.757333333333349" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
-				<element map="0" id="11259143081880763675" rt="806.443" mz="1749.67" it="3.57962e+08" charge="1"/>
-				<element map="1" id="8781789908765837138" rt="818.552" mz="1749.67" it="3.67003e+08" charge="1"/>
-				<element map="2" id="5572181956708182284" rt="843.277" mz="1749.67" it="1.82478e+08" charge="1"/>
+				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
+				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
+				<element map="2" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0.954044" charge="1">
-			<centroid rt="854.844" mz="1752.61" it="1.68751e+08"/>
+		<consensusElement id="e_10052793688680741109" quality="0.954044" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
 			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.342" mz="1752.61" it="1.54686e+08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346" mz="1752.61" it="1.82817e+08" charge="1"/>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0" charge="1">
-			<centroid rt="1196.8" mz="1908.9" it="2.00984e+08"/>
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.8" mz="1908.9" it="2.00984e+08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="LFTFHADICTLPDTEK"/>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0.89488" charge="1">
-			<centroid rt="1081.58" mz="1955.95" it="2.33178e+08"/>
+		<consensusElement id="e_14768204679546465715" quality="0.89488" charge="1">
+			<centroid rt="1081.580000000000155" mz="1955.950000000000046" it="2.331777e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.19" mz="1955.95" it="2.84147e+08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.74" mz="1955.95" it="1.78653e+08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.81" mz="1955.95" it="2.36733e+08" charge="1"/>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0.9286" charge="1">
-			<centroid rt="1454.51" mz="2493.24" it="2.11806e+08"/>
+		<consensusElement id="e_12156709473159629610" quality="0.9286" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
 			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.23" mz="2493.24" it="1.55069e+08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.79" mz="2493.24" it="2.68544e+08" charge="1"/>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureLinkerUnlabeled_4_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeled_4_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_15916652588957785155" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureLinkerUnlabeled" version="version_string" />
 		<processingAction name="Feature grouping" />
@@ -39,299 +39,308 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FAA" charge="23" aa_after="Y" protein_refs="PH_1">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FDD" charge="23" aa_after="Y" protein_refs="PH_3">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="1"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="score_type" higher_score_better="false" significance_threshold="42.2999992370605" >
 		<PeptideHit score="4324.433" sequence="FCC" charge="23" aa_after="Y" protein_refs="PH_5">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="2"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="3">
-		<map id="0" name="FeatureLinkerUnlabeled_1_input1.featureXML" unique_id="3189043221343374669" label="" size="21">
+		<map id="0" name="UNKNOWN" unique_id="3189043221343374669" label="" size="21">
 		</map>
-		<map id="1" name="FeatureLinkerUnlabeled_1_input2.featureXML" unique_id="17129849834928765316" label="" size="20">
+		<map id="1" name="UNKNOWN" unique_id="17129849834928765316" label="" size="20">
 		</map>
-		<map id="2" name="FeatureLinkerUnlabeled_1_input3.featureXML" unique_id="4826876609996876827" label="" size="24">
+		<map id="2" name="UNKNOWN" unique_id="4826876609996876827" label="" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="0" charge="3">
-			<centroid rt="656.405" mz="537.243" it="1.32679e+08"/>
+		<consensusElement id="e_15157403601844400700" quality="0.0" charge="3">
+			<centroid rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08"/>
 			<groupedElementList>
-				<element map="2" id="1966557505224183820" rt="656.405" mz="537.243" it="1.32679e+08" charge="3"/>
+				<element map="2" id="1966557505224183820" rt="656.404999999999973" mz="537.243000000000052" it="1.32679e08" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ACC" charge="3" protein_refs="PH_4">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="sequence" value="SHCIAEVEK"/>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="0" charge="1">
-			<centroid rt="638.468" mz="537.243" it="2.10227e+08"/>
+		<consensusElement id="e_6408859317243173796" quality="0.0" charge="1">
+			<centroid rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08"/>
 			<groupedElementList>
-				<element map="0" id="12975660629189576601" rt="638.468" mz="537.243" it="2.10227e+08" charge="1"/>
+				<element map="0" id="12975660629189576601" rt="638.467999999999961" mz="537.243000000000052" it="2.10227e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="AAA" charge="3" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="sequence" value="SHCIAEVEK"/>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0" charge="2">
-			<centroid rt="640.822" mz="537.243" it="3.46578e+08"/>
+		<consensusElement id="e_474525871221756682" quality="0.0" charge="2">
+			<centroid rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08"/>
 			<groupedElementList>
-				<element map="1" id="757269036628510515" rt="640.822" mz="537.243" it="3.46578e+08" charge="2"/>
+				<element map="1" id="757269036628510515" rt="640.822000000000003" mz="537.243000000000052" it="3.46578e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="ADD" charge="3" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="sequence" value="SHCIAEVEK"/>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0.99974" charge="2">
-			<centroid rt="1009.2" mz="642.352" it="2.4297e+08"/>
+		<consensusElement id="e_12999979801269632061" quality="0.99974" charge="2">
+			<centroid rt="1009.200000000000045" mz="642.351999999999975" it="2.4297e08"/>
 			<groupedElementList>
-				<element map="1" id="8721009512267762600" rt="1006.93" mz="642.352" it="2.64687e+08" charge="3"/>
-				<element map="2" id="15743766982953332227" rt="1011.47" mz="642.352" it="2.21253e+08" charge="2"/>
+				<element map="1" id="8721009512267762600" rt="1006.92999999999995" mz="642.351999999999975" it="2.64687e08" charge="3"/>
+				<element map="2" id="15743766982953332227" rt="1011.470000000000027" mz="642.351999999999975" it="2.21253e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0.982374" charge="2">
-			<centroid rt="875.638" mz="653.354" it="2.67572e+08"/>
+		<consensusElement id="e_17413765565443951891" quality="0.982374" charge="2">
+			<centroid rt="875.638000000000034" mz="653.354000000000042" it="2.67572e08"/>
 			<groupedElementList>
-				<element map="1" id="9947115975316200578" rt="856.941" mz="653.354" it="1.52129e+08" charge="2"/>
-				<element map="2" id="1045454825286354924" rt="894.335" mz="653.354" it="3.83015e+08" charge="2"/>
+				<element map="1" id="9947115975316200578" rt="856.941000000000031" mz="653.354000000000042" it="1.52129e08" charge="2"/>
+				<element map="2" id="1045454825286354924" rt="894.335000000000036" mz="653.354000000000042" it="3.83015e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0" charge="2">
-			<centroid rt="1114.9" mz="710.835" it="2.71023e+08"/>
+		<consensusElement id="e_2927519776102075938" quality="0.0" charge="2">
+			<centroid rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08"/>
 			<groupedElementList>
-				<element map="2" id="8585306356694916618" rt="1114.9" mz="710.835" it="2.71023e+08" charge="2"/>
+				<element map="2" id="8585306356694916618" rt="1114.900000000000091" mz="710.835000000000036" it="2.71023e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="SLHTLFGDELCK"/>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0.998808" charge="2">
-			<centroid rt="561.762" mz="733.275" it="2.08168e+08"/>
+		<consensusElement id="e_16907355690727166316" quality="0.998808" charge="2">
+			<centroid rt="561.761999999999944" mz="733.274999999999977" it="2.08168e08"/>
 			<groupedElementList>
-				<element map="0" id="2744661845964701343" rt="566.639" mz="733.275" it="1.6889e+08" charge="2"/>
-				<element map="2" id="13955064838748220845" rt="556.885" mz="733.275" it="2.47446e+08" charge="2"/>
+				<element map="0" id="2744661845964701343" rt="566.63900000000001" mz="733.274999999999977" it="1.6889e08" charge="2"/>
+				<element map="2" id="13955064838748220845" rt="556.884999999999991" mz="733.274999999999977" it="2.47446e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0.999342" charge="2">
-			<centroid rt="785.3975" mz="778.315" it="3.35197e+08"/>
+		<consensusElement id="e_10306100746905639127" quality="0.999342" charge="2">
+			<centroid rt="785.397500000000036" mz="778.315000000000055" it="3.351965e08"/>
 			<groupedElementList>
-				<element map="1" id="5923487873389524717" rt="788.996" mz="778.315" it="2.97395e+08" charge="2"/>
-				<element map="2" id="9588482092062192060" rt="781.799" mz="778.315" it="3.72998e+08" charge="2"/>
+				<element map="1" id="5923487873389524717" rt="788.995999999999981" mz="778.315000000000055" it="2.97395e08" charge="2"/>
+				<element map="2" id="9588482092062192060" rt="781.798999999999978" mz="778.315000000000055" it="3.72998e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0.9952" charge="2">
-			<centroid rt="824.473333333333" mz="789.372" it="2.19646e+08"/>
+		<consensusElement id="e_12524258085768770586" quality="0.9952" charge="2">
+			<centroid rt="824.473333333333358" mz="789.371999999999957" it="2.19646e08"/>
 			<groupedElementList>
-				<element map="0" id="7002570642037352670" rt="812.972" mz="789.372" it="2.23649e+08" charge="2"/>
-				<element map="1" id="9891393289043950297" rt="820.435" mz="789.372" it="2.36463e+08" charge="2"/>
-				<element map="2" id="17528243079730408472" rt="840.013" mz="789.372" it="1.98826e+08" charge="2"/>
+				<element map="0" id="7002570642037352670" rt="812.97199999999998" mz="789.371999999999957" it="2.23649e08" charge="2"/>
+				<element map="1" id="9891393289043950297" rt="820.434999999999945" mz="789.371999999999957" it="2.36463e08" charge="2"/>
+				<element map="2" id="17528243079730408472" rt="840.013000000000034" mz="789.371999999999957" it="1.98826e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0" charge="2">
-			<centroid rt="836.541" mz="876.804" it="4.39745e+08"/>
+		<consensusElement id="e_1755235105885170967" quality="0.0" charge="2">
+			<centroid rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08"/>
 			<groupedElementList>
-				<element map="0" id="15776542383322853081" rt="836.541" mz="876.804" it="4.39745e+08" charge="2"/>
+				<element map="0" id="15776542383322853081" rt="836.541000000000054" mz="876.803999999999974" it="4.39745e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="ECCHGDLLECADDR"/>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0" charge="1">
-			<centroid rt="817.266" mz="922.481" it="2.63046e+08"/>
+		<consensusElement id="e_14811341817612382122" quality="0.0" charge="1">
+			<centroid rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08"/>
 			<groupedElementList>
-				<element map="2" id="17198512653051715988" rt="817.266" mz="922.481" it="2.63046e+08" charge="1"/>
+				<element map="2" id="17198512653051715988" rt="817.265999999999963" mz="922.480999999999995" it="2.63046e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="AEFVEVTK"/>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.993131" charge="2">
-			<centroid rt="924.713" mz="941.449" it="2.06357e+08"/>
+		<consensusElement id="e_2684106197423007927" quality="0.993131" charge="2">
+			<centroid rt="924.713000000000079" mz="941.448999999999955" it="2.063567e08"/>
 			<groupedElementList>
-				<element map="0" id="12561597102443082088" rt="922.64" mz="941.449" it="2.15944e+08" charge="2"/>
-				<element map="1" id="12352437987179506182" rt="908.712" mz="941.449" it="1.25569e+08" charge="2"/>
-				<element map="2" id="114882254392289457" rt="942.787" mz="941.449" it="2.77557e+08" charge="2"/>
+				<element map="0" id="12561597102443082088" rt="922.639999999999986" mz="941.448999999999955" it="2.15944e08" charge="2"/>
+				<element map="1" id="12352437987179506182" rt="908.711999999999989" mz="941.448999999999955" it="1.25569e08" charge="2"/>
+				<element map="2" id="114882254392289457" rt="942.787000000000035" mz="941.448999999999955" it="2.77557e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2927519776102075938" quality="0.999532" charge="2">
-			<centroid rt="1300.965" mz="944.96" it="2.75438e+08"/>
+		<consensusElement id="e_8119044117483804262" quality="0.999532" charge="2">
+			<centroid rt="1300.965000000000146" mz="944.960000000000036" it="2.754385e08"/>
 			<groupedElementList>
-				<element map="1" id="6122245384109454407" rt="1297.92" mz="944.96" it="3.20176e+08" charge="2"/>
-				<element map="2" id="6916883853867664495" rt="1304.01" mz="944.96" it="2.30701e+08" charge="2"/>
+				<element map="1" id="6122245384109454407" rt="1297.920000000000073" mz="944.960000000000036" it="3.20176e08" charge="2"/>
+				<element map="2" id="6916883853867664495" rt="1304.009999999999991" mz="944.960000000000036" it="2.30701e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0.877351" charge="2">
-			<centroid rt="1241.715" mz="954.949" it="2.3003e+08"/>
+		<consensusElement id="e_17314619952666245179" quality="0.877351" charge="2">
+			<centroid rt="1241.715000000000146" mz="954.948999999999955" it="2.3003e08"/>
 			<groupedElementList>
-				<element map="1" id="7894280344941030689" rt="1192.41" mz="954.949" it="1.93777e+08" charge="2"/>
-				<element map="2" id="8160584573194146770" rt="1291.02" mz="954.949" it="2.66283e+08" charge="2"/>
+				<element map="1" id="7894280344941030689" rt="1192.410000000000082" mz="954.948999999999955" it="1.93777e08" charge="2"/>
+				<element map="2" id="8160584573194146770" rt="1291.019999999999982" mz="954.948999999999955" it="2.66283e08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.96063" charge="1">
-			<centroid rt="1004.22566666667" mz="1014.61" it="3.16178e+08"/>
+		<consensusElement id="e_3023658190814908261" quality="0.96063" charge="1">
+			<centroid rt="1004.225666666666598" mz="1014.610000000000014" it="3.161777e08"/>
 			<groupedElementList>
-				<element map="0" id="2905807036779206701" rt="963.927" mz="1014.61" it="3.71373e+08" charge="1"/>
-				<element map="1" id="6253636756564533798" rt="1005.49" mz="1014.61" it="2.35017e+08" charge="1"/>
-				<element map="2" id="836885712912035377" rt="1043.26" mz="1014.61" it="3.42143e+08" charge="1"/>
+				<element map="0" id="2905807036779206701" rt="963.927000000000021" mz="1014.610000000000014" it="3.71373e08" charge="1"/>
+				<element map="1" id="6253636756564533798" rt="1005.490000000000009" mz="1014.610000000000014" it="2.35017e08" charge="1"/>
+				<element map="2" id="836885712912035377" rt="1043.259999999999991" mz="1014.610000000000014" it="3.42143e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0" charge="1">
-			<centroid rt="796.474" mz="1108.49" it="6.83877e+07"/>
+		<consensusElement id="e_7898004582401008768" quality="0.0" charge="1">
+			<centroid rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07"/>
 			<groupedElementList>
-				<element map="2" id="6004004326366812857" rt="796.474" mz="1108.49" it="6.83877e+07" charge="1"/>
+				<element map="2" id="6004004326366812857" rt="796.474000000000046" mz="1108.490000000000009" it="6.838769e07" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="EACFAVEGPK"/>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0.999798" charge="1">
-			<centroid rt="1035.53" mz="1163.62" it="2.14078e+08"/>
+		<consensusElement id="e_15050004366391181853" quality="0.999798" charge="1">
+			<centroid rt="1035.529999999999973" mz="1163.619999999999891" it="2.140775e08"/>
 			<groupedElementList>
-				<element map="0" id="9150379013440122717" rt="1037.54" mz="1163.62" it="1.34898e+08" charge="1"/>
-				<element map="1" id="340792039157394434" rt="1033.52" mz="1163.62" it="2.93257e+08" charge="1"/>
+				<element map="0" id="9150379013440122717" rt="1037.539999999999964" mz="1163.619999999999891" it="1.34898e08" charge="1"/>
+				<element map="1" id="340792039157394434" rt="1033.519999999999982" mz="1163.619999999999891" it="2.93257e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XDD" charge="3" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="1"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0" charge="2">
-			<centroid rt="1531.86" mz="1247.12" it="2.34128e+08"/>
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="2">
+			<centroid rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08"/>
 			<groupedElementList>
-				<element map="2" id="6589589462220824505" rt="1531.86" mz="1247.12" it="2.34128e+08" charge="2"/>
+				<element map="2" id="6589589462220824505" rt="1531.8599999999999" mz="1247.119999999999891" it="2.34128e08" charge="2"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="GLVLIAFSQYLQQCPFDEHVK"/>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0" charge="1">
-			<centroid rt="979.852" mz="1283.7" it="3.13719e+08"/>
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="1">
+			<centroid rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08"/>
 			<groupedElementList>
-				<element map="0" id="5133610492701656310" rt="979.852" mz="1283.7" it="3.13719e+08" charge="1"/>
+				<element map="0" id="5133610492701656310" rt="979.851999999999976" mz="1283.700000000000046" it="3.13719e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="HPEYAVSVLLR"/>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0" charge="1">
-			<centroid rt="875.319" mz="1305.71" it="2.96944e+08"/>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="1">
+			<centroid rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08"/>
 			<groupedElementList>
-				<element map="0" id="13635893658662189107" rt="875.319" mz="1305.71" it="2.96944e+08" charge="1"/>
+				<element map="0" id="13635893658662189107" rt="875.31899999999996" mz="1305.710000000000036" it="2.96944e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="HLVDEPQNLIK"/>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0.991608" charge="1">
-			<centroid rt="1211.96333333333" mz="1399.69" it="2.24143e+08"/>
+		<consensusElement id="e_7276556891837796968" quality="0.991608" charge="1">
+			<centroid rt="1211.963333333333367" mz="1399.689999999999827" it="2.241427e08"/>
 			<groupedElementList>
-				<element map="0" id="4484104107431321453" rt="1202.52" mz="1399.69" it="2.3497e+08" charge="1"/>
-				<element map="1" id="17796243954070685414" rt="1199.42" mz="1399.69" it="3.17631e+08" charge="1"/>
-				<element map="2" id="8262010749831112791" rt="1233.95" mz="1399.69" it="1.19827e+08" charge="1"/>
+				<element map="0" id="4484104107431321453" rt="1202.519999999999982" mz="1399.690000000000055" it="2.3497e08" charge="1"/>
+				<element map="1" id="17796243954070685414" rt="1199.420000000000073" mz="1399.690000000000055" it="3.17631e08" charge="1"/>
+				<element map="2" id="8262010749831112791" rt="1233.950000000000046" mz="1399.690000000000055" it="1.19827e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0.99151" charge="1">
-			<centroid rt="1049.535" mz="1420.67" it="2.27286e+08"/>
+		<consensusElement id="e_1147219038608936718" quality="0.99151" charge="1">
+			<centroid rt="1049.534999999999855" mz="1420.670000000000073" it="2.272865e08"/>
 			<groupedElementList>
-				<element map="0" id="16829067224526334546" rt="1062.54" mz="1420.67" it="2.58532e+08" charge="1"/>
-				<element map="1" id="8816901613822006667" rt="1036.53" mz="1420.67" it="1.96041e+08" charge="1"/>
+				<element map="0" id="16829067224526334546" rt="1062.539999999999964" mz="1420.670000000000073" it="2.58532e08" charge="1"/>
+				<element map="1" id="8816901613822006667" rt="1036.529999999999973" mz="1420.670000000000073" it="1.96041e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0.994553" charge="1">
-			<centroid rt="761.192" mz="1444.62" it="3.48902e+08"/>
+		<consensusElement id="e_11115414975438642789" quality="0.994553" charge="1">
+			<centroid rt="761.192000000000007" mz="1444.619999999999891" it="3.489015e08"/>
 			<groupedElementList>
-				<element map="0" id="892598954651927234" rt="750.768" mz="1444.62" it="3.03992e+08" charge="1"/>
-				<element map="2" id="10410627859860728742" rt="771.616" mz="1444.62" it="3.93811e+08" charge="1"/>
+				<element map="0" id="892598954651927234" rt="750.768000000000029" mz="1444.619999999999891" it="3.03992e08" charge="1"/>
+				<element map="2" id="10410627859860728742" rt="771.615999999999986" mz="1444.619999999999891" it="3.93811e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XCC" charge="3" protein_refs="PH_4">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="2"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0" charge="1">
-			<centroid rt="542.407" mz="1465.55" it="2.43214e+08"/>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="1">
+			<centroid rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08"/>
 			<groupedElementList>
-				<element map="1" id="15025931485506509003" rt="542.407" mz="1465.55" it="2.43214e+08" charge="1"/>
+				<element map="1" id="15025931485506509003" rt="542.407000000000039" mz="1465.549999999999955" it="2.43214e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="TCVADESHAGCEK"/>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0.924293" charge="1">
-			<centroid rt="1197.24" mz="1479.79" it="3.46508e+08"/>
+		<consensusElement id="e_13424404046998308790" quality="0.924293" charge="1">
+			<centroid rt="1197.239999999999782" mz="1479.789999999999964" it="3.465075e08"/>
 			<groupedElementList>
-				<element map="1" id="18077057999411630341" rt="1158.36" mz="1479.79" it="3.762e+08" charge="1"/>
-				<element map="2" id="4653369483890906761" rt="1236.12" mz="1479.79" it="3.16815e+08" charge="1"/>
+				<element map="1" id="18077057999411630341" rt="1158.3599999999999" mz="1479.789999999999964" it="3.762e08" charge="1"/>
+				<element map="2" id="4653369483890906761" rt="1236.119999999999891" mz="1479.789999999999964" it="3.16815e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0.954008" charge="1">
-			<centroid rt="838.689333333333" mz="1504.57" it="2.57013e+08"/>
+		<consensusElement id="e_12665713047548007769" quality="0.954008" charge="1">
+			<centroid rt="838.689333333333366" mz="1504.569999999999936" it="2.570133e08"/>
 			<groupedElementList>
-				<element map="0" id="11819683491843153899" rt="806.797" mz="1504.57" it="2.60293e+08" charge="1"/>
-				<element map="1" id="510828531039388399" rt="821.924" mz="1504.57" it="1.45679e+08" charge="1"/>
-				<element map="2" id="16395201437334876064" rt="887.347" mz="1504.57" it="3.65068e+08" charge="1"/>
+				<element map="0" id="11819683491843153899" rt="806.797000000000026" mz="1504.569999999999936" it="2.60293e08" charge="1"/>
+				<element map="1" id="510828531039388399" rt="821.923999999999978" mz="1504.569999999999936" it="1.45679e08" charge="1"/>
+				<element map="2" id="16395201437334876064" rt="887.34699999999998" mz="1504.569999999999936" it="3.65068e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0.943733" charge="1">
-			<centroid rt="921.7225" mz="1511.84" it="1.8723e+08"/>
+		<consensusElement id="e_17092894204355333314" quality="0.943733" charge="1">
+			<centroid rt="921.722500000000082" mz="1511.839999999999918" it="1.872305e08"/>
 			<groupedElementList>
-				<element map="0" id="5356901381920669764" rt="888.197" mz="1511.84" it="1.08185e+08" charge="1"/>
-				<element map="2" id="389001383939275187" rt="955.248" mz="1511.84" it="2.66276e+08" charge="1"/>
+				<element map="0" id="5356901381920669764" rt="888.197000000000003" mz="1511.839999999999918" it="1.08185e08" charge="1"/>
+				<element map="2" id="389001383939275187" rt="955.248000000000047" mz="1511.839999999999918" it="2.66276e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0" charge="1">
-			<centroid rt="786.15" mz="1555.63" it="1.86424e+08"/>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="1">
+			<centroid rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08"/>
 			<groupedElementList>
-				<element map="0" id="9201749952666825017" rt="786.15" mz="1555.63" it="1.86424e+08" charge="1"/>
+				<element map="0" id="9201749952666825017" rt="786.149999999999977" mz="1555.630000000000109" it="1.86424e08" charge="1"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="" higher_score_better="true" significance_threshold="31.8621006011963" MZ="1001" RT="90" >
 				<PeptideHit score="35" sequence="XAA" charge="3" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="sequence" value="DDPHACYSTVFDK"/>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0.844874" charge="1">
-			<centroid rt="1360.13" mz="1567.74" it="2.60468e+08"/>
+		<consensusElement id="e_10627069796380146481" quality="0.844874" charge="1">
+			<centroid rt="1360.130000000000109" mz="1567.740000000000009" it="2.604675e08"/>
 			<groupedElementList>
-				<element map="0" id="898063321445019845" rt="1304.43" mz="1567.74" it="3.00518e+08" charge="1"/>
-				<element map="2" id="10053481325799554694" rt="1415.83" mz="1567.74" it="2.20417e+08" charge="1"/>
+				<element map="0" id="898063321445019845" rt="1304.430000000000064" mz="1567.740000000000009" it="3.00518e08" charge="1"/>
+				<element map="2" id="10053481325799554694" rt="1415.829999999999927" mz="1567.740000000000009" it="2.20417e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0.988307" charge="1">
-			<centroid rt="1267.61666666667" mz="1725.81" it="3.19362e+08"/>
+		<consensusElement id="e_10052793688680741109" quality="0.988307" charge="1">
+			<centroid rt="1267.616666666666561" mz="1725.810000000000173" it="3.193617e08"/>
 			<groupedElementList>
-				<element map="0" id="3811900024087146945" rt="1250.54" mz="1725.81" it="2.45958e+08" charge="1"/>
-				<element map="1" id="3477191243131983109" rt="1260.04" mz="1725.81" it="3.674e+08" charge="1"/>
-				<element map="2" id="866116738649891337" rt="1292.27" mz="1725.81" it="3.44727e+08" charge="1"/>
+				<element map="0" id="3811900024087146945" rt="1250.539999999999964" mz="1725.809999999999945" it="2.45958e08" charge="1"/>
+				<element map="1" id="3477191243131983109" rt="1260.039999999999964" mz="1725.809999999999945" it="3.674e08" charge="1"/>
+				<element map="2" id="866116738649891337" rt="1292.269999999999982" mz="1725.809999999999945" it="3.44727e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0.990237" charge="1">
-			<centroid rt="822.757333333333" mz="1749.67" it="3.02481e+08"/>
+		<consensusElement id="e_15166508592180818156" quality="0.990238" charge="1">
+			<centroid rt="822.757333333333349" mz="1749.670000000000073" it="3.02481e08"/>
 			<groupedElementList>
-				<element map="0" id="11259143081880763675" rt="806.443" mz="1749.67" it="3.57962e+08" charge="1"/>
-				<element map="1" id="8781789908765837138" rt="818.552" mz="1749.67" it="3.67003e+08" charge="1"/>
-				<element map="2" id="5572181956708182284" rt="843.277" mz="1749.67" it="1.82478e+08" charge="1"/>
+				<element map="0" id="11259143081880763675" rt="806.442999999999984" mz="1749.670000000000073" it="3.57962e08" charge="1"/>
+				<element map="1" id="8781789908765837138" rt="818.552000000000021" mz="1749.670000000000073" it="3.67003e08" charge="1"/>
+				<element map="2" id="5572181956708182284" rt="843.277000000000044" mz="1749.670000000000073" it="1.82478e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0.996381" charge="1">
-			<centroid rt="854.844" mz="1752.61" it="1.68751e+08"/>
+		<consensusElement id="e_14768204679546465715" quality="0.996381" charge="1">
+			<centroid rt="854.844000000000051" mz="1752.6099999999999" it="1.687515e08"/>
 			<groupedElementList>
-				<element map="1" id="8088443907873716601" rt="846.342" mz="1752.61" it="1.54686e+08" charge="1"/>
-				<element map="2" id="4246219713694864557" rt="863.346" mz="1752.61" it="1.82817e+08" charge="1"/>
+				<element map="1" id="8088443907873716601" rt="846.341999999999985" mz="1752.6099999999999" it="1.54686e08" charge="1"/>
+				<element map="2" id="4246219713694864557" rt="863.346000000000004" mz="1752.6099999999999" it="1.82817e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0" charge="1">
-			<centroid rt="1196.8" mz="1908.9" it="2.00984e+08"/>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
+			<centroid rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08"/>
 			<groupedElementList>
-				<element map="0" id="3903516670498486088" rt="1196.8" mz="1908.9" it="2.00984e+08" charge="1"/>
+				<element map="0" id="3903516670498486088" rt="1196.799999999999955" mz="1908.900000000000091" it="2.00984e08" charge="1"/>
 			</groupedElementList>
 			<UserParam type="string" name="sequence" value="LFTFHADICTLPDTEK"/>
 		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0.976515" charge="1">
-			<centroid rt="1081.58" mz="1955.95" it="2.33178e+08"/>
+		<consensusElement id="e_15885522598119108466" quality="0.976515" charge="1">
+			<centroid rt="1081.580000000000155" mz="1955.950000000000046" it="2.331777e08"/>
 			<groupedElementList>
-				<element map="0" id="11069861101195641174" rt="1045.19" mz="1955.95" it="2.84147e+08" charge="1"/>
-				<element map="1" id="10964759451238497927" rt="1098.74" mz="1955.95" it="1.78653e+08" charge="1"/>
-				<element map="2" id="6290963726642619139" rt="1100.81" mz="1955.95" it="2.36733e+08" charge="1"/>
+				<element map="0" id="11069861101195641174" rt="1045.190000000000055" mz="1955.950000000000046" it="2.84147e08" charge="1"/>
+				<element map="1" id="10964759451238497927" rt="1098.740000000000009" mz="1955.950000000000046" it="1.78653e08" charge="1"/>
+				<element map="2" id="6290963726642619139" rt="1100.809999999999945" mz="1955.950000000000046" it="2.36733e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0.989804" charge="1">
-			<centroid rt="1454.51" mz="2493.24" it="2.11806e+08"/>
+		<consensusElement id="e_3823858840059792698" quality="0.989804" charge="1">
+			<centroid rt="1454.509999999999991" mz="2493.239999999999782" it="2.118065e08"/>
 			<groupedElementList>
-				<element map="0" id="15457684198469067825" rt="1440.23" mz="2493.24" it="1.55069e+08" charge="1"/>
-				<element map="1" id="11001965471019981700" rt="1468.79" mz="2493.24" it="2.68544e+08" charge="1"/>
+				<element map="0" id="15457684198469067825" rt="1440.230000000000018" mz="2493.239999999999782" it="1.55069e08" charge="1"/>
+				<element map="1" id="11001965471019981700" rt="1468.789999999999964" mz="2493.239999999999782" it="2.68544e08" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FileConverter_14_output.consensusXML
+++ b/src/tests/topp/FileConverter_14_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_7765414056999294261" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_7765414056999294261" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />
@@ -399,6 +399,7 @@
 		</PeptideHit>
 		<PeptideHit score="-2.26500010490417" sequence="APAGN" charge="1" aa_before="N" aa_after="V" protein_refs="PH_172">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="114.09" RT="4149.49" >
 		<PeptideHit score="-1.75" sequence="MWN" charge="1" aa_before="T" aa_after="G" protein_refs="PH_175">
@@ -421,16 +422,17 @@
 		</PeptideHit>
 		<PeptideHit score="-2.5239999294281" sequence="TGAMA" charge="1" aa_before="L" aa_after="Y" protein_refs="PH_182">
 		</PeptideHit>
+		<UserParam type="int" name="map_index" value="0"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="1">
 		<map id="0" name="" label="" size="31">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_8350558342054392910" quality="0">
-			<centroid rt="306.58" mz="405.85" it="0"/>
+		<consensusElement id="e_8350558342054392910" quality="0.0">
+			<centroid rt="306.579999999999984" mz="405.850000000000023" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="8350558342054392910" rt="306.58" mz="405.85" it="0"/>
+				<element map="0" id="8350558342054392910" rt="306.579999999999984" mz="405.850000000000023" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="405.85" RT="306.58" >
 				<PeptideHit score="-1.65100002288818" sequence="AATY" charge="1" aa_before="L" aa_after="Q" protein_refs="PH_0">
@@ -453,18 +455,19 @@
 				</PeptideHit>
 				<PeptideHit score="-2.65199995040894" sequence="KSCS" charge="1" aa_before="S" aa_after="C" protein_refs="PH_9">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1406559801721872943" quality="0">
-			<centroid rt="306.58" mz="426.849" it="0"/>
+		<consensusElement id="e_1406559801721872943" quality="0.0">
+			<centroid rt="306.579999999999984" mz="426.84899999999999" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="1406559801721872943" rt="306.58" mz="426.849" it="0"/>
+				<element map="0" id="1406559801721872943" rt="306.579999999999984" mz="426.84899999999999" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17798387198899580015" quality="0">
-			<centroid rt="312.738" mz="484.83" it="0"/>
+		<consensusElement id="e_17798387198899580015" quality="0.0">
+			<centroid rt="312.738" mz="484.829999999999984" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="17798387198899580015" rt="312.738" mz="484.83" it="0"/>
+				<element map="0" id="17798387198899580015" rt="312.738" mz="484.829999999999984" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="484.83" RT="312.738" >
 				<PeptideHit score="-1.56599998474121" sequence="GAGGMGG" charge="1" aa_before="G" aa_after="A" protein_refs="PH_14">
@@ -487,12 +490,13 @@
 				</PeptideHit>
 				<PeptideHit score="-1.77999997138977" sequence="GAGDST" charge="1" aa_before="A" aa_after="E" protein_refs="PH_22">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_12344545729241841954" quality="0">
-			<centroid rt="312.738" mz="506.815" it="0"/>
+		<consensusElement id="e_12344545729241841954" quality="0.0">
+			<centroid rt="312.738" mz="506.814999999999998" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="12344545729241841954" rt="312.738" mz="506.815" it="0"/>
+				<element map="0" id="12344545729241841954" rt="312.738" mz="506.814999999999998" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="506.815" RT="312.738" >
 				<PeptideHit score="-2.58800005912781" sequence="SKVA" charge="1" aa_before="I" aa_after="F" protein_refs="PH_10">
@@ -503,12 +507,13 @@
 				</PeptideHit>
 				<PeptideHit score="-2.65100002288818" sequence="APDT" charge="1" aa_before="A" aa_after="T" protein_refs="PH_13">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_11920699214055941682" quality="0">
-			<centroid rt="3112.53" mz="496.244" it="0"/>
+		<consensusElement id="e_11920699214055941682" quality="0.0">
+			<centroid rt="3112.5300000000002" mz="496.244000000000028" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="11920699214055941682" rt="3112.53" mz="496.244" it="0"/>
+				<element map="0" id="11920699214055941682" rt="3112.5300000000002" mz="496.244000000000028" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="496.244" RT="3112.53" >
 				<PeptideHit score="-2.66000008583069" sequence="LYCS" charge="1" aa_before="M" aa_after="G" protein_refs="PH_23">
@@ -519,18 +524,19 @@
 				</PeptideHit>
 				<PeptideHit score="-2.72000002861023" sequence="GEIPA" charge="1" aa_before="I" aa_after="V" protein_refs="PH_26">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_4482357996615428211" quality="0">
-			<centroid rt="3840.95" mz="430.212" it="0"/>
+		<consensusElement id="e_4482357996615428211" quality="0.0">
+			<centroid rt="3840.949999999999818" mz="430.211999999999989" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="4482357996615428211" rt="3840.95" mz="430.212" it="0"/>
+				<element map="0" id="4482357996615428211" rt="3840.949999999999818" mz="430.211999999999989" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_8982977762164862963" quality="0">
-			<centroid rt="3849.22" mz="446.081" it="0"/>
+		<consensusElement id="e_8982977762164862963" quality="0.0">
+			<centroid rt="3849.2199999999998" mz="446.081000000000017" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="8982977762164862963" rt="3849.22" mz="446.081" it="0"/>
+				<element map="0" id="8982977762164862963" rt="3849.2199999999998" mz="446.081000000000017" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="446.081" RT="3849.22" >
 				<PeptideHit score="-1.2960000038147" sequence="AWGY" charge="1" aa_before="P" aa_after="S" protein_refs="PH_27">
@@ -553,18 +559,19 @@
 				</PeptideHit>
 				<PeptideHit score="-2.12100005149841" sequence="DFKS" charge="1" aa_before="T" aa_after="D" protein_refs="PH_36">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_6480306120740844650" quality="0">
-			<centroid rt="3870.67" mz="453.233" it="0"/>
+		<consensusElement id="e_6480306120740844650" quality="0.0">
+			<centroid rt="3870.670000000000073" mz="453.233000000000004" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="6480306120740844650" rt="3870.67" mz="453.233" it="0"/>
+				<element map="0" id="6480306120740844650" rt="3870.670000000000073" mz="453.233000000000004" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_5218366941595319798" quality="0">
-			<centroid rt="3880.9" mz="400.172" it="0"/>
+		<consensusElement id="e_5218366941595319798" quality="0.0">
+			<centroid rt="3880.900000000000091" mz="400.172000000000025" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="5218366941595319798" rt="3880.9" mz="400.172" it="0"/>
+				<element map="0" id="5218366941595319798" rt="3880.900000000000091" mz="400.172000000000025" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="400.172" RT="3880.9" >
 				<PeptideHit score="-2.11100006103516" sequence="AASVV" charge="1" aa_before="E" aa_after="*" protein_refs="PH_37">
@@ -587,22 +594,24 @@
 				</PeptideHit>
 				<PeptideHit score="-2.53399991989136" sequence="DIPT" charge="1" aa_before="V" aa_after="P" protein_refs="PH_46">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_5333031710178693707" quality="0">
-			<centroid rt="3892.26" mz="437.227" it="0"/>
+		<consensusElement id="e_5333031710178693707" quality="0.0">
+			<centroid rt="3892.260000000000218" mz="437.226999999999975" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="5333031710178693707" rt="3892.26" mz="437.227" it="0"/>
+				<element map="0" id="5333031710178693707" rt="3892.260000000000218" mz="437.226999999999975" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="437.227" RT="3892.26" >
 				<PeptideHit score="-2.49799990653992" sequence="AHGN" charge="1" aa_before="H" aa_after="G" protein_refs="PH_47">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_10879153961746990385" quality="0">
-			<centroid rt="3892.26" mz="526.264" it="0"/>
+		<consensusElement id="e_10879153961746990385" quality="0.0">
+			<centroid rt="3892.260000000000218" mz="526.26400000000001" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="10879153961746990385" rt="3892.26" mz="526.264" it="0"/>
+				<element map="0" id="10879153961746990385" rt="3892.260000000000218" mz="526.26400000000001" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="526.264" RT="3892.26" >
 				<PeptideHit score="-0.0359999984502792" sequence="FEPVPTAI" charge="2" aa_before="F" aa_after="R" protein_refs="PH_48">
@@ -625,18 +634,19 @@
 				</PeptideHit>
 				<PeptideHit score="-1.22200000286102" sequence="YDAHISPA" charge="2" aa_before="S" aa_after="A" protein_refs="PH_57">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_15989098223833503442" quality="0">
-			<centroid rt="3896.37" mz="416.173" it="0"/>
+		<consensusElement id="e_15989098223833503442" quality="0.0">
+			<centroid rt="3896.369999999999891" mz="416.173000000000002" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="15989098223833503442" rt="3896.37" mz="416.173" it="0"/>
+				<element map="0" id="15989098223833503442" rt="3896.369999999999891" mz="416.173000000000002" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_9906295880291651689" quality="0">
-			<centroid rt="3900.47" mz="414.206" it="0"/>
+		<consensusElement id="e_9906295880291651689" quality="0.0">
+			<centroid rt="3900.4699999999998" mz="414.206000000000017" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="9906295880291651689" rt="3900.47" mz="414.206" it="0"/>
+				<element map="0" id="9906295880291651689" rt="3900.4699999999998" mz="414.206000000000017" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="414.206" RT="3900.47" >
 				<PeptideHit score="-2.01099991798401" sequence="RMGY" charge="1" aa_before="L" aa_after="E" protein_refs="PH_58">
@@ -659,12 +669,13 @@
 				</PeptideHit>
 				<PeptideHit score="-2.40700006484985" sequence="QQRP" charge="1" aa_before="H" aa_after="I" protein_refs="PH_67">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_5887356329948937646" quality="0">
-			<centroid rt="3903.97" mz="809.894" it="0"/>
+		<consensusElement id="e_5887356329948937646" quality="0.0">
+			<centroid rt="3903.9699999999998" mz="809.894000000000006" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="5887356329948937646" rt="3903.97" mz="809.894" it="0"/>
+				<element map="0" id="5887356329948937646" rt="3903.9699999999998" mz="809.894000000000006" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="809.894" RT="3903.97" >
 				<PeptideHit score="-2.64299988746643" sequence="TYM" charge="1" aa_before="S" aa_after="R" protein_refs="PH_38">
@@ -687,12 +698,13 @@
 				</PeptideHit>
 				<PeptideHit score="-2.87299990653992" sequence="PTAAG" charge="1" aa_before="S" aa_after="E" protein_refs="PH_76">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_6094505305209605969" quality="0">
-			<centroid rt="3912.22" mz="523.229" it="0"/>
+		<consensusElement id="e_6094505305209605969" quality="0.0">
+			<centroid rt="3912.2199999999998" mz="523.229000000000042" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="6094505305209605969" rt="3912.22" mz="523.229" it="0"/>
+				<element map="0" id="6094505305209605969" rt="3912.2199999999998" mz="523.229000000000042" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="523.229" RT="3912.22" >
 				<PeptideHit score="1.97099995613098" sequence="PGDAGHTR" charge="1" aa_before="L" aa_after="V" protein_refs="PH_77">
@@ -715,12 +727,13 @@
 				</PeptideHit>
 				<PeptideHit score="1.08899998664856" sequence="AAGFWYP" charge="1" aa_before="R" aa_after="V" protein_refs="PH_86">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_18098118596553240659" quality="0">
-			<centroid rt="3940.03" mz="569.239" it="0"/>
+		<consensusElement id="e_18098118596553240659" quality="0.0">
+			<centroid rt="3940.0300000000002" mz="569.239000000000033" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="18098118596553240659" rt="3940.03" mz="569.239" it="0"/>
+				<element map="0" id="18098118596553240659" rt="3940.0300000000002" mz="569.239000000000033" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="569.239" RT="3940.03" >
 				<PeptideHit score="-1.43099999427795" sequence="HVAGAA" charge="1" aa_before="E" aa_after="F" protein_refs="PH_87">
@@ -735,34 +748,37 @@
 				</PeptideHit>
 				<PeptideHit score="-2.43799996376038" sequence="SYWA" charge="1" aa_before="Y" aa_after="D" protein_refs="PH_92">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_15652141835159938212" quality="0">
-			<centroid rt="3945.15" mz="534.233" it="0"/>
+		<consensusElement id="e_15652141835159938212" quality="0.0">
+			<centroid rt="3945.150000000000091" mz="534.232999999999947" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="15652141835159938212" rt="3945.15" mz="534.233" it="0"/>
+				<element map="0" id="15652141835159938212" rt="3945.150000000000091" mz="534.232999999999947" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="534.233" RT="3945.15" >
 				<PeptideHit score="-1.13699996471405" sequence="ANIVGP" charge="1" aa_before="F" aa_after="R" protein_refs="PH_93">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_599348512361307872" quality="0">
-			<centroid rt="3949.25" mz="583.243" it="0"/>
+		<consensusElement id="e_599348512361307872" quality="0.0">
+			<centroid rt="3949.25" mz="583.243000000000052" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="599348512361307872" rt="3949.25" mz="583.243" it="0"/>
+				<element map="0" id="599348512361307872" rt="3949.25" mz="583.243000000000052" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="583.243" RT="3949.25" >
 				<PeptideHit score="-1.92999994754791" sequence="AWKK" charge="1" aa_before="I" aa_after="T" protein_refs="PH_94">
 				</PeptideHit>
 				<PeptideHit score="-1.94900000095367" sequence="AWQK" charge="1" aa_before="A" aa_after="T" protein_refs="PH_95">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_2637402346116824200" quality="0">
-			<centroid rt="3954.38" mz="493.182" it="0"/>
+		<consensusElement id="e_2637402346116824200" quality="0.0">
+			<centroid rt="3954.380000000000109" mz="493.182000000000016" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="2637402346116824200" rt="3954.38" mz="493.182" it="0"/>
+				<element map="0" id="2637402346116824200" rt="3954.380000000000109" mz="493.182000000000016" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="493.182" RT="3954.38" >
 				<PeptideHit score="-0.857999980449677" sequence="AVPAAR" charge="1" aa_before="L" aa_after="R" protein_refs="PH_96">
@@ -785,18 +801,19 @@
 				</PeptideHit>
 				<PeptideHit score="-1.10500001907349" sequence="AVPALL" charge="1" aa_before="E" aa_after="E" protein_refs="PH_30">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_4414002922297518744" quality="0">
-			<centroid rt="3960.52" mz="479.241" it="0"/>
+		<consensusElement id="e_4414002922297518744" quality="0.0">
+			<centroid rt="3960.519999999999982" mz="479.240999999999985" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="4414002922297518744" rt="3960.52" mz="479.241" it="0"/>
+				<element map="0" id="4414002922297518744" rt="3960.519999999999982" mz="479.240999999999985" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_2915417007224777904" quality="0">
-			<centroid rt="3965.65" mz="477.237" it="0"/>
+		<consensusElement id="e_2915417007224777904" quality="0.0">
+			<centroid rt="3965.650000000000091" mz="477.237000000000023" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="2915417007224777904" rt="3965.65" mz="477.237" it="0"/>
+				<element map="0" id="2915417007224777904" rt="3965.650000000000091" mz="477.237000000000023" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="477.237" RT="3965.65" >
 				<PeptideHit score="-0.287999987602234" sequence="QRPYLGGVV" charge="2" aa_before="K" aa_after="F" protein_refs="PH_104">
@@ -819,12 +836,13 @@
 				</PeptideHit>
 				<PeptideHit score="-0.977999985218048" sequence="RISGRGRAI" charge="2" aa_before="T" aa_after="G" protein_refs="PH_112">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1125929225320899819" quality="0">
-			<centroid rt="3976.17" mz="430.225" it="0"/>
+		<consensusElement id="e_1125929225320899819" quality="0.0">
+			<centroid rt="3976.170000000000073" mz="430.225000000000023" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="1125929225320899819" rt="3976.17" mz="430.225" it="0"/>
+				<element map="0" id="1125929225320899819" rt="3976.170000000000073" mz="430.225000000000023" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="430.225" RT="3976.17" >
 				<PeptideHit score="-2.60800004005432" sequence="SQQN" charge="1" aa_before="L" aa_after="Y" protein_refs="PH_113">
@@ -833,12 +851,13 @@
 				</PeptideHit>
 				<PeptideHit score="-2.84100008010864" sequence="KQNS" charge="1" aa_before="K" aa_after="I" protein_refs="PH_115">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_14230304345525297614" quality="0">
-			<centroid rt="3984.41" mz="607.283" it="0"/>
+		<consensusElement id="e_14230304345525297614" quality="0.0">
+			<centroid rt="3984.409999999999855" mz="607.283000000000015" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="14230304345525297614" rt="3984.41" mz="607.283" it="0"/>
+				<element map="0" id="14230304345525297614" rt="3984.409999999999855" mz="607.283000000000015" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="607.283" RT="3984.41" >
 				<PeptideHit score="-0.852999985218048" sequence="EADDSSVLAIEH" charge="3" aa_before="V" aa_after="L" protein_refs="PH_116">
@@ -861,12 +880,13 @@
 				</PeptideHit>
 				<PeptideHit score="-1.09099996089935" sequence="DGHLNEAAGEFAG" charge="3" aa_before="E" aa_after="L" protein_refs="PH_124">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_5910964731362124182" quality="0">
-			<centroid rt="4002.81" mz="662.305" it="0"/>
+		<consensusElement id="e_5910964731362124182" quality="0.0">
+			<centroid rt="4002.809999999999945" mz="662.30499999999995" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="5910964731362124182" rt="4002.81" mz="662.305" it="0"/>
+				<element map="0" id="5910964731362124182" rt="4002.809999999999945" mz="662.30499999999995" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="662.305" RT="4002.81" >
 				<PeptideHit score="-1.8400000333786" sequence="MWNR" charge="1" aa_before="L" aa_after="G" protein_refs="PH_125">
@@ -875,12 +895,13 @@
 				</PeptideHit>
 				<PeptideHit score="-2.58899998664856" sequence="MWRN" charge="1" aa_before="D" aa_after="G" protein_refs="PH_127">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_12130803533387223338" quality="0">
-			<centroid rt="4046.77" mz="643.347" it="0"/>
+		<consensusElement id="e_12130803533387223338" quality="0.0">
+			<centroid rt="4046.769999999999982" mz="643.34699999999998" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="12130803533387223338" rt="4046.77" mz="643.347" it="0"/>
+				<element map="0" id="12130803533387223338" rt="4046.769999999999982" mz="643.34699999999998" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="643.347" RT="4046.77" >
 				<PeptideHit score="-0.802999973297119" sequence="SGWSAR" charge="1" aa_before="A" aa_after="R" protein_refs="PH_128">
@@ -903,12 +924,13 @@
 				</PeptideHit>
 				<PeptideHit score="-1.25100004673004" sequence="SSQGAIT" charge="1" aa_before="P" aa_after="T" protein_refs="PH_137">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_3457319091775253923" quality="0">
-			<centroid rt="4070.27" mz="624.347" it="0"/>
+		<consensusElement id="e_3457319091775253923" quality="0.0">
+			<centroid rt="4070.269999999999982" mz="624.34699999999998" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="3457319091775253923" rt="4070.27" mz="624.347" it="0"/>
+				<element map="0" id="3457319091775253923" rt="4070.269999999999982" mz="624.34699999999998" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="624.347" RT="4070.27" >
 				<PeptideHit score="-0.601999998092651" sequence="GSRGDGP" charge="1" aa_before="R" aa_after="L" protein_refs="PH_138">
@@ -931,12 +953,13 @@
 				</PeptideHit>
 				<PeptideHit score="-1.057000041008" sequence="ARGWGP" charge="1" aa_before="K" aa_after="Y" protein_refs="PH_145">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_3819428448485815653" quality="0">
-			<centroid rt="4073.35" mz="563.3" it="0"/>
+		<consensusElement id="e_3819428448485815653" quality="0.0">
+			<centroid rt="4073.349999999999909" mz="563.299999999999955" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="3819428448485815653" rt="4073.35" mz="563.3" it="0"/>
+				<element map="0" id="3819428448485815653" rt="4073.349999999999909" mz="563.299999999999955" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="563.3" RT="4073.35" >
 				<PeptideHit score="-0.71399998664856" sequence="LARVPA" charge="1" aa_before="W" aa_after="*" protein_refs="PH_146">
@@ -959,12 +982,13 @@
 				</PeptideHit>
 				<PeptideHit score="-1.52900004386902" sequence="IARTY" charge="1" aa_before="E" aa_after="R" protein_refs="PH_153">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_11485771712075315892" quality="0">
-			<centroid rt="4084.98" mz="428.222" it="0"/>
+		<consensusElement id="e_11485771712075315892" quality="0.0">
+			<centroid rt="4084.980000000000018" mz="428.22199999999998" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="11485771712075315892" rt="4084.98" mz="428.222" it="0"/>
+				<element map="0" id="11485771712075315892" rt="4084.980000000000018" mz="428.22199999999998" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="428.222" RT="4084.98" >
 				<PeptideHit score="-1.25100004673004" sequence="SRSAAA" charge="1" aa_before="G" aa_after="G" protein_refs="PH_154">
@@ -987,30 +1011,32 @@
 				</PeptideHit>
 				<PeptideHit score="-2.19700002670288" sequence="HDGFS" charge="1" aa_before="E" aa_after="L" protein_refs="PH_36">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
-		<consensusElement id="e_1069762103160952688" quality="0">
-			<centroid rt="4088.05" mz="432.838" it="0"/>
+		<consensusElement id="e_1069762103160952688" quality="0.0">
+			<centroid rt="4088.050000000000182" mz="432.838000000000022" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="1069762103160952688" rt="4088.05" mz="432.838" it="0"/>
+				<element map="0" id="1069762103160952688" rt="4088.050000000000182" mz="432.838000000000022" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10797331616286057459" quality="0">
-			<centroid rt="4101.48" mz="432.278" it="0"/>
+		<consensusElement id="e_10797331616286057459" quality="0.0">
+			<centroid rt="4101.479999999999563" mz="432.27800000000002" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="10797331616286057459" rt="4101.48" mz="432.278" it="0"/>
+				<element map="0" id="10797331616286057459" rt="4101.479999999999563" mz="432.27800000000002" it="0.0"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_10323114465236158952" quality="0">
-			<centroid rt="4149.49" mz="450.26" it="0"/>
+		<consensusElement id="e_10323114465236158952" quality="0.0">
+			<centroid rt="4149.489999999999782" mz="450.259999999999991" it="0.0"/>
 			<groupedElementList>
-				<element map="0" id="10323114465236158952" rt="4149.49" mz="450.26" it="0"/>
+				<element map="0" id="10323114465236158952" rt="4149.489999999999782" mz="450.259999999999991" it="0.0"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_0" score_type="Inspect" higher_score_better="true" significance_threshold="1" MZ="450.26" RT="4149.49" >
 				<PeptideHit score="-2.33899998664856" sequence="RDAA" charge="1" aa_before="L" aa_after="A" protein_refs="PH_173">
 				</PeptideHit>
 				<PeptideHit score="-2.40700006484985" sequence="RDSG" charge="1" aa_before="A" aa_after="S" protein_refs="PH_174">
 				</PeptideHit>
+				<UserParam type="int" name="map_index" value="0"/>
 			</PeptideIdentification>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/ProteomicsLFQ_1_out.consensusXML
+++ b/src/tests/topp/ProteomicsLFQ_1_out.consensusXML
@@ -25,11 +25,11 @@
 		<SearchParameters db="18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+1-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.05" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 			<VariableModification name="Carbamidomethyl (C)" />
 			<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="InferenceEngine" value="TOPPProteinInference"/>
-				<UserParam type="string" name="TOPPProteinInference:aggregation_method" value="maximum"/>
-				<UserParam type="int" name="TOPPProteinInference:use_shared_peptides" value="1"/>
-				<UserParam type="int" name="TOPPProteinInference:treat_charge_variants_separately" value="1"/>
-				<UserParam type="int" name="TOPPProteinInference:treat_modification_variants_separately" value="1"/>
+			<UserParam type="string" name="InferenceEngine" value="TOPPProteinInference"/>
+			<UserParam type="string" name="TOPPProteinInference:aggregation_method" value="maximum"/>
+			<UserParam type="int" name="TOPPProteinInference:use_shared_peptides" value="1"/>
+			<UserParam type="int" name="TOPPProteinInference:treat_charge_variants_separately" value="1"/>
+			<UserParam type="int" name="TOPPProteinInference:treat_modification_variants_separately" value="1"/>
 		</SearchParameters>
 		<ProteinIdentification score_type="q-value" higher_score_better="false" significance_threshold="0">
 			<ProteinHit id="PH_0" accession="tr|A9GID7|A9GID7_SORC5" score="0.25" coverage="4.40528634361233" sequence="MFELLRGAPAPALAALRVLRHRLDQRRAGEPLAVAVVSPGRAEGKTALAVRLAMTLAEAERARVLLVDGHLACPRVAATLGLRLPAHASFSEQLRRRMAGETRPLGVIAVSQSLSVLAEPSLEASYPAALHSVHFEAAMRTLRRYHDYVVIDGPPILGSGDANVIEDASDGVVLVARASLTRASSLTSAAEQLGDRRILGVVLNDVAPRPVARKRVCIDGAPAGQSA">
@@ -231,180 +231,210 @@
 		<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_7">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" spectrum_reference="spectrum=2492" >
 		<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_4">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" spectrum_reference="spectrum=2583" >
 		<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" spectrum_reference="spectrum=2475" >
 		<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_5">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" spectrum_reference="spectrum=2518" >
 		<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_5">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" spectrum_reference="spectrum=2841" >
 		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" spectrum_reference="spectrum=2880" >
 		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" spectrum_reference="spectrum=2547" >
 		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.327209472656" RT="1918.60864257812" spectrum_reference="spectrum=2791" >
 		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="616.232177734375" RT="1807.71862792969" spectrum_reference="spectrum=2599" >
 		<PeptideHit score="0.024390243902439" sequence="AAC(Carbamidomethyl)AGEAGESPEEC(Carbamidomethyl)VGPR" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.700805664062" RT="1966.28894042969" spectrum_reference="spectrum=2817" >
 		<PeptideHit score="0" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_12">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="532.240295410156" RT="1521.95227050781" spectrum_reference="spectrum=2316" >
 		<PeptideHit score="0.024390243902439" sequence="DGAGRCEAER" charge="2" aa_before="R" aa_after="L" protein_refs="PH_11">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="331.152160644531" RT="1735.58251953125" spectrum_reference="spectrum=2494" >
 		<PeptideHit score="0" sequence="ISPDFRTR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_13">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="552.744079589844" RT="1520.14294433594" spectrum_reference="spectrum=2314" >
 		<PeptideHit score="0" sequence="LAMTLAEAER" charge="2" aa_before="R" aa_after="A" protein_refs="PH_15">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="508.246765136719" RT="1672.48266601562" spectrum_reference="spectrum=2402" >
 		<PeptideHit score="0" sequence="SHCIAEVEK" charge="2" aa_before="K" aa_after="D" protein_refs="PH_9">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="421.758544921875" RT="1995.35205078125" spectrum_reference="spectrum=2856" >
 		<PeptideHit score="0" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_8">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_3" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="394.492736816406" RT="1890.35544672525" spectrum_reference="spectrum=2665" >
 		<PeptideHit score="0.0344827586206897" sequence="ALAYGMERDR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_20">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_3" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1616.5348799874" spectrum_reference="spectrum=2387" >
 		<PeptideHit score="0" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_19">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_3" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.323974609375" RT="1850.49163490269" spectrum_reference="spectrum=2638" >
 		<PeptideHit score="0" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_17">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="455.713287353516" RT="2155.63891601562" spectrum_reference="spectrum=3173" >
 		<PeptideHit score="0.0454545454545455" sequence="AGDLLFFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_30">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732208251953" RT="2013.36364746094" spectrum_reference="spectrum=2946" >
 		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="379.71484375" RT="2010.87902832031" spectrum_reference="spectrum=2941" >
 		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" spectrum_reference="spectrum=2981" >
 		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="379.715393066406" RT="2069.04321289062" spectrum_reference="spectrum=3047" >
 		<PeptideHit score="0.0344827586206897" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" spectrum_reference="spectrum=3546" >
 		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="435.910125732422" RT="2488.0380859375" spectrum_reference="spectrum=3542" >
 		<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" spectrum_reference="spectrum=2927" >
 		<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_21 PH_22 PH_23 PH_26 PH_27 PH_28 PH_29">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" spectrum_reference="spectrum=3554" >
 		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_25">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="409.209625244141" RT="2125.17431640625" spectrum_reference="spectrum=3020" >
 		<PeptideHit score="0" sequence="KM(Oxidation)NALPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_36">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="4"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="396.193115234375" RT="2159.67651367188" spectrum_reference="spectrum=3064" >
 		<PeptideHit score="0" sequence="QDLLFR" charge="2" aa_before="R X" aa_after="L X" protein_refs="PH_34 PH_35">
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
+		<UserParam type="int" name="map_index" value="4"/>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
@@ -435,9 +465,9 @@
 	</mapList>
 	<consensusElementList>
 		<consensusElement id="e_2935923263525422257" quality="0.0" charge="3">
-			<centroid rt="1523.370634117893133" mz="368.843772909670918" it="2788.027832"/>
+			<centroid rt="1523.370634117893133" mz="368.843772909671031" it="2788.046387"/>
 			<groupedElementList>
-				<element map="1" id="4021463513649428920" rt="1523.370634117893133" mz="368.843772909670918" it="2788.027832" charge="3"/>
+				<element map="1" id="4021463513649428920" rt="1523.370634117893133" mz="368.843772909671031" it="2788.046387" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832366943359" RT="1517.88525390625" spectrum_reference="spectrum=2311" >
 				<PeptideHit score="0" sequence="DGDIEAEISR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_10">
@@ -448,10 +478,10 @@
 			<UserParam type="string" name="feature_id" value="2935923263525422257"/>
 		</consensusElement>
 		<consensusElement id="e_10409195546240342212" quality="0.4906" charge="3">
-			<centroid rt="1552.032972701433209" mz="358.174576486337685" it="9.099985e05"/>
+			<centroid rt="1552.032972701433209" mz="358.174576486337685" it="9.099498e05"/>
 			<groupedElementList>
-				<element map="0" id="14317784148091680644" rt="1558.221639541818604" mz="358.174576486337685" it="1.358151e06" charge="3"/>
-				<element map="2" id="6748518772549940365" rt="1545.844305861047587" mz="358.174576486337685" it="4.618462e05" charge="3"/>
+				<element map="0" id="14317784148091680644" rt="1558.221639541818604" mz="358.174576486337685" it="1.358065e06" charge="3"/>
+				<element map="2" id="6748518772549940365" rt="1545.844305861047587" mz="358.174576486337685" it="4.618349e05" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" spectrum_reference="spectrum=2458" >
 				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_3">
@@ -488,9 +518,9 @@
 			<UserParam type="string" name="feature_id" value="2477368416748083016"/>
 		</consensusElement>
 		<consensusElement id="e_8563167430029240731" quality="0.0" charge="3">
-			<centroid rt="1717.691479978357847" mz="558.594863858504482" it="3.881571e06"/>
+			<centroid rt="1717.691479978357847" mz="558.594863858504482" it="3.881534e06"/>
 			<groupedElementList>
-				<element map="1" id="9140546320740515641" rt="1717.691479978357847" mz="558.594863858504482" it="3.881571e06" charge="3"/>
+				<element map="1" id="9140546320740515641" rt="1717.691479978357847" mz="558.594863858504482" it="3.881534e06" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="558.594543457031" RT="1725.173828125" spectrum_reference="spectrum=2476" >
 				<PeptideHit score="0" sequence="QEPERNEC(Carbamidomethyl)FLSHK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_9">
@@ -501,11 +531,11 @@
 			<UserParam type="string" name="feature_id" value="8563167430029240731"/>
 		</consensusElement>
 		<consensusElement id="e_17879691353184002386" quality="0.968095" charge="2">
-			<centroid rt="1725.339746191795939" mz="569.752618393021066" it="1.176551e07"/>
+			<centroid rt="1725.339746191795939" mz="569.752618393021066" it="1.176546e07"/>
 			<groupedElementList>
 				<element map="0" id="4835329514588776807" rt="1759.952247496006748" mz="569.752618393021066" it="2.056782e07" charge="2"/>
-				<element map="1" id="11399299100673837381" rt="1690.933087267142128" mz="569.752618393021066" it="1.103692e07" charge="2"/>
-				<element map="2" id="7138020121190169918" rt="1725.133903812239168" mz="569.752618393021066" it="3.69181e06" charge="2"/>
+				<element map="1" id="11399299100673837381" rt="1690.933087267142128" mz="569.752618393021066" it="1.10367e07" charge="2"/>
+				<element map="2" id="7138020121190169918" rt="1725.133903812239168" mz="569.752618393021066" it="3.691858e06" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" spectrum_reference="spectrum=2609" >
 				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_3">
@@ -534,11 +564,11 @@
 			<UserParam type="string" name="feature_id" value="17879691353184002386"/>
 		</consensusElement>
 		<consensusElement id="e_17757401347613427925" quality="0.956186" charge="2">
-			<centroid rt="1726.141158019428985" mz="449.744389900420913" it="2.278309e06"/>
+			<centroid rt="1726.141158019428985" mz="449.744389900420913" it="2.27826e06"/>
 			<groupedElementList>
-				<element map="0" id="7276556891837796968" rt="1781.642176761832616" mz="449.74438990042097" it="1.971638e06" charge="2"/>
-				<element map="1" id="15721057298497490036" rt="1673.962452377517366" mz="449.74438990042097" it="4.102819e06" charge="2"/>
-				<element map="2" id="276808963686810837" rt="1722.818844918936748" mz="449.74438990042097" it="7.604709e05" charge="2"/>
+				<element map="0" id="7276556891837796968" rt="1781.642176761832616" mz="449.74438990042097" it="1.971525e06" charge="2"/>
+				<element map="1" id="15721057298497490036" rt="1673.962452377517366" mz="449.74438990042097" it="4.102785e06" charge="2"/>
+				<element map="2" id="276808963686810837" rt="1722.818844918936748" mz="449.74438990042097" it="7.604711e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" spectrum_reference="spectrum=2588" >
 				<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_3">
@@ -561,10 +591,10 @@
 			<UserParam type="string" name="feature_id" value="17757401347613427925"/>
 		</consensusElement>
 		<consensusElement id="e_4349546871070693707" quality="0.464827" charge="3">
-			<centroid rt="1727.822072097351338" mz="300.165352089204305" it="1.325325e07"/>
+			<centroid rt="1727.822072097351338" mz="300.165352089204305" it="1.325309e07"/>
 			<groupedElementList>
-				<element map="0" id="893904610286969204" rt="1781.755161199008398" mz="300.165352089204305" it="1.292532e07" charge="3"/>
-				<element map="1" id="7344192187426184761" rt="1673.888982995694278" mz="300.165352089204305" it="1.358117e07" charge="3"/>
+				<element map="0" id="893904610286969204" rt="1781.755161199008398" mz="300.165352089204305" it="1.2925e07" charge="3"/>
+				<element map="1" id="7344192187426184761" rt="1673.888982995694278" mz="300.165352089204305" it="1.358118e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" spectrum_reference="spectrum=2619" >
 				<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3">
@@ -581,11 +611,11 @@
 			<UserParam type="string" name="feature_id" value="4349546871070693707"/>
 		</consensusElement>
 		<consensusElement id="e_3725296011092108785" quality="0.976134" charge="2">
-			<centroid rt="1728.548430752432978" mz="443.711267907820911" it="3.678042e07"/>
+			<centroid rt="1728.548430752432978" mz="443.711267907821082" it="3.678015e07"/>
 			<groupedElementList>
-				<element map="0" id="15004869347769368353" rt="1749.175535582311113" mz="443.711267907820911" it="6.20244e07" charge="2"/>
-				<element map="1" id="12561328592123678330" rt="1703.692170433927913" mz="443.711267907820911" it="3.474625e07" charge="2"/>
-				<element map="2" id="16987762588190708774" rt="1732.777586241060135" mz="443.711267907820911" it="1.357063e07" charge="2"/>
+				<element map="0" id="15004869347769368353" rt="1749.175535582311113" mz="443.711267907821025" it="6.202405e07" charge="2"/>
+				<element map="1" id="12561328592123678330" rt="1703.692170433927913" mz="443.711267907821025" it="3.474578e07" charge="2"/>
+				<element map="2" id="16987762588190708774" rt="1732.777586241060135" mz="443.711267907821025" it="1.357063e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" spectrum_reference="spectrum=2548" >
 				<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_3">
@@ -608,9 +638,9 @@
 			<UserParam type="string" name="feature_id" value="3725296011092108785"/>
 		</consensusElement>
 		<consensusElement id="e_4287466236848599457" quality="0.0" charge="2">
-			<centroid rt="1738.717245765771395" mz="541.24188634517111" it="1.456498e05"/>
+			<centroid rt="1738.717245765771395" mz="541.24188634517111" it="1.45653e05"/>
 			<groupedElementList>
-				<element map="2" id="3110306690676341028" rt="1738.717245765771395" mz="541.24188634517111" it="1.456498e05" charge="2"/>
+				<element map="2" id="3110306690676341028" rt="1738.717245765771395" mz="541.24188634517111" it="1.45653e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_3" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="541.241516113281" RT="1738.83692720403" spectrum_reference="spectrum=2475" >
 				<PeptideHit score="0" sequence="CC(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_17">
@@ -621,10 +651,10 @@
 			<UserParam type="string" name="feature_id" value="4287466236848599457"/>
 		</consensusElement>
 		<consensusElement id="e_3103608995878612024" quality="0.479435" charge="3">
-			<centroid rt="1743.877520074776385" mz="431.20554824377092" it="7.502512e06"/>
+			<centroid rt="1743.877520074776385" mz="431.20554824377092" it="7.502234e06"/>
 			<groupedElementList>
-				<element map="0" id="2684106197423007927" rt="1765.721442974537695" mz="431.20554824377092" it="1.240657e07" charge="3"/>
-				<element map="2" id="14426272183616168414" rt="1722.033597175015075" mz="431.20554824377092" it="2.598459e06" charge="3"/>
+				<element map="0" id="2684106197423007927" rt="1765.721442974537695" mz="431.20554824377092" it="1.240589e07" charge="3"/>
+				<element map="2" id="14426272183616168414" rt="1722.033597175015075" mz="431.20554824377092" it="2.59858e06" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" spectrum_reference="spectrum=2615" >
 				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_3">
@@ -687,9 +717,9 @@
 			<UserParam type="string" name="feature_id" value="9283548542228005819"/>
 		</consensusElement>
 		<consensusElement id="e_14976954448023685397" quality="0.0" charge="2">
-			<centroid rt="1765.461085654869748" mz="646.30468413227095" it="1.228439e06"/>
+			<centroid rt="1765.461085654869748" mz="646.30468413227095" it="1.22851e06"/>
 			<groupedElementList>
-				<element map="0" id="12524258085768770586" rt="1765.461085654869748" mz="646.30468413227095" it="1.228439e06" charge="2"/>
+				<element map="0" id="12524258085768770586" rt="1765.461085654869748" mz="646.30468413227095" it="1.22851e06" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" spectrum_reference="spectrum=2625" >
 				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_3">
@@ -706,11 +736,11 @@
 			<UserParam type="string" name="feature_id" value="14976954448023685397"/>
 		</consensusElement>
 		<consensusElement id="e_4052294204879239723" quality="0.962518" charge="2">
-			<centroid rt="1791.525739737286813" mz="487.732534471620966" it="6.794489e07"/>
+			<centroid rt="1791.525739737286813" mz="487.732534471620966" it="6.794448e07"/>
 			<groupedElementList>
-				<element map="0" id="474525871221756682" rt="1850.125290409182526" mz="487.732534471620966" it="9.063513e07" charge="2"/>
-				<element map="1" id="3689406389503231823" rt="1772.139821339987066" mz="487.732534471620966" it="8.830588e07" charge="2"/>
-				<element map="2" id="11164532998186420766" rt="1752.312107462691074" mz="487.732534471620966" it="2.489364e07" charge="2"/>
+				<element map="0" id="474525871221756682" rt="1850.125290409182526" mz="487.732534471620966" it="9.063494e07" charge="2"/>
+				<element map="1" id="3689406389503231823" rt="1772.139821339987066" mz="487.732534471620966" it="8.830524e07" charge="2"/>
+				<element map="2" id="11164532998186420766" rt="1752.312107462691074" mz="487.732534471620966" it="2.489327e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" spectrum_reference="spectrum=2769" >
 				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_3">
@@ -745,9 +775,9 @@
 			<UserParam type="string" name="feature_id" value="4052294204879239723"/>
 		</consensusElement>
 		<consensusElement id="e_14278822580076064845" quality="0.0" charge="2">
-			<centroid rt="1792.508458559750579" mz="739.765263949420955" it="6.884387e05"/>
+			<centroid rt="1792.508458559750579" mz="739.765263949421069" it="6.884174e05"/>
 			<groupedElementList>
-				<element map="1" id="7061025990090747374" rt="1792.508458559750579" mz="739.765263949420955" it="6.884387e05" charge="2"/>
+				<element map="1" id="7061025990090747374" rt="1792.508458559750579" mz="739.765263949421069" it="6.884174e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="739.765686035156" RT="1790.20324707031" spectrum_reference="spectrum=2570" >
 				<PeptideHit score="0" sequence="ETYGDMADC(Carbamidomethyl)C(Carbamidomethyl)EK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_9">
@@ -758,10 +788,10 @@
 			<UserParam type="string" name="feature_id" value="14278822580076064845"/>
 		</consensusElement>
 		<consensusElement id="e_2523775179728812781" quality="0.472916" charge="3">
-			<centroid rt="1811.235115053637628" mz="325.490781803337597" it="5.915498e07"/>
+			<centroid rt="1811.235115053637628" mz="325.490781803337597" it="5.915382e07"/>
 			<groupedElementList>
-				<element map="0" id="2927519776102075938" rt="1850.265746451289033" mz="325.490781803337597" it="6.698248e07" charge="3"/>
-				<element map="1" id="575144564576995072" rt="1772.204483655986223" mz="325.490781803337597" it="5.132749e07" charge="3"/>
+				<element map="0" id="2927519776102075938" rt="1850.265746451289033" mz="325.490781803337597" it="6.69823e07" charge="3"/>
+				<element map="1" id="575144564576995072" rt="1772.204483655986223" mz="325.490781803337597" it="5.132535e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" spectrum_reference="spectrum=2663" >
 				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_3">
@@ -778,9 +808,9 @@
 			<UserParam type="string" name="feature_id" value="2523775179728812781"/>
 		</consensusElement>
 		<consensusElement id="e_8737956799617760608" quality="0.0" charge="3">
-			<centroid rt="1834.748833270941759" mz="674.2851509018044" it="1.724392e05"/>
+			<centroid rt="1834.748833270941759" mz="674.285150901804514" it="1.724374e05"/>
 			<groupedElementList>
-				<element map="1" id="17475759268436611148" rt="1834.748833270941759" mz="674.2851509018044" it="1.724392e05" charge="3"/>
+				<element map="1" id="17475759268436611148" rt="1834.748833270941759" mz="674.285150901804514" it="1.724374e05" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="674.286315917969" RT="1832.42224121094" spectrum_reference="spectrum=2625" >
 				<PeptideHit score="0.024390243902439" sequence="VASLRETYGDM(Oxidation)ADC(Carbamidomethyl)C(Carbamidomethyl)EK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_9">
@@ -791,10 +821,10 @@
 			<UserParam type="string" name="feature_id" value="8737956799617760608"/>
 		</consensusElement>
 		<consensusElement id="e_1479160453569602855" quality="0.491104" charge="2">
-			<centroid rt="1837.250854197166973" mz="693.813928283221003" it="2.815806e05"/>
+			<centroid rt="1837.250854197166973" mz="693.813928283221003" it="2.815717e05"/>
 			<groupedElementList>
-				<element map="1" id="2067209405782217684" rt="1849.395393886169131" mz="693.813928283221003" it="2.620175e05" charge="2"/>
-				<element map="2" id="9450327747750257644" rt="1825.106314508164587" mz="693.813928283221003" it="3.011437e05" charge="2"/>
+				<element map="1" id="2067209405782217684" rt="1849.395393886169131" mz="693.813928283221003" it="2.620202e05" charge="2"/>
+				<element map="2" id="9450327747750257644" rt="1825.106314508164587" mz="693.813928283221003" it="3.011231e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="693.814819335938" RT="1846.52856445312" spectrum_reference="spectrum=2643" >
 				<PeptideHit score="0" sequence="YICDNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9">
@@ -824,10 +854,10 @@
 			<UserParam type="string" name="feature_id" value="14086301720075657476"/>
 		</consensusElement>
 		<consensusElement id="e_17798533385406028685" quality="0.486907" charge="2">
-			<centroid rt="1932.984971234705427" mz="751.810528712020982" it="9.588147e05"/>
+			<centroid rt="1932.984971234705427" mz="751.810528712021096" it="9.588147e05"/>
 			<groupedElementList>
-				<element map="1" id="11630589982317102322" rt="1920.390701033215009" mz="751.810528712020982" it="1.376247e06" charge="2"/>
-				<element map="2" id="18365384202816725379" rt="1945.579241436195844" mz="751.810528712020982" it="5.413825e05" charge="2"/>
+				<element map="1" id="11630589982317102322" rt="1920.390701033215009" mz="751.810528712021096" it="1.376247e06" charge="2"/>
+				<element map="2" id="18365384202816725379" rt="1945.579241436195844" mz="751.810528712021096" it="5.413825e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="751.809936523438" RT="1915.91174316406" spectrum_reference="spectrum=2748" >
 				<PeptideHit score="0" sequence="EYEATLEEC(Carbamidomethyl)C(Carbamidomethyl)AK" charge="2" aa_before="K" aa_after="D" protein_refs="PH_9">
@@ -844,9 +874,9 @@
 			<UserParam type="string" name="feature_id" value="17798533385406028685"/>
 		</consensusElement>
 		<consensusElement id="e_4877407491526870466" quality="0.0" charge="2">
-			<centroid rt="1942.879141971103763" mz="395.239463487570902" it="1.80147e08"/>
+			<centroid rt="1942.879141971103763" mz="395.239463487571015" it="1.801494e08"/>
 			<groupedElementList>
-				<element map="0" id="4584897071539917580" rt="1942.879141971103763" mz="395.239463487570902" it="1.80147e08" charge="2"/>
+				<element map="0" id="4584897071539917580" rt="1942.879141971103763" mz="395.239463487571015" it="1.801494e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_1" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" spectrum_reference="spectrum=2811" >
 				<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_3">
@@ -856,11 +886,11 @@
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="4877407491526870466"/>
 		</consensusElement>
-		<consensusElement id="e_5634796270667792442" quality="0.495959" charge="2">
-			<centroid rt="1951.959204563567937" mz="461.747653035420967" it="6.930613e07"/>
+		<consensusElement id="e_5634796270667792442" quality="0.495958" charge="2">
+			<centroid rt="1951.959204563567937" mz="461.747653035420967" it="6.930444e07"/>
 			<groupedElementList>
-				<element map="1" id="17287849381738438716" rt="1951.23183628886045" mz="461.747653035420967" it="8.861719e07" charge="2"/>
-				<element map="2" id="6330535588886112108" rt="1952.686572838275424" mz="461.747653035420967" it="4.999507e07" charge="2"/>
+				<element map="1" id="17287849381738438716" rt="1951.23183628886045" mz="461.747653035420967" it="8.861572e07" charge="2"/>
+				<element map="2" id="6330535588886112108" rt="1952.686572838275424" mz="461.747653035420967" it="4.999316e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="461.747375488281" RT="1948.32080078125" spectrum_reference="spectrum=2794" >
 				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9">
@@ -877,9 +907,9 @@
 			<UserParam type="string" name="feature_id" value="5634796270667792442"/>
 		</consensusElement>
 		<consensusElement id="e_17153118873428995855" quality="0.0" charge="2">
-			<centroid rt="1981.815619247727682" mz="351.204368724971005" it="3.483081e05"/>
+			<centroid rt="1981.815619247727682" mz="351.204368724971005" it="3.483088e05"/>
 			<groupedElementList>
-				<element map="1" id="13641829453453140763" rt="1981.815619247727682" mz="351.204368724971005" it="3.483081e05" charge="2"/>
+				<element map="1" id="13641829453453140763" rt="1981.815619247727682" mz="351.204368724971005" it="3.483088e05" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="351.204498291016" RT="1983.37719726562" spectrum_reference="spectrum=2840" >
 				<PeptideHit score="0" sequence="GACLLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_9">
@@ -890,9 +920,9 @@
 			<UserParam type="string" name="feature_id" value="17153118873428995855"/>
 		</consensusElement>
 		<consensusElement id="e_6330378408783783417" quality="0.0" charge="2">
-			<centroid rt="1993.808614097229111" mz="395.726522907820936" it="6914.921387"/>
+			<centroid rt="1993.808614097229111" mz="395.726522907820936" it="6914.953125"/>
 			<groupedElementList>
-				<element map="1" id="4143272592559840046" rt="1993.808614097229111" mz="395.726522907820936" it="6914.921387" charge="2"/>
+				<element map="1" id="4143272592559840046" rt="1993.808614097229111" mz="395.726522907820936" it="6914.953125" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_2" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.700927734375" RT="1989.79528808594" spectrum_reference="spectrum=2848" >
 				<PeptideHit score="0" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_12">
@@ -903,9 +933,9 @@
 			<UserParam type="string" name="feature_id" value="6330378408783783417"/>
 		</consensusElement>
 		<consensusElement id="e_8183479809560916255" quality="0.0" charge="2">
-			<centroid rt="2023.952879757459868" mz="461.747653035420967" it="1.54652e08"/>
+			<centroid rt="2023.952879757459868" mz="461.747653035420967" it="1.546597e08"/>
 			<groupedElementList>
-				<element map="3" id="8269033494178950104" rt="2023.952879757459868" mz="461.747653035420967" it="1.54652e08" charge="2"/>
+				<element map="3" id="8269033494178950104" rt="2023.952879757459868" mz="461.747653035420967" it="1.546597e08" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="461.747497558594" RT="2015.59265136719" spectrum_reference="spectrum=2950" >
 				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
@@ -922,9 +952,9 @@
 			<UserParam type="string" name="feature_id" value="8183479809560916255"/>
 		</consensusElement>
 		<consensusElement id="e_1710461392160758637" quality="0.0" charge="2">
-			<centroid rt="2072.094747027906124" mz="395.726522907820936" it="7876.618652"/>
+			<centroid rt="2072.094747027906124" mz="395.726522907820936" it="7877.71875"/>
 			<groupedElementList>
-				<element map="3" id="5790065978798102656" rt="2072.094747027906124" mz="395.726522907820936" it="7876.618652" charge="2"/>
+				<element map="3" id="5790065978798102656" rt="2072.094747027906124" mz="395.726522907820936" it="7877.71875" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.700897216797" RT="2085.73901367188" spectrum_reference="spectrum=3077" >
 				<PeptideHit score="0.0454545454545455" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_31">
@@ -935,9 +965,9 @@
 			<UserParam type="string" name="feature_id" value="1710461392160758637"/>
 		</consensusElement>
 		<consensusElement id="e_626016427783280945" quality="0.0" charge="2">
-			<centroid rt="2074.443091819254732" mz="554.26060201207099" it="3.17402e07"/>
+			<centroid rt="2074.443091819254732" mz="554.26060201207099" it="3.174019e07"/>
 			<groupedElementList>
-				<element map="3" id="11486987517808453959" rt="2074.443091819254732" mz="554.26060201207099" it="3.17402e07" charge="2"/>
+				<element map="3" id="11486987517808453959" rt="2074.443091819254732" mz="554.26060201207099" it="3.174019e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" spectrum_reference="spectrum=3097" >
 				<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
@@ -954,9 +984,9 @@
 			<UserParam type="string" name="feature_id" value="626016427783280945"/>
 		</consensusElement>
 		<consensusElement id="e_14545089398880866717" quality="0.0" charge="2">
-			<centroid rt="2089.596567615912136" mz="421.758354535420949" it="2.062206e07"/>
+			<centroid rt="2089.596567615912136" mz="421.758354535420949" it="2.062205e07"/>
 			<groupedElementList>
-				<element map="3" id="5322749189241434745" rt="2089.596567615912136" mz="421.758354535420949" it="2.062206e07" charge="2"/>
+				<element map="3" id="5322749189241434745" rt="2089.596567615912136" mz="421.758354535420949" it="2.062205e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="421.758056640625" RT="2091.08642578125" spectrum_reference="spectrum=3087" >
 				<PeptideHit score="0.0344827586206897" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_24">
@@ -966,11 +996,11 @@
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="14545089398880866717"/>
 		</consensusElement>
-		<consensusElement id="e_18251849631538333325" quality="0.496263" charge="2">
-			<centroid rt="2133.57651881922493" mz="428.234180955670922" it="3.274044e06"/>
+		<consensusElement id="e_18251849631538333325" quality="0.496264" charge="2">
+			<centroid rt="2133.57651881922493" mz="428.234180955671036" it="3.274066e06"/>
 			<groupedElementList>
-				<element map="4" id="15293352267620635047" rt="2136.810805324523244" mz="428.234180955670922" it="3.64396e06" charge="2"/>
-				<element map="5" id="14355553896400643137" rt="2130.342232313926615" mz="428.234180955670922" it="2.904127e06" charge="2"/>
+				<element map="4" id="15293352267620635047" rt="2136.810805324523244" mz="428.234180955671036" it="3.643801e06" charge="2"/>
+				<element map="5" id="14355553896400643137" rt="2130.342232313926615" mz="428.234180955671036" it="2.904332e06" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="428.234222412109" RT="2133.27758789062" spectrum_reference="spectrum=3034" >
 				<PeptideHit score="0" sequence="FVEGLYK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_33">
@@ -987,9 +1017,9 @@
 			<UserParam type="string" name="feature_id" value="18251849631538333325"/>
 		</consensusElement>
 		<consensusElement id="e_8734334354285411525" quality="0.0" charge="3">
-			<centroid rt="2194.417408158830767" mz="518.889165386937634" it="5.997949e06"/>
+			<centroid rt="2194.417408158830767" mz="518.889165386937748" it="5.997954e06"/>
 			<groupedElementList>
-				<element map="5" id="11321705335266637823" rt="2194.417408158830767" mz="518.889165386937634" it="5.997949e06" charge="3"/>
+				<element map="5" id="11321705335266637823" rt="2194.417408158830767" mz="518.889165386937748" it="5.997954e06" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_6" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="518.888854980469" RT="2194.63940429688" spectrum_reference="spectrum=2949" >
 				<PeptideHit score="0" sequence="DDPHAC(Carbamidomethyl)YSTVFDK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_37">
@@ -1000,9 +1030,9 @@
 			<UserParam type="string" name="feature_id" value="8734334354285411525"/>
 		</consensusElement>
 		<consensusElement id="e_14868461944796607728" quality="0.0" charge="3">
-			<centroid rt="2238.001169587713321" mz="499.882010688371054" it="30530.642578"/>
+			<centroid rt="2238.001169587713321" mz="499.882010688371054" it="30527.400391"/>
 			<groupedElementList>
-				<element map="4" id="6675346238472377214" rt="2238.001169587713321" mz="499.882010688371054" it="30530.642578" charge="3"/>
+				<element map="4" id="6675346238472377214" rt="2238.001169587713321" mz="499.882010688371054" it="30527.400391" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="499.880798339844" RT="2240.0859375" spectrum_reference="spectrum=3174" >
 				<PeptideHit score="0.024390243902439" sequence="DDPHACYSTVFDK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_32">
@@ -1013,10 +1043,10 @@
 			<UserParam type="string" name="feature_id" value="14868461944796607728"/>
 		</consensusElement>
 		<consensusElement id="e_12697467487414938944" quality="0.485666" charge="2">
-			<centroid rt="2242.337765575648064" mz="653.361704997970946" it="1.060555e08"/>
+			<centroid rt="2242.337765575648064" mz="653.361704997970946" it="1.06056e08"/>
 			<groupedElementList>
-				<element map="4" id="17198820827940555384" rt="2224.181259049191794" mz="653.361704997970946" it="1.269411e08" charge="2"/>
-				<element map="5" id="7063966219209930662" rt="2260.494272102104333" mz="653.361704997970946" it="8.516995e07" charge="2"/>
+				<element map="4" id="17198820827940555384" rt="2224.181259049191794" mz="653.361704997970946" it="1.269412e08" charge="2"/>
+				<element map="5" id="7063966219209930662" rt="2260.494272102104333" mz="653.361704997970946" it="8.517081e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="653.36181640625" RT="2211.3291015625" spectrum_reference="spectrum=3125" >
 				<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_32">
@@ -1045,11 +1075,11 @@
 			<UserParam type="string" name="feature_id" value="12697467487414938944"/>
 		</consensusElement>
 		<consensusElement id="e_17351069880123432645" quality="0.968209" charge="3">
-			<centroid rt="2260.942433254937896" mz="435.910228820904251" it="1.676967e07"/>
+			<centroid rt="2260.942433254937896" mz="435.910228820904251" it="1.676971e07"/>
 			<groupedElementList>
-				<element map="3" id="17480794184187398956" rt="2298.172553600013089" mz="435.910228820904251" it="2.26026e05" charge="3"/>
-				<element map="4" id="16929718536696058955" rt="2224.364794739552963" mz="435.910228820904251" it="3.150147e07" charge="3"/>
-				<element map="5" id="13058174462349305798" rt="2260.289951425247637" mz="435.910228820904251" it="1.85815e07" charge="3"/>
+				<element map="3" id="17480794184187398956" rt="2298.172553600013089" mz="435.910228820904251" it="2.260549e05" charge="3"/>
+				<element map="4" id="16929718536696058955" rt="2224.364794739552963" mz="435.910228820904251" it="3.150138e07" charge="3"/>
+				<element map="5" id="13058174462349305798" rt="2260.289951425247637" mz="435.910228820904251" it="1.85817e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" spectrum_reference="spectrum=3307" >
 				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
@@ -1077,12 +1107,12 @@
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="17351069880123432645"/>
 		</consensusElement>
-		<consensusElement id="e_9280572821339638149" quality="0.964839" charge="2">
-			<centroid rt="2277.79777736408505" mz="464.250362519471025" it="1.502992e08"/>
+		<consensusElement id="e_9280572821339638149" quality="0.96484" charge="2">
+			<centroid rt="2277.79777736408505" mz="464.250362519471025" it="1.503057e08"/>
 			<groupedElementList>
-				<element map="3" id="8416276272241661922" rt="2334.721360102528706" mz="464.250362519470968" it="2.610086e08" charge="2"/>
-				<element map="4" id="7933270947021762650" rt="2255.407456717279274" mz="464.250362519470968" it="1.152158e08" charge="2"/>
-				<element map="5" id="3429226038186940441" rt="2243.26451527244717" mz="464.250362519470968" it="7.467317e07" charge="2"/>
+				<element map="3" id="8416276272241661922" rt="2334.721360102528706" mz="464.250362519471025" it="2.610213e08" charge="2"/>
+				<element map="4" id="7933270947021762650" rt="2255.407456717279274" mz="464.250362519471025" it="1.152157e08" charge="2"/>
+				<element map="5" id="3429226038186940441" rt="2243.26451527244717" mz="464.250362519471025" it="7.468001e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="464.250213623047" RT="2321.49926757812" spectrum_reference="spectrum=3328" >
 				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
@@ -1123,10 +1153,10 @@
 			<UserParam type="string" name="feature_id" value="9280572821339638149"/>
 		</consensusElement>
 		<consensusElement id="e_14629045591043354911" quality="0.4867" charge="3">
-			<centroid rt="2313.268755076402158" mz="547.31743613990443" it="4.039545e07"/>
+			<centroid rt="2313.268755076402158" mz="547.31743613990443" it="4.039555e07"/>
 			<groupedElementList>
-				<element map="4" id="1306039369812879929" rt="2301.485282554100195" mz="547.31743613990443" it="6.220473e07" charge="3"/>
-				<element map="5" id="4169697051499708787" rt="2325.052227598704121" mz="547.31743613990443" it="1.858616e07" charge="3"/>
+				<element map="4" id="1306039369812879929" rt="2301.485282554100195" mz="547.31743613990443" it="6.220494e07" charge="3"/>
+				<element map="5" id="4169697051499708787" rt="2325.052227598704121" mz="547.31743613990443" it="1.858615e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="547.317077636719" RT="2281.44189453125" spectrum_reference="spectrum=3243" >
 				<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="R" aa_after="S" protein_refs="PH_32">
@@ -1154,11 +1184,11 @@
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="14629045591043354911"/>
 		</consensusElement>
-		<consensusElement id="e_1958179543060470692" quality="0.485249" charge="2">
-			<centroid rt="2371.16334092527768" mz="501.795134726820947" it="6.962823e07"/>
+		<consensusElement id="e_1958179543060470692" quality="0.485248" charge="2">
+			<centroid rt="2371.16334092527768" mz="501.795134726820947" it="6.963177e07"/>
 			<groupedElementList>
-				<element map="3" id="1713197315473853654" rt="2391.725500002956324" mz="501.795134726820947" it="7.701591e07" charge="2"/>
-				<element map="4" id="2652253729487148893" rt="2350.601181847599037" mz="501.795134726820947" it="6.224055e07" charge="2"/>
+				<element map="3" id="1713197315473853654" rt="2391.725500002956324" mz="501.795134726820947" it="7.702192e07" charge="2"/>
+				<element map="4" id="2652253729487148893" rt="2350.601181847599037" mz="501.795134726820947" it="6.224162e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_4" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="501.794891357422" RT="2431.52172851562" spectrum_reference="spectrum=3482" >
 				<PeptideHit score="0.0454545454545455" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_25">
@@ -1188,9 +1218,9 @@
 			<UserParam type="string" name="feature_id" value="8571969588491709856"/>
 		</consensusElement>
 		<consensusElement id="e_15364592766247890342" quality="0.0" charge="3">
-			<centroid rt="2427.530873031208103" mz="504.619115012304292" it="7.962601e05"/>
+			<centroid rt="2427.530873031208103" mz="504.619115012304292" it="7.962602e05"/>
 			<groupedElementList>
-				<element map="5" id="7215943084481145332" rt="2427.530873031208103" mz="504.619115012304292" it="7.962601e05" charge="3"/>
+				<element map="5" id="7215943084481145332" rt="2427.530873031208103" mz="504.619115012304292" it="7.962602e05" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_6" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="504.618865966797" RT="2421.07788085938" spectrum_reference="spectrum=3168" >
 				<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_37">
@@ -1201,9 +1231,9 @@
 			<UserParam type="string" name="feature_id" value="15364592766247890342"/>
 		</consensusElement>
 		<consensusElement id="e_4314556777634898838" quality="0.0" charge="3">
-			<centroid rt="2460.04595369292656" mz="627.645224415137705" it="5.109413e06"/>
+			<centroid rt="2460.04595369292656" mz="627.645224415137705" it="5.109212e06"/>
 			<groupedElementList>
-				<element map="4" id="12118934174490584131" rt="2460.04595369292656" mz="627.645224415137705" it="5.109413e06" charge="3"/>
+				<element map="4" id="12118934174490584131" rt="2460.04595369292656" mz="627.645224415137705" it="5.109212e06" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="627.646362304688" RT="2476.88061523438" spectrum_reference="spectrum=3440" >
 				<PeptideHit score="0" sequence="RPC(Carbamidomethyl)FSALTPDETYVPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_32">
@@ -1214,9 +1244,9 @@
 			<UserParam type="string" name="feature_id" value="4314556777634898838"/>
 		</consensusElement>
 		<consensusElement id="e_5251706238937085209" quality="0.0" charge="3">
-			<centroid rt="2474.847621703377627" mz="381.576298143604333" it="4.397785e07"/>
+			<centroid rt="2474.847621703377627" mz="381.576298143604333" it="4.397568e07"/>
 			<groupedElementList>
-				<element map="4" id="9681608301587048926" rt="2474.847621703377627" mz="381.576298143604333" it="4.397785e07" charge="3"/>
+				<element map="4" id="9681608301587048926" rt="2474.847621703377627" mz="381.576298143604333" it="4.397568e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="381.576354980469" RT="2494.88159179688" spectrum_reference="spectrum=3462" >
 				<PeptideHit score="0" sequence="KQTALVELLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_32">
@@ -1227,9 +1257,9 @@
 			<UserParam type="string" name="feature_id" value="5251706238937085209"/>
 		</consensusElement>
 		<consensusElement id="e_4426839943702196831" quality="0.0" charge="2">
-			<centroid rt="2475.227594120808135" mz="571.860808982021013" it="5.355857e07"/>
+			<centroid rt="2475.227594120808135" mz="571.860808982021013" it="5.355722e07"/>
 			<groupedElementList>
-				<element map="4" id="12383683518728261590" rt="2475.227594120808135" mz="571.860808982021013" it="5.355857e07" charge="2"/>
+				<element map="4" id="12383683518728261590" rt="2475.227594120808135" mz="571.860808982021013" it="5.355722e07" charge="2"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="571.860717773438" RT="2492.93994140625" spectrum_reference="spectrum=3459" >
 				<PeptideHit score="0" sequence="KQTALVELLK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_32">
@@ -1240,9 +1270,9 @@
 			<UserParam type="string" name="feature_id" value="4426839943702196831"/>
 		</consensusElement>
 		<consensusElement id="e_9569484589158075318" quality="0.0" charge="3">
-			<centroid rt="2488.240274421161303" mz="480.608772593904405" it="1.25568e07"/>
+			<centroid rt="2488.240274421161303" mz="480.608772593904405" it="1.255644e07"/>
 			<groupedElementList>
-				<element map="4" id="655481111622903641" rt="2488.240274421161303" mz="480.608772593904405" it="1.25568e07" charge="3"/>
+				<element map="4" id="655481111622903641" rt="2488.240274421161303" mz="480.608772593904405" it="1.255644e07" charge="3"/>
 			</groupedElementList>
 			<PeptideIdentification identification_run_ref="PI_5" score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="480.608703613281" RT="2412.92065429688" spectrum_reference="spectrum=3369" >
 				<PeptideHit score="0" sequence="RHPEYAVSVLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_32">

--- a/src/topp/FeatureLinkerBase.cpp
+++ b/src/topp/FeatureLinkerBase.cpp
@@ -207,7 +207,7 @@ protected:
         // associate mzML file with map i in consensusXML
         if (ms_runs.size() > 1 || ms_runs.empty())
         {
-          OPENMS_LOG_WARN << "Exactly one MS runs should be associated with a FeatureMap. " 
+          OPENMS_LOG_WARN << "Exactly one MS run should be associated with a FeatureMap. "
             << ms_runs.size() 
             << " provided." << endl;
         }
@@ -282,6 +282,9 @@ protected:
     }
     else
     {
+      //TODO isn't it better to have this option/functionality in the FeatureGroupingAlgorithm class?
+      // Otherwise everyone has to remember e.g. to annotate the old map_index etc.
+      bool keep_subelements = getFlag_("keep_subelements");
       vector<ConsensusMap> maps(ins.size());
       ConsensusXMLFile f;
       for (Size i = 0; i < ins.size(); ++i)
@@ -292,12 +295,21 @@ protected:
         StringList ms_runs;
         maps[i].getPrimaryMSRunPath(ms_runs);
         ms_run_locations.insert(ms_run_locations.end(), ms_runs.begin(), ms_runs.end());
+        if (keep_subelements)
+        {
+          std::function<void (PeptideIdentification &)> saveOldMapIndex = [](PeptideIdentification& p)
+              {
+                //TODO check existence first. but fail if not present
+                p.setMetaValue("old_map_index", p.getMetaValue("map_index"));
+              };
+          maps[i].applyFunctionOnPeptideIDs(saveOldMapIndex, true);
+        }
       }
       // group
       algorithm->group(maps, out_map);
 
       // set file descriptions:
-      bool keep_subelements = getFlag_("keep_subelements");
+
       if (!keep_subelements)
       {
         for (Size i = 0; i < ins.size(); ++i)

--- a/src/topp/FeatureLinkerBase.cpp
+++ b/src/topp/FeatureLinkerBase.cpp
@@ -297,11 +297,19 @@ protected:
         ms_run_locations.insert(ms_run_locations.end(), ms_runs.begin(), ms_runs.end());
         if (keep_subelements)
         {
-          std::function<void (PeptideIdentification &)> saveOldMapIndex = [](PeptideIdentification& p)
+          std::function<void(PeptideIdentification &)> saveOldMapIndex =
+            [](PeptideIdentification &p)
+            {
+              if (p.metaValueExists("map_index"))
               {
-                //TODO check existence first. but fail if not present
                 p.setMetaValue("old_map_index", p.getMetaValue("map_index"));
-              };
+              }
+              else
+              {
+                OPENMS_LOG_WARN << "Warning: map_index not found in PeptideID. The tool will not be able to assign a"
+                                   "consistent one. Check the settings of previous tools." << std::endl;
+              }
+            };
           maps[i].applyFunctionOnPeptideIDs(saveOldMapIndex, true);
         }
       }

--- a/src/topp/FeatureLinkerUnlabeled.cpp
+++ b/src/topp/FeatureLinkerUnlabeled.cpp
@@ -222,14 +222,20 @@ protected:
             tmp_map.getProteinIdentifications().end());
 
           // add unassigned peptide identifications to result map
-          dummy.getUnassignedPeptideIdentifications().insert(
-            dummy.getUnassignedPeptideIdentifications().end(),
-            tmp_map.getUnassignedPeptideIdentifications().begin(),
-            tmp_map.getUnassignedPeptideIdentifications().end());
+          auto& newIDs = dummy.getUnassignedPeptideIdentifications();
+          for (const PeptideIdentification& pepID : tmp_map.getUnassignedPeptideIdentifications())
+          {
+            auto newPepID = pepID;
+            //TODO during linking of consensusMaps we have the problem that old identifications
+            // already have a map_index associated. Since we link the consensusFeatures only anyway
+            // (without keeping the subfeatures) it should be ok for now to "re"-index
+            newPepID.setMetaValue("map_index", i);
+            newIDs.push_back(newPepID);
+          }
         }
         else
         {
-          // copy the meta-data from the refernce map
+          // copy the meta-data from the reference map
           dummy.getColumnHeaders()[i].filename = ins[i];
           dummy.getColumnHeaders()[i].size = ref_size;
           dummy.getColumnHeaders()[i].unique_id = ref_id;
@@ -241,10 +247,16 @@ protected:
             ref_protids.end());
 
           // add unassigned peptide identifications to result map
-          dummy.getUnassignedPeptideIdentifications().insert(
-            dummy.getUnassignedPeptideIdentifications().end(),
-            ref_pepids.begin(),
-            ref_pepids.end());
+          auto& newIDs = dummy.getUnassignedPeptideIdentifications();
+          for (const PeptideIdentification& pepID : ref_pepids)
+          {
+            auto newPepID = pepID;
+            //TODO during linking of consensusMaps we have the problem that old identifications
+            // already have a map_index associated. Since we link the consensusFeatures only anyway
+            // (without keeping the subfeatures) it should be ok for now to "re"-index
+            newPepID.setMetaValue("map_index", i);
+            newIDs.push_back(newPepID);
+          }
         }
       }
 

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -847,6 +847,10 @@ protected:
       {
         MapConversion::convert(0, exp, cm, exp.size());
       }
+      for (auto& pepID : cm.getUnassignedPeptideIdentifications())
+      {
+        pepID.setMetaValue("map_index", 0);
+      }
 
       addDataProcessing_(cm, getProcessingInfo_(DataProcessing::
                                                 FORMAT_CONVERSION));


### PR DESCRIPTION
and fix indices for assigned PepIDs when linking consensusMaps.

Signed-off-by: Julianus Pfeuffer <jpfeuffer@fu-berlin.de>