### PR TITLE
Improvements to SqliteConnector

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/String.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/String.h
@@ -97,6 +97,8 @@ public:
     OPENMS_DLLAPI String(const QString& s);
     /// Constructor from char*
     OPENMS_DLLAPI String(const char* s);
+    /// Constructor from unsigned char*
+    OPENMS_DLLAPI String(const unsigned char* s);
     /// Constructor from a char
     OPENMS_DLLAPI String(const char c);
     /// Constructor from char* (only @p length characters)
@@ -108,7 +110,6 @@ public:
     String(InputIterator first, InputIterator last) :
       std::string(first, last)
     {
-
     }
 
     /// Constructor from an integer

--- a/src/openms/include/OpenMS/DATASTRUCTURES/String.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/String.h
@@ -98,7 +98,7 @@ public:
     /// Constructor from char*
     OPENMS_DLLAPI String(const char* s);
     /// Constructor from unsigned char*
-    OPENMS_DLLAPI String(const unsigned char* s);
+    OPENMS_DLLAPI explicit String(const unsigned char* s);
     /// Constructor from a char
     OPENMS_DLLAPI String(const char c);
     /// Constructor from char* (only @p length characters)

--- a/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
+++ b/src/openms/include/OpenMS/FORMAT/SqliteConnector.h
@@ -84,6 +84,18 @@ public:
     }
 
     /**
+      @brief Checks whether the given table exists
+
+      @p tablename The name of the table to be checked
+
+      @returns Whether the table exists or not
+    */
+    bool tableExists(const String& tablename)
+    {
+      return tableExists(db_, tablename);
+    }
+
+    /**
       @brief Checkes whether the given table contains a certain column
 
       @p tablename The name of the table (needs to exist)
@@ -130,7 +142,7 @@ public:
       databases, and the raw data needs to be passed separately as it cannot be
       part of a true SQL statement
 
-        INSERT INTO TBL (ID, DATA) VALUES (100, ?1), (101, ?2), (102, ?3)" 
+        INSERT INTO TBL (ID, DATA) VALUES (100, ?1), (101, ?2), (102, ?3)"
 
       See also https://www.sqlite.org/c3ref/bind_blob.html
 
@@ -155,12 +167,10 @@ public:
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    void executePreparedStatement(sqlite3_stmt** stmt, const String& prepare_statement)
+    void prepareStatement(sqlite3_stmt** stmt, const String& prepare_statement)
     {
-      executePreparedStatement(db_, stmt, prepare_statement);
+      prepareStatement(db_, stmt, prepare_statement);
     }
-
-
 
     /**
       @brief Checks whether the given table exists
@@ -168,9 +178,9 @@ public:
       @p db The sqlite database (needs to be open)
       @p tablename The name of the table to be checked
 
-      @returns Whether the column exists or not
+      @returns Whether the table exists or not
     */
-    static bool tableExists(sqlite3 *db, const String& tablename);
+    static bool tableExists(sqlite3* db, const String& tablename);
 
     /**
       @brief Checks whether the given table contains a certain column
@@ -181,7 +191,7 @@ public:
 
       @returns Whether the column exists or not
     */
