### PR TITLE
MapAlignerTreeGuided: Better memory usage and new option

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h
@@ -92,12 +92,12 @@ public:
      * @brief Align feature maps tree guided using align() of @ref OpenMS::MapAlignmentAlgorithmIdentification and use TreeNode with larger 10/90 percentile range as reference.
      *
      * @param tree Vector of BinaryTreeNodes that contains order for alignment.
-     * @param feature_maps_transformed Vector with copied input maps for transformation process.
+     * @param feature_maps_transformed Vector with input maps for transformation process.
      * @param maps_ranges Vector that contains all sorted RTs of extracted identifications for each map; needed to determine the 10/90 percentiles.
      * @param map_transformed FeatureMap to store all features of combined maps with original and transformed RTs in order of alignment.
      * @param trafo_order Vector to store indices of maps in order of alignment.
     */
-    void treeGuidedAlignment(const std::vector<BinaryTreeNode>& tree, std::vector<FeatureMap> feature_maps_transformed,
+    void treeGuidedAlignment(const std::vector<BinaryTreeNode>& tree, std::vector<FeatureMap>& feature_maps_transformed,
                              std::vector<std::vector<double>>& maps_ranges, FeatureMap& map_transformed,
                              std::vector<Size>& trafo_order);
 

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h
@@ -92,7 +92,7 @@ public:
      * @brief Align feature maps tree guided using align() of @ref OpenMS::MapAlignmentAlgorithmIdentification and use TreeNode with larger 10/90 percentile range as reference.
      *
      * @param tree Vector of BinaryTreeNodes that contains order for alignment.
-     * @param feature_maps_transformed Vector with input maps for transformation process.
+     * @param feature_maps_transformed Vector with input maps for transformation process. Because the transformed maps are stored within this vector it's not const.
      * @param maps_ranges Vector that contains all sorted RTs of extracted identifications for each map; needed to determine the 10/90 percentiles.
      * @param map_transformed FeatureMap to store all features of combined maps with original and transformed RTs in order of alignment.
      * @param trafo_order Vector to store indices of maps in order of alignment.

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.cpp
@@ -63,9 +63,7 @@ namespace OpenMS
     defaultsToParam_();
   }
 
