### PR TITLE
Check only 1x if output file can be written

### DIFF
--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -1330,7 +1330,6 @@ namespace OpenMS
 
       case ParameterInformation::OUTPUT_FILE:
       {
-        outputFileWritable_(param_value, param_name);
         // determine file type as string
         FileTypes::Type f_type = FileHandler::getTypeByFileName(param_value);
         // Wrong ending, unknown is is ok.


### PR DESCRIPTION
Happens already here https://github.com/OpenMS/OpenMS/blob/ca57038b730ba5995662476e64b4019130cc024e/src/openms/source/APPLICATIONS/TOPPBase.cpp#L1296

replaces https://github.com/OpenMS/OpenMS/pull/4526https://github.com/OpenMS/OpenMS/pull/4526