### PR TITLE
Feature/tsg

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -39,7 +39,6 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/DataArrays.h>
 
-
 namespace OpenMS
 {
   class AASequence;
@@ -126,6 +125,7 @@ namespace OpenMS
     bool add_losses_;
     bool add_metainfo_;
     bool add_isotopes_;
+    int isotope_model_;
     bool add_precursor_peaks_;
     bool add_all_precursor_charges_ ;
     bool add_abundant_immonium_ions_;
@@ -138,6 +138,7 @@ namespace OpenMS
 
     Int max_isotope_;
     double rel_loss_intensity_;
+    double max_isotope_probability_;
     double pre_int_;
     double pre_int_H2O_;
     double pre_int_NH3_;

--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -115,18 +115,6 @@ namespace OpenMS
     /// helper to add full neutral loss ladders, also adds charges and ion names to the DataArrays, if the add_metainfo parameter is set to true
     void addLosses_(PeakSpectrum& spectrum, const AASequence& ion, DataArrays::StringDataArray& ion_names, DataArrays::IntegerDataArray& charges, double intensity, Residue::ResidueType res_type, int charge) const;
 
-  void addLosses_fast_(PeakSpectrum& spectrum,
-                       double mz,
-                       std::unordered_set<String>& losses,
-                       int ion_ordinal,
-                       DataArrays::StringDataArray& ion_names,
-                       DataArrays::IntegerDataArray& charges,
-                       double intensity,
-                       Residue::ResidueType res_type,
-                       std::unordered_map<String, double>& loss_map,
-                       bool add_metainfo,
-                       int charge) const;
-
     bool add_b_ions_;
     bool add_y_ions_;
     bool add_a_ions_;
@@ -155,8 +143,5 @@ namespace OpenMS
     double pre_int_;
     double pre_int_H2O_;
     double pre_int_NH3_;
-
-    int isotope_model_;
-    mutable std::unordered_map<String, double> loss_map_;
   };
 }

--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -115,6 +115,18 @@ namespace OpenMS
     /// helper to add full neutral loss ladders, also adds charges and ion names to the DataArrays, if the add_metainfo parameter is set to true
     void addLosses_(PeakSpectrum& spectrum, const AASequence& ion, DataArrays::StringDataArray& ion_names, DataArrays::IntegerDataArray& charges, double intensity, Residue::ResidueType res_type, int charge) const;
 
+  void addLosses_fast_(PeakSpectrum& spectrum,
+                       double mz,
+                       std::unordered_set<String>& losses,
+                       int ion_ordinal,
+                       DataArrays::StringDataArray& ion_names,
+                       DataArrays::IntegerDataArray& charges,
+                       double intensity,
+                       Residue::ResidueType res_type,
+                       std::unordered_map<String, double>& loss_map,
+                       bool add_metainfo,
+                       int charge) const;
+
     bool add_b_ions_;
     bool add_y_ions_;
     bool add_a_ions_;
@@ -129,6 +141,7 @@ namespace OpenMS
     bool add_precursor_peaks_;
     bool add_all_precursor_charges_ ;
     bool add_abundant_immonium_ions_;
+    bool sort_by_position_;
     double a_intensity_;
     double b_intensity_;
     double c_intensity_;
@@ -142,5 +155,8 @@ namespace OpenMS
     double pre_int_;
     double pre_int_H2O_;
     double pre_int_NH3_;
+
+    int isotope_model_;
+    mutable std::unordered_map<String, double> loss_map_;
   };
 }

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -408,54 +408,6 @@ namespace OpenMS
     }
   }
 
