### PR TITLE
Feature/pydoc

### DIFF
--- a/src/pyOpenMS/addons/AASequence.pyx
+++ b/src/pyOpenMS/addons/AASequence.pyx
@@ -5,3 +5,18 @@
         for k,v in mmap.iteritems():
             c_mmap[ _String(<char *>k) ] = v # add <size_t> ?
         self.inst.get().getAAFrequencies(c_mmap)
+
+    def __iter__(self):
+        cdef int n = self.inst.get().size()
+        cdef int i = 0
+
+        cdef Residue py_result 
+        while i < n:
+
+            py_result = Residue.__new__(Residue)
+            py_result.inst = shared_ptr[_Residue](new _Residue( deref(self.inst.get())[i] ))
+
+            yield py_result
+
+            i += 1
+

--- a/src/pyOpenMS/addons/NASequence.pyx
+++ b/src/pyOpenMS/addons/NASequence.pyx
@@ -1,0 +1,20 @@
+
+
+
+
+
+    ## def __iter__(self):
+    ##     _r = self.inst.get().getSequence()
+    ##     cdef libcpp_vector[const _Ribonucleotide *].iterator it__r = _r.begin()
+    ##     cdef Ribonucleotide item_py_result
+    ##     while it__r != _r.end():
+    ##        item_py_result = Ribonucleotide.__new__(Ribonucleotide)
+    ##        item_py_result.inst = shared_ptr[_Ribonucleotide](new _Ribonucleotide(deref(deref(it__r))))
+    ##        yield py_result
+    ##        inc(it__r)
+
+    def __iter__(self):
+
+        for r in self.getSequence():
+          yield r
+

--- a/src/pyOpenMS/addons/RNaseDB.pyx
+++ b/src/pyOpenMS/addons/RNaseDB.pyx
@@ -5,3 +5,8 @@
 
     def __init__(self):
       self.inst = AutowrapPtrHolder[_RNaseDB](_getInstance_RNaseDB())
+
+    def __dealloc__(self):
+      # Careful here, the wrapped ptr is a single instance and we should not
+      # reset it, therefore use 'wrap-manual-dealloc'
+      pass

--- a/src/pyOpenMS/addons/RibonucleotideDB.pyx
+++ b/src/pyOpenMS/addons/RibonucleotideDB.pyx
@@ -2,6 +2,18 @@
 
 
 
+    # NOTE: using shared_ptr for a singleton will lead to segfaults, use raw ptr instead
+    # cdef AutowrapPtrHolder[_RibonucleotideDB] inst
+
+    def __init__(self):
+      self.inst = AutowrapPtrHolder[_RibonucleotideDB](_getInstance_RibonucleotideDB())
+
+    def __dealloc__(self):
+      # Careful here, the wrapped ptr is a single instance and we should not
+      # reset it, therefore use 'wrap-manual-dealloc'
+      pass
+
+
     def getRibonucleotideAlternatives(self, bytes code ):
         """Cython signature: libcpp_pair[const Ribonucleotide *,const Ribonucleotide *] getRibonucleotideAlternatives(const libcpp_string & code)"""
         assert isinstance(code, bytes), 'arg code wrong type'

--- a/src/pyOpenMS/addons/RibonucleotideDB.pyx
+++ b/src/pyOpenMS/addons/RibonucleotideDB.pyx
@@ -1,0 +1,20 @@
+
+
+
+
+    def getRibonucleotideAlternatives(self, bytes code ):
+        """Cython signature: libcpp_pair[const Ribonucleotide *,const Ribonucleotide *] getRibonucleotideAlternatives(const libcpp_string & code)"""
+        assert isinstance(code, bytes), 'arg code wrong type'
+    
+        _r = self.inst.get().getRibonucleotideAlternatives((<libcpp_string>code))
+        cdef const _Ribonucleotide * out_ptr1 = _r.first
+        cdef const _Ribonucleotide * out_ptr2 = _r.second
+
+        cdef Ribonucleotide out1 = Ribonucleotide.__new__(Ribonucleotide)
+        cdef Ribonucleotide out2 = Ribonucleotide.__new__(Ribonucleotide)
+
+        out1.inst = shared_ptr[_Ribonucleotide](new _Ribonucleotide(deref(_r.first)))
+        out2.inst = shared_ptr[_Ribonucleotide](new _Ribonucleotide(deref(_r.second)))
+
+        cdef list py_result = [out1, out2]
+        return py_result 

