### PR TITLE
[FIX] removing superfluous includes to improve compilation time

### DIFF
--- a/doc/doxygen/parameters/TOPPDocumenter.cpp
+++ b/doc/doxygen/parameters/TOPPDocumenter.cpp
@@ -42,8 +42,9 @@
 #include <QtCore/QProcess>
 #include <QDir>
 
-#include <fstream>
 #include <iostream>
+#include <fstream>
+#include <sstream>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h
@@ -34,8 +34,9 @@
 
 #pragma once
 
-#include <OpenMS/DATASTRUCTURES/ChargePair.h>
+
 #include <OpenMS/DATASTRUCTURES/Map.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
 #include <vector>
 #include <set>
@@ -45,6 +46,7 @@ namespace OpenMS
 
   class MassExplainer;
   class FeatureMap;
+  class ChargePair;
 
   class OPENMS_DLLAPI ILPDCWrapper
   {

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h
@@ -37,6 +37,8 @@
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 
+#include <tuple>
+
 namespace OpenMS
 {
   /**

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -52,6 +52,9 @@ namespace OpenMS
   class OPENMS_DLLAPI AbsoluteQuantitationMethod
   {
 public:
+    bool operator==(const AbsoluteQuantitationMethod& other) const;
+    bool operator!=(const AbsoluteQuantitationMethod& other) const;
+
     void setComponentName(const String& component_name); ///< Component name setter
     String getComponentName() const; ///< Component name getter
 

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -52,44 +52,6 @@ namespace OpenMS
   class OPENMS_DLLAPI AbsoluteQuantitationMethod
   {
 public:
-    inline bool operator==(const AbsoluteQuantitationMethod& other) const
-    {
-      return
-        std::tie(
-          component_name_,
-          feature_name_,
-          IS_name_,
-          llod_,
-          ulod_,
-          lloq_,
-          uloq_,
-          n_points_,
-          correlation_coefficient_,
-          concentration_units_,
-          transformation_model_,
-          transformation_model_params_
-        ) == std::tie(
-          other.component_name_,
-          other.feature_name_,
-          other.IS_name_,
-          other.llod_,
-          other.ulod_,
-          other.lloq_,
-          other.uloq_,
-          other.n_points_,
-          other.correlation_coefficient_,
-          other.concentration_units_,
-          other.transformation_model_,
-          other.transformation_model_params_
-        )
-      ;
-    }
-
-    inline bool operator!=(const AbsoluteQuantitationMethod& other) const
-    {
-      return !(*this == other);
-    }
-
     void setComponentName(const String& component_name); ///< Component name setter
     String getComponentName() const; ///< Component name getter
 

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -38,10 +38,10 @@
 #include <OpenMS/CHEMISTRY/DigestionEnzyme.h>
 
 #include <boost/regex.hpp>
-
 #include <string>
 #include <vector>
-#include <functional>
+
+#include <functional> // for std::function
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/CONCEPT/FuzzyStringComparator.h
+++ b/src/openms/include/OpenMS/CONCEPT/FuzzyStringComparator.h
@@ -34,12 +34,13 @@
 
 #pragma once
 
-#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Types.h> 
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 
 #include <map>
+#include <sstream>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/DATASTRUCTURES/ChargePair.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ChargePair.h
@@ -79,7 +79,7 @@ public:
     ChargePair& operator=(const ChargePair& rhs);
 
     /// Destructor
-    virtual ~ChargePair();
+    virtual ~ChargePair() = default;
 
     //@}
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Stephan Aiche $
+// $Authors: Stephan Aiche, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #pragma once
@@ -43,9 +43,6 @@
 #include <cmath>
 #include <iterator>
 #include <vector>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string/trim.hpp>
 
 namespace OpenMS
 {
@@ -238,6 +235,28 @@ public:
 
   };
 
+  namespace detail
+  {
+    template <typename T>
+    T convert(const String& s);
+  
+    template<>
+    inline Int convert(const String& s)
+    {
+      return s.toInt();
+    }
+    template<>
+    inline double convert(const String& s)
+    {
+      return s.toDouble();
+    }
+    template<>
+    inline float convert(const String& s)
+    {
+      return s.toFloat();
+    }
+  }
+
   template <typename T>
   inline std::vector<T> ListUtils::create(const std::vector<String>& s)
   {
@@ -247,9 +266,9 @@ public:
     {
       try
       {
-        c.push_back(boost::lexical_cast<T>(boost::trim_copy(*it))); // succeeds only if the whole output can be explained, i.e. "1.3 3" will fail (which is good)
+        c.push_back(detail::convert<T>(String(*it).trim())); // succeeds only if the whole output can be explained, i.e. "1.3 3" will fail (which is good)
       }
-      catch (boost::bad_lexical_cast&)
+      catch (...)
       {
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Could not convert string '") + *it + "'");
       }

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
@@ -41,6 +41,8 @@
 #include <OpenMS/METADATA/CVTermList.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 
+#include <ostream>
+
 namespace OpenMS
 {
   namespace Internal
@@ -87,16 +89,16 @@ public:
 protected:
 
       /// Progress logger
-      const ProgressLogger & logger_;
+      const ProgressLogger& logger_;
 
       ///Controlled vocabulary (psi-ms from OpenMS/share/OpenMS/CV/psi-ms.obo)
       ControlledVocabulary cv_;
 
       String tag_;
 
-      TargetedExperiment * exp_;
+      TargetedExperiment* exp_;
 
-      const TargetedExperiment * cexp_;
+      const TargetedExperiment* cexp_;
 
       TargetedExperiment::Publication actual_publication_;
 

--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 

--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 #include <OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h>
 
+#include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/DATASTRUCTURES/LPWrapper.h>
 #include <OpenMS/DATASTRUCTURES/MassExplainer.h>
 #include <OpenMS/SYSTEM/StopWatch.h>

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/CHEMISTRY/Element.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -104,7 +104,7 @@ namespace OpenMS
     defaults_.setValue("uis_threshold_peak_area", 0, "Peak area threshold to consider identification transition (set to -1 to consider all)");
     defaults_.setValue("scoring_model", "default", "Scoring model to use", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("scoring_model", ListUtils::create<String>("default,single_transition"));
-    defaults_.setValue("im_extra_drift", 0.0, "Extra drift time to extract for IM scoring (as a fraction, e.g. 0.25 means 25\% extra on each side)", ListUtils::create<String>("advanced"));
+    defaults_.setValue("im_extra_drift", 0.0, "Extra drift time to extract for IM scoring (as a fraction, e.g. 0.25 means 25% extra on each side)", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("im_extra_drift", 0.0);
 
     defaults_.insert("TransitionGroupPicker:", MRMTransitionGroupPicker().getDefaults());

--- a/src/openms/source/ANALYSIS/OPENSWATH/SONARScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SONARScoring.cpp
@@ -43,6 +43,8 @@
 
 #include <OpenMS/OPENSWATHALGO/ALGO/Scoring.h>
 
+#include <boost/cast.hpp>
+
 // #define DEBUG_SONAR
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/PIP/LocalLinearMap.cpp
+++ b/src/openms/source/ANALYSIS/PIP/LocalLinearMap.cpp
@@ -37,6 +37,7 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace std;
 

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -34,8 +34,47 @@
 
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
 
+#include <tuple>
+
 namespace OpenMS
 {
+
+  bool AbsoluteQuantitationMethod::operator==(const AbsoluteQuantitationMethod& other) const
+  {
+    return
+      std::tie(
+        component_name_,
+        feature_name_,
+        IS_name_,
+        llod_,
+        ulod_,
+        lloq_,
+        uloq_,
+        n_points_,
+        correlation_coefficient_,
+        concentration_units_,
+        transformation_model_,
+        transformation_model_params_
+      ) == std::tie(
+        other.component_name_,
+        other.feature_name_,
+        other.IS_name_,
+        other.llod_,
+        other.ulod_,
+        other.lloq_,
+        other.uloq_,
+        other.n_points_,
+        other.correlation_coefficient_,
+        other.concentration_units_,
+        other.transformation_model_,
+        other.transformation_model_params_
+      );
+  }
+
+  bool AbsoluteQuantitationMethod::operator!=(const AbsoluteQuantitationMethod& other) const
+  {
+    return !(*this == other);
+  }
   void AbsoluteQuantitationMethod::setLLOD(const double llod)
   {
     llod_ = llod;

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <QDir>
 #include <fstream>
+#include <istream>
 #include <iomanip>
 #include <iostream>
 

--- a/src/openms/source/DATASTRUCTURES/ChargePair.cpp
+++ b/src/openms/source/DATASTRUCTURES/ChargePair.cpp
@@ -35,6 +35,8 @@
 #include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/DATASTRUCTURES/Adduct.h>
 
+#include <ostream>
+
 namespace OpenMS
 {
 
@@ -97,11 +99,6 @@ namespace OpenMS
     is_active_ = rhs.is_active_;
 
     return *this;
-  }
-
-  /// Destructor
-  ChargePair::~ChargePair()
-  {
   }
 
   //@}

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -34,11 +34,12 @@
 
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 
-#include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 #include <OpenMS/CONCEPT/PrecisionWrapper.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 
 #include <QtCore/QString>
+
+#include <sstream>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -41,6 +41,7 @@
 #include <OpenMS/ANALYSIS/XLMS/OPXLHelper.h>
 #include <OpenMS/CONCEPT/Constants.h>
 
+#include <boost/lexical_cast.hpp>
 
 #include <sys/stat.h>
 #include <cerrno>

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -43,6 +43,7 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/CHEMISTRY/CrossLinksDB.h>
 
+#include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 
 using namespace std;

--- a/src/openms/source/FORMAT/InspectInfile.cpp
+++ b/src/openms/source/FORMAT/InspectInfile.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/FORMAT/PTMXMLFile.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/MascotInfile.cpp
+++ b/src/openms/source/FORMAT/MascotInfile.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/FORMAT/MascotInfile.h>
 
+#include <sstream>
+
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#include <sstream>
+
 namespace OpenMS
 {
 
@@ -142,17 +144,13 @@ namespace OpenMS
     }
     catch (Exception::BaseException& e)
     {
-      std::string expr;
-      expr.append(e.getFile());
-      expr.append("@");
-      std::stringstream ss;
-      ss << e.getLine(); // we need c++11!! maybe in 2012?
-      expr.append(ss.str());
-      expr.append("-");
-      expr.append(e.getFunction());
-      std::string mess = "- due to that error of type ";
-      mess.append(e.getName());
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, expr, mess);
+      String expr;
+      expr += e.getFile();
+      expr += "@";
+      expr += e.getLine();
+      expr += "-";
+      expr += e.getFunction();
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, expr, String("- due to that error of type ") + e.getName());
     }
   }
 

--- a/src/openms/source/FORMAT/PercolatorOutfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorOutfile.cpp
@@ -254,7 +254,7 @@ namespace OpenMS
 
       PeptideIdentification peptide;
       peptide.setIdentifier("id");
-      if (!boost::math::isnan(meta_data.rt))
+      if (!std::isnan(meta_data.rt))
       {
         peptide.setRT(meta_data.rt);
       }
@@ -262,7 +262,7 @@ namespace OpenMS
       {
         ++no_rt;
       }
-      if (!boost::math::isnan(meta_data.precursor_mz))
+      if (!std::isnan(meta_data.precursor_mz))
       {
         peptide.setMZ(meta_data.precursor_mz);
       }

--- a/src/openms/source/FORMAT/SequestInfile.cpp
+++ b/src/openms/source/FORMAT/SequestInfile.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/FORMAT/PTMXMLFile.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/SequestOutfile.cpp
+++ b/src/openms/source/FORMAT/SequestOutfile.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 
 #include <fstream>
+#include <sstream>
 
 using namespace std;
 

--- a/src/openms/source/METADATA/ExperimentalSettings.cpp
+++ b/src/openms/source/METADATA/ExperimentalSettings.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/METADATA/ExperimentalSettings.h>
 
+#include <ostream>
+
 using namespace std;
 
 namespace OpenMS
@@ -150,8 +152,8 @@ namespace OpenMS
 
   std::ostream & operator<<(std::ostream & os, const ExperimentalSettings & /*exp*/)
   {
-    os << "-- EXPERIMENTALSETTINGS BEGIN --" << std::endl;
-    os << "-- EXPERIMENTALSETTINGS END --" << std::endl;
+    os << "-- EXPERIMENTALSETTINGS BEGIN --\n";
+    os << "-- EXPERIMENTALSETTINGS END --\n";
     return os;
   }
 

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -89,7 +89,7 @@ namespace OpenMS
 
   bool PeptideIdentification::hasRT() const
   {
-    return !boost::math::isnan(rt_);
+    return !std::isnan(rt_);
   }
 
   double PeptideIdentification::getMZ() const
@@ -104,7 +104,7 @@ namespace OpenMS
 
   bool PeptideIdentification::hasMZ() const
   {
-    return !boost::math::isnan(mz_);
+    return !std::isnan(mz_);
   }
 
   const std::vector<PeptideHit>& PeptideIdentification::getHits() const

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -185,7 +185,7 @@ namespace OpenMS
     for (vector<PeptideIdentification>::iterator it = peptides.begin();
             it != peptides.end(); ++it)
     {
-      if (boost::math::isnan(it->getRT()))
+      if (std::isnan(it->getRT()))
       {
         if (lookup.empty())
         {

--- a/src/openms/source/SIMULATION/EGHFitter1D.cpp
+++ b/src/openms/source/SIMULATION/EGHFitter1D.cpp
@@ -255,7 +255,7 @@ namespace OpenMS
     }
 
     QualityType correlation = Math::pearsonCorrelationCoefficient(real_data.begin(), real_data.end(), model_data.begin(), model_data.end());
-    if (boost::math::isnan(correlation))
+    if (std::isnan(correlation))
       correlation = -1.0;
 
     return correlation;

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -48,15 +48,18 @@
 #include <QtNetwork/QHostInfo>
 
 #ifdef OPENMS_WINDOWSPLATFORM
-#  include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName()
-#else
+#include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName()
 #endif
 
-using namespace std;
+#ifdef OPENMS_HAS_UNISTD_H
+#include <unistd.h> // for readLink() and getpid()
+#endif
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
+
+using namespace std;
 
 namespace OpenMS
 {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/BiGaussFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/BiGaussFitter1D.cpp
@@ -103,7 +103,7 @@ namespace OpenMS
     // fit offset
     QualityType quality;
     quality = fitOffset_(model, set, stdev1, stdev2, interpolation_step_);
-    if (boost::math::isnan(quality))
+    if (std::isnan(quality))
       quality = -1.0;
 
     return quality;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EmgFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EmgFitter1D.cpp
@@ -226,7 +226,7 @@ namespace OpenMS
     }
 
     QualityType correlation = Math::pearsonCorrelationCoefficient(real_data.begin(), real_data.end(), model_data.begin(), model_data.end());
-    if (boost::math::isnan(correlation))
+    if (std::isnan(correlation))
     {
       correlation = -1.0;
     }
@@ -266,7 +266,7 @@ namespace OpenMS
     symmetry_ = fabs(set[set.size() - 1].getPos() - set[median].getPos()) / fabs(set[median].getPos() - set[0].getPos());
 
     // check the symmetry
-    if (boost::math::isinf(symmetry_) || boost::math::isnan(symmetry_))
+    if (std::isinf(symmetry_) || std::isnan(symmetry_))
     {
       symmetric_ = true;
       symmetry_ = 10.0;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ExtendedIsotopeFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ExtendedIsotopeFitter1D.cpp
@@ -138,7 +138,7 @@ namespace OpenMS
     }
 
     QualityType correlation = Math::pearsonCorrelationCoefficient(real_data.begin(), real_data.end(), model_data.begin(), model_data.end());
-    if (boost::math::isnan(correlation))
+    if (std::isnan(correlation))
       correlation = -1.0;
 
     return correlation;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
@@ -416,7 +416,7 @@ param.setValue( "deltaRelError", deltaRelError_);
     quality = fitter.fit1d(rt_input_data, model);
 
     // Check quality
-    if (boost::math::isnan(quality)) quality = -1.0;
+    if (std::isnan(quality)) quality = -1.0;
 
     return quality;
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussFitter1D.cpp
@@ -102,7 +102,7 @@ namespace OpenMS
     // fit offset
     QualityType quality;
     quality = fitOffset_(model, set, stdev, stdev, interpolation_step_);
-    if (boost::math::isnan(quality))
+    if (std::isnan(quality))
       quality = -1.0;
 
     return quality;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/IsotopeFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/IsotopeFitter1D.cpp
@@ -129,7 +129,7 @@ namespace OpenMS
     // fit offset
     QualityType quality;
     quality = fitOffset_(model, set, stdev, stdev, interpolation_step_);
-    if (boost::math::isnan(quality))
+    if (std::isnan(quality))
       quality = -1.0;
 
     return quality;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -38,7 +38,7 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/replace.hpp>
-
+#include <boost/algorithm/string/classification.hpp>
 #include <iostream>
 #include <ostream>
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -44,7 +44,6 @@
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
 
 using namespace std;
-using namespace boost::math;
 
 namespace OpenMS
 {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -42,7 +42,6 @@
 // #define DEBUG
 
 using namespace std;
-using namespace boost::math;
 
 namespace OpenMS
 {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -43,7 +43,6 @@
 //#define DEBUG
 
 using namespace std;
-using namespace boost::math;
 
 namespace OpenMS
 {

--- a/src/tests/class_tests/openms/source/DBoundingBox_test.cpp
+++ b/src/tests/class_tests/openms/source/DBoundingBox_test.cpp
@@ -41,6 +41,9 @@
 
 /////////////////////////////////////////////////////////////
 
+
+#include <sstream>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -45,6 +45,8 @@
 #include <OpenMS/CHEMISTRY/ElementDB.h>
 #include <OpenMS/CONCEPT/Constants.h>
 
+#include <sstream>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/HiddenMarkovModel_test.cpp
+++ b/src/tests/class_tests/openms/source/HiddenMarkovModel_test.cpp
@@ -38,6 +38,7 @@
 ///////////////////////////
 
 #include <iostream>
+#include <sstream>
 
 #include <OpenMS/ANALYSIS/ID/HiddenMarkovModel.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>

--- a/src/tests/class_tests/openms/source/ILPDCWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/ILPDCWrapper_test.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/ANALYSIS/DECHARGING/ILPDCWrapper.h>
 ///////////////////////////
 
+#include <OpenMS/DATASTRUCTURES/ChargePair.h>
 #include <OpenMS/DATASTRUCTURES/MassExplainer.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/KERNEL/MSChromatogram.h>
 ///////////////////////////
 
+#include <sstream>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -43,6 +43,8 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
+#include <sstream>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/Matrix_test.cpp
+++ b/src/tests/class_tests/openms/source/Matrix_test.cpp
@@ -42,6 +42,8 @@
 // Includes go here....
 #include <OpenMS/DATASTRUCTURES/Matrix.h>
 
+#include <sstream>
+
 ///////////////////////////
 
 START_TEST(Matrix, "$Id$");

--- a/src/tests/class_tests/openms/source/SequestInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/SequestInfile_test.cpp
@@ -42,8 +42,9 @@
 
 #include <iostream>
 #include <fstream>
-#include <string>
 #include <map>
+#include <string>
+#include <sstream>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -39,6 +39,9 @@
 #include <OpenMS/ANALYSIS/SVM/SimpleSVM.h>
 ///////////////////////////
 
+#include <sstream>
+
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/StreamHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/StreamHandler_test.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/CONCEPT/StreamHandler.h>
 ///////////////////////////
 
+#include <sstream>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -85,7 +85,6 @@
 
 using namespace std;
 using namespace OpenMS;
-using namespace boost::math;
 
 //-------------------------------------------------------------
 //Doxygen docu

--- a/src/utils/MultiplexResolver.cpp
+++ b/src/utils/MultiplexResolver.cpp
@@ -51,7 +51,6 @@
 
 using namespace std;
 using namespace OpenMS;
-using namespace boost::math;
 
 //#define DEBUG
 
@@ -277,7 +276,7 @@ private:
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The meta value 'map_index' is missing in the input data. In the IDMapper tool, please set the advanced parameter consensus:annotate_ids_with_subelements = true.");
     }
     double detected_delta_mass_at_label_set = deltaMassFromMapIndex_(consensus->getFeatures(), consensus->getPeptideIdentifications()[0].getMetaValue("map_index"));
-    if (boost::math::isnan(detected_delta_mass_at_label_set))
+    if (std::isnan(detected_delta_mass_at_label_set))
     {
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No delta mass with this map_index could be found.", "");
     }
@@ -331,11 +330,10 @@ private:
       std::vector<MultiplexDeltaMasses::DeltaMass> pattern = it_pattern->getDeltaMasses();
       
       double shift = matchLabelSet_(pattern, label_set, index_label_set);
-      if (!boost::math::isnan(shift))
+      if (!std::isnan(shift))
       {        
-        // reset boolean vector
-        unsigned i = delta_mass_matched.size();
-        delta_mass_matched.assign(i, false);
+        // reset boolean vector to false
+        delta_mass_matched.assign(delta_mass_matched.size(), false);
         
         bool match = matchDeltaMasses_(consensus, pattern, shift, delta_mass_matched);
         if (match)
@@ -522,7 +520,7 @@ private:
   {
     // unsigned found_pattern_count = 0;
     std::vector<MultiplexDeltaMasses> theoretical_masses = generator.getDeltaMassesList();
-    unsigned multiplicity = theoretical_masses[0].getDeltaMasses().size();
+    size_t multiplicity = theoretical_masses[0].getDeltaMasses().size();
     
     for (ConsensusMap::ConstIterator cit = map_in.begin(); cit != map_in.end(); ++cit)
     {

--- a/src/utils/MzMLSplitter.cpp
+++ b/src/utils/MzMLSplitter.cpp
@@ -39,6 +39,7 @@
 
 #include <QFile>
 #include <iomanip>
+#include <sstream>
 
 using namespace OpenMS;
 using namespace std;


### PR DESCRIPTION
removing a boost includes from a widely used header (ListUtils.h) improves compile time significantly (at least on VS), by 16% (Release build) and 9% (Debug build) for all affected .cpps

Release
before: 14m 47s 805ms 
after:  12m 25s 281ms  -->~ -16%

Debug:
before: 11m 31s
after: 10m 30s   -->~ -9%
