### PR TITLE
fix doxygen errors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ the authors tag in the respective file header.
  - Johan Teleman
  - Johannes Junker
  - Johannes Veit
+ - Julia Thueringer
  - Juliane Schmachtenberg
  - Julianus Pfeuffer
  - Katharina Albers

--- a/doc/TOPP_tutorial/TOPP_scripting.doxygen
+++ b/doc/TOPP_tutorial/TOPP_scripting.doxygen
@@ -206,7 +206,7 @@
                    <ul>
                    <li>Number of PeptideIdentifications</li>
                    <li>Number of MS2 spectra</li>
-                   <li>Ratio of #pepID/#MS2</li>
+                   <li>Ratio of \#pepID/\#MS2</li>
                    </ul>
               </TD>
         </TR>

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -347,7 +347,7 @@ EXTENSION_MAPPING      =
 # case of backward compatibilities issues.
 # The default value is: YES.
 
-MARKDOWN_SUPPORT       = NO
+MARKDOWN_SUPPORT       = YES
 
 # When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
 # to that level are automatically included in the table of contents, even if

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -346,8 +346,8 @@ EXTENSION_MAPPING      =
 # mix doxygen, HTML, and XML commands with Markdown formatting. Disable only in
 # case of backward compatibilities issues.
 # The default value is: YES.
-
-MARKDOWN_SUPPORT       = YES
+## --> this still needs some work from our side, since indentation of doxygen snippets must be carefully checked
+MARKDOWN_SUPPORT       = NO
 
 # When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
 # to that level are automatically included in the table of contents, even if

--- a/doc/doxygen/public/FAQ.doxygen
+++ b/doc/doxygen/public/FAQ.doxygen
@@ -86,15 +86,15 @@
 			<LI><B>A TOPP tool crashes when loading a certain input file. Other files work properly.</B><BR>
 				If an XML input file is used, please check if the file is valid.
 
-				For most XML data formats, this can be done using the @em FileInfo tool:
-				@code
+				For most XML data formats, this can be done using the @ref TOPP_FileInfo tool:
+				@code{.sh}
  FileInfo -v -in <file>
-				@endcode
+@endcode
 
 				You can also check for corrupt data in peak files:
-				@code
+				@code{.sh}
  FileInfo -c -in <file>
-				@endcode
+@endcode
 
 		</UL>
 */

--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -123,7 +123,7 @@
   - @subpage TOPP_OMSSAAdapter - Identifies MS/MS spectra using OMSSA (external).
   - @subpage TOPP_PepNovoAdapter - Identifies MS/MS spectra using PepNovo (external).
   - @subpage TOPP_SpecLibSearcher - Identifies peptide MS/MS spectra by spectral matching with a searchable spectral library.
-  - @subpage TOPP_SimpleSearchEngine - A simple database search engine for annotating MS/MS spectra.
+  - @subpage UTILS_SimpleSearchEngine - A simple database search engine for annotating MS/MS spectra.
   - @subpage TOPP_XTandemAdapter - Identifies MS/MS spectra using XTandem (external).
 
   <b>Protein/Peptide Processing</b>

--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -162,6 +162,11 @@
   - @subpage TOPP_RTModel - Trains a model for the retention time prediction of peptides from a training set.
   - @subpage TOPP_RTPredict - Predicts retention times for peptides using a model trained by RTModel.
 
+  <b>Cross-linking</b>
+  - @subpage TOPP_OpenPepXL - Search for peptide pairs linked with a labeled cross-linker.
+  - @subpage TOPP_OpenPepXLLF - Search for cross-linked peptide pairs in tandem MS spectra.
+  - @subpage TOPP_XFDR - Calculates false discovery rate estimates on cross-link identifications.
+
   <b>Misc</b>
   - @subpage TOPP_QualityControl - A one-in-all QC tool to generate an augmented mzTab
   - @subpage TOPP_GenericWrapper - Allows the generic wrapping of external tools.

--- a/doc/doxygen/public/UTILS.doxygen
+++ b/doc/doxygen/public/UTILS.doxygen
@@ -85,11 +85,8 @@
   - @subpage UTILS_SpectraSTSearchAdapter - An interface to the 'SEARCH' mode of the SpectraST program (external, beta).
 
   <b>Cross-linking</b>
-  - @subpage UTILS_OpenPepXL - Search for peptide pairs linked with a labeled cross-linker.
-  - @subpage UTILS_OpenPepXLLF - Search for cross-linked peptide pairs in tandem MS spectra.
   - @subpage UTILS_RNPxlSearch - Annotates RNA-to-peptide cross-links in MS/MS spectra.
   - @subpage UTILS_RNPxlXICFilter - Removes MS2 spectra from treatment based on the fold change between control and treatment for RNA-to-peptide cross-linking experiments.
-  - @subpage UTILS_XFDR - Calculates false discovery rate estimates on cross-link identifications.
 
   <b>Quantitation</b>
   - @subpage UTILS_ERPairFinder - Evaluates pair ratios on enhanced resolution (zoom) scans.

--- a/doc/doxygen/public/UTILS.doxygen
+++ b/doc/doxygen/public/UTILS.doxygen
@@ -77,7 +77,7 @@
   - @subpage UTILS_IDExtractor - Extracts n peptides randomly or best n from idXML files.
   - @subpage UTILS_IDMassAccuracy - Calculates a distribution of the mass error from given mass spectra and IDs.
   - @subpage UTILS_IDScoreSwitcher - Switches between different scores of peptide or protein hits in identification data.
-  - @subpage TOPP_MSFraggerAdapter - Peptide Identification with MSFragger.
+  - @subpage UTILS_MSFraggerAdapter - Peptide Identification with MSFragger.
   - @subpage UTILS_NovorAdapter - De novo sequencing from tandem mass spectrometry data.
   - @subpage UTILS_PSMFeatureExtractor - Creates search engine specific features for PercolatorAdapter input.
   - @subpage UTILS_SequenceCoverageCalculator - Prints information about idXML files.
@@ -95,7 +95,7 @@
   - @subpage UTILS_ERPairFinder - Evaluates pair ratios on enhanced resolution (zoom) scans.
   - @subpage UTILS_FeatureFinderMetaboIdent - Detects features in MS1 data corresponding to small molecule identifications.
   - @subpage UTILS_FeatureFinderSuperHirn - Finds features using the SuperHirn algorithm (can handle centroided or profile data, see .ini file).
-  - @subpage UTILS_ProteomicLFQ - A standard Proteomics LFQ pipeline.
+  - @subpage UTILS_ProteomicsLFQ - A standard Proteomics LFQ pipeline.
   - @subpage UTILS_MetaboliteAdductDecharger - Decharges and merges different feature charge variants of the same small molecule.
   - @subpage UTILS_MultiplexResolver - Resolves conflicts between identifications and quantifications in multiplex data.
 
@@ -105,7 +105,7 @@
   - @subpage UTILS_SiriusAdapter - De novo metabolite identification.
 
   <b>Targeted Experiments and OpenSWATH</b>
-  - @subpage TOPP_CorrelateMassTraces - Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps. <!-- ClusterMassTracesByPrecursor -->
+  - @subpage UTILS_ClusterMassTracesByPrecursor - Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps.
   - @subpage UTILS_MRMPairFinder - Evaluates labeled pair ratios on MRM features.
   - @subpage UTILS_OpenSwathDIAPreScoring - SWATH (data-independent acquisition) pre-scoring.
   - @subpage UTILS_OpenSwathFileSplitter - A tool for splitting a single SWATH / DIA file into a set of files, each containing one SWATH window.
@@ -127,7 +127,7 @@
   - @subpage UTILS_QCShrinker - Removes extra verbose table attachments from a qcML file that are not needed anymore, e.g. for a final report.
 
   <b>Misc</b>
-  - @subpage TOPP_ClusterMassTraces - Cluster mass traces occurring in the same map together.
+  - @subpage UTILS_ClusterMassTraces - Cluster mass traces occurring in the same map together.
   - @subpage UTILS_DeMeanderize - Orders the spectra of MALDI spotting plates correctly.
   - @subpage UTILS_ImageCreator - Creates images from MS1 data (with MS2 data points indicated as dots).
   - @subpage UTILS_MassCalculator - Calculates masses and mass-to-charge ratios of peptide sequences.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
@@ -42,19 +42,18 @@
 // Doxygen docu
 //-------------------------------------------------------------
 
