### PR TITLE
[FIX] pyopenms-nightly - variable for push 

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -402,7 +402,7 @@ if(NOT PY_NUM_MODULES)
 endif()
 
 # set data variable nightly builds use repository last change date
-set(OPENMS_GIT_LC_DATE OPENMS_GIT_LC_DATE)
+set(OPENMS_GIT_LC_DATE ${OPENMS_GIT_LC_DATE})
 
 set(_env_py_in ${PROJECT_SOURCE_DIR}/env.py.in)
 set(_env_py ${CMAKE_BINARY_DIR}/pyOpenMS/env.py)


### PR DESCRIPTION
PyPI push not working due to unresolved variable ("OPENMS_GIT_LC_DATE").

Uploading pyopenms_nightly-2.6.0.devOPENMS_GIT_LC_DATE-cp35-cp35m-manylinux2014_x86_64.whl