### PR TITLE
Py circ

### DIFF
--- a/src/pyOpenMS/pxds/DataProcessing.pxd
+++ b/src/pyOpenMS/pxds/DataProcessing.pxd
@@ -1,5 +1,4 @@
 from Types cimport *
-from SpectrumSettings cimport *
 from Peak1D cimport *
 from String cimport *
 from Software cimport *

--- a/src/pyOpenMS/pxds/MSSpectrum.pxd
+++ b/src/pyOpenMS/pxds/MSSpectrum.pxd
@@ -1,10 +1,10 @@
 from libcpp.vector cimport vector as libcpp_vector
 from libcpp.string cimport string as libcpp_string
-from SpectrumSettings cimport *
 from Peak1D cimport *
 from String cimport *
 from RangeManager cimport *
 from DataArrays cimport *
+from SpectrumSettings cimport *
 
 # this class has addons, see the ./addons folder (../addons/MSSpectrum.pyx)
 

--- a/src/pyOpenMS/pxds/MetaInfoDescription.pxd
+++ b/src/pyOpenMS/pxds/MetaInfoDescription.pxd
@@ -3,15 +3,14 @@ from libcpp.vector cimport vector as libcpp_vector
 from DataValue cimport *
 from String cimport *
 from Types cimport *
-from MetaInfoRegistry cimport *
-from DataProcessing cimport *
 from MetaInfoInterface cimport *
+from DataProcessing cimport *
 
 cdef extern from "<OpenMS/METADATA/MetaInfoDescription.h>" namespace "OpenMS":
 
     cdef cppclass MetaInfoDescription(MetaInfoInterface):
         # wrap-inherits:
-        #  MetaInfoInterface
+        #   MetaInfoInterface
 
         MetaInfoDescription() nogil except +
         MetaInfoDescription(MetaInfoDescription) nogil except +

--- a/src/pyOpenMS/pxds/PeptideHit.pxd
+++ b/src/pyOpenMS/pxds/PeptideHit.pxd
@@ -1,7 +1,6 @@
 from Types cimport *
 from DataValue cimport *
 from Feature cimport *
-from ProteinIdentification cimport *
 from AASequence cimport *
 from PeptideEvidence cimport *
 from MetaInfoInterface cimport *

--- a/src/pyOpenMS/pxds/PeptideIdentification.pxd
+++ b/src/pyOpenMS/pxds/PeptideIdentification.pxd
@@ -6,7 +6,6 @@ from String cimport *
 from Types cimport *
 from MetaInfoInterface cimport *
 from PeptideHit cimport *
-from ProteinHit cimport *
 
 cdef extern from "<OpenMS/METADATA/PeptideIdentification.h>" namespace "OpenMS":
 

--- a/src/pyOpenMS/pxds/ProteinHit.pxd
+++ b/src/pyOpenMS/pxds/ProteinHit.pxd
@@ -3,7 +3,6 @@ from Types cimport *
 from DataValue cimport *
 from Feature cimport *
 from UniqueIdInterface cimport *
-from ProteinIdentification cimport *
 from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/ProteinHit.h>" namespace "OpenMS":

--- a/src/pyOpenMS/pxds/ProteinIdentification.pxd
+++ b/src/pyOpenMS/pxds/ProteinIdentification.pxd
@@ -8,8 +8,7 @@ from ProteinHit cimport *
 from DigestionEnzymeProtein cimport *
 from PeptideIdentification cimport *
 from DateTime cimport *
-from MSExperiment cimport *
-
+# from MSExperiment cimport *
 
 cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS":
 
@@ -84,8 +83,12 @@ cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS":
         void setIdentifier(String id_) nogil except +
 
         void setPrimaryMSRunPath(StringList& s) nogil except +
-        void setPrimaryMSRunPath(StringList& s, MSExperiment& e) nogil except +
         void getPrimaryMSRunPath(StringList& toFill) nogil except +
+
+        # This causes as problem with circular dependencies when trying to use
+        # ExperimentalSettings in MSExperiment
+        # TODO: use addons if we really need this
+        # void setPrimaryMSRunPath(StringList& s, MSExperiment& e) nogil except +
 
 cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS::ProteinIdentification":
 

--- a/src/pyOpenMS/pxds/SequestOutfile.pxd
+++ b/src/pyOpenMS/pxds/SequestOutfile.pxd
@@ -5,6 +5,7 @@ from libcpp.vector cimport vector as libcpp_vector
 from Types cimport *
 from String cimport *
 from PeptideIdentification cimport *
+from ProteinIdentification cimport *
 from DateTime cimport *
 
 cdef extern from "<OpenMS/FORMAT/SequestOutfile.h>" namespace "OpenMS":

--- a/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
+++ b/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
@@ -3,6 +3,7 @@ from MSSpectrum cimport *
 from MSExperiment cimport *
 from Peak1D cimport *
 from PeptideIdentification cimport *
+from ProteinIdentification cimport *
 from SpectrumLookup cimport *
 
 cdef extern from "<OpenMS/METADATA/SpectrumMetaDataLookup.h>" namespace "OpenMS":


### PR DESCRIPTION
Fix circular dependencies that prevent Cython from compiling the pyOpenMS bindings