### PR TITLE
[Feature] FFC/FeatureFinderAlgorithmPicked speedup

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Marc Sturm $
+// $Authors: Marc Sturm, Tom Lukas Lankenau $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h>

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -325,7 +325,7 @@ namespace OpenMS
       for (Size s = min_spectra_; s < end_iteration; ++s)
       {
         ff_->setProgress(s);
-        SpectrumType& spectrum = map_[s];
+        const SpectrumType& spectrum = map_[s];
         //iterate over all peaks of the scan
         for (Size p = 0; p < spectrum.size(); ++p)
         {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -726,11 +726,11 @@ namespace OpenMS
 
             bool feature_ok = checkFeatureQuality_(fitter, new_traces, seed_mz, min_feature_score, error_msg, fit_score, correlation, final_score);
 
-#pragma omp critical (FeatureFinderAlgorithmPicked_DEBUG)
             {
               //write debug output of feature
               if (debug_)
               {
+#pragma omp critical (FeatureFinderAlgorithmPicked_DEBUG)
                 writeFeatureDebugInfo_(fitter, traces, new_traces, feature_ok, error_msg, final_score, plot_nr, peak);
               }
             }
@@ -840,9 +840,9 @@ namespace OpenMS
       // used in any feature with higher intensity, we can add it to the
       // features_ list.
       std::vector<Size> seeds_contained;
-      for (std::map<Size, Feature>::iterator iter = tmp_feature_map.begin(); iter != tmp_feature_map.end(); ++iter)
+      for (auto & iter : tmp_feature_map)
       {
-        Size seed_nr = iter->first;
+        Size seed_nr = iter.first;
         bool is_used = false;
         for (unsigned long i : seeds_contained)
         {
@@ -853,9 +853,9 @@ namespace OpenMS
           ++feature_candidates;
 
           //re-set label
-          iter->second.setMetaValue(3, feature_nr_global);
+          iter.second.setMetaValue(3, feature_nr_global);
           ++feature_nr_global;
-          features_->push_back(iter->second);
+          features_->push_back(iter.second);
 
           std::vector<Size> curr_seed = seeds_in_features[seed_nr];
           for (unsigned long k : curr_seed)
@@ -1764,6 +1764,7 @@ namespace OpenMS
     double high_bound = fitter->getUpperRTBound();
 
     if (debug_) log_ << "    => RT bounds: " << low_bound << " - " << high_bound << std::endl;
+    std::vector<double> v_theo, v_real;
     for (Size t = 0; t < traces.size(); ++t)
     {
       const MassTrace& trace = traces[t];
@@ -1772,7 +1773,8 @@ namespace OpenMS
       MassTrace new_trace;
       //compute average relative deviation and correlation
       double deviation = 0.0;
-      std::vector<double> v_theo, v_real;
+      v_theo.clear();
+      v_real.clear();
       for (Size k = 0; k < trace.peaks.size(); ++k)
       {
         //consider peaks when inside RT bounds only
@@ -1781,7 +1783,6 @@ namespace OpenMS
           new_trace.peaks.push_back(trace.peaks[k]);
 
           double theo = traces.baseline + fitter->computeTheoretical(trace, k);
-
           v_theo.push_back(theo);
           double real = trace.peaks[k].second->getIntensity();
           v_real.push_back(real);

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -219,7 +219,7 @@ namespace OpenMS
 
     //reserve space for calculated scores
     UInt charge_count = charge_high - charge_low + 1;
-    for (auto & s : map_)
+    for (auto& s : map_)
     {
       Size scan_size = s.size();
       s.getFloatDataArrays().resize(3 + 2 * charge_count);
@@ -394,9 +394,9 @@ namespace OpenMS
         isotope_distributions_[index].trimmed_left = size_before - d.size();
         d.trimRight(intensity_percentage_optional_);
 
-        for (auto & it : d)
+        for (auto& peak : d)
         {
-          isotope_distributions_[index].intensity.push_back(it.getIntensity());
+          isotope_distributions_[index].intensity.push_back(peak.getIntensity());
           //if(debug_) log_ << " - " << it->second << std::endl;
         }
 
@@ -432,7 +432,7 @@ namespace OpenMS
           }
         }
         isotope_distributions_[index].max = max;
-        for (double & i : isotope_distributions_[index].intensity)
+        for (double& i : isotope_distributions_[index].intensity)
         {
           i /= max;
         }
@@ -566,7 +566,7 @@ namespace OpenMS
         //seeds
         FeatureMap seed_map;
         seed_map.reserve(seeds.size());
-        for (auto & seed : seeds)
+        for (auto& seed : seeds)
         {
           Size spectrum = seed.spectrum;
           Size peak = seed.peak;
@@ -780,7 +780,7 @@ namespace OpenMS
                 double average_mz = 0.0;
                 for (Size t = 0; t < traces.size(); ++t)
                 {
-                  for (auto & p : traces[t].peaks)
+                  for (auto& p : traces[t].peaks)
                   {
                     average_mz += p.second->getMZ() * p.second->getIntensity();
                     total_intensity += p.second->getIntensity();
@@ -840,11 +840,11 @@ namespace OpenMS
       // used in any feature with higher intensity, we can add it to the
       // features_ list.
       std::vector<Size> seeds_contained;
-      for (auto & iter : tmp_feature_map)
+      for (auto& f : tmp_feature_map)
       {
-        Size seed_nr = iter.first;
+        Size seed_nr = f.first;
         bool is_used = false;
-        for (unsigned long i : seeds_contained)
+        for (Size i : seeds_contained)
         {
           if (seed_nr == i) { is_used = true; break; }
         }
@@ -853,12 +853,12 @@ namespace OpenMS
           ++feature_candidates;
 
           //re-set label
-          iter.second.setMetaValue(3, feature_nr_global);
+          f.second.setMetaValue(3, feature_nr_global);
           ++feature_nr_global;
-          features_->push_back(iter.second);
+          features_->push_back(f.second);
 
           std::vector<Size> curr_seed = seeds_in_features[seed_nr];
-          for (unsigned long k : curr_seed)
+          for (Size k : curr_seed)
           {
             seeds_contained.push_back(k);
           }
@@ -1005,7 +1005,7 @@ namespace OpenMS
       FeatureXMLFile().store("debug/abort_reasons.featureXML", abort_map);
 
       //store input map with calculated scores (without overall score)
-      for (auto & s : map_)
+      for (auto& s : map_)
       {
         s.getFloatDataArrays().erase(s.getFloatDataArrays().begin() + 2);
       }
@@ -1057,7 +1057,7 @@ namespace OpenMS
     //calculate the RT range sum of feature 1
     double s1 = 0.0;
     const std::vector<ConvexHull2D>& hulls1 = f1.getConvexHulls();
-    for (const auto & i : hulls1)
+    for (const auto& i : hulls1)
     {
       s1 += i.getBoundingBox().width();
     }
@@ -1065,17 +1065,17 @@ namespace OpenMS
     //calculate the RT range sum of feature 2
     double s2 = 0.0;
     const std::vector<ConvexHull2D>& hulls2 = f2.getConvexHulls();
-    for (const auto & j : hulls2)
+    for (const auto& j : hulls2)
     {
       s2 += j.getBoundingBox().width();
     }
 
     //calculate overlap
     double overlap = 0.0;
-    for (const auto & i : hulls1)
+    for (const auto& i : hulls1)
     {
       DBoundingBox<2> bb1 = i.getBoundingBox();
-      for (const auto & j : hulls2)
+      for (const auto& j : hulls2)
       {
         DBoundingBox<2> bb2 = j.getBoundingBox();
         if (bb1.intersects(bb2))

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -1914,7 +1914,7 @@ namespace OpenMS
 
     }
 
-    return feature_ok;
+    return true;
   }
 
   void FeatureFinderAlgorithmPicked::writeFeatureDebugInfo_(TraceFitter* fitter,

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -325,7 +325,7 @@ namespace OpenMS
       for (Size s = min_spectra_; s < end_iteration; ++s)
       {
         ff_->setProgress(s);
-        const SpectrumType& spectrum = map_[s];
+        SpectrumType& spectrum = map_[s];
         //iterate over all peaks of the scan
         for (Size p = 0; p < spectrum.size(); ++p)
         {


### PR DESCRIPTION
Worked once more at FeatureFinderCentroided. 
As the main runtime goes into `run()`, I focused on that. For exact changes look into the single commits. I think they explain quiet good, what happened.

As a result the runtime reduced from `1:21:54`  to `1:07:29` (Wall)
I compared the output file from the "develop"-Branch and from my "ffc-testzone"-Featurebranch with FuzzyFinder. For some reason the representation of the intensities changed in the output. This lead to some decimal points being cut off and to a slightly changed output:
```
PASSED.

  relative_max:        1
  relative_acceptable: 1

  absolute_max:        0.009062
  absolute_acceptable: 0.01

  whitelist cases:
    "completion_time"      1x
    "feature id"         70791x
    "featureMap version"   1x
    "parameter"            1x
    "software name"        1x

Maximum relative error was attained at these lines, enclosed in "":

./F_QC_20140521_2.featureXML:2307927:
"                       <intensity>1.040731e04</intensity>"     <-- from ffc-testzone

./R_QC_20140521_2.featureXML:2307927:
"                       <intensity>10407.311523</intensity>"    <-- from develop
```
I also ran all the tests and they all passed.

If someone is interested in working on this in the future again: I refactored the individual steps in run(), so that they appear in perf and one can see where the runtime disappears.
![Step](https://user-images.githubusercontent.com/39794212/81085827-024f3380-8ef8-11ea-87e2-1ff616d71587.PNG)
![StepThree](https://user-images.githubusercontent.com/39794212/81085829-03806080-8ef8-11ea-98ef-f21132afdb1b.PNG)
![StepThreeThree](https://user-images.githubusercontent.com/39794212/81085833-04b18d80-8ef8-11ea-9488-a5e7a740cdf3.PNG)


