### PR TITLE
PeptideIndexer does not match all peptides to DB

### DIFF
--- a/share/OpenMS/CHEMISTRY/Enzymes.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes.xml
@@ -3,7 +3,7 @@
   <NODE name="Enzymes">
     <NODE name="Trypsin">
       <ITEM name="Name" value="Trypsin" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[KR])(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[KRX])(?!P)" type="string" />
       <ITEM name="RegExDescription" value="Trypsin cleaves following a K or R residue unless the next residue is P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -15,7 +15,7 @@
     </NODE>
     <NODE name="Arg-C">
       <ITEM name="Name" value="Arg-C" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=R)(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[RX])(?!P)" type="string" />
       <ITEM name="RegExDescription" value="Arg-C cleaves following R residue unless the next residue is P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -32,7 +32,7 @@
     </NODE>
     <NODE name="Arg-C/P">
       <ITEM name="Name" value="Arg-C/P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=R)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[RX])" type="string" />
       <ITEM name="RegExDescription" value="Arg-C/P cleaves after R residues." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -41,8 +41,8 @@
     </NODE>
     <NODE name="Asp-N">
       <ITEM name="Name" value="Asp-N" type="string" />
-      <ITEM name="RegEx" value="(?=[BD])" type="string" />
-      <ITEM name="RegExDescription" value="Asp-N cleaves before B or D." type="string" />
+      <ITEM name="RegEx" value="(?=[DBX])" type="string" />
+      <ITEM name="RegExDescription" value="Asp-N cleaves before D(or B)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001304" type="string" />
@@ -56,8 +56,8 @@
     </NODE>
     <NODE name="Asp-N/B">
       <ITEM name="Name" value="Asp-N/B" type="string" />
-      <ITEM name="RegEx" value="(?=[D])" type="string" />
-      <ITEM name="RegExDescription" value="Asp-N/B cleaves before D." type="string" />
+      <ITEM name="RegEx" value="(?=[DX])" type="string" />
+      <ITEM name="RegExDescription" value="Asp-N/B cleaves before D(while B is ignored)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="XTandemID" value="[X]|[D]" type="string" />
@@ -65,8 +65,8 @@
     </NODE>
     <NODE name="Asp-N_ambic">
       <ITEM name="Name" value="Asp-N_ambic" type="string" />
-      <ITEM name="RegEx" value="(?=[DE])" type="string" />
-      <ITEM name="RegExDescription" value="Asp-N Ammonium bicarbonate cleaves before D or E." type="string" />
+      <ITEM name="RegEx" value="(?=[DBEZX])" type="string" />
+      <ITEM name="RegExDescription" value="Asp-N Ammonium bicarbonate cleaves before D(or B) or E(or Z)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001305" type="string" />
@@ -75,8 +75,8 @@
     </NODE>
     <NODE name="Chymotrypsin">
       <ITEM name="Name" value="Chymotrypsin" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[FLWY])(?!P)" type="string" />
-      <ITEM name="RegExDescription" value="Chymotrypsin cleaves following F, Y, W or L residue unless the next residue is P." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FYWLJX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="Chymotrypsin cleaves following F, Y, W or L(or J) residue unless the next residue is P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001306" type="string" />
@@ -87,8 +87,8 @@
     </NODE>
     <NODE name="Chymotrypsin/P">
       <ITEM name="Name" value="Chymotrypsin/P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[FLWY])" type="string" />
-      <ITEM name="RegExDescription" value="Chymotrypsin cleaves following F, Y, W or L residue." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FYWLJX])" type="string" />
+      <ITEM name="RegExDescription" value="Chymotrypsin cleaves following F, Y, W or L(or J) residue." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="XTandemID" value="[FYWL]|[X]" type="string" />
@@ -96,7 +96,7 @@
     </NODE>
     <NODE name="CNBr">
       <ITEM name="Name" value="CNBr" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=M)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[MX])" type="string" />
       <ITEM name="RegExDescription" value="CNBr cleaves following M." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -107,8 +107,8 @@
     </NODE>
     <NODE name="Formic_acid">
       <ITEM name="Name" value="Formic_acid" type="string" />