-    static bool columnExists(sqlite3 *db, const String& tablename, const String& colname);
+    static bool columnExists(sqlite3* db, const String& tablename, const String& colname);
 
     /**
       @brief Executes a given SQL statement (insert statement)
@@ -193,7 +203,7 @@ public:
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    static void executeStatement(sqlite3 *db, const std::stringstream& statement);
+    static void executeStatement(sqlite3* db, const std::stringstream& statement);
 
     /**
       @brief Executes a given SQL statement (insert statement)
@@ -205,7 +215,7 @@ public:
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    static void executeStatement(sqlite3 *db, const String& statement);
+    static void executeStatement(sqlite3* db, const String& statement);
 
     /**
       @brief Converts an SQL statement into a prepared statement
@@ -221,22 +231,22 @@ public:
       calls sqlite3_prepare_v2.
 
       @p db The sqlite database (needs to be open)
-      @p statement The SQL statement
-      @p data The data to bind
+      @p stmt The prepared statement (output)
+      @p prepare_statement The SQL statement to prepare (input)
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    static void executePreparedStatement(sqlite3 *db, sqlite3_stmt** stmt, const String& prepare_statement);
+    static void prepareStatement(sqlite3* db, sqlite3_stmt** stmt, const String& prepare_statement);
 
 
     /**
-      @brief Executes raw data SQL statements (insert statements) 
+      @brief Executes raw data SQL statements (insert statements)
 
       This is useful for a case where raw data should be inserted into sqlite
       databases, and the raw data needs to be passed separately as it cannot be
       part of a true SQL statement
 
-        INSERT INTO TBL (ID, DATA) VALUES (100, ?1), (101, ?2), (102, ?3)" 
+        INSERT INTO TBL (ID, DATA) VALUES (100, ?1), (101, ?2), (102, ?3)"
 
       See also https://www.sqlite.org/c3ref/bind_blob.html
 
@@ -246,7 +256,7 @@ public:
 
       @exception Exception::IllegalArgument is thrown if the SQL command fails.
     */
-    static void executeBindStatement(sqlite3 *db, const String& prepare_statement, const std::vector<String>& data);
+    static void executeBindStatement(sqlite3* db, const String& prepare_statement, const std::vector<String>& data);
 
 protected:
 
@@ -273,26 +283,23 @@ protected:
         @brief Extracts a specific value from an SQL column
 
         @p dst Destination (where to store the value)
-        @p sqlite3_stmt Sqlite statement object
-        @p pos Column position 
+        @p stmt Sqlite statement object
+        @p pos Column position
 
-        For example, to extract a specific integer from column 5 of an SQL statement, one can use
+        For example, to extract a specific integer from column 5 of an SQL statement, one can use:
 
-          sqlite3_stmt * stmt;
-          sqlite3 *db;
-          SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-          sqlite3_step( stmt );
+          sqlite3_stmt* stmt;
+          sqlite3* db;
+          SqliteConnector::prepareStatement(db, &stmt, select_sql);
+          sqlite3_step(stmt);
 
           double target;
-          while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
+          while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
           {
             extractValue<double>(&target, stmt, 5);
             sqlite3_step( stmt );
           }
           sqlite3_finalize(stmt);
-
-
-
       */
       template <typename ValueType>
       void extractValue(ValueType* /* dst */, sqlite3_stmt* /* stmt */, int /* pos */)

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -228,7 +228,7 @@ namespace OpenMS
       Sql::extractValue<std::string>(&mytransition.PeptideSequence, stmt, 8);
       if (sqlite3_column_type( stmt, 9 ) != SQLITE_NULL)
       {
-        String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 9 ))).split(';', mytransition.ProteinName);
+        String(sqlite3_column_text(stmt, 9)).split(';', mytransition.ProteinName);
       }
       Sql::extractValue<std::string>(&mytransition.Annotation, stmt, 10);
       Sql::extractValue<std::string>(&mytransition.FullPeptideName, stmt, 11);
@@ -246,14 +246,14 @@ namespace OpenMS
       Sql::extractValue<std::string>(&mytransition.fragment_type, stmt, 23);
       if (sqlite3_column_type( stmt, 24 ) != SQLITE_NULL)
       {
-        String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 24 ))).split(';', mytransition.uniprot_id);
+        String(sqlite3_column_text(stmt, 24)).split(';', mytransition.uniprot_id);
       }
       Sql::extractValue<int>((int*)&mytransition.detecting_transition, stmt, 25);
       Sql::extractValue<int>((int*)&mytransition.identifying_transition, stmt, 26);
       Sql::extractValue<int>((int*)&mytransition.quantifying_transition, stmt, 27);
       if (sqlite3_column_type( stmt, 28 ) != SQLITE_NULL)
       {
-        String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 28 ))).split('|', mytransition.peptidoforms);
+        String(sqlite3_column_text(stmt, 28)).split('|', mytransition.peptidoforms);
       }
       // optional attributes only present in newer file versions
       if (drift_time_exists) Sql::extractValue<double>(&mytransition.drift_time, stmt, 29);

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -81,9 +81,9 @@ namespace OpenMS
     db = conn.getDB();
 
     // Count transitions
