### PR TITLE
[Feature] Allow inference on consensusXML

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.h
@@ -114,6 +114,7 @@ namespace OpenMS
     /// Loops over all runs in the ConsensusMaps' protein IDs. (experimental)
     void inferPosteriorProbabilities(
         ConsensusMap& cmap,
+        bool greedy_group_resolution,
         boost::optional<const ExperimentalDesign> exp_des = boost::optional<const ExperimentalDesign>());
 
   private:

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
@@ -500,6 +500,11 @@ namespace OpenMS {
     void getUpstreamNodesNonRecursive(std::queue<vertex_t>& q, Graph graph, int lvl,
         bool stop_at_first, std::vector<vertex_t>& result);
 
+    /// @todo untested
+    /// Removes all edges from a peptide (and its PSMs) to its parent protein groups (and its proteins)
+    /// except for the best protein group
+    /// Also removes the corresponding PeptideEvidences in the underlying ID data structure for now
+    /// @todo make the removals optional
     void resolveGraphPeptideCentric_(Graph& fg);
 
     template<class NodeType>

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
@@ -366,10 +366,11 @@ namespace OpenMS {
 
     /// @todo untested
     /// Removes all edges from a peptide (and its PSMs) to its parent protein groups (and its proteins)
-    /// except for the best protein group
+    /// except for the best protein group.
+    /// @pre Graph must contain PeptideCluster nodes (e.g. with clusterIndistProteinsAndPeptides).
     /// @param removeAssociationsInData Also removes the corresponding PeptideEvidences in the underlying
     ///     ID data structure. Only deactivate if you know what you are doing.
-    void resolveGraphPeptideCentric(bool removeAssociationsInData);
+    void resolveGraphPeptideCentric(bool removeAssociationsInData = true);
 
 
 
@@ -506,6 +507,9 @@ namespace OpenMS {
 
     void getUpstreamNodesNonRecursive(std::queue<vertex_t>& q, Graph graph, int lvl,
         bool stop_at_first, std::vector<vertex_t>& result);
+
+    void getDownstreamNodesNonRecursive(std::queue<vertex_t>& q, Graph graph, int lvl,
+                                      bool stop_at_first, std::vector<vertex_t>& result);
 
 
     /// see equivalent public method

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
@@ -335,7 +335,7 @@ namespace OpenMS {
 
 
     /// Do sth on connected components (your functor object has to inherit from std::function or be a lambda)
-    void applyFunctorOnCCs(const std::function<unsigned long(Graph&)>& functor);
+    void applyFunctorOnCCs(const std::function<unsigned long(Graph&, unsigned int)>& functor);
     /// Do sth on connected components single threaded (your functor object has to inherit from std::function or be a lambda)
     void applyFunctorOnCCsST(const std::function<void(Graph&)>& functor);
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDBoostGraph.h
@@ -364,6 +364,13 @@ namespace OpenMS {
     /// Splits the initialized graph into connected components and clears it.
     void computeConnectedComponents();
 
+    /// @todo untested
+    /// Removes all edges from a peptide (and its PSMs) to its parent protein groups (and its proteins)
+    /// except for the best protein group
+    /// @param removeAssociationsInData Also removes the corresponding PeptideEvidences in the underlying
+    ///     ID data structure. Only deactivate if you know what you are doing.
+    void resolveGraphPeptideCentric(bool removeAssociationsInData);
+
 
 
     /// Zero means the graph was not split yet
@@ -500,12 +507,9 @@ namespace OpenMS {
     void getUpstreamNodesNonRecursive(std::queue<vertex_t>& q, Graph graph, int lvl,
         bool stop_at_first, std::vector<vertex_t>& result);
 
-    /// @todo untested
-    /// Removes all edges from a peptide (and its PSMs) to its parent protein groups (and its proteins)
-    /// except for the best protein group
-    /// Also removes the corresponding PeptideEvidences in the underlying ID data structure for now
-    /// @todo make the removals optional
-    void resolveGraphPeptideCentric_(Graph& fg);
+
+    /// see equivalent public method
+    void resolveGraphPeptideCentric_(Graph& fg, bool removeAssociationsInData);
 
     template<class NodeType>
     void getDownstreamNodes(vertex_t start, Graph graph, std::vector<NodeType>& result)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -138,7 +138,14 @@ namespace OpenMS
         if (!ids.empty())
         {
           new_type = findScoreType(ids[0], type);
-          break;
+          if (new_type == ids[0].getScoreType())
+          {
+            return;
+          }
+          else
+          {
+            break;
+          }
         }
       }
       if (new_type.empty())
@@ -158,6 +165,7 @@ namespace OpenMS
 
       function<void(PeptideIdentification&)> f = [&counter,this](PeptideIdentification& id){switchScores(id,counter);};
       cmap.applyFunctionOnPeptideIDs(f, unassigned_peptides_too);
+
     }
 
 
@@ -170,7 +178,7 @@ namespace OpenMS
       if (possible_types.find(curr_score_type) != possible_types.end())
       {
         OPENMS_LOG_INFO << "Requested score type already set as main score: " + curr_score_type + "\n";
-        return "";
+        return curr_score_type;
       }
       else
       {

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -1,0 +1,229 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+
+#include <vector>
+#include <set>
+
+using namespace std;
+
+namespace OpenMS
+{
+
+  class OPENMS_DLLAPI IDScoreSwitcherAlgorithm:
+    public DefaultParamHandler
+  {
+  public:
+    IDScoreSwitcherAlgorithm ();
+
+    enum class ScoreType
+    {
+      RAW,
+      RAW_EVAL,
+      PP,
+      PEP,
+      FDR,
+      QVAL,
+    };
+
+    template <typename IDType>
+    void switchScores(IDType& id, Size& counter)
+    {
+      for (typename std::vector<typename IDType::HitType>::iterator hit_it = id.getHits().begin();
+           hit_it != id.getHits().end(); ++hit_it, ++counter)
+      {
+        if (!hit_it->metaValueExists(new_score_))
+        {
+          String msg = "Meta value '" + new_score_ + "' not found for " +
+                       describeHit_(*hit_it);
+          throw Exception::MissingInformation(__FILE__, __LINE__,
+                                              OPENMS_PRETTY_FUNCTION, msg);
+        }
+
+        String old_score_meta = (old_score_.empty() ? id.getScoreType() :
+                                 old_score_);
+        DataValue dv = hit_it->getMetaValue(old_score_meta);
+        if (!dv.isEmpty()) // meta value for old score already exists
+        {
+          if (fabs((double(dv) - hit_it->getScore()) * 2.0 /
+                   (double(dv) + hit_it->getScore())) > tolerance_)
+          {
+            String msg = "Meta value '" + old_score_meta + "' already exists "
+                                                           "with a conflicting value for " + describeHit_(*hit_it);
+            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                          msg, dv.toString());
+          } // else: values match, nothing to do
+        }
+        else
+        {
+          hit_it->setMetaValue(old_score_meta, hit_it->getScore());
+        }
+        hit_it->setScore(hit_it->getMetaValue(new_score_));
+      }
+      id.setScoreType(new_score_type_);
+      id.setHigherScoreBetter(higher_better_);
+    }
+
+    /// Looks at the first Hit of the given @p id and according to the given @p type ,
+    /// deduces a fitting score and score direction to be switched to.
+    /// Then tries to switch all hits.
+    void switchToGeneralScoreType(vector<PeptideIdentification>& id, ScoreType type, Size& counter)
+    {
+      if (id.empty()) return;
+      String t = findScoreType(id[0], type);
+      if (t.empty())
+      {
+        String msg = "First encountered ID does not have the requested score type.";
+        throw Exception::MissingInformation(__FILE__, __LINE__,
+                                            OPENMS_PRETTY_FUNCTION, msg);
+      }
+      new_score_ = t;
+      new_score_type_ = t;
+      if (type != ScoreType::RAW && higher_better_ != type_to_better_[type])
+      {
+        OPENMS_LOG_WARN << "Requested non-raw score type does not match the expected score direction. Correcting!\n";
+        higher_better_ = type_to_better_[type];
+      }
+      for (auto& i : id)
+      {
+        switchScores(i, counter);
+      }
+    }
+
+    /// Looks at the first Hit of the given @p id and according to the given @p type ,
+    /// deduces a fitting score and score direction to be switched to.
+    /// Then tries to switch all hits.
+    void switchToGeneralScoreType(ConsensusMap& cmap, ScoreType type, Size& counter, bool unassigned_peptides_too = true)
+    {
+      String new_type = "";
+      for (const auto& f : cmap)
+      {
+        const auto& ids = f.getPeptideIdentifications();
+        if (!ids.empty())
+        {
+          new_type = findScoreType(ids[0], type);
+          break;
+        }
+      }
+      if (new_type.empty())
+      {
+        String msg = "First encountered ID does not have the requested score type.";
+        throw Exception::MissingInformation(__FILE__, __LINE__,
+                                            OPENMS_PRETTY_FUNCTION, msg);
+      }
+      new_score_ = new_type;
+      new_score_type_ = new_type;
+
+      if (type != ScoreType::RAW && higher_better_ != type_to_better_[type])
+      {
+        OPENMS_LOG_WARN << "Requested non-raw score type does not match the expected score direction. Correcting!\n";
+        higher_better_ = type_to_better_[type];
+      }
+
+      function<void(PeptideIdentification&)> f = [&counter,this](PeptideIdentification& id){switchScores(id,counter);};
+      cmap.applyFunctionOnPeptideIDs(f, unassigned_peptides_too);
+    }
+
+
+    /// finds a certain score type in an ID and its metavalues if present, otherwise returns empty string
+    template <typename IDType>
+    String findScoreType(IDType& id, IDScoreSwitcherAlgorithm::ScoreType type)
+    {
+      String curr_score_type = id.getScoreType();
+      set<String>& possible_types = type_to_str_[type];
+      if (possible_types.find(curr_score_type) != possible_types.end())
+      {
+        OPENMS_LOG_INFO << "Requested score type already set as main score: " + curr_score_type + "\n";
+        return "";
+      }
+      else
+      {
+        if (id.getHits().empty())
+        {
+          OPENMS_LOG_WARN << "Identification entry used to check for alternative score was empty.\n";
+          return "";
+        }
+        const auto& hit = id.getHits()[0];
+        for (const auto& poss_str : possible_types)
+        {
+          if (hit.metaValueExists(poss_str) || hit.metaValueExists(poss_str + "_score")) return poss_str;
+        }
+        OPENMS_LOG_WARN << "Score of requested type not found in the UserParams of the checked ID object.\n";
+        return "";
+      }
+    }
+
+  private:
+    String describeHit_(const PeptideHit& hit);
+    String describeHit_(const ProteinHit& hit);
+    void updateMembers_() override;
+
+    /// relative tolerance for score comparisons:
+    const double tolerance_ = 1e-6;
+
+    String new_score_, new_score_type_, old_score_; // tool parameters
+    bool higher_better_; // for the new scores, are higher ones better?
+
+    map<ScoreType, set<String>> type_to_str_ =
+        {
+            {ScoreType::RAW, {"XTandem", "OMSSA", "SEQUEST:xcorr", "Mascot", "mvh"}},
+            //TODO find out reasonable raw scores for SES that provide evalues as main score or see below
+            //TODO there is no test for spectraST idXML, so I dont know its score
+            //TODO check if we should combine RAW and RAW_EVAL:
+            // What if a SE does not have an e-value score (spectrast, OMSSA, crux/sequest, myrimatch),
+            // then you need additional ifs/trys
+            {ScoreType::RAW_EVAL, {"expect", "SpecEValue", "E-Value", "evalue"}},
+            {ScoreType::PP, {"Posterior Probability"}},
+            {ScoreType::PEP, {"Posterior Error Probability", "pep", "MS:1001493"}}, // TODO add CV terms
+            {ScoreType::FDR, {"FDR", "fdr", "false discovery rate"}},
+            {ScoreType::QVAL, {"q-value", "qvalue", "MS:1001491", "q-Value", "qval"}}
+        };
+
+    map<ScoreType, bool> type_to_better_ =
+        {
+            {ScoreType::RAW, true}, //TODO this might actually not always be true
+            {ScoreType::RAW_EVAL, false},
+            {ScoreType::PP, true},
+            {ScoreType::PEP, false},
+            {ScoreType::FDR, false},
+            {ScoreType::QVAL, false}
+        };
+
+  };
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
@@ -28,6 +28,7 @@ IDMapper.h
 IDMergerAlgorithm.h
 IDRipper.h
 IDScoreGetterSetter.h
+IDScoreSwitcherAlgorithm.h
 MessagePasserFactory.h
 MetaboliteSpectralMatching.h
 PeptideProteinResolution.h

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -720,6 +720,10 @@ public:
       }
     }
 
+    /// Removes protein hits from the protein IDs in a @p cmap that are not referenced by a peptide in the features
+    /// or if requested in the unassigned peptide list
+    static void removeUnreferencedProteins(ConsensusMap& cmap, bool include_unassigned);
+
     /// Removes protein hits from @p proteins that are not referenced by a peptide in @p peptides
     static void removeUnreferencedProteins(
       std::vector<ProteinIdentification>& proteins,

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -71,15 +71,16 @@ namespace OpenMS
 
     unsigned long operator() (IDBoostGraph::Graph& fg) {
       //TODO do quick bruteforce calculation if the cc is really small?
+      #pragma omp atomic
       cnt_++;
       // this skips CCs with just peps or prots. We only add edges between different types.
       // and if there were no edges, it would not be a CC.
       if (boost::num_vertices(fg) >= 2)
       {
-        OPENMS_LOG_DEBUG << "Running cc " << String(cnt_) << "...\n";
+        OPENMS_LOG_DEBUG << "Running cc " << String(cnt_) << "..." << std::endl;
         unsigned long nrEdges = boost::num_edges(fg);
 
-        OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges.";
+        OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges." << std::endl;
 
         bool graph_mp_ownership_acquired = false;
         bool update_PSM_probabilities = param_.getValue("update_PSM_probabilities").toBool();
@@ -234,7 +235,7 @@ namespace OpenMS
             boost::apply_visitor(bound_visitor, fg[nodeId]);
           }
 
-          OPENMS_LOG_DEBUG << "Finished cc " << String(cnt_) << "...\n";
+          OPENMS_LOG_DEBUG << "Finished cc " << String(cnt_) << std::endl;;
 
           //TODO we could write out/save the posteriors here,
           // so we can easily read them later for the best params of the grid search

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -77,13 +77,6 @@ namespace OpenMS
       // and if there were no edges, it would not be a CC.
       if (boost::num_vertices(fg) >= 2)
       {
-        if (idx == 9)
-        {
-          std::ofstream ofs;
-          ofs.open ("cc_" + String(idx) + ".graphviz"
-              , std::ofstream::out);
-          IDBoostGraph::printGraph(ofs, fg);
-        }
 
         OPENMS_LOG_DEBUG << "Running cc " << String(idx) << "..." << std::endl;
         unsigned long nrEdges = boost::num_edges(fg);
@@ -280,7 +273,7 @@ namespace OpenMS
             boost::apply_visitor(bound_visitor, fg[nodeId]);
           }
 
-          OPENMS_LOG_DEBUG << "Finished cc " << String(idx) << "after " << String(nrMessagesNeeded) << " messages" << std::endl;;
+          OPENMS_LOG_DEBUG << "Finished cc " << String(idx) << "after " << String(nrMessagesNeeded) << " messages" << std::endl;
 
           //TODO we could write out/save the posteriors here,
           // so we can easily read them later for the best params of the grid search
@@ -307,8 +300,8 @@ namespace OpenMS
                 "_b" + String(param_.getValue("model_parameters:pep_spurious_emission")) + "_g" +
                 String(param_.getValue("model_parameters:prot_prior")) + "_c" +
                 String(param_.getValue("model_parameters:pep_prior")) + "_p" + String(pnorm) + "_"
-                + String(idx) + ".graphviz"
-                , std::ofstream::out | std::ofstream::app);
+                + String(idx) + ".dot"
+                , std::ofstream::out);
             IDBoostGraph::printGraph(ofs, fg);
           }
           OPENMS_LOG_WARN << "Warning: Loopy belief propagation encountered a problem in a connected component. Skipping"
@@ -777,7 +770,7 @@ namespace OpenMS
       setScoreTypeAndSettings_(proteinIDs[0]);
       IDBoostGraph ibg(proteinIDs[0], cmap, nr_top_psms, use_run_info, use_unannotated_ids, exp_des);
       inferPosteriorProbabilities_(ibg);
-      //if (greedy_group_resolution) ibg.
+      if (greedy_group_resolution) ibg.re
 
       OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(cmap, 0) << std::endl;
     }

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -734,7 +734,21 @@ namespace OpenMS
   {
     IDScoreSwitcherAlgorithm switcher;
     Size counter(0);
-    switcher.switchToGeneralScoreType(cmap, IDScoreSwitcherAlgorithm::ScoreType::PEP, counter);
+    try
+    {
+      switcher.switchToGeneralScoreType(cmap, IDScoreSwitcherAlgorithm::ScoreType::PEP, counter);
+    }
+    catch (OpenMS::Exception::MissingInformation& e)
+    {
+      throw OpenMS::Exception::MissingInformation(
+          __FILE__,
+          __LINE__,
+          OPENMS_PRETTY_FUNCTION,
+          "Epifany needs Posterior Error Probabilities in the Peptide Hits. Use Percolator with PEP score"
+          " or run IDPosteriorErrorProbability first.");
+    }
+
+
     //TODO BIG filtering needs to account for run info if used
     cmap.applyFunctionOnPeptideIDs(checkConvertAndFilterPepHits_);
     //TODO BIG filter empty PeptideIDs afterwards
@@ -770,7 +784,7 @@ namespace OpenMS
       setScoreTypeAndSettings_(proteinIDs[0]);
       IDBoostGraph ibg(proteinIDs[0], cmap, nr_top_psms, use_run_info, use_unannotated_ids, exp_des);
       inferPosteriorProbabilities_(ibg);
-      if (greedy_group_resolution) ibg.re
+      if (greedy_group_resolution) ibg.resolveGraphPeptideCentric(true);
 
       OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(cmap, 0) << std::endl;
     }
@@ -794,6 +808,7 @@ namespace OpenMS
         setScoreTypeAndSettings_(proteinID);
         IDBoostGraph ibg(proteinID, cmap, nr_top_psms, use_run_info, use_unannotated_ids);
         inferPosteriorProbabilities_(ibg);
+        if (greedy_group_resolution) ibg.resolveGraphPeptideCentric(true);
 
         OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(cmap, 0, proteinID.getIdentifier()) << std::endl;
       }

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -77,6 +77,14 @@ namespace OpenMS
       // and if there were no edges, it would not be a CC.
       if (boost::num_vertices(fg) >= 2)
       {
+        if (idx == 9)
+        {
+          std::ofstream ofs;
+          ofs.open ("cc_" + String(idx) + ".graphviz"
+              , std::ofstream::out);
+          IDBoostGraph::printGraph(ofs, fg);
+        }
+
         OPENMS_LOG_DEBUG << "Running cc " << String(idx) << "..." << std::endl;
         unsigned long nrEdges = boost::num_edges(fg);
 
@@ -272,7 +280,7 @@ namespace OpenMS
             boost::apply_visitor(bound_visitor, fg[nodeId]);
           }
 
