### PR TITLE
fix: vector out of bounds in EMG derivative calculations

### DIFF
--- a/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
+++ b/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
@@ -496,7 +496,7 @@ namespace OpenMS
     std::vector<double> derivatives(xs.size() + 1); // One more element to account for derivatives from right to left
     derivatives.front() = 1.0;
     derivatives.back() = -1.0;
-    for (Size k = i - 1; k < xs.size() && k <= j + 1; ++k)
+    for (Size k = i - 1; k < xs.size() && k <= j + 1 && i > 1; ++k)
     {
       derivatives[k] = (ys[k] - ys[k - 1]) / (xs[k] - xs[k - 1]);
     }


### PR DESCRIPTION
# Description
There is an edge case in the calculation of the derivatives where no data points are found that are below the intensity threshold for calculating the derivatives.  This results in an attempt to access a location in a vector that is less than 0.

# Fix
Added a check for the edge case where there would be an attempt to access a vector index of less than 0. 