-      <ITEM name="RegEx" value="((?&lt;=D))|((?=D))" type="string" />
-      <ITEM name="RegExDescription" value="Formic_acid cuts after D and next residue is D." type="string" />
+      <ITEM name="RegEx" value="((?&lt;=[DBX]))|((?=[DBX]))" type="string" />
+      <ITEM name="RegExDescription" value="Formic_acid cuts after D(or B) and next residue is D (or B)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001308" type="string" />
@@ -117,7 +117,7 @@
     </NODE>
     <NODE name="Lys-C">
       <ITEM name="Name" value="Lys-C" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=K)(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[KX])(?!P)" type="string" />
       <ITEM name="RegExDescription" value="Lys-C cuts after K if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -132,8 +132,8 @@
     </NODE>
     <NODE name="Lys-N">
       <ITEM name="Name" value="Lys-N" type="string" />
-      <ITEM name="RegEx" value="(?=K)" type="string" />
-      <ITEM name="RegExDescription" value="Lys-N cuts before K" type="string" />
+      <ITEM name="RegEx" value="(?=[KX])" type="string" />
+      <ITEM name="RegExDescription" value="Lys-N cuts before K." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="" type="string" />
@@ -147,7 +147,7 @@
     </NODE>
     <NODE name="Lys-C/P">
       <ITEM name="Name" value="Lys-C/P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=K)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[KX])" type="string" />
       <ITEM name="RegExDescription" value="Lys-C/P cuts after K." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -158,8 +158,8 @@
     </NODE>
     <NODE name="PepsinA">
       <ITEM name="Name" value="PepsinA" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[FL])" type="string" />
-      <ITEM name="RegExDescription" value="PepsinA cuts after F or L." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FLJX])" type="string" />
+      <ITEM name="RegExDescription" value="PepsinA cuts after F or L(or J)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001311" type="string" />
@@ -169,8 +169,8 @@
     </NODE>
     <NODE name="TrypChymo">
       <ITEM name="Name" value="TrypChymo" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[KRFLWY])(?!P)" type="string" />
-      <ITEM name="RegExDescription" value="TrypChymo cuts after F, Y, W, L, K or R if not followed by P." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FYWLJKRX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="TrypChymo cuts after F, Y, W, L(or J), K or R if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001312" type="string" />
@@ -179,7 +179,7 @@
     </NODE>
     <NODE name="Trypsin/P">
       <ITEM name="Name" value="Trypsin/P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[KR])" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[KRX])" type="string" />
       <ITEM name="RegExDescription" value="Trypsin/P cuts after K or R." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -192,8 +192,8 @@
     </NODE>
     <NODE name="V8-DE">
       <ITEM name="Name" value="V8-DE" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[BDEZ])(?!P)" type="string" />
-      <ITEM name="RegExDescription" value="V8-DE cuts after B, D, E or Z if not followed by P." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[DBEZX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="V8-DE cuts after D(or B) or E(or Z) if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001314" type="string" />
@@ -201,8 +201,8 @@
     </NODE>
     <NODE name="V8-E">
       <ITEM name="Name" value="V8-E" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[EZ])(?!P)" type="string" />
-      <ITEM name="RegExDescription" value="V8-E cuts after E or Z if not followed by P." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[EZX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="V8-E cuts after E(or Z) if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001315" type="string" />
@@ -210,8 +210,8 @@
     </NODE>
     <NODE name="leukocyte elastase">
       <ITEM name="Name" value="leukocyte elastase" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[AILV])(?!P)" type="string" />
-      <ITEM name="RegExDescription" value="leukocyte elastase cuts after A, L, I or V if not followed by P." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[ALIJVX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="leukocyte elastase cuts after A or L or I(or J) or V if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001915" type="string" />
@@ -220,7 +220,7 @@
     </NODE>
     <NODE name="proline endopeptidase">
       <ITEM name="Name" value="proline endopeptidase" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[HKR]P)(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[HKRX][PX])(?!P)" type="string" />
       <ITEM name="RegExDescription" value="proline endopeptidase cuts after HP, KP or RP if not followed by P." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -228,8 +228,8 @@
     </NODE>    
     <NODE name="glutamyl endopeptidase">
       <ITEM name="Name" value="glutamyl endopeptidase" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[DE])" type="string" />
-      <ITEM name="RegExDescription" value="glutamyl endopeptidase cuts after D or E." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[DBEZX])" type="string" />
+      <ITEM name="RegExDescription" value="glutamyl endopeptidase cuts after D(or B) or E(or Z)." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001917" type="string" />
@@ -245,8 +245,8 @@
     </NODE>
     <NODE name="alphaLP">
       <ITEM name="Name" value="Alpha-lytic protease" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[TASV])" type="string" />
