### PR TITLE
Fix AScore Scoring

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -167,6 +167,9 @@ namespace OpenMS
     */
     void determineHighestScoringPermutations_(const std::vector<std::vector<double>>& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const std::vector<std::vector<Size>>& permutations, std::multimap<double, Size>& ranking) const;
 
+    /// Computes probability for a peak depth of one given spectra and mass_tolerance variables
+    double computeBaseProbability_(double ppm_reference_mz) const;
+
     /// Computes the cumulative binomial probabilities.
     double computeCumulativeScore_(Size N, Size n, double p) const;
     
@@ -197,7 +200,8 @@ namespace OpenMS
     Size max_peptide_length_; ///< Limit for peptide lengths that can be analyzed
     Size max_permutations_; ///< Limit for number of sequence permutations that can be handled
     double unambiguous_score_; ///< Score for unambiguous assignments (all sites phosphorylated)
-    
+    double base_match_probability_; ///< Probability of a match at a peak depth of 1
+
   };
 
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -393,7 +393,7 @@ namespace OpenMS
             + scores[7] * 0.5
             + scores[8] * 0.25
             + scores[9] * 0.25)
-           / 10.0;
+           / 7.0;
   }
 
   vector<Size> AScore::getSites_(const AASequence& without_phospho) const

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -128,6 +128,9 @@ namespace OpenMS
     }
     vector<PeakSpectrum> windows_top10 = peakPickingPerWindowsInSpectrum_(real_spectrum);
 
+    // compute match probability for a peak depth of 1
+    base_match_probability_ = computeBaseProbability_(real_spectrum.back().getMZ());
+
     // calculate peptide score for each possible phospho site permutation
     vector<vector<double>> peptide_site_scores = calculatePermutationPeptideScores_(th_spectra, windows_top10);
 
@@ -164,7 +167,7 @@ namespace OpenMS
 
         computeSiteDeterminingIons_(th_spectra, *s_it, site_determining_ions);
         Size N = site_determining_ions[0].size(); // all possibilities have the same number so take the first one
-        double p = static_cast<double>(s_it->peak_depth) / 100.0;
+        double p = static_cast<double>(s_it->peak_depth) * base_match_probability_;
 
         Size n_first = 0; // number of matching peaks for first peptide
         for (Size window_idx = 0; window_idx != windows_top10.size(); ++window_idx) // for each 100 m/z window
@@ -200,6 +203,16 @@ namespace OpenMS
     }
     phospho.setScore(best_Ascore);
     return phospho;
+  }
+
+  double AScore::computeBaseProbability_(double ppm_reference_mz) const
+  {
+    double base_match_probability = 2. * fragment_mass_tolerance_ / 100.;
+    if (fragment_tolerance_ppm_)
+    {
+      base_match_probability *= ppm_reference_mz * 1e-6; // 1e-6 converts fragment_mass_tolerance_ to ppm
+    }
+    return base_match_probability;
   }
 
   double AScore::computeCumulativeScore_(Size N, Size n, double p) const
@@ -569,9 +582,9 @@ namespace OpenMS
         {
           n += numberOfMatchedIons_(*it, windows_top10[current_win], i);
         }
-        double p = static_cast<double>(i) / 100.0;
+        double p = static_cast<double>(i) * base_match_probability_;
         double cumulative_score = computeCumulativeScore_(N, n, p);
-        
+
         //abs is used to avoid -0 score values
         (*site_score)[i - 1] = abs((-10.0 * log10(cumulative_score)));
       }

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -189,6 +189,7 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
 
   vector<ProbablePhosphoSites> sites;
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_1);
+  TEST_REAL_SIMILAR( ranking.rbegin()->first, .4);
   ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1, sites, permutations,ranking);
   TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 3);
@@ -208,6 +209,7 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   TEST_EQUAL(sites[2].peak_depth, 1);
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_3);
+  TEST_REAL_SIMILAR(ranking.rbegin()->first, .4);
   ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_3, sites, permutations, ranking);
   TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 1);
