### PR TITLE
Store name of float data arrays and unit names

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
@@ -232,6 +232,12 @@ namespace OpenMS
   {
     OPENMS_LOG_DEBUG << "Picking chromatogram using crawdad " << std::endl;
 
+    // copy meta data of the input chromatogram
+    picked_chrom.clear(true);
+    picked_chrom.ChromatogramSettings::operator=(chromatogram);
+    picked_chrom.MetaInfoInterface::operator=(chromatogram);
+    picked_chrom.setName(chromatogram.getName());
+
     std::vector<double> time;
     std::vector<double> intensity;
     for (Size i = 0; i < chromatogram.size(); i++)

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -461,12 +461,11 @@ namespace OpenMS
   void ControlledVocabulary::getAllChildTerms(set<String>& terms, const String& parent) const
   {
     //cerr << "Parent: " << parent << "\n";
-    const set<String>& children = getTerm(parent).children;
-    for (set<String>::const_iterator it = children.begin(); it != children.end(); ++it)
+    for (const auto& it : getTerm(parent).children)
     {
-      terms.insert(*it);
-      //TODO This is not save for cyclic graphs. Are they allowed in CVs?
-      getAllChildTerms(terms, *it);
+      terms.insert(it);
+      //TODO: This is not safe for cyclic graphs. Are they allowed in CVs?
+      getAllChildTerms(terms, it);
     }
   }
 
@@ -506,20 +505,20 @@ namespace OpenMS
 
   bool ControlledVocabulary::isChildOf(const String& child, const String& parent) const
   {
-    //cout << "CHECK child:" << child << " parent: " << parent << "\n";
+    // cout << "CHECK child:" << child << " parent: " << parent << "\n";
     const CVTerm& ch = getTerm(child);
 
-    for (set<String>::const_iterator it = ch.parents.begin(); it != ch.parents.end(); ++it)
+    for (const auto & it : ch.parents)
     {
-      //cout << "Parent: " << ch.parents[i] << "\n";
+      // cout << "Parent: " << it << "\n";
 
-      //check if it is a direct parent
-      if (*it == parent)
+      // check if it is a direct parent
+      if (it == parent)
       {
         return true;
       }
-      //check if it is an indirect parent
-      else if (isChildOf(*it, parent))
+      // check if it is an indirect parent
+      else if (isChildOf(it, parent))
       {
         return true;
       }
@@ -530,14 +529,14 @@ namespace OpenMS
 
   std::ostream& operator<<(std::ostream& os, const ControlledVocabulary& cv)
   {
-    for (Map<String, ControlledVocabulary::CVTerm>::const_iterator it = cv.terms_.begin(); it != cv.terms_.end(); ++it)
+    for (const auto & it : cv.terms_)
     {
       os << "[Term]\n";
-      os << "id: '" << it->second.id << "'\n";
-      os << "name: '" << it->second.name <<  "'\n";
-      for (set<String>::const_iterator it2 = it->second.parents.begin(); it2 != it->second.parents.end(); ++it2)
+      os << "id: '" << it.second.id << "'\n";
+      os << "name: '" << it.second.name <<  "'\n";
+      for (const auto & parent_term : it.second.parents)
       {
-        cout << "is_a: '" << *it2 <<  "'\n";
+        cout << "is_a: '" << parent_term <<  "'\n";
       }
     }
     return os;

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1468,6 +1468,11 @@ namespace OpenMS
         {
           bin_data_.back().meta.setName(cv_.getTerm(accession).name);
         }
+
+        if (!unit_accession.empty())
+        {
+          bin_data_.back().meta.setMetaValue("unit_accession", unit_accession);
+        }
       }
       //------------------------- spectrum ----------------------------
       else if (parent_tag == "spectrum")
@@ -3372,7 +3377,7 @@ namespace OpenMS
           // retrieving the identifier and looking up the term within the
           // correct ontology in our cv_ object.
           char s[8];
-          snprintf(s, sizeof(s), "%07d", metaValue.getUnit()); // all CV use 7 digit indentifiers padded with zeros
+          snprintf(s, sizeof(s), "%07d", metaValue.getUnit()); // all CV use 7 digit identifiers padded with zeros
           String unitstring = String(s);
           if (metaValue.getUnitType() == DataValue::UnitType::UNIT_ONTOLOGY)
           {
@@ -5382,6 +5387,7 @@ namespace OpenMS
       String encoded_string;
       bool no_numpress = true;
       std::vector<float> data_to_encode = array;
+      MetaInfoDescription array_metadata = array;
       // bool is32bit = true;
 
       // Compute the array-type and the compression CV term
@@ -5393,13 +5399,23 @@ namespace OpenMS
       {
         // Try and identify whether we have a CV term for this particular array (otherwise write the array name itself)
         ControlledVocabulary::CVTerm bi_term = getChildWithName_("MS:1000513", array.getName()); // name: binary data array
+
+        String unit_cv_term = "";
+        if (array_metadata.metaValueExists("unit_accession"))
+        {
+          ControlledVocabulary::CVTerm unit = cv_.getTerm(array_metadata.getMetaValue("unit_accession"));
+          unit_cv_term = " unitAccession=\"" + unit.id + "\" unitName=\"" + unit.name + "\" unitCvRef=\"" + unit.id.prefix(2) + "\"";
+          array_metadata.removeMetaValue("unit_accession"); // prevent this from being written as userParam
+        }
+
         if (bi_term.id != "")
         {
-          cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"" + bi_term.id + "\" name=\"" + bi_term.name + "\" />\n";
+          cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"" + bi_term.id + "\" name=\"" + bi_term.name + "\"" + unit_cv_term + " />\n";
         }
         else
         {
-          cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000786\" name=\"non-standard data array\" value=\"" + array.getName() + "\" />\n";
+          cv_term_type = "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000786\" name=\"non-standard data array\" value=\"" +
+            array.getName() + "\"" + unit_cv_term + " />\n";
         }
 
         compression_term = MzMLHandlerHelper::getCompressionTerm_(pf_options_, pf_options_.getNumpressConfigurationFloatDataArray(), "\t\t\t\t\t\t", true);
@@ -5440,11 +5456,11 @@ namespace OpenMS
       os << compression_term << "\n";
       if (isSpectrum)
       {
-        writeUserParam_(os, array, 6, "/mzML/run/spectrumList/spectrum/binaryDataArrayList/binaryDataArray/cvParam/@accession", validator);
+        writeUserParam_(os, array_metadata, 6, "/mzML/run/spectrumList/spectrum/binaryDataArrayList/binaryDataArray/cvParam/@accession", validator);
       }
       else
       {
-        writeUserParam_(os, array, 6, "/mzML/run/chromatogramList/chromatogram/binaryDataArrayList/binaryDataArray/cvParam/@accession", validator);
+        writeUserParam_(os, array_metadata, 6, "/mzML/run/chromatogramList/chromatogram/binaryDataArrayList/binaryDataArray/cvParam/@accession", validator);
       }
       os << "\t\t\t\t\t\t<binary>" << encoded_string << "</binary>\n";
       os << "\t\t\t\t\t</binaryDataArray>\n";

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1457,21 +1457,18 @@ namespace OpenMS
       //------------------------- binaryDataArray ----------------------------
       else if (parent_tag == "binaryDataArray")
       {
+        // store name for all non-default arrays
+        if (cv_.isChildOf(accession, "MS:1000513")) // other array names as string
+        {
+          bin_data_.back().meta.setName(cv_.getTerm(accession).name);
+        }
+
         if (!MzMLHandlerHelper::handleBinaryDataArrayCVParam(bin_data_, accession, value, name, unit_accession))
         {
           if (!cv_.isChildOf(accession, "MS:1000513")) //other array names as string
           {
             warning(LOAD, String("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
           }
-        }
-        if (cv_.isChildOf(accession, "MS:1000513")) // other array names as string
-        {
-          bin_data_.back().meta.setName(cv_.getTerm(accession).name);
-        }
-
-        if (!unit_accession.empty())
-        {
-          bin_data_.back().meta.setMetaValue("unit_accession", unit_accession);
         }
       }
       //------------------------- spectrum ----------------------------
@@ -5568,7 +5565,9 @@ namespace OpenMS
         const ChromatogramType::IntegerDataArray& array = chromatogram.getIntegerDataArrays()[m];
         std::vector<Int64> data64_to_encode(array.size());
         for (Size p = 0; p < array.size(); ++p)
+        {
           data64_to_encode[p] = array[p];
+        }
         Base64::encodeIntegers(data64_to_encode, Base64::BYTEORDER_LITTLEENDIAN, encoded_string, options_.getCompression());
         String data_processing_ref_string = "";
         if (array.getDataProcessing().size() != 0)
@@ -5598,7 +5597,9 @@ namespace OpenMS
         std::vector<String> data_to_encode;
         data_to_encode.resize(array.size());
         for (Size p = 0; p < array.size(); ++p)
+        {
           data_to_encode[p] = array[p];
+        }
         Base64::encodeStrings(data_to_encode, encoded_string, options_.getCompression());
         String data_processing_ref_string = "";
         if (array.getDataProcessing().size() != 0)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1413,7 +1413,10 @@ namespace OpenMS
           }
         }
         //no value, although there should be a numerical value
-        else if (term.xref_type != ControlledVocabulary::CVTerm::NONE && term.xref_type != ControlledVocabulary::CVTerm::XSD_STRING)
+        else if (term.xref_type != ControlledVocabulary::CVTerm::NONE &&
+                 term.xref_type != ControlledVocabulary::CVTerm::XSD_STRING && // should be numerical
+                 !cv_.isChildOf(accession, "MS:1000513") // here the value type relates to the binary data array, not the 'value=' attribute!
+                )
         {
           warning(LOAD, String("The CV term '") + accession + " - " + term.name + "' used in tag '" + parent_tag + "' should have a numerical value. The value is '" + value + "'.");
           return;
@@ -1456,14 +1459,14 @@ namespace OpenMS
       {
         if (!MzMLHandlerHelper::handleBinaryDataArrayCVParam(bin_data_, accession, value, name, unit_accession))
         {
-          if (cv_.isChildOf(accession, "MS:1000513")) //other array names as string
-          {
-            bin_data_.back().meta.setName(cv_.getTerm(accession).name);
-          }
-          else
+          if (!cv_.isChildOf(accession, "MS:1000513")) //other array names as string
           {
             warning(LOAD, String("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
           }
+        }
+        if (cv_.isChildOf(accession, "MS:1000513")) // other array names as string
+        {
+          bin_data_.back().meta.setName(cv_.getTerm(accession).name);
         }
       }
       //------------------------- spectrum ----------------------------

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -307,6 +307,15 @@ namespace OpenMS
                                                        const String& name,
                                                        const String& unit_accession)
   {
+
+    bool is_default_array = (accession == "MS:1000514" || accession == "MS:1000515" || accession == "MS:1000595");
+
+    // store unit accession for non-default arrays
+    if (!unit_accession.empty() && !is_default_array)
+    {
+      data.back().meta.setMetaValue("unit_accession", unit_accession);
+    }
+
     //MS:1000518 ! binary data type
     if (accession == "MS:1000523") //64-bit float
     {
@@ -375,7 +384,7 @@ namespace OpenMS
       data.back().compression = false;
       data.back().np_compression = MSNumpressCoder::NONE;
     }
-    else if (accession == "MS:1000514" || accession == "MS:1000515" || accession == "MS:1000595")    // handle m/z, intensity, rt
+    else if (is_default_array) // handle m/z, intensity, rt
     {
       data.back().meta.setName(name);
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -307,7 +307,6 @@ namespace OpenMS
                                                        const String& name,
                                                        const String& unit_accession)
   {
-
     bool is_default_array = (accession == "MS:1000514" || accession == "MS:1000515" || accession == "MS:1000595");
 
     // store unit accession for non-default arrays

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -476,6 +476,9 @@ set_tests_properties("TOPP_FileConverter_30_out" PROPERTIES DEPENDS "TOPP_FileCo
 add_test("TOPP_FileConverter_31" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileConverter_30_output.mzML -change_im_format single -out_type mzML -out FileConverter_31.tmp)
 add_test("TOPP_FileConverter_31_out" ${DIFF} -in1 FileConverter_31.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_31_output.mzML -whitelist "location=" "<offset")
 set_tests_properties("TOPP_FileConverter_31_out" PROPERTIES DEPENDS "TOPP_FileConverter_31")
+add_test("TOPP_FileConverter_32" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileConverter_32_input.mzML -out_type mzML -out FileConverter_32.tmp)
+add_test("TOPP_FileConverter_32_out" ${DIFF} -in1 FileConverter_32.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_32_output.mzML -whitelist "location=" "<offset")
+set_tests_properties("TOPP_FileConverter_32_out" PROPERTIES DEPENDS "TOPP_FileConverter_32")
 
 #------------------------------------------------------------------------------
 # FileFilter tests

--- a/src/tests/topp/FileConverter_32_input.mzML
+++ b/src/tests/topp/FileConverter_32_input.mzML
@@ -1,0 +1,452 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd">
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="4">
+		<software id="so_in_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="2.4.0-feature-im-convert-2018-08-13" >
+			<cvParam cvRef="MS" accession="MS:1000757" name="FileFilter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000031" name="instrument model" />
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="5">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1001486" name="data filtering" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="2018-08-13+17:27" />
+				<userParam name="parameter: in" type="xsd:string" value="/home/hr/openmsall/source/OpenMS_merges/src/tests/topp/FileFilter_49_input.mzML"/>
+				<userParam name="parameter: in_type" type="xsd:string" value=""/>
+				<userParam name="parameter: out" type="xsd:string" value="/home/hr/openmsall/source/OpenMS_merges/src/tests/topp/FileConverter_29_input.mzML"/>
+				<userParam name="parameter: out_type" type="xsd:string" value=""/>
+				<userParam name="parameter: rt" type="xsd:string" value="5:9"/>
+				<userParam name="parameter: mz" type="xsd:string" value=":"/>
+				<userParam name="parameter: int" type="xsd:string" value=":"/>
+				<userParam name="parameter: sort" type="xsd:string" value="false"/>
+				<userParam name="parameter: log" type="xsd:string" value=""/>
+				<userParam name="parameter: debug" type="xsd:integer" value="0"/>
+				<userParam name="parameter: threads" type="xsd:integer" value="1"/>
+				<userParam name="parameter: no_progress" type="xsd:string" value="false"/>
+				<userParam name="parameter: force" type="xsd:string" value="false"/>
+				<userParam name="parameter: test" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:sn" type="xsd:double" value="0"/>
+				<userParam name="parameter: peak_options:rm_pc_charge" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:pc_mz_range" type="xsd:string" value=":"/>
+				<userParam name="parameter: peak_options:pc_mz_list" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:level" type="xsd:string" value="[1, 2, 3]"/>
+				<userParam name="parameter: peak_options:sort_peaks" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:no_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:remove_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:mz_precision" type="xsd:string" value="64"/>
+				<userParam name="parameter: peak_options:int_precision" type="xsd:string" value="32"/>
+				<userParam name="parameter: peak_options:indexed_file" type="xsd:string" value="true"/>
+				<userParam name="parameter: peak_options:zlib_compression" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:numpress:masstime" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:lossy_mass_accuracy" type="xsd:double" value="-1"/>
+				<userParam name="parameter: peak_options:numpress:intensity" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:float_da" type="xsd:string" value="none"/>
+				<userParam name="parameter: spectra:remove_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:remove_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:remove_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:select_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_polarity" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:blackorwhitelist:file" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:blackorwhitelist:similarity_threshold" type="xsd:double" value="-1"/>
+				<userParam name="parameter: spectra:blackorwhitelist:rt" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: spectra:blackorwhitelist:mz" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: spectra:blackorwhitelist:use_ppm_tolerance" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:blackorwhitelist:blacklist" type="xsd:string" value="true"/>
+				<userParam name="parameter: feature:q" type="xsd:string" value=":"/>
+				<userParam name="parameter: consensus:map" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:map_and" type="xsd:string" value="false"/>
+				<userParam name="parameter: consensus:blackorwhitelist:blacklist" type="xsd:string" value="true"/>
+				<userParam name="parameter: consensus:blackorwhitelist:file" type="xsd:string" value=""/>
+				<userParam name="parameter: consensus:blackorwhitelist:maps" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:blackorwhitelist:rt" type="xsd:double" value="60"/>
+				<userParam name="parameter: consensus:blackorwhitelist:mz" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: consensus:blackorwhitelist:use_ppm_tolerance" type="xsd:string" value="false"/>
+				<userParam name="parameter: f_and_c:charge" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:size" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:remove_meta" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_clashes" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:keep_best_score_id" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:sequences_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:sequence_comparison_method" type="xsd:string" value="substring"/>
+				<userParam name="parameter: id:accessions_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_annotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unannotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unassigned_ids" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:blacklist" type="xsd:string" value=""/>
+				<userParam name="parameter: id:rt" type="xsd:double" value="0.1"/>
+				<userParam name="parameter: id:mz" type="xsd:double" value="0.001"/>
+				<userParam name="parameter: id:blacklist_imperfect" type="xsd:string" value="false"/>
+				<userParam name="parameter: algorithm:SignalToNoise:max_intensity" type="xsd:integer" value="-1"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_stdev_factor" type="xsd:double" value="3"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_percentile" type="xsd:integer" value="95"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_mode" type="xsd:integer" value="0"/>
+				<userParam name="parameter: algorithm:SignalToNoise:win_len" type="xsd:double" value="200"/>
+				<userParam name="parameter: algorithm:SignalToNoise:bin_count" type="xsd:integer" value="30"/>
+				<userParam name="parameter: algorithm:SignalToNoise:min_required_elements" type="xsd:integer" value="10"/>
+				<userParam name="parameter: algorithm:SignalToNoise:noise_for_empty_window" type="xsd:double" value="1e+20"/>
+				<userParam name="parameter: algorithm:SignalToNoise:write_log_messages" type="xsd:string" value="true"/>
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_1_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_3_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_5_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_7_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0">
+		<spectrumList count="8" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="spectrum=10" index="0" defaultArrayLength="100" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=11" index="1" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AACAQAAAEEEAACBBAAAAQQAAMEEAAEBBAAAgQQAAIEEAAABBAADAQAAAoEAAAOBAAABgQQAAIEEAAABBAABgQQAAEEEAAMBAAABAQQAAQEAAADBBAAAAQAAAAEAAAIBBAABQQQAAgD8AAEBBAABgQQAAgEAAAJhBAAAAQQAAwEAAAEBBAABwQQAAgEEAAGBBAACIQQAAkEEAAIBBAABQQQAAoEEAAJBBAACQQQAAoEEAAIhBAACQQQAAgEEAAJhBAACAQAAAwEAAAKBAAAAAQAAAQEAAAIA/AAAAQAAA4EAAAHBBAACAQAAAAEIAAABBAACAQQAAgEEAAGBBAADAQQAA0EEAAOBBAADwQQAAkEEAAABCAACgQQAACEIAABBCAAAAQgAAwEEAAEBBAADAQQAAgEAAAABBAAAQQgAAEEIAAEBBAACgQQAAoEEAAOBBAAAAQAAAIEIAAOBBAAAYQgAAsEEAAEBBAAAgQQAAoEEAAMBAAABAQQAAAEAAAIBAAACQQQAAAEEAAABBAAAgQQAAwEAAAIBBAACAQQAAgEAAAMBBAAAgQgAAgEAAABhCAAAQQgAA0EEAAAhCAADgQQAAAEIAAPBBAACwQQAAYEEAAJBBAACQQQAAcEEAAPBBAACQQQAAQEEAAEBBAABwQQAAQEEAABBBAABAQQAAkEEAABxCAABAQgAAwEAAAKhBAAAQQQAAwEAAAEBAAADAQQAAqEEAAMBBAADAQAAA2EEAAMBBAADAQQAAwEAAAEBAAADwQQAAHEIAAChCAAAQQgAAKEIAABBCAAAoQgAAEEIAAARCAABAQgAA8EEAABBCAADYQQAABEIAAEBCAABYQgAAcEIAAPBBAABMQgAAKEIAAFhCAAA0QgAANEIAAFhCAABkQgAAZEIAAFhCAABMQgAAQEIAAHBCAACIQgAAMEIAAEBCAADgQQAAQEIAAKBBAABQQgAAwEEAAGBCAABgQgAAcEIAAIBCAACAQQAAgEIAACBCAAAAQgAAIEIAAABCAAAQQgAAgEEAAABBAACYQgAAAEEAAEBBAACQQgAAoEIAAJBCAACgQgAAmEIAAHBCAADAQQAAgEIAAIBAAACAQgAAkEIAAJBCAABAQQAAiEIAAABBAABgQgAAAEEAAEBCAAAQQgAAgEAAACBCAAAgQgAAgEEAAGBCAACgQQAAUEIAAMBBAADAQQAAgEEAAOBBAAAwQgAAAEIAAABCAABAQgAAIEIAAHBCAAC+QgAAtEIAAMhCAACqQgAAyEIAAKBCAAC+QgAAoEIAAIJCAAC0QgAAlkIAAKpCAABIQgAAIEIAAEhCAAA0QgAAtEIAAHBCAABIQgAANEIAAEhCAABcQgAAgkIAAIxCAABwQgAAjEIAAHBCAAAgQQAAIEEAAPBBAAAgQgAADEIAAAxCAAAgQgAAoEAAAKBAAADwQQAAIEEAACBBAADwQQAAyEEAAPBBAACMQgAAoEEAAMhBAABcQgAAoEEAAHBBAABwQQAAoEEAAKBBAAC0QgAAlkIAAKBCAACgQgAAjEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+            <cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" value="" unitCvRef="MS" unitAccession="MS:1002814" unitName      ="volt-second per square centimeter"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=12" index="2" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=13" index="3" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>mpmZQM3MLEEAAEBBmpkZQTMzU0FmZmZBAABAQQAAQEGamRlBZmbmQAAAwEBmZgZBZmaGQQAAQEGamRlBZmaGQc3MLEFmZuZAZmZmQWZmZkAzM1NBmpkZQJqZGUCamZlBmpl5QZqZmT9mZmZBZmaGQZqZmUBmZrZBmpkZQWZm5kBmZmZBAACQQZqZmUFmZoZBMzOjQc3MrEGamZlBmpl5QQAAwEHNzKxBzcysQQAAwEEzM6NBzcysQZqZmUFmZrZBmpmZQGZm5kAAAMBAmpkZQGZmZkCamZk/mpkZQGZmBkEAAJBBmpmZQJqZGUKamRlBmpmZQZqZmUFmZoZBZmbmQZqZ+UFmZgZCAAAQQs3MrEGamRlCAADAQTMzI0LNzCxCmpkZQmZm5kFmZmZBZmbmQZqZmUCamRlBzcwsQs3MLEJmZmZBAADAQQAAwEFmZgZCmpkZQAAAQEJmZgZCZmY2QjMz00FmZmZBAABAQQAAwEFmZuZAZmZmQZqZGUCamZlAzcysQZqZGUGamRlBAABAQWZm5kCamZlBmpmZQZqZmUBmZuZBAABAQpqZmUBmZjZCzcwsQpqZ+UEzMyNCZmYGQpqZGUIAABBCMzPTQWZmhkHNzKxBzcysQQAAkEEAABBCzcysQWZmZkFmZmZBAACQQWZmZkHNzCxBZmZmQc3MrEEzMztCZmZmQmZm5kCamclBzcwsQWZm5kBmZmZAZmbmQZqZyUFmZuZBZmbmQJqZAUJmZuZBZmbmQWZm5kBmZmZAAAAQQjMzO0KamUlCzcwsQpqZSULNzCxCmplJQs3MLEJmZh5CZmZmQgAAEELNzCxCmpkBQmZmHkJmZmZCmpmBQgAAkEIAABBCzcx0QpqZSUKamYFCAABYQgAAWEKamYFCzcyIQs3MiEKamYFCzcx0QmZmZkIAAJBCMzOjQjMzU0JmZmZCZmYGQmZmZkIAAMBBmpl5QmZm5kFmZoZCZmaGQgAAkEKamZlCmpmZQZqZmUIAAEBCmpkZQgAAQEKamRlCzcwsQpqZmUGamRlBZma2QpqZGUFmZmZBzcysQgAAwELNzKxCAADAQmZmtkIAAJBCZmbmQZqZmUKamZlAmpmZQs3MrELNzKxCZmZmQTMzo0KamRlBZmaGQpqZGUFmZmZCzcwsQpqZmUAAAEBCAABAQpqZmUFmZoZCAADAQZqZeUJmZuZBZmbmQZqZmUFmZgZCMzNTQpqZGUKamRlCZmZmQgAAQEIAAJBCAADkQgAA2EIAAPBCAADMQgAA8EIAAMBCAADkQgAAwEIAAJxCAADYQgAAtEIAAMxCAABwQgAAQEIAAHBCAABYQgAA2EIAAJBCAABwQgAAWEIAAHBCAACEQgAAnEIAAKhCAACQQgAAqEIAAJBCAABAQQAAQEEAABBCAABAQgAAKEIAAChCAABAQgAAwEAAAMBAAAAQQgAAQEEAAEBBAAAQQgAA8EEAABBCAACoQgAAwEEAAPBBAACEQgAAwEEAAJBBAACQQQAAwEEAAMBBAADYQgAAtEIAAMBCAADAQgAAqEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+						<cvParam cvRef="MS" accession="MS:1000786" name="non-standard data array" value="Ion Mobility" />
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=14" index="4" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="7" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=15" index="5" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="7.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>MzOzQJqZSUEAAGBBMzMzQWZmdkFmZoZBAABgQQAAYEEzMzNBZmYGQQAA4EDNzBxBzcycQQAAYEEzMzNBzcycQZqZSUFmZgZBZmaGQWZmhkBmZnZBMzMzQDMzM0AzM7NBmpmRQTMzsz9mZoZBzcycQTMzs0DNzNRBMzMzQWZmBkFmZoZBAACoQTMzs0HNzJxBZma+QZqZyUEzM7NBmpmRQQAA4EGamclBmpnJQQAA4EFmZr5BmpnJQTMzs0HNzNRBMzOzQGZmBkEAAOBAMzMzQGZmhkAzM7M/MzMzQM3MHEEAAKhBMzOzQDMzM0IzMzNBMzOzQTMzs0HNzJxBZmYGQpqZEULNzBxCAAAoQpqZyUEzMzNCAADgQWZmPkKamUlCMzMzQmZmBkJmZoZBZmYGQjMzs0AzMzNBmplJQpqZSUJmZoZBAADgQQAA4EHNzBxCMzMzQAAAYELNzBxCzcxUQmZm9kFmZoZBAABgQQAA4EFmZgZBZmaGQTMzM0AzM7NAmpnJQTMzM0EzMzNBAABgQWZmBkEzM7NBMzOzQTMzs0BmZgZCAABgQjMzs0DNzFRCmplJQpqZEUJmZj5CzcwcQjMzM0IAAChCZmb2Qc3MnEGamclBmpnJQQAAqEEAAChCmpnJQWZmhkFmZoZBAACoQWZmhkGamUlBZmaGQZqZyUFmZlpCZmaGQmZmBkEzM+tBmplJQWZmBkFmZoZAZmYGQjMz60FmZgZCZmYGQTMzF0JmZgZCZmYGQmZmBkFmZoZAAAAoQmZmWkIzM2tCmplJQjMza0KamUlCMzNrQpqZSULNzDhCZmaGQgAAKEKamUlCMzMXQs3MOEJmZoZCMzOXQgAAqEIAAChCzcyOQjMza0IzM5dCAAB8QgAAfEIzM5dCmpmfQpqZn0IzM5dCzcyOQmZmhkIAAKhCZma+QmZmdkJmZoZCzcwcQmZmhkIAAOBBmpmRQmZmBkLNzJxCzcycQgAAqEIzM7NCMzOzQTMzs0IAAGBCMzMzQgAAYEIzMzNCmplJQjMzs0EzMzNBzczUQjMzM0FmZoZBmpnJQgAA4EKamclCAADgQs3M1EIAAKhCZmYGQjMzs0IzM7NAMzOzQpqZyUKamclCZmaGQWZmvkIzMzNBzcycQjMzM0FmZoZCmplJQjMzs0AAAGBCAABgQjMzs0HNzJxCAADgQZqZkUJmZgZCZmYGQjMzs0HNzBxCZmZ2QjMzM0IzMzNCZmaGQgAAYEIAAKhCAAAFQwAA/EIAAAxDAADuQgAADEMAAOBCAAAFQwAA4EIAALZCAAD8QgAA0kIAAO5CAACMQgAAYEIAAIxCAAB8QgAA/EIAAKhCAACMQgAAfEIAAIxCAACaQgAAtkIAAMRCAACoQgAAxEIAAKhCAABgQQAAYEEAAChCAABgQgAAREIAAERCAABgQgAA4EAAAOBAAAAoQgAAYEEAAGBBAAAoQgAADEIAAChCAADEQgAA4EEAAAxCAACaQgAA4EEAAKhBAACoQQAA4EEAAOBBAAD8QgAA0kIAAOBCAADgQgAAxEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+            <cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" value="" unitCvRef="MS" unitAccession="MS:1002814" unitName="    volt-second per square centimeter"/>
+            <!-- Note that here we have the ion mobility array in milliseconds -->
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=16" index="6" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="8" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=17" index="7" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="8.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>zczMQGZmZkEAAIBBzcxMQc3MjEGamZlBAACAQQAAgEHNzExBmpkZQQAAAEEzMzNBMzOzQQAAgEHNzExBMzOzQWZmZkGamRlBmpmZQZqZmUDNzIxBzcxMQM3MTEDNzMxBZmamQc3MzD+amZlBMzOzQc3MzEAzM/NBzcxMQZqZGUGamZlBAADAQc3MzEEzM7NBmpnZQWZm5kHNzMxBZmamQQAAAEJmZuZBZmbmQQAAAEKamdlBZmbmQc3MzEEzM/NBzczMQJqZGUEAAABBzcxMQJqZmUDNzMw/zcxMQDMzM0EAAMBBzczMQM3MTELNzExBzczMQc3MzEEzM7NBmpkZQmZmJkIzMzNCAABAQmZm5kHNzExCAAAAQpqZWUJmZmZCzcxMQpqZGUKamZlBmpkZQs3MzEDNzExBZmZmQmZmZkKamZlBAAAAQgAAAEIzMzNCzcxMQAAAgEIzMzNCMzNzQs3MDEKamZlBAACAQQAAAEKamRlBmpmZQc3MTEDNzMxAZmbmQc3MTEHNzExBAACAQZqZGUHNzMxBzczMQc3MzECamRlCAACAQs3MzEAzM3NCZmZmQmZmJkKamVlCMzMzQs3MTEIAAEBCzcwMQjMzs0FmZuZBZmbmQQAAwEEAAEBCZmbmQZqZmUGamZlBAADAQZqZmUFmZmZBmpmZQWZm5kGamXlCmpmZQpqZGUFmZgZCZmZmQZqZGUGamZlAmpkZQmZmBkKamRlCmpkZQc3MLEKamRlCmpkZQpqZGUGamZlAAABAQpqZeUJmZoZCZmZmQmZmhkJmZmZCZmaGQmZmZkIzM1NCmpmZQgAAQEJmZmZCzcwsQjMzU0KamZlCzcysQgAAwEIAAEBCMzOjQmZmhkLNzKxCAACQQgAAkELNzKxCZma2QmZmtkLNzKxCMzOjQpqZmUIAAMBCmpnZQs3MjEKamZlCMzMzQpqZmUIAAABCZmamQpqZGUIzM7NCMzOzQgAAwELNzMxCzczMQc3MzEIAAIBCzcxMQgAAgELNzExCZmZmQs3MzEHNzExBMzPzQs3MTEGamZlBZmbmQgAAAENmZuZCAAAAQzMz80IAAMBCmpkZQs3MzELNzMxAzczMQmZm5kJmZuZCmpmZQZqZ2ULNzExBMzOzQs3MTEGamZlCZmZmQs3MzEAAAIBCAACAQs3MzEEzM7NCAAAAQmZmpkKamRlCmpkZQs3MzEEzMzNCzcyMQs3MTELNzExCmpmZQgAAgEIAAMBCAAAYQwAAEEMAACBDAAAIQwAAIEMAAABDAAAYQwAAAEMAANBCAAAQQwAA8EIAAAhDAACgQgAAgEIAAKBCAACQQgAAEEMAAMBCAACgQgAAkEIAAKBCAACwQgAA0EIAAOBCAADAQgAA4EIAAMBCAACAQQAAgEEAAEBCAACAQgAAYEIAAGBCAACAQgAAAEEAAABBAABAQgAAgEEAAIBBAABAQgAAIEIAAEBCAADgQgAAAEIAACBCAACwQgAAAEIAAMBBAADAQQAAAEIAAABCAAAQQwAA8EIAAABDAAAAQwAA4EI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+            <cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" value="" unitCvRef="MS" unitAccession="MS:1002814" unitName="    volt-second per square centimeter"/>
+            <!-- Note that here we have the ion mobility array in milliseconds -->
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
+</mzML>
+<indexList count="1">
+	<index name="spectrum">
+		<offset idRef="spectrum=10">12236</offset>
+		<offset idRef="spectrum=11">15279</offset>
+		<offset idRef="spectrum=12">23979</offset>
+		<offset idRef="spectrum=13">26994</offset>
+		<offset idRef="spectrum=14">35694</offset>
+		<offset idRef="spectrum=15">38709</offset>
+		<offset idRef="spectrum=16">47409</offset>
+		<offset idRef="spectrum=17">50424</offset>
+	</index>
+</indexList>
+<indexListOffset>59154</indexListOffset>
+<fileChecksum>0</fileChecksum>
+</indexedmzML>

--- a/src/tests/topp/FileConverter_32_output.mzML
+++ b/src/tests/topp/FileConverter_32_output.mzML
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd">
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+		<sourceFileList count="1">
+			<sourceFile id="sf_ru_0" name="FileConverter_32_input.mzML" location="file:///home/hr/openmsall/source/OpenMS_experimental/src/tests/topp">
+				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="8653b60abb36f9f7e37b41603e27b328c03f1d8c" />
+				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
+				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+			</sourceFile>
+		</sourceFileList>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="5">
+		<software id="so_in_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="2.4.0-feature-im-convert-2018-08-13" >
+			<cvParam cvRef="MS" accession="MS:1000757" name="FileFilter" />
+		</software>
+		<software id="so_dp_sp_0_pm_2" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000756" name="FileConverter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000031" name="instrument model" />
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="5">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1001486" name="data filtering" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="2018-08-13+17:27" />
+				<userParam name="parameter: in" type="xsd:string" value="/home/hr/openmsall/source/OpenMS_merges/src/tests/topp/FileFilter_49_input.mzML"/>
+				<userParam name="parameter: in_type" type="xsd:string" value=""/>
+				<userParam name="parameter: out" type="xsd:string" value="/home/hr/openmsall/source/OpenMS_merges/src/tests/topp/FileConverter_29_input.mzML"/>
+				<userParam name="parameter: out_type" type="xsd:string" value=""/>
+				<userParam name="parameter: rt" type="xsd:string" value="5:9"/>
+				<userParam name="parameter: mz" type="xsd:string" value=":"/>
+				<userParam name="parameter: int" type="xsd:string" value=":"/>
+				<userParam name="parameter: sort" type="xsd:string" value="false"/>
+				<userParam name="parameter: log" type="xsd:string" value=""/>
+				<userParam name="parameter: debug" type="xsd:integer" value="0"/>
+				<userParam name="parameter: threads" type="xsd:integer" value="1"/>
+				<userParam name="parameter: no_progress" type="xsd:string" value="false"/>
+				<userParam name="parameter: force" type="xsd:string" value="false"/>
+				<userParam name="parameter: test" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:sn" type="xsd:double" value="0.0"/>
+				<userParam name="parameter: peak_options:rm_pc_charge" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:pc_mz_range" type="xsd:string" value=":"/>
+				<userParam name="parameter: peak_options:pc_mz_list" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:level" type="xsd:string" value="[1, 2, 3]"/>
+				<userParam name="parameter: peak_options:sort_peaks" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:no_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:remove_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:mz_precision" type="xsd:string" value="64"/>
+				<userParam name="parameter: peak_options:int_precision" type="xsd:string" value="32"/>
+				<userParam name="parameter: peak_options:indexed_file" type="xsd:string" value="true"/>
+				<userParam name="parameter: peak_options:zlib_compression" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:numpress:masstime" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:lossy_mass_accuracy" type="xsd:double" value="-1.0"/>
+				<userParam name="parameter: peak_options:numpress:intensity" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:float_da" type="xsd:string" value="none"/>
+				<userParam name="parameter: spectra:remove_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:remove_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:remove_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:select_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_polarity" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:blackorwhitelist:file" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:blackorwhitelist:similarity_threshold" type="xsd:double" value="-1.0"/>
+				<userParam name="parameter: spectra:blackorwhitelist:rt" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: spectra:blackorwhitelist:mz" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: spectra:blackorwhitelist:use_ppm_tolerance" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:blackorwhitelist:blacklist" type="xsd:string" value="true"/>
+				<userParam name="parameter: feature:q" type="xsd:string" value=":"/>
+				<userParam name="parameter: consensus:map" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:map_and" type="xsd:string" value="false"/>
+				<userParam name="parameter: consensus:blackorwhitelist:blacklist" type="xsd:string" value="true"/>
+				<userParam name="parameter: consensus:blackorwhitelist:file" type="xsd:string" value=""/>
+				<userParam name="parameter: consensus:blackorwhitelist:maps" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:blackorwhitelist:rt" type="xsd:double" value="60.0"/>
+				<userParam name="parameter: consensus:blackorwhitelist:mz" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: consensus:blackorwhitelist:use_ppm_tolerance" type="xsd:string" value="false"/>
+				<userParam name="parameter: f_and_c:charge" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:size" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:remove_meta" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_clashes" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:keep_best_score_id" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:sequences_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:sequence_comparison_method" type="xsd:string" value="substring"/>
+				<userParam name="parameter: id:accessions_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_annotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unannotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unassigned_ids" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:blacklist" type="xsd:string" value=""/>
+				<userParam name="parameter: id:rt" type="xsd:double" value="0.1"/>
+				<userParam name="parameter: id:mz" type="xsd:double" value="0.001"/>
+				<userParam name="parameter: id:blacklist_imperfect" type="xsd:string" value="false"/>
+				<userParam name="parameter: algorithm:SignalToNoise:max_intensity" type="xsd:integer" value="-1"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_stdev_factor" type="xsd:double" value="3.0"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_percentile" type="xsd:integer" value="95"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_mode" type="xsd:integer" value="0"/>
+				<userParam name="parameter: algorithm:SignalToNoise:win_len" type="xsd:double" value="200.0"/>
+				<userParam name="parameter: algorithm:SignalToNoise:bin_count" type="xsd:integer" value="30"/>
+				<userParam name="parameter: algorithm:SignalToNoise:min_required_elements" type="xsd:integer" value="10"/>
+				<userParam name="parameter: algorithm:SignalToNoise:noise_for_empty_window" type="xsd:double" value="1.0e20"/>
+				<userParam name="parameter: algorithm:SignalToNoise:write_log_messages" type="xsd:string" value="true"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_2">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_1_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_3_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_5_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+		<dataProcessing id="dp_sp_7_bi_0">
+			<processingMethod order="0" softwareRef="so_default">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<userParam name="warning" type="xsd:string" value="fictional processing method used to fulfill format requirements" />
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0" defaultSourceFileRef="sf_ru_0">
+		<spectrumList count="8" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="spectrum=10" index="0" defaultArrayLength="100" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=11" index="1" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="5.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AACAQAAAEEEAACBBAAAAQQAAMEEAAEBBAAAgQQAAIEEAAABBAADAQAAAoEAAAOBAAABgQQAAIEEAAABBAABgQQAAEEEAAMBAAABAQQAAQEAAADBBAAAAQAAAAEAAAIBBAABQQQAAgD8AAEBBAABgQQAAgEAAAJhBAAAAQQAAwEAAAEBBAABwQQAAgEEAAGBBAACIQQAAkEEAAIBBAABQQQAAoEEAAJBBAACQQQAAoEEAAIhBAACQQQAAgEEAAJhBAACAQAAAwEAAAKBAAAAAQAAAQEAAAIA/AAAAQAAA4EAAAHBBAACAQAAAAEIAAABBAACAQQAAgEEAAGBBAADAQQAA0EEAAOBBAADwQQAAkEEAAABCAACgQQAACEIAABBCAAAAQgAAwEEAAEBBAADAQQAAgEAAAABBAAAQQgAAEEIAAEBBAACgQQAAoEEAAOBBAAAAQAAAIEIAAOBBAAAYQgAAsEEAAEBBAAAgQQAAoEEAAMBAAABAQQAAAEAAAIBAAACQQQAAAEEAAABBAAAgQQAAwEAAAIBBAACAQQAAgEAAAMBBAAAgQgAAgEAAABhCAAAQQgAA0EEAAAhCAADgQQAAAEIAAPBBAACwQQAAYEEAAJBBAACQQQAAcEEAAPBBAACQQQAAQEEAAEBBAABwQQAAQEEAABBBAABAQQAAkEEAABxCAABAQgAAwEAAAKhBAAAQQQAAwEAAAEBAAADAQQAAqEEAAMBBAADAQAAA2EEAAMBBAADAQQAAwEAAAEBAAADwQQAAHEIAAChCAAAQQgAAKEIAABBCAAAoQgAAEEIAAARCAABAQgAA8EEAABBCAADYQQAABEIAAEBCAABYQgAAcEIAAPBBAABMQgAAKEIAAFhCAAA0QgAANEIAAFhCAABkQgAAZEIAAFhCAABMQgAAQEIAAHBCAACIQgAAMEIAAEBCAADgQQAAQEIAAKBBAABQQgAAwEEAAGBCAABgQgAAcEIAAIBCAACAQQAAgEIAACBCAAAAQgAAIEIAAABCAAAQQgAAgEEAAABBAACYQgAAAEEAAEBBAACQQgAAoEIAAJBCAACgQgAAmEIAAHBCAADAQQAAgEIAAIBAAACAQgAAkEIAAJBCAABAQQAAiEIAAABBAABgQgAAAEEAAEBCAAAQQgAAgEAAACBCAAAgQgAAgEEAAGBCAACgQQAAUEIAAMBBAADAQQAAgEEAAOBBAAAwQgAAAEIAAABCAABAQgAAIEIAAHBCAAC+QgAAtEIAAMhCAACqQgAAyEIAAKBCAAC+QgAAoEIAAIJCAAC0QgAAlkIAAKpCAABIQgAAIEIAAEhCAAA0QgAAtEIAAHBCAABIQgAANEIAAEhCAABcQgAAgkIAAIxCAABwQgAAjEIAAHBCAAAgQQAAIEEAAPBBAAAgQgAADEIAAAxCAAAgQgAAoEAAAKBAAADwQQAAIEEAACBBAADwQQAAyEEAAPBBAACMQgAAoEEAAMhBAABcQgAAoEEAAHBBAABwQQAAoEEAAKBBAAC0QgAAlkIAAKBCAACgQgAAjEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+						<cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" unitAccession="MS:1002814" unitName="volt-second per square centimeter" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=12" index="2" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=13" index="3" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="6.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>mpmZQM3MLEEAAEBBmpkZQTMzU0FmZmZBAABAQQAAQEGamRlBZmbmQAAAwEBmZgZBZmaGQQAAQEGamRlBZmaGQc3MLEFmZuZAZmZmQWZmZkAzM1NBmpkZQJqZGUCamZlBmpl5QZqZmT9mZmZBZmaGQZqZmUBmZrZBmpkZQWZm5kBmZmZBAACQQZqZmUFmZoZBMzOjQc3MrEGamZlBmpl5QQAAwEHNzKxBzcysQQAAwEEzM6NBzcysQZqZmUFmZrZBmpmZQGZm5kAAAMBAmpkZQGZmZkCamZk/mpkZQGZmBkEAAJBBmpmZQJqZGUKamRlBmpmZQZqZmUFmZoZBZmbmQZqZ+UFmZgZCAAAQQs3MrEGamRlCAADAQTMzI0LNzCxCmpkZQmZm5kFmZmZBZmbmQZqZmUCamRlBzcwsQs3MLEJmZmZBAADAQQAAwEFmZgZCmpkZQAAAQEJmZgZCZmY2QjMz00FmZmZBAABAQQAAwEFmZuZAZmZmQZqZGUCamZlAzcysQZqZGUGamRlBAABAQWZm5kCamZlBmpmZQZqZmUBmZuZBAABAQpqZmUBmZjZCzcwsQpqZ+UEzMyNCZmYGQpqZGUIAABBCMzPTQWZmhkHNzKxBzcysQQAAkEEAABBCzcysQWZmZkFmZmZBAACQQWZmZkHNzCxBZmZmQc3MrEEzMztCZmZmQmZm5kCamclBzcwsQWZm5kBmZmZAZmbmQZqZyUFmZuZBZmbmQJqZAUJmZuZBZmbmQWZm5kBmZmZAAAAQQjMzO0KamUlCzcwsQpqZSULNzCxCmplJQs3MLEJmZh5CZmZmQgAAEELNzCxCmpkBQmZmHkJmZmZCmpmBQgAAkEIAABBCzcx0QpqZSUKamYFCAABYQgAAWEKamYFCzcyIQs3MiEKamYFCzcx0QmZmZkIAAJBCMzOjQjMzU0JmZmZCZmYGQmZmZkIAAMBBmpl5QmZm5kFmZoZCZmaGQgAAkEKamZlCmpmZQZqZmUIAAEBCmpkZQgAAQEKamRlCzcwsQpqZmUGamRlBZma2QpqZGUFmZmZBzcysQgAAwELNzKxCAADAQmZmtkIAAJBCZmbmQZqZmUKamZlAmpmZQs3MrELNzKxCZmZmQTMzo0KamRlBZmaGQpqZGUFmZmZCzcwsQpqZmUAAAEBCAABAQpqZmUFmZoZCAADAQZqZeUJmZuZBZmbmQZqZmUFmZgZCMzNTQpqZGUKamRlCZmZmQgAAQEIAAJBCAADkQgAA2EIAAPBCAADMQgAA8EIAAMBCAADkQgAAwEIAAJxCAADYQgAAtEIAAMxCAABwQgAAQEIAAHBCAABYQgAA2EIAAJBCAABwQgAAWEIAAHBCAACEQgAAnEIAAKhCAACQQgAAqEIAAJBCAABAQQAAQEEAABBCAABAQgAAKEIAAChCAABAQgAAwEAAAMBAAAAQQgAAQEEAAEBBAAAQQgAA8EEAABBCAACoQgAAwEEAAPBBAACEQgAAwEEAAJBBAACQQQAAwEEAAMBBAADYQgAAtEIAAMBCAADAQgAAqEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+						<cvParam cvRef="MS" accession="MS:1000786" name="non-standard data array" value="Ion Mobility"  />
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=14" index="4" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="7" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=15" index="5" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="7.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>MzOzQJqZSUEAAGBBMzMzQWZmdkFmZoZBAABgQQAAYEEzMzNBZmYGQQAA4EDNzBxBzcycQQAAYEEzMzNBzcycQZqZSUFmZgZBZmaGQWZmhkBmZnZBMzMzQDMzM0AzM7NBmpmRQTMzsz9mZoZBzcycQTMzs0DNzNRBMzMzQWZmBkFmZoZBAACoQTMzs0HNzJxBZma+QZqZyUEzM7NBmpmRQQAA4EGamclBmpnJQQAA4EFmZr5BmpnJQTMzs0HNzNRBMzOzQGZmBkEAAOBAMzMzQGZmhkAzM7M/MzMzQM3MHEEAAKhBMzOzQDMzM0IzMzNBMzOzQTMzs0HNzJxBZmYGQpqZEULNzBxCAAAoQpqZyUEzMzNCAADgQWZmPkKamUlCMzMzQmZmBkJmZoZBZmYGQjMzs0AzMzNBmplJQpqZSUJmZoZBAADgQQAA4EHNzBxCMzMzQAAAYELNzBxCzcxUQmZm9kFmZoZBAABgQQAA4EFmZgZBZmaGQTMzM0AzM7NAmpnJQTMzM0EzMzNBAABgQWZmBkEzM7NBMzOzQTMzs0BmZgZCAABgQjMzs0DNzFRCmplJQpqZEUJmZj5CzcwcQjMzM0IAAChCZmb2Qc3MnEGamclBmpnJQQAAqEEAAChCmpnJQWZmhkFmZoZBAACoQWZmhkGamUlBZmaGQZqZyUFmZlpCZmaGQmZmBkEzM+tBmplJQWZmBkFmZoZAZmYGQjMz60FmZgZCZmYGQTMzF0JmZgZCZmYGQmZmBkFmZoZAAAAoQmZmWkIzM2tCmplJQjMza0KamUlCMzNrQpqZSULNzDhCZmaGQgAAKEKamUlCMzMXQs3MOEJmZoZCMzOXQgAAqEIAAChCzcyOQjMza0IzM5dCAAB8QgAAfEIzM5dCmpmfQpqZn0IzM5dCzcyOQmZmhkIAAKhCZma+QmZmdkJmZoZCzcwcQmZmhkIAAOBBmpmRQmZmBkLNzJxCzcycQgAAqEIzM7NCMzOzQTMzs0IAAGBCMzMzQgAAYEIzMzNCmplJQjMzs0EzMzNBzczUQjMzM0FmZoZBmpnJQgAA4EKamclCAADgQs3M1EIAAKhCZmYGQjMzs0IzM7NAMzOzQpqZyUKamclCZmaGQWZmvkIzMzNBzcycQjMzM0FmZoZCmplJQjMzs0AAAGBCAABgQjMzs0HNzJxCAADgQZqZkUJmZgZCZmYGQjMzs0HNzBxCZmZ2QjMzM0IzMzNCZmaGQgAAYEIAAKhCAAAFQwAA/EIAAAxDAADuQgAADEMAAOBCAAAFQwAA4EIAALZCAAD8QgAA0kIAAO5CAACMQgAAYEIAAIxCAAB8QgAA/EIAAKhCAACMQgAAfEIAAIxCAACaQgAAtkIAAMRCAACoQgAAxEIAAKhCAABgQQAAYEEAAChCAABgQgAAREIAAERCAABgQgAA4EAAAOBAAAAoQgAAYEEAAGBBAAAoQgAADEIAAChCAADEQgAA4EEAAAxCAACaQgAA4EEAAKhBAACoQQAA4EEAAOBBAAD8QgAA0kIAAOBCAADgQgAAxEI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+						<cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" unitAccession="MS:1002814" unitName="volt-second per square centimeter" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=16" index="6" defaultArrayLength="100">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="8" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1068">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAABaQAAAAAAAQFpAAAAAAACAWkAAAAAAAMBaQAAAAAAAAFtAAAAAAABAW0AAAAAAAIBbQAAAAAAAwFtAAAAAAAAAXEAAAAAAAEBcQAAAAAAAgFxAAAAAAADAXEAAAAAAAABdQAAAAAAAQF1AAAAAAACAXUAAAAAAAMBdQAAAAAAAAF5AAAAAAABAXkAAAAAAAIBeQAAAAAAAwF5AAAAAAAAAX0AAAAAAAEBfQAAAAAAAgF9AAAAAAADAX0AAAAAAAABgQAAAAAAAIGBAAAAAAABAYEAAAAAAAGBgQAAAAAAAgGBAAAAAAACgYEAAAAAAAMBgQAAAAAAA4GBAAAAAAAAAYUAAAAAAACBhQAAAAAAAQGFAAAAAAABgYUAAAAAAAIBhQAAAAAAAoGFAAAAAAADAYUAAAAAAAOBhQAAAAAAAAGJAAAAAAAAgYkAAAAAAAEBiQAAAAAAAYGJAAAAAAACAYkAAAAAAAKBiQAAAAAAAwGJAAAAAAADgYkAAAAAAAABjQAAAAAAAIGNAAAAAAABAY0AAAAAAAGBjQAAAAAAAgGNAAAAAAACgY0AAAAAAAMBjQAAAAAAA4GNAAAAAAAAAZEAAAAAAACBkQAAAAAAAQGRAAAAAAABgZEAAAAAAAIBkQAAAAAAAoGRAAAAAAADAZEAAAAAAAOBkQAAAAAAAAGVAAAAAAAAgZUAAAAAAAEBlQAAAAAAAYGVAAAAAAACAZUAAAAAAAKBlQAAAAAAAwGVAAAAAAADgZUAAAAAAAABmQAAAAAAAIGZAAAAAAABAZkAAAAAAAGBmQAAAAAAAgGZAAAAAAACgZkAAAAAAAMBmQAAAAAAA4GZAAAAAAAAAZ0AAAAAAACBnQAAAAAAAQGdAAAAAAABgZ0AAAAAAAIBnQAAAAAAAoGdAAAAAAADAZ0AAAAAAAOBnQAAAAAAAAGhAAAAAAAAgaEAAAAAAAEBoQAAAAAAAYGhAAAAAAACAaEAAAAAAAKBoQAAAAAAAwGhAAAAAAADgaEA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AADIQgAAykIAAMxCAADOQgAA0EIAANJCAADUQgAA1kIAANhCAADaQgAA3EIAAN5CAADgQgAA4kIAAORCAADmQgAA6EIAAOpCAADsQgAA7kIAAPBCAADyQgAA9EIAAPZCAAD4QgAA+kIAAPxCAAD+QgAAAEMAAAFDAAACQwAAA0MAAARDAAAFQwAABkMAAAdDAAAIQwAACUMAAApDAAALQwAADEMAAA1DAAAOQwAAD0MAABBDAAARQwAAEkMAABNDAAAUQwAAFUMAABZDAAAXQwAAGEMAABlDAAAaQwAAG0MAABxDAAAdQwAAHkMAAB9DAAAgQwAAIUMAACJDAAAjQwAAJEMAACVDAAAmQwAAJ0MAAChDAAApQwAAKkMAACtDAAAsQwAALUMAAC5DAAAvQwAAMEMAADFDAAAyQwAAM0MAADRDAAA1QwAANkMAADdDAAA4QwAAOUMAADpDAAA7QwAAPEMAAD1DAAA+QwAAP0MAAEBDAABBQwAAQkMAAENDAABEQwAARUMAAEZDAABHQw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=17" index="7" defaultArrayLength="290">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="8.2" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<precursorList count="1">
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="412.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000828" name="isolation window lower offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							<cvParam cvRef="MS" accession="MS:1000829" name="isolation window upper offset" value="12.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+						</activation>
+					</precursor>
+				</precursorList>
+				<binaryDataArrayList count="3">
+					<binaryDataArray encodedLength="3096">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAABZQAAAAAAAAFlAAAAAAAAAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAQFlAAAAAAABAWUAAAAAAAEBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAACAWUAAAAAAAIBZQAAAAAAAgFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAMBZQAAAAAAAwFlAAAAAAADAWUAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQAAAAAAAAFpAAAAAAAAAWkAAAAAAAABaQA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1548">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>zczMQGZmZkEAAIBBzcxMQc3MjEGamZlBAACAQQAAgEHNzExBmpkZQQAAAEEzMzNBMzOzQQAAgEHNzExBMzOzQWZmZkGamRlBmpmZQZqZmUDNzIxBzcxMQM3MTEDNzMxBZmamQc3MzD+amZlBMzOzQc3MzEAzM/NBzcxMQZqZGUGamZlBAADAQc3MzEEzM7NBmpnZQWZm5kHNzMxBZmamQQAAAEJmZuZBZmbmQQAAAEKamdlBZmbmQc3MzEEzM/NBzczMQJqZGUEAAABBzcxMQJqZmUDNzMw/zcxMQDMzM0EAAMBBzczMQM3MTELNzExBzczMQc3MzEEzM7NBmpkZQmZmJkIzMzNCAABAQmZm5kHNzExCAAAAQpqZWUJmZmZCzcxMQpqZGUKamZlBmpkZQs3MzEDNzExBZmZmQmZmZkKamZlBAAAAQgAAAEIzMzNCzcxMQAAAgEIzMzNCMzNzQs3MDEKamZlBAACAQQAAAEKamRlBmpmZQc3MTEDNzMxAZmbmQc3MTEHNzExBAACAQZqZGUHNzMxBzczMQc3MzECamRlCAACAQs3MzEAzM3NCZmZmQmZmJkKamVlCMzMzQs3MTEIAAEBCzcwMQjMzs0FmZuZBZmbmQQAAwEEAAEBCZmbmQZqZmUGamZlBAADAQZqZmUFmZmZBmpmZQWZm5kGamXlCmpmZQpqZGUFmZgZCZmZmQZqZGUGamZlAmpkZQmZmBkKamRlCmpkZQc3MLEKamRlCmpkZQpqZGUGamZlAAABAQpqZeUJmZoZCZmZmQmZmhkJmZmZCZmaGQmZmZkIzM1NCmpmZQgAAQEJmZmZCzcwsQjMzU0KamZlCzcysQgAAwEIAAEBCMzOjQmZmhkLNzKxCAACQQgAAkELNzKxCZma2QmZmtkLNzKxCMzOjQpqZmUIAAMBCmpnZQs3MjEKamZlCMzMzQpqZmUIAAABCZmamQpqZGUIzM7NCMzOzQgAAwELNzMxCzczMQc3MzEIAAIBCzcxMQgAAgELNzExCZmZmQs3MzEHNzExBMzPzQs3MTEGamZlBZmbmQgAAAENmZuZCAAAAQzMz80IAAMBCmpkZQs3MzELNzMxAzczMQmZm5kJmZuZCmpmZQZqZ2ULNzExBMzOzQs3MTEGamZlCZmZmQs3MzEAAAIBCAACAQs3MzEEzM7NCAAAAQmZmpkKamRlCmpkZQs3MzEEzMzNCzcyMQs3MTELNzExCmpmZQgAAgEIAAMBCAAAYQwAAEEMAACBDAAAIQwAAIEMAAABDAAAYQwAAAEMAANBCAAAQQwAA8EIAAAhDAACgQgAAgEIAAKBCAACQQgAAEEMAAMBCAACgQgAAkEIAAKBCAACwQgAA0EIAAOBCAADAQgAA4EIAAMBCAACAQQAAgEEAAEBCAACAQgAAYEIAAGBCAACAQgAAAEEAAABBAABAQgAAgEEAAIBBAABAQgAAIEIAAEBCAADgQgAAAEIAACBCAACwQgAAAEIAAMBBAADAQQAAAEIAAABCAAAQQwAA8EIAAABDAAAAQwAA4EI=</binary>
+					</binaryDataArray>
+					<binaryDataArray arrayLength="290" encodedLength="1548" >
+						<cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" unitAccession="MS:1002814" unitName="volt-second per square centimeter" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>5/upPgRWjj4pXI8+hxZZPk5ikD5zaJE+PQpXPgrXoz4Sg0A+nu+nPsP1qD556aY+d76fPlyPQj5U46U+vHSTPi/dpD7Jdj4+pptEPgwCqz7l0KI+MQisPjVeOj45tEg+nMSgPlYOrT7ByqE+8KdGPn9qPD51k5g+30+NPtEiWz70/VQ+4XqUPgaBlT6q8VI+K4eWPlCNlz5g5VA+mG6SPpqZmT4X2U4+46WbPs3MTD4IrJw+g8BKPi2ynT6+n5o+Gy9dPpZDiz5xPYo+ZDtfPicxiD7dJIY+AiuHPrpJjD5SuJ4+TDeJPjm0SD4bL10+EoNAPocWWT556aY+c2iRPphukj68dJM+4XqUPi/dpD4GgZU+CtejPiuHlj5QjZc+YOVQPvT9VD7Jdj4+pptEPmQ7Xz5/ajw+F9lOPoPASj7RIls+PQpXPlyPQj6q8VI+3SSGPs3MTD7wp0Y+dZOYPk5ikD6WQ4s+cT2KPilcjz4MAqs+nu+nPlYOrT4CK4c+BFaOPkw3iT7n+6k+w/WoPicxiD7fT40+VOOlPjEIrD7ByqE+mpmZPjVeOj6+n5o+46WbPpzEoD4IrJw+d76fPi2ynT5SuJ4+5dCiPrpJjD7RIls+yXY+PsP1qD49Clc+lkOLPuf7qT5MN4k+cT2KPhsvXT4MAqs+f2o8Pp7vpz6cxKA+BoGVPjEIrD66SYw+JzGIPmQ7Xz7dJIY+30+NPnnppj6HFlk+NV46PgRWjj4Sg0A+VOOlPgIrhz5WDq0+KVyPPphukj7wp0Y+9P1UPqrxUj7ByqE+vHSTPqabRD7l0KI+YOVQPgrXoz5zaJE+L92kPk5ikD45tEg+46WbPs3MTD5cj0I+K4eWPne+nz5QjZc+UriePuF6lD4X2U4+dZOYPr6fmj6DwEo+CKycPi2ynT6amZk+K4eWPk5ikD5zaJE+ukmMPvT9VD5xPYo+mG6SPpZDiz68dJM+qvFSPuF6lD4GgZU+Gy9dPmDlUD49Clc+30+NPilcjz6HFlk+BFaOPkw3iT5kO18+dZOYPgIrhz4nMYg+F9lOPpqZmT5QjZc+zcxMPr6fmj5SuJ4+0SJbPi2ynT5WDq0+ObRIPuOlmz6DwEo+DAKrPgisnD41Xjo+8KdGPjEIrD6mm0Q+L92kPt0khj4K16M+XI9CPuf7qT53vp8+w/WoPpzEoD7Jdj4+nu+nPn9qPD556aY+5dCiPhKDQD5U46U+wcqhPlTjpT5zaJE+vp+aPuOlmz6amZk+CKycPs3MTD45tEg+dZOYPi2ynT6cxKA+F9lOPlK4nj4rh5Y+PQpXPhKDQD4pXI8+L92kPoPASj70/VQ+CtejPgRWjj5cj0I+5dCiPphukj6q8VI+wcqhPrx0kz6mm0Q+NV46PmQ7Xz7Jdj4+hxZZPrpJjD556aY+30+NPt0khj5WDq0+nu+nPgIrhz4xCKw+lkOLPsP1qD7RIls+8KdGPn9qPD5xPYo+TmKQPuf7qT4nMYg+DAKrPkw3iT4bL10+UI2XPuF6lD5g5VA+BoGVPne+nz4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
+</mzML>
+<indexList count="1">
+	<index name="spectrum">
+		<offset idRef="spectrum=10">13242</offset>
+		<offset idRef="spectrum=11">16285</offset>
+		<offset idRef="spectrum=12">25067</offset>
+		<offset idRef="spectrum=13">28082</offset>
+		<offset idRef="spectrum=14">36783</offset>
+		<offset idRef="spectrum=15">39798</offset>
+		<offset idRef="spectrum=16">48580</offset>
+		<offset idRef="spectrum=17">51595</offset>
+	</index>
+</indexList>
+<indexListOffset>60407</indexListOffset>
+<fileChecksum>0</fileChecksum>
+</indexedmzML>


### PR DESCRIPTION
a couple of features:

- Keep the name of float data arrays (instead of deleting them)
- fix check for numerical value for data arrays (relates to content of array)
- store unit metadata for float data array descriptor
- add test for all of this

this is a partial PR based on #4436