-    SqliteConnector::executePreparedStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
+    SqliteConnector::prepareStatement(db, &cntstmt, "SELECT COUNT(*) FROM TRANSITION;");
     sqlite3_step( cntstmt );
-    int num_transitions = sqlite3_column_int( cntstmt, 0 );
+    int num_transitions = sqlite3_column_int(cntstmt, 0);
     sqlite3_finalize(cntstmt);
 
     String select_drift_time = "";
@@ -206,13 +206,13 @@ namespace OpenMS
 
 
     // Execute SQL select statement
-    SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-    sqlite3_step( stmt );
+    SqliteConnector::prepareStatement(db, &stmt, select_sql);
+    sqlite3_step(stmt);
 
     Size progress = 0;
     startProgress(0, num_transitions, "reading PQP file");
     // Convert SQLite data to TSVTransition data structure
-    while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
+    while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
     {
       setProgress(progress++);
       TSVTransition mytransition;

--- a/src/openms/source/DATASTRUCTURES/String.cpp
+++ b/src/openms/source/DATASTRUCTURES/String.cpp
@@ -60,6 +60,11 @@ namespace OpenMS
   {
   }
 
+  String::String(const unsigned char* s) :
+    string(reinterpret_cast<const char*>(s))
+  {
+  }
+
   String::String(const QString& s) :
     string(s.toStdString())
   {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -98,10 +98,10 @@ namespace OpenMS
      *
      * It is designed to work with containers of type MSSpectrum and
      * MSChromatogram to provide a single function for both use-cases.
-     * 
+     *
      */
     template<class ContainerT>
-    void populateContainer_sub_(sqlite3_stmt *stmt, std::vector<ContainerT >& containers)
+    void populateContainer_sub_(sqlite3_stmt *stmt, std::vector<ContainerT>& containers)
     {
       // perform first step
       sqlite3_step(stmt);
@@ -603,7 +603,7 @@ namespace OpenMS
         OpenMS::Precursor precursor;
         OpenMS::Product product;
 
-        chrom.setNativeID(String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1))));
+        chrom.setNativeID(String(sqlite3_column_text(stmt, 1)));
         if (sqlite3_column_type(stmt, 2) != SQLITE_NULL) precursor.setCharge(sqlite3_column_int(stmt, 2));
         if (sqlite3_column_type(stmt, 3) != SQLITE_NULL) precursor.setDriftTime(sqlite3_column_double(stmt, 3));
         if (sqlite3_column_type(stmt, 4) != SQLITE_NULL) precursor.setMZ(sqlite3_column_double(stmt, 4));
@@ -611,7 +611,7 @@ namespace OpenMS
         if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) precursor.setIsolationWindowUpperOffset(sqlite3_column_double(stmt, 6));
         if (sqlite3_column_type(stmt, 7) != SQLITE_NULL)
         {
-          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 7))));
+          precursor.setMetaValue("peptide_sequence", String(sqlite3_column_text(stmt, 7)));
         }
         // if (sqlite3_column_type(stmt, 8) != SQLITE_NULL) product.setCharge(sqlite3_column_int(stmt, 8));
         if (sqlite3_column_type(stmt, 9) != SQLITE_NULL) product.setMZ(sqlite3_column_double(stmt, 9));
@@ -686,7 +686,7 @@ namespace OpenMS
         OpenMS::Precursor precursor;
         OpenMS::Product product;
 
-        spec.setNativeID(String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1))));
+        spec.setNativeID(String(sqlite3_column_text(stmt, 1)));
         if (sqlite3_column_type(stmt, 2) != SQLITE_NULL) spec.setMSLevel(sqlite3_column_int(stmt, 2));
         if (sqlite3_column_type(stmt, 3) != SQLITE_NULL) spec.setRT(sqlite3_column_double(stmt, 3));
         if (sqlite3_column_type(stmt, 4) != SQLITE_NULL) precursor.setCharge(sqlite3_column_int(stmt, 4));