-      <ITEM name="RegExDescription" value="Alpha-lytic protease (aLP) cuts after T, A, S, and V." type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[TASVX])" type="string" />
+      <ITEM name="RegExDescription" value="Alpha-lytic protease (aLP) cuts after T, A, S, or V." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="XTandemID" value="[ASTV]|[X]" type="string" />
@@ -254,7 +254,7 @@
     </NODE>
     <NODE name="2-iodobenzoate">
       <ITEM name="Name" value="2-iodobenzoate" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=W)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[WX])" type="string" />
       <ITEM name="RegExDescription" value="2-iodobenzoate cuts after W." type="string" />
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
@@ -268,7 +268,8 @@
     </NODE>
     <NODE name="staphylococcal protease/D">
       <ITEM name="Name" value="staphylococcal protease/D" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=E)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[EZX])" type="string" />
+      <ITEM name="RegExDescription" value="staphylococcal protease/D cuts after E(or Z)." type="string" />
       <ITEM name="CruxID" value="staph-protease" type="string" />
       <NODE name="Synonyms">
         <ITEM name="Glu-C/D" value="Glu-C/D" type="string" />
@@ -277,12 +278,14 @@
     </NODE>
     <NODE name="proline-endopeptidase/HKR">
       <ITEM name="Name" value="proline-endopeptidase/HKR" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[PX])" type="string" />
+      <ITEM name="RegExDescription" value="proline-endopeptidase/HKR cuts after P." type="string" />
       <ITEM name="CruxID" value="proline-endopeptidase" type="string" />
     </NODE>
     <NODE name="Glu-C+P">
       <ITEM name="Name" value="Glu-C+P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[DE])(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[DBEZX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="Glu-C+P cuts after D(or B) or E(or Z) unless followed by P." type="string" />
       <ITEM name="CruxID" value="glu-c" type="string" />
       <NODE name="Synonyms">
         <ITEM name="Glu-C+P" value="Glu-C+P" type="string" />
@@ -291,23 +294,27 @@
     </NODE>
     <NODE name="PepsinA + P">
       <ITEM name="Name" value="PepsinA + P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[FL])(?!P)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FLJX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="PepsinA + P cuts after F or L(or J) unless followed by P." type="string" />
       <ITEM name="CruxID" value="pepsin-a" type="string" />
     </NODE>
     <NODE name="cyanogen-bromide">
       <ITEM name="Name" value="cyanogen-bromide" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=M)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[MX])" type="string" />
+      <ITEM name="RegExDescription" value="cyanogen-bromide cuts after M." type="string" />
       <ITEM name="CruxID" value="cyanogen-bromide" type="string" />
     </NODE>
     <NODE name="Clostripain/P">
       <ITEM name="Name" value="Clostripain/P" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=R)" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[RX])" type="string" />
+      <ITEM name="RegExDescription" value="Clostripain/P cuts after R." type="string" />
       <ITEM name="CruxID" value="clostripain" type="string" />
     </NODE>
     <NODE name="elastase-trypsin-chymotrypsin">
       <ITEM name="Name" value="elastase-trypsin-chymotrypsin" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[ALIVKRWFYX])(?!P)" type="string" />
+      <ITEM name="RegExDescription" value="elastase-trypsin-chymotrypsin cuts after A,L,I(or J),V,K,R,W,F,Y unless followed by P." type="string" />
       <ITEM name="CruxID" value="elastase-trypsin-chymotrypsin" type="string" />
-      <ITEM name="RegEx" value="(?&lt;=[ALIVKRWFY])(?!P)" type="string" />
     </NODE>
     <NODE name="no cleavage">
       <ITEM name="Name" value="no cleavage" type="string" />

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -213,14 +213,8 @@ public:
       enzyme.setEnzyme(enzyme_name_);
       enzyme.setSpecificity(enzyme.getSpecificityByName(enzyme_specificity_));
 
-      bool xtandem_fix_parameters = true, msgfplus_fix_parameters = true;
-
-      // specificity is none or semi? don't automate xtandem 
-      if (enzyme.getSpecificity() == EnzymaticDigestion::SPEC_SEMI ||
-          enzyme.getSpecificity() == EnzymaticDigestion::SPEC_NONE) 
-      {
-        xtandem_fix_parameters = false;
-      }
+      bool xtandem_fix_parameters = true;
+      bool msgfplus_fix_parameters = true;
 
       // determine if search engine is solely xtandem or MSGFPlus
       for (const auto& prot_id : prot_ids)