-          OPENMS_LOG_DEBUG << "Finished cc " << String(idx) << "after " << String(nrMessagesNeeded) << std::endl;;
+          OPENMS_LOG_DEBUG << "Finished cc " << String(idx) << "after " << String(nrMessagesNeeded) << " messages" << std::endl;;
 
           //TODO we could write out/save the posteriors here,
           // so we can easily read them later for the best params of the grid search

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -77,6 +77,10 @@ namespace OpenMS
       if (boost::num_vertices(fg) >= 2)
       {
         OPENMS_LOG_DEBUG << "Running cc " << String(cnt_) << "...\n";
+        unsigned long nrEdges = boost::num_edges(fg);
+
+        OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges.";
+
         bool graph_mp_ownership_acquired = false;
         bool update_PSM_probabilities = param_.getValue("update_PSM_probabilities").toBool();
         bool annotate_group_posterior = param_.getValue("annotate_group_probabilities").toBool();
@@ -193,9 +197,6 @@ namespace OpenMS
               .getValue("loopy_belief_propagation:dampening_lambda");
           double initConvergenceThreshold = param_.getValue(
               "loopy_belief_propagation:convergence_threshold");
-          unsigned long nrEdges = boost::num_edges(fg);
-
-          OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges.";
 
           //TODO parametrize the type of scheduler.
           evergreen::PriorityScheduler<IDBoostGraph::vertex_t> scheduler(initDampeningLambda,

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -195,6 +195,8 @@ namespace OpenMS
               "loopy_belief_propagation:convergence_threshold");
           unsigned long nrEdges = boost::num_edges(fg);
 
+          OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges.";
+
           //TODO parametrize the type of scheduler.
           evergreen::PriorityScheduler<IDBoostGraph::vertex_t> scheduler(initDampeningLambda,
                                                               initConvergenceThreshold,

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -69,18 +69,18 @@ namespace OpenMS
         cnt_(0)
     {}
 
-    unsigned long operator() (IDBoostGraph::Graph& fg) {
+    unsigned long operator() (IDBoostGraph::Graph& fg, unsigned int idx) {
+
       //TODO do quick bruteforce calculation if the cc is really small?
-      #pragma omp atomic
-      cnt_++;
+
       // this skips CCs with just peps or prots. We only add edges between different types.
       // and if there were no edges, it would not be a CC.
       if (boost::num_vertices(fg) >= 2)
       {
-        OPENMS_LOG_DEBUG << "Running cc " << String(cnt_) << "..." << std::endl;
+        OPENMS_LOG_DEBUG << "Running cc " << String(idx) << "..." << std::endl;
         unsigned long nrEdges = boost::num_edges(fg);
 
-        OPENMS_LOG_DEBUG << "CC " << String(cnt_) << " has " << String(nrEdges) << " edges." << std::endl;
+        OPENMS_LOG_DEBUG << "CC " << String(idx) << " has " << String(nrEdges) << " edges." << std::endl;
 
         bool graph_mp_ownership_acquired = false;
         bool update_PSM_probabilities = param_.getValue("update_PSM_probabilities").toBool();
@@ -235,7 +235,7 @@ namespace OpenMS
             boost::apply_visitor(bound_visitor, fg[nodeId]);
           }
 
-          OPENMS_LOG_DEBUG << "Finished cc " << String(cnt_) << std::endl;;
+          OPENMS_LOG_DEBUG << "Finished cc " << String(idx) << std::endl;;
 
           //TODO we could write out/save the posteriors here,
           // so we can easily read them later for the best params of the grid search
@@ -262,7 +262,7 @@ namespace OpenMS
                 "_b" + String(param_.getValue("model_parameters:pep_spurious_emission")) + "_g" +
                 String(param_.getValue("model_parameters:prot_prior")) + "_c" +
                 String(param_.getValue("model_parameters:pep_prior")) + "_p" + String(pnorm) + "_"
-                + String(cnt_) + ".graphviz"
+                + String(idx) + ".graphviz"
                 , std::ofstream::out | std::ofstream::app);
             IDBoostGraph::printGraph(ofs, fg);
           }
@@ -291,7 +291,7 @@ namespace OpenMS
         param_(param)
     {}
 
-    unsigned long operator() (IDBoostGraph::Graph& fg) {
+    unsigned long operator() (IDBoostGraph::Graph& fg, unsigned int idx) {
       //TODO do quick bruteforce calculation if the cc is really small
 
       double pnorm = param_.getValue("loopy_belief_propagation:p_norm_inference");

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -317,7 +317,7 @@ namespace OpenMS
     {
       vector<String> out;
       pid.getPrimaryMSRunPath(out);
-      mergedOriginFiles.emplace_back(out);
+      mergedOriginFiles.insert(mergedOriginFiles.end(), out.begin(), out.end());
     }
     newProtIDRun.setPrimaryMSRunPath(mergedOriginFiles);
 

--- a/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusMapMergerAlgorithm.cpp
@@ -128,8 +128,6 @@ namespace OpenMS
     if (experiment_type != "label-free")
     {
       OPENMS_LOG_WARN << "Merging untested for labelled experiments" << endl;
-
-
     }
 
     // Unfortunately we need a kind of bimap here.

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -882,7 +882,17 @@ namespace OpenMS
 
   double FalseDiscoveryRate::rocN(const ConsensusMap& ids, Size fp_cutoff) const
   {
-    bool higher_score_better(ids[0].getPeptideIdentifications().begin()->isHigherScoreBetter());
+    bool higher_score_better(false);
+    // Check first ID in a feature for the score orientation.
+    for (const auto& f : ids)
+    {
+      const auto& pepids = f.getPeptideIdentifications();
+      if (!pepids.empty())
+      {
+        higher_score_better = pepids[0].isHigherScoreBetter();
+        break;
+      }
+    }
     bool use_all_hits = param_.getValue("use_all_hits").toBool();
 
     ScoreToTgtDecLabelPairs scores_labels;

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -741,6 +741,7 @@ namespace OpenMS
       }
       pl.endProgress();
     }
+    OPENMS_LOG_INFO << "Annotated " << String(protIDs_.getIndistinguishableProteins().size()) << " indist. protein groups.\n";
   }
 
   void IDBoostGraph::calculateAndAnnotateIndistProteins(bool addSingletons)
@@ -816,14 +817,10 @@ namespace OpenMS
           }
         }
 
