### PR TITLE
[Fix] check only db filename during merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ openms-build
 *.swp
 cmake-build-debug
 cmake-build-release
+cmake-build-*
+*.code-workspace
 .vs

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -254,6 +254,7 @@ public:
 
       std::pair<int,int> getChargeRange() const;
       int getChargeValue_(String& charge_str) const;
+      bool mergeable(const ProteinIdentification::SearchParameters& sp, const String& experiment_type) const;
 
     };
 
@@ -406,6 +407,7 @@ public:
     /// if this object has inference data
     bool hasInferenceData() const;
     bool hasInferenceEngineAsSearchEngine() const;
+    bool peptideIDsMergeable(const ProteinIdentification& idRun, const String& experiment_type) const;
     //@}
 
 protected:

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -252,10 +252,17 @@ public:
 
       bool operator!=(const SearchParameters& rhs) const;
 
+      /// returns the charge range from the search engine settings as a pair of ints
       std::pair<int,int> getChargeRange() const;
-      int getChargeValue_(String& charge_str) const;
+
+      /// Tests if these search engine settings are mergeable with @param sp
+      /// depending on the given @param experiment_type.
+      /// Modifications are compared as sets. Databases based on filename.
+      /// "labeled_MS1" experiments additionally allow different modifications.
       bool mergeable(const ProteinIdentification::SearchParameters& sp, const String& experiment_type) const;
 
+      private:
+      int getChargeValue_(String& charge_str) const;
     };
 
     /** @name Constructors, destructors, assignment operator <br> */
@@ -394,20 +401,30 @@ public:
        @param raw Store paths to the raw files (or equivalent) rather than mzMLs
     */
     void setPrimaryMSRunPath(const StringList& s, bool raw = false);
+
     /// set the file path to the primary MS run but try to use the mzML annotated in the MSExperiment.
     void setPrimaryMSRunPath(const StringList& s, MSExperiment& e);
     void addPrimaryMSRunPath(const String& s, bool raw = false);
     void addPrimaryMSRunPath(const StringList& s, bool raw = false);
+
     /**
        Get the file paths to the primary MS runs
 
        @param raw Get raw files (or equivalent) instead of mzMLs
     */
     void getPrimaryMSRunPath(StringList& output, bool raw = false) const;
-    /// if this object has inference data
+
+    /// Checks if this object has inference data. Looks for "InferenceEngine" metavalue.
+    /// If not, falls back to old behaviour of reading the search engine name.
     bool hasInferenceData() const;
+
+    /// Checks if the search engine name matches an inference engine known to OpenMS.
     bool hasInferenceEngineAsSearchEngine() const;
-    bool peptideIDsMergeable(const ProteinIdentification& idRun, const String& experiment_type) const;
+
+    /// Checks if the peptide IDs of this IDRun are mergeable with another @param id_run
+    /// given an @param experiment_type .
+    /// Checks search engine and search engine settings.
+    bool peptideIDsMergeable(const ProteinIdentification& id_run, const String& experiment_type) const;
     //@}
 
 protected:

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -360,6 +360,7 @@ namespace OpenMS
     bool ok = true;
     for (const auto& idRun : protRuns)
     {
+      // collect warnings and throw at the end if at least one failed
       ok = ok && ref.peptideIDsMergeable(idRun, experiment_type);
     }
     if (!ok /*&& TODO and no force flag*/)

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -32,11 +32,11 @@
 // $Authors: Julianus Pfeuffer $
 // --------------------------------------------------------------------------
 
+#include <include/OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <QFile>
 #include <unordered_map>
-#include <include/OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
-
 
 using namespace std;
 namespace OpenMS
@@ -379,7 +379,7 @@ namespace OpenMS
       const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
       if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
           params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-          params.db != sp.db ||
+          QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
           params.db_version != sp.db_version ||
           params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
           params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||
@@ -449,7 +449,7 @@ namespace OpenMS
     const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
     if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
         params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-        params.db != sp.db ||
