### PR TITLE
Support for raw files as primary MS runs (solves #4332)

### DIFF
--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationDataConverter.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationDataConverter.h
@@ -202,6 +202,5 @@ namespace OpenMS
     static void exportMSRunInformation_(
       IdentificationData::ProcessingStepRef step_ref,
       ProteinIdentification& protein);
-
   };
 }

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationDataConverter.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationDataConverter.h
@@ -197,5 +197,11 @@ namespace OpenMS
     /// Helper function to export DB search parameters to legacy format
     static ProteinIdentification::SearchParameters exportDBSearchParameters_(
       IdentificationData::SearchParamRef ref);
+
+    /// Helper function to export (primary) MS run information to legacy format
+    static void exportMSRunInformation_(
+      IdentificationData::ProcessingStepRef step_ref,
+      ProteinIdentification& protein);
+
   };
 }

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -237,16 +237,16 @@ public:
 
       SearchParameters();
       /// Copy constructor
-      SearchParameters(const SearchParameters &) = default;
+      SearchParameters(const SearchParameters&) = default;
       /// Move constructor
       SearchParameters(SearchParameters&&) = default;
       /// Destructor
       ~SearchParameters() = default;
 
       /// Assignment operator
-      SearchParameters & operator=(const SearchParameters &) = default;
+      SearchParameters& operator=(const SearchParameters&) = default;
       /// Move assignment operator
-      SearchParameters& operator=(SearchParameters&&) & = default;
+      SearchParameters& operator=(SearchParameters&&)& = default;
 
       bool operator==(const SearchParameters& rhs) const;
 
@@ -282,13 +282,13 @@ public:
     ///@name Protein hit information (public members)
     //@{
     /// Returns the protein hits
-    const std::vector<ProteinHit> & getHits() const;
+    const std::vector<ProteinHit>& getHits() const;
     /// Returns the protein hits (mutable)
-    std::vector<ProteinHit> & getHits();
+    std::vector<ProteinHit>& getHits();
     /// Appends a protein hit
-    void insertHit(const ProteinHit & input);
+    void insertHit(const ProteinHit& input);
     /// Appends a protein hit
-    void insertHit(ProteinHit && input);
+    void insertHit(ProteinHit&& input);
 
     /**
         @brief Sets the protein hits
@@ -305,7 +305,7 @@ public:
     /// Returns the protein groups (mutable)
     std::vector<ProteinGroup>& getProteinGroups();
     /// Appends a new protein group
-    void insertProteinGroup(const ProteinGroup & group);
+    void insertProteinGroup(const ProteinGroup& group);
 
     /// Returns the indistinguishable proteins
     const std::vector<ProteinGroup>& getIndistinguishableProteins() const;
@@ -350,7 +350,7 @@ public:
     */
     void computeModifications(
       const std::vector<PeptideIdentification>& pep_ids,
-      const StringList & skip_modifications);
+      const StringList& skip_modifications);
 
 
     ///@name General information
@@ -382,7 +382,7 @@ public:
     /// Returns the search parameters
     const SearchParameters& getSearchParameters() const;
     /// Returns the search parameters (mutable)
-    SearchParameters& getSearchParameters();    
+    SearchParameters& getSearchParameters();
     /// Returns the identifier
     const String& getIdentifier() const;
     /// Sets the identifier
@@ -390,12 +390,12 @@ public:
     /// set the file path to the primary MS run (usually the mzML file obtained after data conversion from raw files)
     void setPrimaryMSRunPath(const StringList& s);
     /// set the file path to the primary MS run but try to use the mzML annotated in the MSExperiment.
-    void setPrimaryMSRunPath(const StringList& s, MSExperiment & e);
+    void setPrimaryMSRunPath(const StringList& s, MSExperiment& e);
     void addPrimaryMSRunPath(const String& toAdd);
     void addPrimaryMSRunPath(const StringList& toAdd);
     /// get the file path to the first MS run
     void getPrimaryMSRunPath(StringList& toFill) const;