@@ -696,7 +696,7 @@ namespace OpenMS
         if (sqlite3_column_type(stmt, 8) != SQLITE_NULL) precursor.setIsolationWindowUpperOffset(sqlite3_column_double(stmt, 8));
         if (sqlite3_column_type(stmt, 9) != SQLITE_NULL)
         {
-          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 9))));
+          precursor.setMetaValue("peptide_sequence", String(sqlite3_column_text(stmt, 9)));
         }
         // if (sqlite3_column_type(stmt, 10) != SQLITE_NULL) product.setCharge(sqlite3_column_int(stmt, 10));
         if (sqlite3_column_type(stmt, 11) != SQLITE_NULL) product.setMZ(sqlite3_column_double(stmt, 11));

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
         Size id_orig = sqlite3_column_int( stmt, 0 );
 
         // map the sql table id to the index in the "containers" vector
-        if (sql_container_map.find(id_orig) == sql_container_map.end()) 
+        if (sql_container_map.find(id_orig) == sql_container_map.end())
         {
           Size tmp = sql_container_map.size();
           sql_container_map[id_orig] = tmp;
@@ -125,7 +125,7 @@ namespace OpenMS
 
         if (curr_id >= containers.size())
         {
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
               "Data for non-existent spectrum / chromatogram found");
         }
         if (native_id != containers[curr_id].getNativeID())
@@ -150,7 +150,7 @@ namespace OpenMS
 
           void* byte_buffer = reinterpret_cast<void *>(&uncompressed[0]);
           Size buffer_size = uncompressed.size();
-          const double * float_buffer = reinterpret_cast<const double *>(byte_buffer);
+          const double* float_buffer = reinterpret_cast<const double *>(byte_buffer);
           if (buffer_size % sizeof(double) != 0)
           {
             throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Bad BufferCount?");
@@ -278,7 +278,7 @@ namespace OpenMS
                       ";";
 
         sqlite3_stmt * stmt;
-        conn.executePreparedStatement(&stmt, select_sql);
+        conn.prepareStatement(&stmt, select_sql);
         sqlite3_step( stmt );
 
         // read data (throw exception if we find multiple runs)
@@ -396,8 +396,8 @@ namespace OpenMS
       SqliteConnector conn(filename_);
 
       int ret(0);
-      sqlite3_stmt * stmt;
-      conn.executePreparedStatement(&stmt, "SELECT COUNT(*) FROM SPECTRUM;");
+      sqlite3_stmt* stmt;
+      conn.prepareStatement(&stmt, "SELECT COUNT(*) FROM SPECTRUM;");
       sqlite3_step(stmt);
       Sql::extractValue<int>(&ret, stmt, 0);
       sqlite3_finalize(stmt);
@@ -407,7 +407,7 @@ namespace OpenMS
 
     std::vector<size_t> MzMLSqliteHandler::getSpectraIndicesbyRT(double RT,
                                                                  double deltaRT,
-                                                                 const std::vector<int> & indices) const
+                                                                 const std::vector<int>& indices) const
     {
       // this is necessary for some applications such as the m/z correction
       SqliteConnector conn(filename_);
@@ -436,7 +436,7 @@ namespace OpenMS
 
       // Execute SQL statement
       sqlite3_stmt * stmt;
-      conn.executePreparedStatement(&stmt, select_sql);
+      conn.prepareStatement(&stmt, select_sql);
       sqlite3_step(stmt);
 
       std::vector<size_t> result;
@@ -446,7 +446,7 @@ namespace OpenMS
         sqlite3_step(stmt);
       }
       sqlite3_finalize(stmt);
-      
+
       return result;
     }
 
@@ -455,8 +455,8 @@ namespace OpenMS
       SqliteConnector conn(filename_);
       int ret(0);
 
