### PR TITLE
Update OpenSwathOSWWriter.cpp

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -456,7 +456,7 @@ namespace OpenMS
       }
     }
 
-    if (enable_uis_scoring_)
+    if (enable_uis_scoring_ && !sql_feature_uis_transition.empty())
     {
       sql << sql_feature.str() << sql_feature_ms1.str() << sql_feature_ms1_precursor.str() << sql_feature_ms2.str() << sql_feature_uis_transition.str();
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -456,7 +456,7 @@ namespace OpenMS
       }
     }
 
-    if (enable_uis_scoring_ && !sql_feature_uis_transition.empty())
+    if (enable_uis_scoring_ && !sql_feature_uis_transition.str().empty() )
     {
       sql << sql_feature.str() << sql_feature_ms1.str() << sql_feature_ms1_precursor.str() << sql_feature_ms2.str() << sql_feature_uis_transition.str();
     }


### PR DESCRIPTION
- Fixes https://github.com/OpenMS/OpenMS/issues/4268
- Removes a side effect of UIS scoring (no transition level output in OSW when enabled)

@grosenberger we should test this and investigate what other side effects UIS scoring has