-    void getPrimaryMSRunPath(std::set<String> &toFill) const;
+    void getPrimaryMSRunPath(std::set<String>& toFill) const;
     /// if this object has inference data
     bool hasInferenceData() const;
     bool hasInferenceEngineAsSearchEngine() const;

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -387,14 +387,22 @@ public:
     const String& getIdentifier() const;
     /// Sets the identifier
     void setIdentifier(const String& id);
-    /// set the file path to the primary MS run (usually the mzML file obtained after data conversion from raw files)
-    void setPrimaryMSRunPath(const StringList& s);
+    /**
+       Set the file paths to the primary MS runs (usually the mzML files obtained after data conversion from raw files)
+
+       @param raw Store paths to the raw files (or equivalent) rather than mzMLs
+    */
+    void setPrimaryMSRunPath(const StringList& s, bool raw = false);
     /// set the file path to the primary MS run but try to use the mzML annotated in the MSExperiment.
     void setPrimaryMSRunPath(const StringList& s, MSExperiment& e);
-    void addPrimaryMSRunPath(const String& s);
-    void addPrimaryMSRunPath(const StringList& s);
-    /// get the file path to the first MS run
-    void getPrimaryMSRunPath(StringList& output) const;
+    void addPrimaryMSRunPath(const String& s, bool raw = false);
+    void addPrimaryMSRunPath(const StringList& s, bool raw = false);
+    /**
+       Get the file paths to the primary MS runs
+
+       @param raw Get raw files (or equivalent) instead of mzMLs
+    */
+    void getPrimaryMSRunPath(StringList& output, bool raw = false) const;
     /// if this object has inference data
     bool hasInferenceData() const;
     bool hasInferenceEngineAsSearchEngine() const;

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -391,11 +391,10 @@ public:
     void setPrimaryMSRunPath(const StringList& s);
     /// set the file path to the primary MS run but try to use the mzML annotated in the MSExperiment.
     void setPrimaryMSRunPath(const StringList& s, MSExperiment& e);
-    void addPrimaryMSRunPath(const String& toAdd);
-    void addPrimaryMSRunPath(const StringList& toAdd);
+    void addPrimaryMSRunPath(const String& s);
+    void addPrimaryMSRunPath(const StringList& s);
     /// get the file path to the first MS run
-    void getPrimaryMSRunPath(StringList& toFill) const;
-    void getPrimaryMSRunPath(std::set<String>& toFill) const;
+    void getPrimaryMSRunPath(StringList& output) const;
     /// if this object has inference data
     bool hasInferenceData() const;
     bool hasInferenceEngineAsSearchEngine() const;

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -173,7 +173,7 @@ namespace OpenMS
 
     // Mapping from old run ID String to new runIDs indices, i.e. calculate from the file/label pairs (=ColumnHeaders),
     // which ProteinIdentifications need to be merged.
-    map<String,set<Size>> runIDToNewRunIdcs;
+    map<String, set<Size>> runIDToNewRunIdcs;
     // this is to check how many old runs contribute to the new runs
     // this can help save time and we can double check
     vector<Size> nrInputsForNewRunIDs(new_size, 0);
@@ -181,8 +181,9 @@ namespace OpenMS
     {
       for (auto& oldProtID : cmap.getProteinIdentifications())
       {
-        set<String> currentContent;
-        oldProtID.getPrimaryMSRunPath(currentContent);
+        StringList primary_runs;
+        oldProtID.getPrimaryMSRunPath(primary_runs);
+        set<String> currentContent(primary_runs.begin(), primary_runs.end());
         const set<String>& mergeRequest = newidxToOriginsetMapIdxPair.second.first;
         // if this run is fully covered by a requested merged set, use it for it.
         Size count = 1;

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -503,7 +503,10 @@ namespace OpenMS
       }
       else
       {
-        String ms_run_location = path + "/" + filename;
+        // use Windows or UNIX path separator?
+        String actual_path = path.hasPrefix("file:///") ? path.substr(8) : path;
+        String sep = (actual_path.has('\\') && !actual_path.has('/')) ? "\\" : "/";
+        String ms_run_location = path + sep + filename;
         toFill.push_back(ms_run_location);
       }
     }

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -70,7 +70,7 @@ namespace OpenMS
     return accessions < rhs.accessions;
   }
 
