### PR TITLE
[FIX] findExecutable should skip directories in Env with same name

### DIFF
--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -679,7 +679,7 @@ namespace OpenMS
 
   bool File::findExecutable(OpenMS::String& exe_filename)
   {
-    if (exists(exe_filename)) return true;
+    if (exists(exe_filename) && !isDirectory(exe_filename)) return true;
 
     StringList paths = getPathLocations();
     StringList exe_filenames = { exe_filename };

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -697,7 +697,7 @@ namespace OpenMS
     {
       for (const String& fn : exe_filenames)
       {
-        if (exists(p + fn))
+        if (exists(p + fn) && !isDirectory(p + fn))
         {
           exe_filename = p + fn;
           return true;


### PR DESCRIPTION
Important on Unices.