--- a/src/openms/source/FORMAT/MSPFile.cpp
+++ b/src/openms/source/FORMAT/MSPFile.cpp
@@ -432,7 +432,7 @@ namespace OpenMS
         {
           if (rich_spec.getStringDataArrays()[k].getName() == "IonName")
           {
-            ion_name = k;
+            ion_name = (int)k;
             break;
           }
         }

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
@@ -2,21 +2,21 @@
 <msms_pipeline_analysis date="2007-12-05T17:49:46" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/pepXML/pepXML_v117.xsd" summary_xml=".xml">
 <msms_run_summary base_name="test" raw_data_type="raw" raw_data=".mzML" search_engine="X! Tandem (k-score)">
 	<sample_enzyme name="trypsin">
-		<specificity cut="KR" no_cut="P" sense="C"/>
+		<specificity cut="KRX" no_cut="P" sense="C"/>
 	</sample_enzyme>
 	<search_summary base_name="test" search_engine="X! Tandem (k-score)" precursor_mass_type="monoisotopic" fragment_mass_type="monoisotopic" out_data_type="" out_data="" search_id="1">
 		<search_database local_path="./current.fasta" type="AA"/>
-		<aminoacid_modification aminoacid="C" massdiff="57.021464" mass="160.0306489852" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
-		<terminal_modification terminus="n" massdiff="-17.026549" mass="0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
-		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
+		<aminoacid_modification aminoacid="C" massdiff="57.021464000000002" mass="160.030648985200003" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
+		<terminal_modification terminus="n" massdiff="-17.026548999999999" mass="0.0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
+		<terminal_modification terminus="n" massdiff="-18.010565" mass="0.0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
 	<analysis_timestamp analysis="peptideprophet" time="2007-12-05T17:49:52" id="1"/>
-	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="0" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.824299494200204" assumed_charge="3" index="0" retention_time_sec="1.3653" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.824299494200204" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
 		<alternative_protein protein="ddb000015734" num_tol_term="2"/>
-			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.0027399681">
+			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.002739968099998">
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="8" all_ntt_prob="(8,8,8)">
@@ -25,10 +25,10 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="1" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.775813381399757" assumed_charge="2" index="1" retention_time_sec="1.719" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
-			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.0187239681">
+		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.775813381399757" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.018723968099998">
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="7.7" all_ntt_prob="(7.7,7.7,7.7)">
@@ -37,9 +37,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="2" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.728529126200101" assumed_charge="2" index="2" retention_time_sec="2.0436" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.728529126200101" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="4.9" all_ntt_prob="(4.9,4.9,4.9)">
 			</peptideprophet_result>
@@ -47,9 +47,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="3" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104000352" assumed_charge="3" index="3" retention_time_sec="2.7843" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -60,9 +60,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="4" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104000352" assumed_charge="2" index="4" retention_time_sec="3.085" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -73,14 +73,14 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="5" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.121229500200116" assumed_charge="3" index="5" retention_time_sec="3.4018" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.121229500200116" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
 		<alternative_protein protein="rev000450478" num_tol_term="2"/>
 			<modification_info modified_peptide="RSHTILNSSQSFAKGC[160]VQC[160]K">
-				<mod_aminoacid_mass position="16" mass="160.0306489852"/>
-				<mod_aminoacid_mass position="19" mass="160.0306489852"/>
+				<mod_aminoacid_mass position="16" mass="160.030648985200003"/>
+				<mod_aminoacid_mass position="19" mass="160.030648985200003"/>
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="14" all_ntt_prob="(14,14,14)">
@@ -89,9 +89,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="6" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316001" assumed_charge="3" index="6" retention_time_sec="4.4573" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316001" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
 		<alternative_protein protein="ddb000450900" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
@@ -101,9 +101,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="7" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.759391317599921" assumed_charge="2" index="7" retention_time_sec="4.8288" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.759391317599921" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
 		<alternative_protein protein="ddb000012684" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