-  const ProteinIdentification::ProteinGroup::FloatDataArrays &ProteinIdentification::ProteinGroup::getFloatDataArrays() const
+  const ProteinIdentification::ProteinGroup::FloatDataArrays& ProteinIdentification::ProteinGroup::getFloatDataArrays() const
   {
     return float_data_arrays_;
   }
@@ -80,32 +80,32 @@ namespace OpenMS
     float_data_arrays_ = fda;
   }
 
-  const ProteinIdentification::ProteinGroup::StringDataArrays &ProteinIdentification::ProteinGroup::getStringDataArrays() const
+  const ProteinIdentification::ProteinGroup::StringDataArrays& ProteinIdentification::ProteinGroup::getStringDataArrays() const
   {
     return string_data_arrays_;
   }
 
-  void ProteinIdentification::ProteinGroup::setStringDataArrays(const ProteinIdentification::ProteinGroup::StringDataArrays &sda)
+  void ProteinIdentification::ProteinGroup::setStringDataArrays(const ProteinIdentification::ProteinGroup::StringDataArrays& sda)
   {
     string_data_arrays_ = sda;
   }
 
-  ProteinIdentification::ProteinGroup::StringDataArrays &ProteinIdentification::ProteinGroup::getStringDataArrays()
+  ProteinIdentification::ProteinGroup::StringDataArrays& ProteinIdentification::ProteinGroup::getStringDataArrays()
   {
     return string_data_arrays_;
   }
 
-  const ProteinIdentification::ProteinGroup::IntegerDataArrays &ProteinIdentification::ProteinGroup::getIntegerDataArrays() const
+  const ProteinIdentification::ProteinGroup::IntegerDataArrays& ProteinIdentification::ProteinGroup::getIntegerDataArrays() const
   {
     return integer_data_arrays_;
   }
 
-  ProteinIdentification::ProteinGroup::IntegerDataArrays &ProteinIdentification::ProteinGroup::getIntegerDataArrays()
+  ProteinIdentification::ProteinGroup::IntegerDataArrays& ProteinIdentification::ProteinGroup::getIntegerDataArrays()
   {
     return integer_data_arrays_;
   }
 
-  void ProteinIdentification::ProteinGroup::setIntegerDataArrays(const ProteinIdentification::ProteinGroup::IntegerDataArrays &ida)
+  void ProteinIdentification::ProteinGroup::setIntegerDataArrays(const ProteinIdentification::ProteinGroup::IntegerDataArrays& ida)
   {
     integer_data_arrays_ = ida;
   }
@@ -369,21 +369,21 @@ namespace OpenMS
       OPENMS_LOG_WARN << "Setting empty MS runs paths." << std::endl;
       this->setMetaValue("spectra_data", DataValue(s));
       return;
-    }     
+    }
 
     for (const String& filename : s)
     {
       if (!filename.hasSuffix("mzML"))
       {
         OPENMS_LOG_WARN << "To ensure tracability of results please prefer mzML files as primary MS run." << std::endl
-                        << "Filename: '" << filename << "'" << std::endl;                          
+                        << "Filename: '" << filename << "'" << std::endl;
       }
     }
 
     this->setMetaValue("spectra_data", DataValue(s));
   }
 
