### PR TITLE
Cherry-picked commits for feature

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -258,7 +258,7 @@ namespace OpenMS
       /** User parameter name for the M/Z of other chromatograms which have been merged into this one
               String
        */
-      extern OPENMS_DLLAPI const std::string   MERGED_WITH;
+      extern OPENMS_DLLAPI const std::string   MERGED_CHROMATOGRAM_MZS;
 
       /** User parameter name for precursor mz error in ppm
               String

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -255,6 +255,11 @@ namespace OpenMS
 
     namespace UserParam
     {
+      /** User parameter name for the M/Z of other chromatograms which have been merged into this one
+              String
+       */
+      extern OPENMS_DLLAPI const std::string   MERGED_WITH;
+
       /** User parameter name for precursor mz error in ppm
               String
       */
@@ -264,7 +269,6 @@ namespace OpenMS
               String
       */
       extern OPENMS_DLLAPI const std::string   FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM;
-
 
       /** User parameter name for fragment annotations
               String

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
@@ -47,7 +47,6 @@ namespace OpenMS
     @brief A 1-dimensional raw data point or peak for chromatograms.
 
     This datastructure is intended for chromatograms.
-    If you want to annotated single peaks with meta data, use RichChromatogramPeak instead.
 
     @ingroup Kernel
   */

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -424,7 +424,7 @@ public:
 
       @param other a reference to the MSChromatogram to take ChromatogramPeaks from
     */
-    void mergePeaks(MSChromatogram& other);
+    void mergePeaks(MSChromatogram& other, bool add_meta=true);
 
 protected:
 

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -422,9 +422,11 @@ public:
       @note Make sure BOTH chromatograms are sorted with respect to RT. Otherwise the result is
       undefined.
 
+      MZ of the destination MSChromatogram remains unchanged. If add_meta is true a metavalue "merged_with" is added with the MZ of the source MSChromatogram
+
       @param other a reference to the MSChromatogram to take ChromatogramPeaks from
     */
-    void mergePeaks(MSChromatogram& other, bool add_meta=true);
+    void mergePeaks(MSChromatogram& other, bool add_meta=false);
 
 protected:
 

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -416,6 +416,16 @@ public:
 
     ///@}
 
+    /**
+      @brief Adds all the ChromatogramPeaks from another MSChromatogram and updates the metadata to indicate a merge
+
+      @note Make sure BOTH chromatograms are sorted with respect to RT. Otherwise the result is
+      undefined.
+
+      @param other a reference to the MSChromatogram to take ChromatogramPeaks from
+    */
+    void mergePeaks(MSChromatogram& other);
+
 protected:
 
     /// Name

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -422,6 +422,8 @@ public:
       @note Make sure BOTH chromatograms are sorted with respect to RT. Otherwise the result is
       undefined.
 
+      @note Peak level metadata stored in float_array string_array and int_array of the destination MSChromatogram is not guaranteed to be correct after merging
+
       MZ of the destination MSChromatogram remains unchanged. If add_meta is true a metavalue "merged_with" is added with the MZ of the source MSChromatogram
 
       @param other a reference to the MSChromatogram to take ChromatogramPeaks from