--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -23,11 +23,17 @@ if iswin and IS_DEBUG:
 
 # use autowrap to generate Cython and .cpp file for wrapping OpenMS:
 import autowrap.Main
+import autowrap.CodeGenerator
+import autowrap.DeclResolver
 import glob
 import pickle
 import os.path
 import os
 import shutil
+
+classdocu_base = "http://www.openms.de/current_doxygen/html/"
+autowrap.CodeGenerator.special_class_doc = "\n    Documentation is available at " + classdocu_base + "class%(namespace)s_1_1%(cpp_name)s.html\n"
+autowrap.DeclResolver.default_namespace = "OpenMS"
 
 def chunkIt(seq, num):
     avg = len(seq) / float(num)

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -20,9 +20,10 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         AASequence() nogil except +
         AASequence(AASequence) nogil except + # wrap-ignore
 
-
         AASequence operator+(AASequence)    nogil except +
         AASequence iadd(AASequence)   nogil except + # wrap-as:operator+=
+
+        Residue operator[](int) nogil except + # wrap-upper-limit:size()
 
         # check if sequence is empty
         bool empty() nogil except +

--- a/src/pyOpenMS/pxds/NASequence.pxd
+++ b/src/pyOpenMS/pxds/NASequence.pxd
@@ -28,9 +28,7 @@ cdef extern from "<OpenMS/CHEMISTRY/NASequence.h>" namespace "OpenMS":
 
         libcpp_vector[ const Ribonucleotide * ] getSequence() nogil except +
 
-        #Ribonucleotide * operator[](size_t index) nogil except +
-
-
+        const Ribonucleotide * operator[](size_t index) nogil except +
 
         # check if sequence is empty
         bool empty() nogil except +

--- a/src/pyOpenMS/pxds/RNaseDigestion.pxd
+++ b/src/pyOpenMS/pxds/RNaseDigestion.pxd
@@ -7,8 +7,8 @@ cdef extern from "<OpenMS/CHEMISTRY/RNaseDigestion.h>" namespace "OpenMS":
 
     cdef cppclass RNaseDigestion:
 
-      RNaseDigestion() nogil except + #wrap-ignore
-      RNaseDigestion(RNaseDigestion) nogil except + #wrap-ignore
+      RNaseDigestion() nogil except +
+      RNaseDigestion(RNaseDigestion) nogil except + # wrap-ignore
 
       SignedSize getMissedCleavages() nogil except +
       void setMissedCleavages(SignedSize missed_cleavages) nogil except +
@@ -17,7 +17,10 @@ cdef extern from "<OpenMS/CHEMISTRY/RNaseDigestion.h>" namespace "OpenMS":
       void setEnzyme(String name) nogil except +
 
 #      void digest(const String & rna, libcpp_vector[ String ] & output, Size min_length, Size max_length) nogil except +
+      void digest(NASequence & rna, libcpp_vector[ NASequence ] & output) nogil except +
       void digest(NASequence & rna, libcpp_vector[ NASequence ] & output, Size min_length, Size max_length) nogil except +
+
+      void digest(IdentificationData & id_data) nogil except +
       void digest(IdentificationData & id_data, Size min_length, Size max_length) nogil except +
 
       # Returns the specificity for the digestion

--- a/src/pyOpenMS/pxds/RibonucleotideDB.pxd
+++ b/src/pyOpenMS/pxds/RibonucleotideDB.pxd
@@ -10,6 +10,10 @@ cdef extern from "<OpenMS/CHEMISTRY/RibonucleotideDB.h>" namespace "OpenMS":
 
         RibonucleotideDB(RibonucleotideDB) nogil except + #wrap-ignore
 
+        const Ribonucleotide * getRibonucleotide(const libcpp_string& code) nogil except +
+        const Ribonucleotide * getRibonucleotidePrefix(const libcpp_string& code) nogil except +
+        libcpp_pair[const Ribonucleotide *, const Ribonucleotide *] getRibonucleotideAlternatives(const libcpp_string& code) nogil except + # wrap-ignore
+
 # COMMENT: wrap static methods
 cdef extern from "<OpenMS/CHEMISTRY/RibonucleotideDB.h>" namespace "OpenMS::RibonucleotideDB":
     

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5103,6 +5103,105 @@ def testModificationsDB():
     assert m.getUniModAccession() == "UniMod:35"
 
 @report
