### PR TITLE
[FIX] IdXML Allow missed cleavages to be a signed Integer

### DIFF
--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -493,7 +493,7 @@ namespace OpenMS
 
       optionalAttributeAsString_(param_.taxonomy, attributes, "taxonomy");
       param_.charges = attributeAsString_(attributes, "charges");
-      optionalAttributeAsUInt_(param_.missed_cleavages, attributes, "missed_cleavages");
+      optionalAttributeAsInt_(param_.missed_cleavages, attributes, "missed_cleavages");
       param_.fragment_mass_tolerance = attributeAsDouble_(attributes, "peak_mass_tolerance");
 
       String peak_unit;


### PR DESCRIPTION
e.g. for MSGF+ which uses -1 to denote unlimited

fixes #4614 