### PR TITLE
MapAlignerIdentification: option to use "identity" transformation when data is missing

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h
@@ -100,6 +100,8 @@ public:
       @param data Vector of input data (FeatureMap, ConsensusMap, PeakMap or @p vector<PeptideIdentification>) that should be aligned.
       @param transformations Vector of RT transformations that will be computed.
       @param reference_index Index in @p data of the reference to align to, if any
+
+      @throw Exception::MissingInformation Not enough suitable RT data to perform alignment
     */
     template <typename DataType>
     void align(std::vector<DataType>& data,
@@ -335,4 +337,3 @@ private:
   };
 
 } // namespace OpenMS
-

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -85,7 +85,7 @@
 #include <cmath>
 
 using namespace std;
-  
+
 namespace OpenMS
 {
 
@@ -173,7 +173,7 @@ namespace OpenMS
     registerStringOption_("write_ini", "<file>", "", "Writes the default configuration file", false);
     registerStringOption_("write_ctd", "<out_dir>", "", "Writes the common tool description file(s) (Toolname(s).ctd) to <out_dir>", false, true);
     registerFlag_("no_progress", "Disables progress logging to command line", true);
-    registerFlag_("force", "Overwrite tool specific checks.", true);
+    registerFlag_("force", "Override tool-specific checks", true);
     registerFlag_("test", "Enables the test mode (needed for internal use only)", true);
     registerFlag_("-help", "Shows options");
     registerFlag_("-helphelp", "Shows all options (including advanced)", false);
@@ -306,7 +306,7 @@ namespace OpenMS
           writeDebug_("Parameters from common section with tool name:", param_common_tool_, 2);
           param_common_ = param_inifile_.copy("common:", true);
           writeDebug_("Parameters from common section without tool name:", param_common_, 2);
-        
+
           // set type on command line if given in .ini file
           if (param_inifile_.exists(getIniLocation_() + "type") && !param_cmdline_.exists("type"))
             param_cmdline_.setValue("type", param_inifile_.getValue(getIniLocation_() + "type"));
@@ -381,8 +381,8 @@ namespace OpenMS
   #ifdef ENABLE_UPDATE_CHECK
       // disable collection of usage statistics if environment variable is present
       char* disable_usage = getenv("OPENMS_DISABLE_UPDATE_CHECK");
- 
-      // only perform check if variable is not set or explicitly enabled by setting it to "OFF"  
+
+      // only perform check if variable is not set or explicitly enabled by setting it to "OFF"
       if (!test_mode_ && (disable_usage == nullptr || strcmp(disable_usage, "OFF") == 0))
       {
         UpdateCheck::run(tool_name_, version_, debug_level_);
@@ -1283,7 +1283,7 @@ namespace OpenMS
         else
         {
           writeLog_("Input file '" + param_value + "' could not be found (by searching on PATH). "
-                    "Either provide a full filepath or fix your PATH environment!" + 
+                    "Either provide a full filepath or fix your PATH environment!" +
                     (p.required ? "" : " Since this file is not strictly required, you might also pass the empty string \"\" as "
                     "argument to prevent it's usage (this might limit the usability of the tool)."));
           throw FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, param_value);
@@ -1305,7 +1305,7 @@ namespace OpenMS
         if (!ListUtils::contains(p.valid_strings, param_value))
         {
           throw InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-            String("Invalid value '") + param_value + "' for string parameter '" + param_name + "' given. Valid strings are: '" + 
+            String("Invalid value '") + param_value + "' for string parameter '" + param_name + "' given. Valid strings are: '" +
             ListUtils::concatenate(p.valid_strings, "', '") + "'.");
         }
         break;
@@ -1546,7 +1546,7 @@ namespace OpenMS
     {
       OPENMS_LOG_ERROR << "Process '" << String(executable) << "' failed to start. Does it exist? Is it executable?" << std::endl;
       return EXTERNAL_PROGRAM_ERROR;
-    } 
+    }
 
     bool any_failure = (success == false || qp.exitStatus() != 0 || qp.exitCode() != 0);
     if (debug_level_ >= 4 || any_failure)