-  MapAlignmentAlgorithmTreeGuided::~MapAlignmentAlgorithmTreeGuided()
-  {
-  }
+  MapAlignmentAlgorithmTreeGuided::~MapAlignmentAlgorithmTreeGuided() = default;
 
   void MapAlignmentAlgorithmTreeGuided::updateMembers_()
   {
@@ -177,7 +175,7 @@ namespace OpenMS
 
   // Align feature maps tree guided using align() of MapAlignmentAlgorithmIdentification and use TreeNode with larger 10/90 percentile range as reference.
   void MapAlignmentAlgorithmTreeGuided::treeGuidedAlignment(const std::vector<BinaryTreeNode>& tree,
-                                                            std::vector<FeatureMap> feature_maps_transformed,
+                                                            std::vector<FeatureMap>& feature_maps_transformed,
                                                             std::vector<std::vector<double>>& maps_ranges,
                                                             FeatureMap& map_transformed,
                                                             std::vector<Size>& trafo_order)
@@ -227,7 +225,6 @@ namespace OpenMS
       vector<double> tmp;
       std::merge(maps_ranges[node.right_child].begin(), maps_ranges[node.right_child].end(), maps_ranges[node.left_child].begin(), maps_ranges[node.left_child].end(), std::back_inserter(tmp));
 
-      last_trafo = to_transform;
       to_align.push_back(feature_maps_transformed[to_transform]);
       to_align.push_back(feature_maps_transformed[ref]);
 
@@ -241,10 +238,21 @@ namespace OpenMS
       MapAlignmentTransformer::transformRetentionTimes(feature_maps_transformed[to_transform],
               transformations_align[0], true);
 
-      // combine aligned maps, store in both, because tree always calls smaller number
+      // combine aligned maps, store at smaller index, because tree always calls smaller number
+      // clear feature map at larger index to save memory
       feature_maps_transformed[ref] += feature_maps_transformed[to_transform];
       feature_maps_transformed[ref].updateRanges();
-      feature_maps_transformed[to_transform] = feature_maps_transformed[ref];
+      if (ref < to_transform)
+      {
+        feature_maps_transformed[to_transform].clear(true);
+        last_trafo = ref;
+      }
+      else
+      {
+        feature_maps_transformed[to_transform] = feature_maps_transformed[ref];
+        feature_maps_transformed[ref].clear(true);
+        last_trafo = to_transform;
+      }
 
       // update order of alignment for both aligned maps
       map_sets[ref].insert(map_sets[ref].end(), map_sets[to_transform].begin(), map_sets[to_transform].end());

--- a/src/tests/class_tests/openms/source/MapAlignmentAlgorithmTreeGuided_test.cpp
+++ b/src/tests/class_tests/openms/source/MapAlignmentAlgorithmTreeGuided_test.cpp
@@ -67,6 +67,8 @@ vector<FeatureMap> maps(3);
 FeatureXMLFile().load(OPENMS_GET_TEST_DATA_PATH("MapAlignmentAlgorithmTreeGuided_test_in0.featureXML"), maps[0]);
 FeatureXMLFile().load(OPENMS_GET_TEST_DATA_PATH("MapAlignmentAlgorithmTreeGuided_test_in1.featureXML"), maps[1]);
 FeatureXMLFile().load(OPENMS_GET_TEST_DATA_PATH("MapAlignmentAlgorithmTreeGuided_test_in2.featureXML"), maps[2]);
+// copy maps for computeTrafosByOriginalRT and computeTransformedFeatureMaps
+vector<FeatureMap> maps_orig = maps;
 
 MapAlignmentAlgorithmTreeGuided aligner;
 aligner.setLogType(ProgressLogger::CMD);
@@ -106,7 +108,7 @@ START_SECTION((static void buildTree(std::vector<FeatureMap>& feature_maps, std:
 }
 END_SECTION
 
-START_SECTION((void treeGuidedAlignment(const std::vector<BinaryTreeNode>& tree, std::vector<FeatureMap> feature_maps_transformed,
+START_SECTION((void treeGuidedAlignment(const std::vector<BinaryTreeNode>& tree, std::vector<FeatureMap>& feature_maps_transformed,
         std::vector<std::vector<double>>& maps_ranges, FeatureMap& map_transformed, std::vector<Size>& trafo_order)))
 {
   aligner.treeGuidedAlignment(result_tree, maps, maps_ranges, map_transformed, trafo_order);
@@ -137,7 +139,7 @@ END_SECTION
 START_SECTION((void computeTrafosByOriginalRT(std::vector<FeatureMap>& feature_maps, FeatureMap& map_transformed,
         std::vector<TransformationDescription>& transformations, const std::vector<Size>& trafo_order)))
 {
-  aligner.computeTrafosByOriginalRT(maps, map_transformed, trafos, trafo_order);
+  aligner.computeTrafosByOriginalRT(maps_orig, map_transformed, trafos, trafo_order);
 
   TEST_EQUAL(trafos.size(), 3);
 
@@ -145,7 +147,7 @@ START_SECTION((void computeTrafosByOriginalRT(std::vector<FeatureMap>& feature_m
   {
     // first rt in trafo should be the same as in original map
     Size j = 0;
-    for (auto feature_it = maps[i].begin(); feature_it < maps[i].end(); ++feature_it)
+    for (auto feature_it = maps_orig[i].begin(); feature_it < maps_orig[i].end(); ++feature_it)
     {
       TEST_REAL_SIMILAR(trafos[i].getDataPoints()[j].first, feature_it->getRT());
       ++j;
@@ -156,10 +158,10 @@ END_SECTION
 
 START_SECTION((static void computeTransformedFeatureMaps(std::vector<FeatureMap>& feature_maps, const std::vector<TransformationDescription>& transformations)))
 {
-  OpenMS::MapAlignmentAlgorithmTreeGuided::computeTransformedFeatureMaps(maps, trafos);
+  OpenMS::MapAlignmentAlgorithmTreeGuided::computeTransformedFeatureMaps(maps_orig, trafos);
 
   // check storing of original RTs:
-  for (auto& map : maps)
+  for (auto& map : maps_orig)
   {
     for (auto feat_it = map.begin(); feat_it < map.end(); ++feat_it)
     {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1165,6 +1165,14 @@ add_test("TOPP_MapAlignerTreeGuided_2_out2" ${DIFF} -in1 MapAlignerTreeGuided_2_
 set_tests_properties("TOPP_MapAlignerTreeGuided_2_out2" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_2")
 add_test("TOPP_MapAlignerTreeGuided_2_out3" ${DIFF} -in1 MapAlignerTreeGuided_2_output3.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_2_output3.trafoXML )
 set_tests_properties("TOPP_MapAlignerTreeGuided_2_out3" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_2")
+# loading files twice option
+add_test("TOPP_MapAlignerTreeGuided_3" ${TOPP_BIN_PATH}/MapAlignerTreeGuided -test -ini ${DATA_DIR_TOPP}/MapAlignerTreeGuided_parameters2.ini -in ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input1.featureXML ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input2.featureXML ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input3.featureXML -out MapAlignerTreeGuided_3_output1.tmp MapAlignerTreeGuided_3_output2.tmp MapAlignerTreeGuided_3_output3.tmp)
+add_test("TOPP_MapAlignerTreeGuided_3_out1" ${DIFF} -in1 MapAlignerTreeGuided_3_output1.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output1.featureXML )
+set_tests_properties("TOPP_MapAlignerTreeGuided_1_out1" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
+add_test("TOPP_MapAlignerTreeGuided_3_out2" ${DIFF} -in1 MapAlignerTreeGuided_3_output2.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output2.featureXML )
+set_tests_properties("TOPP_MapAlignerTreeGuided_1_out2" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
+add_test("TOPP_MapAlignerTreeGuided_3_out3" ${DIFF} -in1 MapAlignerTreeGuided_3_output3.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output3.featureXML )
+set_tests_properties("TOPP_MapAlignerTreeGuided_1_out3" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
 
 #------------------------------------------------------------------------------
 # MapRTTransformer tests

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1168,11 +1168,11 @@ set_tests_properties("TOPP_MapAlignerTreeGuided_2_out3" PROPERTIES DEPENDS "TOPP
 # loading files twice option
 add_test("TOPP_MapAlignerTreeGuided_3" ${TOPP_BIN_PATH}/MapAlignerTreeGuided -test -ini ${DATA_DIR_TOPP}/MapAlignerTreeGuided_parameters2.ini -in ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input1.featureXML ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input2.featureXML ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_input3.featureXML -out MapAlignerTreeGuided_3_output1.tmp MapAlignerTreeGuided_3_output2.tmp MapAlignerTreeGuided_3_output3.tmp)
 add_test("TOPP_MapAlignerTreeGuided_3_out1" ${DIFF} -in1 MapAlignerTreeGuided_3_output1.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output1.featureXML )
-set_tests_properties("TOPP_MapAlignerTreeGuided_1_out1" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
+set_tests_properties("TOPP_MapAlignerTreeGuided_3_out1" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
 add_test("TOPP_MapAlignerTreeGuided_3_out2" ${DIFF} -in1 MapAlignerTreeGuided_3_output2.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output2.featureXML )
-set_tests_properties("TOPP_MapAlignerTreeGuided_1_out2" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
+set_tests_properties("TOPP_MapAlignerTreeGuided_3_out2" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
 add_test("TOPP_MapAlignerTreeGuided_3_out3" ${DIFF} -in1 MapAlignerTreeGuided_3_output3.tmp -in2 ${DATA_DIR_TOPP}/MapAlignerTreeGuided_1_output3.featureXML )
-set_tests_properties("TOPP_MapAlignerTreeGuided_1_out3" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
+set_tests_properties("TOPP_MapAlignerTreeGuided_3_out3" PROPERTIES DEPENDS "TOPP_MapAlignerTreeGuided_3")
 
 #------------------------------------------------------------------------------
 # MapRTTransformer tests

--- a/src/tests/topp/MapAlignerTreeGuided_parameters2.ini
+++ b/src/tests/topp/MapAlignerTreeGuided_parameters2.ini
@@ -9,7 +9,7 @@
       </ITEMLIST>
       <ITEMLIST name="trafo_out" type="output-file" description="Transformation output files. This option or &apos;out&apos; has to be provided; they can be used together." required="false" advanced="false" supported_formats="*.trafoXML">
       </ITEMLIST>
-      <ITEM name="copy_data" value="false" type="string" description="When aligning a large dataset with many files, load the input files twice and bypass copying." required="false" advanced="false" restrictions="true,false" />
+      <ITEM name="copy_data" value="true" type="string" description="When aligning a large dataset with many files, load the input files twice and bypass copying." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />

--- a/src/topp/MapAlignerTreeGuided.cpp
+++ b/src/topp/MapAlignerTreeGuided.cpp
@@ -164,6 +164,8 @@ private:
     TOPPMapAlignerBase::registerOptionsAndFlags_("featureXML",
                                                  REF_NONE);
     registerSubsection_("algorithm", "Algorithm parameters section");
+    registerStringOption_("copy_data", "String", "true", "When aligning a large dataset with many files, load the input files twice and bypass copying.", false, false);
+    setValidStrings_("copy_data", {"true","false"});
   }
 
   Param getSubsectionDefaults_(const String& section) const override
@@ -221,8 +223,18 @@ private:
     // alignment
     vector<Size> trafo_order;
     FeatureMap map_transformed;
-    // alignment uses copy of feature_maps, returning result within map_transformed (to keep original data)
-    algoTree.treeGuidedAlignment(tree, feature_maps, maps_ranges, map_transformed, trafo_order);
+    // depending on the selected parameter, the input data for the alignment are copied or reloaded after alignment
+    if (getStringOption_("copy_data") == "true")
+    {
+      vector<FeatureMap> copied_maps = feature_maps;
+      algoTree.treeGuidedAlignment(tree, copied_maps, maps_ranges, map_transformed, trafo_order);
+    }
+    else
+    {
+      algoTree.treeGuidedAlignment(tree, feature_maps, maps_ranges, map_transformed, trafo_order);
+      // load() of FeatureXMLFile clears featureMap, so we don't have to care
+      loadInputMaps_(feature_maps, in_files, fxml_file);
+    }
 
     //-------------------------------------------------------------
     // generating output


### PR DESCRIPTION
Because the alignment of large data sets can lead to an out of memory problem, I have changed the following:
1. internally the growing FeatureMap is no longer copied. Instead, all maps that are no longer needed are deleted from the temporary vector.
2. the user of the TOPP tool is given the option to choose whether the input data is copied or loaded twice during the alignment.