-      sqlite3_stmt * stmt;
-      conn.executePreparedStatement(&stmt, "SELECT COUNT(*) FROM CHROMATOGRAM;");
+      sqlite3_stmt* stmt;
+      conn.prepareStatement(&stmt, "SELECT COUNT(*) FROM CHROMATOGRAM;");
       sqlite3_step(stmt);
       Sql::extractValue<int>(&ret, stmt, 0);
       sqlite3_finalize(stmt);
@@ -464,7 +464,7 @@ namespace OpenMS
       return (Size)ret;
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3 *db, std::vector<MSChromatogram>& chromatograms) const
+    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3* db, std::vector<MSChromatogram>& chromatograms) const
     {
       std::string select_sql;
       select_sql = "SELECT " \
@@ -479,15 +479,15 @@ namespace OpenMS
 
 
       // Execute SQL statement
-      sqlite3_stmt * stmt;
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      populateContainer_sub_< MSChromatogram > (stmt, chromatograms);
+      sqlite3_stmt* stmt;
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      populateContainer_sub_<MSChromatogram>(stmt, chromatograms);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3 *db,
+    void MzMLSqliteHandler::populateChromatogramsWithData_(sqlite3* db,
                                                            std::vector<MSChromatogram>& chromatograms,
-                                                           const std::vector<int> & indices) const
+                                                           const std::vector<int>& indices) const
     {
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == chromatograms.size(), "Chromatograms and indices need to have the same length.")
@@ -504,13 +504,13 @@ namespace OpenMS
       select_sql += integerConcatenateHelper(indices) + ");";
 
       // Execute SQL statement
-      sqlite3_stmt * stmt;
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      populateContainer_sub_< MSChromatogram > (stmt, chromatograms);
+      sqlite3_stmt* stmt;
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      populateContainer_sub_<MSChromatogram>(stmt, chromatograms);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3 *db, std::vector<MSSpectrum>& spectra) const
+    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3* db, std::vector<MSSpectrum>& spectra) const
     {
       std::string select_sql;
       select_sql = "SELECT " \
@@ -524,15 +524,15 @@ namespace OpenMS
                     ";";
 
       // Execute SQL statement
-      sqlite3_stmt * stmt;
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      populateContainer_sub_< MSSpectrum> (stmt, spectra);
+      sqlite3_stmt* stmt;
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      populateContainer_sub_<MSSpectrum>(stmt, spectra);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3 *db,
+    void MzMLSqliteHandler::populateSpectraWithData_(sqlite3* db,
                                                      std::vector<MSSpectrum>& spectra,
-                                                     const std::vector<int> & indices) const
+                                                     const std::vector<int>& indices) const
     {
       OPENMS_PRECONDITION(!indices.empty(), "Need to select at least one index.")
       OPENMS_PRECONDITION(indices.size() == spectra.size(), "Spectra and indices need to have the same length.")
@@ -549,17 +549,17 @@ namespace OpenMS
       select_sql += integerConcatenateHelper(indices) + ");";
 
       // Execute SQL statement
-      sqlite3_stmt * stmt;
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      populateContainer_sub_< MSSpectrum > (stmt, spectra);
+      sqlite3_stmt* stmt;
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      populateContainer_sub_<MSSpectrum>(stmt, spectra);
       sqlite3_finalize(stmt);
     }
 
-    void MzMLSqliteHandler::prepareChroms_(sqlite3 *db,
+    void MzMLSqliteHandler::prepareChroms_(sqlite3* db,
                                            std::vector<MSChromatogram>& chromatograms,
-                                           const std::vector<int> & indices) const
+                                           const std::vector<int>& indices) const
     {
-      sqlite3_stmt * stmt;
+      sqlite3_stmt* stmt;
       std::string select_sql;
       select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
@@ -594,8 +594,8 @@ namespace OpenMS
       // from sqlite3_column_blob(), sqlite3_column_text(), etc. into
       // sqlite3_free().
 
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      sqlite3_step( stmt );
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      sqlite3_step(stmt);
 
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
       {
@@ -603,15 +603,15 @@ namespace OpenMS
         OpenMS::Precursor precursor;
         OpenMS::Product product;
 
-        chrom.setNativeID(String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 1 ))));
+        chrom.setNativeID(String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1))));
         if (sqlite3_column_type(stmt, 2) != SQLITE_NULL) precursor.setCharge(sqlite3_column_int(stmt, 2));
         if (sqlite3_column_type(stmt, 3) != SQLITE_NULL) precursor.setDriftTime(sqlite3_column_double(stmt, 3));
         if (sqlite3_column_type(stmt, 4) != SQLITE_NULL) precursor.setMZ(sqlite3_column_double(stmt, 4));
         if (sqlite3_column_type(stmt, 5) != SQLITE_NULL) precursor.setIsolationWindowLowerOffset(sqlite3_column_double(stmt, 5));
         if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) precursor.setIsolationWindowUpperOffset(sqlite3_column_double(stmt, 6));
