### PR TITLE
OpenPepXL, OpenPepXLLF: remove xml from valid extensions

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FileTypes.h
+++ b/src/openms/include/OpenMS/FORMAT/FileTypes.h
@@ -110,6 +110,7 @@ namespace OpenMS
       SPLIB,              ///< SpectraST binary spectral library file (sptxt is the equivalent text-based format, similar to the MSP format)
       NOVOR,              ///< Novor custom parameter file
       XQUESTXML,          ///< xQuest XML file format for protein-protein cross-link identifications (.xquest.xml)
+      SPECXML,            ///< xQuest XML file format for matched spectra for spectra visualization in the xQuest results manager (.spec.xml)
       JSON,               ///< JavaScript Object Notation file (.json)
       RAW,                ///< Thermo Raw File (.raw)
       EXE,                ///< Executable (.exe)

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -83,6 +83,8 @@ namespace OpenMS
     if (basename.hasSuffix(".xquest.xml"))
       return FileTypes::XQUESTXML;
 
+    if (basename.hasSuffix(".spec.xml"))
+      return FileTypes::SPECXML;
     try
     {
       tmp = basename.suffix('.');

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -139,6 +139,7 @@ namespace OpenMS
     targetMap[FileTypes::SPLIB] = "splib";
     targetMap[FileTypes::NOVOR] = "novor";
     targetMap[FileTypes::PARAMXML] = "paramXML";
+    targetMap[FileTypes::SPECXML] = "spec.xml";
     targetMap[FileTypes::XQUESTXML] = "xquest.xml";
     targetMap[FileTypes::JSON] = "json";
     targetMap[FileTypes::RAW] = "raw";

--- a/src/topp/OpenPepXL.cpp
+++ b/src/topp/OpenPepXL.cpp
@@ -163,10 +163,10 @@ protected:
     setValidFormats_("out_mzIdentML", ListUtils::create<String>("mzid"));
 
     registerOutputFile_("out_xquestxml", "<xQuestXML_file>", "", "Results in the xquest.xml format (at least one of these output parameters should be set, otherwise you will not have any results).", false, false);
-    setValidFormats_("out_xquestxml", ListUtils::create<String>("xml,xquest.xml"));
+    setValidFormats_("out_xquestxml", ListUtils::create<String>("xquest.xml"));
 
     registerOutputFile_("out_xquest_specxml", "<xQuestSpecXML_file>", "", "Matched spectra in the xQuest .spec.xml format for spectra visualization in the xQuest results manager.", false, false);
-    setValidFormats_("out_xquest_specxml", ListUtils::create<String>("xml,spec.xml"));
+    setValidFormats_("out_xquest_specxml", ListUtils::create<String>("spec.xml"));
   }
 
   ExitCodes main_(int, const char**) override

--- a/src/topp/OpenPepXLLF.cpp
+++ b/src/topp/OpenPepXLLF.cpp
@@ -154,10 +154,10 @@ protected:
     setValidFormats_("out_mzIdentML", ListUtils::create<String>("mzid"));
 
     registerOutputFile_("out_xquestxml", "<xQuestXML_file>", "", "Results in the xquest.xml format (at least one of these output parameters should be set, otherwise you will not have any results).", false, false);
-    setValidFormats_("out_xquestxml", ListUtils::create<String>("xml,xquest.xml"));
+    setValidFormats_("out_xquestxml", ListUtils::create<String>("xquest.xml"));
 
     registerOutputFile_("out_xquest_specxml", "<xQuestSpecXML_file>", "", "Matched spectra in the xQuest .spec.xml format for spectra visualization in the xQuest results manager.", false, false);
-    setValidFormats_("out_xquest_specxml", ListUtils::create<String>("xml,spec.xml"));
+    setValidFormats_("out_xquest_specxml", ListUtils::create<String>("spec.xml"));
   }
 
   ExitCodes main_(int, const char**) override


### PR DESCRIPTION
since https://github.com/OpenMS/OpenMS/blob/c19b545636e76a5770f095f944e0b196b9b56c82/src/openms/source/FORMAT/XQuestResultXMLFile.cpp#L97 will raise an error when a .xml file is given.

I suggest to remove xml also for spec.xml