### PR TITLE
fix TICCalculator

### DIFF
--- a/src/utils/TICCalculator.cpp
+++ b/src/utils/TICCalculator.cpp
@@ -283,30 +283,19 @@ protected:
       map.setSkipXMLChecks(true);
 
       double TIC = 0.0;
-      long int nr_peaks = 0;
+      long nr_peaks = 0;
 
       if (load_data)
       {
-
         // firstprivate means that each thread has its own instance of the
         // variable, each copy initialized with the initial value 
-#ifdef _OPENMP
-#pragma omp parallel for firstprivate(map) 
-#endif
+#pragma omp parallel for firstprivate(map) reduction(+: TIC, nr_peaks)
         for (SignedSize i =0; i < (SignedSize)map.getNrSpectra(); i++)
         {
           OpenMS::Interfaces::SpectrumPtr sptr = map.getSpectrumById(i);
-          double nr_peaks_l = sptr->getIntensityArray()->data.size();
-          double TIC_l = std::accumulate(sptr->getIntensityArray()->data.begin(), sptr->getIntensityArray()->data.end(), 0.0);
-#ifdef _OPENMP
-#pragma omp critical (indexed)
-#endif
-          {
-            TIC += TIC_l;
-            nr_peaks += nr_peaks_l;
-          }
+          nr_peaks += sptr->getIntensityArray()->data.size();
+          TIC += std::accumulate(sptr->getIntensityArray()->data.begin(), sptr->getIntensityArray()->data.end(), 0.0);
         }
-
       }
 
       std::cout << "There are " << map.getNrSpectra() << " spectra and " << nr_peaks << " peaks in the input file." << std::endl;
@@ -392,10 +381,8 @@ protected:
       FileAbstraction filestream(in);
 
       double TIC = 0.0;
-      long int nr_peaks = 0;
-#ifdef _OPENMP
-#pragma omp parallel for firstprivate(filestream) 
-#endif
+      long nr_peaks = 0;
+#pragma omp parallel for firstprivate(filestream) reduction(+: TIC, nr_peaks)
       for (SignedSize i=0; i < (SignedSize)spectra_index.size(); ++i)
       {
         BinaryDataArrayPtr mz_array(new BinaryDataArray);
@@ -406,15 +393,8 @@ protected:
         filestream.getStream().seekg(spectra_index[i]);
         Internal::CachedMzMLHandler::readSpectrumFast(mz_array, intensity_array, filestream.getStream(), ms_level, rt);
 
-        double nr_peaks_l = intensity_array->data.size();
-        double TIC_l = std::accumulate(intensity_array->data.begin(), intensity_array->data.end(), 0.0);
-#ifdef _OPENMP
-#pragma omp critical (indexed)
-#endif
-        {
-          TIC += TIC_l;
-          nr_peaks += nr_peaks_l;
-        }
+        nr_peaks += intensity_array->data.size();
+        TIC += std::accumulate(intensity_array->data.begin(), intensity_array->data.end(), 0.0);
       }
 
       std::cout << "There are " << spectra_index.size() << " spectra and " << nr_peaks << " peaks in the input file." << std::endl;


### PR DESCRIPTION
this fixes #4389 (confirmed and fixed on VS2015).
by replacing the `omp critical` with `reduction(+,...`.
ATM I have **no** idea why the critical solution was broken.
The current solution works, as well as switching to `std::atomic` for TIC and nr_peaks.
Still puzzled why critical section breaks (since the final sums are lower, it seems that the addition is not atomic).
Somewhat confirming that this might be a VS bug: g++7.1 does not need this fix. It works as expected in both variants.