### PR TITLE
Minor changes to allow compiling with Visual Studio 2019

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -38,6 +38,7 @@
 #include <map>
 #include <set>
 #include <algorithm>
+#include <string>
 
 #include <OpenMS/CONCEPT/Types.h>
 

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include <boost/shared_ptr.hpp>
 
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/MockObjects.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/MockObjects.h
@@ -40,6 +40,7 @@
 #include <boost/shared_ptr.hpp>
 #include <map>
 #include <vector>
+#include <string>
 
 namespace OpenSwath
 {

--- a/src/openswathalgo/source/OPENSWATHALGO/DATAACCESS/MockObjects.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/DATAACCESS/MockObjects.cpp
@@ -34,7 +34,6 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/MockObjects.h>
 
-#include <string>
 
 namespace OpenSwath
 {

--- a/src/tests/class_tests/openms/source/CrossLinksDB_test.cpp
+++ b/src/tests/class_tests/openms/source/CrossLinksDB_test.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 struct ResidueModificationOriginCmp
 {
-  bool operator() (const ResidueModification* a, const ResidueModification* b)
+  bool operator() (const ResidueModification* a, const ResidueModification* b) const
   {
     if (a->getOrigin() == b->getOrigin())
     {

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -46,7 +46,7 @@ using namespace std;
 
 struct ResidueModificationOriginCmp
 {
-  bool operator() (const ResidueModification* a, const ResidueModification* b)
+  bool operator() (const ResidueModification* a, const ResidueModification* b) const
   {
     return a->getOrigin() < b->getOrigin();
   }


### PR DESCRIPTION
In VS2019 the standard libraries were refactored to not define std::string, which led to some compilation errors where string wasn't explicitly included. A comparison operator in two of the tests also needed to be defined const.