--- a/src/openms/source/CONCEPT/Constants.cpp
+++ b/src/openms/source/CONCEPT/Constants.cpp
@@ -154,6 +154,9 @@ namespace OpenMS
 
     namespace UserParam
     {
+      // User parameter name for the M/Z of other chromatograms which have been merged into this one
+      const std::string MERGED_WITH = "merged_with";
+
       // User parameter name for precursor mz error in ppm
       const std::string PRECURSOR_ERROR_PPM_USERPARAM = "precursor_mz_error_ppm";
 

--- a/src/openms/source/CONCEPT/Constants.cpp
+++ b/src/openms/source/CONCEPT/Constants.cpp
@@ -155,7 +155,7 @@ namespace OpenMS
     namespace UserParam
     {
       // User parameter name for the M/Z of other chromatograms which have been merged into this one
-      const std::string MERGED_WITH = "merged_chromatogram_mzs";
+      const std::string MERGED_CHROMATOGRAM_MZS = "merged_chromatogram_mzs";
 
       // User parameter name for precursor mz error in ppm
       const std::string PRECURSOR_ERROR_PPM_USERPARAM = "precursor_mz_error_ppm";

--- a/src/openms/source/CONCEPT/Constants.cpp
+++ b/src/openms/source/CONCEPT/Constants.cpp
@@ -155,7 +155,7 @@ namespace OpenMS
     namespace UserParam
     {
       // User parameter name for the M/Z of other chromatograms which have been merged into this one
-      const std::string MERGED_WITH = "merged_with";
+      const std::string MERGED_WITH = "merged_chromatogram_mzs";
 
       // User parameter name for precursor mz error in ppm
       const std::string PRECURSOR_ERROR_PPM_USERPARAM = "precursor_mz_error_ppm";

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -432,10 +432,16 @@ OpenMS::MSChromatogram::Iterator set_sum_similar_union(OpenMS::MSChromatogram::I
           d_first->setIntensity(d_first->getIntensity() + first2->getIntensity());
           first2++;
         }
-        else if (first2->getRT() < first1->getRT()) {
+        else
+        {
+          if (first2->getRT() < first1->getRT())
+          {
             *d_first = *first2++;
-        } else {
+          }
+          else 
+          {
             *d_first = *first1++;
+          }
         }
     }
     return std::copy(first2, last2, d_first);

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -448,10 +448,23 @@ OpenMS::MSChromatogram::Iterator set_sum_similar_union(OpenMS::MSChromatogram::I
 }
 
 
-void MSChromatogram::mergePeaks(MSChromatogram& other)
+void MSChromatogram::mergePeaks(MSChromatogram& other, bool add_meta)
 {
   vector<ChromatogramPeak> temp;
   temp.reserve((this->end() - this->begin()) + (other.end() - other.begin()) );
   ContainerType::assign(temp.begin(), set_sum_similar_union(this->begin(), this->end(), other.begin(), other.end(), temp.begin()));
-  this->setMetaValue("merged_with",String(other.getMZ()));   
+  if (add_meta)
+  {
+    if (this->getMetaValue("merged_with") == DataValue::EMPTY)
+    {
+      this->setMetaValue("merged_with",DoubleList(other.getMZ()));
+    }
+    else
+    {
+      DoubleList ls = this->getMetaValue("merged_with").toDoubleList();
+      ls.push_back(other.getMZ());
+      this->setMetaValue("merged_with", ls);
+    }
+
+  }
 }

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -455,16 +455,12 @@ void MSChromatogram::mergePeaks(MSChromatogram& other, bool add_meta)
   ContainerType::assign(temp.begin(), set_sum_similar_union(this->begin(), this->end(), other.begin(), other.end(), temp.begin()));
   if (add_meta)
   {
-    if (this->getMetaValue("merged_with") == DataValue::EMPTY)
+    DoubleList ls = DoubleList();
+    if (this->getMetaValue(Constants::UserParam::MERGED_WITH) != DataValue::EMPTY)
     {
-      this->setMetaValue("merged_with",DoubleList(other.getMZ()));
+      ls = this->getMetaValue(Constants::UserParam::MERGED_WITH).toDoubleList();
     }
-    else
-    {
-      DoubleList ls = this->getMetaValue("merged_with").toDoubleList();
-      ls.push_back(other.getMZ());
-      this->setMetaValue("merged_with", ls);
-    }
-
+    ls.push_back(other.getMZ());
+    this->setMetaValue(Constants::UserParam::MERGED_WITH, ls);
   }
 }

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -416,25 +416,26 @@ void MSChromatogram::clear(bool clear_meta_data)
   }
 }
 
