### PR TITLE
Add a missing const operator[] for IsotopeDistribution

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
@@ -221,6 +221,8 @@ public:
     //@{
     /// operator which access a cell of the distribution and wraps it in SpectrumFragment struct
     Peak1D& operator[](const Size& index){ return distribution_[index];}
+    /// const operator which access a cell of the distribution and wraps it in SpectrumFragment struct
+    const Peak1D& operator[](const Size& index) const { return distribution_[index]; }
     //@}
 
 protected:   

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
@@ -219,9 +219,9 @@ public:
 
     /// @name Data Access Operators
     //@{
-    /// operator which access a cell of the distribution and wraps it in SpectrumFragment struct
+    /// operator to access a cell of the distribution and wraps it in SpectrumFragment struct
     Peak1D& operator[](const Size& index){ return distribution_[index];}
-    /// const operator which access a cell of the distribution and wraps it in SpectrumFragment struct
+    /// const operator to access a cell of the distribution and wraps it in SpectrumFragment struct
     const Peak1D& operator[](const Size& index) const { return distribution_[index]; }
     //@}
 


### PR DESCRIPTION
I wasn't able to pass a const IsotopeDistribution& to functions and read their peaks because the only operator[] was non-const. This adds the missing const operator[] to IsotopeDistribution.