### PR TITLE
[FIX] OpenPepXL: sort spectra by RT after parallel preprocessing

### DIFF
--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -254,6 +254,9 @@ using namespace OpenMS;
     progresslogger.endProgress();
     picked_spectra.clear(true);
 
+    // sort the spectra by RT, the order might have been changed by parallel preprocessing
+    spectra.sortSpectra(false);
+
     ProteaseDigestion digestor;
     digestor.setEnzyme(enzyme_name_);
     digestor.setMissedCleavages(missed_cleavages_);

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -251,6 +251,9 @@ using namespace OpenMS;
     progresslogger.endProgress();
     picked_spectra.clear(true);
 
+    // sort the spectra by RT, the order might have been changed by parallel preprocessing
+    spectra.sortSpectra(false);
+
     ProteaseDigestion digestor;
     digestor.setEnzyme(enzyme_name_);
     digestor.setMissedCleavages(missed_cleavages_);


### PR DESCRIPTION
The deisotoping and filtering of spectra is done in parallel and the spectra are collected out of order in a new map.
This will not affect the final results, but will make the process itself more reproducible and easier to compare between runs.
Without this the MS2 spectra might be analyzed in a different order every time, even with exactly the same inputs, and that might make it more difficult to identify problems in the future.