### PR TITLE
[FIX] make decharger safe for eval order of string manip. stmts

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -209,8 +209,10 @@ namespace OpenMS
       }
 
       // determine charge of adduct (by # of '+' or '-')
-      Int pos_charge = adduct[1].size() - adduct[1].remove('+').size();
-      Int neg_charge = adduct[1].size() - adduct[1].remove('-').size();
+      Size charge_s_len = adduct[1].size();
+      Int pos_charge = charge_s_len - adduct[1].remove('+').size();
+      charge_s_len = adduct[1].size();
+      Int neg_charge = charge_s_len - adduct[1].remove('-').size();
       if (pos_charge > 0 && neg_charge > 0)
       {
         String error = "FeatureDeconvolution::potential_adducts mixes charges for an adduct!";

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -223,8 +223,10 @@ namespace OpenMS
       }
 
       // determine charge of adduct (by # of '+' or '-')
-      Int pos_charge = adduct[1].size() - adduct[1].remove('+').size();
-      Int neg_charge = adduct[1].size() - adduct[1].remove('-').size();
+      Size charge_s_len = adduct[1].size();
+      Int pos_charge = charge_s_len - adduct[1].remove('+').size();
+      charge_s_len = adduct[1].size();
+      Int neg_charge = charge_s_len - adduct[1].remove('-').size();
       if (pos_charge > 0 && neg_charge > 0)
       {
         String error = "MetaboliteFeatureDeconvolution::potential_adduct mixes charges for an adduct!";


### PR DESCRIPTION
fixes #4439 (probably at least part of it)