-/**
-    @page TOPP_IDConflictResolver IDConflictResolver
 
-    @brief Resolves ambiguous annotations of features with peptide identifications.
-
-    The peptide identifications are filtered so that only one identification
-    with a single hit (with the best score) is associated to each feature. (If
-    two IDs have the same best score, either one of them may be selected.)
-*/
 
 namespace OpenMS
 {
 
+/**
+    @brief Resolves ambiguous annotations of features with peptide identifications.
+
+    The peptide identifications are filtered so that only one identification
+    with a single hit (with the best score) is associated to each feature.
+    (If two IDs have the same best score, either one of them may be selected.)
+*/
 class OPENMS_DLLAPI IDConflictResolverAlgorithm
 {
 public:

--- a/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
@@ -126,8 +126,8 @@ namespace OpenMS
 
   //IMPLEMENTATIONS:
 
-  template <typename L>
-  MessagePasserFactory<L>::MessagePasserFactory(double alpha, double beta, double gamma, double p, double pep_prior) {
+  template <typename Label>
+  MessagePasserFactory<Label>::MessagePasserFactory(double alpha, double beta, double gamma, double p, double pep_prior) {
     assert(0. <= alpha && alpha <= 1.);
     assert(0. <= beta && beta <= 1.);
     assert(0. <= gamma && gamma <= 1.);
@@ -141,8 +141,8 @@ namespace OpenMS
     pepPrior_ = pep_prior;
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createProteinFactor(L id, int nrMissingPeps) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, int nrMissingPeps = 0) {
     double prior = gamma_;
     if (nrMissingPeps > 0)
     {
@@ -150,32 +150,32 @@ namespace OpenMS
       prior = -prior/(prior * powFactor - prior - powFactor);
     }
     double table[] = {1.0 - prior, prior};
-    evergreen::LabeledPMF<L> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
-    return evergreen::TableDependency<L>(lpmf,p_);
+    evergreen::LabeledPMF<Label> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createProteinFactor(L id, double prior, int nrMissingPeps) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, double prior, int nrMissingPeps = 0) {
     if (nrMissingPeps > 0)
     {
       double powFactor = std::pow(1.0 - alpha_, -nrMissingPeps);
       prior = -prior/(prior * powFactor - prior - powFactor);
     }
     double table[] = {1.0 - prior, prior};
-    evergreen::LabeledPMF<L> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
-    return evergreen::TableDependency<L>(lpmf,p_);
+    evergreen::LabeledPMF<Label> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createPeptideEvidenceFactor(L id, double prob) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createPeptideEvidenceFactor(Label id, double prob) {
     double table[] = {(1 - prob) * (1 - pepPrior_), prob * pepPrior_};
-    evergreen::LabeledPMF<L> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
-    return evergreen::TableDependency<L>(lpmf,p_);
+    evergreen::LabeledPMF<Label> lpmf({id}, evergreen::PMF({0L}, evergreen::Tensor<double>::from_array(table)));
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createSumEvidenceFactor(size_t nrParents, L nId, L pepId) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createSumEvidenceFactor(size_t nrParents, Label nId, Label pepId) {
     evergreen::Tensor<double> table({static_cast<unsigned long>(nrParents + 1) , 2});
     for (unsigned long i=0; i <= nrParents; ++i) {
       double notConditional = notConditionalGivenSum(i);
@@ -185,13 +185,13 @@ namespace OpenMS
       table[indexArr2] = 1.0 - notConditional;
     }
     //std::cout << table << std::endl;
-    evergreen::LabeledPMF<L> lpmf({nId, pepId}, evergreen::PMF({0L,0L}, table));
+    evergreen::LabeledPMF<Label> lpmf({nId, pepId}, evergreen::PMF({0L,0L}, table));
     //std::cout << lpmf << std::endl;
-    return evergreen::TableDependency<L>(lpmf,p_);
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createRegularizingSumEvidenceFactor(size_t nrParents, L nId, L pepId) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createRegularizingSumEvidenceFactor(size_t nrParents, Label nId, Label pepId) {
     evergreen::Tensor<double> table({static_cast<unsigned long>(nrParents + 1) , 2});
     unsigned long z[2]{0ul,0ul};
     unsigned long z1[2]{0ul,1ul};
@@ -205,25 +205,25 @@ namespace OpenMS
       table[indexArr2] = (1.0 - notConditional) / i;
     }
     //std::cout << table << std::endl;
-    evergreen::LabeledPMF<L> lpmf({nId, pepId}, evergreen::PMF({0L,0L}, table));
+    evergreen::LabeledPMF<Label> lpmf({nId, pepId}, evergreen::PMF({0L,0L}, table));
     //std::cout << lpmf << std::endl;
-    return evergreen::TableDependency<L>(lpmf,p_);
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createSumFactor(size_t nrParents, L nId) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createSumFactor(size_t nrParents, Label nId) {
     evergreen::Tensor<double> table({nrParents+1});
     for (unsigned long i=0; i <= nrParents; ++i) {
       table[i] = 1.0/(nrParents+1.);
     }
     //std::cout << table << std::endl;
-    evergreen::LabeledPMF<L> lpmf({nId}, evergreen::PMF({0L}, table));
+    evergreen::LabeledPMF<Label> lpmf({nId}, evergreen::PMF({0L}, table));
     //std::cout << lpmf << std::endl;
-    return evergreen::TableDependency<L>(lpmf,p_);
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createReplicateFactor(L seqId, L repId) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createReplicateFactor(Label seqId, Label repId) {
     using arr = unsigned long[2];
     evergreen::Tensor<double> table({2,2});
     table[arr{0,0}] = 0.999;
@@ -231,13 +231,13 @@ namespace OpenMS
     table[arr{1,0}] = 0.1;
     table[arr{1,1}] = 0.9;
     //std::cout << table << std::endl;
-    evergreen::LabeledPMF<L> lpmf({seqId,repId}, evergreen::PMF({0L,0L}, table));
+    evergreen::LabeledPMF<Label> lpmf({seqId,repId}, evergreen::PMF({0L,0L}, table));
     //std::cout << lpmf << std::endl;
-    return evergreen::TableDependency<L>(lpmf,p_);
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::TableDependency<L> MessagePasserFactory<L>::createChargeFactor(L repId, L chgId, int chg) {
+  template <typename Label>
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createChargeFactor(Label repId, Label chgId, int chg) {
     double chgPrior = chgLLhoods[chg];
     using arr = unsigned long[2];
     evergreen::Tensor<double> table({2,2});
@@ -246,44 +246,44 @@ namespace OpenMS
     table[arr{1,0}] = 0.1;
     table[arr{1,1}] = chgPrior;
     //std::cout << table << std::endl;
-    evergreen::LabeledPMF<L> lpmf({repId,chgId}, evergreen::PMF({0L,0L}, table));
+    evergreen::LabeledPMF<Label> lpmf({repId,chgId}, evergreen::PMF({0L,0L}, table));
     //std::cout << lpmf << std::endl;
-    return evergreen::TableDependency<L>(lpmf,p_);
+    return evergreen::TableDependency<Label>(lpmf,p_);
   }
 
-  template <typename L>
-  evergreen::AdditiveDependency<L> MessagePasserFactory<L>::createPeptideProbabilisticAdderFactor(const std::set<L> & parentProteinIDs, L nId) {
-    std::vector<std::vector<L>> parents;
-    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const L& l){return std::vector<L>{l};});
-    return evergreen::AdditiveDependency<L>(parents, {nId}, p_);
+  template <typename Label>
+  evergreen::AdditiveDependency<Label> MessagePasserFactory<Label>::createPeptideProbabilisticAdderFactor(const std::set<Label> & parentProteinIDs, Label nId) {
+    std::vector<std::vector<Label>> parents;
+    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const Label& l){return std::vector<Label>{l};});
+    return evergreen::AdditiveDependency<Label>(parents, {nId}, p_);
   }
 
-  template <typename L>
-  evergreen::AdditiveDependency<L> MessagePasserFactory<L>::createPeptideProbabilisticAdderFactor(const std::vector<L> & parentProteinIDs, L nId) {
-    std::vector<std::vector<L>> parents;
-    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const L& l){return std::vector<L>{l};});
-    return evergreen::AdditiveDependency<L>(parents, {nId}, p_);
+  template <typename Label>
+  evergreen::AdditiveDependency<Label> MessagePasserFactory<Label>::createPeptideProbabilisticAdderFactor(const std::vector<Label> & parentProteinIDs, Label nId) {
+    std::vector<std::vector<Label>> parents;
+    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const Label& l){return std::vector<Label>{l};});
+    return evergreen::AdditiveDependency<Label>(parents, {nId}, p_);
   }
 
-  template <typename L>
-  evergreen::PseudoAdditiveDependency<L> MessagePasserFactory<L>::createBFPeptideProbabilisticAdderFactor(const std::set<L> & parentProteinIDs, L nId, const std::vector<evergreen::TableDependency<L>> & deps) {
-    std::vector<std::vector<L>> parents;
-    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const L& l){return std::vector<L>{l};});
-    return evergreen::PseudoAdditiveDependency<L>(parents, {nId}, deps, p_);
+  template <typename Label>
+  evergreen::PseudoAdditiveDependency<Label> MessagePasserFactory<Label>::createBFPeptideProbabilisticAdderFactor(const std::set<Label> & parentProteinIDs, Label nId, const std::vector<evergreen::TableDependency<Label>> & deps) {
+    std::vector<std::vector<Label>> parents;
+    std::transform(parentProteinIDs.begin(), parentProteinIDs.end(), std::back_inserter(parents), [](const Label& l){return std::vector<Label>{l};});
+    return evergreen::PseudoAdditiveDependency<Label>(parents, {nId}, deps, p_);
   }
 
   /// Works on a vector of protein indices (potentially not consecutive)
   // TODO we could recollect the protIDs from the union of parents.
-  template <typename L>
-  void MessagePasserFactory<L>::fillVectorsOfMessagePassers(const std::vector<L> & protIDs,
-                                                            const std::vector<std::vector<L>> & parentsOfPeps,
-                                                            const std::vector<double> & pepEvidences,
-                                                            evergreen::InferenceGraphBuilder<L> & igb)
+  template <typename Label>
+  void MessagePasserFactory<Label>::fillVectorsOfMessagePassers(const std::vector<Label>& protIDs,
+                                                            const std::vector<std::vector<Label>>& parentsOfPeps,
+                                                            const std::vector<double>& pepEvidences,
+                                                            evergreen::InferenceGraphBuilder<Label>& igb)
   {
     //TODO asserts could be loosened
     assert(parentsOfPeps.size() == pepEvidences.size());
     for (const std::vector<uiint>& parents : parentsOfPeps)
-      for (L parent : parents)
+      for (Label parent : parents)
         assert(std::find(protIDs.begin(), protIDs.end(), parent) != protIDs.end());
 
     for (uiint pid : protIDs)
@@ -298,11 +298,11 @@ namespace OpenMS
   }
 
   /* unused but working
-  template <typename L>
-  void MessagePasserFactory<L>::fillVectorsOfMessagePassersBruteForce(const std::vector<L> & protIDs,
-                                                                      const std::vector<std::vector<L>> & parentsOfPeps,
+  template <typename Label>
+  void MessagePasserFactory<Label>::fillVectorsOfMessagePassersBruteForce(const std::vector<Label> & protIDs,
+                                                                      const std::vector<std::vector<Label>> & parentsOfPeps,
                                                                       const std::vector<double> & pepEvidences,
-                                                                      evergreen::InferenceGraphBuilder<L> & igb)
+                                                                      evergreen::InferenceGraphBuilder<Label> & igb)
   {
     assert(parentsOfPeps.size() == pepEvidences.size());
     for (std::vector<uiint> parents : parentsOfPeps)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
@@ -155,7 +155,7 @@ namespace OpenMS
   }
 
   template <typename Label>
-  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, double prior, int nrMissingPeps = 0) {
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, double prior, int nrMissingPeps) {
     if (nrMissingPeps > 0)
     {
       double powFactor = std::pow(1.0 - alpha_, -nrMissingPeps);

--- a/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/MessagePasserFactory.h
@@ -142,7 +142,7 @@ namespace OpenMS
   }
 
   template <typename Label>
-  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, int nrMissingPeps = 0) {
+  evergreen::TableDependency<Label> MessagePasserFactory<Label>::createProteinFactor(Label id, int nrMissingPeps) {
     double prior = gamma_;
     if (nrMissingPeps > 0)
     {

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusMSConverter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusMSConverter.h
@@ -80,7 +80,7 @@ public:
   };
 
   /**
-    @brief Internal structure used in @ref TOPP_SiriusAdapter that is used
+    @brief Internal structure used in @ref UTILS_SiriusAdapter that is used
     for the conversion of a MzMlFile to an internal format.
 
     @ingroup ID

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusMSConverter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusMSConverter.h
@@ -80,7 +80,7 @@ public:
   };
 
   /**
-    @brief Internal structure used in @ref SiriusAdapter that is used
+    @brief Internal structure used in @ref TOPP_SiriusAdapter that is used
     for the conversion of a MzMlFile to an internal format.
 
     @ingroup ID

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
@@ -76,7 +76,7 @@ namespace OpenMS
       BimapType;
 
       /// Binomial GLM
-      struct
+      struct GLM_
       {
         double intercept;
         double rt_coef;
@@ -91,7 +91,7 @@ namespace OpenMS
       } glm_;
 
       /// Helper for RT normalization (range 0-100)
-      struct
+      struct RTNorm_
       {
         double min_rt;
         double max_rt;

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -142,7 +142,7 @@ public:
      * @param trafo Optional transformation of the experimental retention time
      *              to the normalized retention time space used in the
      *              transition list.
-     * @param swath_map Optional SWATH-MS (DIA) map corresponding from which
+     * @param swath_maps Optional SWATH-MS (DIA) map corresponding from which
      *                  the chromatograms were extracted. Use empty map if no
      *                  data is available.
      * @param transition_group_map Output mapping of transition groups
@@ -259,17 +259,16 @@ private:
      * The function is used twice, for target and decoy identification transitions. The results are
      * reported analogously to the ones for detecting transitions but must be stored separately.
      *
-     * @param transition_group Containing all detecting, identifying transitions
      * @param transition_group_identification Containing all detecting and identifying transitions
      * @param scorer An instance of OpenSwathScoring
      * @param feature_idx The index of the current feature
      * @param native_ids_detection The native IDs of the detecting transitions
-     * @param sn_win_len_ The signal to noise window length
-     * @param sn_bin_count_ The signal to noise bin count
      * @param det_intensity_ratio_score The intensity score of the detection transitions for normalization
      * @param det_mi_ratio_score The MI score of the detection transitions for normalization
-     * @param write_log_messages Whether to write signal to noise log messages
-     * @value a struct of type OpenSwath_Ind_Scores containing either target or decoy values
+     * @param swath_maps Optional SWATH-MS (DIA) map corresponding from which
+     *                  the chromatograms were extracted. Use empty map if no
+     *                  data is available.
+     * @return a struct of type OpenSwath_Ind_Scores containing either target or decoy values
     */
     OpenSwath_Ind_Scores scoreIdentification_(MRMTransitionGroupType& transition_group_identification,
                                               OpenSwathScoring& scorer,

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathQC.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathQC.h
@@ -101,9 +101,9 @@ namespace OpenSwath
       determine the charge states of all isotopic envelopes and return their total counts
       using getSpectraProcessingFunc().
 
-      @param [IN] swath_maps Swath maps of mixed ms-level
-      @param [IN] nr_samples Number of spectra to sample per Swath map. To sample all spectra, set to -1
-      @param [IN] mz_tol     Error tolerance in Th in which an isotopic peak is expected (assuming C12-C13 distance)
+      @param[in] swath_maps Swath maps of mixed ms-level
+      @param[in] nr_samples Number of spectra to sample per Swath map. To sample all spectra, set to -1
+      @param[in] mz_tol     Error tolerance in Th in which an isotopic peak is expected (assuming C12-C13 distance)
       @return Distribution of charge (key = charge, value = counts)
 
       @throw Exception::Postcondition if Deisotoper did not return charge data
@@ -143,9 +143,9 @@ namespace OpenSwath
 
       If the total number of spectra is unknown, pass 0 as first argument, which will return true for every query, i.e. sample everything.
 
-      @param [IN] total_spec_count Total number of spectra expected
-      @param [IN] subsample_count Number of spectra which should be sampled from @p total_spec_count
-      @param [IN] idx Index of the spectrum under question
+      @param[in] total_spec_count Total number of spectra expected
+      @param[in] subsample_count Number of spectra which should be sampled from @p total_spec_count
+      @param[in] idx Index of the spectrum under question
 
     */
     static bool isSubsampledSpectrum_(const size_t total_spec_count, const size_t subsample_count, const size_t idx);

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/ProteinResolver.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/ProteinResolver.h
@@ -164,50 +164,50 @@ public:
     */
     void resolveID(std::vector<PeptideIdentification> & peptide_identifications);
 
-    /**
-      @brief NOT IMPLEMENTED YET
+    // /**
+      // @brief NOT IMPLEMENTED YET
 
-      @param protein_nodes
-      @param peptide_nodes
-      @param reindexed_proteins
-      @param reindexed_peptides
-      @param peptide_identifications
-      @param output
-    */
+      // @param protein_nodes
+      // @param peptide_nodes
+      // @param reindexed_proteins
+      // @param reindexed_peptides
+      // @param peptide_identifications
+      // @param output
+    // */
     // void writeProteinsAndPeptidesmzTab(std::vector<ProteinEntry>& protein_nodes, std::vector<PeptideEntry>& peptide_nodes, std::vector<Size>& reindexed_proteins, std::vector<Size>& reindexed_peptides, std::vector<PeptideIdentification>& peptide_identifications, String& output  );
-    /**
-      @brief Writing peptide table into text file
+    // /**
+      // @brief Writing peptide table into text file
 
-      @param peptides
-      @param reindexed_peptides
-      @param identifications
-      @param output_file
-    */
+      // @param peptides
+      // @param reindexed_peptides
+      // @param identifications
+      // @param output_file
+    // */
     // void writePeptideTable(std::vector<PeptideEntry> & peptides, std::vector<Size> & reindexed_peptides, std::vector<PeptideIdentification> & identifications, String & output_file); // not implemented
-    /**
-      @brief Writing peptide table into text file
+    // /**
+      // @brief Writing peptide table into text file
 
-      @param peptides
-      @param reindexed_peptides
-      @param consensus
-      @param output
-    */
+      // @param peptides
+      // @param reindexed_peptides
+      // @param consensus
+      // @param output
+    // */
     // void writePeptideTable(std::vector<PeptideEntry> & peptides, std::vector<Size> & reindexed_peptides, ConsensusMap & consensus, String & output_file); // not implemented
-    /**
-      @brief Writing protein table into text file
+    // /**
+      // @brief Writing protein table into text file
 
-      @param proteins
-      @param reindexed_proteins
-      @param output_file
-    */
+      // @param proteins
+      // @param reindexed_proteins
+      // @param output_file
+    // */
     // void writeProteinTable(std::vector<ProteinEntry> & proteins, std::vector<Size> & reindexed_proteins, String & output_file); // not implemented
-    /**
-      @brief Writing protein groups into text file
+    // /**
+      // @brief Writing protein groups into text file
 
-      @param isd_groups ISD groups
-      @param msd_groups MSD groups
-      @param output_file Path of output file
-    */
+      // @param isd_groups ISD groups
+      // @param msd_groups MSD groups
+      // @param output_file Path of output file
+    // */
     // void writeProteinGroups(std::vector<ISDGroup> & isd_groups, std::vector<MSDGroup> & msd_groups, String & output_file); // not implemented
 
     /**

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/MorpheusScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/MorpheusScore.h
@@ -51,15 +51,15 @@ struct OPENMS_DLLAPI MorpheusScore
   /// score and subscores
   struct OPENMS_DLLAPI Result
   {
-    Size matches = 0; //< matched theoretical peaks
-    Size n_peaks = 0; //< number of theoretical peaks
-    float score = 0; //< Morpheus score (matched peaks + matched ion current / TIC)
-    float MIC = 0; //< ion current of matches (experimental peaks)
-    float TIC = 0; //< total ion current (experimental peak) 
-    float err = 0; //< average absolute mass error of matched fragments (in Da)
+    Size matches = 0; ///< matched theoretical peaks
+    Size n_peaks = 0; ///< number of theoretical peaks
+    float score = 0; ///< Morpheus score (matched peaks + matched ion current / TIC)
+    float MIC = 0; ///< ion current of matches (experimental peaks)
+    float TIC = 0; ///< total ion current (experimental peak) 
+    float err = 0; ///< average absolute mass error of matched fragments (in Da)
   };
 
-  /// returns Morpheus Score, #matched ions, #total ions, #matched intensities, #total fragment intensities (TIC)
+  /// returns Morpheus Score, \#matched ions, \#total ions, \#matched intensities, \#total fragment intensities (TIC)
   static Result compute(double fragment_mass_tolerance, 
                         bool fragment_mass_tolerance_unit_ppm, 
                         const PeakSpectrum& exp_spectrum, 

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLAlgorithm.h
@@ -49,8 +49,6 @@ namespace OpenMS
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_OpenPepXL OpenPepXL
-
   @brief Search for peptide pairs linked with a labeled cross-linker
 
   This tool performs a search for cross-links in the given mass spectra.

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.h
@@ -49,8 +49,6 @@ namespace OpenMS
   //-------------------------------------------------------------
 
   /**
-    @page TOPP_OpenPepXLLF OpenPepXLLF
-
     @brief Search for cross-linked peptide pairs in tandem MS spectra
 
     This tool performs a search for cross-links in the given mass spectra.

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/XFDRAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/XFDRAlgorithm.h
@@ -50,8 +50,6 @@ namespace OpenMS
   //-------------------------------------------------------------
 
   /**
-      @page TOPP_XFDR XFDR
-
       @brief Calculates false discovery rate estimates on crosslink identifications.
 
       This tool calculates and FDR estimate for crosslink identifications, which are produced by OpenPepXL.
@@ -61,27 +59,7 @@ namespace OpenMS
 
       @experimental This tool is work in progress and usage and input requirements might change.
 
-      <center>
-          <table>
-              <tr>
-                  <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-                  <td VALIGN="middle" ROWSPAN=3> \f$ \longrightarrow \f$ XFDR \f$ \longrightarrow \f$</td>
-                  <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-              </tr>
-              <tr>
-                  <td VALIGN="middle" ALIGN = "center" ROWSPAN=1>  OpenPepXL </td>
-                  <td VALIGN="middle" ALIGN = "center" ROWSPAN=1>  OpenPepXLLF </td>
-                  <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> - </td>
-              </tr>
-              <tr>
-              </tr>
-          </table>
-      </center>
 
-      <B>The command line parameters of this tool are:</B>
-      @verbinclude UTILS_XFDR.cli
-      <B>INI file documentation of this tool:</B>
-      @htmlinclude UTILS_XFDR.html
   */
 
   class OPENMS_DLLAPI XFDRAlgorithm :

--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -69,7 +69,7 @@ namespace OpenMS
   */
   struct Citation
   {
-    std::string authors;    ///< list of authors in AMA style, i.e. <surname> <initials>, ...
+    std::string authors;    ///< list of authors in AMA style, i.e. `<surname>` `<initials>`, ...
     std::string title;      ///< title of article
     std::string when_where; ///< suggested format: journal. year; volume, issue: pages
     std::string doi;        ///< plain DOI (no urls), e.g. 10.1021/pr100177k

--- a/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
@@ -165,9 +165,9 @@ public:
     return data_fg_[pos];
   }
 
-  /** @brief Retrieve a FASTA entry at global position @pos (must not be behind the currently active chunk, but can be smaller)
+  /** @brief Retrieve a FASTA entry at global position @p pos (must not be behind the currently active chunk, but can be smaller)
 
-    This query is fast, if @pos hits the currently active chunk, and slow (read from disk) for
+    This query is fast, if @p pos contains the currently active chunk, and slow (read from disk) for
     earlier entries. Can be used before reaching the end of the file,
     since it will reset the file position after its done reading (if reading from disk is required), but
     must not be used for entries beyond the active chunk (unseen data).

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.h
@@ -43,7 +43,7 @@ namespace OpenMS
           public:
 
           /**
-          @brief Internal structure used in @ref TOPP_SiriusAdapter that is used
+          @brief Internal structure used in @ref UTILS_SiriusAdapter that is used
            for the conversion of the Csi:FingerID output to an mzTab.
 
            CsiAdapterHit:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.h
@@ -43,7 +43,7 @@ namespace OpenMS
           public:
 
           /**
-          @brief Internal structure used in @ref SiriusAdapter that is used
+          @brief Internal structure used in @ref TOPP_SiriusAdapter that is used
            for the conversion of the Csi:FingerID output to an mzTab.
 
            CsiAdapterHit:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SiriusMzTabWriter.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SiriusMzTabWriter.h
@@ -43,7 +43,7 @@ namespace OpenMS
   public:
 
     /**
-    @brief Internal structure used in @ref SiriusAdapter that is used
+    @brief Internal structure used in @ref UTILS_SiriusAdapter that is used
     for the conversion of the sirius output to an mzTab.
     @ingroup ID
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -45,7 +45,8 @@ namespace OpenMS
   namespace Internal
   {
 
-    /**@brief Helper for mzML file format
+    /**
+     * @brief Helper for mzML file format
      *
      * This class provides common structures and re-useable helper functions
      * for parsing the mzML format. These are mainly used by MzMLHandler and MzMLSpectrumDecoder.
@@ -59,9 +60,10 @@ namespace OpenMS
 
     public:
 
-      /**@brief Representation for binary data in mzML
+      /**
+       * @brief Representation for binary data in mzML
        *
-       * Represents data in the <binaryDataArray> tag
+       * Represents data in the `<binaryDataArray>` tag
        *
        **/
       struct BinaryData

--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -947,12 +947,12 @@ public:
       *
       * Additionally this function fills two std::maps with mappings for external usage.
       *
-      * @param[IN] prot_ids Data structure containing protein identifications
-      * @param[IN] peptide_ids Data structure containing peptide identifications
-      * @param[IN] filename Input idXML file name
-      * @param[IN] first_run_inference_only Is all protein inference information stored in the first run?
-      * @param[OUT] map_run_fileidx_2_msfileidx Mapping from (run index, input file index) to experimental design file index. The experimental design file index is either given, or a simplified version created from the input file index on the fly.
-      * @param[OUT] idrun_2_run_index Mapping from protein identification identifier (search engine + date) to run index, i.e. for storing file origins from different runs
+      * @param[in] prot_ids Data structure containing protein identifications
+      * @param[in] peptide_ids Data structure containing peptide identifications
+      * @param[in] filename Input idXML file name
+      * @param[in] first_run_inference_only Is all protein inference information stored in the first run?
+      * @param[out] map_run_fileidx_2_msfileidx Mapping from (run index, input file index) to experimental design file index. The experimental design file index is either given, or a simplified version created from the input file index on the fly.
+      * @param[out] idrun_2_run_index Mapping from protein identification identifier (search engine + date) to run index, i.e. for storing file origins from different runs
       *
       * @return mzTab object
     */

--- a/src/openms/include/OpenMS/KERNEL/ConsensusFeature.h
+++ b/src/openms/include/OpenMS/KERNEL/ConsensusFeature.h
@@ -275,7 +275,7 @@ public:
       @brief Computes the uncharged parent RT & mass, assuming the handles are charge variants.
 
       The position of the feature handles (decharged) is averaged (using intensity as weights if
-      @param intensity_weighted_averaging is true). Intensities are summed up. Charge is set to 0.
+      @p intensity_weighted_averaging is true). Intensities are summed up. Charge is set to 0.
       Mass calculation: If the given features contain a metavalue "dc_charge_adduct_mass" then this
       will be used as adduct mass instead of weight(H+) * charge.
 

--- a/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
+++ b/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
@@ -82,10 +82,10 @@ namespace MSNumpress {
 	
 	/**
 	 * Compute the maximal linear fixed point that prevents integer overflow.
-     *
-	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-     *
+   *
+	 * @param data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+   *
 	 * @return		the linear fixed point safe to use
 	 */
 	double optimalLinearFixedPoint(
@@ -100,9 +100,9 @@ namespace MSNumpress {
      * this and in that case abandon numpress or use optimalLinearFixedPoint
      * which returns the largest safe value.
      *
-	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-	 * @mass_acc	desired m/z accuracy in Th
+	 * @param data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+	 * @param mass_acc	desired m/z accuracy in Th
      *
 	 * @return		the linear fixed point that satisfies the accuracy requirement (or -1 in case of failure).
 	 */
@@ -123,10 +123,10 @@ namespace MSNumpress {
 	 * This encoding is suitable for typical m/z or retention time binary arrays. 
 	 * On a test set, the encoding was empirically show to be accurate to at least 0.002 ppm.
 	 *
-	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-	 * @result		pointer to where resulting bytes should be stored
-	 * @fixedPoint	the scaling factor used for getting the fixed point repr. 
+	 * @param data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+	 * @param result		pointer to where resulting bytes should be stored
+	 * @param fixedPoint	the scaling factor used for getting the fixed point repr. 
 	 * 				This is stored in the binary and automatically extracted
 	 * 				on decoding.
 	 * @return		the number of encoded bytes
@@ -140,8 +140,8 @@ namespace MSNumpress {
 	/**
 	 * Calls lower level encodeLinear while handling vector sizes appropriately
 	 *
-	 * @data		vector of doubles to be encoded
-	 * @result		vector of resulting bytes (will be resized to the number of bytes)
+	 * @param data		vector of doubles to be encoded
+	 * @param result		vector of resulting bytes (will be resized to the number of bytes)
 	 */
 	void encodeLinear(
 		const std::vector<double> &data, 
@@ -157,10 +157,10 @@ namespace MSNumpress {
 	 * that the last encoded int does not use the last byte in the data. In addition the last encoded 
 	 * int need to use either the last halfbyte, or the second last followed by a 0x0 halfbyte. 
 	 *
-	 * @data		pointer to array of bytes to be decoded (need memorycont. repr.)
-	 * @dataSize	number of bytes from *data to decode
-	 * @result		pointer to were resulting doubles should be stored
-	 * @return		the number of decoded doubles, or -1 if dataSize < 4 or 4 < dataSize < 8
+	 * @param data		pointer to array of bytes to be decoded (need memorycont. repr.)
+	 * @param dataSize	number of bytes from *data to decode
+	 * @param result		pointer to were resulting doubles should be stored
+	 * @param return		the number of decoded doubles, or -1 if dataSize < 4 or 4 < dataSize < 8
 	 */
 	size_t decodeLinear(
 		const unsigned char *data,
@@ -174,8 +174,8 @@ namespace MSNumpress {
 	 * that the last encoded int does not use the last byte in the data. In addition the last encoded 
 	 * int need to use either the last halfbyte, or the second last followed by a 0x0 halfbyte. 
 	 *
-	 * @data		vector of bytes to be decoded
-	 * @result		vector of resulting double (will be resized to the number of doubles)
+	 * @param data		vector of bytes to be decoded
+	 * @param result		vector of resulting double (will be resized to the number of doubles)
 	 */
 	void decodeLinear(
 		const std::vector<unsigned char> &data,
@@ -192,9 +192,9 @@ namespace MSNumpress {
 	 * This encoding is suitable for typical m/z or retention time binary arrays, and is
 	 * intended to be used before zlib compression to improve compression.
 	 *
-	 * @data		pointer to array of doubles to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-	 * @result		pointer to were resulting bytes should be stored
+	 * @param data		pointer to array of doubles to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+	 * @param result		pointer to were resulting bytes should be stored
 	 */
 	size_t encodeSafe(
 		const double *data, 
@@ -209,9 +209,9 @@ namespace MSNumpress {
 	 *
 	 * Might throw const char* is something goes wrong during decoding.
 	 *
-	 * @data		pointer to array of bytes to be decoded (need memorycont. repr.)
-	 * @dataSize	number of bytes from *data to decode
-	 * @result		pointer to were resulting doubles should be stored
+	 * @param data		pointer to array of bytes to be decoded (need memorycont. repr.)
+	 * @param dataSize	number of bytes from *data to decode
+	 * @param result		pointer to were resulting doubles should be stored
 	 * @return		the number of decoded bytes
 	 */
 	size_t decodeSafe(
@@ -229,9 +229,9 @@ namespace MSNumpress {
 	 * The resulting binary is maximally dataSize * 5 bytes, but much less if the 
 	 * data is close to 0 on average.
 	 *
-	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-	 * @result		pointer to where resulting bytes should be stored
+	 * @param data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+	 * @param result		pointer to where resulting bytes should be stored
 	 * @return		the number of encoded bytes
 	 */
 	size_t encodePic(
@@ -242,8 +242,8 @@ namespace MSNumpress {
 	/**
 	 * Calls lower level encodePic while handling vector sizes appropriately
 	 *
-	 * @data		vector of doubles to be encoded
-	 * @result		vector of resulting bytes (will be resized to the number of bytes)
+	 * @param data		vector of doubles to be encoded
+	 * @param result		vector of resulting bytes (will be resized to the number of bytes)
 	 */
 	void encodePic(
 		const std::vector<double> &data,
@@ -258,9 +258,9 @@ namespace MSNumpress {
 	 * that the last encoded int does not use the last byte in the data. In addition the last encoded 
 	 * int need to use either the last halfbyte, or the second last followed by a 0x0 halfbyte. 
 	 *
-	 * @data		pointer to array of bytes to be decoded (need memorycont. repr.)
-	 * @dataSize	number of bytes from *data to decode
-	 * @result		pointer to were resulting doubles should be stored
+	 * @param data		pointer to array of bytes to be decoded (need memorycont. repr.)
+	 * @param dataSize	number of bytes from *data to decode
+	 * @param result		pointer to were resulting doubles should be stored
 	 * @return		the number of decoded doubles
 	 */
 	size_t decodePic(
@@ -275,7 +275,7 @@ namespace MSNumpress {
 	 * that the last encoded int does not use the last byte in the data. In addition the last encoded 
 	 * int need to use either the last halfbyte, or the second last followed by a 0x0 halfbyte. 
 	 *
-	 * @data		vector of bytes to be decoded
+	 * @param data		vector of bytes to be decoded
 	 * @result		vector of resulting double (will be resized to the number of doubles)
 	 */
 	void decodePic(
@@ -297,9 +297,9 @@ namespace MSNumpress {
 	 *
 	 * the result vector is exactly |data| * 2 + 8 bytes long
 	 *
-	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
-	 * @dataSize	number of doubles from *data to encode
-	 * @result		pointer to were resulting bytes should be stored
+	 * @param data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @param dataSize	number of doubles from *data to encode
+	 * @param result		pointer to were resulting bytes should be stored
 	 * @return		the number of encoded bytes
 	 */
 	size_t encodeSlof(
@@ -311,7 +311,7 @@ namespace MSNumpress {
 	/**
 	 * Calls lower level encodeSlof while handling vector sizes appropriately
 	 *
-	 * @data		vector of doubles to be encoded
+	 * @param data		vector of doubles to be encoded
 	 * @result		vector of resulting bytes (will be resized to the number of bytes)
 	 */
 	void encodeSlof(
@@ -326,9 +326,9 @@ namespace MSNumpress {
 	 *
 	 * Note that this method may throw a const char* if it deems the input data to be corrupt.
 	 *
-	 * @data		pointer to array of bytes to be decoded (need memorycont. repr.)
-	 * @dataSize	number of bytes from *data to decode
-	 * @result		pointer to were resulting doubles should be stored
+	 * @param data		pointer to array of bytes to be decoded (need memorycont. repr.)
+	 * @param dataSize	number of bytes from *data to decode
+	 * @param result		pointer to were resulting doubles should be stored
 	 * @return		the number of decoded doubles
 	 */
 	size_t decodeSlof(
@@ -341,8 +341,8 @@ namespace MSNumpress {
 	 *
 	 * Note that this method may throw a const char* if it deems the input data to be corrupt.
 	 *
-	 * @data		vector of bytes to be decoded
-	 * @result		vector of resulting double (will be resized to the number of doubles)
+	 * @param data		vector of bytes to be decoded
+	 * @param result		vector of resulting double (will be resized to the number of doubles)
 	 */
 	void decodeSlof(
 		const std::vector<unsigned char> &data,

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -486,7 +486,7 @@ namespace OpenMS
                              MoleculeType expected_type) const;
 
     /**
-      @brief Helper functor for adding processing steps to elements in a @t boost::multi_index_container structure
+      @brief Helper functor for adding processing steps to elements in a @em boost::multi_index_container structure
 
       The validity of the processing step reference cannot be checked here!
     */
@@ -507,7 +507,7 @@ namespace OpenMS
     };
 
     /**
-      @brief Helper functor for adding scores to elements in a @t boost::multi_index_container structure
+      @brief Helper functor for adding scores to elements in a @em boost::multi_index_container structure
 
       The validity of the score type reference cannot be checked here!
     */
@@ -537,7 +537,7 @@ namespace OpenMS
     };
 
     /**
-      @brief Helper functor for removing invalid parent matches from elements in a @t boost::multi_index_container structure
+      @brief Helper functor for removing invalid parent matches from elements in a @em boost::multi_index_container structure
 
       Used during filtering, to update parent matches after parents have been removed.
     */

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -485,7 +485,7 @@ namespace OpenMS
     void checkParentMatches_(const ParentMatches& matches,
                              MoleculeType expected_type) const;
 
-    /*!
+    /**
       @brief Helper functor for adding processing steps to elements in a @t boost::multi_index_container structure
 
       The validity of the processing step reference cannot be checked here!
@@ -506,7 +506,7 @@ namespace OpenMS
       ProcessingStepRef step_ref;
     };
 
-    /*!
+    /**
       @brief Helper functor for adding scores to elements in a @t boost::multi_index_container structure
 
       The validity of the score type reference cannot be checked here!
@@ -536,7 +536,7 @@ namespace OpenMS
       double value;
     };
 
-    /*!
+    /**
       @brief Helper functor for removing invalid parent matches from elements in a @t boost::multi_index_container structure
 
       Used during filtering, to update parent matches after parents have been removed.
@@ -562,7 +562,7 @@ namespace OpenMS
     };
 
 
-    /// Helper function for adding entries (derived from ScoredProcessingResult) to a @t boost::multi_index_container structure
+    /// Helper function for adding entries (derived from ScoredProcessingResult) to a @em boost::multi_index_container structure
     template <typename ContainerType, typename ElementType>
     typename ContainerType::iterator insertIntoMultiIndex_(
       ContainerType& container, const ElementType& element)

--- a/src/openms/include/OpenMS/QC/Contaminants.h
+++ b/src/openms/include/OpenMS/QC/Contaminants.h
@@ -55,13 +55,13 @@ namespace OpenMS
     /// structure for storing results
     struct ContaminantsSummary
     {
-      ///(# contaminants in assigned/ #peptides in assigned)
+      ///(\#contaminants in assigned/ \#peptides in assigned)
       double assigned_contaminants_ratio;
       
-      ///(# contaminants in unassigned/ #peptides in unassigned)
+      ///(\#contaminants in unassigned/ \#peptides in unassigned)
       double unassigned_contaminants_ratio;
       
-      ///(# all contaminants/ #peptides in all)
+      ///(\#all contaminants/ \#peptides in all)
       double all_contaminants_ratio;
       
       ///(intensity of contaminants in assigned/ intensity of peptides in assigned)

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -107,8 +107,6 @@ namespace OpenMS
     tools_map["NoiseFilterGaussian"] = Internal::ToolDescription("NoiseFilterGaussian", "Signal processing and preprocessing");
     tools_map["NoiseFilterSGolay"] = Internal::ToolDescription("NoiseFilterSGolay", "Signal processing and preprocessing");
     tools_map["OMSSAAdapter"] = Internal::ToolDescription("OMSSAAdapter", "Identification");
-    tools_map["OpenPepXL"] = Internal::ToolDescription("OpenPepXL", "Identification");
-    tools_map["OpenPepXLLF"] = Internal::ToolDescription("OpenPepXLLF", "Identification");
     tools_map["OpenSwathAnalyzer"] = Internal::ToolDescription("OpenSwathAnalyzer", "Targeted Experiments");
     tools_map["OpenSwathAssayGenerator"] = Internal::ToolDescription("OpenSwathAssayGenerator", "Targeted Experiments");
     tools_map["OpenSwathChromatogramExtractor"] = Internal::ToolDescription("OpenSwathChromatogramExtractor", "Targeted Experiments");
@@ -148,7 +146,6 @@ namespace OpenMS
     tools_map["SpectraMerger"] = Internal::ToolDescription("SpectraMerger", "Signal processing and preprocessing");
     tools_map["TextExporter"] = Internal::ToolDescription("TextExporter", "File Handling");
     tools_map["TOFCalibration"] = Internal::ToolDescription("TOFCalibration", "Signal processing and preprocessing");
-    tools_map["XFDR"] = Internal::ToolDescription("XFDR", "ID Processing");
     tools_map["XTandemAdapter"] = Internal::ToolDescription("XTandemAdapter", "Identification");
     // STOP! insert your tool in alphabetical order for easier maintenance (only tools requiring the GUI lib should be added below)
 
@@ -224,6 +221,8 @@ namespace OpenMS
     util_map["MultiplexResolver"] = Internal::ToolDescription("MultiplexResolver", util_category);
     util_map["MzMLSplitter"] = Internal::ToolDescription("MzMLSplitter", util_category);
     util_map["NucleicAcidSearchEngine"] = Internal::ToolDescription("NucleicAcidSearchEngine", util_category);
+    util_map["OpenPepXL"] = Internal::ToolDescription("OpenPepXL", "Identification");
+    util_map["OpenPepXLLF"] = Internal::ToolDescription("OpenPepXLLF", "Identification");
     util_map["OpenSwathWorkflow"] = Internal::ToolDescription("OpenSwathWorkflow", util_category);
     util_map["OpenSwathRewriteToFeatureXML"] = Internal::ToolDescription("OpenSwathRewriteToFeatureXML", "Targeted Experiments");
     util_map["OpenSwathFileSplitter"] = Internal::ToolDescription("OpenSwathFileSplitter", "Targeted Experiments");
@@ -254,6 +253,7 @@ namespace OpenMS
     util_map["SvmTheoreticalSpectrumGeneratorTrainer"] = Internal::ToolDescription("SvmTheoreticalSpectrumGeneratorTrainer", util_category);
     util_map["TICCalculator"] = Internal::ToolDescription("TICCalculator", util_category);
     util_map["TransformationEvaluation"] = Internal::ToolDescription("TransformationEvaluation", util_category);
+    util_map["XFDR"] = Internal::ToolDescription("XFDR", "ID Processing");
     util_map["XMLValidator"] = Internal::ToolDescription("XMLValidator", util_category);
     // STOP! insert your tool in alphabetical order for easier maintenance (only tools requiring the GUI lib should be added below)
 

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -107,6 +107,8 @@ namespace OpenMS
     tools_map["NoiseFilterGaussian"] = Internal::ToolDescription("NoiseFilterGaussian", "Signal processing and preprocessing");
     tools_map["NoiseFilterSGolay"] = Internal::ToolDescription("NoiseFilterSGolay", "Signal processing and preprocessing");
     tools_map["OMSSAAdapter"] = Internal::ToolDescription("OMSSAAdapter", "Identification");
+    tools_map["OpenPepXL"] = Internal::ToolDescription("OpenPepXL", "Identification");
+    tools_map["OpenPepXLLF"] = Internal::ToolDescription("OpenPepXLLF", "Identification");
     tools_map["OpenSwathAnalyzer"] = Internal::ToolDescription("OpenSwathAnalyzer", "Targeted Experiments");
     tools_map["OpenSwathAssayGenerator"] = Internal::ToolDescription("OpenSwathAssayGenerator", "Targeted Experiments");
     tools_map["OpenSwathChromatogramExtractor"] = Internal::ToolDescription("OpenSwathChromatogramExtractor", "Targeted Experiments");
@@ -146,6 +148,7 @@ namespace OpenMS
     tools_map["SpectraMerger"] = Internal::ToolDescription("SpectraMerger", "Signal processing and preprocessing");
     tools_map["TextExporter"] = Internal::ToolDescription("TextExporter", "File Handling");
     tools_map["TOFCalibration"] = Internal::ToolDescription("TOFCalibration", "Signal processing and preprocessing");
+    tools_map["XFDR"] = Internal::ToolDescription("XFDR", "ID Processing");
     tools_map["XTandemAdapter"] = Internal::ToolDescription("XTandemAdapter", "Identification");
     // STOP! insert your tool in alphabetical order for easier maintenance (only tools requiring the GUI lib should be added below)
 
@@ -221,8 +224,6 @@ namespace OpenMS
     util_map["MultiplexResolver"] = Internal::ToolDescription("MultiplexResolver", util_category);
     util_map["MzMLSplitter"] = Internal::ToolDescription("MzMLSplitter", util_category);
     util_map["NucleicAcidSearchEngine"] = Internal::ToolDescription("NucleicAcidSearchEngine", util_category);
-    util_map["OpenPepXL"] = Internal::ToolDescription("OpenPepXL", "Identification");
-    util_map["OpenPepXLLF"] = Internal::ToolDescription("OpenPepXLLF", "Identification");
     util_map["OpenSwathWorkflow"] = Internal::ToolDescription("OpenSwathWorkflow", util_category);
     util_map["OpenSwathRewriteToFeatureXML"] = Internal::ToolDescription("OpenSwathRewriteToFeatureXML", "Targeted Experiments");
     util_map["OpenSwathFileSplitter"] = Internal::ToolDescription("OpenSwathFileSplitter", "Targeted Experiments");
@@ -253,7 +254,6 @@ namespace OpenMS
     util_map["SvmTheoreticalSpectrumGeneratorTrainer"] = Internal::ToolDescription("SvmTheoreticalSpectrumGeneratorTrainer", util_category);
     util_map["TICCalculator"] = Internal::ToolDescription("TICCalculator", util_category);
     util_map["TransformationEvaluation"] = Internal::ToolDescription("TransformationEvaluation", util_category);
-    util_map["XFDR"] = Internal::ToolDescription("XFDR", "ID Processing");
     util_map["XMLValidator"] = Internal::ToolDescription("XMLValidator", util_category);
     // STOP! insert your tool in alphabetical order for easier maintenance (only tools requiring the GUI lib should be added below)
 

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -93,8 +93,6 @@ namespace OpenMS
 
       @todo Allow reordering the layer list by drag-and-drop (Hiwi, Johannes)
 
-      @htmlinclude OpenMS_SpectrumCanvas.parameters
-
       @ingroup SpectrumWidgets
   */
   class OPENMS_GUI_DLLAPI SpectrumCanvas :

--- a/src/topp/DTAExtractor.cpp
+++ b/src/topp/DTAExtractor.cpp
@@ -46,29 +46,30 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_DTAExtractor DTAExtractor
+@page TOPP_DTAExtractor DTAExtractor
 
-    @brief Extracts scans of an mzML file to several files in DTA format.
+@brief Extracts scans of an mzML file to several files in DTA format.
 <center>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-            <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ DTAExtractor \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any signal-/preprocessing tool </td>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> - </td>
-        </tr>
-    </table>
+<table>
+    <tr>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+        <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ DTAExtractor \f$ \longrightarrow \f$</td>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
+    </tr>
+    <tr>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any signal-/preprocessing tool </td>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> - </td>
+    </tr>
+</table>
 </center>
-    The retention time, the m/z ratio (for MS level > 1) and the file extension are appended to the output file name.
-    You can limit the exported spectra by m/z range, retention time range or MS level.
 
-    <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_DTAExtractor.cli
-    <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_DTAExtractor.html
+The retention time, the m/z ratio (for MS level > 1) and the file extension are appended to the output file name.
+You can limit the exported spectra by m/z range, retention time range or MS level.
+
+<B>The command line parameters of this tool are:</B>
+@verbinclude TOPP_DTAExtractor.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_DTAExtractor.html
 */
 
 // We do not want this class to show up in the docu:

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -57,29 +57,29 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_EICExtractor EICExtractor
+@page TOPP_EICExtractor EICExtractor
 
-    @brief Extracts EICs from an MS experiment, in order to quantify analytes at a given position
+@brief Extracts EICs from an MS experiment, in order to quantify analytes at a given position
 
 <CENTER>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-            <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ EICExtractor \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_FileConverter</td>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> statistical tools, e.g., Excel, R, ... </td>
-        </tr>
-    </table>
+<table>
+    <tr>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+        <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ EICExtractor \f$ \longrightarrow \f$</td>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
+    </tr>
+    <tr>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_FileConverter</td>
+  <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> statistical tools, e.g., Excel, R, ... </td>
+    </tr>
+</table>
 </CENTER>
 
-  Use this instead of FeatureFinder, if you have bad features  which are not recognized (much noise etc)
-    or if you want to quantify non-peptides.
+Use this instead of FeatureFinder, if you have bad features  which are not recognized (much noise etc)
+or if you want to quantify non-peptides.
 
-    The input EDTA file specifies where to search for signal in RT and m/z.
-    Retention time is in seconds [s]. A third intensity column is ignored but needs to be present.
+The input EDTA file specifies where to search for signal in RT and m/z.
+Retention time is in seconds [s]. A third intensity column is ignored but needs to be present.
 
 Example (replace space separator with &lt;TAB&gt;):<br>
 @code
@@ -90,25 +90,25 @@ RT m/z int
 59.2 431.85 0
 @endcode
 
-  RT positions can also be automatically generated using the 'auto-RT' functionality, which can be enabled by the flag 'auto_rt:enabled'.
-  All EDTA input lines with negative RT and some m/z values are replaced by 'n' other lines, where the m/z value is identical
-  and the RT column is replaced by of the 'n' RT estimates as discovered by the auto-RT functionality.
-  This allows you to specify only the expected m/z positions and let the auto-RT function handle the RT positions.
-  Info: auto-RT positions are only generated once from the FIRST mzML input file. All other mzML input files are expected to
-        have similar RT positions!
-  To debug auto-RT, you can specify an mzML output file (see 'auto_rt:out_debug_TIC' option) which will contain four single spectra which represent:
-    1. the TIC (of the first mzML input file)
-    2. the smoothed version of #1
-    3. the signal/noise (S/N) ratio of #2
-    4. the centroided version of #2 (not #3!)
-  Since you can specify the smoothing aggressiveness using 'auto_rt:FHWM' and
-  the minimum S/N theshold for centroided using 'auto_rt:SNThreshold', this should give you all information needed to set the best parameters which fit your data.
-  Sensible default thresholds have been chosen though, such that adaption should only be required in extreme cases.
+RT positions can also be automatically generated using the 'auto-RT' functionality, which can be enabled by the flag 'auto_rt:enabled'.
+All EDTA input lines with negative RT and some m/z values are replaced by 'n' other lines, where the m/z value is identical
+and the RT column is replaced by of the 'n' RT estimates as discovered by the auto-RT functionality.
+This allows you to specify only the expected m/z positions and let the auto-RT function handle the RT positions.
+Info: auto-RT positions are only generated once from the FIRST mzML input file. All other mzML input files are expected to
+      have similar RT positions!
+To debug auto-RT, you can specify an mzML output file (see 'auto_rt:out_debug_TIC' option) which will contain four single spectra which represent:
+  1. the TIC (of the first mzML input file)
+  2. the smoothed version of #1
+  3. the signal/noise (S/N) ratio of #2
+  4. the centroided version of #2 (not #3!)
+Since you can specify the smoothing aggressiveness using 'auto_rt:FHWM' and
+the minimum S/N theshold for centroided using 'auto_rt:SNThreshold', this should give you all information needed to set the best parameters which fit your data.
+Sensible default thresholds have been chosen though, such that adaption should only be required in extreme cases.
 
-    The intensity reported is the MAXIMUM intensity of all peaks each within the given tolerances for this row's position.
+The intensity reported is the MAXIMUM intensity of all peaks each within the given tolerances for this row's position.
 
-  As output, one file in text format is given. It contains the actual RT and m/z positions of the data,
-  as well as RT delta (in [s]) and m/z delta (in ppm) from the expected position as specified in the EDTA file or as found by the auto-RT feature.
+As output, one file in text format is given. It contains the actual RT and m/z positions of the data,
+as well as RT delta (in [s]) and m/z delta (in ppm) from the expected position as specified in the EDTA file or as found by the auto-RT feature.
 
 <pre>
   RT	  - expected RT position (in [s])

--- a/src/topp/FalseDiscoveryRate.cpp
+++ b/src/topp/FalseDiscoveryRate.cpp
@@ -75,7 +75,7 @@ using namespace std;
     This should be a serious concern, since it indicates a possible problem with the target/decoy annotation step (@ref TOPP_PeptideIndexer), e.g. due to a misconfigured database.
 
     @note FalseDiscoveryRate only annotates peptides and proteins with their FDR. By setting FDR:PSM or FDR:protein the maximum q-value (e.g., 0.05 corresponds to an FDR of 5%) can be controlled on the PSM and protein level.
-    Alternatively, FDR filtering can be performed in the @ref IDFilter tool by setting score:pep and score:prot to the maximum q-value. After potential filtering, associations are
+    Alternatively, FDR filtering can be performed in the @ref TOPP_IDFilter tool by setting score:pep and score:prot to the maximum q-value. After potential filtering, associations are
     automatically updated and unreferenced proteins/peptides removed based on the advanced cleanup parameters.
 
     @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -75,7 +75,7 @@ using namespace std;
   Mass traces alone would allow for further analysis such as metabolite ID or
   statistical evaluation. However, in general, monoisotopic mass traces are
   accompanied by satellite C13 peaks and thus may render the analysis more
-  difficult. @ref FeatureFinderMetabo fulfills a further data reduction step by
+  difficult. FeatureFinderMetabo fulfills a further data reduction step by
   assembling compatible mass traces to metabolite features (that is, all mass
   traces originating from one metabolite). To this end, multiple metabolite
   hypotheses are formulated and scored according to how well differences in RT (optional),

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -281,4 +281,4 @@ int main(int argc, const char** argv)
   return tool.main(argc, argv);
 }
 
-//@endcond
+///@endcond

--- a/src/topp/FidoAdapter.cpp
+++ b/src/topp/FidoAdapter.cpp
@@ -69,10 +69,10 @@ using namespace std;
      </tr>
     <tr>
       <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_PeptideIndexer </td>
-      <td VALIGN="middle" ALIGN="center" ROWSPAN=3> @ref TOPP_ProteinQuantifier\n(via @p protein_groups parameter) </td>
+      <td VALIGN="middle" ALIGN="center" ROWSPAN=3> @ref TOPP_ProteinQuantifier \n(via @p protein_groups parameter) </td>
     </tr>
     <tr>
-      <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_IDPosteriorErrorProbability\n(with @p prob_correct option) </td>
+      <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_IDPosteriorErrorProbability \n(with @p prob_correct option) </td>
     </tr>
     <tr>
       <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref UTILS_IDScoreSwitcher </td>
@@ -90,7 +90,7 @@ using namespace std;
 
  <b>Input format:</b>
 
- Care has to be taken to provide suitable input data for this adapter. In the peptide/protein identification results (e.g. coming from a database search engine), the proteins have to be annotated with target/decoy meta data. To achieve this, run @ref TOPP_PeptideIndexer.@n
+ Care has to be taken to provide suitable input data for this adapter. In the peptide/protein identification results (e.g. coming from a database search engine), the proteins have to be annotated with target/decoy meta data. To achieve this, run @ref TOPP_PeptideIndexer .@n
  In addition, the scores for peptide hits in the input data have to be posterior probabilities - as produced e.g. by PeptideProphet in the TPP or by @ref TOPP_IDPosteriorErrorProbability (with the @p prob_correct option switched on) in OpenMS. If scores are found to be posterior error probabilities (PEPs, lower is better), they are converted to posterior probabilities (higher is better) using "1 - PEP".@n
  If the posterior (error) probabilities are stored in user parameters ("UserParam") in the idXML instead of in the score fields, @ref UTILS_IDScoreSwitcher can be used to rewrite the scores. (This may be the case e.g. if @ref TOPP_FalseDiscoveryRate and @ref TOPP_IDFilter were applied for FDR filtering prior to protein inference.)
 

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -63,69 +63,68 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_FileFilter FileFilter
+@page TOPP_FileFilter FileFilter
 
-    @brief Extracts portions of the data from an mzML, featureXML or consensusXML file.
+@brief Extracts portions of the data from an mzML, featureXML or consensusXML file.
 <center>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-            <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ FileFilter \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any tool yielding output @n in mzML, featureXML @n or consensusXML format</td>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any tool that profits on reduced input </td>
-        </tr>
+<table>
+    <tr>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+        <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ FileFilter \f$ \longrightarrow \f$</td>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
+    </tr>
+    <tr>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any tool yielding output @n in mzML, featureXML @n or consensusXML format</td>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> any tool that profits on reduced input </td>
+    </tr>
 
-    </table>
+</table>
 </center>
-    With this tool it is possible to extract m/z, retention time and intensity ranges from an input file
-    and to write all data that lies within the given ranges to an output file.
+With this tool it is possible to extract m/z, retention time and intensity ranges from an input file
+and to write all data that lies within the given ranges to an output file.
 
-    Depending on the input file type, additional specific operations are possible:
-    - mzML
-        - extract spectra of a certain MS level
-        - filter by signal-to-noise estimation
-        - filter by scan mode of the spectra
-        - filter by scan polarity of the spectra
-    - remove MS2 scans whose precursor matches identifications (from an idXML file in 'id:blacklist')
-    - featureXML
-        - filter by feature charge
-        - filter by feature size (number of subordinate features)
-        - filter by overall feature quality
-    - consensusXML
-        - filter by size (number of elements in consensus features)
-        - filter by consensus feature charge
-        - filter by map (extracts specified maps and re-evaluates consensus centroid)@n e.g. FileFilter -map 2 3 5 -in file1.consensusXML -out file2.consensusXML@n If a single map is specified, the feature itself can be extracted.@n e.g. FileFilter -map 5 -in file1.consensusXML -out file2.featureXML
-    - featureXML / consensusXML:
-    - remove items with a certain meta value annotation. Allowing for >, < and = comparisons. List types are compared by length, not content. Integer, Double and String are compared using their build-in operators.
-        - filter sequences, e.g. "LYSNLVER" or the modification "(Phospho)"@n e.g. FileFilter -id:sequences_whitelist Phospho -in file1.consensusXML -out file2.consensusXML
-        - filter accessions, e.g. "sp|P02662|CASA1_BOVIN"
-        - remove features with annotations
-        - remove features without annotations
-        - remove unassigned peptide identifications
-        - filter id with best score of features with multiple peptide identifications@n e.g. FileFilter -id:remove_unannotated_features -id:remove_unassigned_ids -id:keep_best_score_id -in file1.featureXML -out file2.featureXML
-        - remove features with id clashes (different sequences mapped to one feature)
+Depending on the input file type, additional specific operations are possible:
+- mzML
+    - extract spectra of a certain MS level
+    - filter by signal-to-noise estimation
+    - filter by scan mode of the spectra
+    - filter by scan polarity of the spectra
+- remove MS2 scans whose precursor matches identifications (from an idXML file in 'id:blacklist')
+- featureXML
+    - filter by feature charge
+    - filter by feature size (number of subordinate features)
+    - filter by overall feature quality
+- consensusXML
+    - filter by size (number of elements in consensus features)
+    - filter by consensus feature charge
+    - filter by map (extracts specified maps and re-evaluates consensus centroid)@n e.g. FileFilter -map 2 3 5 -in file1.consensusXML -out file2.consensusXML@n If a single map is specified, the feature itself can be extracted.@n e.g. FileFilter -map 5 -in file1.consensusXML -out file2.featureXML
+- featureXML / consensusXML:
+- remove items with a certain meta value annotation. Allowing for >, < and = comparisons. List types are compared by length, not content. Integer, Double and String are compared using their build-in operators.
+    - filter sequences, e.g. "LYSNLVER" or the modification "(Phospho)"@n e.g. FileFilter -id:sequences_whitelist Phospho -in file1.consensusXML -out file2.consensusXML
+    - filter accessions, e.g. "sp|P02662|CASA1_BOVIN"
+    - remove features with annotations
+    - remove features without annotations
+    - remove unassigned peptide identifications
+    - filter id with best score of features with multiple peptide identifications@n e.g. FileFilter -id:remove_unannotated_features -id:remove_unassigned_ids -id:keep_best_score_id -in file1.featureXML -out file2.featureXML
+    - remove features with id clashes (different sequences mapped to one feature)
 
-    The priority of the id-flags is (decreasing order): remove_annotated_features / remove_unannotated_features -> remove_clashes -> keep_best_score_id -> sequences_whitelist / accessions_whitelist
+The priority of the id-flags is (decreasing order): remove_annotated_features / remove_unannotated_features -> remove_clashes -> keep_best_score_id -> sequences_whitelist / accessions_whitelist
 
-    MS2 and higher spectra can be filtered according to precursor m/z (see 'peak_options:pc_mz_range'). This flag can be combined with 'rt' range to filter precursors by RT and m/z.
-    If you want to extract an MS1 region with untouched MS2 spectra included, you will need to split the dataset by MS level, then use the 'mz' option for MS1 data and 'peak_options:pc_mz_range' for MS2 data. Afterwards merge the two files again. RT can be filtered at any step.
+MS2 and higher spectra can be filtered according to precursor m/z (see 'peak_options:pc_mz_range'). This flag can be combined with 'rt' range to filter precursors by RT and m/z.
+If you want to extract an MS1 region with untouched MS2 spectra included, you will need to split the dataset by MS level, then use the 'mz' option for MS1 data and 'peak_options:pc_mz_range' for MS2 data. Afterwards merge the two files again. RT can be filtered at any step.
 
-    @note For filtering peptide/protein identification data, see the @ref TOPP_IDFilter tool.
+@note For filtering peptide/protein identification data, see the @ref TOPP_IDFilter tool.
 
-    @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
+@note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
 
-    <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_FileFilter.cli
-    <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_FileFilter.html
+<B>The command line parameters of this tool are:</B>
+@verbinclude TOPP_FileFilter.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_FileFilter.html
 
-    For the parameters of the S/N algorithm section see the class documentation there: @n
-        @ref OpenMS::SignalToNoiseEstimatorMedian "peak_options:sn"@n
+For the parameters of the S/N algorithm section see the class documentation there: @n
+    @ref OpenMS::SignalToNoiseEstimatorMedian "peak_options:sn"@n
 
-    @todo add tests for selecting modes (port remove modes) (Andreas)
 */
 
 // We do not want this class to show up in the docu:

--- a/src/topp/IDFileConverter.cpp
+++ b/src/topp/IDFileConverter.cpp
@@ -65,9 +65,9 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_IDFileConverter IDFileConverter
+@page TOPP_IDFileConverter IDFileConverter
 
-    @brief Converts peptide/protein identification engine file formats.
+@brief Converts peptide/protein identification engine file formats.
 
 <CENTER>
     <table>
@@ -111,13 +111,13 @@ of OpenPepXL / OpenPepXLLF with the xQuest / xProphet / xTract pipeline. It will
 
 <B>Details on additional parameters:</B>
 
-@p mz_file:@n
+@p mz_file: @n
 Some search engine output files (like pepXML, mascotXML, Sequest .out files) may not contain retention times, only scan numbers or spectrum IDs. To be able to look up the actual RT values, the raw file has to be provided using the parameter @p mz_file. (If the identification results should be used later to annotate feature maps or consensus maps, it is critical that they contain RT values. See also @ref TOPP_IDMapper.)
 
-@p mz_name:@n
+@p mz_name: @n
 pepXML files can contain results from multiple experiments. However, the idXML format does not support this. The @p mz_name parameter (or @p mz_file, if given) thus serves to define what parts to extract from the pepXML.
 
-@p scan_regex:@n
+@p scan_regex: @n
 This advanced parameter defines a spectrum reference format via a Perl-style regular expression. The reference format connects search hits to the MS2 spectra that were searched, and may be needed to look up e.g. retention times in the raw data (@p mz_file). See the documentation of class @ref OpenMS::SpectrumLookup "SpectrumLookup" for details on how to specify spectrum reference formats. Note that it is not necessary to look up any information in the raw data if that information can be extracted directly from the spectrum reference, in which case @p mz_file is not needed.@n
 For Mascot results exported to (Mascot) XML, scan numbers that can be used to look up retention times (via @p mz_file) should be given in the "pep_scan_title" XML elements, but the format can vary. Some default formats are defined in the Mascot XML reader, but if those fail to extract the scan numbers, @p scan_regex can be used to overwrite the defaults.@n
 For pepXML, supplying @p scan_regex may be necessary for files exported from Mascot, but only if the default reference formats (same as for Mascot XML) do not match. The spectrum references to which @p scan_regex is applied are read from the "spectrum" attribute of the "spectrum_query" elements.@n

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -670,3 +670,5 @@ int main(int argc, const char** argv)
   LuciphorAdapter tool;
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -768,3 +768,5 @@ int main(int argc, const char** argv)
 
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/topp/MapAlignerTreeGuided.cpp
+++ b/src/topp/MapAlignerTreeGuided.cpp
@@ -46,61 +46,51 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_MapAlignerTreeGuided MapAlignerTreeGuided
+@page TOPP_MapAlignerTreeGuided MapAlignerTreeGuided
 
-  @brief Corrects retention time distortions between maps, using information from peptides identified in different maps.
+@brief Corrects retention time distortions between maps, using information from peptides identified in different maps.
 
-<CENTER>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential predecessor tools </td>
-            <td VALIGN= "middle" ROWSPAN=2> \f$ \longrightarrow \f$ MapAlignerTreeGuided \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> @ref TOPP_IDMapper @n (or any other source of FDR-filtered featureXMLs) </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> @ref TOPP_FeatureLinkerUnlabeledKD or @n @ref TOPP_FeatureLinkerUnlabeledQT </td>
-        </tr>
-    </table>
-</CENTER>
 
-    This tool provides an algorithm to align the retention time scales of multiple input files, correcting shifts and
-    distortions between them. Retention time adjustment may be necessary to correct for chromatography differences e.g.
-    before data from multiple LC-MS runs can be combined (feature grouping), or when one run should be annotated with
-    peptide identifications obtained in a different run.
+potential predecessor tools                                              | -> MapAlignerTreeGuided -> | potential successor tools
+------------------------------------------------------------------------ | -------------------------- | -------------------------
+@ref TOPP_IDMapper @n (or any other source of FDR-filtered featureXMLs)  | ^                          | @ref TOPP_FeatureLinkerUnlabeledKD or @n @ref TOPP_FeatureLinkerUnlabeledQT 
 
-    All map alignment tools (MapAligner...) collect retention time data from the input files and - by fitting a model to
-    this data - compute transformations that map all runs to a common retention time scale. They can apply the transformations
-    right away and return output files with aligned time scales (parameter @p out), and/or return descriptions of the
-    transformations in trafoXML format (parameter @p trafo_out). Transformations stored as trafoXML can be applied to
-    arbitrary files with the @ref TOPP_MapRTTransformer tool.
 
-    The map alignment tools differ in how they obtain retention time data for the modeling of transformations, and
-    consequently what types of data they can be applied to. The alignment algorithm implemented here is based on peptide
-    identifications and applicable to annotated featureXML files. It finds peptide sequences that each pair of input files
-    have in common, uses them as points of correspondence between the inputs and to evaluate the distances between the
-    maps for hierarchical clustering. Tree based, the alignment of each cluster pair is performed with the method align() of the
-    @ref OpenMS::MapAlignmentAlgorithmIdentification. For more details and algorithm-specific parameters (set in the INI file)
-    see "Detailed Description" in the @ref OpenMS::MapAlignmentAlgorithmTreeGuided "algorithm documentation".
+This tool provides an algorithm to align the retention time scales of multiple input files, correcting shifts and
+distortions between them. Retention time adjustment may be necessary to correct for chromatography differences e.g.
+before data from multiple LC-MS runs can be combined (feature grouping), or when one run should be annotated with
+peptide identifications obtained in a different run.
 
-    @see @ref TOPP_MapAlignerIdentification @ref TOPP_MapAlignerPoseClustering @ref TOPP_MapAlignerSpectrum @ref TOPP_MapRTTransformer
+All map alignment tools (MapAligner...) collect retention time data from the input files and - by fitting a model to
+this data - compute transformations that map all runs to a common retention time scale. They can apply the transformations
+right away and return output files with aligned time scales (parameter @p out), and/or return descriptions of the
+transformations in trafoXML format (parameter @p trafo_out). Transformations stored as trafoXML can be applied to
+arbitrary files with the @ref TOPP_MapRTTransformer tool.
 
-		Note that alignment is based on the sequence including modifications, thus an exact match is required. I.e., a peptide with oxidised methionine will not be matched to its unmodified version. This behavior is generally desired since (some) modifications can cause retention time shifts.
+The map alignment tools differ in how they obtain retention time data for the modeling of transformations, and
+consequently what types of data they can be applied to. The alignment algorithm implemented here is based on peptide
+identifications and applicable to annotated featureXML files. It finds peptide sequences that each pair of input files
+have in common, uses them as points of correspondence between the inputs and to evaluate the distances between the
+maps for hierarchical clustering. Tree based, the alignment of each cluster pair is performed with the method align() of the
+@ref OpenMS::MapAlignmentAlgorithmIdentification. For more details and algorithm-specific parameters (set in the INI file)
+see "Detailed Description" in the @ref OpenMS::MapAlignmentAlgorithmTreeGuided "algorithm documentation".
 
-    Also note that convex hulls are removed for alignment and are therefore missing in the output files.
+@see @ref TOPP_MapAlignerIdentification @ref TOPP_MapAlignerPoseClustering @ref TOPP_MapAlignerSpectrum @ref TOPP_MapRTTransformer
 
-    Since %OpenMS 1.8, the extraction of data for the alignment has been separate from the modeling of RT transformations based on that data. It is now possible to use different models independently of the chosen algorithm. This algorithm has been tested with the "b_spline" model. The different available models are:
-    - @ref OpenMS::TransformationModelLinear "linear": Linear model.
-    - @ref OpenMS::TransformationModelBSpline "b_spline": Smoothing spline (non-linear).
-    - @ref OpenMS::TransformationModelLowess "lowess": Local regression (non-linear).
-    - @ref OpenMS::TransformationModelInterpolated "interpolated": Different types of interpolation.
+Note that alignment is based on the sequence including modifications, thus an exact match is required. I.e., a peptide with oxidised methionine will not be matched to its unmodified version. This behavior is generally desired since (some) modifications can cause retention time shifts.
 
-    <B>The command line parameters of this tool are:</B> @n
-    @verbinclude TOPP_MapAlignerTreeGuided.cli
-    <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_MapAlignerTreeGuided.html
+Also note that convex hulls are removed for alignment and are therefore missing in the output files.
+
+Since %OpenMS 1.8, the extraction of data for the alignment has been separate from the modeling of RT transformations based on that data. It is now possible to use different models independently of the chosen algorithm. This algorithm has been tested with the "b_spline" model. The different available models are:
+- @ref OpenMS::TransformationModelLinear "linear": Linear model.
+- @ref OpenMS::TransformationModelBSpline "b_spline": Smoothing spline (non-linear).
+- @ref OpenMS::TransformationModelLowess "lowess": Local regression (non-linear).
+- @ref OpenMS::TransformationModelInterpolated "interpolated": Different types of interpolation.
+
+<B>The command line parameters of this tool are:</B> @n
+@verbinclude TOPP_MapAlignerTreeGuided.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_MapAlignerTreeGuided.html
 */
 
 // We do not want this class to show up in the docu:

--- a/src/topp/MapAlignerTreeGuided.cpp
+++ b/src/topp/MapAlignerTreeGuided.cpp
@@ -50,10 +50,20 @@ using namespace std;
 
 @brief Corrects retention time distortions between maps, using information from peptides identified in different maps.
 
-
-potential predecessor tools                                              | -> MapAlignerTreeGuided -> | potential successor tools
------------------------------------------------------------------------- | -------------------------- | -------------------------
-@ref TOPP_IDMapper @n (or any other source of FDR-filtered featureXMLs)  | ^                          | @ref TOPP_FeatureLinkerUnlabeledKD or @n @ref TOPP_FeatureLinkerUnlabeledQT 
+<CENTER>
+    <table>
+        <tr>
+            <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential predecessor tools </td>
+            <td VALIGN= "middle" ROWSPAN=2> \f$ \longrightarrow \f$ MapAlignerTreeGuided \f$ \longrightarrow \f$</td>
+            <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential successor tools </td>
+        </tr>
+        <tr>
+            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_IDMapper @n (or any other source of FDR-filtered
+featureXMLs) </td>
+            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_FeatureLinkerUnlabeledKD or @n @ref TOPP_FeatureLinkerUnlabeledQT </td>
+        </tr>
+    </table>
+</CENTER>
 
 
 This tool provides an algorithm to align the retention time scales of multiple input files, correcting shifts and

--- a/src/topp/MassTraceExtractor.cpp
+++ b/src/topp/MassTraceExtractor.cpp
@@ -55,7 +55,7 @@ using namespace std;
 /**
         @page TOPP_MassTraceExtractor MassTraceExtractor
 
-        @brief MassTraceExtractor extracts mass traces from a @ref MSExperiment map and stores them into a @ref FeatureXMLFile.
+        @brief MassTraceExtractor extracts mass traces from a MSExperiment map and stores them into a FeatureXMLFile.
 
         <CENTER>
         <table>
@@ -77,7 +77,7 @@ using namespace std;
 
 
         This TOPP tool detects mass traces in centroided LC-MS maps and stores them as features in
-        a @ref FeatureMap. These features may be either used directly as input for an metabolite ID approach or further
+        a FeatureMap. These features may be either used directly as input for an metabolite ID approach or further
         be assembled to aggregate features according to a theoretical isotope pattern. For metabolomics experiments,
         the @ref TOPP_FeatureFinderMetabo tool offers both mass trace extraction and isotope pattern assembly.
         For proteomics data, please refer to the @ref TOPP_FeatureFinderCentroided tool.

--- a/src/topp/OpenPepXL.cpp
+++ b/src/topp/OpenPepXL.cpp
@@ -51,7 +51,7 @@ using namespace OpenMS;
 //-------------------------------------------------------------
 
 /**
-  @page UTILS_OpenPepXL OpenPepXL
+  @page TOPP_OpenPepXL OpenPepXL
 
   @brief Search for peptide pairs linked with a labeled cross-linker
 
@@ -123,9 +123,9 @@ using namespace OpenMS;
   </CENTER>
 
   <B>The command line parameters of this tool are:</B>
-  @verbinclude UTILS_OpenPepXL.cli
+  @verbinclude TOPP_OpenPepXL.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude UTILS_OpenPepXL.html
+  @htmlinclude TOPP_OpenPepXL.html
 */
 
 /// @cond TOPPCLASSES
@@ -135,7 +135,7 @@ class TOPPOpenPepXL :
 {
 public:
   TOPPOpenPepXL() :
-    TOPPBase("OpenPepXL", "Tool for protein-protein cross-linking identification using labeled linkers.", false)
+    TOPPBase("OpenPepXL", "Tool for protein-protein cross-linking identification using labeled linkers.", true)
   {
   }
 

--- a/src/topp/OpenPepXL.cpp
+++ b/src/topp/OpenPepXL.cpp
@@ -51,7 +51,7 @@ using namespace OpenMS;
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_OpenPepXL OpenPepXL
+  @page UTILS_OpenPepXL OpenPepXL
 
   @brief Search for peptide pairs linked with a labeled cross-linker
 
@@ -127,6 +127,8 @@ using namespace OpenMS;
   <B>INI file documentation of this tool:</B>
   @htmlinclude UTILS_OpenPepXL.html
 */
+
+/// @cond TOPPCLASSES
 
 class TOPPOpenPepXL :
   public TOPPBase
@@ -301,3 +303,5 @@ int main(int argc, const char** argv)
 
   return tool.main(argc, argv);
 }
+
+/// @endcond

--- a/src/topp/OpenPepXLLF.cpp
+++ b/src/topp/OpenPepXLLF.cpp
@@ -53,7 +53,7 @@ using namespace OpenMS;
 //-------------------------------------------------------------
 
 /**
-  @page UTILS_OpenPepXLLF OpenPepXLLF
+  @page TOPP_OpenPepXLLF OpenPepXLLF
 
   @brief Search for cross-linked peptide pairs in tandem MS spectra
 
@@ -117,9 +117,9 @@ using namespace OpenMS;
   </CENTER>
 
   <B>The command line parameters of this tool are:</B>
-  @verbinclude UTILS_OpenPepXLLF.cli
+  @verbinclude TOPP_OpenPepXLLF.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude UTILS_OpenPepXLLF.html
+  @htmlinclude TOPP_OpenPepXLLF.html
 */
 
 /// @cond TOPPCLASSES
@@ -130,7 +130,7 @@ class TOPPOpenPepXLLF :
 {
 public:
   TOPPOpenPepXLLF() :
-    TOPPBase("OpenPepXLLF", "Tool for protein-protein cross linking with label-free linkers.", false)
+    TOPPBase("OpenPepXLLF", "Tool for protein-protein cross linking with label-free linkers.", true)
   {
   }
 

--- a/src/topp/OpenPepXLLF.cpp
+++ b/src/topp/OpenPepXLLF.cpp
@@ -53,7 +53,7 @@ using namespace OpenMS;
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_OpenPepXLLF OpenPepXLLF
+  @page UTILS_OpenPepXLLF OpenPepXLLF
 
   @brief Search for cross-linked peptide pairs in tandem MS spectra
 
@@ -121,6 +121,9 @@ using namespace OpenMS;
   <B>INI file documentation of this tool:</B>
   @htmlinclude UTILS_OpenPepXLLF.html
 */
+
+/// @cond TOPPCLASSES
+
 
 class TOPPOpenPepXLLF :
   public TOPPBase
@@ -295,3 +298,5 @@ int main(int argc, const char** argv)
 
   return tool.main(argc, argv);
 }
+
+/// @endcond

--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -69,7 +69,7 @@ using namespace OpenMS;
               <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential successor tools </td>
           </tr>
           <tr>
-              <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref </td>
+              <td VALIGN="middle" ALIGN = "center" ROWSPAN=1>  </td>
               <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_OpenSwathDecoyGenerator  </td>
           </tr>
       </table>
@@ -100,6 +100,7 @@ using namespace OpenMS;
 
 // We do not want this class to show up in the docu:
 /// @cond TOPPCLASSES
+
 class TOPPOpenSwathAssayGenerator :
   public TOPPBase
 {

--- a/src/topp/PeakPickerWavelet.cpp
+++ b/src/topp/PeakPickerWavelet.cpp
@@ -45,72 +45,73 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_PeakPickerWavelet PeakPickerWavelet
+@page TOPP_PeakPickerWavelet PeakPickerWavelet
 
-  @brief A tool for peak detection in profile data. Executes the peak picking with the algorithm described in described in Lange et al. (2006) Proc. PSB-06.
+@brief A tool for peak detection in profile data. Executes the peak picking with the algorithm described in described in Lange et al. (2006) Proc. PSB-06.
 <CENTER>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-      <td VALIGN="middle" ROWSPAN=4> \f$ \longrightarrow \f$ PeakPickerWavelet \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_BaselineFilter </td>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=3> any tool operating on MS peak data @n (in mzML format)</td>
-        </tr>
-        <tr>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_NoiseFilterGaussian </td>
-        </tr>
+<table>
     <tr>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_NoiseFilterSGolay </td>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+  <td VALIGN="middle" ROWSPAN=4> \f$ \longrightarrow \f$ PeakPickerWavelet \f$ \longrightarrow \f$</td>
+        <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
     </tr>
-    </table>
+    <tr>
+        <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_BaselineFilter </td>
+  <td VALIGN="middle" ALIGN = "center" ROWSPAN=3> any tool operating on MS peak data @n (in mzML format)</td>
+    </tr>
+    <tr>
+  <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_NoiseFilterGaussian </td>
+    </tr>
+<tr>
+  <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_NoiseFilterSGolay </td>
+</tr>
+</table>
 </CENTER>
-    The conversion of the ''raw'' ion count data acquired
-    by the machine into peak lists for further processing
-    is usually called peak picking. The choice of the algorithm
-    should mainly depend on the resolution of the data.
-    As the name implies, the @ref OpenMS::PeakPickerHiRes "high_res"
-    algorithm is fit for high resolution data whereas in case
-    of low-resoluted data the @ref OpenMS::PeakPickerCWT "wavelet"
-    algorithm offers the ability to resolve highly convoluted
-    and asymmetric signals, separation of overlapping peaks
-    and nonlinear optimization.
 
-    @ref TOPP_example_signalprocessing_parameters is explained in the TOPP tutorial.
+The conversion of the ''raw'' ion count data acquired
+by the machine into peak lists for further processing
+is usually called peak picking. The choice of the algorithm
+should mainly depend on the resolution of the data.
+As the name implies, the @ref OpenMS::PeakPickerHiRes "high_res"
+algorithm is fit for high resolution data whereas in case
+of low-resoluted data the @ref OpenMS::PeakPickerCWT "wavelet"
+algorithm offers the ability to resolve highly convoluted
+and asymmetric signals, separation of overlapping peaks
+and nonlinear optimization.
 
-    <B>The command line parameters of this tool are:</B>
-  @verbinclude TOPP_PeakPickerWavelet.cli
-    <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_PeakPickerWavelet.html
+@ref TOPP_example_signalprocessing_parameters is explained in the TOPP tutorial.
 
-  For the parameters of the algorithm section see the algorithm documentation: @n
-    @ref OpenMS::PeakPickerCWT "PeakPickerCWT" @n
+<B>The command line parameters of this tool are:</B>
+@verbinclude TOPP_PeakPickerWavelet.cli
+<B>INI file documentation of this tool:</B>
+@htmlinclude TOPP_PeakPickerWavelet.html
 
-    In the following table you, can find example values of the most important algorithm parameters for
-    different instrument types. @n These parameters are not valid for all instruments of that type,
-    but can be used as a starting point for finding suitable parameters.
-    <table>
-        <tr BGCOLOR="#EBEBEB">
-            <td>&nbsp;</td>
-            <td><b>Q-TOF</b></td>
-            <td><b>LTQ Orbitrap</b></td>
-        </tr>
-        <tr>
-            <td BGCOLOR="#EBEBEB"><b>signal_to_noise</b></td>
-            <td>2</td>
-            <td>0</td>
-        </tr>
-        <tr>
-        <td BGCOLOR="#EBEBEB"><b>peak_width ("wavelet" only)</b></td>
-            <td>0.1</td>
-            <td>0.012</td>
-        </tr>
-    </table>
+For the parameters of the algorithm section see the algorithm documentation: @n
+@ref OpenMS::PeakPickerCWT "PeakPickerCWT" @n
 
-  In order to impove the results of the peak detection on low resolution data @ref TOPP_NoiseFilterSGolay or @ref TOPP_NoiseFilterGaussian and @ref TOPP_BaselineFilter can be applied.
-    For high resolution data this is not necessary.
+In the following table you, can find example values of the most important algorithm parameters for
+different instrument types. @n These parameters are not valid for all instruments of that type,
+but can be used as a starting point for finding suitable parameters.
+<table>
+    <tr BGCOLOR="#EBEBEB">
+        <td>&nbsp;</td>
+        <td><b>Q-TOF</b></td>
+        <td><b>LTQ Orbitrap</b></td>
+    </tr>
+    <tr>
+        <td BGCOLOR="#EBEBEB"><b>signal_to_noise</b></td>
+        <td>2</td>
+        <td>0</td>
+    </tr>
+    <tr>
+    <td BGCOLOR="#EBEBEB"><b>peak_width ("wavelet" only)</b></td>
+        <td>0.1</td>
+        <td>0.012</td>
+    </tr>
+</table>
+
+In order to impove the results of the peak detection on low resolution data @ref TOPP_NoiseFilterSGolay or @ref TOPP_NoiseFilterGaussian and @ref TOPP_BaselineFilter can be applied.
+For high resolution data this is not necessary.
 */
 
 // We do not want this class to show up in the docu:

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -87,7 +87,7 @@ using namespace std;
 depending on the search engine. Must be prepared beforehand. If you do not want
 to use the specific features, use the generic-feature-set flag. Will incorporate
 the score attribute of a PSM, so be sure, the score you want is set as main
-score with @ref TOPP_IDScoreSwitcher . Be aware, that you might very well
+score with @ref UTILS_IDScoreSwitcher . Be aware, that you might very well
 experience a performance loss compared to the search engine specific features.
 You can also perform protein inference with percolator when you activate the protein fdr parameter.
 Additionally you need to set the enzyme setting.

--- a/src/topp/XFDR.cpp
+++ b/src/topp/XFDR.cpp
@@ -52,7 +52,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page UTILS_XFDR XFDR
+    @page TOPP_XFDR XFDR
 
     @brief Calculates false discovery rate estimates on crosslink identifications.
 
@@ -69,17 +69,17 @@ using namespace std;
                 <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
             </tr>
             <tr>
-                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_OpenPepXL </td>
-                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_OpenPepXLLF </td>
+                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_OpenPepXL </td>
+                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_OpenPepXLLF </td>
                 <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> - </td>
             </tr>
         </table>
     </center>
 
     <B>The command line parameters of this tool are:</B>
-    @verbinclude UTILS_XFDR.cli
+    @verbinclude TOPP_XFDR.cli
     <B>INI file documentation of this tool:</B>
-    @htmlinclude UTILS_XFDR.html
+    @htmlinclude TOPP_XFDR.html
 */
 
 // We do not want this class to show up in the docu:
@@ -91,7 +91,7 @@ public TOPPBase
 public:
 
   TOPPXFDR() :
-    TOPPBase("XFDR", "Calculates false discovery rate estimates on crosslink identifications", false)
+    TOPPBase("XFDR", "Calculates false discovery rate estimates on crosslink identifications", true)
   {
   }
 

--- a/src/topp/XFDR.cpp
+++ b/src/topp/XFDR.cpp
@@ -42,9 +42,6 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/ANALYSIS/XLMS/XFDRAlgorithm.h>
 
-// #include <string>
-// #include <cmath>
-
 #include <cassert>
 
 using namespace OpenMS;
@@ -55,7 +52,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_XFDR XFDR
+    @page UTILS_XFDR XFDR
 
     @brief Calculates false discovery rate estimates on crosslink identifications.
 
@@ -72,21 +69,21 @@ using namespace std;
                 <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
             </tr>
             <tr>
-                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1>  OpenPepXL </td>
-                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1>  OpenPepXLLF </td>
+                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_OpenPepXL </td>
+                <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_OpenPepXLLF </td>
                 <td VALIGN="middle" ALIGN = "center" ROWSPAN=2> - </td>
-            </tr>
-            <tr>
             </tr>
         </table>
     </center>
 
     <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_XFDR.cli
+    @verbinclude UTILS_XFDR.cli
     <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_XFDR.html
+    @htmlinclude UTILS_XFDR.html
 */
 
+// We do not want this class to show up in the docu:
+/// @cond TOPPCLASSES
 
 class TOPPXFDR final :
 public TOPPBase
@@ -318,3 +315,5 @@ int main(int argc, const char ** argv)
   TOPPXFDR tool;
   return tool.main(argc, argv);
 }
+
+/// @endcond

--- a/src/utils/ClusterMassTraces.cpp
+++ b/src/utils/ClusterMassTraces.cpp
@@ -180,3 +180,4 @@ int main( int argc, const char** argv )
   return tool.main(argc,argv);
 }
 
+///@endcond

--- a/src/utils/ClusterMassTraces.cpp
+++ b/src/utils/ClusterMassTraces.cpp
@@ -43,7 +43,7 @@ using namespace OpenMS;
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_ClusterMassTraces ClusterMassTraces
+  @page UTILS_ClusterMassTraces ClusterMassTraces
 
   @brief Cluster mass traces occurring in the same map together
 
@@ -64,9 +64,9 @@ using namespace OpenMS;
    - calculate the most likely precursor(s) and DB-search
 
   <B>The command line parameters of this tool are:</B>
-  @verbinclude TOPP_ClusterMassTraces.cli
+  @verbinclude UTILS_ClusterMassTraces.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude TOPP_ClusterMassTraces.html
+  @htmlinclude UTILS_ClusterMassTraces.html
 
 */
 

--- a/src/utils/ClusterMassTracesByPrecursor.cpp
+++ b/src/utils/ClusterMassTracesByPrecursor.cpp
@@ -46,7 +46,7 @@
 //-------------------------------------------------------------
 
 /**
-  @page TOPP_CorrelateMassTraces CorrelateMassTraces
+  @page UTILS_ClusterMassTracesByPrecursor ClusterMassTracesByPrecursor
 
   @brief Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps.
 
@@ -72,9 +72,9 @@
     If one fragment matches to multiple precursors, it is assigned to all of them. If it doesnt match any, it is assigned to all
   
   <B>The command line parameters of this tool are:</B>
-  @verbinclude TOPP_CorrelateMassTraces.cli
+  @verbinclude UTILS_ClusterMassTracesByPrecursor.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude TOPP_CorrelateMassTraces.html
+  @htmlinclude UTILS_ClusterMassTracesByPrecursor.html
 
 */
 

--- a/src/utils/ClusterMassTracesByPrecursor.cpp
+++ b/src/utils/ClusterMassTracesByPrecursor.cpp
@@ -423,3 +423,4 @@ int main( int argc, const char** argv )
   return tool.main(argc,argv);
 }
 
+///@endcond

--- a/src/utils/LowMemPeakPickerHiRes.cpp
+++ b/src/utils/LowMemPeakPickerHiRes.cpp
@@ -83,9 +83,9 @@ using namespace std;
   @ref TOPP_example_signalprocessing_parameters is explained in the TOPP tutorial.
 
   <B>The command line parameters of this tool are:</B>
-  @verbinclude TOPP_LowMemPeakPickerHiRes.cli
+  @verbinclude UTILS_LowMemPeakPickerHiRes.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude TOPP_LowMemPeakPickerHiRes.html
+  @htmlinclude UTILS_LowMemPeakPickerHiRes.html
 
   For the parameters of the algorithm section see the algorithm documentation: @ref OpenMS::PeakPickerHiRes "PeakPickerHiRes"
 

--- a/src/utils/MSFraggerAdapter.cpp
+++ b/src/utils/MSFraggerAdapter.cpp
@@ -49,7 +49,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_MSFraggerAdapter MSFraggerAdapter
+    @page UTILS_MSFraggerAdapter MSFraggerAdapter
 
     @brief Peptide Identification with MSFragger
 

--- a/src/utils/MSstatsConverter.cpp
+++ b/src/utils/MSstatsConverter.cpp
@@ -65,9 +65,9 @@ using namespace std;
     [1] M. Choi et al. MSstats: an R package for statistical analysis for quantitative mass spectrometry-based proteomic experiments. Bioinformatics (2014), 30 (17): 2524-2526
 
     <B>The command line parameters of this tool are:</B>
-    @verbinclude UTILS_MSstats.cli
+    @verbinclude UTILS_MSstatsConverter.cli
     <B>INI file documentation of this tool:</B>
-    @htmlinclude UTILS_MSstats.html
+    @htmlinclude UTILS_MSstatsConverter.html
  */
 
 // We do not want this class to show up in the docu:

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -3637,3 +3637,5 @@ int main(int argc, const char** argv)
   TOPPMetaProSIP tool;
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/utils/MetaboliteSpectralMatcher.cpp
+++ b/src/utils/MetaboliteSpectralMatcher.cpp
@@ -54,7 +54,7 @@ using namespace std;
 /**
         @page UTILS_MetaboliteSpectralMatcher MetaboliteSpectralMatcher
 
-        @brief MetaboliteSpectralMatcher identify small molecules from tandem MS spectra.
+        @brief MetaboliteSpectralMatcher identifies small molecules from tandem MS spectra using a spectral library.
 
         <CENTER>
         <table>
@@ -71,12 +71,6 @@ using namespace std;
         </tr>
         </table>
         </CENTER>
-
-        <B>The command line parameters of this tool are:</B>
-        @verbinclude TOPP_MetaboliteSpectralMatcher.cli
-
-
-        MetaboliteSpectralMatcher matches spectra from a spectral library with tandem MS spectra.
 
         <B>The command line parameters of this tool are:</B>
         @verbinclude UTILS_MetaboliteSpectralMatcher.cli

--- a/src/utils/MultiplexResolver.cpp
+++ b/src/utils/MultiplexResolver.cpp
@@ -651,4 +651,4 @@ int main(int argc, const char** argv)
   return tool.main(argc, argv);
 }
 
-//@endcond
+///@endcond

--- a/src/utils/PeakPickerIterative.cpp
+++ b/src/utils/PeakPickerIterative.cpp
@@ -147,3 +147,4 @@ int main( int argc, const char** argv )
   return tool.main(argc,argv);
 }
 
+///@endcond

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -3092,3 +3092,5 @@ int main(int argc, const char** argv)
   RNPxlSearch tool;
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/utils/RNPxlXICFilter.cpp
+++ b/src/utils/RNPxlXICFilter.cpp
@@ -61,8 +61,8 @@ using namespace OpenMS;
       <td ALIGN = "center" BGCOLOR="#EBEBEB"> potential successor tools </td>
     </tr>
     <tr>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_PeakPickerHires </td>
-      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_RNPxl </td>
+      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_PeakPickerHiRes </td>
+      <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref UTILS_RNPxlSearch </td>
     </tr>
   </table>
 </CENTER>

--- a/src/utils/RNPxlXICFilter.cpp
+++ b/src/utils/RNPxlXICFilter.cpp
@@ -301,3 +301,5 @@ int main(int argc, const char** argv)
   TOPPRNPxlXICFilter tool;
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/utils/SimpleSearchEngine.cpp
+++ b/src/utils/SimpleSearchEngine.cpp
@@ -52,7 +52,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page TOPP_SimpleSearchEngine SimpleSearchEngine
+    @page UTILS_SimpleSearchEngine SimpleSearchEngine
 
     @brief Identifies peptides in MS/MS spectra.
 
@@ -76,9 +76,9 @@ using namespace std;
     @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
 
     <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_SimpleSearchEngine.cli
+    @verbinclude UTILS_SimpleSearchEngine.cli
     <B>INI file documentation of this tool:</B>
-    @htmlinclude TOPP_SimpleSearchEngine.html
+    @htmlinclude UTILS_SimpleSearchEngine.html
 */
 
 // We do not want this class to show up in the docu:

--- a/src/utils/SimpleSearchEngine.cpp
+++ b/src/utils/SimpleSearchEngine.cpp
@@ -155,3 +155,5 @@ int main(int argc, const char** argv)
   SimpleSearchEngine tool;
   return tool.main(argc, argv);
 }
+
+///@endcond

--- a/src/utils/SpectraSTSearchAdapter.cpp
+++ b/src/utils/SpectraSTSearchAdapter.cpp
@@ -362,3 +362,4 @@ int main(int argc, const char ** argv)
   return tool.main(argc, argv);
 }
 
+///@endcond


### PR DESCRIPTION
this fixes quite a lot of broken links in our documenation, especially with TOPP/UTILS


I also tried to switch to MARKDOWN support, but accidental use of indentation will break a lot of our pages since the markdown interpreter runs first and converts these parts to verbatim blocks...
If at some point this is fixed, we could use

| potential predecessor tools   |    MapAlignerTreeGuided    | potential successor tools |
| ----------------------------- | -------------------------- | --------------------------  |
| TOPP_IDMapper                 | ^                          | TOPP_FeatureLinkerUnlabeledKD |

as table format