+        QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
         params.db_version != sp.db_version ||
         params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
         params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -35,7 +35,6 @@
 #include <include/OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-#include <QFile>
 #include <unordered_map>
 
 using namespace std;
@@ -377,9 +376,13 @@ namespace OpenMS
         break;
       }
       const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
+      String spdb = sp.db;
+      spdb.substitute("\\","/");
+      String pdb = params.db;
+      pdb.substitute("\\","/");
       if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
           params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-          QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
+          File::basename(pdb) != File::basename(spdb) ||
           params.db_version != sp.db_version ||
           params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
           params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||
@@ -418,10 +421,9 @@ namespace OpenMS
     }
     if (!ok /*&& TODO and no force flag*/)
     {
-      throw Exception::BaseException(__FILE__,
+      throw Exception::MissingInformation(__FILE__,
                                      __LINE__,
                                      OPENMS_PRETTY_FUNCTION,
-                                     "InvalidData",
                                      "Search settings are not matching across IdentificationRuns. "
                                      "See warnings. Aborting..");
     }
@@ -447,9 +449,13 @@ namespace OpenMS
       + " does not match with the others." + warn;
     }
     const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
+    String spdb = sp.db;
+    spdb.substitute("\\","/");
+    String pdb = params.db;
+    pdb.substitute("\\","/");
     if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
         params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-        QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
+        File::basename(pdb) != File::basename(spdb) ||
         params.db_version != sp.db_version ||
         params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
         params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||
@@ -485,10 +491,9 @@ namespace OpenMS
 
     if (!ok /*&& TODO and no force flag*/)
     {
-      throw Exception::BaseException(__FILE__,
+      throw Exception::MissingInformation(__FILE__,
                                      __LINE__,
                                      OPENMS_PRETTY_FUNCTION,
-                                     "InvalidData",
                                      "Search settings are not matching across IdentificationRuns. "
                                      "See warnings. Aborting..");
     }

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -32,8 +32,7 @@
 // $Authors: Julianus Pfeuffer $
 // --------------------------------------------------------------------------
 
-#include <include/OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
-#include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
+#include <OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <unordered_map>
 

--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -405,77 +405,18 @@ namespace OpenMS
 
   bool IDMergerAlgorithm::checkOldRunConsistency_(const vector<ProteinIdentification>& protRuns, const ProteinIdentification& ref, const String& experiment_type) const
   {
-    const String& engine = ref.getSearchEngine();
-    const String& version = ref.getSearchEngineVersion();
-    ProteinIdentification::SearchParameters params = ref.getSearchParameters();
-    set<String> fixed_mods(params.fixed_modifications.begin(), params.fixed_modifications.end());
-    set<String> var_mods(params.variable_modifications.begin(), params.variable_modifications.end());
-    bool ok = false;
-    unsigned runID = 0;
-    //TODO if one equals the ref, continue
+    bool ok = true;
     for (const auto& idRun : protRuns)
     {
-      ok = true;
-      if (idRun.getSearchEngine() != engine || idRun.getSearchEngineVersion() != version)
-      {
-        ok = false;
-       OPENMS_LOG_WARN << "Search engine " + idRun.getSearchEngine() + " from IDRun " + String(runID) + " does not match "
-        "with the others. You probably do not want to merge the results with this tool." << std::endl;
-        break;
-      }
-      const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
-      String spdb = sp.db;
-      spdb.substitute("\\","/");
-      String pdb = params.db;
-      pdb.substitute("\\","/");
-      if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
-          params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-          File::basename(pdb) != File::basename(spdb) ||
-          params.db_version != sp.db_version ||
-          params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
-          params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||
-          params.charges != sp.charges ||
-          params.digestion_enzyme != sp.digestion_enzyme ||
-          params.taxonomy != sp.taxonomy)
-      {
-        ok = false;
-       OPENMS_LOG_WARN << "Searchengine settings from IDRun " + String(runID) + " does not match with the others."
-        " You probably do not want to merge the results with this tool if they differ significantly." << std::endl;
-        break;
-      }
-
-      set<String> curr_fixed_mods(sp.fixed_modifications.begin(), sp.fixed_modifications.end());
-      set<String> curr_var_mods(sp.variable_modifications.begin(), sp.variable_modifications.end());
-      if (fixed_mods != curr_fixed_mods ||
-          var_mods != curr_var_mods)
-      {
-        if (experiment_type != "labeled_MS1")
-        {
-          ok = false;
-         OPENMS_LOG_WARN << "Used modification settings from IDRun " + String(runID) + " does not match with the others."
-          " Since the experiment is not annotated as MS1-labeled "
-          "you probably do not want to merge the results with this tool." << std::endl;
-          break;
-        }
-        else
-        {
-          //TODO actually introduce a flag for labelling modifications in the Mod datastructures?
-          //OR put a unique ID for the used mod as a UserParam to the mapList entries (consensusHeaders)
-          //TODO actually you would probably need an experimental design here, because
-          //settings have to agree exactly in a FractionGroup but can slightly differ across runs.
-         OPENMS_LOG_WARN << "Used modification settings from IDRun " + String(runID) + " does not match with the others."
-          " Although it seems to be an MS1-labeled experiment,"
-          " check carefully that only non-labelling mods differ." << std::endl;
-        }
-      }
+      ok = ok && ref.peptideIDsMergeable(idRun, experiment_type);
     }
     if (!ok /*&& TODO and no force flag*/)
     {
       throw Exception::MissingInformation(__FILE__,
-                                     __LINE__,
-                                     OPENMS_PRETTY_FUNCTION,
-                                     "Search settings are not matching across IdentificationRuns. "
-                                     "See warnings. Aborting..");
+                                          __LINE__,
+                                          OPENMS_PRETTY_FUNCTION,
+                                          "Search settings are not matching across IdentificationRuns. "
+                                          "See warnings. Aborting..");
     }
     return ok;
   }