-  void ProteinIdentification::setPrimaryMSRunPath(const StringList& s, MSExperiment & e)
+  void ProteinIdentification::setPrimaryMSRunPath(const StringList& s, MSExperiment& e)
   {
     StringList ms_path;
     e.getPrimaryMSRunPath(ms_path);
@@ -394,7 +394,7 @@ namespace OpenMS
     else
     {
       setPrimaryMSRunPath(s);
-    }        
+    }
   }
 
   /// get the file path to the first MS runs
@@ -526,17 +526,17 @@ namespace OpenMS
     for (Size pep_i = 0; pep_i != pep_ids.size(); ++pep_i)
     {
       // peptide hits
-      const PeptideIdentification & peptide_id = pep_ids[pep_i];
+      const PeptideIdentification& peptide_id = pep_ids[pep_i];
       const vector<PeptideHit>& peptide_hits = peptide_id.getHits();
       for (Size ph_i = 0; ph_i != peptide_hits.size(); ++ph_i)
       {
-        const PeptideHit & peptide_hit = peptide_hits[ph_i];
+        const PeptideHit& peptide_hit = peptide_hits[ph_i];
         const std::vector<PeptideEvidence>& ph_evidences = peptide_hit.getPeptideEvidences();
 
         // matched proteins for hit
         for (Size pep_ev_i = 0; pep_ev_i != ph_evidences.size(); ++pep_ev_i)
         {
-          const PeptideEvidence & evidence = ph_evidences[pep_ev_i];
+          const PeptideEvidence& evidence = ph_evidences[pep_ev_i];
           map_acc_2_evidence[evidence.getProteinAccession()].insert(evidence);
         }
       }
@@ -551,11 +551,11 @@ namespace OpenMS
       }
       vector<bool> covered_amino_acids(protein_length, false);
 
