### PR TITLE
fix docu for MapAlignerTreeGuided

### DIFF
--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -100,10 +100,11 @@
 
   <b>Map Alignment</b>
   - @subpage TOPP_ConsensusMapNormalizer - Normalizes maps of one consensusXML file (after linking).
-  - @subpage TOPP_MapAlignerIdentification - Corrects retention time distortions between maps based on common peptide identifications.
-  - @subpage TOPP_MapAlignerPoseClustering - Corrects retention time distortions between maps using a pose clustering approach.
-  - @subpage TOPP_MapAlignerSpectrum - Corrects retention time distortions between maps by spectrum alignment.
-  - @subpage TOPP_MapRTTransformer - Applies retention time transformations to maps.
+  - @subpage TOPP_MapAlignerIdentification - Corrects RT distortions between maps based on common peptide identifications using one map as reference.
+  - @subpage TOPP_MapAlignerTreeGuided - Corrects RT distortions between maps based on common peptide identifications guided by a similarity tree.
+  - @subpage TOPP_MapAlignerPoseClustering - Corrects RT distortions between maps using a pose clustering approach (not using pep-ids and a linear model).
+  - @subpage TOPP_MapAlignerSpectrum - Corrects RT distortions between maps by spectrum alignment.
+  - @subpage TOPP_MapRTTransformer - Applies RT transformations to maps.
   - @subpage TOPP_FeatureLinkerLabeled - Groups corresponding isotope-labeled features in a feature map.
   - @subpage TOPP_FeatureLinkerUnlabeled - Groups corresponding features from multiple maps.
   - @subpage TOPP_FeatureLinkerUnlabeledQT - Groups corresponding features from multiple maps using a QT clustering approach.

--- a/src/topp/MapAlignerTreeGuided.cpp
+++ b/src/topp/MapAlignerTreeGuided.cpp
@@ -54,11 +54,11 @@ using namespace std;
     <table>
         <tr>
             <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential predecessor tools </td>
-            <td VALIGN="middle" ROWSPAN=4> \f$ \longrightarrow \f$ MapAlignerTreeGuided \f$ \longrightarrow \f$</td>
+            <td VALIGN= "middle" ROWSPAN=2> \f$ \longrightarrow \f$ MapAlignerTreeGuided \f$ \longrightarrow \f$</td>
             <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential successor tools </td>
         </tr>
         <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> @ref TOPP_XTandemAdapter @n (or another search engine adapter) </td>
+            <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> @ref TOPP_IDMapper @n (or any other source of FDR-filtered featureXMLs) </td>
         </tr>
         <tr>
             <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> @ref TOPP_FeatureLinkerUnlabeledKD or @n @ref TOPP_FeatureLinkerUnlabeledQT </td>


### PR DESCRIPTION
adds MapAlignerTreeGuided to TOPP docu

@timosachsenberg  @jpfeuffer  any idea why our `\f$ \longrightarrow \f$` are shown as unrelated formula `1 + 10^-5` in our docs currently?
e.g. https://abibuilder.informatik.uni-tuebingen.de/archive/openms/Documentation/nightly/html/a16150.html