--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -34,7 +34,6 @@
 
 #include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-#include <QFile>
 #include <unordered_map>
 
 using namespace std;
@@ -425,9 +424,13 @@ namespace OpenMS
         break;
       }
       const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
+      String spdb = sp.db;
+      spdb.substitute("\\","/");
+      String pdb = params.db;
+      pdb.substitute("\\","/");
       if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
           params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-          QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
+          File::basename(pdb) != File::basename(spdb) ||
           params.db_version != sp.db_version ||
           params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
           params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||

--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <QFile>
 #include <unordered_map>
 
 using namespace std;
@@ -426,7 +427,7 @@ namespace OpenMS
       const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
       if (params.precursor_mass_tolerance != sp.precursor_mass_tolerance ||
           params.precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
-          params.db != sp.db ||
+          QFile(params.db.toQString()).fileName().section("/",-1,-1) != QFile(sp.db.toQString()).fileName().section("/",-1,-1) ||
           params.db_version != sp.db_version ||
           params.fragment_mass_tolerance != sp.fragment_mass_tolerance ||
           params.fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||

--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -408,6 +408,7 @@ namespace OpenMS
     bool ok = true;
     for (const auto& idRun : protRuns)
     {
+      // collect warnings and throw at the end if at least one failed
       ok = ok && ref.peptideIDsMergeable(idRun, experiment_type);
     }
     if (!ok /*&& TODO and no force flag*/)

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -492,7 +492,7 @@ namespace OpenMS
         se == "ProteinInference";
   }
 