-      const String & accession = protein_hits_[i].getAccession();
+      const String& accession = protein_hits_[i].getAccession();
       double coverage = 0.0;
       if (map_acc_2_evidence.find(accession) != map_acc_2_evidence.end())
       {
-        const set<PeptideEvidence> & evidences = map_acc_2_evidence.find(accession)->second;
+        const set<PeptideEvidence>& evidences = map_acc_2_evidence.find(accession)->second;
         for (set<PeptideEvidence>::const_iterator sit = evidences.begin(); sit != evidences.end(); ++sit)
         {
           int start = sit->getStart();
@@ -586,7 +586,7 @@ namespace OpenMS
 
   void ProteinIdentification::computeModifications(
     const std::vector<PeptideIdentification>& pep_ids,
-    const StringList & skip_modifications)
+    const StringList& skip_modifications)
   {
     // map protein accession to observed position,modifications pairs
     map<String, set<pair<Size, ResidueModification>>> prot2mod;
@@ -594,12 +594,12 @@ namespace OpenMS
     for (Size pep_i = 0; pep_i != pep_ids.size(); ++pep_i)
     {
       // peptide hits
-      const PeptideIdentification & peptide_id = pep_ids[pep_i];
+      const PeptideIdentification& peptide_id = pep_ids[pep_i];
       const vector<PeptideHit> peptide_hits = peptide_id.getHits();
       for (Size ph_i = 0; ph_i != peptide_hits.size(); ++ph_i)
       {
-        const PeptideHit & peptide_hit = peptide_hits[ph_i];
-        const AASequence & aas = peptide_hit.getSequence();
+        const PeptideHit& peptide_hit = peptide_hits[ph_i];
+        const AASequence& aas = peptide_hit.getSequence();
         const std::vector<PeptideEvidence>& ph_evidences = peptide_hit.getPeptideEvidences();
 
         // skip unmodified peptides
@@ -616,7 +616,7 @@ namespace OpenMS
             {
               for (Size phe_i = 0; phe_i != ph_evidences.size(); ++phe_i)
               {
-                const String & acc = ph_evidences[phe_i].getProteinAccession();
+                const String& acc = ph_evidences[phe_i].getProteinAccession();
                 const Size mod_pos = ph_evidences[phe_i].getStart(); // mod at N terminus
                 prot2mod[acc].insert(make_pair(mod_pos, *res_mod));
               }
@@ -634,7 +634,7 @@ namespace OpenMS
               {
                 for (Size phe_i = 0; phe_i != ph_evidences.size(); ++phe_i)
                 {
-                  const String & acc = ph_evidences[phe_i].getProteinAccession();
+                  const String& acc = ph_evidences[phe_i].getProteinAccession();
                   const Size mod_pos = ph_evidences[phe_i].getStart() + ai; // start + ai
                   prot2mod[acc].insert(make_pair(mod_pos, *res_mod));
                 }
@@ -651,7 +651,7 @@ namespace OpenMS
             {
               for (Size phe_i = 0; phe_i != ph_evidences.size(); ++phe_i)
               {
-                const String & acc = ph_evidences[phe_i].getProteinAccession();
+                const String& acc = ph_evidences[phe_i].getProteinAccession();
                 const Size mod_pos = ph_evidences[phe_i].getEnd(); // mod at C terminus
                 prot2mod[acc].insert(make_pair(mod_pos, *res_mod));
               }
@@ -663,7 +663,7 @@ namespace OpenMS
 
     for (Size i = 0; i < protein_hits_.size(); ++i)
     {
-      const String & accession = protein_hits_[i].getAccession();
+      const String& accession = protein_hits_[i].getAccession();
       if (prot2mod.find(accession) != prot2mod.end())
       {
         protein_hits_[i].setModifications(prot2mod[accession]);

--- a/src/pyOpenMS/pxds/ProteinIdentification.pxd
+++ b/src/pyOpenMS/pxds/ProteinIdentification.pxd
@@ -83,7 +83,12 @@ cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS":
         void setIdentifier(String id_) nogil except +
 
         void setPrimaryMSRunPath(StringList& s) nogil except +
-        void getPrimaryMSRunPath(StringList& toFill) nogil except +
+        void addPrimaryMSRunPath(StringList& s) nogil except +
+        void getPrimaryMSRunPath(StringList& output) nogil except +
+
+        void setPrimaryMSRunPath(StringList& s, bool raw) nogil except +
+        void addPrimaryMSRunPath(StringList& s, bool raw) nogil except +
+        void getPrimaryMSRunPath(StringList& output, bool raw) nogil except +
 
         # This causes as problem with circular dependencies when trying to use
         # ExperimentalSettings in MSExperiment

--- a/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
+++ b/src/tests/topp/NucleicAcidSearchEngine_11_out.idXML
@@ -8,7 +8,8 @@
 			<ProteinHit id="PH_0" accession="dme-let-7-5p" score="0.0" coverage="100.0" sequence="UGAGGUAGUAGGUUGUAUAGU" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[file:///U:\Byron\DATA\20180522_Let7-+Um_mixture_ramp_02/minimal_01a.raw]"/>
+            <UserParam type="stringList" name="spectra_data" value="[NucleicAcidSearchEngine_1.mzML]"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///U:\Byron\DATA\20180522_Let7-+Um_mixture_ramp_02\minimal_01a.raw]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="hyperscore" higher_score_better="true" significance_threshold="0.0" MZ="2263.620361328119998" RT="14.104380000000001" spectrum_reference="controllerType=0 controllerNumber=1 scan=88" >
 			<PeptideHit score="50.529285659036816" sequence="" charge="-3" aa_before="[" aa_after="]" start="0" end="20" protein_refs="PH_0" >

--- a/src/tests/topp/OpenPepXLLF_output.idXML
+++ b/src/tests/topp/OpenPepXLLF_output.idXML
@@ -28,6 +28,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
 			<UserParam type="string" name="SpectrumIdentificationProtocol" value="MS:1002494"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///C:\MSData\LRRK2_DSG\GUA1354-S15-A-LRRK2_DSG_A4.raw]"/>
 			<UserParam type="stringList" name="spectra_data" value="[file://OpenPepXLLF_input.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="OpenPepXL:score" higher_score_better="true" significance_threshold="0.0" MZ="787.740356445312955" RT="2175.300299999999879" spectrum_reference="controllerType=0 controllerNumber=1 scan=2395" >

--- a/src/tests/topp/OpenPepXLLF_output2.idXML
+++ b/src/tests/topp/OpenPepXLLF_output2.idXML
@@ -33,7 +33,8 @@
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
 			<UserParam type="string" name="SpectrumIdentificationProtocol" value="MS:1002494"/>
-			<UserParam type="stringList" name="spectra_data" value="[file://OpenPepXLLF_input2.mzML]"/>
+            <UserParam type="stringList" name="spectra_data_raw" value="[file:///D:\RAW\ETHZurich_2018_05\BSA_PDH_CID\aleitner_C1708_079.raw]"/>
+            <UserParam type="stringList" name="spectra_data" value="[file://OpenPepXLLF_input2.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="OpenPepXL:score" higher_score_better="true" significance_threshold="0.0" MZ="440.218688964843977" RT="273.605999999999995" spectrum_reference="controllerType=0 controllerNumber=1 scan=505" >
 			<PeptideHit score="-0.07670961257237" sequence="C(Carbamidomethyl)ASIQK" charge="3" aa_before="R" aa_after="F" start="198" end="203" protein_refs="PH_0" >

--- a/src/tests/topp/SimpleSearchEngine_1_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_1_out.idXML
@@ -15,6 +15,7 @@
 			<ProteinHit id="PH_2" accession="BSA3" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
+            <UserParam type="stringList" name="spectra_data_raw" value="[file://./KKramer_150612_yeastTAP_4_120min.raw]"/>
 			<UserParam type="stringList" name="spectra_data" value="[file://SimpleSearchEngine_1.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="hyperscore" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" >

--- a/src/tests/topp/THIRDPARTY/MyriMatchAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MyriMatchAdapter_1_out.idXML
@@ -12,7 +12,8 @@
 			</ProteinHit>
 			<ProteinHit id="PH_2" accession="BSA3" score="0" sequence="" >
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="mvh" higher_score_better="true" significance_threshold="0" MZ="520.263365947832" RT="2655.09570312498" >
 			<PeptideHit score="39.267901895785" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" protein_refs="PH_0" >

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_1_out.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/OMSSAAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2014-05-27T14:37:29" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
@@ -12,7 +12,8 @@
 			</ProteinHit>
 			<ProteinHit id="PH_2" accession="test2_rev ##1" score="-10.3000001907349" sequence="" >
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="XTandem" higher_score_better="true" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="56.5" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0"  end="13" protein_refs="PH_2" >

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_2_out.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/OMSSAAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2014-05-27T14:37:29" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
@@ -10,7 +10,8 @@
 			</ProteinHit>
 			<ProteinHit id="PH_1" accession="BSA2 ##2" score="-14.8999996185303" sequence="" >
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///C:/testing/test_file_path/test_file_name.raw]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/abi-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="XTandem" higher_score_better="true" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="77.9" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0"  end="27" protein_refs="PH_1" >

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -809,8 +809,9 @@ protected:
     const vector<String>& primary_files,
     const IdentificationData::DBSearchParam& search_param)
   {
+    String input_file = test_mode_ ? File::basename(in_mzml) : in_mzml;
     IdentificationData::InputFileRef file_ref =
-      id_data.registerInputFile(in_mzml);
+      id_data.registerInputFile(input_file);
     IdentificationData::ScoreType score("hyperscore", true);
     IdentificationData::ScoreTypeRef score_ref =
       id_data.registerScoreType(score);


### PR DESCRIPTION
These changes unify the handling of primary MS run information in class `ProteinIdentification` and extend it to support keeping track of raw files (in addition to mzMLs).
This also avoids the warning in NucleicAcidSearchEngine mentioned in #4332.