@@ -2206,7 +2206,7 @@ namespace OpenMS
       }
     }
   }
-  
+
   void TOPPBase::addDataProcessing_(FeatureMap& map, const DataProcessing& dp) const
   {
     map.getDataProcessing().push_back(dp);
@@ -2293,7 +2293,7 @@ namespace OpenMS
       lines.insert(4, QString("<citations>"));
       lines.insert(5, QString("  <citation doi=\"") + QString::fromStdString(cite_openms_.doi) + "\" url=\"\" />");
       int l = 5;
-      for (const Citation& c : citations_) 
+      for (const Citation& c : citations_)
       {
         lines.insert(++l, QString("  <citation doi=\"") + QString::fromStdString(c.doi) + "\" url=\"\" />");
       }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -173,7 +173,7 @@ namespace OpenMS
     registerStringOption_("write_ini", "<file>", "", "Writes the default configuration file", false);
     registerStringOption_("write_ctd", "<out_dir>", "", "Writes the common tool description file(s) (Toolname(s).ctd) to <out_dir>", false, true);
     registerFlag_("no_progress", "Disables progress logging to command line", true);
-    registerFlag_("force", "Override tool-specific checks", true);
+    registerFlag_("force", "Overrides tool-specific checks", true);
     registerFlag_("test", "Enables the test mode (needed for internal use only)", true);
     registerFlag_("-help", "Shows options");
     registerFlag_("-helphelp", "Shows all options (including advanced)", false);

--- a/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_out.ini
+++ b/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_out.ini
@@ -41,7 +41,7 @@
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-      <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+      <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
     </NODE>
   </NODE>

--- a/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_subsec_out.ini
+++ b/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_subsec_out.ini
@@ -8,7 +8,7 @@
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-      <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+      <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="param1" value="param1_value" type="string" description="param1_description" required="false" advanced="false" />

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1131,6 +1131,12 @@ set_tests_properties("TOPP_MapAlignerIdentification_5_out2" PROPERTIES DEPENDS "
 add_test("TOPP_MapAlignerIdentification_6" ${TOPP_BIN_PATH}/MapAlignerIdentification -test -ini ${DATA_DIR_TOPP}/MapAlignerIdentification_parameters.ini -in ${DATA_DIR_TOPP}/MapAlignerIdentification_1_input1.featureXML -trafo_out MapAlignerIdentification_6_output1.tmp -reference:file ${DATA_DIR_TOPP}/MapAlignerIdentification_1_input2.featureXML)
 add_test("TOPP_MapAlignerIdentification_6_out1" ${DIFF} -in1 MapAlignerIdentification_6_output1.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerIdentification_6_output1.trafoXML )
 set_tests_properties("TOPP_MapAlignerIdentification_6_out1" PROPERTIES DEPENDS "TOPP_MapAlignerIdentification_6")
+# "force" option (not enough RT data):
+add_test("TOPP_MapAlignerIdentification_7" ${TOPP_BIN_PATH}/MapAlignerIdentification -test -in ${DATA_DIR_TOPP}/MapAlignerIdentification_7_input1.idXML -out MapAlignerIdentification_7_output1.tmp -trafo_out MapAlignerIdentification_7_output2.tmp -reference:file ${DATA_DIR_TOPP}/MapAlignerIdentification_7_input2.idXML -force)
+add_test("TOPP_MapAlignerIdentification_7_out1" ${DIFF} -in1 MapAlignerIdentification_7_output1.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerIdentification_7_input1.idXML)
+add_test("TOPP_MapAlignerIdentification_7_out2" ${DIFF} -in1 MapAlignerIdentification_7_output2.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerIdentification_7_output2.trafoXML -whitelist "TrafoXML version=")
+set_tests_properties("TOPP_MapAlignerIdentification_7_out1" PROPERTIES DEPENDS "TOPP_MapAlignerIdentification_7")
+set_tests_properties("TOPP_MapAlignerIdentification_7_out2" PROPERTIES DEPENDS "TOPP_MapAlignerIdentification_7")
 
 #------------------------------------------------------------------------------
 # MapAlignerSpectrum tests:

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -34,7 +34,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="algorithm" description="Algorithm section">
           <ITEM name="debug" value="false" type="bool" description="When debug mode is activated, several files with intermediate results are written to the folder &apos;debug&apos; (do not use in parallel mode)." required="false" advanced="false" />
@@ -116,7 +116,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="feature" description="Additional options for featureXML input">
           <ITEM name="use_centroid_rt" value="false" type="bool" description="Use the RT coordinates of the feature centroids for matching, instead of the RT ranges of the features/mass traces." required="false" advanced="false" />
@@ -148,7 +148,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="algorithm" description="Algorithm parameters section">
           <ITEM name="second_nearest_gap" value="2" type="double" description="Only link features whose distance to the second nearest neighbors (for both sides) is larger by &apos;second_nearest_gap&apos; than the distance between the matched pair itself." required="false" advanced="false" restrictions="1:" />

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -32,7 +32,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="algorithm" description="Algorithm section">
           <ITEM name="debug" value="false" type="bool" description="When debug mode is activated, several files with intermediate results are written to the folder &apos;debug&apos; (do not use in parallel mode)." required="false" advanced="false" />
@@ -114,7 +114,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="feature" description="Additional options for featureXML input">
           <ITEM name="use_centroid_rt" value="false" type="bool" description="Use the RT coordinates of the feature centroids for matching, instead of the RT ranges of the features/mass traces." required="false" advanced="false" />
@@ -146,7 +146,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-        <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+        <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
         <NODE name="algorithm" description="Algorithm parameters section">
           <ITEM name="second_nearest_gap" value="2" type="double" description="Only link features whose distance to the second nearest neighbors (for both sides) is larger by &apos;second_nearest_gap&apos; than the distance between the matched pair itself." required="false" advanced="false" restrictions="1:" />

--- a/src/tests/topp/MapAlignerIdentification_7_input1.idXML
+++ b/src/tests/topp/MapAlignerIdentification_7_input1.idXML
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+1-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.05" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+		<VariableModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+	</SearchParameters>
+	<IdentificationRun date="2009-11-17T11:11:11" search_engine="OMSSA" search_engine_version="2.1.4" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="FDR" higher_score_better="false" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="P02769|ALBU_BOVIN" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="tr|A9G8G1|A9G8G1_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="tr|A9GID7|A9GID7_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_3" accession="tr|A9GN44|A9GN44_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_4" accession="tr|A9GV08|A9GV08_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+                        <UserParam type="stringList" name="spectra_data" value="[share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+			<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
+			<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
+			<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
+			<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
+			<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
+			<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+			<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
+			<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
+			<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_3" >
+				<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
+			<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+			<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
+			<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+			<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.32470703125" RT="1804.15795898438" >
+			<PeptideHit score="0" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="3.85390695500564e-05"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
+			<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
+			<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
+			<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_4" >
+				<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="722.327209472656" RT="1918.60864257812" >
+			<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0326599590408071"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
+			<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
+			<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
+			<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
+			<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/MapAlignerIdentification_7_input2.idXML
+++ b/src/tests/topp/MapAlignerIdentification_7_input2.idXML
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+1-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.05" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+		<VariableModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+	</SearchParameters>
+	<IdentificationRun date="2009-11-17T11:11:29" search_engine="OMSSA" search_engine_version="2.1.4" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="FDR" higher_score_better="false" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="P02769|ALBU_BOVIN" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="sp|O46375|TTHY_BOVIN" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="tr|A9G4J7|A9G4J7_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_3" accession="tr|A9GJA3|A9GJA3_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+			<ProteinHit id="PH_4" accession="tr|A9GPT8|A9GPT8_SORC5" score="0" sequence="" >
+				<UserParam type="float" name="OMSSA_score" value="0"/>
+			</ProteinHit>
+                        <UserParam type="stringList" name="spectra_data" value="[share/OpenMS/examples/FRACTIONS/BSA2_F2.mzML]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="409.209625244141" RT="2125.17431640625" >
+			<PeptideHit score="0" sequence="KM(Oxidation)NALPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_4" >
+				<UserParam type="float" name="OMSSA_score" value="0.372243462149079"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="428.234222412109" RT="2133.27758789062" >
+			<PeptideHit score="0" sequence="FVEGLYK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.000359920032318736"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="396.193115234375" RT="2159.67651367188" >
+			<PeptideHit score="0" sequence="QDLLFR" charge="2" aa_before="R X" aa_after="L X" protein_refs="PH_2 PH_3" >
+				<UserParam type="float" name="OMSSA_score" value="0.0262935042571441"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="653.36181640625" RT="2211.3291015625" >
+			<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0126612648870973"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="435.910797119141" RT="2211.69580078125" >
+			<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="2.55714795835858e-07"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="653.361877441406" RT="2236.6865234375" >
+			<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00369772364772338"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="435.910278320312" RT="2239.33520507812" >
+			<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="1.10396016339594e-07"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="499.880798339844" RT="2240.0859375" >
+			<PeptideHit score="0.024390243902439" sequence="DDPHACYSTVFDK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.670964311055543"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="464.250061035156" RT="2250.060546875" >
+			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.000118336398159532"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="547.317077636719" RT="2281.44189453125" >
+			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="R" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.00160478309243352"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="547.317260742188" RT="2320.04614257812" >
+			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="R" aa_after="S" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="3.53616565959601e-12"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="501.794799804688" RT="2341.02001953125" >
+			<PeptideHit score="0" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0181360790892431"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="480.608703613281" RT="2412.92065429688" >
+			<PeptideHit score="0" sequence="RHPEYAVSVLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="9.07782012840389e-06"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="480.6083984375" RT="2448.30102539062" >
+			<PeptideHit score="0" sequence="RHPEYAVSVLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="1.59734773381327e-12"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="627.646362304688" RT="2476.88061523438" >
+			<PeptideHit score="0" sequence="RPC(Carbamidomethyl)FSALTPDETYVPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="5.78187927541962e-05"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="480.608581542969" RT="2487.84423828125" >
+			<PeptideHit score="0" sequence="RHPEYAVSVLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="6.99722411410769e-13"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="571.860717773438" RT="2492.93994140625" >
+			<PeptideHit score="0" sequence="KQTALVELLK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="2.62096624298549e-05"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="381.576354980469" RT="2494.88159179688" >
+			<PeptideHit score="0" sequence="KQTALVELLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="2.89327520051305e-10"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/MapAlignerIdentification_7_output2.trafoXML
+++ b/src/tests/topp/MapAlignerIdentification_7_output2.trafoXML
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TrafoXML version="1.0" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/TrafoXML_1_0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Transformation name="identity">
+  </Transformation>
+</TrafoXML>

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -10,7 +10,7 @@
       <ITEM name="debug" value="4" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
-      <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
+      <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="signal_to_noise" value="1" type="double" description="Minimal signal to noise ratio for a peak to be picked." required="false" advanced="false" restrictions="0:" />

--- a/src/topp/MapAlignerIdentification.cpp
+++ b/src/topp/MapAlignerIdentification.cpp
@@ -177,7 +177,7 @@ private:
         model_type = "identity";
         transformations.resize(data.size());
       }
-      else throw(err);
+      else throw;
     }
 
     if (model_type != "none")

