### PR TITLE
[BUILD] Increase clang template depth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,13 @@ if(ADDRESS_SANITIZER)
 endif()
 
 #------------------------------------------------------------------------------
+# Increase Clang Template Depth
+#------------------------------------------------------------------------------
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth=1024")
+endif()
+
+#------------------------------------------------------------------------------
 # Enable SIRIUS_test (SiriusAdapter) 
 #------------------------------------------------------------------------------
 option(ENABLE_SIRIUS_TEST "Enable test for fingerid (SiriusAdapter)" ON)


### PR DESCRIPTION
Using Clang 3.8 (08 Mar 2016, so not ancient at least) to compile OpenMS on my computer, I get this error with our current settings. Reproducibly, with any current branch I have including develop, both release and debug builds:

```
In file included from /home/eugen/Development/OpenMS/src/openms/source/CHEMISTRY/ResidueModification.cpp:36:
In file included from /home/eugen/Development/OpenMS/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h:38:
In file included from /home/eugen/Development/OpenMS/src/openms/include/OpenMS/DATASTRUCTURES/String.h:40:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.3.0/../../../../include/c++/5.3.0/algorithm:60:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.3.0/../../../../include/c++/5.3.0/utility:70:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.3.0/../../../../include/c++/5.3.0/bits/stl_pair.h:59:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.3.0/../../../../include/c++/5.3.0/bits/move.h:57:
/usr/lib/gcc/x86_64-linux-gnu/5.3.0/../../../../include/c++/5.3.0/type_traits:115:26: fatal error: recursive template instantiation exceeded maximum depth of 256
    : public conditional<_B1::value, _B1, _B2>::type

```

So the maximal depth for LLVM / clang 3.8 seems to be set to 256 and that is not enough to compile OpenMS.

This is what the GCC docs say:

`-ftemplate-depth=n`
    Set the maximum instantiation depth for template classes to n. A limit on the template instantiation depth is needed to detect endless recursions during template class instantiation. ANSI/ISO C++ conforming programs must not rely on a maximum depth greater than 17 (changed to 1024 in C++11). The default value is 900, as the compiler can run out of stack space before hitting 1024 in some situations.

Clang 4 and 5 still say they have -`ftemplate-depth=N` set to `256` by default in their docs, e.g. here https://releases.llvm.org/5.0.1/tools/clang/docs/UsersManual.html .
They changed it to `1024` for clang 7.
What I am most confused about is what is different in our travis builds where clang 5.0.0 is used and it seems to work fine. I have not found a way to change this parameter globally for my clang installation, except maybe by changing the clang source code myself and recompiling it.

@jpfeuffer maybe there is a more elegant way of doing this, e.g. checking the depth and increasing it if its below 1024, or checking for the clang version.

Adding the lines in this PR solves the issue for me, but it does not discriminate between clang versions, just sets the parameter to the default of the newer ones.
If we officially still support clang versions from 2016 and 2017, we should fix this default.
Otherwise I'll just upgrade my clang :)
