### PR TITLE
[FIX] MAD set primary output optional

### DIFF
--- a/src/utils/MetaboliteAdductDecharger.cpp
+++ b/src/utils/MetaboliteAdductDecharger.cpp
@@ -106,7 +106,7 @@ protected:
   {
     registerInputFile_("in", "<file>", "", "input file ");
     setValidFormats_("in", ListUtils::create<String>("featureXML"));
-    registerOutputFile_("out_cm", "<file>", "", "output consensus map");
+    registerOutputFile_("out_cm", "<file>", "", "output consensus map", false);
     registerOutputFile_("out_fm", "<file>", "", "output feature map", false);
     registerOutputFile_("outpairs", "<file>", "", "output file", false);
     setValidFormats_("out_fm", ListUtils::create<String>("featureXML"));


### PR DESCRIPTION
Minor fix. 

A lot of metabolomics workflows use the featureXML output of the MetaboliteAdductDecharger, but an output folder has to be specified every time since the consensusXML output was mandatory. 
-> set all outputs to optional. 