### PR TITLE
Feature/matrix py

### DIFF
--- a/src/pyOpenMS/addons/MatrixDouble.pyx
+++ b/src/pyOpenMS/addons/MatrixDouble.pyx
@@ -1,0 +1,95 @@
+from Matrix cimport *
+
+
+# continue with extra code if needed
+    def get_matrix(self):
+        """Cython signature: numpy_matrix get_matrix()
+        """
+
+        cdef _Matrix[double] * mat_ = self.inst.get()
+
+        cdef unsigned int rows = mat_.rows()
+        cdef unsigned int cols = mat_.cols()
+        cdef np.ndarray[double, ndim=2] data
+        data = np.zeros( (rows,cols), dtype=np.float64)
+
+        cdef libcpp_vector[double] tmp_vec;
+        tmp_vec.reserve( rows * cols);
+
+        cdef int i = 0
+        cdef int j = 0
+        for i in range(int(rows)):
+            for j in range(int(cols)):
+                data[i][j] = mat_.getValue(j,i) ## first try
+        return data
+
+    def get_matrix_as_view(self):
+        """Cython signature: numpy_matrix get_matrix()
+        """
+
+        cdef _Matrix[double] * mat_ = self.inst.get()
+
+        cdef unsigned int rows = mat_.rows()
+        cdef unsigned int cols = mat_.cols()
+        cdef unsigned int n = rows * cols
+        cdef np.ndarray[double, ndim=2] data
+        data = np.zeros( (rows,cols), dtype=np.float64)
+
+        cdef libcpp_vector[double] * vec_ptr = <libcpp_vector[double]*> mat_
+        cdef double * raw_ptr =  address(deref(vec_ptr)[0]) 
+
+        ## # We use a memory view to get the data from the raw data
+        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
+        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
+        cdef double[:] vec_view = <double[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
+        xarr = np.asarray(vec_view) # numpy array refer to the underlying buffer without copy
+        xarr = xarr.reshape(rows, cols)
+        return xarr
+
+
+
+    def get_matrix_as_vec(self):
+        """Cython signature: numpy_matrix get_matrix()
+        """
+
+        cdef _Matrix[double] * mat_ = self.inst.get()
+
+        cdef unsigned int rows = mat_.rows()
+        cdef unsigned int cols = mat_.cols()
+        cdef unsigned int n = rows * cols
+        cdef np.ndarray[double, ndim=2] data
+        data = np.zeros( (rows,cols), dtype=np.float64)
+
+        cdef libcpp_vector[double] tmp_vec;
+        tmp_vec.reserve( rows * cols);
+
+        cdef int i = 0
+        cdef int j = 0
+        for i in range(int(rows)):
+            for j in range(int(cols)):
+                ### data[i][j] = mat_.getValue(j,i) ## first try
+                tmp_vec.push_back( mat_.getValue(j,i) )
+
+        xarr = np.asarray(tmp_vec) # numpy array refer to the underlying buffer without copy
+        xarr = xarr.reshape(rows, cols)
+        return xarr
+
+
+    def set_matrix(self, np.ndarray[double, ndim=2, mode="c"] data not None):
+        """Cython signature: numpy_matrix set_matrix()
+        """
+
+        cdef _Matrix[double] * mat_ = self.inst.get()
+
+        cdef unsigned int rows = data.shape[0]
+        cdef unsigned int cols = data.shape[1]
+        mat_.resize(rows, cols, 0)
+
+        cdef int i = 0
+        cdef int j = 0
+        for i in range(int(rows)):
+            for j in range(int(cols)):
+                mat_.setValue(j,i,data[i][j])
+
+
+

--- a/src/pyOpenMS/pxds/Matrix.pxd
+++ b/src/pyOpenMS/pxds/Matrix.pxd
@@ -15,8 +15,8 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Matrix.h>" namespace "OpenMS":
         # const_reference operator()(size_t i, size_t j) nogil except +
         # reference operator()(size_t i, size_t j) nogil except +
         # const_reference getValue(size_t i, size_t j) nogil except +
-        ValueT getValue(size_t i, size_t j) nogil except +
-        void setValue(size_t i, size_t j, ValueT value) nogil except +
+        ValueT getValue(size_t i, size_t j) nogil
+        void setValue(size_t i, size_t j, ValueT value) nogil
         ## The following two lines introduce an odd bug:
         # static PyObject *__pyx_convert_vector_to_py_double is declared twice by Cython:
         # TODO look into Cython Bug
@@ -25,8 +25,8 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Matrix.h>" namespace "OpenMS":
         void clear() nogil except +
         void resize(size_t i, size_t j, ValueT value) nogil except +
         void resize(libcpp_pair[ size_t, size_t ] & size_pair, ValueT value) nogil except +
-        size_t rows() nogil except +
-        size_t cols() nogil except +
+        size_t rows() nogil
+        size_t cols() nogil
         libcpp_pair[ size_t, size_t ] sizePair() nogil except +
         size_t index(size_t row, size_t col) nogil except +
         libcpp_pair[ size_t, size_t ] indexPair(size_t index) nogil except +


### PR DESCRIPTION
Faster access to data in the matrix class

# Benchmarks

Code for benchmark:

```
import pyopenms
import numpy as np
m = pyopenms.MatrixDouble()
N = 9000
m.resize(N+1, N+1, 5.0)
```
## Naive
```
rows = N
cols = N
data = np.ndarray(shape=(int(rows), int(cols)), dtype=np.float64)
for i in range(int(rows)):
            for j in range(int(cols)):
                data[i][j] = m.getValue(j,i)

print sum(sum(data))
```

-> takes 28 seconds

# Store in Numpy
```
data = m.get_matrix()
print sum(sum(data))
```

for some reason the access to numpy `data[i][j] =` is slow. It still takes 12 seconds

# Store in temporary vector

```
data = m.get_matrix_as_vec()
print sum((data))
```

storing data in a vector and then copying it was faster, taking 6 seconds

# Memory view
```
data = m.get_matrix_as_view()
print sum(sum(data))
```
however, the fastest approach was the memory view approach, which only takes 0.5 seconds. This of course makes some assumptions, namely that the `Matrix` object is a C++ vector of length col*row with the ptr to the object being the start of the data


-> Overall we get a 60x increase in speed when using the memory view
