### PR TITLE
[Fix] precision text vs mz tab

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/SVOutStream.h
+++ b/src/openms/include/OpenMS/FORMAT/SVOutStream.h
@@ -157,12 +157,12 @@ public:
     template <typename NumericT>
     SVOutStream& writeValueOrNan(NumericT thing)
     {
-      if ((boost::math::isfinite)(thing)) return operator<<(thing);
+      if ((boost::math::isfinite)(thing)) return operator<<(String(thing));
 
       bool old = modifyStrings(false);
       if ((boost::math::isnan)(thing)) operator<<(nan_);
       else if (thing < 0) operator<<("-" + inf_);
-      else operator<<(inf_);
+      else operator<<(String(inf_));
       modifyStrings(old);
       return *this;
     }

--- a/src/tests/class_tests/openms/source/SVOutStream_test.cpp
+++ b/src/tests/class_tests/openms/source/SVOutStream_test.cpp
@@ -74,7 +74,9 @@ START_SECTION((template <typename T> SVOutStream& operator<<(const T& value)))
   out << 456 << endl;
   // different cases for Unix/Windows:
   TEST_EQUAL((strstr.str() == "123,3.14,-1.23e+45\n456\n") ||
-             (strstr.str() == "123,3.14,-1.23e+045\n456\n"), true);
+             (strstr.str() == "123,3.14,-1.23e+045\n456\n") ||
+             (strstr.str() == "123,3.14,-1.23e45\n456\n"), true)
+  std::cout << strstr.str() << std::endl;
 }
 {
   stringstream strstr;
@@ -83,6 +85,7 @@ START_SECTION((template <typename T> SVOutStream& operator<<(const T& value)))
   out << 456 << nl;
   // different cases for Unix/Windows:
   TEST_EQUAL((strstr.str() == "123_/_3.14_/_-1.23e+45\n456\n") ||
+                 (strstr.str() == "123_/_3.14_/_-1.23e45\n456\n") ||
              (strstr.str() == "123_/_3.14_/_-1.23e+045\n456\n"), true);
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -215,6 +215,15 @@ START_SECTION((String(float f, bool full_precision = true)))
   TEST_EQUAL(s2, "17.012")
 END_SECTION
 
+START_SECTION((String(float f)))
+  float f = 50254.199219;
+  double d = f;
+  String s(f);
+  TEST_EQUAL(s,"50254.199219")
+  String s2(d);
+  TEST_EQUAL(s2, "50254.19921875")
+END_SECTION
+
 START_SECTION((String(double d, bool full_precision = true)))
   String s(double(17.012345));
   TEST_EQUAL(s,"17.012345")

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -162,7 +162,7 @@ namespace OpenMS
     out.writeValueOrNan(rt);
     out.writeValueOrNan(mz);
     out.writeValueOrNan(intensity);
-    out << charge;
+    out << String(charge);
     out.writeValueOrNan(width);
   }
 
