### PR TITLE
Feature/aasequence speed

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -39,6 +39,7 @@
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 
 #include <set>
+#include <unordered_map>
 
 namespace OpenMS
 {
@@ -175,7 +176,7 @@ protected:
     std::vector<ResidueModification*> mods_;
 
     /// Stores the mappings of (unique) names to the modifications
-    Map<String, std::set<const ResidueModification*> > modification_names_;
+    std::unordered_map<String, std::set<const ResidueModification*> > modification_names_;
 
     /// Helper function to check if a residue matches the origin for a modification
     bool residuesMatch_(const String& residue, const ResidueModification* origin) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -100,6 +100,12 @@ public:
     */
     void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 
+    const ResidueModification* searchModifications_fast(const String& mod_name, 
+bool& multiple_matches,
+                                                        const String& residue = "",
+                                                        ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY
+                                                        ) const;
+
     /**
        @brief Returns the modification with the given name
 

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1001,12 +1001,11 @@ namespace OpenMS
           "Cannot convert string to peptide modification: missing ')'");
     }
 
-    ModificationsDB* mod_db = ModificationsDB::getInstance();
-
     // First search for N or C terminal modifications (start of peptide indicates N-terminal modification as well)
     if (aas.peptide_.empty() || specificity == ResidueModification::N_TERM ||
                                 specificity == ResidueModification::PROTEIN_N_TERM)
     {
+      ModificationsDB* mod_db = ModificationsDB::getInstance();
       // Advance iterator one or two positions (we may or may not have a dot
       // after the closing bracket) to point to the first AA of the peptide.
       String::ConstIterator next_aa = mod_end;
@@ -1028,11 +1027,13 @@ namespace OpenMS
     const String& res = aas.peptide_.back()->getOneLetterCode();
     if (specificity == ResidueModification::PROTEIN_C_TERM)
     {
+      ModificationsDB* mod_db = ModificationsDB::getInstance();
       aas.c_term_mod_ = proteinTerminalResidueHelper(mod_db, 'c', str, mod, res);
       return mod_end;
     }
     else if (specificity == ResidueModification::C_TERM)
     {
+      ModificationsDB* mod_db = ModificationsDB::getInstance();
       aas.c_term_mod_ = terminalResidueHelper(mod_db, 'c', true, str, mod, res);
       return mod_end;
     }
@@ -1044,6 +1045,8 @@ namespace OpenMS
     }
     catch(...)  // no internal mod for this residue
     {
+      ModificationsDB* mod_db = ModificationsDB::getInstance();
+
       // TODO: get rid of this code path, its deprecated and is only a hack for
       // C/N-terminal modifications that don't use the dot notation
       if (std::distance(str_it, str.begin()) == -1)

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1380,7 +1380,12 @@ namespace OpenMS
   void AASequence::parseString_(const String& pep, AASequence& aas,
                                 bool permissive)
   {
+    // Reserving space, populate it and then shrink again (since we probably
+    // over-allocate due to modifications). This substantially speeds up the
+    // function for unmodified sequences (3x speedup).
     aas.peptide_.clear();
+    aas.peptide_.reserve(pep.size());
+
     String peptide(pep);
     peptide.trim();
 
@@ -1482,6 +1487,8 @@ namespace OpenMS
     // since the user might just want to represent the sequence (including modifications on other AA's),
     // e.g. when digesting a peptide
     // We check for 'weightless' X in places where a mass is needed, e.g. during getMonoMass()
+
+    aas.peptide_.shrink_to_fit();
   }
 
   void AASequence::getAAFrequencies(Map<String, Size>& frequency_table) const

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1384,10 +1384,10 @@ namespace OpenMS
     // over-allocate due to modifications). This substantially speeds up the
     // function for unmodified sequences (3x speedup).
     aas.peptide_.clear();
-    aas.peptide_.reserve(pep.size());
 
     String peptide(pep);
     peptide.trim();
+    aas.peptide_.reserve(peptide.size());
 
     if (peptide.empty()) return;
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -119,7 +119,8 @@ namespace OpenMS
     #pragma omp critical(OpenMS_ModificationsDB)
     {
       bool found = true;
-      if (!modification_names_.has(mod_name))
+      auto modifications = modification_names_.find(mod_name);
+      if (modifications == modification_names_.end())
       {
         // Try to fix things, Skyline for example uses unimod:10 and not UniMod:10 syntax
         if (mod_name.size() > 6 && mod_name.prefix(6).toLower() == "unimod")
@@ -127,7 +128,8 @@ namespace OpenMS
           mod_name = "UniMod" + mod_name.substr(6, mod_name.size() - 6);
         }
 
-        if (!modification_names_.has(mod_name))
+        modifications = modification_names_.find(mod_name);
+        if (modifications == modification_names_.end())
         {
           OPENMS_LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
           found = false; 
@@ -136,8 +138,7 @@ namespace OpenMS
 
       if (found)
       {
-        const set<const ResidueModification*>& temp = modification_names_[mod_name];
-        for (const auto& it : temp)
+        for (const auto& it : modifications->second)
         {
           if (residuesMatch_(residue, it) &&
                (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY ||

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -188,7 +188,7 @@ namespace OpenMS
     bool has_mod;
     #pragma omp critical(OpenMS_ModificationsDB)
     {
-      has_mod = modification_names_.has(modification);
+      has_mod = (modification_names_.find(modification) != modification_names_.end());
     }
     return has_mod;
   }
@@ -203,7 +203,7 @@ namespace OpenMS
     bool one_mod(true);
     #pragma omp critical(OpenMS_ModificationsDB)
     {
-      if (modification_names_[mod_name].size() > 1)
+      if (modification_names_.find(mod_name)->second.size() > 1)
       {
         one_mod = false;
       }
@@ -216,7 +216,7 @@ namespace OpenMS
     Size index(numeric_limits<Size>::max());
     #pragma omp critical(OpenMS_ModificationsDB)
     {
-      const ResidueModification* mod = *modification_names_[mod_name].begin();
+      const ResidueModification* mod = *(modification_names_.find(mod_name)->second.begin());
       for (Size i = 0; i != mods_.size(); ++i)
       {
         if (mods_[i] == mod)

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -132,7 +132,7 @@ namespace OpenMS
                                                                        ResidueModification::TermSpecificity term_spec
                                                                        ) const
   {
-    const ResidueModification* mod;
+    const ResidueModification* mod(nullptr);
 
     String mod_name = mod_name_;
     multiple_matches = false;

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -254,7 +254,7 @@ namespace OpenMS
     }
     if (multiple_matches)
     {
-      OPENMS_LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one of:";
+      OPENMS_LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one only.";
       // for (auto it = mods.begin(); it != mods.end(); ++it)
       // {
       //   OPENMS_LOG_WARN << " " << (*it)->getFullId();

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -139,10 +139,10 @@ namespace OpenMS
 
     char res = '?'; // empty
     if (!residue.empty()) res = residue[0];
-    bool found = true;
 
     #pragma omp critical(OpenMS_ModificationsDB)
     {
+      bool found = true;
       auto modifications = modification_names_.find(mod_name);
       if (modifications == modification_names_.end())
       {

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -75,30 +75,6 @@ namespace OpenMS
     }
   }
 
-  bool ModificationsDB::residuesMatch_(const String& residue, const ResidueModification* curr_mod) const
-  {
-
-    // residues match if they are equal or they match everything (X/.)
-    bool matching =  (
-             residue.empty() ||
-             (curr_mod->getOrigin() == residue[0]) ||
-             (residue == "X") ||
-             (curr_mod->getOrigin() == 'X') ||
-             (residue == ".") );
-
-    // residues do NOT match if the modification is user-defined and has origin
-    // X (which here means an actual input AA X and it does *not* mean "match
-    // all AA") while the current residue is not X. Make sure we dont match things like
-    // PEPN[400] and PEPX[400] since these have very different masses.
-    bool non_matching_user_defined =  (
-         curr_mod->isUserDefined() &&
-         curr_mod->getOrigin() == 'X' &&
-         !residue.empty() &&
-         String(curr_mod->getOrigin()) != residue );
-
-    return matching && !non_matching_user_defined;
-  }
-
   bool ModificationsDB::is_instantiated_ = false;
 
   ModificationsDB* ModificationsDB::getInstance(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
@@ -157,7 +133,6 @@ namespace OpenMS
     return mods_[index];
   }
 
-
   void ModificationsDB::searchModifications(set<const ResidueModification*>& mods,
                                             const String& mod_name_,
                                             const String& residue,
@@ -166,6 +141,9 @@ namespace OpenMS
     mods.clear();
 
     String mod_name = mod_name_;
+
+    char res = '?'; // empty
+    if (!residue.empty()) res = residue[0];
 
     #pragma omp critical(OpenMS_ModificationsDB)
     {
@@ -191,7 +169,7 @@ namespace OpenMS
       {
         for (const auto& it : modifications->second)
         {
-          if (residuesMatch_(residue, it) &&
+          if ( residuesMatch_fast_(res, it) &&
                (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY ||
                (term_spec == it->getTermSpecificity())))
           {
@@ -204,7 +182,7 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
-    set<const ResidueModification*> mods;
+    set<const ResidueModification*> mods; // set is faster than unordered_set (for few values)
     // if residue is specified, try residue-specific search first to avoid
     // ambiguities (e.g. "Carbamidomethyl (N-term)"/"Carbamidomethyl (C)"):
     if (!residue.empty() &&
@@ -289,12 +267,14 @@ namespace OpenMS
   void ModificationsDB::searchModificationsByDiffMonoMass(vector<String>& mods, double mass, double max_error, const String& residue, ResidueModification::TermSpecificity term_spec)
   {
     mods.clear();
+    char res = '?'; // empty
+    if (!residue.empty()) res = residue[0];
     #pragma omp critical(OpenMS_ModificationsDB)
     {
       for (auto const & m : mods_)
       {
         if ((fabs(m->getDiffMonoMass() - mass) <= max_error) &&
-            residuesMatch_(residue, m) &&
+            residuesMatch_fast_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
         {
@@ -309,6 +289,8 @@ namespace OpenMS
   {
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
+    char res = '?'; // empty
+    if (!residue.empty()) res = residue[0];
     #pragma omp critical(OpenMS_ModificationsDB)
     {
       for (auto const & m : mods_)
@@ -318,7 +300,7 @@ namespace OpenMS
         // first matching UniMod entry)
         double mass_error = fabs(m->getDiffMonoMass() - mass);
         if ((mass_error < min_error) &&
-            residuesMatch_(residue, m) &&
+            residuesMatch_fast_(res, m) &&
             ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
              (term_spec == m->getTermSpecificity())))
         {

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -535,7 +535,8 @@ namespace OpenMS
         try
         {
           // terminal modifications don't apply to residues (side chain), so only consider internal ones
-          mod = ModificationsDB::getInstance()->getModification(modification, residue->getOneLetterCode(), ResidueModification::ANYWHERE);
+          static const ModificationsDB* mdb = ModificationsDB::getInstance();
+          mod = mdb->getModification(modification, residue->getOneLetterCode(), ResidueModification::ANYWHERE);
         }
         catch (...)
         {

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -514,11 +514,22 @@ namespace OpenMS
     bool residue_found(true), mod_found(true);
     #pragma omp critical (ResidueDB)
     {
-      if (residue_names_.find(res_name) == residue_names_.end())
+      // Perform a single lookup of the residue name in our database, we assume
+      // that if it is present in residue_mod_names_ then we have seen it
+      // before and can directly grab it. If its not present, we may have as
+      // unmodified residue in residue_names_ but need to create a new entry as
+      // modified residue. If the residue itself is unknow, we will throw (see
+      // below).
+      const auto& rm_entry = residue_mod_names_.find(res_name);
+      if (rm_entry == residue_mod_names_.end())
       {
-        residue_found = false;
+        if (residue_names_.find(res_name) == residue_names_.end())
+        {
+          residue_found = false;
+        }
       }
-      else
+
+      if (residue_found)
       {
         const ResidueModification* mod;
         try
@@ -537,11 +548,17 @@ namespace OpenMS
           const String& id = mod->getId().empty() ? mod->getFullId() : mod->getId();
 
           // check if modified residue is already present in ResidueDB
-          if (residue_mod_names_.has(res_name) && residue_mod_names_[res_name].has(id))
+          bool found = false;
+          if (rm_entry != residue_mod_names_.end())
           {
-            res = residue_mod_names_[res_name][id];
+            const auto& inner = rm_entry->second.find(id);
+            if (inner != rm_entry->second.end())
+            {
+              res = inner->second;
+              found = true;
+            }
           }
-          else
+          if (!found)
           {
             // create and register this modified residue
             res = new Residue(*residue_names_[res_name]);


### PR DESCRIPTION
Several performance improvements for `AASequence` and parsing from string, especially for modified sequences

- use `std::unordered_map` to store modification names
- reserve space for new residues
- faster check if residues match a given modification or not
- remove unnecessary double lookups in the map

# Benchmarks

Benchmarking was done with 

```
  int nr_mol = 2e7; // for AASequence
  nr_mol = 1e6; // for Oxidation
  int nr_fragments = 0;
  for (Size i = 0; i < nr_mol;  i++) 
  {
    auto pep = AASequence::fromString("DFPMIAMNGMER"); 
    nr_fragments += pep.size();
  }
```

## Unmodified AASequence

This is quite fast, the current PR reduces execution time from 4.5 s to 2s for 2e7 iterations, basically reducing time from 220 nsec to 95 nsec for parsing. This is mainly due to reserving space in the vector

## Modified AASequence

Modifications slow down parsing significantly, taking about 3.2 usec before optimization. Therefore a modified sequence would take about 15x longer to parse (or 32x longer after the optimization above) which means that speed will always be dominated by modified AA strings. A modification with 3 oxidized residues now takes only 1.5 usec to parse (down from 3.2 usec) with each modification taking about 400 nsec to parse:

- 1.5 usec for three mods
- 1.1 usec for two mods
- 700 nsec for one modification

Most of the time is spent looking up modifications names in `searchModifications` and in identifying the correct one among the results (e.g. for Oxidation there are 13 results in the hash, so that means the code needs to iterate through all 13 and find the correct one. It seems a bit excessive since we have a different modification for each oxidized amino acid).