@@ -227,6 +229,7 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   TEST_EQUAL(sites[2].peak_depth, 1);
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_2);
+  TEST_REAL_SIMILAR(ranking.rbegin()->first, .4);
   ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_2, sites, permutations, ranking);
   TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 2);
@@ -253,6 +256,7 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   permutations = { {3}, {6} };
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_1);
+  TEST_REAL_SIMILAR(ranking.rbegin()->first, 94.10714285714287);
   ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1, sites, permutations, ranking);
   TEST_EQUAL(sites.size(), 1)
   TEST_EQUAL(sites[0].seq_1, 0)

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -638,7 +638,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit1 = ptr_test->compute(hit1, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
-  TEST_REAL_SIMILAR(static_cast<double>(hit1.getMetaValue("AScore_1")), 9.40409359086883);
+  TEST_REAL_SIMILAR(static_cast<double>(hit1.getMetaValue("AScore_1")), 8.65157151899052);
   TEST_EQUAL(hit1.getSequence().toString(), "QSS(Phospho)VTQSK");
   
   // ===========================================================================
@@ -648,7 +648,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit2 = ptr_test->compute(hit2, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=21.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit2.getMetaValue("AScore_1")), 20.4116482719882);
+  TEST_REAL_SIMILAR(static_cast<double>(hit2.getMetaValue("AScore_1")), 18.8755623850511);
   TEST_EQUAL(hit2.getSequence().toString(), "RIRLT(Phospho)ATTR");
   
   // ===========================================================================
@@ -658,7 +658,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit3 = ptr_test->compute(hit3, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit3.getMetaValue("AScore_1")), 92.2548303427145);
+  TEST_REAL_SIMILAR(static_cast<double>(hit3.getMetaValue("AScore_1")), 88.3030731386678);
   TEST_EQUAL(hit3.getSequence().toString(), "QSSVTQVTEQS(Phospho)PK"); 
   
   // ===========================================================================
@@ -672,7 +672,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit4 = ptr_test->compute(hit4, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit4.getMetaValue("AScore_1")), 20.1669211754322);
+  TEST_REAL_SIMILAR(static_cast<double>(hit4.getMetaValue("AScore_1")), 49.2714597801023);
   TEST_EQUAL(hit4.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");
   
   // ===========================================================================
@@ -688,7 +688,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit5 = ptr_test->compute(hit5, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
-  TEST_REAL_SIMILAR(static_cast<double>(hit5.getMetaValue("AScore_1")), 9.40409359086883);
+  TEST_REAL_SIMILAR(static_cast<double>(hit5.getMetaValue("AScore_1")), 6.53833235677545);
   TEST_EQUAL(hit5.getSequence().toString(), "QSS(Phospho)VTQSK");
   
   params.setValue("fragment_mass_tolerance", 70.0); // 0.05 Da were converted to ppm based on a small peptide
@@ -700,7 +700,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   hit6 = ptr_test->compute(hit6, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 20.1669211754322);
+  TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 40.6506162613816);
   TEST_EQUAL(hit6.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");
 
   // ===========================================================================


### PR DESCRIPTION
This PR addresses #4358 and changes some scoring constants within the AScore class to help it fall more in line with Beausoleil et al. 

**Weighted average:**  
Within the weighted average step of the PepScore calculation, the algorithm was dividing by the wrong constant to make the dot product a weighted average at original line 396. I fixed this to be the true constant and added a couple tests to prove that this is a weighted average.

**Match Probability:**  
The interpretation I always had of Beausoleil et al. was that the probability of a match that you use for calculating the PepScore and AScore is based on the window size for matching. For mass units in mz, I made the probability based on 2 times the mass window. When the mass units are in ppm, the issue for this algorithm is that there is no straight forward way to go from counts of matched peaks to a score that takes into account the difference in window sizes for each theoretical peak. So I mitigate this issue by basing the probability on a very conservative estimate, the largest mz measured for a spectra. Tests are changed to address both situations.