### PR TITLE
some minor fixes

### DIFF
--- a/share/OpenMS/SCRIPTS/InternalCalibration_Residuals.R
+++ b/share/OpenMS/SCRIPTS/InternalCalibration_Residuals.R
@@ -18,8 +18,13 @@ if (!all(required_cols %in% colnames(d))) {
 
 dpm = melt(d[, grep("^mz.[ab]", colnames(d), invert = TRUE)], id.vars = c("RT", "mz.ref", "intensity"))
 head(dpm)
-## for peptide ID data, mz.ref will be mostly unique
-if (length(unique(d$mz.ref)) / nrow(d) > 0.5) {
+## for peptide ID data:
+##   - mz.ref will be mostly unique (assume oversampling of at most 3)
+##   - and RT of more than 20min
+## otherwise we assume direct-injection (and facet-wrap by each mz-ref) 
+##    - unless its more than 100 facets... which will be hard to read
+if ((length(unique(d$mz.ref)) / nrow(d) > 0.333  && diff(range(d$RT, na.rm = TRUE)) > 1200) 
+    || length(unique(d$mz.ref)) > 100 ) {
   dpm2 = dpm
   dpm2$masstrace = ""
 } else {

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -257,7 +257,7 @@ namespace OpenMS
         //Add MetaInfo, when modifications has it (Andreas)
       }
 
-      writeUserParam_("UserParam", os, search_param, 4);
+      writeUserParam_("UserParam", os, search_param, 3);
 
       os << "\t\t</SearchParameters>\n";
 

--- a/src/openms/source/QC/MzCalibration.cpp
+++ b/src/openms/source/QC/MzCalibration.cpp
@@ -140,7 +140,7 @@ namespace OpenMS
         throw Exception::IllegalArgument(__FILE__,
                                          __LINE__,
                                          OPENMS_PRETTY_FUNCTION,
-                                         "The matching spectrum of the mzML is not a MS2 Spectrum.");
+                                         "The matching spectrum of the mzML is not an MS2 Spectrum.");
       }
 
       // set meta values

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
@@ -404,8 +404,8 @@ namespace OpenMS
 
   struct SpectraPickInfo
   {
-    int picked{0}; //< number of picked spectra
-    int total{0}; //< overall number of spectra
+    uint32_t picked{0}; //< number of picked spectra
+    uint32_t total{0}; //< overall number of spectra
   };
 
   void PeakPickerHiRes::pickExperiment(const PeakMap& input,

--- a/src/tests/class_tests/openms/source/MzCalibration_test.cpp
+++ b/src/tests/class_tests/openms/source/MzCalibration_test.cpp
@@ -240,7 +240,7 @@ START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const 
   exp.getSpectra()[0].setNativeID("XTandem::4");
   exp.getSpectra()[0].setMSLevel(1);
   spectra_map.calculateMap(exp);
-  TEST_EXCEPTION_WITH_MESSAGE(Exception::IllegalArgument, cal.compute(fmap, exp, spectra_map), "The matching spectrum of the mzML is not a MS2 Spectrum.");
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::IllegalArgument, cal.compute(fmap, exp, spectra_map), "The matching spectrum of the mzML is not an MS2 Spectrum.");
 
   //test exception PepID without 'spectrum_reference'
   fmap = fmap_ref; // reset FeatureMap

--- a/src/topp/PeakPickerHiRes.cpp
+++ b/src/topp/PeakPickerHiRes.cpp
@@ -80,7 +80,7 @@ using namespace std;
   is usually called peak picking or centroiding. The choice of the algorithm
   should mainly depend on the resolution of the data.
   As the name implies, the @ref OpenMS::PeakPickerHiRes "high_res"
-  algorithm is fit for high resolution (orbitrap or FTICR) data.
+  algorithm is fit for high resolution (Orbitrap or FTICR) data.
 
   @ref TOPP_example_signalprocessing_parameters is explained in the TOPP tutorial.
 


### PR DESCRIPTION
PP-HiRes now gives the user some feedback of which MS-levels were actually picked in `auto-mode`.

```
11:10:22 NOTICE: PeakPickerHiRes of node #4 started. Processing ...
Picked spectra by MS-level:
  MS-level 1: 8259 / 8259
  MS-level 2: 0 / 7482
```