@@ -113,9 +113,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="8" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.534914328700097" assumed_charge="2" index="8" retention_time_sec="5.1785" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.534914328700097" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="1.1" all_ntt_prob="(1.1,1.1,1.1)">

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out_1.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out_1.pepxml
@@ -2,44 +2,44 @@
 <msms_pipeline_analysis date="2007-12-05T17:49:46" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/pepXML/pepXML_v117.xsd" summary_xml=".xml">
 <msms_run_summary base_name="test" raw_data_type="raw" raw_data=".mzML" search_engine="X! Tandem (k-score)">
 	<sample_enzyme name="trypsin">
-		<specificity cut="KR" no_cut="P" sense="C"/>
+		<specificity cut="KRX" no_cut="P" sense="C"/>
 	</sample_enzyme>
 	<search_summary base_name="test" search_engine="X! Tandem (k-score)" precursor_mass_type="monoisotopic" fragment_mass_type="monoisotopic" out_data_type="" out_data="" search_id="1">
 		<search_database local_path="./current.fasta" type="AA"/>
-		<aminoacid_modification aminoacid="C" massdiff="57.021464" mass="160.0306489852" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
-		<terminal_modification terminus="n" massdiff="-17.026549" mass="0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
-		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
+		<aminoacid_modification aminoacid="C" massdiff="57.021464000000002" mass="160.030648985200003" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
+		<terminal_modification terminus="n" massdiff="-17.026548999999999" mass="0.0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
+		<terminal_modification terminus="n" massdiff="-18.010565" mass="0.0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
-	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="0" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.824299494200204" assumed_charge="3" index="0" retention_time_sec="1.3653" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.824299494200204" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
 		<alternative_protein protein="ddb000015734" num_tol_term="2"/>
-			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.0027399681">
+			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.002739968099998">
 			</modification_info>
 			<search_score name="expect" value="8"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="1" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.775813381399757" assumed_charge="2" index="1" retention_time_sec="1.719" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
-			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.0187239681">
+		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.775813381399757" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.018723968099998">
 			</modification_info>
 			<search_score name="expect" value="7.7"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="2" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.728529126200101" assumed_charge="2" index="2" retention_time_sec="2.0436" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.728529126200101" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<search_score name="expect" value="4.9"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="3" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104000352" assumed_charge="3" index="3" retention_time_sec="2.7843" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -47,9 +47,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="4" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104000352" assumed_charge="2" index="4" retention_time_sec="3.085" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -57,40 +57,40 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="5" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.121229500200116" assumed_charge="3" index="5" retention_time_sec="3.4018" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.121229500200116" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
 		<alternative_protein protein="rev000450478" num_tol_term="2"/>
 			<modification_info modified_peptide="RSHTILNSSQSFAKGC[160]VQC[160]K">
-				<mod_aminoacid_mass position="16" mass="160.0306489852"/>
-				<mod_aminoacid_mass position="19" mass="160.0306489852"/>
+				<mod_aminoacid_mass position="16" mass="160.030648985200003"/>
+				<mod_aminoacid_mass position="19" mass="160.030648985200003"/>
 			</modification_info>
 			<search_score name="expect" value="14"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="6" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.195424231600555" assumed_charge="3" index="6" retention_time_sec="4.4573" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.195424231600555" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
 		<alternative_protein protein="ddb000450900" num_tol_term="2"/>
 			<search_score name="expect" value="0.65"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="7" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.759391317599921" assumed_charge="2" index="7" retention_time_sec="4.8288" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.759391317599921" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
 		<alternative_protein protein="ddb000012684" num_tol_term="2"/>
 			<search_score name="expect" value="0.0046"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="8" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.534914328700097" assumed_charge="2" index="8" retention_time_sec="5.1785" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.534914328700097" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>
 			<search_score name="expect" value="1.1"/>
 		</search_hit>

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out_mzML.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out_mzML.pepxml
@@ -2,21 +2,21 @@
 <msms_pipeline_analysis date="2007-12-05T17:49:46" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://sashimi.sourceforge.net/schema_revision/pepXML/pepXML_v117.xsd" summary_xml=".xml">
 <msms_run_summary base_name="test" raw_data_type="raw" raw_data=".mzML" search_engine="X! Tandem (k-score)">
 	<sample_enzyme name="trypsin">
