### PR TITLE
FileMerger: allow fasta output

### DIFF
--- a/src/topp/FileMerger.cpp
+++ b/src/topp/FileMerger.cpp
@@ -120,7 +120,7 @@ protected:
     registerStringOption_("in_type", "<type>", "", "Input file type (default: determined from file extension or content)", false);
     setValidStrings_("in_type", valid_in);
     registerOutputFile_("out", "<file>", "", "Output file");
-    setValidFormats_("out", ListUtils::create<String>("mzML,featureXML,consensusXML,traML"));
+    setValidFormats_("out", ListUtils::create<String>("mzML,featureXML,consensusXML,traML,FASTA"));
 
     registerFlag_("annotate_file_origin", "Store the original filename in each feature using meta value \"file_origin\" (for featureXML and consensusXML only).");
     registerStringOption_("append_method", "<choice>", "append_rows", "Append consensusMaps rowise or colwise. (Please use colwise for the MSstatsConverter)", false);

--- a/src/topp/FileMerger.cpp
+++ b/src/topp/FileMerger.cpp
@@ -120,7 +120,7 @@ protected:
     registerStringOption_("in_type", "<type>", "", "Input file type (default: determined from file extension or content)", false);
     setValidStrings_("in_type", valid_in);
     registerOutputFile_("out", "<file>", "", "Output file");
-    setValidFormats_("out", ListUtils::create<String>("mzML,featureXML,consensusXML,traML,FASTA"));
+    setValidFormats_("out", ListUtils::create<String>("mzML,featureXML,consensusXML,traML,fasta"));
 
     registerFlag_("annotate_file_origin", "Store the original filename in each feature using meta value \"file_origin\" (for featureXML and consensusXML only).");
     registerStringOption_("append_method", "<choice>", "append_rows", "Append consensusMaps rowise or colwise. (Please use colwise for the MSstatsConverter)", false);

--- a/src/topp/FileMerger.cpp
+++ b/src/topp/FileMerger.cpp
@@ -114,7 +114,7 @@ protected:
 
   void registerOptionsAndFlags_() override
   {
-    StringList valid_in = ListUtils::create<String>("mzData,mzXML,mzML,dta,dta2d,mgf,featureXML,consensusXML,fid,traML,FASTA");
+    StringList valid_in = ListUtils::create<String>("mzData,mzXML,mzML,dta,dta2d,mgf,featureXML,consensusXML,fid,traML,fasta");
     registerInputFileList_("in", "<files>", StringList(), "Input files separated by blank");
     setValidFormats_("in", valid_in);
     registerStringOption_("in_type", "<type>", "", "Input file type (default: determined from file extension or content)", false);


### PR DESCRIPTION
Currently merging works for fasta only if the outfile is named .tmp. 

Documentation on the possible combinations of input types and output types would be nice. I would need help for this.