-        auto clusterIt = indistProteins.find(childPeps);
-        if (clusterIt != indistProteins.end())
+        auto clusterIt = indistProteins.emplace(childPeps, ProteinNodeSet({*ui}));
+        if (!clusterIt.second) //no insertion -> append
         {
-          clusterIt->second.insert(*ui);
-        }
-        else
-        {
-          indistProteins[childPeps] = ProteinNodeSet({*ui});
+          (clusterIt.first)->second.insert(*ui);
         }
       }
     }
@@ -919,7 +916,7 @@ namespace OpenMS
         }
         else if (graph[*adjIt].which() > graph[curr_node].which())
         {
-            q.emplace(*adjIt);
+          q.emplace(*adjIt);
         }
       }
     }
@@ -1296,14 +1293,10 @@ namespace OpenMS
               }
             }
 
-            auto clusterIt = indistProteins.find(childPeps);
-            if (clusterIt != indistProteins.end())
+            auto clusterIt = indistProteins.emplace(childPeps, ProteinNodeSet({*ui}));
+            if (!clusterIt.second) //no insertion -> append
             {
-              clusterIt->second.insert(*ui);
-            }
-            else
-            {
-              indistProteins[childPeps] = ProteinNodeSet({*ui});
+              (clusterIt.first)->second.insert(*ui);
             }
           }
         }