-		<specificity cut="KR" no_cut="P" sense="C"/>
+		<specificity cut="KRX" no_cut="P" sense="C"/>
 	</sample_enzyme>
 	<search_summary base_name="test" search_engine="X! Tandem (k-score)" precursor_mass_type="monoisotopic" fragment_mass_type="monoisotopic" out_data_type="" out_data="" search_id="1">
 		<search_database local_path="./current.fasta" type="AA"/>
-		<aminoacid_modification aminoacid="C" massdiff="57.021464" mass="160.0306489852" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
-		<terminal_modification terminus="n" massdiff="-17.026549" mass="0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
-		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
+		<aminoacid_modification aminoacid="C" massdiff="57.021464000000002" mass="160.030648985200003" variable="Y" binary="N" description="Carbamidomethyl (C)"/>
+		<terminal_modification terminus="n" massdiff="-17.026548999999999" mass="0.0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
+		<terminal_modification terminus="n" massdiff="-18.010565" mass="0.0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
 	<analysis_timestamp analysis="peptideprophet" time="2007-12-05T17:49:52" id="1"/>
-	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.824299494200204" assumed_charge="3" index="1" retention_time_sec="1.3653" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.824299494200204" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
 		<alternative_protein protein="ddb000015734" num_tol_term="2"/>
-			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.0027399681">
+			<modification_info modified_peptide="n[-17]ELNKEMAAEKAKAAAG" mod_nterm_mass="-17.002739968099998">
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="8" all_ntt_prob="(8,8,8)">
@@ -25,10 +25,10 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="2" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1273.775813381399757" assumed_charge="2" index="2" retention_time_sec="1.719" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
-			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.0187239681">
+		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.775813381399757" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+			<modification_info modified_peptide="n[-16]QLPGVNIKPVVK" mod_nterm_mass="-16.018723968099998">
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="7.7" all_ntt_prob="(7.7,7.7,7.7)">
@@ -37,9 +37,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.728529126200101" assumed_charge="2" index="3" retention_time_sec="2.0436" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.728529126200101" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="4.9" all_ntt_prob="(4.9,4.9,4.9)">
 			</peptideprophet_result>
@@ -47,9 +47,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="5" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104000352" assumed_charge="3" index="5" retention_time_sec="2.7843" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -60,9 +60,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.2" start_scan="7" end_scan="7" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="6" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.7.7.2" start_scan="7" end_scan="7" precursor_neutral_mass="2285.138699104000352" assumed_charge="2" index="6" retention_time_sec="3.085" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104000352" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
@@ -73,14 +73,14 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="7" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2307.121229500200116" assumed_charge="3" index="7" retention_time_sec="3.4018" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.121229500200116" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
 		<alternative_protein protein="rev000450478" num_tol_term="2"/>
 			<modification_info modified_peptide="RSHTILNSSQSFAKGC[160]VQC[160]K">
-				<mod_aminoacid_mass position="16" mass="160.0306489852"/>
-				<mod_aminoacid_mass position="19" mass="160.0306489852"/>
+				<mod_aminoacid_mass position="16" mass="160.030648985200003"/>
+				<mod_aminoacid_mass position="19" mass="160.030648985200003"/>
 			</modification_info>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="14" all_ntt_prob="(14,14,14)">
@@ -89,9 +89,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.10.10.3" start_scan="10" end_scan="10" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="9" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.10.10.3" start_scan="10" end_scan="10" precursor_neutral_mass="2269.1954242316001" assumed_charge="3" index="9" retention_time_sec="4.4573" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316001" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
 		<alternative_protein protein="ddb000450900" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
@@ -101,9 +101,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.11.11.2" start_scan="11" end_scan="11" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="10" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.11.11.2" start_scan="11" end_scan="11" precursor_neutral_mass="1612.759391317599921" assumed_charge="2" index="10" retention_time_sec="4.8288" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.759391317599921" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
 		<alternative_protein protein="ddb000012684" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
@@ -113,9 +113,9 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.12.12.2" start_scan="12" end_scan="12" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="11" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.12.12.2" start_scan="12" end_scan="12" precursor_neutral_mass="1023.534914328700097" assumed_charge="2" index="11" retention_time_sec="5.1785" >
 	<search_result>
-		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
+		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.534914328700097" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>
 			<analysis_result analysis="peptideprophet">
 			<peptideprophet_result probability="1.1" all_ntt_prob="(1.1,1.1,1.1)">

