### PR TITLE
Remove redundant field from IdentificationData::ScoreType

### DIFF
--- a/src/openms/include/OpenMS/METADATA/CVTerm.h
+++ b/src/openms/include/OpenMS/METADATA/CVTerm.h
@@ -66,24 +66,22 @@ public:
       {
       }
 
-
       /// Copy constructor
       Unit(const Unit &) = default;
-      
+
       /// Move constructor
       Unit(Unit&&) = default;
-
 
       /// Destructor
       virtual ~Unit()
       {
       }
 
-
       /// Assignment operator
-      Unit & operator=(const Unit &) = default;
+      Unit& operator=(const Unit&) = default;
+
       /// Move assignment operator
-      Unit& operator=(Unit&&) & = default;
+      Unit& operator=(Unit&&)& = default;
 
       bool operator==(const Unit& rhs) const
       {
@@ -109,7 +107,7 @@ public:
     CVTerm(const String& accession, const String& name = "", const String& cv_identifier_ref = "", const String& value = "", const Unit& unit = Unit());
 
     /// Copy constructor
-    CVTerm(const CVTerm &) = default;
+    CVTerm(const CVTerm&) = default;
 
     /// Move constructor
     CVTerm(CVTerm&&) = default;
@@ -118,10 +116,10 @@ public:
     virtual ~CVTerm();
 
     /// Assignment operator
-    CVTerm & operator=(const CVTerm &) = default;
+    CVTerm& operator=(const CVTerm&) = default;
 
     /// Move assignment operator
-    CVTerm& operator=(CVTerm&&) & = default;
+    CVTerm& operator=(CVTerm&&)& = default;
 
     /** @name Accessors
     */
@@ -130,7 +128,7 @@ public:
     void setAccession(const String& accession);
 
     /// returns the accession string of the term
-    const String & getAccession() const;
+    const String& getAccession() const;
 
     /// sets the name of the term
     void setName(const String& name);

--- a/src/openms/include/OpenMS/METADATA/ID/ScoreType.h
+++ b/src/openms/include/OpenMS/METADATA/ID/ScoreType.h
@@ -44,9 +44,7 @@ namespace OpenMS
     */
     struct ScoreType: public MetaInfoInterface
     {
-      CVTerm cv_term;
-
-      String name;
+      CVTerm cv_term; // @TODO: derive from CVTerm instead?
 
       bool higher_better;
 
@@ -56,13 +54,14 @@ namespace OpenMS
       }
 
       explicit ScoreType(const CVTerm& cv_term, bool higher_better):
-        cv_term(cv_term), name(cv_term.getName()), higher_better(higher_better)
+        cv_term(cv_term), higher_better(higher_better)
       {
       }
 
       explicit ScoreType(const String& name, bool higher_better):
-        cv_term(), name(name), higher_better(higher_better)
+        cv_term(), higher_better(higher_better)
       {
+        cv_term.setName(name);
       }
 
       ScoreType(const ScoreType& other) = default;
@@ -70,15 +69,16 @@ namespace OpenMS
       // don't include "higher_better" in the comparison:
       bool operator<(const ScoreType& other) const
       {
-        return (std::tie(cv_term.getAccession(), name) <
-                std::tie(other.cv_term.getAccession(), other.name));
+        // @TODO: implement/use "CVTerm::operator<"?
+        return (std::tie(cv_term.getAccession(), cv_term.getName()) <
+                std::tie(other.cv_term.getAccession(),
+                         other.cv_term.getName()));
       }
 
       // don't include "higher_better" in the comparison:
       bool operator==(const ScoreType& other) const
       {
-        return (std::tie(cv_term.getAccession(), name) ==
-                std::tie(other.cv_term.getAccession(), other.name));
+        return cv_term == other.cv_term;
       }
     };
 

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -599,12 +599,10 @@ namespace OpenMS
     fdr_score.higher_better = false;
     if (use_qvalue)
     {
-      fdr_score.name = "q-value";
       fdr_score.cv_term = CVTerm("MS:1002354", "PSM-level q-value", "MS");
     }
     else
     {
-      fdr_score.name = "FDR";
       fdr_score.cv_term = CVTerm("MS:1002355", "PSM-level FDRScore", "MS");
     }
     IdentificationData::ScoreTypeRef fdr_ref =

