### PR TITLE
ModificationsDB::getInstance performance fix

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -66,15 +66,23 @@ namespace OpenMS
       to search engines, e.g. Mascot.
 
       In some scenarios, it might be useful to define different modification
-      databases. This can be done by providing a path when initializing
-      ModificationsDB.
+      databases. This can be done by providing a path through
+      initializeModificationsDB(), however it is important that this is done
+      *before* the first call to getInstance().
   */
   class OPENMS_DLLAPI ModificationsDB
   {
 public:
 
     /// Returns a pointer to the modifications DB (singleton)
-    static ModificationsDB* getInstance(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo", OpenMS::String xlmod_file = "CHEMISTRY/XLMOD.obo");
+    static ModificationsDB* getInstance()
+    {
+      static ModificationsDB* db_ = ModificationsDB::initializeModificationDB();
+      return db_;
+    }
+
+    /// Initializes the modification DB with non-default modification files (can only be done once)
+    static ModificationsDB* initializeModificationsDB(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo", OpenMS::String xlmod_file = "CHEMISTRY/XLMOD.obo");
 
     /// Check whether ModificationsDB was instantiated before
     static bool isInstantiated();

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -75,11 +75,7 @@ namespace OpenMS
 public:
 
     /// Returns a pointer to the modifications DB (singleton)
-    static ModificationsDB* getInstance()
-    {
-      static ModificationsDB* db_ = ModificationsDB::initializeModificationsDB();
-      return db_;
-    }
+    static ModificationsDB* getInstance();
 
     /// Initializes the modification DB with non-default modification files (can only be done once)
     static ModificationsDB* initializeModificationsDB(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo", OpenMS::String xlmod_file = "CHEMISTRY/XLMOD.obo");

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -77,7 +77,7 @@ public:
     /// Returns a pointer to the modifications DB (singleton)
     static ModificationsDB* getInstance()
     {
-      static ModificationsDB* db_ = ModificationsDB::initializeModificationDB();
+      static ModificationsDB* db_ = ModificationsDB::initializeModificationsDB();
       return db_;
     }
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -50,8 +50,14 @@ namespace OpenMS
 {
   bool ModificationsDB::is_instantiated_ = false;
 
-  ModificationsDB* ModificationsDB::getInstance(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
+  ModificationsDB* ModificationsDB::initializeModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
   {
+    // Currently its not possible to check for double initialization since getInstance() also calls this function.
+    // if (is_instantiated_)
+    // {
+    //   throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Cannot initialize ModificationsDB twice");
+    // }
+
     static ModificationsDB* db_ = new ModificationsDB(unimod_file, psimod_file, xlmod_file);
     return db_;
   }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -50,6 +50,12 @@ namespace OpenMS
 {
   bool ModificationsDB::is_instantiated_ = false;
 
+  ModificationsDB* ModificationsDB::getInstance()
+  {
+    static ModificationsDB* db_ = ModificationsDB::initializeModificationsDB();
+    return db_;
+  }
+
   ModificationsDB* ModificationsDB::initializeModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
   {
     // Currently its not possible to check for double initialization since getInstance() also calls this function.

--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -245,7 +245,7 @@ protected:
     {
       if (!ModificationsDB::isInstantiated()) // We need to ensure that ModificationsDB was not instantiated before!
       {
-        ModificationsDB* ptr = ModificationsDB::getInstance(unimod_file, String(""), String(""));
+        ModificationsDB* ptr = ModificationsDB::initializeModificationsDB(unimod_file, String(""), String(""));
         OPENMS_LOG_INFO << "Unimod XML: " << ptr->getNumberOfModifications() << " modification types and residue specificities imported from file: " << unimod_file << std::endl;
       }
       else


### PR DESCRIPTION
this is a substantial improvement for performance on my machine, almost 100x fold for `static ModificationsDB* getInstance`. Basically on my Linux system the time before the fix was almost 100 ns and now is around 1-2ns -- it turns out this matters because people assumed `ModificationsDB::getInstance` is basically free and its all over the place. 

I am not sure why that is the case, there are no such issues with other singletons. It may be because of the default function arguments. 