--- a/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
@@ -88,12 +88,12 @@ START_SECTION(static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(
 
   std::vector<OPXLDataStructs::AASeqWithMass> peptides = OPXLHelper::digestDatabase(fasta_db, digestor, min_peptide_length, cross_link_residue1, cross_link_residue2, fixed_modifications, variable_modifications, max_variable_mods_per_peptide);
 
-  TEST_EQUAL(peptides.size(), 880)
+  TEST_EQUAL(peptides.size(), 886)
   TEST_EQUAL(peptides[5].peptide_mass > 5, true) // not an empty AASequence
   TEST_EQUAL(peptides[5].peptide_mass, peptides[5].peptide_seq.getMonoWeight())
   TEST_EQUAL(peptides[500].peptide_mass > 5, true) // not an empty AASequence
   TEST_EQUAL(peptides[500].peptide_mass, peptides[500].peptide_seq.getMonoWeight())
-  TEST_EQUAL(peptides[668].position, OPXLDataStructs::C_TERM)
+  TEST_EQUAL(peptides[668].position, OPXLDataStructs::INTERNAL)
   TEST_EQUAL(peptides[778].position, OPXLDataStructs::N_TERM)
 END_SECTION
 
@@ -126,8 +126,8 @@ START_SECTION(static std::vector<OPXLDataStructs::XLPrecursor> enumerateCrossLin
   // std::sort(precursors.begin(), precursors.end(), OPXLDataStructs::XLPrecursorComparator());
 
   TOLERANCE_ABSOLUTE(1e-3)
-  TEST_EQUAL(precursors.size(), 15990)
-  TEST_EQUAL(spectrum_precursor_correction_positions.size(), 15990)
+  TEST_EQUAL(precursors.size(), 16081)
+  TEST_EQUAL(spectrum_precursor_correction_positions.size(), 16081)
   // sample about 1/15 of the data, since a lot of precursors are generated
 
   for (Size i = 0; i < precursors.size(); i += 2000)
@@ -174,7 +174,7 @@ START_SECTION(static std::vector <OPXLDataStructs::ProteinProteinCrossLink> buil
       filtered_precursors.push_back(*low_it);
     }
   }
-  TEST_EQUAL(precursors.size(), 15990)
+  TEST_EQUAL(precursors.size(), 16081)
   TEST_EQUAL(filtered_precursors.size(), 35)
   std::vector< int > precursor_corrections(59, 0);
   std::vector< int > precursor_correction_positions(59, 0);

--- a/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
@@ -53,7 +53,7 @@ START_TEST(ProteaseDB, "$Id$")
 
 ProteaseDB* ptr = nullptr;
 ProteaseDB* nullPointer = nullptr;
-String RKP("(?<=R)(?!P)");
+String RKP("(?<=[RX])(?!P)");
 START_SECTION(ProteaseDB* getInstance())
     ptr = ProteaseDB::getInstance();
     TEST_NOT_EQUAL(ptr, nullPointer)

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -546,7 +546,7 @@ START_SECTION((bool isValidProduct(const AASequence& protein, int pep_pos, int p
     pd.setEnzyme("glutamyl endopeptidase");
     pd.setSpecificity(EnzymaticDigestion::SPEC_SEMI);
     //                                  |6*  |11|14*|18 |22|25 |29* |34*
-    prot = AASequence::fromString("MCABCDPLFGKACDPBCRAAAKAARPBBDPBBCDP"); // 4 real cleavages at {(0),11,18,22,25}
+    prot = AASequence::fromString("MCABCDPLFGKACDPHCRAAAKAARPHHDPHHCDP"); // 4 real cleavages at {(0),11,18,22,25}
 
     pd.setMissedCleavages(0); // redundant, by default zero, should be zero
     TEST_EQUAL(pd.isValidProduct(prot, 6, 8, true, true, true), true); // valid C and N-term

--- a/src/tests/topp/PeptideIndexer_7_out.idXML
+++ b/src/tests/topp/PeptideIndexer_7_out.idXML
@@ -5,76 +5,79 @@
 	</SearchParameters>
 	<IdentificationRun date="2005-01-27T17:47:41" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" >
-			<ProteinHit id="PH_0" accession="BSA4" score="0" sequence="" >
+			<ProteinHit id="PH_0" accession="BSA3" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
-			<ProteinHit id="PH_1" accession="DECOY_BSA4" score="0" sequence="" >
+			<ProteinHit id="PH_1" accession="BSA4" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="DECOY_BSA4" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_2" accession="DECOY_revonly" score="0" sequence="" >
+			<ProteinHit id="PH_3" accession="DECOY_revonly" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_3" accession="tryptic_cleavage_test_protein1" score="0" sequence="" >
+			<ProteinHit id="PH_4" accession="tryptic_cleavage_test_protein1" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="[" aa_after="]" start="0" end="7" protein_refs="PH_2" >
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.862100000000002" MZ="0.0" RT="0.0" >
+			<PeptideHit score="40.0" sequence="DFIANGER" charge="2" aa_before="[" aa_after="]" start="0" end="7" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="MDCDEFGK" charge="2" aa_before="[" aa_after="A" start="0" end="7" protein_refs="PH_3" >
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.862100000000002" MZ="0.0" RT="0.0" >
+			<PeptideHit score="40.0" sequence="MDCDEFGK" charge="2" aa_before="[" aa_after="A" start="0" end="7" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MDCDEFGKADCR" charge="2" aa_before="[" aa_after="A" start="0" end="11" protein_refs="PH_3" >
+			<PeptideHit score="40.0" sequence="MDCDEFGKADCR" charge="2" aa_before="[" aa_after="A" start="0" end="11" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MDCDEFGKADCRA" charge="2" >
+			<PeptideHit score="40.0" sequence="MDCDEFGKADCRA" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MDCDEFGKADCRAAAKAAR" charge="2" >
+			<PeptideHit score="40.0" sequence="MDCDEFGKADCRAAAKAAR" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MDCDEFGKADCRAAAKAARPDDDD" charge="2" >
+			<PeptideHit score="40.0" sequence="MDCDEFGKADCRAAAKAARPDDDD" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="DCDEFGK" charge="2" aa_before="M" aa_after="A" start="1" end="7" protein_refs="PH_3" >
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.862100000000002" MZ="0.0" RT="0.0" >
+			<PeptideHit score="40.0" sequence="DCDEFGK" charge="2" aa_before="M" aa_after="A" start="1" end="7" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="DCDEFGKADCR" charge="2" aa_before="M" aa_after="A" start="1" end="11" protein_refs="PH_3" >
+			<PeptideHit score="40.0" sequence="DCDEFGKADCR" charge="2" aa_before="M" aa_after="A" start="1" end="11" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="DCDEFGKADCRA" charge="2" >
+			<PeptideHit score="40.0" sequence="DCDEFGKADCRA" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="DCDEFGKADCRAAAKAAR" charge="2" >
+			<PeptideHit score="40.0" sequence="DCDEFGKADCRAAAKAAR" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="DCDEFGKADCRAAAKAARPDDDD" charge="2" >
+			<PeptideHit score="40.0" sequence="DCDEFGKADCRAAAKAARPDDDD" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="ADCR" charge="2" aa_before="R R K" aa_after="] ] A" start="17 17 8" end="20 20 11" protein_refs="PH_0 PH_1 PH_3" >
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.862100000000002" MZ="0.0" RT="0.0" >
+			<PeptideHit score="1.0e-04" sequence="ADCR" charge="2" aa_before="[ R R K" aa_after="S ] ] A" start="0 17 17 8" end="3 20 20 11" protein_refs="PH_0 PH_1 PH_2 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="ADCRAAAK" charge="2" aa_before="K" aa_after="A" start="8" end="15" protein_refs="PH_3" >
+			<PeptideHit score="1.0e-04" sequence="ADCRAAAK" charge="2" aa_before="K" aa_after="A" start="8" end="15" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="DEFGK" charge="2" >
+			<PeptideHit score="1.0e-04" sequence="DEFGK" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="GKADCRAA" charge="2" >
+			<PeptideHit score="1.0e-04" sequence="GKADCRAA" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
 		</PeptideIdentification>


### PR DESCRIPTION
this PR fixes two issues:
1) removing restriction on x!tandem special cutting rule: cutting sites are now also valid in semi-specific and unspecific digest settings, since peptides like
D.PTDDIYNRQDFGWSFAGYGAPIMEDD.P would otherwise not be found in semi-tryptic (since both ends require the special cutting rule).

2) our regular expressions for all enzymes do not consider ambiguous amino acids (B, Z, J and X), thus a peptide
`K.ACDX.A` would not be considered fully tryptic (since the `X` at the c-term is not recognized as `K|R`).
This PR fixes all the regexes.