-  bool ProteinIdentification::peptideIDsMergeable(const ProteinIdentification& idRun, const String& experiment_type) const
+  bool ProteinIdentification::peptideIDsMergeable(const ProteinIdentification& id_run, const String& experiment_type) const
   {
     const String& warn = " You probably do not want to merge the results with this tool."
                          " For merging searches with different engines/settings please use ConsensusID or PercolatorAdapter"
@@ -502,18 +502,18 @@ namespace OpenMS
 
     bool ok = true;
 
-    if (idRun.getSearchEngine() != engine || idRun.getSearchEngineVersion() != version)
+    if (id_run.getSearchEngine() != engine || id_run.getSearchEngineVersion() != version)
     {
       ok = false;
-      OPENMS_LOG_WARN << "Search engine " + idRun.getSearchEngine() + "from IDRun " + idRun.getIdentifier()
+      OPENMS_LOG_WARN << "Search engine " + id_run.getSearchEngine() + "from IDRun " + id_run.getIdentifier()
                          + " does not match with the others." + warn;
     }
     const ProteinIdentification::SearchParameters& params = this->getSearchParameters();
-    const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
+    const ProteinIdentification::SearchParameters& sp = id_run.getSearchParameters();
     if (!params.mergeable(sp, experiment_type))
     {
       ok = false;
-      OPENMS_LOG_WARN << "Searchengine settings or modifications from IDRun " + idRun.getIdentifier() + " do not match with the others." + warn;
+      OPENMS_LOG_WARN << "Searchengine settings or modifications from IDRun " + id_run.getIdentifier() + " do not match with the others." + warn;
     }
     // TODO else merge as far as possible (mainly mods I guess)
     return ok;

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -149,6 +149,50 @@ namespace OpenMS
     return !(*this == rhs);
   }
 
+  bool ProteinIdentification::SearchParameters::mergeable(const ProteinIdentification::SearchParameters& sp, const String& experiment_type) const
+  {
+    String spdb = sp.db;
+    spdb.substitute("\\","/");
+    String pdb = this->db;
+    pdb.substitute("\\","/");
+
+    if  (this->precursor_mass_tolerance != sp.precursor_mass_tolerance ||
+        this->precursor_mass_tolerance_ppm != sp.precursor_mass_tolerance_ppm ||
+        File::basename(pdb) != File::basename(spdb) ||
+        this->db_version != sp.db_version ||
+        this->fragment_mass_tolerance != sp.fragment_mass_tolerance ||
+        this->fragment_mass_tolerance_ppm != sp.fragment_mass_tolerance_ppm ||
+        this->charges != sp.charges ||
+        this->digestion_enzyme != sp.digestion_enzyme ||
+        this->taxonomy != sp.taxonomy)
+    {
+      return false;
+    }
+
+    set<String> fixed_mods(this->fixed_modifications.begin(), this->fixed_modifications.end());
+    set<String> var_mods(this->variable_modifications.begin(), this->variable_modifications.end());
+    set<String> curr_fixed_mods(sp.fixed_modifications.begin(), sp.fixed_modifications.end());
+    set<String> curr_var_mods(sp.variable_modifications.begin(), sp.variable_modifications.end());
+    if (fixed_mods != curr_fixed_mods ||
+        var_mods != curr_var_mods)
+    {
+      if (experiment_type != "labeled_MS1")
+      {
+        return false;
+      }
+      else
+      {
+        //TODO actually introduce a flag for labelling modifications in the Mod datastructures?
+        //OR put a unique ID for the used mod as a UserParam to the mapList entries (consensusHeaders)
+        //TODO actually you would probably need an experimental design here, because
+        //settings have to agree exactly in a FractionGroup but can slightly differ across runs.
+        //Or just ignore labelling mods during the check
+        return true;
+      }
+    }
+    return true;
+  }
+
   int ProteinIdentification::SearchParameters::getChargeValue_(String& charge_str) const
   {
     // We have to do this because some people/tools put the + or - AFTER the number...
@@ -447,6 +491,34 @@ namespace OpenMS
         (se == "Percolator" && !indistinguishable_proteins_.empty()) || // be careful, Percolator could be run with or without protein inference
         se == "ProteinInference";
   }