--- a/src/topp/MapAlignerIdentification.cpp
+++ b/src/topp/MapAlignerIdentification.cpp
@@ -175,6 +175,7 @@ private:
           << "\nSince 'force' is set, processing will continue using 'identity' transformations."
           << endl;
         model_type = "identity";
+        transformations.resize(data.size());
       }
       else throw(err);
     }

--- a/src/topp/MapAlignerIdentification.cpp
+++ b/src/topp/MapAlignerIdentification.cpp
@@ -116,7 +116,7 @@ public:
 
 private:
   template <typename MapType, typename FileType>
-  void loadInitialMaps_(vector<MapType>& maps, StringList& ins, 
+  void loadInitialMaps_(vector<MapType>& maps, StringList& ins,
                         FileType& input_file)
   {
     // custom progress logger for this task:
@@ -134,7 +134,7 @@ private:
   // helper function to avoid code duplication between consensusXML and
   // featureXML storage operations:
   template <typename MapType, typename FileType>
-  void storeTransformedMaps_(vector<MapType>& maps, StringList& outs, 
+  void storeTransformedMaps_(vector<MapType>& maps, StringList& outs,
                              FileType& output_file)
   {
     // custom progress logger for this task:
@@ -145,7 +145,7 @@ private:
     {
       progresslogger.setProgress(i);
       // annotate output with data processing info:
-      addDataProcessing_(maps[i], 
+      addDataProcessing_(maps[i],
                          getProcessingInfo_(DataProcessing::ALIGNMENT));
       output_file.store(outs[i], maps[i]);
     }
@@ -158,11 +158,27 @@ private:
                          vector<TransformationDescription>& transformations,
                          Int reference_index)
   {
-    algorithm.align(data, transformations, reference_index);
-
     // find model parameters:
     Param model_params = getParam_().copy("model:", true);
     String model_type = model_params.getValue("type");
+
+    try
+    {
+      algorithm.align(data, transformations, reference_index);
+    }
+    catch (Exception::MissingInformation& err)
+    {
+      if (getFlag_("force"))
+      {
+        OPENMS_LOG_ERROR
+          << "Error: alignment failed. Details:\n" << err.getMessage()
+          << "\nSince 'force' is set, processing will continue using 'identity' transformations."
+          << endl;
+        model_type = "identity";
+      }
+      else throw(err);
+    }
+
     if (model_type != "none")
     {
       model_params = model_params.copy(model_type + ":", true);
@@ -191,7 +207,7 @@ private:
     // custom progress logger for this task:
     ProgressLogger progresslogger;
     progresslogger.setLogType(log_type_);
-    progresslogger.startProgress(0, trafos.size(), 
+    progresslogger.startProgress(0, trafos.size(),
                                  "writing transformation files");
     for (Size i = 0; i < transformations.size(); ++i)
     {
@@ -356,22 +372,23 @@ private:
           size_t n_fractions = frac2files.size();
 
           // TODO FRACTIONS: determine map index based on annotated MS files (getPrimaryMSRuns())
-          for (size_t feature_map_index = 0; 
-            feature_map_index != n_fractions; 
-            ++feature_map_index)
+          for (size_t feature_map_index = 0; feature_map_index != n_fractions;
+               ++feature_map_index)
           {
             fraction_maps.push_back(feature_maps[feature_map_index]);
           }
           performAlignment_(algorithm, fraction_maps, fraction_transformations,
-            reference_index);
+                            reference_index);
           applyTransformations_(fraction_maps, fraction_transformations);
 
           // copy into transformations and feature maps
-          transformations.insert(transformations.end(), fraction_transformations.begin(), fraction_transformations.end());
+          transformations.insert(transformations.end(),
+                                 fraction_transformations.begin(),
+                                 fraction_transformations.end());
 
           Size f = 0;
-          for (size_t feature_map_index = 0; 
-            feature_map_index != n_fractions; 
+          for (size_t feature_map_index = 0;
+            feature_map_index != n_fractions;
             ++feature_map_index,
             ++f)
           {
@@ -430,7 +447,7 @@ private:
 
       if (!output_files.empty())
       {
-        progresslogger.startProgress(0, output_files.size(), 
+        progresslogger.startProgress(0, output_files.size(),
                                      "writing output files");
         for (Size i = 0; i < output_files.size(); ++i)
         {


### PR DESCRIPTION
As requested by @timosachsenberg. When the "force" flag is set, MapAlignerIdentification will now finish by applying the "identity" transformation (i.e. no change to RTs) when there isn't enough suitable RT data to calculate an alignment. Previously (and still without "-force") it would fail with an error.
I think not having the expected data is actually an error condition, hence the requirement to use "-force".