### PR TITLE
[GUI,FIX] removal of temporary theoretical spectrum layers

### DIFF
--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -955,7 +955,7 @@ namespace OpenMS
     tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
 
     String layer_caption = aa_sequence.toString().toQString() + QString(" (identification view)");
-    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_CHROMATOGRAM, false, false, false, "", layer_caption.toQString());
+    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_PEAK, false, false, false, layer_caption.toQString(), layer_caption.toQString());
 
     // get layer index of new layer
     Size theoretical_spectrum_layer_index = tv_->getActive1DWidget()->canvas()->activeLayerIndex();


### PR DESCRIPTION
This fixes a TOPPView crash caused by accumulating DataLayers from theoretical spectra in IDView.

The parameter `caption` in `addData()` is not used as the layer name. The `filename` parameter is used for that and was set as an empty string. The removal of these temporary layers relies on using the caption as the layer name (to identify them as temporary layers), so they were not removed and caused several problems.
After adding exactly 10 layers TOPPView just crashes for some reason.

Now the `layer_caption` of the theoretical spectra is also used as the filename and the layers are removed correctly. This makes the IDView for normal proteomics data usable again.
Tested on Linux and Windows.