### PR TITLE
MetaboliteSpectralMatcher: make database mandatory

### DIFF
--- a/src/utils/MetaboliteSpectralMatcher.cpp
+++ b/src/utils/MetaboliteSpectralMatcher.cpp
@@ -102,7 +102,7 @@ protected:
   {
     registerInputFile_("in", "<file>", "", "Input spectra.");
     setValidFormats_("in", ListUtils::create<String>("mzML"));
-    registerInputFile_("database", "<file>", "CHEMISTRY/MetaboliteSpectralDB.mzML", "Default spectral database.", false);
+    registerInputFile_("database", "<file>", "", "Default spectral database.", true);
     setValidFormats_("database", ListUtils::create<String>("mzML"));
     registerOutputFile_("out", "<file>", "", "mzTab file");
     setValidFormats_("out", ListUtils::create<String>("mzTab"));


### PR DESCRIPTION
since the file is not included in the distribution
I guess its better to make the argument mandatory

see https://github.com/OpenMS/OpenMS/issues/2078

if at some point the data is available somewhere
(internet, submodule, ...) then it might be better
to have this info in the description?