--- a/src/openms/source/METADATA/ID/IdentificationData.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationData.cpp
@@ -173,6 +173,12 @@ namespace OpenMS
   IdentificationData::ScoreTypeRef
   IdentificationData::registerScoreType(const ScoreType& score)
   {
+    if (score.cv_term.getAccession().empty() && score.cv_term.getName().empty())
+    {
+      String msg = "score type must have an accession or a name";
+      throw Exception::IllegalArgument(__FILE__, __LINE__,
+                                       OPENMS_PRETTY_FUNCTION, msg);
+    }
     pair<ScoreTypes::iterator, bool> result;
     result = score_types_.insert(score);
     if (!result.second && (score.higher_better != result.first->higher_better))
@@ -414,7 +420,7 @@ namespace OpenMS
   {
     for (ScoreTypeRef it = score_types_.begin(); it != score_types_.end(); ++it)
     {
-      if (it->name == score_name)
+      if (it->cv_term.getName() == score_name)
       {
         return make_pair(it, true);
       }

--- a/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
@@ -274,7 +274,7 @@ namespace OpenMS
           software.setName(ana_res.score_type); // e.g. "peptideprophet"
           IdentificationData::AppliedProcessingStep sub_applied;
           IdentificationData::ScoreType main_score;
-          main_score.name = ana_res.score_type + "_probability";
+          main_score.cv_term.setName(ana_res.score_type + "_probability");
           main_score.higher_better = ana_res.higher_is_better;
           IdentificationData::ScoreTypeRef main_score_ref =
             id_data.registerScoreType(main_score);
@@ -283,7 +283,7 @@ namespace OpenMS
           for (const pair<const String, double>& sub_pair : ana_res.sub_scores)
           {
             IdentificationData::ScoreType sub_score;
-            sub_score.name = sub_pair.first;
+            sub_score.cv_term.setName(sub_pair.first);
             IdentificationData::ScoreTypeRef sub_score_ref =
               id_data.registerScoreType(sub_score);
             software.assigned_scores.push_back(sub_score_ref);
@@ -398,7 +398,7 @@ namespace OpenMS
         // add meta values for "secondary" scores:
         for (auto it = ++scores.begin(); it != scores.end(); ++it)
         {
-          hit_copy.setMetaValue(it->first->name, it->second);
+          hit_copy.setMetaValue(it->first->cv_term.getName(), it->second);
         }
         auto pos =
           query_match.peak_annotations.find(applied.processing_step_opt);
@@ -424,7 +424,7 @@ namespace OpenMS
       peptide.setMetaValue("spectrum_reference", query.data_id);
       peptide.setHits(psm.second.first);
       const IdentificationData::ScoreType& score_type = *psm.second.second;
-      peptide.setScoreType(score_type.name);
+      peptide.setScoreType(score_type.cv_term.getName());
       peptide.setHigherScoreBetter(score_type.higher_better);
       if (psm.first.second) // processing step given
       {
@@ -476,7 +476,7 @@ namespace OpenMS
           // add meta values for "secondary" scores:
           for (auto it = ++scores.begin(); it != scores.end(); ++it)
           {
-            hit_copy.setMetaValue(it->first->name, it->second);
+            hit_copy.setMetaValue(it->first->cv_term.getName(), it->second);
           }
           prot_data[applied.processing_step_opt].first.push_back(hit_copy);
           prot_data[applied.processing_step_opt].second = scores[0].first;
@@ -530,7 +530,7 @@ namespace OpenMS
         {
           const IdentificationData::ScoreType& score_type =
             *pd_pos->second.second;
-          protein.setScoreType(score_type.name);
+          protein.setScoreType(score_type.cv_term.getName());
           protein.setHigherScoreBetter(score_type.higher_better);
         }
       }
@@ -788,7 +788,7 @@ namespace OpenMS
     {
       const IdentificationData::ScoreType& score_type = *score_pair.first;
       MzTabParameter param;
-      param.setName(score_type.name); // or "score_type.cv_term.getName()"?
+      param.setName(score_type.cv_term.getName());
       param.setAccession(score_type.cv_term.getAccession());
       param.setCVLabel(score_type.cv_term.getCVIdentifierRef());
       output[score_pair.second] = param;

--- a/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
+++ b/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
@@ -16,7 +16,7 @@
 				<UserParam type="string" name="label" value="UGAGGUAGUAGGUUGUAUAGU"/>
 				<UserParam type="float" name="OMS:precursor_mz_error_ppm" value="-1.851164946914477"/>
 				<UserParam type="int" name="isotope_offset" value="2"/>
-				<UserParam type="float" name="q-value" value="0.0"/>
+				<UserParam type="float" name="PSM-level q-value" value="0.0"/>
 			</PeptideHit>
 			<UserParam type="int" name="scan_index" value="0"/>
 			<UserParam type="float" name="precursor_intensity" value="3.688524e06"/>

--- a/src/tests/topp/NucleicAcidSearchEngine_12_out.mzTab
+++ b/src/tests/topp/NucleicAcidSearchEngine_12_out.mzTab
@@ -3,7 +3,7 @@ MTD	mzTab-mode	null
 MTD	mzTab-type	null
 MTD	description	null
 MTD	osm_search_engine_score[1]	[, , hyperscore, ]
-MTD	osm_search_engine_score[2]	[MS, MS:1002354, q-value, ]
+MTD	osm_search_engine_score[2]	[MS, MS:1002354, PSM-level q-value, ]
 MTD	software[1]	[, , NucleicAcidSearchEngine, test]
 MTD	ms_run[1]-location	./NucleicAcidSearchEngine_1.mzML
 


### PR DESCRIPTION
A score type (e.g. from a database search engine) is identified by a CV term, which includes a name field. For simplicity, just use that field even if there's no full CV term for a score type, only a name.

Also clean up some whitespace issues in "CVTerm.h".