@@ -1462,14 +1455,10 @@ namespace OpenMS
               }
             }
 
-            auto clusterIt = indistProteins.find(childPeps);
-            if (clusterIt != indistProteins.end())
+            auto clusterIt = indistProteins.emplace(childPeps, ProteinNodeSet({*ui}));
+            if (!clusterIt.second) //no insertion -> append
             {
-              clusterIt->second.insert(*ui);
-            }
-            else
-            {
-              indistProteins[childPeps] = ProteinNodeSet({*ui});
+              (clusterIt.first)->second.insert(*ui);
             }
           }
         }
@@ -1524,14 +1513,10 @@ namespace OpenMS
               }
             }
 
-            auto clusterIt = pepClusters.find(parents);
-            if (clusterIt != pepClusters.end())
+            auto clusterIt = indistProteins.emplace(parents, PeptideNodeSet({*ui}));
+            if (!clusterIt.second) //no insertion -> append
             {
-              clusterIt->second.insert(*ui);
-            }
-            else
-            {
-              pepClusters[parents] = PeptideNodeSet({*ui});
+              (clusterIt.first)->second.insert(*ui);
             }
           }
         }

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -604,7 +604,7 @@ namespace OpenMS
 
 
   /// Do sth on ccs
-  void IDBoostGraph::applyFunctorOnCCs(const std::function<unsigned long(Graph&)>& functor)
+  void IDBoostGraph::applyFunctorOnCCs(const std::function<unsigned long(Graph&, unsigned int)>& functor)
   {
     if (ccs_.empty()) {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No connected components annotated. Run computeConnectedComponents first!");
@@ -635,7 +635,7 @@ namespace OpenMS
       #ifdef INFERENCE_BENCH
       unsigned long result = functor(curr_cc);
       #else
-      functor(curr_cc);
+      functor(curr_cc, i);
       #endif
 
 

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -726,14 +726,14 @@ namespace OpenMS
         const Graph& curr_cc = ccs_.at(i);
 
         #ifdef INFERENCE_MT_DEBUG
-       OPENMS_LOG_INFO << "Processing on thread# " << omp_get_thread_num() << std::endl;
+        OPENMS_LOG_INFO << "Processing on thread# " << omp_get_thread_num() << std::endl;
         #endif
 
         #ifdef INFERENCE_DEBUG
-       OPENMS_LOG_INFO << "Processing cc " << i << " with " << boost::num_vertices(curr_cc) << " vertices." << std::endl;
-       OPENMS_LOG_INFO << "Printing cc " << i << std::endl;
+        OPENMS_LOG_INFO << "Processing cc " << i << " with " << boost::num_vertices(curr_cc) << " vertices." << std::endl;
+        OPENMS_LOG_INFO << "Printing cc " << i << std::endl;
         printGraph(LOG_INFO, curr_cc);
-       OPENMS_LOG_INFO << "Printed cc " << i << std::endl;
+        OPENMS_LOG_INFO << "Printed cc " << i << std::endl;
         #endif
 
         annotateIndistProteins_(curr_cc, addSingletons);
@@ -974,7 +974,7 @@ namespace OpenMS
       #pragma omp parallel for
       for (int i = 0; i < static_cast<int>(ccs_.size()); i += 1)
       {
-        const Graph& curr_cc = ccs_.at(i);
+        Graph& curr_cc = ccs_.at(i);
 
         #ifdef INFERENCE_MT_DEBUG
         OPENMS_LOG_INFO << "Processing on thread# " << omp_get_thread_num() << std::endl;
@@ -982,9 +982,9 @@ namespace OpenMS
 
         #ifdef INFERENCE_DEBUG
         OPENMS_LOG_INFO << "Processing cc " << i << " with " << boost::num_vertices(curr_cc) << " vertices." << std::endl;
-       OPENMS_LOG_INFO << "Printing cc " << i << std::endl;
+        OPENMS_LOG_INFO << "Printing cc " << i << std::endl;
         printGraph(LOG_INFO, curr_cc);
-       OPENMS_LOG_INFO << "Printed cc " << i << std::endl;
+        OPENMS_LOG_INFO << "Printed cc " << i << std::endl;
         #endif
 
         resolveGraphPeptideCentric_(curr_cc, removeAssociationsInData);

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -1513,7 +1513,7 @@ namespace OpenMS
               }
             }
 
-            auto clusterIt = indistProteins.emplace(parents, PeptideNodeSet({*ui}));
+            auto clusterIt = pepClusters.emplace(parents, PeptideNodeSet({*ui}));
             if (!clusterIt.second) //no insertion -> append
             {
               (clusterIt.first)->second.insert(*ui);

--- a/src/openms/source/ANALYSIS/ID/IDScoreSwitcherAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDScoreSwitcherAlgorithm.cpp
@@ -1,0 +1,84 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <unordered_map>
+
+using namespace std;
+namespace OpenMS
+{
+
+  IDScoreSwitcherAlgorithm::IDScoreSwitcherAlgorithm() :
+      IDScoreSwitcherAlgorithm::DefaultParamHandler("IDScoreSwitcherAlgorithm")
+  {
+    defaults_.setValue("new_score", "", "Name of the meta value to use as the new score");
+    defaults_.setValue("new_score_orientation", "", "Orientation of the new score (are higher or lower values better?)");
+    defaults_.setValidStrings("new_score_orientation", {"lower_better","higher_better"});
+    defaults_.setValue("new_score_type", "", "Name to use as the type of the new score (default: same as 'new_score')");
+    defaults_.setValue("old_score", "", "Name to use for the meta value storing the old score (default: old score type)");
+    defaults_.setValue("proteins", "false", "Apply to protein scores instead of PSM scores");
+    defaults_.setValidStrings("proteins", {"true","false"});
+    defaultsToParam_();
+    updateMembers_();
+  }
+
+  void IDScoreSwitcherAlgorithm::updateMembers_()
+  {
+    new_score_ = param_.getValue("new_score");
+    new_score_type_ = param_.getValue("new_score_type");
+    old_score_ = param_.getValue("old_score");
+    higher_better_ = (param_.getValue("new_score_orientation").toString() ==
+                      "higher_better");
+
+    if (new_score_type_.empty()) new_score_type_ = new_score_;
+  }
+
+
+
+  String IDScoreSwitcherAlgorithm::describeHit_(const PeptideHit& hit)
+  {
+    return "peptide hit with sequence '" + hit.getSequence().toString() +
+           "', charge " + String(hit.getCharge()) + ", score " +
+           String(hit.getScore());
+  }
+
+
+  String IDScoreSwitcherAlgorithm::describeHit_(const ProteinHit& hit)
+  {
+    return "protein hit with accession '" + hit.getAccession() + "', score " +
+           String(hit.getScore());
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/sources.cmake
+++ b/src/openms/source/ANALYSIS/ID/sources.cmake
@@ -29,6 +29,7 @@ IDMergerAlgorithm.cpp
 IDRipper.cpp
 IDDecoyProbability.cpp
 IDScoreGetterSetter.cpp
+IDScoreSwitcherAlgorithm.cpp
 MessagePasserFactory.cpp
 MetaboliteSpectralMatching.cpp
 PeptideProteinResolution.cpp

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -237,6 +237,43 @@ namespace OpenMS
   }
 
 
+  void IDFilter::removeUnreferencedProteins(ConsensusMap& cmap, bool include_unassigned)
+  {
+    // collect accessions that are referenced by peptides for each ID run:
+    map<String, unordered_set<String> > run_to_accessions;
+
+    function<void(const PeptideIdentification&)> f =
+        [&run_to_accessions](const PeptideIdentification& pepid)
+    {
+      const String& run_id = pepid.getIdentifier();
+      // extract protein accessions of each peptide hit:
+      for (vector<PeptideHit>::const_iterator hit_it =
+          pepid.getHits().begin(); hit_it != pepid.getHits().end();
+           ++hit_it)
+      {
+
+        const set<String>& current_accessions =
+            hit_it->extractProteinAccessionsSet();
+
+        run_to_accessions[run_id].insert(current_accessions.begin(),
+                                         current_accessions.end());
+      }
+    };
+    cmap.applyFunctionOnPeptideIDs(f,include_unassigned);
+
+    vector<ProteinIdentification>& prots = cmap.getProteinIdentifications();
+
+    for (vector<ProteinIdentification>::iterator prot_it = prots.begin();
+         prot_it != prots.end(); ++prot_it)
+    {
+      const String& run_id = prot_it->getIdentifier();
+      const unordered_set<String>& accessions = run_to_accessions[run_id];
+      struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
+      keepMatchingItems(prot_it->getHits(), acc_filter);
+    }
+  }
+
+
   void IDFilter::removeUnreferencedProteins(
     vector<ProteinIdentification>& proteins,
     const vector<PeptideIdentification>& peptides)

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -357,7 +357,21 @@ namespace OpenMS
             // empty accessions are not written out (legacy code)
             if (!protein_accession.empty())
             {
-              protein_accessions.push_back("PH_" + String(accession_to_id[protein_accession]));
+              const auto acc = accession_to_id.find(protein_accession);
+              if (acc != accession_to_id.end())
+              {
+                protein_accessions.emplace_back("PH_" + String(prot_count));
+              }
+              else
+              {
+                throw Exception::ElementNotFound(
+                    __FILE__,
+                    __LINE__,
+                    OPENMS_PRETTY_FUNCTION,
+                    "No accession " + protein_accession + " found in run '" + protein_ids[i].getIdentifier() +
+                    "' for PSM " + p_hit.getSequence().toString() + "_" + String(p_hit.getCharge()) +
+                    ". Please contact the maintainer of this tool e.g. on GitHub as this should not happen.");
+              }
             }
           }
 

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -555,7 +555,7 @@ namespace OpenMS
     Size i(0);
     for (auto const & p : s)
     {
-      if (!p.hasSuffix("mzML"))
+      if (!p.hasSuffix("mzML") && !p.hasSuffix("mzml"))
       {
         OPENMS_LOG_WARN << "To ensure tracability of results please prefer mzML files as primary MS run." << std::endl
                         << "Filename: '" << p << "'" << std::endl;                          

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -367,7 +367,7 @@ namespace OpenMS
 
     for (const String& filename : s)
     {
-      if (!filename.hasSuffix("mzML"))
+      if (!filename.hasSuffix("mzML") && !filename.hasSuffix("mzml"))
       {
         OPENMS_LOG_WARN << "To ensure tracability of results please prefer mzML files as primary MS run." << std::endl
                         << "Filename: '" << filename << "'" << std::endl;                          

--- a/src/tests/class_tests/openms/source/IDBoostGraph_test.cpp
+++ b/src/tests/class_tests/openms/source/IDBoostGraph_test.cpp
@@ -51,11 +51,10 @@ START_TEST(IDBoostGraph, "$Id$")
       idf.load(OPENMS_GET_TEST_DATA_PATH("newMergerTest_out.idXML"),prots,peps);
       IDBoostGraph idb{prots[0], peps, 1, false};
       TEST_EQUAL(idb.getNrConnectedComponents(), 0)
+      // 6 proteins (1 unmatched and omitted since we build the graph psm-centric) plus 4 peptides (top per psm).
       TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 9)
       idb.computeConnectedComponents();
       TEST_EQUAL(idb.getNrConnectedComponents(), 3)
-      // The next lines do not sum up to 9 because protein PH2 is unmatched
-      // If you want to avoid that, filter unmatched proteins first!
       TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 3)
       TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 4)
       TEST_EQUAL(boost::num_vertices(idb.getComponent(2)), 2)
@@ -82,8 +81,6 @@ START_TEST(IDBoostGraph, "$Id$")
           // Now it is 5 ccs because there is an unmatched peptide and a new PSM that only matches to
           // previously uncovered protein PH2.
           TEST_EQUAL(idb.getNrConnectedComponents(), 5)
-          // The next lines do not sum up to 9 because protein PH2 is unmatched
-          // If you want to avoid that, filter unmatched proteins first!
           TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 4)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 2)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(2)), 5)
