### PR TITLE
[FIX] making MzIdentML pass through the validator

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1329,11 +1329,11 @@ namespace OpenMS
             }
             if (pe->getStart() != PeptideEvidence::UNKNOWN_POSITION)
             {
-              e += " start=\"" + String(pe->getStart()) + "\"";
+              e += " start=\"" + String(pe->getStart() + 1) + "\"";
             }
             else if (hit.metaValueExists("start"))
             {
-              e += " start=\"" + String(hit.getMetaValue("start")) + "\"";
+              e += " start=\"" + String( int(hit.getMetaValue("start")) + 1) + "\"";
             }
             else
             {
@@ -1341,11 +1341,11 @@ namespace OpenMS
             }
             if (pe->getEnd() != PeptideEvidence::UNKNOWN_POSITION)
             {
-              e += " end=\"" + String(pe->getEnd()) + "\"";
+              e += " end=\"" + String(pe->getEnd() + 1) + "\"";
             }
             else if (hit.metaValueExists("end"))
             {
-              e += " end=\"" + String(hit.getMetaValue("end")) + "\"";
+              e += " end=\"" + String( int(hit.getMetaValue("end")) + 1) + "\"";
             }
             else
             {
@@ -1871,11 +1871,11 @@ namespace OpenMS
             }
             if (pe->getStart() != PeptideEvidence::UNKNOWN_POSITION)
             {
-              e += " start=\"" + String(pe->getStart()) + "\"";
+              e += " start=\"" + String(pe->getStart() + 1) + "\"";
             }
             else if (hit.metaValueExists("start"))
             {
-              e += " start=\"" + String(hit.getMetaValue("start")) + "\"";
+              e += " start=\"" + String( int(hit.getMetaValue("start")) + 1) + "\"";
             }
             else
             {
@@ -1883,11 +1883,11 @@ namespace OpenMS
             }
             if (pe->getEnd() != PeptideEvidence::UNKNOWN_POSITION)
             {
-              e += " end=\"" + String(pe->getEnd()) + "\"";
+              e += " end=\"" + String(pe->getEnd() + 1) + "\"";
             }
             else if (hit.metaValueExists("end"))
             {
-              e += " end=\"" + String(hit.getMetaValue("end")) + "\"";
+              e += " end=\"" + String( int(hit.getMetaValue("end")) + 1) + "\"";
             }
             else
             {
@@ -1944,7 +1944,7 @@ namespace OpenMS
             }
             if (start[ev] != String(PeptideEvidence::UNKNOWN_POSITION))
             {
-              e += " start=\"" + start[ev] + "\"";
+              e += " start=\"" + String(start[ev].toInt() + 1) + "\"";
             }
             else
             {
@@ -1952,7 +1952,7 @@ namespace OpenMS
             }
             if (end[ev] != String(PeptideEvidence::UNKNOWN_POSITION))
             {
-              e += " end=\"" + end[ev] + "\"";
+              e += " end=\"" + String(end[ev].toInt() + 1) + "\"";
             }
             else
             {


### PR DESCRIPTION
using the mzIdentMLValidator_GUI_v1.4.35 at
https://github.com/HUPO-PSI/mzIdentML/blob/master/validator/mzIdentMLValidator_GUI_v1.4.35-SNAPSHOT.zip
I got this error from semantic validation:
```
Message 1:
    Rule ID: PeptideEvidenceObjectRule
    Level: ERROR
    Context(/MzIdentML/SequenceCollection/PeptideEvidence )
    --> The PeptideEvidence (id='PEV_4952186547965636686') element at /MzIdentML/SequenceCollection/PeptideEvidence has wrong start and end attributes set (start must be >= 1 and end >=start, but < length of the protein sequence.
    Tip: <PeptideEvidence> elements must have correct start and end attributes set, unless it's a de novo search.
```
because our internal Peptide Evidence starts at 0 and it looks like the mzid standard expects the indices to start at 1. Our files had 0s at start positions for N-terminal peptides. I added a `+ 1` to all start and end positions in this first commit.

With this our files pass semantic validation.


Additionally, using MIAPE-compliant validation, I get the following additional errors, mostly about missing elements that we do not consider yet.
Can we ignore these for now, or is MIAPE compliance important for us?
I can try to fix these as well, but I don't have much time today and this might not be finished this year.

```
Message 2:
    Rule ID: AnalysisSoftwareObjectRule
    Level: ERROR
    Context(/MzIdentML/AnalysisSoftwareList/AnalysisSoftware )
    --> There is not a contactRole element to refer to a software vendor in the Analysis Software (id='SOF_204927807111747809') element at /MzIdentML/AnalysisSoftwareList/AnalysisSoftware
    Tip: Add the contactRole element to the AnalysisSoftware.

Message 3:
    Rule ID: MandatoryElementsObjectRule
    Level: ERROR
    Context(/MzIdentML/Provider )
    --> The element on xPath:'/MzIdentML/Provider' is required for the current type of validation.
    Tip: Add the element in the appropriate location.

Message 4:
    Rule ID: RegExpEnzymeObjectRule
    Level: ERROR
    Context(/MzIdentML/AnalysisProtocolCollection/SpectrumIdentificationProtocol/Enzymes/Enzyme )
    --> There is not a regular expression in Enzyme (id='ENZ_8993046335874597718') element at /MzIdentML/AnalysisProtocolCollection/SpectrumIdentificationProtocol/Enzymes/Enzyme/SiteRegexp
    Tip: Add the element 'SiteRegexp' to the Enzyme.

Message 5:
    Rule ID: DecoyDatabase_must_rule
    Level: ERROR
    Context(/searchDatabase/cvParam/@accession ) in 2 locations
    --> The result found at: /searchDatabase/cvParam/@accession for which the values is  ''MS:1001029'' didn't match the 1 specified CV term:
  - Any children term of MS:1001450 (decoy DB details). The term can be repeated. The matching value has to be the identifier of the term, not its name.
```