@@ -270,7 +270,7 @@ namespace OpenMS
       {
         if (meta_value_provider.metaValueExists(*its))
         {
-          output << meta_value_provider.getMetaValue(*its);
+          output << String(meta_value_provider.getMetaValue(*its));
         }
         else
         {
@@ -283,15 +283,15 @@ namespace OpenMS
   // stream output operator for a ProteinHit
   SVOutStream& operator<<(SVOutStream& out, const ProteinHit& hit)
   {    
-    out << hit.getScore() << hit.getRank() << hit.getAccession() << hit.getDescription()
-        << hit.getCoverage() << hit.getSequence();
+    out << String(hit.getScore()) << hit.getRank() << hit.getAccession() << hit.getDescription()
+        << String(hit.getCoverage()) << hit.getSequence();
     return out;
   }
 
   // stream output operator for a ProteinGroup
   SVOutStream& operator<<(SVOutStream& out, const ProteinIdentification::ProteinGroup& grp)
   {
-    out << grp.probability;
+    out << String(grp.probability);
     String grpaccs = grp.accessions[0];
     for (Size s = 1; s < grp.accessions.size(); s++)
     {
@@ -407,12 +407,12 @@ namespace OpenMS
 
     if (!pes.empty())
     {
-      out << hit.getScore() << hit.getRank() << hit.getSequence()
+      out << String(hit.getScore()) << hit.getRank() << hit.getSequence()
           << hit.getCharge() << pes[0].getAABefore() << pes[0].getAAAfter();
     }
     else
     {
-      out << hit.getScore() << hit.getRank() << hit.getSequence()
+      out << String(hit.getScore()) << hit.getRank() << hit.getSequence()
           << hit.getCharge() << PeptideEvidence::UNKNOWN_AA << PeptideEvidence::UNKNOWN_AA;
     }
     return out;
@@ -433,7 +433,7 @@ namespace OpenMS
 
       if (pid.hasRT())
       {
-        out << pid.getRT();
+        out << String(pid.getRT());
       }
       else
       {
@@ -442,7 +442,7 @@ namespace OpenMS
 
       if (pid.hasMZ())
       {
-        out << pid.getMZ();
+        out << String(pid.getMZ());
       }
       else
       {
@@ -467,7 +467,7 @@ namespace OpenMS
       {
         if (hit_it->metaValueExists("predicted_RT"))
         {
-          out << hit_it->getMetaValue("predicted_RT");
+          out << String(hit_it->getMetaValue("predicted_RT"));
         }
         else out << "-1";
       }
@@ -475,12 +475,12 @@ namespace OpenMS
       {
         if (pid.metaValueExists("first_dim_rt"))
         {
-          out << pid.getMetaValue("first_dim_rt");
+          out << String(pid.getMetaValue("first_dim_rt"));
         }
         else out << "-1";
         if (hit_it->metaValueExists("predicted_RT_first_dim"))
         {
-          out << hit_it->getMetaValue("predicted_RT_first_dim");
+          out << String(hit_it->getMetaValue("predicted_RT_first_dim"));
         }
         else out << "-1";
       }
@@ -488,7 +488,7 @@ namespace OpenMS
       {
         if (hit_it->metaValueExists("predicted_PT"))
         {
-          out << hit_it->getMetaValue("predicted_PT");
+          out << String(hit_it->getMetaValue("predicted_PT"));
         }
         else out << "-1";
       }
@@ -723,16 +723,16 @@ protected:
           }
           if (minimal)
           {
-            output << citer->getRT() << citer->getMZ()
-                   << citer->getIntensity();
+            output << String(citer->getRT()) << String(citer->getMZ())
+                   << String(citer->getIntensity());
           }
           else
           {
-            output << *citer << citer->getQuality(0) << citer->getQuality(1);
+            output << *citer << String(citer->getQuality(0)) << String(citer->getQuality(1));
             if (citer->getConvexHulls().size() > 0)
             {
-              output << citer->getConvexHulls().begin()->getBoundingBox().minX() 
-                     << citer->getConvexHulls().begin()->getBoundingBox().maxX();
+              output << String(citer->getConvexHulls().begin()->getBoundingBox().minX())
+                     << String(citer->getConvexHulls().begin()->getBoundingBox().maxX());
             }
             else
             {
@@ -1158,7 +1158,7 @@ protected:
             {
               if (fdit->second.metaValueExists(*kit))
               {
-                output << fdit->second.getMetaValue(*kit);
+                output << String(fdit->second.getMetaValue(*kit));
               }
               else output << "";
             }
@@ -1348,7 +1348,7 @@ protected:
             if (it->getMSLevel() == 1)
             {
               ++output_count;
-              output << "MS" << it->getMSLevel() << it->getRT() << "" << "" << it->size() << index << name << nl;
+              output << "MS" << it->getMSLevel() << String(it->getRT()) << "" << "" << it->size() << index << name << nl;
             }
             else if (it->getMSLevel() == 2)
             {
@@ -1362,7 +1362,7 @@ protected:
               }
 
               ++output_count;
-              output << "MS" << it->getMSLevel() << it->getRT() << precursor_mz << precursor_charge << it->size() << index << name << nl;
+              output << "MS" << it->getMSLevel() << String(it->getRT()) << precursor_mz << precursor_charge << it->size() << index << name << nl;
             }
           }
 
@@ -1386,10 +1386,10 @@ protected:
             if (it->getChromatogramType() == ChromatogramSettings::SELECTED_REACTION_MONITORING_CHROMATOGRAM)
             {
               ++output_count;
-              output << "MRM Q1=" << it->getPrecursor().getMZ() << " Q3=" << it->getProduct().getMZ() << nl;
+              output << "MRM Q1=" << String(it->getPrecursor().getMZ()) << " Q3=" << String(it->getProduct().getMZ()) << nl;
               for (MSChromatogram::ConstIterator cit = it->begin(); cit != it->end(); ++cit)
               {
-                output << cit->getRT() << " " << cit->getIntensity() << nl;
+                output << String(cit->getRT()) << " " << String(cit->getIntensity()) << nl;
               }
               output << nl;
             }


### PR DESCRIPTION
fixes #4518 

by using StringConversion mechanisms of Boost::Karma from @cbielow for all doubles.
Note that mzTab converts all floats to doubles and therefore will have different precision
for intensity until we change the behaviour of the mzTab writer.
I showed that behaviour in a new String_test, to show that this is currently intended.