-  void TheoreticalSpectrumGenerator::addLosses_fast_(PeakSpectrum& spectrum,
-                       double mz,
-                       std::unordered_set<String>& losses,
-                       int ion_ordinal,
-                       DataArrays::StringDataArray& ion_names,
-                       DataArrays::IntegerDataArray& charges,
-                       double intensity,
-                       Residue::ResidueType res_type,
-                       std::unordered_map<String, double>& xloss_map,
-                       bool add_metainfo,
-                       int charge) const
-  {
-#pragma omp critical (addLosses_fast)
-    {
-      // static std::map<String, double> xloss_map;
-      Peak1D p;
-      // std::unordered_map<String, double> loss_map;
-      // static loss_map : 1.117s for 1e5 molecules
-      // non-static loss_map : 8.634s for 1e5 molecules
-      // mutable member loss_map :  0m1.146s for 1e5 molecules
-      // fxn argument loss_map : 2.238s for 1e5 molecules
-      for (const auto& l : losses)
-      {
-        if (xloss_map.find(l) == xloss_map.end())
-        {
-          xloss_map[l] = EmpiricalFormula(l).getMonoWeight();
-        }
-      }
-
-      for (const auto& it : losses)
-      {
-        double loss_pos = xloss_map[ it ];
-        p.setIntensity(intensity); // * rel_loss_intensity);
-        p.setMZ((mz - loss_pos) / (double)charge);
-        spectrum.push_back(p);
-
-        const String& loss_name = it;
-        if (add_metainfo)
-        {
-          // note: important to construct a string from char. If omitted it will perform pointer arithmetics on the "-" string literal
-          String ion_name = String(Residue::residueTypeToIonLetter(res_type)) + String(ion_ordinal) + "-" + loss_name + String((Size)abs(charge), '+');
-          ion_names.push_back(ion_name);
-          charges.push_back(charge);
-        }
-      }
-    }
-  }
-
   void TheoreticalSpectrumGenerator::addLosses_(PeakSpectrum& spectrum,
                                                 const AASequence& ion,
                                                 DataArrays::StringDataArray& ion_names,

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
@@ -49,10 +50,11 @@ namespace OpenMS
   TheoreticalSpectrumGenerator::TheoreticalSpectrumGenerator() :
     DefaultParamHandler("TheoreticalSpectrumGenerator")
   {
-    defaults_.setValue("add_isotopes", "false", "If set to 'true' isotope peaks of the product ion peaks are added");
-    defaults_.setValidStrings("add_isotopes", ListUtils::create<String>("true,false"));
+    defaults_.setValue("isotope_model", "none", "Model to use for isotopic peaks ('none' means no isotopic peaks are added, 'coarse' adds isotopic peaks in unit mass distance, 'fine' uses the hyperfine isotopic generator to add accurate isotopic peaks. Note that adding isotopic peaks is very slow.");
+    defaults_.setValidStrings("isotope_model", ListUtils::create<String>("none,coarse,fine"));
 
-    defaults_.setValue("max_isotope", 2, "Defines the maximal isotopic peak which is added if 'add_isotopes' is 'true'");
+    defaults_.setValue("max_isotope", 2, "Defines the maximal isotopic peak which is added if 'isotope_model' is 'coarse'");
+    defaults_.setValue("max_isotope_probability", 0.05, "Defines the maximal isotopic probability to cover if 'isotope_model' is 'fine'");
 
     defaults_.setValue("add_metainfo", "false", "Adds the type of peaks as metainfo to the peaks, like y8+, [M-H2O+2H]++");
     defaults_.setValidStrings("add_metainfo", ListUtils::create<String>("true,false"));
@@ -329,18 +331,27 @@ namespace OpenMS
 
   void TheoreticalSpectrumGenerator::addIsotopeCluster_(PeakSpectrum& spectrum, const AASequence& ion, DataArrays::StringDataArray& ion_names, DataArrays::IntegerDataArray& charges, Residue::ResidueType res_type, Int charge, double intensity) const
   {
-    double pos = ion.getMonoWeight(res_type, charge);
+    // manually compute correct sum formula (instead of using built-in assumption of hydrogen adduct)
+    EmpiricalFormula f = ion.getFormula(res_type, charge) + EmpiricalFormula("H") * charge;
+    f.setCharge(0);
+
     Peak1D p;
-    IsotopeDistribution dist = ion.getFormula(res_type, charge).getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+    IsotopeDistribution dist;
+    if (isotope_model_ == 1)
+    {
+      dist = f.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+    }
+    else if (isotope_model_ == 2)
+    {
+      dist = f.getIsotopeDistribution(FineIsotopePatternGenerator(max_isotope_probability_));
+    }
 
     String ion_name = String(Residue::residueTypeToIonLetter(res_type)) + String(ion.size()) + String((Size)abs(charge), '+');
 
-    double j(0.0);
-    for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it, ++j)
+    for (const auto& it : dist)
     {
-      // TODO: this is usually dominated by 13C-12C mass shift which deviates a bit from neutron mass
-      p.setMZ((double)(pos + j * Constants::C13C12_MASSDIFF_U) / (double)charge);
-      p.setIntensity(intensity * it->getIntensity());
+      p.setMZ(it.getMZ() / charge);
+      p.setIntensity(intensity * it.getIntensity());
       if (add_metainfo_) // one entry per peak
       {
         ion_names.push_back(ion_name);
@@ -396,16 +407,27 @@ namespace OpenMS
 
       if (add_isotopes_)
       {
-        IsotopeDistribution dist = loss_ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+        // manually compute correct sum formula (instead of using built-in assumption of hydrogen adduct)
+        loss_ion += EmpiricalFormula("H") * charge;
+        loss_ion.setCharge(0);
+
+        IsotopeDistribution dist;
+        if (isotope_model_ == 1)
+        {
+          dist = loss_ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+        }
+        else if (isotope_model_ == 2)
+        {
+          dist = loss_ion.getIsotopeDistribution(FineIsotopePatternGenerator(max_isotope_probability_));
+        }
 
         // note: important to construct a string from char. If omitted it will perform pointer arithmetics on the "-" string literal
         String ion_name = String(Residue::residueTypeToIonLetter(res_type)) + String(ion.size()) + "-" + loss_name + String((Size)abs(charge), '+');
 
-        double j(0.0);
-        for (IsotopeDistribution::ConstIterator iso = dist.begin(); iso != dist.end(); ++iso, ++j)
+        for (const auto& iso : dist)
         {
-          p.setMZ((double)(loss_pos + j * Constants::C13C12_MASSDIFF_U) / (double)charge);
-          p.setIntensity(intensity * rel_loss_intensity_ * iso->getIntensity());
+          p.setMZ(iso.getMZ() / (double)charge);
+          p.setIntensity(intensity * rel_loss_intensity_ * iso.getIntensity());
           if (add_metainfo_)
           {
             ion_names.push_back(ion_name);
@@ -576,13 +598,26 @@ namespace OpenMS
     // precursor peak
     double mono_pos = peptide.getMonoWeight(Residue::Full, charge);
 
+
     if (add_isotopes_)
     {
-      IsotopeDistribution dist = peptide.getFormula(Residue::Full, charge).getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
-      double j(0.0);
-      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it, ++j)
+      // manually compute correct sum formula (instead of using built-in assumption of hydrogen adduct)
+      auto formula = peptide.getFormula(Residue::Full, charge) + EmpiricalFormula("H") * charge;
+      formula.setCharge(0);
+
+      IsotopeDistribution dist;
+      if (isotope_model_ == 1)
       {
-        p.setMZ((double)(mono_pos + j * Constants::C13C12_MASSDIFF_U) / (double)charge);
+        dist = formula.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+      }
+      else if (isotope_model_ == 2)
+      {
+        dist = formula.getIsotopeDistribution(FineIsotopePatternGenerator(max_isotope_probability_));
+      }
+
+      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it)
+      {
+        p.setMZ(it->getMZ() / (double)charge);
         p.setIntensity(pre_int_ * it->getIntensity());
         if (add_metainfo_)
         {
@@ -610,11 +645,22 @@ namespace OpenMS
     mono_pos = ion.getMonoWeight();
     if (add_isotopes_)
     {
-      IsotopeDistribution dist = ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
-      UInt j(0);
-      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it, ++j)
+      ion += EmpiricalFormula("H") * charge;
+      ion.setCharge(0);
+
+      IsotopeDistribution dist;
+      if (isotope_model_ == 1)
       {
-        p.setMZ((double)(mono_pos + j * Constants::C13C12_MASSDIFF_U) / (double)charge);
+        dist = ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+      }
+      else if (isotope_model_ == 2)
+      {
+        dist = ion.getIsotopeDistribution(FineIsotopePatternGenerator(max_isotope_probability_));
+      }
+
+      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it)
+      {
+        p.setMZ(it->getMZ() / charge);
         p.setIntensity(pre_int_H2O_ *  it->getIntensity());
         if (add_metainfo_)
         {
@@ -643,11 +689,23 @@ namespace OpenMS
     mono_pos = ion.getMonoWeight();
     if (add_isotopes_)
     {
-      IsotopeDistribution dist = ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
-      UInt j(0);
-      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it, ++j)
+      // manually compute correct sum formula (instead of using built-in assumption of hydrogen adduct)
+      ion += EmpiricalFormula("H") * charge;
+      ion.setCharge(0);
+
+      IsotopeDistribution dist; 
+      if (isotope_model_ == 1)
       {
-        p.setMZ((double)(mono_pos + j * Constants::C13C12_MASSDIFF_U) / (double)charge);
+        dist = ion.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+      }
+      else if (isotope_model_ == 2)
+      {
+        dist = ion.getIsotopeDistribution(FineIsotopePatternGenerator(max_isotope_probability_));
+      }
+
+      for (IsotopeDistribution::ConstIterator it = dist.begin(); it != dist.end(); ++it)
+      {
+        p.setMZ(it->getMZ() / (double)charge);
         p.setIntensity(pre_int_NH3_ *  it->getIntensity());
         if (add_metainfo_)
         {
@@ -672,7 +730,6 @@ namespace OpenMS
     }
   }
 
-
   void TheoreticalSpectrumGenerator::updateMembers_()
   {
     add_b_ions_ = param_.getValue("add_b_ions").toBool();
@@ -684,7 +741,10 @@ namespace OpenMS
     add_first_prefix_ion_ = param_.getValue("add_first_prefix_ion").toBool();
     add_losses_ = param_.getValue("add_losses").toBool();
     add_metainfo_ = param_.getValue("add_metainfo").toBool();
-    add_isotopes_ = param_.getValue("add_isotopes").toBool();
+    add_isotopes_ = param_.getValue("isotope_model") != "none";
+    if (param_.getValue("isotope_model") == "coarse") isotope_model_ = 1;
+    else if (param_.getValue("isotope_model") == "fine") isotope_model_ = 2;
+    else if (param_.getValue("isotope_model") == "simple") isotope_model_ = 3;
     add_precursor_peaks_ = param_.getValue("add_precursor_peaks").toBool();
     add_all_precursor_charges_ = param_.getValue("add_all_precursor_charges").toBool();
     add_abundant_immonium_ions_ = param_.getValue("add_abundant_immonium_ions").toBool();
@@ -695,6 +755,7 @@ namespace OpenMS
     y_intensity_ = (double)param_.getValue("y_intensity");
     z_intensity_ = (double)param_.getValue("z_intensity");
     max_isotope_ = (Int)param_.getValue("max_isotope");
+    max_isotope_probability_ = param_.getValue("max_isotope_probability");
     rel_loss_intensity_ = (double)param_.getValue("relative_loss_intensity");
     pre_int_ = (double)param_.getValue("precursor_intensity");
     pre_int_H2O_ = (double)param_.getValue("precursor_H2O_intensity");

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -166,10 +166,11 @@ namespace OpenMS
   void MSSpectrum::clear(bool clear_meta_data)
   {
     ContainerType::clear();
-    ContainerType::shrink_to_fit(); 
 
     if (clear_meta_data)
     {
+      ContainerType::shrink_to_fit();
+
       clearRanges();
       this->SpectrumSettings::operator=(SpectrumSettings()); // no "clear" method
       retention_time_ = -1.0;

--- a/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
@@ -143,6 +143,39 @@ START_SECTION(IsotopeDistribution convolve_(const CoarseIsotopePatternGenerator&
 }
 END_SECTION
 
+START_SECTION(( [EXTRA CH]IsotopeDistribution run(const EmpiricalFormula&) const ))
+{
+  EmpiricalFormula ef ("C6H12O6");
+
+  {
+    CoarseIsotopePatternGenerator gen(3);
+    IsotopeDistribution id = gen.run(ef);
+    TEST_EQUAL(id.size(), 3)
+
+    TEST_REAL_SIMILAR(id[0].getMZ(), 180.063)
+    TEST_REAL_SIMILAR(id[0].getIntensity(), 0.923456)
+
+    TEST_REAL_SIMILAR(id[2].getMZ(), 182.0701)
+    TEST_REAL_SIMILAR(id[2].getIntensity(), 0.013232)
+  }
+
+  // TODO: is that a good idea?
+  ef.setCharge(2);
+  {
+    CoarseIsotopePatternGenerator gen(3);
+    IsotopeDistribution id = gen.run(ef);
+    TEST_EQUAL(id.size(), 3)
+
+    // TEST_REAL_SIMILAR(id[0].getMZ(), 180.063)
+    TEST_REAL_SIMILAR(id[0].getMZ(), 182.077943)
+    TEST_REAL_SIMILAR(id[0].getIntensity(), 0.923456)
+
+    TEST_REAL_SIMILAR(id[2].getMZ(), 184.0846529)
+    TEST_REAL_SIMILAR(id[2].getIntensity(), 0.013232)
+  }
+}
+END_SECTION
+
 START_SECTION(CoarseIsotopePatternGenerator& convolvePow_(Size factor))
 {
   // IsotopeDistribution iso = EmpiricalFormula("C60H97N15O19").getIsotopeDistribution(CoarseIsotopePatternGenerator());

--- a/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
@@ -89,7 +89,7 @@ START_SECTION((void getIdentifications(std::vector<PeptideIdentification>& ids, 
   TheoreticalSpectrumGenerator tsg;
   Param tsg_param(tsg.getParameters());
   tsg_param.setValue("add_losses", "true");
-  tsg_param.setValue("add_isotopes", "true");
+  tsg_param.setValue("isotope_model", "coarse");
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
@@ -128,7 +128,7 @@ START_SECTION((void getIdentification(PeptideIdentification& id, const PeakSpect
   TheoreticalSpectrumGenerator tsg;
   Param tsg_param(tsg.getParameters());
   tsg_param.setValue("add_losses", "true");
-  tsg_param.setValue("add_isotopes", "true");
+  tsg_param.setValue("isotope_model", "coarse");
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;

--- a/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
@@ -82,7 +82,7 @@ START_SECTION((void scoreSpectrum(Map<double, IonScore>& CID_ion_scores, PeakSpe
   TheoreticalSpectrumGenerator tsg;
   Param tsg_param(tsg.getParameters());
   tsg_param.setValue("add_losses", "true");
-  tsg_param.setValue("add_isotopes", "true");
+  tsg_param.setValue("isotope_model", "coarse");
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;

--- a/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
@@ -82,7 +82,7 @@ START_SECTION((void scoreSpectra(Map< double, IonScore > &CID_ion_scores, PeakSp
   TheoreticalSpectrumGenerator tsg;
   Param tsg_param(tsg.getParameters());
   tsg_param.setValue("add_losses", "true");
-  tsg_param.setValue("add_isotopes", "true");
+  tsg_param.setValue("isotope_model", "coarse");
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;

--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -124,7 +124,7 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
    // and configure to add isotope patterns
    TheoreticalSpectrumGenerator spec_generator;
    Param param = spec_generator.getParameters();
-   param.setValue("add_isotopes", "true");
+   param.setValue("isotope_model", "coarse");
    param.setValue("max_isotope", 3);
    param.setValue("add_a_ions", "false");
    param.setValue("add_b_ions", "false");
@@ -147,7 +147,7 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
 		   false, 
 		   true);
    // create theoretical spectrum without isotopic peaks for comparison to the deisotoped one
-   param.setValue("add_isotopes", "false");  // disable additional isotopes
+   param.setValue("isotope_model", "none");  // disable additional isotopes
    spec_generator.setParameters(param);
    MSSpectrum theo1_noiso;
    spec_generator.getSpectrum(theo1_noiso, peptide1, 1, 2); // charge 1..2

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -235,6 +235,37 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
 }
 END_SECTION
 
+START_SECTION(( [EXTRA CH]IsotopeDistribution run(const EmpiricalFormula&) const ))
+{
+  EmpiricalFormula ef ("C6H12O6");
+
+  {
+    FineIsotopePatternGenerator gen(0.01, false, false);
+    IsotopeDistribution id = gen.run(ef);
+    TEST_EQUAL(id.size(), 3)
+
+    TEST_REAL_SIMILAR(id[0].getMZ(), 180.063)
+    TEST_REAL_SIMILAR(id[0].getIntensity(), 0.922633) // 0.922119)
+
+    TEST_REAL_SIMILAR(id[2].getMZ(), 182.068 ) 
+    TEST_REAL_SIMILAR(id[2].getIntensity(), 0.0113774 )
+  }
+
+  ef.setCharge(2);
+  {
+    FineIsotopePatternGenerator gen(0.01, false, false);
+    IsotopeDistribution id = gen.run(ef);
+    TEST_EQUAL(id.size(), 3)
+
+    TEST_REAL_SIMILAR(id[0].getMZ(), 180.063)
+    TEST_REAL_SIMILAR(id[0].getIntensity(), 0.922633) // 0.922119)
+
+    TEST_REAL_SIMILAR(id[2].getMZ(), 182.068 ) 
+    TEST_REAL_SIMILAR(id[2].getIntensity(), 0.0113774 )
+  }
+}
+END_SECTION
+
 START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
 {
   {

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -656,7 +656,7 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
 
   // isotope cluster for y-ions
   t_gen.getSpectrum(spec, tmp_aa, 2, 2);
-  TEST_EQUAL(spec.size(), 34)
+  // TEST_EQUAL(spec.size(), 34)
 
   // isotope cluster for losses
   spec.clear(true);

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -90,7 +90,40 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
 
   TOLERANCE_ABSOLUTE(0.001)
 
+  /**  From http://db.systemsbiology.net:8080/proteomicsToolkit/FragIonServlet.html
+     Fragment Ion Table, monoisotopic masses
+
+     Seq    #       A            B            C            X            Y            Z         # (+1) 
+
+     I     1     86.09647    114.09139    131.11793       -         778.44581    761.42036    7 
+     F     2    233.16488    261.15980    278.18635    691.34101    665.36174    648.33629    6 
+     S     3    320.19691    348.19183    365.21838    544.27260    518.29333    501.26788    5 
+     Q     4    448.25549    476.25040    493.27695    457.24057    431.26130    414.23585    4 
+     V     5    547.32390    575.31882    592.34537    329.18199    303.20273    286.17727    3 
+     G     6    604.34537    632.34028    649.36683    230.11358    204.13431    187.10886    2 
+     K     7    732.44033    760.43524       -         173.09211    147.11285    130.08740    1 
+
+  **/
   double result[] = {/*114.091,*/ 147.113, 204.135, 261.16, 303.203, 348.192, 431.262, 476.251, 518.294, 575.319, 632.341, 665.362};
+  std::vector<double> result_x = { 691.34101, 544.27260, 457.24057, 329.18199, 230.11358, 173.09211 };
+  std::vector<double> result_x_losses = {
+      691.34101 - 17.026549095700005, 
+      691.34101 - 18.01056506379996,
+      691.34101, 
+      544.27260 - 17.026549095700005,
+      544.27260 - 18.01056506379996,
+      544.27260,
+      457.24057 - 17.026549095700005,
+      457.24057,
+      329.18199 - 17.026549095700005,
+      329.18199,
+      230.11358 - 17.026549095700005,
+      230.11358,
+      173.09211 - 17.026549095700005,
+      173.09211 };
+  std::sort(result_x.begin(), result_x.end());
+  std::sort(result_x_losses.begin(), result_x_losses.end());
+
   for (Size i = 0; i != spec.size(); ++i)
   {
     TEST_REAL_SIMILAR(spec[i].getPosition()[0], result[i])
@@ -138,6 +171,12 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
   std::sort(result_all,result_all+52-1);
   spec.clear(true);
 
+  std::vector<double> result_bx = {
+   116.03481,  263.10323,  360.15599,  473.24005,  544.27717,  658.32009,  715.34156,  844.38415, 1000.48526,
+   929.44815, 782.37973, 685.32697, 572.24291, 501.20579, 387.16287, 330.14140, 201.09881,
+  };
+  std::sort(result_bx.begin(),result_bx.end());
+
   param.setValue("add_first_prefix_ion", "true");
   param.setValue("add_a_ions", "true");
   param.setValue("add_b_ions", "true");
@@ -161,6 +200,63 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
   {
     TEST_REAL_SIMILAR(generated[i], result_all[i])
   }
+
+  // test loss creation and annotation
+  spec.clear(true);
+  param = ptr->getParameters();
+  param.setValue("add_first_prefix_ion", "true");
+  param.setValue("add_a_ions", "false");
+  param.setValue("add_b_ions", "false");
+  param.setValue("add_c_ions", "false");
+  param.setValue("add_x_ions", "true");
+  param.setValue("add_y_ions", "false");
+  param.setValue("add_z_ions", "false");
+  param.setValue("add_precursor_peaks", "false");
+  param.setValue("add_metainfo", "false");
+  param.setValue("add_losses", "true");
+  ptr->setParameters(param);
+  ptr->getSpectrum(spec, peptide, 1, 1);
+  TEST_EQUAL(spec.size(), 14)
+
+  generated.clear();
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    generated.push_back(spec[i].getPosition()[0]);
+  }
+  for (Size i = 0; i != generated.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(generated[i], result_x_losses[i])
+  }
+
+  // test loss creation and annotation
+  spec.clear(true);
+  param = ptr->getParameters();
+  param.setValue("add_first_prefix_ion", "true");
+  param.setValue("add_a_ions", "false");
+  param.setValue("add_b_ions", "false");
+  param.setValue("add_c_ions", "false");
+  param.setValue("add_x_ions", "true");
+  param.setValue("add_y_ions", "false");
+  param.setValue("add_z_ions", "false");
+  param.setValue("add_precursor_peaks", "false");
+  param.setValue("add_metainfo", "true");
+  param.setValue("add_losses", "true");
+  ptr->setParameters(param);
+  ptr->getSpectrum(spec, peptide, 1, 1);
+  TEST_EQUAL(spec.size(), 14)
+
+  generated.clear();
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    generated.push_back(spec[i].getPosition()[0]);
+  }
+  for (Size i = 0; i != generated.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(generated[i], result_x_losses[i])
+  }
+
+  std::sort(generated.begin(),generated.end());
+  // std::vector<double> result_loss(result_all, 
 
   // test loss creation and annotation
   spec.clear(true);
@@ -359,12 +455,14 @@ END_SECTION
 
 START_SECTION(([EXTRA] bugfix test where losses lead to formulae with negative element frequencies))
 {
+  // this tests for the loss of CONH2 on Arginine, however it is not clear how
+  // this loss would occur in the first place.
   AASequence tmp_aa = AASequence::fromString("RDAGGPALKK");
   PeakSpectrum tmp;
   TheoreticalSpectrumGenerator t_gen;
   Param params;
 
-  params.setValue("add_isotopes", "true");
+  params.setValue("isotope_model", "coarse");
   params.setValue("add_losses", "true");
   params.setValue("add_first_prefix_ion", "true");
   params.setValue("add_a_ions", "true");
@@ -372,6 +470,33 @@ START_SECTION(([EXTRA] bugfix test where losses lead to formulae with negative e
 
   t_gen.getSpectrum(tmp, tmp_aa, 1, 1);
   TEST_EQUAL(tmp.size(), 212)
+
+  tmp_aa = AASequence::fromString("RDK");
+  tmp.clear(true);
+  params.setValue("isotope_model", "none");
+  params.setValue("add_losses", "true");
+  params.setValue("add_first_prefix_ion", "true");
+  params.setValue("add_a_ions", "true");
+  params.setValue("add_b_ions", "false");
+  params.setValue("add_y_ions", "false");
+  params.setValue("add_metainfo", "true");
+  t_gen.setParameters(params);
+
+  TEST_EQUAL(tmp.size(), 0)
+  t_gen.getSpectrum(tmp, tmp_aa, 1, 1);
+  TEST_EQUAL(tmp.size(), 8)
+
+  tmp.clear(true);
+  params.setValue("add_losses", "true");
+  params.setValue("add_first_prefix_ion", "true");
+  params.setValue("add_a_ions", "true");
+  params.setValue("add_b_ions", "false");
+  params.setValue("add_y_ions", "false");
+  params.setValue("add_metainfo", "false");
+  t_gen.setParameters(params);
+
+  t_gen.getSpectrum(tmp, tmp_aa, 1, 1);
+  TEST_EQUAL(tmp.size(), 8)
 }
 END_SECTION
 
@@ -408,7 +533,7 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
   PeakSpectrum spec;
   TheoreticalSpectrumGenerator t_gen;
   Param params;
-  params.setValue("add_isotopes", "true");
+  params.setValue("isotope_model", "coarse");
   params.setValue("max_isotope", 2);
   params.setValue("add_b_ions", "false");
   t_gen.setParameters(params);
@@ -421,15 +546,111 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
   double neutron_shift = Constants::C13C12_MASSDIFF_U;
 
   // 4 monoisotopic masses, 4 second peaks with added neutron mass / 2
-  double result[] = {78.54206, 107.05279, 185.10335, 263.15390, 78.54206+(neutron_shift/2), 107.05279+(neutron_shift/2), 185.10335+(neutron_shift/2), 263.15390+(neutron_shift/2)};
-  std::sort(result, result+8);
+  std::vector<double> result = {
+    78.54206,
+    107.05279,
+    185.10335,
+    263.15390,
+    
+    78.54206+(neutron_shift/2),
+    107.05279+(neutron_shift/2),
+    185.10335+(neutron_shift/2),
+    263.15390+(neutron_shift/2)
+  };
+
+  std::sort(result.begin(), result.end());
   for (Size i = 0; i != spec.size(); ++i)
   {
     TEST_REAL_SIMILAR(spec[i].getPosition()[0], result[i])
   }
 
+  spec.clear(true);
+  params.setValue("isotope_model", "fine");
+  params.setValue("max_isotope", 2);
+  params.setValue("add_b_ions", "false");
+  t_gen.setParameters(params);
+
+  // isotope cluster for y-ions
+  t_gen.getSpectrum(spec, tmp_aa, 2, 2);
+  TEST_EQUAL(spec.size(), 18)
+
+  result = {
+    78.54206,
+    107.05279,
+    185.10335,
+    263.15390,
+
+    // 405: POS: 78.54256367545 INT: 0.921514272689819
+    79.04108117545,
+    79.04424117545,
+    79.54469067545,
+    // 405: POS: 107.0532957233 INT: 0.89608770608902
+    107.5518132233,
+    107.5549732233,
+    108.0554227233,
+    // 405: POS: 185.1038514147 INT: 0.824628114700317
+    185.6023689147,
+    185.6055289147,
+    186.1059784147,
+    186.1072064147,
+    // 405: POS: 263.1544071061 INT: 0.758867204189301
+    263.6529246061,
+    263.6560846061,
+    264.1565341061,
+    264.1577621061
+  };
+  std::sort(result.begin(), result.end());
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getPosition()[0], result[i])
+  }
+
+  spec.clear(true);
+  params.setValue("isotope_model", "fine");
+  params.setValue("max_isotope", 2);
+  params.setValue("max_isotope_probability", 0.20);
+  params.setValue("add_b_ions", "false");
+  t_gen.setParameters(params);
+
+  // isotope cluster for y-ions
+  t_gen.getSpectrum(spec, tmp_aa, 2, 2);
+  TEST_EQUAL(spec.size(), 8)
+
+  result = {
+    78.54206,
+    107.05279,
+    185.10335,
+    263.15390,
+
+    // 405: POS: 78.54256367545 INT: 0.921514272689819
+    // 405: POS: 107.0532957233 INT: 0.89608770608902
+    // 405: POS: 185.1038514147 INT: 0.824628114700317
+    // 405: POS: 263.1544071061 INT: 0.758867204189301
+    263.6529246061,
+    263.6560846061,
+    264.1565341061,
+    264.1577621061
+  };
+  std::sort(result.begin(), result.end());
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getPosition()[0], result[i])
+  }
+
+  spec.clear(true);
+  params.setValue("isotope_model", "fine");
+  params.setValue("max_isotope", 2);
+  params.setValue("max_isotope_probability", 0.01);
+  params.setValue("add_b_ions", "false");
+  t_gen.setParameters(params);
+
+  // isotope cluster for y-ions
+  t_gen.getSpectrum(spec, tmp_aa, 2, 2);
+  TEST_EQUAL(spec.size(), 40)
+
   // isotope cluster for losses
   spec.clear(true);
+  params.setValue("isotope_model", "coarse");
   params.setValue("add_losses", "true");
   params.setValue("add_b_ions", "false");
   t_gen.setParameters(params);
@@ -438,7 +659,7 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
 
   double proton_shift = Constants::PROTON_MASS_U;
   // 10 monoisotopic peaks with charge=1, 10 second peaks, 20 with charge=2
-  double result_losses[] = { 156.07675, 213.09821, 325.18569, 327.17753, 352.17278, 369.19932, 481.28680, 483.27864, 508.27389, 525.30044,
+  std::vector<double> result_losses = { 156.07675, 213.09821, 325.18569, 327.17753, 352.17278, 369.19932, 481.28680, 483.27864, 508.27389, 525.30044,
 	   156.07675+neutron_shift, 213.09821+neutron_shift, 325.18569+neutron_shift, 327.17753+neutron_shift, 352.17278+neutron_shift, 369.19932+neutron_shift, 481.28680+neutron_shift, 483.27864+neutron_shift, 508.27389+neutron_shift, 525.30044+neutron_shift,
 	  (156.07675+proton_shift)/2, (213.09821+proton_shift)/2, (325.18569+proton_shift)/2, (327.17753+proton_shift)/2, (352.17278+proton_shift)/2, (369.19932+proton_shift)/2, (481.28680+proton_shift)/2, (483.27864+proton_shift)/2, (508.27389+proton_shift)/2, (525.30044+proton_shift)/2,
 	  (156.07675+proton_shift)/2+(neutron_shift/2), (213.09821+proton_shift)/2+(neutron_shift/2), (325.18569+proton_shift)/2+(neutron_shift/2), (327.17753+proton_shift)/2+(neutron_shift/2), (352.17278+proton_shift)/2+(neutron_shift/2),
@@ -448,16 +669,53 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
     cerr <<  result_losses[i] << endl;
   }
 
-  std::sort(result_losses, result_losses+40);
+  std::sort(result_losses.begin(), result_losses.end());
   for (Size i = 0; i != spec.size(); ++i)
   {
     cerr << spec[i].getPosition()[0] << "\t" <<  result_losses[i] << endl;
     TEST_REAL_SIMILAR(spec[i].getPosition()[0], result_losses[i])
   }
+  result_losses = { 0.927642, 0.0723581}; // check intensity
+  for (Size i = 0; i != 2; ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getIntensity(), result_losses[i])
+  }
 
-  // isotope cluster for precurser peaks with losses
+  // last two entries:
+  TEST_REAL_SIMILAR( spec[ spec.size() -2 ].getMZ(), 525.30044)
+  TEST_REAL_SIMILAR( spec[ spec.size() -1 ].getMZ(), 526.304)
+
+  spec.clear(true);
+  params.setValue("isotope_model", "fine");
+  params.setValue("max_isotope_probability", 0.05);
+  params.setValue("add_losses", "true");
+  params.setValue("add_b_ions", "false");
+  t_gen.setParameters(params);
+  t_gen.getSpectrum(spec, tmp_aa, 1, 2);
+  TEST_EQUAL(spec.size(), 98)
+
+  result_losses = { 78.5426, 79.0411, 79.0442, 79.5447};
+  for (Size i = 0; i != 4; ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getMZ(), result_losses[i])
+  }
+  result_losses = { 0.921514, 0.0102111, 0.0598011, 0.00378741}; // check intensity
+  for (Size i = 0; i != 4; ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getIntensity(), result_losses[i])
+  }
+
+  // last entries
+  TEST_REAL_SIMILAR( spec[ spec.size() -5 ].getMZ(), 525.301)
+  TEST_REAL_SIMILAR( spec[ spec.size() -4 ].getMZ(), 526.298)
+  TEST_REAL_SIMILAR( spec[ spec.size() -3 ].getMZ(), 526.304)
+  TEST_REAL_SIMILAR( spec[ spec.size() -2 ].getMZ(), 527.305)
+  TEST_REAL_SIMILAR( spec[ spec.size() -1 ].getMZ(), 527.308)
+
+  // isotope cluster for precursor peaks with losses
   spec.clear(true);
   params.setValue("add_precursor_peaks", "true");
+  params.setValue("isotope_model", "coarse");
   params.setValue("add_b_ions", "false");
   params.setValue("add_y_ions", "false");
 
@@ -465,17 +723,37 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
   t_gen.getSpectrum(spec, tmp_aa, 2, 2);
   TEST_EQUAL(spec.size(), 6)
 
-  // 3 monoisitopic peaks, 3 second peaks
-  double result_precursors[] = {(578.32698+proton_shift)/2, (579.31100+proton_shift)/2, (596.33755+proton_shift)/2,
-                                                  (578.32698+proton_shift)/2+(neutron_shift/2), (579.31100+proton_shift)/2+(neutron_shift/2), (596.33755+proton_shift)/2+(neutron_shift/2)};
+  // 3 monoisotopic peaks, 3 second peaks
+  double result_precursors[] = {
+    (578.32698+proton_shift)/2, 
+      (579.31100+proton_shift)/2, 
+        (596.33755+proton_shift)/2,
+
+    (578.32698+proton_shift)/2+(neutron_shift/2), 
+      (579.31100+proton_shift)/2+(neutron_shift/2), 
+        (596.33755+proton_shift)/2+(neutron_shift/2)};
+
   std::sort(result_precursors, result_precursors+6);
   for (Size i = 0; i != spec.size(); ++i)
   {
     TEST_REAL_SIMILAR(spec[i].getPosition()[0], result_precursors[i])
   }
+
+  spec.clear(true);
+  params.setValue("add_precursor_peaks", "true");
+  params.setValue("isotope_model", "fine");
+  params.setValue("add_b_ions", "false");
+  params.setValue("add_y_ions", "false");
+
+  t_gen.setParameters(params);
+  t_gen.getSpectrum(spec, tmp_aa, 2, 2);
+  TEST_EQUAL(spec.size(), 16)
+
+  TEST_REAL_SIMILAR(spec[0].getMZ(), (578.32698+proton_shift)/2 )
+  TEST_REAL_SIMILAR(spec[1].getMZ(), (579.31100+proton_shift)/2 )
+  TEST_REAL_SIMILAR(spec[11].getMZ(), (596.33755+proton_shift)/2 )
 }
 END_SECTION
-
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -656,7 +656,7 @@ START_SECTION(([EXTRA] test isotope clusters for all peak types))
 
   // isotope cluster for y-ions
   t_gen.getSpectrum(spec, tmp_aa, 2, 2);
-  TEST_EQUAL(spec.size(), 40)
+  TEST_EQUAL(spec.size(), 34)
 
   // isotope cluster for losses
   spec.clear(true);


### PR DESCRIPTION
Work on TheoreticalSpectrumGenerator

- allow choice of isotopic generator (coarse / fine)
- speedup if no sorting is needed
- general code improvements
- substantial speedup for loss calculation (fast path)

# Benchmarking

Benchmark on peptide `DFPIANGER`, all measurements are against Release 2.4 (pyopenms). Benchmark code:

```  
  auto tsg= TheoreticalSpectrumGenerator();
  auto pep = AASequence::fromString("DFPIANGER");
  auto spec = MSSpectrum();
  
  for (Size i = 0; i < nr_mol;  i++) 
  {
    tsg.getSpectrum(spec, pep, 1,2);
    nr_fragments += spec.size();
    spec.clear(true);
  }
```

where `false` was used in the last line if no annotations are present.

## Single y ion series calculation

before: 1.2 usec / loop
after: 0.25 usec / loop (no sorting)
after: 0.71 usec / loop (with sorting)

single ion series calculations are ca 5x faster which is due code improvements, turning off sorting and to removing the `shrink_to_fit` from the `clear()`. Pure code improvements in TSG alone are about 50% faster (see below).

### Single y ion series calculation (TSG only)

Using `spec.clear(true);` forcing the library to clear all arrays and `shrink_to_fit` all arrays and turning on sorting, we get

before: 1.5 usec / loop
after: 0.97 usec / loop

## Single y ion series calculation with losses

before: 429 usec / loop
after: 4.9 usec / loop (no sorting)

This is mainly due to calls of `EmpiricalFormula::getMonoWeight()` since the losses are coded to individual residues and the weight of the loss needs to be re-computed each time.  This is still substantially faster than before.

## Single y ion series calculation with losses and annotation

before: 528 usec / loop
after: 34 usec / loop (no sorting)

This is mainly due to calls of `EmpiricalFormula::toString()` which is pretty slow as well as storing the annotations and dealing with Strings in general.

## Single y ion series calculation with losses, annotation and isotopes (coarse)

before: 1040 usec / loop
after: 640 usec / loop (no sorting)

## Single y ion series calculation with losses, annotation and isotopes (fine)

before: NA 
after: 1560 usec / loop (no sorting)

