### PR TITLE
FFM resolve discrepancy of number of features and chromatograms

### DIFF
--- a/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
@@ -167,6 +167,7 @@ namespace OpenMS
       chromatogram.sortByPosition();
 
       tmp_chromatograms.push_back(chromatogram);
+
     }
     return tmp_chromatograms;
   }
@@ -941,10 +942,11 @@ namespace OpenMS
       f.applyMemberFunction(&UniqueIdInterface::setUniqueId);
       output_featmap.push_back(f);
 
-      if (report_chromatograms_)
+      if (report_chromatograms_ && f.getIntensity() != 0)
       {
         output_chromatograms.push_back(feat_hypos[hypo_idx].getChromatograms(f.getUniqueId()));
       }
+
       // add used traces to exclusion map
       for (Size lab_idx = 0; lab_idx < labels.size(); ++lab_idx)
       {

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -325,14 +325,14 @@ protected:
     // store chromatograms
     if (!out_chrom.empty())
     {
-        if (feat_chromatograms.size() == feat_map.size())
+      if (feat_chromatograms.size() == feat_map.size())
         {
           MSExperiment out_exp;
             for (Size i = 0; i < feat_chromatograms.size(); ++i)
             {
                 for (Size j = 0; j < feat_chromatograms[i].size(); ++j)
                 {
-                    out_exp.addChromatogram(feat_chromatograms[i][j]);
+                  out_exp.addChromatogram(feat_chromatograms[i][j]);
                 }
             }
           MzMLFile().store(out_chrom, out_exp);


### PR DESCRIPTION
Resolves the error `FF-Metabo: Internal error. The number of features 1214 and chromatograms 1218 are different! Aborting.` by only using chromatograms with a feature intensity != 0. 