+
+  bool ProteinIdentification::peptideIDsMergeable(const ProteinIdentification& idRun, const String& experiment_type) const
+  {
+    const String& warn = " You probably do not want to merge the results with this tool."
+                         " For merging searches with different engines/settings please use ConsensusID or PercolatorAdapter"
+                         " to create a comparable score.";
+    const String& engine = this->getSearchEngine();
+    const String& version = this->getSearchEngineVersion();
+
+    bool ok = true;
+
+    if (idRun.getSearchEngine() != engine || idRun.getSearchEngineVersion() != version)
+    {
+      ok = false;
+      OPENMS_LOG_WARN << "Search engine " + idRun.getSearchEngine() + "from IDRun " + idRun.getIdentifier()
+                         + " does not match with the others." + warn;
+    }
+    const ProteinIdentification::SearchParameters& params = this->getSearchParameters();
+    const ProteinIdentification::SearchParameters& sp = idRun.getSearchParameters();
+    if (!params.mergeable(sp, experiment_type))
+    {
+      ok = false;
+      OPENMS_LOG_WARN << "Searchengine settings or modifications from IDRun " + idRun.getIdentifier() + " do not match with the others." + warn;
+    }
+    // TODO else merge as far as possible (mainly mods I guess)
+    return ok;
+  }
+
 
   // Equality operator
   bool ProteinIdentification::operator==(const ProteinIdentification& rhs) const

--- a/src/tests/class_tests/openms/data/newIDMergerTest1.idXML
+++ b/src/tests/class_tests/openms/data/newIDMergerTest1.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/Users/pfeuffer/svn/OpenMS/Tutorials/UM_2015/Example_Data/Labelfree/databases/s_pyo_sf370_potato_human_target_decoy_with_contaminants.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/foo/s_pyo_sf370_potato_human_target_decoy_with_contaminants.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Acetyl (N-term)" />
 		<VariableModification name="Gln-&gt;pyro-Glu (N-term Q)" />

--- a/src/tests/class_tests/openms/source/IDMergerAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/IDMergerAlgorithm_test.cpp
@@ -38,6 +38,8 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/test_config.h>
+#include <QFile>
+#include <QDir>
 
 using namespace OpenMS;
 using namespace std;
@@ -191,6 +193,37 @@ START_TEST(IDMergerAlgorithm, "$Id$")
       TEST_EQUAL(toFill.size(), 2)
 
     }
+    END_SECTION
+
+    START_SECTION(check search setting consistency)
+        {
+          IdXMLFile f;
+          vector<ProteinIdentification> pr1;
+          vector<PeptideIdentification> pe1;
+          f.load(OPENMS_GET_TEST_DATA_PATH("newIDMergerTest1.idXML"),pr1,pe1);
+
+          vector<ProteinIdentification> pr2;
+          vector<PeptideIdentification> pe2;
+          f.load(OPENMS_GET_TEST_DATA_PATH("newIDMergerTest2.idXML"),pr2,pe2);
+          // fail with different db filename
+          pr2[0].getSearchParameters().db = "baz";
+
+          IDMergerAlgorithm ima("mymerge");
+          ima.insertRuns(std::move(pr1), std::move(pe1));
+          TEST_EXCEPTION(Exception::MissingInformation,ima.insertRuns(pr2, pe2))
+
+          // check windows path with correct filename
+          String fn = "C:\\foo\\s_pyo_sf370_potato_human_target_decoy_with_contaminants.fasta";
+          pr2[0].getSearchParameters().db = fn;
+
+          ima.insertRuns(std::move(pr2), std::move(pe2));
+
+          ProteinIdentification prres;
+          vector<PeptideIdentification> peres;
+          ima.returnResultsAndClear(prres,peres);
+
+          TEST_EQUAL(prres.getHits().size(),6)
+        }
     END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/IDMergerAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/IDMergerAlgorithm_test.cpp
@@ -38,8 +38,6 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/test_config.h>
-#include <QFile>
-#include <QDir>
 
 using namespace OpenMS;
 using namespace std;


### PR DESCRIPTION
some workflow engine might symlink or copy databases around.
Better to just check the basename during merging.