### PR TITLE
[FIX] avoid stall on Windows when TOPPAS calls a TOPP tool with a ver…

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASToolConfigDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASToolConfigDialog.h
@@ -38,7 +38,6 @@
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
 #include <OpenMS/DATASTRUCTURES/Param.h>
-#include <OpenMS/VISUAL/LayerData.h>
 
 class QComboBox;
 class QPushButton;

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
@@ -106,8 +106,8 @@ protected:
 
     static bool copy_(const QString & from, const QString & to); ///< STATIC(!) function which calls QFile::copy(); needs to be static, since we need to pass a function pointer (which does not work on member functions)
     // convenience members, not required for operation, but for progress during copying
-    int files_written_;   ///< files that were already written
-    int files_total_;     ///< total number of files from upstream
+    int files_written_ = 0;   ///< files that were already written
+    int files_total_ = 0;     ///< total number of files from upstream
   };
 }
 

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -83,6 +83,7 @@ namespace OpenMS
     out_dir_(File::getUserDirectory().toQString()),
     changed_(false),
     running_(false),
+    error_occured_(false),
     user_specified_out_dir_(false),
     clipboard_(nullptr),
     dry_run_(true),
@@ -621,7 +622,6 @@ namespace OpenMS
 
   void TOPPASScene::runPipeline()
   {
-
     error_occured_ = false;
     resume_source_ = nullptr; // we are not resuming, so reset the resume node
 

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/VISUAL/TOPPASToolVertex.h>
 
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -501,6 +502,11 @@ namespace OpenMS
 
     bool ini_round_dependent = false; // indicates if we need a new INI file for each round (usually GenericWrapper issue)
 
+    // maximum number of filenames per TOPP parameter file-list to put on the commandline
+    // If more filenames are needed, e.g. for MapAligner's -in/-out etc., they are put in the .INI file
+    // to avoid exceed the 8kb length limit of the Windows commandline
+    static constexpr size_t MAX_FILES_CMDLINE {10};
+
     for (int round = 0; round < round_total_; ++round)
     {
       debugOut_(String("Enqueueing process nr ") + round + "/" + round_total_);
@@ -530,7 +536,7 @@ namespace OpenMS
         bool store_to_ini = false;
         // check for GenericWrapper input/output files and put them in INI file:
         // OR if there are a lot of input files (which might exceed the 8k length limit of cmd.exe on Windows)
-        if (param_name.hasPrefix("ETool:") || file_list.size() > 10)
+        if (param_name.hasPrefix("ETool:") || file_list.size() > MAX_FILES_CMDLINE)
         {
           store_to_ini = true;
           ini_round_dependent = true;
@@ -573,7 +579,7 @@ namespace OpenMS
         
         // check for GenericWrapper input/output files and put them in INI file:
         // OR if there are a lot of input files (which might exceed the 8k length limit of cmd.exe on Windows)
-        if (param_name.hasPrefix("ETool:") || output_files.size() > 10)
+        if (param_name.hasPrefix("ETool:") || output_files.size() > MAX_FILES_CMDLINE)
         {
           store_to_ini = true;
           ini_round_dependent = true;

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -525,19 +525,22 @@ namespace OpenMS
 
         String param_name = in_params[param_index].param_name;
 
+        const QStringList& file_list = ite->second.filenames.get();
+
         bool store_to_ini = false;
         // check for GenericWrapper input/output files and put them in INI file:
-        if (param_name.hasPrefix("ETool:"))
+        // OR if there are a lot of input files (which might exceed the 8k length limit of cmd.exe on Windows)
+        if (param_name.hasPrefix("ETool:") || file_list.size() > 10)
         {
           store_to_ini = true;
           ini_round_dependent = true;
         }
+
         if (!store_to_ini)
-          args << "-" + param_name.toQString();
-
-        const QStringList& file_list = ite->second.filenames.get();
-
-        if (store_to_ini)
+        {
+          args << "-" + param_name.toQString() << file_list;
+        }
+        else
         {
           if (param_tmp.getValue(param_name).valueType() == DataValue::STRING_LIST)
           {
@@ -552,11 +555,6 @@ namespace OpenMS
             param_tmp.setValue(param_name, String(file_list[0]));
           }
         }
-        else
-        {
-          args << file_list;
-        }
-
       }
 
       // OUTGOING EDGES
@@ -570,18 +568,23 @@ namespace OpenMS
         String param_name = out_params[param_index].param_name;
 
         bool store_to_ini = false;
+        
+        const QStringList& output_files = output_files_[round][param_index].filenames.get();
+        
         // check for GenericWrapper input/output files and put them in INI file:
-        if (param_name.hasPrefix("ETool:"))
+        // OR if there are a lot of input files (which might exceed the 8k length limit of cmd.exe on Windows)
+        if (param_name.hasPrefix("ETool:") || output_files.size() > 10)
         {
           store_to_ini = true;
           ini_round_dependent = true;
         }
+
+        
         if (!store_to_ini)
-          args << "-" + param_name.toQString();
-
-        const QStringList& output_files = output_files_[round][param_index].filenames.get();
-
-        if (store_to_ini)
+        {
+          args << "-" + param_name.toQString() << output_files;
+        }
+        else
         {
           if (param_tmp.getValue(param_name).valueType() == DataValue::STRING_LIST)
           {
@@ -592,10 +595,6 @@ namespace OpenMS
             if (output_files.size() > 1) throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Multiple files were given to a param which supports only single files! ('" + param_name + "')");
             param_tmp.setValue(param_name, String(output_files[0]));
           }
-        }
-        else
-        {
-          args << output_files;
         }
       }
 

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -504,8 +504,8 @@ namespace OpenMS
 
     // maximum number of filenames per TOPP parameter file-list to put on the commandline
     // If more filenames are needed, e.g. for MapAligner's -in/-out etc., they are put in the .INI file
-    // to avoid exceed the 8kb length limit of the Windows commandline
-    static constexpr size_t MAX_FILES_CMDLINE {10};
+    // to avoid exceeding the 8KB length limit of the Windows commandline
+    static constexpr int MAX_FILES_CMDLINE {10};
 
     for (int round = 0; round < round_total_; ++round)
     {


### PR DESCRIPTION
…y long list of input files (exceeding the 8k length limit)

Fixed by moving the list of files into the .ini file.