-        if (sqlite3_column_type(stmt, 7) != SQLITE_NULL) 
+        if (sqlite3_column_type(stmt, 7) != SQLITE_NULL)
         {
-          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 7 ))));
+          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 7))));
         }
         // if (sqlite3_column_type(stmt, 8) != SQLITE_NULL) product.setCharge(sqlite3_column_int(stmt, 8));
         if (sqlite3_column_type(stmt, 9) != SQLITE_NULL) product.setMZ(sqlite3_column_double(stmt, 9));
@@ -677,10 +677,10 @@ namespace OpenMS
       // from sqlite3_column_blob(), sqlite3_column_text(), etc. into
       // sqlite3_free().
 
-      SqliteConnector::executePreparedStatement(db, &stmt, select_sql);
-      sqlite3_step( stmt );
+      SqliteConnector::prepareStatement(db, &stmt, select_sql);
+      sqlite3_step(stmt);
 
-      while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
+      while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
       {
         MSSpectrum spec;
         OpenMS::Precursor precursor;
@@ -694,9 +694,9 @@ namespace OpenMS
         if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) precursor.setMZ(sqlite3_column_double(stmt, 6));
         if (sqlite3_column_type(stmt, 7) != SQLITE_NULL) precursor.setIsolationWindowLowerOffset(sqlite3_column_double(stmt, 7));
         if (sqlite3_column_type(stmt, 8) != SQLITE_NULL) precursor.setIsolationWindowUpperOffset(sqlite3_column_double(stmt, 8));
-        if (sqlite3_column_type(stmt, 9) != SQLITE_NULL) 
+        if (sqlite3_column_type(stmt, 9) != SQLITE_NULL)
         {
-          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, 9 ))));
+          precursor.setMetaValue("peptide_sequence", String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, 9))));
         }
         // if (sqlite3_column_type(stmt, 10) != SQLITE_NULL) product.setCharge(sqlite3_column_int(stmt, 10));
         if (sqlite3_column_type(stmt, 11) != SQLITE_NULL) product.setMZ(sqlite3_column_double(stmt, 11));

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteSwathHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteSwathHandler.cpp
@@ -63,7 +63,7 @@ namespace OpenMS
                     "WHERE MSLEVEL == 2 "\
                     ";";
 
-      conn.executePreparedStatement(&stmt, select_sql);
+      conn.prepareStatement(&stmt, select_sql);
       sqlite3_step( stmt );
 
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
@@ -93,7 +93,7 @@ namespace OpenMS
                    "FROM SPECTRUM " \
                    "WHERE MSLEVEL == 1;";
 
-      conn.executePreparedStatement(&stmt, select_sql);
+      conn.prepareStatement(&stmt, select_sql);
       sqlite3_step(stmt);
 
       while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
@@ -122,7 +122,7 @@ namespace OpenMS
                           "WHERE ISOLATION_TARGET BETWEEN ";
 
       select_sql += String(center - 0.01) + " AND " + String(center + 0.01) + ";";
-      conn.executePreparedStatement(&stmt, select_sql);
+      conn.prepareStatement(&stmt, select_sql);
       sqlite3_step(stmt);
 
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -120,23 +120,23 @@ namespace OpenMS
 
         for (int i = 0; i < cols; i++)
         {
-          if (OpenMS::String(sqlite3_column_name( stmt, i )) == "FEATURE_ID")
+          if (OpenMS::String(sqlite3_column_name(stmt, i)) == "FEATURE_ID")
           {
-            psm_id = OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i )));
+            psm_id = OpenMS::String(sqlite3_column_text(stmt, i));
           }
