### PR TITLE
Opt include

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -768,6 +768,22 @@ protected:
     */
     void checkParam_(const Param& param, const String& filename, const String& location) const;
 
+    /**
+      @brief checks if an input file exists (respecting the flags)
+
+      Checks if String/Format restrictions are met (or throws InvalidParameter() otherwise).
+      
+      For InputFile(s), it checks if the file is readable/findable. 
+      If 'is_executable' is specified as a tag, the filename is searched on PATH and upon success, the full absolute path is returned.
+      
+      For OutputFile(s), it checks if the file is writeable.
+
+      @param filename ...as given via commandline/ini/default
+      @param param_name Name of the parameter (key)
+      @param p All meta information for this param
+
+    */
+    void fileParamValidityCheck_(String& filename, const String& param_name, const ParameterInformation& p) const;
 
     /**
       @brief Checks if the parameters of the provided ini file are applicable to this tool

--- a/src/topp/InternalCalibration.cpp
+++ b/src/topp/InternalCalibration.cpp
@@ -174,7 +174,7 @@ protected:
     setValidFormats_("in", {"mzML"});
     registerOutputFile_("out", "<file>", "", "Output file ");
     setValidFormats_("out", {"mzML"});
-    registerInputFile_("rscript_executable", "<file>", "Rscript", "Path to the Rscript executable (default: 'Rscript').", false); // do not use required+'is_executable' here, since R is only required for optional QC plots
+    registerInputFile_("rscript_executable", "<file>", "Rscript", "Path to the Rscript executable (default: 'Rscript').", false, false, {"is_executable"});
         
     addEmptyLine_();
 
@@ -239,7 +239,6 @@ protected:
     //-------------------------------------------------------------
     String in = getStringOption_("in");
     String out = getStringOption_("out");
-    String rscript_executable = getStringOption_("rscript_executable"); 
     String cal_id = getStringOption_("cal:id_in");
     String cal_lock = getStringOption_("cal:lock_in");
     String file_cal_lock_out = getStringOption_("cal:lock_out");
@@ -359,13 +358,21 @@ protected:
     // these limits are a little loose, but should prevent grossly wrong models without burdening the user with yet another parameter.
     MZTrafoModel::setCoefficientLimits(tol_ppm, tol_ppm, 0.5); 
 
+    String file_models_plot = getStringOption_("quality_control:models_plot");
+    String file_residuals_plot = getStringOption_("quality_control:residuals_plot");
+    String rscript_executable;
+    if (!file_models_plot.empty() || !file_residuals_plot.empty())
+    { // only check for existance of Rscript if output files are requested...
+      rscript_executable = getStringOption_("rscript_executable");
+    }
+
     if (!ic.calibrate(exp, ms_level, md, rt_chunk, use_RANSAC, 
                       getDoubleOption_("goodness:median"),
                       getDoubleOption_("goodness:MAD"), 
                       getStringOption_("quality_control:models"),
-                      getStringOption_("quality_control:models_plot"),
+                      file_models_plot,
                       getStringOption_("quality_control:residuals"),
-                      getStringOption_("quality_control:residuals_plot"),
+                      file_residuals_plot,
                       rscript_executable))
     {
       OPENMS_LOG_ERROR << "\nCalibration failed. See error message above!" << std::endl;

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -1931,7 +1931,7 @@ public:
 class RIntegration
 {
 public:
-  // Perform a simple check if R and all R dependencies are thereget
+  // Perform a simple check if R and all R dependencies are there
   static bool checkRDependencies(const String& tmp_path, StringList package_names, const QString& executable = QString("R"))
   {
     String random_name = String::random(8);
@@ -2069,7 +2069,7 @@ protected:
     registerInputFile_("in_featureXML", "<file>", "", "Feature data annotated with identifications (IDMapper)");
     setValidFormats_("in_featureXML", ListUtils::create<String>("featureXML"));
 
-    registerInputFile_("r_executable", "<file>", "R", "Path to the R executable (default: 'R')", false);
+    registerInputFile_("r_executable", "<file>", "R", "Path to the R executable (default: 'R')", false, false, {"is_executable"});
 
     registerDoubleOption_("mz_tolerance_ppm", "<tol>", 10.0, "Tolerance in ppm", false);
 
@@ -2931,7 +2931,6 @@ protected:
     Int debug_level = getIntOption_("debug");
     String in_mzml = getStringOption_("in_mzML");
     String in_features = getStringOption_("in_featureXML");
-    QString executable = getStringOption_("r_executable").toQString();
     double mz_tolerance_ppm_ = getDoubleOption_("mz_tolerance_ppm");
     double rt_tolerance_s = getDoubleOption_("rt_tolerance_s");
 
@@ -2952,6 +2951,7 @@ protected:
     // Do we want to create a qc report?  
     if (!qc_output_directory.empty())
     {
+      QString executable = getStringOption_("r_executable").toQString();
       // convert path to absolute path
       QDir qc_dir(qc_output_directory.toQString());
       qc_output_directory = String(qc_dir.absolutePath());
@@ -2968,7 +2968,7 @@ protected:
       bool R_is_working = RIntegration::checkRDependencies(tmp_path, package_names, executable);
       if (!R_is_working)
       {
-        OPENMS_LOG_INFO << "There was a problem detecting R and/or of one of the required libraries. Make sure you have the directory of your R executable in your system path variable." << endl;
+        OPENMS_LOG_INFO << "There was a problem detecting one of the required R libraries." << endl;
         return EXTERNAL_PROGRAM_ERROR;
       }
     }
@@ -3622,6 +3622,7 @@ protected:
     // quality report
     if (!qc_output_directory.empty())
     {
+      QString executable = getStringOption_("r_executable").toQString();
       // TODO plot merged is now passed as false
       MetaProSIPReporting::createQualityReport(tmp_path, qc_output_directory, file_suffix, file_extension_, sippeptide_clusters, n_heatmap_bins, score_plot_y_axis_min, report_natural_peptides, executable);
     }

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -3333,7 +3333,7 @@ protected:
         Size consecutive_isotopes = 0;
         Size j = i;
 
-        while (j != -1)
+        while (j != std::numeric_limits<Size>::max()) // unsigned type wrap-around is well defined
         {
           if (isotopic_intensities[j] <= 1e-4) break;
           ++consecutive_isotopes;

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -1400,8 +1400,8 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(12, 0.9893);
-    isotopes.insert(13, 0.0107);
+    isotopes.insert(12, 0.9893f);
+    isotopes.insert(13, 0.0107f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1515,8 +1515,8 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(14, 0.99632);
-    isotopes.insert(15, 0.368);
+    isotopes.insert(14, 0.99632f);
+    isotopes.insert(15, 0.368f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1586,8 +1586,8 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(1, 0.999885);
-    isotopes.insert(2, 0.000115);
+    isotopes.insert(1, 0.999885f);
+    isotopes.insert(2, 0.000115f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1657,9 +1657,9 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(1, 0.99757);
-    isotopes.insert(2, 0.00038);
-    isotopes.insert(3, 0.00205);
+    isotopes.insert(1, 0.99757f);
+    isotopes.insert(2, 0.00038f);
+    isotopes.insert(3, 0.00205f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1697,8 +1697,8 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(14, 0.99632);
-    isotopes.insert(15, 0.368);
+    isotopes.insert(14, 0.99632f);
+    isotopes.insert(15, 0.368f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1733,8 +1733,8 @@ public:
 
     // reset to natural occurance
     IsotopeDistribution isotopes;
-    isotopes.insert(12, 0.9893);
-    isotopes.insert(13, 0.010);
+    isotopes.insert(12, 0.9893f);
+    isotopes.insert(13, 0.010f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1771,8 +1771,8 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(1, 0.999885);
-    isotopes.insert(2, 0.000115);
+    isotopes.insert(1, 0.999885f);
+    isotopes.insert(2, 0.000115f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -1810,9 +1810,9 @@ public:
     // reset to natural occurance
     IsotopeDistribution isotopes;
     isotopes.clear();
-    isotopes.insert(1, 0.99757);
-    isotopes.insert(2, 0.00038);
-    isotopes.insert(3, 0.00205);
+    isotopes.insert(1, 0.99757f);
+    isotopes.insert(2, 0.00038f);
+    isotopes.insert(3, 0.00205f);
     e2->setIsotopeDistribution(isotopes);
     return ret;
   }
@@ -3331,33 +3331,21 @@ protected:
       {
         if (isotopic_intensities[i] < 1e-4) continue;
         Size consecutive_isotopes = 0;
-        Int j = i;
+        Size j = i;
 
-        while (j >= 0)
+        while (j != -1)
         {
-          if (isotopic_intensities[j] > 1e-4)
-          {
-            ++consecutive_isotopes;
-            --j;
-          }
-          else
-          {
-            break;
-          }
+          if (isotopic_intensities[j] <= 1e-4) break;
+          ++consecutive_isotopes;
+          --j;
         }
         j = i + 1;
 
-        while ((Size)j < isotopic_intensities.size())
+        while (j < isotopic_intensities.size())
         {
-          if (isotopic_intensities[j] > 1e-4)
-          {
-            ++consecutive_isotopes;
-            ++j;
-          }
-          else
-          {
-            break;
-          }
+          if (isotopic_intensities[j] <= 1e-4) break;
+          ++consecutive_isotopes;
+          ++j;
         }
 
         if (consecutive_isotopes < min_consecutive_isotopes)

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -292,7 +292,7 @@ protected:
       {
         mod = db_ptr->getRibonucleotide(m);
       }
-      catch (Exception::ElementNotFound& e)
+      catch (Exception::ElementNotFound& /*e*/)
       {
         // commas between numbers were removed - try reinserting them:
         m = boost::regex_replace(m, double_digits, "$&,");


### PR DESCRIPTION
augments #4381

fix behaviour of TOPPBase InputFile tags ('is_executable' and 'skipexists').
They are checked now more frequently, i.e. if the value is required or non-empty.
The checks happens when `getStringOption_()` is called.