@@ -104,8 +101,6 @@ START_TEST(IDBoostGraph, "$Id$")
           TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 8)
           idb.computeConnectedComponents();
           TEST_EQUAL(idb.getNrConnectedComponents(), 2)
-          // The next lines do not sum up to 9 because protein PH2 is unmatched
-          // If you want to avoid that, filter unmatched proteins first!
           TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 6)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 2)
 
@@ -117,6 +112,38 @@ START_TEST(IDBoostGraph, "$Id$")
           TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 25)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 11)
 
+        }
+    END_SECTION
+
+    START_SECTION(IDBoostGraph graph-based group resolution)
+        {
+          vector<ProteinIdentification> prots;
+          vector<PeptideIdentification> peps;
+          IdXMLFile idf;
+          idf.load(OPENMS_GET_TEST_DATA_PATH("newMergerTest_out.idXML"),prots,peps);
+          IDBoostGraph idb{prots[0], peps, 1, false};
+          TEST_EQUAL(idb.getNrConnectedComponents(), 0)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 9)
+          idb.computeConnectedComponents();
+          TEST_EQUAL(idb.getNrConnectedComponents(), 3)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 3)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 4)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(2)), 2)
+          TEST_EXCEPTION(Exception::MissingInformation, idb.clusterIndistProteinsAndPeptidesAndExtendGraph());
+          idb.clusterIndistProteinsAndPeptides();
+          // Only cc 0 and 1 have indist prot group
+          TEST_EQUAL(boost::num_edges(idb.getComponent(0)), 3)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(1)), 4)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(2)), 1)
+          idb.resolveGraphPeptideCentric();
+          TEST_EQUAL(idb.getNrConnectedComponents(), 3)
+          // Only cc 0 and 1 have indist prot group
+          TEST_EQUAL(boost::num_edges(idb.getComponent(0)), 4)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(1)), 5)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(2)), 2)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 4)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 5)
+          TEST_EQUAL(boost::num_vertices(idb.getComponent(2)), 2)
         }
     END_SECTION
 