-
-OpenMS::MSChromatogram::Iterator set_sum_similar_union(OpenMS::MSChromatogram::Iterator first1,
+// This helper function is based on the cstd::set_union implementation. It is different in that it has a separate concept of "close enough to merge"
+// This is defined as having retention times of within 1/1000 seconds
+OpenMS::MSChromatogram::Iterator setSumSimilarUnion(OpenMS::MSChromatogram::Iterator first1,
                     OpenMS::MSChromatogram::Iterator last1,
                     OpenMS::MSChromatogram::Iterator first2,
                     OpenMS::MSChromatogram::Iterator last2,
                     OpenMS::MSChromatogram::Iterator d_first)
 {
     for (; first1 != last1; ++d_first) {
-        if (first2 == last2)
+        if (first2 == last2)  //return if there is no more to merge from the second vector
             return std::copy(first1, last1, d_first);
-        if ( round( ( first1->getRT() ) * 1000) == round( (first2->getRT()  * 1000 ) ) )
+        if ( round( ( first1->getRT() ) * 1000) == round( (first2->getRT()  * 1000 ) ) ) //if RTs are "close enough" copy the peak from 1 and add the intensity from 2
         {
           *d_first = *first1++;
           d_first->setIntensity(d_first->getIntensity() + first2->getIntensity());
           first2++;
         }
-        else
+        else // Otherwise choose whichever peak is smaller and add it to the output list
         {
-          if (first2->getRT() < first1->getRT())
+          if (first2->getRT() < first1->getRT()) 
           {
             *d_first = *first2++;
           }
@@ -452,15 +453,15 @@ void MSChromatogram::mergePeaks(MSChromatogram& other, bool add_meta)
 {
   vector<ChromatogramPeak> temp;
   temp.reserve((this->end() - this->begin()) + (other.end() - other.begin()) );
-  ContainerType::assign(temp.begin(), set_sum_similar_union(this->begin(), this->end(), other.begin(), other.end(), temp.begin()));
+  ContainerType::assign(temp.begin(), setSumSimilarUnion(this->begin(), this->end(), other.begin(), other.end(), temp.begin()));
   if (add_meta)
   {
-    DoubleList ls = DoubleList();
-    if (this->getMetaValue(Constants::UserParam::MERGED_WITH) != DataValue::EMPTY)
+    DoubleList ls;
+    if (this->getMetaValue(Constants::UserParam::MERGED_CHROMATOGRAM_MZS) != DataValue::EMPTY)
     {
-      ls = this->getMetaValue(Constants::UserParam::MERGED_WITH).toDoubleList();
+      ls = this->getMetaValue(Constants::UserParam::MERGED_CHROMATOGRAM_MZS).toDoubleList();
     }
     ls.push_back(other.getMZ());
-    this->setMetaValue(Constants::UserParam::MERGED_WITH, ls);
+    this->setMetaValue(Constants::UserParam::MERGED_CHROMATOGRAM_MZS, ls);
   }
 }

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -415,3 +415,24 @@ void MSChromatogram::clear(bool clear_meta_data)
     integer_data_arrays_.clear();
   }
 }
+
+void MSChromatogram::mergePeaks(MSChromatogram& other)
+{
+  vector<ChromatogramPeak> temp;
+  std::merge(this->begin(), this->end(), other.begin(), other.end(), std::back_inserter(temp), ChromatogramPeak::RTLess());
+  this->clear(false);
+  for(iterator it = temp.begin(); it != temp.end(); it++)
+  {
+    if( (it + 1) != temp.end() && round( ( it->getRT() ) * 1000) == round( ( (it + 1)->getRT()  * 1000 ) ) )
+    {
+      it->setIntensity(it->getIntensity() + (it + 1)->getIntensity());
+      this->push_back(*it);
+      ++it; //skip the next element since we already have added it
+    }
+    else
+    {
+      this->push_back(*it);
+    }
+    this->setMetaValue("merged_with",String(other.getMZ()));   
+  }
+}

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -1091,8 +1091,10 @@ START_SECTION(void mergePeaks(MSChromatogram & other) )
   a.sortByPosition();
   b.sortByPosition();
   c.sortByPosition();
-  a.mergePeaks(b);
-  c.setMetaValue("merged_with",DoubleList(c.getMZ()));
+  a.mergePeaks(b, true);
+  DoubleList dl = DoubleList();
+  dl.push_back(b.getMZ());
+  c.setMetaValue(Constants::UserParam::MERGED_WITH, dl);
   TEST_EQUAL(a, c)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -77,6 +77,14 @@ ChromatogramPeak p3;
 p3.setIntensity(3.0f);
 p3.setRT(30.0);
 
+ChromatogramPeak p4;
+p4.setIntensity(6.0f);
+p4.setRT(30);
+
+ChromatogramPeak p5;
+p5.setIntensity(3.0f);
+p5.setRT(30.0001);
+
 
 START_SECTION((const String& getName() const ))
 {
@@ -1067,6 +1075,25 @@ START_SECTION(([MSChromatogram::MZLess] bool operator()(const MSChromatogram &a,
     TEST_EQUAL(MSChromatogram::MZLess().operator ()(b,a), false)
 
     TEST_EQUAL(MSChromatogram::MZLess().operator ()(a,a), false)
+}
+END_SECTION
+
+START_SECTION(void mergePeaks(MSChromatogram & other) )
+{
+  MSChromatogram a, b, c;
+  a.push_back(p1);
+  b.push_back(p2);
+  a.push_back(p3);
+  b.push_back(p5);
+  c.push_back(p1);
+  c.push_back(p2);
+  c.push_back(p4);
+  a.sortByPosition();
+  b.sortByPosition();
+  c.sortByPosition();
+  a.mergePeaks(b);
+  c.setMetaValue("merged_with",String(c.getMZ()));
+  TEST_EQUAL(a, c)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -1092,7 +1092,7 @@ START_SECTION(void mergePeaks(MSChromatogram & other) )
   b.sortByPosition();
   c.sortByPosition();
   a.mergePeaks(b);
-  c.setMetaValue("merged_with",String(c.getMZ()));
+  c.setMetaValue("merged_with",DoubleList(c.getMZ()));
   TEST_EQUAL(a, c)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -1092,9 +1092,8 @@ START_SECTION(void mergePeaks(MSChromatogram & other) )
   b.sortByPosition();
   c.sortByPosition();
   a.mergePeaks(b, true);
-  DoubleList dl = DoubleList();
-  dl.push_back(b.getMZ());
-  c.setMetaValue(Constants::UserParam::MERGED_WITH, dl);
+  DoubleList dl = { b.getMZ() };
+  c.setMetaValue(Constants::UserParam::MERGED_CHROMATOGRAM_MZS, dl);
   TEST_EQUAL(a, c)
 }
 END_SECTION


### PR DESCRIPTION
Added utility function MSChromatogram to allow merging the ChromatogramPeaks from two MSChromatograms. Function is useful for summing intensity of multiple isotope traces in an isotopic envelope.