+def testRNaseDB():
+    """
+    @tests: RNaseDB
+        const DigestionEnzymeRNA* getEnzyme(const String& name) nogil except +
+        const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) nogil except +
+        void getAllNames(libcpp_vector[ String ]& all_names) nogil except +
+        bool hasEnzyme(const String& name) nogil except +
+        bool hasRegEx(const String& cleavage_regex) nogil except +
+     """
+    db = pyopenms.RNaseDB()
+    names = []
+    db.getAllNames(names)
+
+    e = db.getEnzyme("RNase_T1")
+    assert e.getRegEx() == u'(?<=G)'
+    assert e.getThreePrimeGain() == u'p'
+
+    assert db.hasRegEx(u'(?<=G)')
+    assert db.hasEnzyme("RNase_T1")
+    
+
+@report
+def testRibonucleotideDB():
+    """
+    @tests: RibonucleotideDB
+    """
+    r = pyopenms.RibonucleotideDB()
+
+    uridine = r.getRibonucleotide("U")
+
+    assert uridine.getName() == u'uridine'
+    assert uridine.getCode() == u'U'
+    assert uridine.getFormula().toString() == u'C9H12N2O6'
+    assert uridine.isModified() == False
+
+@report
+def testRibonucleotide():
+    """
+    @tests: Ribonucleotide
+    """
+    r = pyopenms.Ribonucleotide()
+
+    assert not r.isModified()
+
+    r.setHTMLCode("test")
+    assert r.getHTMLCode() == "test"
+
+    r.setOrigin("A")
+    assert r.getOrigin() == "A"
+
+    r.setNewCode("A")
+    assert r.getNewCode() == "A"
+
+
+@report
+def testRNaseDigestion():
+    """
+    @tests: RNaseDigestion
+     """
+
+    dig = pyopenms.RNaseDigestion()
+    dig.setEnzyme("RNase_T1")
+    assert dig.getEnzymeName() == "RNase_T1"
+
+    oligo = pyopenms.NASequence.fromString("pAUGUCGCAG");
+
+    result = []
+    dig.digest(oligo, result)
+    assert len(result) == 3
+
+
+@report
+def testNASequence():
+    """
+    @tests: NASequence
+     """
+
+    oligo = pyopenms.NASequence.fromString("pAUGUCGCAG");
+
+    assert oligo.size() == 9
+    seq_formula = oligo.getFormula()
+    seq_formula.toString() == u'C86H108N35O64P9'
+
+    oligo_mod = pyopenms.NASequence.fromString("A[m1A][Gm]A")
+    seq_formula = oligo_mod.getFormula()
+    seq_formula.toString() == u'C42H53N20O23P3'
+
+    for r in oligo:
+        pass
+
+    assert oligo_mod[1].isModified()
+
+    charge = 2
+    oligo_mod.getMonoWeight(pyopenms.NASequence.NASFragmentType.WIon, charge)
+    oligo_mod.getFormula(pyopenms.NASequence.NASFragmentType.WIon, charge)
+
+
+
+@report
 def testExperimentalDesign():
     """
     @tests: ExperimentalDesign


### PR DESCRIPTION
adds the following documentation to all classes:

```
Documentation is available at " + classdocu_base + "class%(namespace)s_1_1%(cpp_name)s.html
```

so that the class documentation reads as follows:


```
cdef class FloatDataArray:
    """   
    Cython implementation of _FloatDataArray

    Documentation is available at http://www.openms.de/current_doxygen/html/classOpenMS_1_1DataArrays_1_1FloatDataArray.html

     -- Inherits from ['MetaInfoDescription']

    The representation of extra float data attached to a spectrum or chromatogram.
    Raw data access is proved by `get_peaks` and `set_peaks`, which yields numpy arrays
    """
```

NOTE: We will have to adjust the URL to point to the release documentation

@jpfeuffer do we have a stable redirect from the release docu that we can use? E.g. http://www.openms.de/release24_doxygen or something like that?