--- a/src/tests/class_tests/openms/source/IDBoostGraph_test.cpp
+++ b/src/tests/class_tests/openms/source/IDBoostGraph_test.cpp
@@ -138,9 +138,10 @@ START_TEST(IDBoostGraph, "$Id$")
           idb.resolveGraphPeptideCentric();
           TEST_EQUAL(idb.getNrConnectedComponents(), 3)
           // Only cc 0 and 1 have indist prot group
-          TEST_EQUAL(boost::num_edges(idb.getComponent(0)), 4)
-          TEST_EQUAL(boost::num_edges(idb.getComponent(1)), 5)
-          TEST_EQUAL(boost::num_edges(idb.getComponent(2)), 2)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(0)), 3)
+          // There is one shared peptide in the second component whose edge will be resolved
+          TEST_EQUAL(boost::num_edges(idb.getComponent(1)), 3)
+          TEST_EQUAL(boost::num_edges(idb.getComponent(2)), 1)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(0)), 4)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(1)), 5)
           TEST_EQUAL(boost::num_vertices(idb.getComponent(2)), 2)

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -607,6 +607,25 @@ protected:
         MzIdentMLFile().load(in, protein_ids, peptide_ids);
       }
       //else catched by TOPPBase:registerInput being mandatory mzid or idxml
