### PR TITLE
[FIX] TOPPView when running TOPP tool 

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -3000,7 +3000,6 @@ namespace OpenMS
       }
       else
       {
-
         f.store(topp_.file_name + "_in", *layer.getPeakData());
       }
     }


### PR DESCRIPTION
 fixes bug when running a TOPP tool from TOPPView and the current temporary path contains spaces 
(which yields a message box saying that the TOPP tool could not be executed (when writing the default ini file)

fixes  #4164