-          if (OpenMS::String(sqlite3_column_name( stmt, i )) == "GROUP_ID")
+          if (OpenMS::String(sqlite3_column_name(stmt, i)) == "GROUP_ID")
           {
             if (std::find(group_id_index.begin(), group_id_index.end(),
-                  OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i )))) != group_id_index.end())
+                  OpenMS::String(sqlite3_column_text(stmt, i))) != group_id_index.end())
             {
               scan_id = std::find(group_id_index.begin(), group_id_index.end(),
-                          OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i )))) - group_id_index.begin();
+                          OpenMS::String(sqlite3_column_text(stmt, i))) - group_id_index.begin();
             }
             else
             {
-              group_id_index.push_back(OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i ))));
+              group_id_index.push_back(OpenMS::String(sqlite3_column_text(stmt, i)));
               scan_id = std::find(group_id_index.begin(), group_id_index.end(),
-                          OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i )))) - group_id_index.begin();
+                          OpenMS::String(sqlite3_column_text(stmt, i))) - group_id_index.begin();
             }
           }
           if (OpenMS::String(sqlite3_column_name( stmt, i )) == "DECOY")
@@ -152,7 +152,7 @@ namespace OpenMS
           }
           if (OpenMS::String(sqlite3_column_name( stmt, i )) == "MODIFIED_SEQUENCE")
           {
-            peptide = OpenMS::String(reinterpret_cast<const char*>(sqlite3_column_text( stmt, i )));
+            peptide = OpenMS::String(sqlite3_column_text(stmt, i));
           }
           if (OpenMS::String(sqlite3_column_name( stmt, i )).substr(0,4) == "VAR_")
           {

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -101,8 +101,8 @@ namespace OpenMS
       }
 
       // Execute SQL select statement
-      conn.executePreparedStatement(&stmt, select_sql);
-      sqlite3_step( stmt );
+      conn.prepareStatement(&stmt, select_sql);
+      sqlite3_step(stmt);
 
       int cols = sqlite3_column_count(stmt);
 

--- a/src/openms/source/FORMAT/SqliteConnector.cpp
+++ b/src/openms/source/FORMAT/SqliteConnector.cpp
@@ -67,7 +67,7 @@ namespace OpenMS
     sqlite3_step(xcntstmt);
     while (sqlite3_column_type(xcntstmt, 0) != SQLITE_NULL)
     {
-      String name = String(reinterpret_cast<const char*>(sqlite3_column_text(xcntstmt, 1)));
+      String name = String(sqlite3_column_text(xcntstmt, 1));
       if (colname == name)
       {
         found = true;
@@ -179,7 +179,7 @@ namespace OpenMS
       {
         if (sqlite3_column_type(stmt, pos) != SQLITE_NULL)
         {
-          *dst = String(reinterpret_cast<const char*>(sqlite3_column_text(stmt, pos)));
+          *dst = String(sqlite3_column_text(stmt, pos));
         }
       }
 

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -168,6 +168,11 @@ START_SECTION((String(const char* s)))
   TEST_EQUAL(s,"blablabla")
 END_SECTION
 
+START_SECTION((String(const unsigned char* s)))
+  unsigned char s[] = "testtest";
+  TEST_EQUAL(String(s),"testtest")
+END_SECTION
+
 START_SECTION((String(size_t len, char c)))
   String s(17,'b');
   TEST_EQUAL(s,"bbbbbbbbbbbbbbbbb")


### PR DESCRIPTION
Three main things:
1. Changed name of function `executePreparedStatement` to `prepareStatement`, because (in contrast to the other `execute...` functions) it doesn't actually run the statement against the database. I think that's quite an important distinction that should be reflected in the name.
2. Added a constructor from `unsigned char*` to String to simplify reading text results from SQLite.
3. Simplified the implementation of the `tableExists` function.