+      if (protein_ids.empty())
+      {
+        throw Exception::ElementNotFound(
+            __FILE__,
+            __LINE__,
+            OPENMS_PRETTY_FUNCTION,
+            "File '" + in + "' has not ProteinIDRuns.");
+      }
+      else if (protein_ids.size() > 1)
+      {
+        throw Exception::InvalidValue(
+            __FILE__,
+            __LINE__,
+            OPENMS_PRETTY_FUNCTION,
+            "File '" + in + "' has more than one ProteinIDRun. This is currently not correctly handled."
+            "Please use the merge_proteins_add_psms option if you used IDMerger. Alternatively, pass"
+            " all original single-run idXML inputs as list to this tool.",
+            "# runs: " + String(protein_ids.size()));
+      }
 
       //being paranoid about the presence of target decoy denominations, which are crucial to the percolator process
       for (vector<PeptideIdentification>::iterator pit = peptide_ids.begin(); pit != peptide_ids.end(); ++pit)

--- a/src/utils/IDScoreSwitcher.cpp
+++ b/src/utils/IDScoreSwitcher.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 
+#include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
@@ -72,18 +73,13 @@ class TOPPIDScoreSwitcher :
 public:
 
   TOPPIDScoreSwitcher() :
-    TOPPBase("IDScoreSwitcher", "Switches between different scores of peptide or protein hits in identification data", false), tolerance_(1e-6)
+    TOPPBase("IDScoreSwitcher", "Switches between different scores of peptide or protein hits in identification data", false)
   {
   }
 
 protected:
 
