### PR TITLE
[GUI,FIX] precalculated ppm errors were always read from the first PeptideHit

### DIFF
--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -673,9 +673,9 @@ namespace OpenMS
               double ppm_error(0);
 
               // Protein:RNA cross-link, Protein-Protein cross-link, or other data with a precomputed precursor error
-              if (pi[pi_idx].getHits()[0].metaValueExists(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))
+              if (ph.metaValueExists(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))
               {
-                ppm_error = fabs((double)pi[pi_idx].getHits()[0].getMetaValue(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM));
+                ppm_error = fabs((double)ph.getMetaValue(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM));
               }
               else if (!ph.getSequence().empty()) // works for normal linear fragments with the correct modifications included in the AASequence
               {


### PR DESCRIPTION
The `precursor error (|ppm|)` column in TOPPView IdentificationView is read from a MetaValue if it is available. For some reason it was always read from the first PeptideHit of the spectrum. This fixes this and shows the correct number for each PeptideHit.