-  /// relative tolerance for score comparisons:
-  const double tolerance_;
-
-  String new_score_, new_score_type_, old_score_; // tool parameters
-  bool higher_better_; // for the new scores, are higher ones better?
-
+  IDScoreSwitcherAlgorithm switcher_{};
 
   void registerOptionsAndFlags_() override
   {
@@ -91,81 +87,15 @@ protected:
     setValidFormats_("in", ListUtils::create<String>("idXML"));
     registerOutputFile_("out", "<file>", "", "Output file");
     setValidFormats_("out", ListUtils::create<String>("idXML"));
-
-    registerStringOption_("new_score", "<name>", "", "Name of the meta value to use as the new score");
-    registerStringOption_("new_score_orientation", "<choice>", "", "Orientation of the new score (are higher or lower values better?)");
-    setValidStrings_("new_score_orientation", ListUtils::create<String>("lower_better,higher_better"));
-    registerStringOption_("new_score_type", "<name>", "", "Name to use as the type of the new score (default: same as 'new_score')", false);
-    registerStringOption_("old_score", "<name>", "", "Name to use for the meta value storing the old score (default: old score type)", false);
     registerFlag_("proteins", "Apply to protein scores instead of PSM scores");
+    registerFullParam_(switcher_.getParameters());
   }
-
-
-  String describeHit_(const PeptideHit& hit)
-  {
-    return "peptide hit with sequence '" + hit.getSequence().toString() +
-      "', charge " + String(hit.getCharge()) + ", score " + 
-      String(hit.getScore());
-  }
-
-
-  String describeHit_(const ProteinHit& hit)
-  {
-    return "protein hit with accession '" + hit.getAccession() + "', score " +
-      String(hit.getScore());
-  }
-
-
-  template <typename IDType>
-  void switchScores_(IDType& id, Size& counter)
-  {
-    for (typename vector<typename IDType::HitType>::iterator hit_it = id.getHits().begin();
-         hit_it != id.getHits().end(); ++hit_it, ++counter)
-    {
-      if (!hit_it->metaValueExists(new_score_))
-      {
-        String msg = "Meta value '" + new_score_ + "' not found for " + 
-          describeHit_(*hit_it);
-        throw Exception::MissingInformation(__FILE__, __LINE__,
-                                            OPENMS_PRETTY_FUNCTION, msg);
-      }
-
-      String old_score_meta = (old_score_.empty() ? id.getScoreType() : 
-                               old_score_);
-      DataValue dv = hit_it->getMetaValue(old_score_meta);
-      if (!dv.isEmpty()) // meta value for old score already exists
-      {
-        if (fabs((double(dv) - hit_it->getScore()) * 2.0 /
-                 (double(dv) + hit_it->getScore())) > tolerance_)
-        {
-          String msg = "Meta value '" + old_score_meta + "' already exists "
-            "with a conflicting value for " + describeHit_(*hit_it);
-          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                        msg, dv.toString());
-        } // else: values match, nothing to do
-      }
-      else
-      {
-        hit_it->setMetaValue(old_score_meta, hit_it->getScore());
-      }
-      hit_it->setScore(hit_it->getMetaValue(new_score_));
-    }
-    id.setScoreType(new_score_type_);
-    id.setHigherScoreBetter(higher_better_);
-  }
-
 
   ExitCodes main_(int, const char**) override
   {
+    switcher_.setParameters(getParam_().copySubset(switcher_.getParameters()));
     String in = getStringOption_("in"), out = getStringOption_("out");
-    bool do_proteins = getFlag_("proteins");
-    new_score_ = getStringOption_("new_score");
-    new_score_type_ = getStringOption_("new_score_type");
-    old_score_ = getStringOption_("old_score");
-    higher_better_ = (getStringOption_("new_score_orientation") == 
-                      "higher_better");
-
-    if (new_score_type_.empty()) new_score_type_ = new_score_;
+    bool do_proteins_ = getFlag_("proteins");
 
     vector<ProteinIdentification> proteins;
     vector<PeptideIdentification> peptides;
@@ -173,27 +103,25 @@ protected:
     IdXMLFile().load(in, proteins, peptides);
 
     Size counter = 0;
-    if (do_proteins)
+    if (do_proteins_)
     {
-      for (vector<ProteinIdentification>::iterator prot_it = proteins.begin();
-           prot_it != proteins.end(); ++prot_it)
+      for (auto& pid : proteins)
       {
-        switchScores_<ProteinIdentification>(*prot_it, counter);
+        switcher_.switchScores<ProteinIdentification>(pid, counter);
       }
     }
     else
     {
-      for (vector<PeptideIdentification>::iterator pep_it = peptides.begin();
-           pep_it != peptides.end(); ++pep_it)
+      for (auto& pepid : peptides)
       {
-        switchScores_<PeptideIdentification>(*pep_it, counter);
+        switcher_.switchScores<PeptideIdentification>(pepid, counter);
       }
     }
 
     IdXMLFile().store(out, proteins, peptides);
 
     OPENMS_LOG_INFO << "Successfully switched " << counter << " "
-             << (do_proteins ? "protein" : "PSM") << " scores." << endl;
+             << (do_proteins_ ? "protein" : "PSM") << " scores." << endl;
 
     return EXECUTION_OK;
   }


### PR DESCRIPTION
- Adds methods for working with IDs on cXML (FDR, Filtering)
- Refactored IDSwitcher to Algorithm
- Implement requestGeneralScoreType (with which you can choose a wanted score type in your ID and it checks for the dozens of different meta values)
- Implemented resolution on the IDBoostGraph data structure (before it was building its own)
- TODO more tests. Only the new resolution has one.
- Fixes HUGE bug in idXML writer, where it didn't bounds check for an existing protein accession and just associated those peptides with a random (usually first) protein.
- Don't allow Percolator to run on idXMLs with multiple runs since it just does nonsense.