### PR TITLE
[FIX] Comet pepXML modification parsing

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -347,7 +347,7 @@ public:
 
     /// creates a new modification from a mass and adds it to ModificationDB
     /// if not terminal, needs a Residue to be put on.
-    static const ResidueModification* createUnknownFromMass(double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue = nullptr);
+    static const ResidueModification* createUnknownFromMassString(const String& mod, double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue = nullptr);
     //@}
 
 protected:

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -344,6 +344,10 @@ public:
 
     /// less operator
     bool operator<(const ResidueModification& modification) const;
+
+    /// creates a new modification from a mass and adds it to ModificationDB
+    /// if not terminal, needs a Residue to be put on.
+    static const ResidueModification* createUnknownFromMass(double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue = nullptr);
     //@}
 
 protected:

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -250,6 +250,12 @@ private:
     /// Have we checked the "base_name" attribute in the "msms_run_summary" element?
     bool checked_base_name_;
 
+    /// Does the file have decoys (e.g. from Comet's internal decoy search)
+    bool has_decoys_;
+
+    /// In case it has decoys, what is the prefix?
+    String decoy_prefix_;
+
     /// current base name
     String current_base_name_;
 

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -159,7 +159,7 @@ private:
       bool variable;
       String description;
       String terminus;
-      bool protein_terminus; // "true" if protein terminus, "false" if peptide terminus
+      bool protein_terminus{}; // "true" if protein terminus, "false" if peptide terminus
 
       AminoAcidModification() :
         mass(0),
@@ -167,20 +167,9 @@ private:
       {
       }
 
-      AminoAcidModification(const AminoAcidModification& rhs) :
-        aminoacid(rhs.aminoacid),
-        massdiff(rhs.massdiff),
-        mass(rhs.mass),
-        variable(rhs.variable),
-        description(rhs.description),
-        terminus(rhs.terminus),
-        protein_terminus(rhs.protein_terminus)
-      {
-      }
+      AminoAcidModification(const AminoAcidModification& rhs) = default;
 
-      virtual ~AminoAcidModification()
-      {
-      }
+      virtual ~AminoAcidModification() = default;
 
       AminoAcidModification& operator=(const AminoAcidModification& rhs)
       {
@@ -221,7 +210,7 @@ private:
     String status_;
 
     /// Get RT and m/z for peptide ID from precursor scan (should only matter for RT)?
-    bool use_precursor_data_;
+    bool use_precursor_data_{};
 
     /// Mapping between scan number in the pepXML file and index in the corresponding MSExperiment
     std::map<Size, Size> scan_map_;
@@ -239,19 +228,19 @@ private:
     bool search_score_summary_;
 
     /// Are we currently in an "search_summary" element (should be skipped)?
-    bool search_summary_;
+    bool search_summary_{};
 
     /// Do current entries belong to the experiment of interest (for pepXML files that bundle results from different experiments)?
-    bool wrong_experiment_;
+    bool wrong_experiment_{};
 
     /// Have we seen the experiment of interest at all?
-    bool seen_experiment_;
+    bool seen_experiment_{};
 
     /// Have we checked the "base_name" attribute in the "msms_run_summary" element?
-    bool checked_base_name_;
+    bool checked_base_name_{};
 
     /// Does the file have decoys (e.g. from Comet's internal decoy search)
-    bool has_decoys_;
+    bool has_decoys_{};
 
     /// In case it has decoys, what is the prefix?
     String decoy_prefix_;
@@ -281,13 +270,13 @@ private:
     String current_sequence_;
 
     /// RT and m/z of current PeptideIdentification
-    double rt_, mz_;
+    double rt_{}, mz_{};
 
     /// Precursor ion charge
-    Int charge_;
+    Int charge_{};
 
     /// ID of current search result
-    UInt search_id_;
+    UInt search_id_{};
 
     /// Identifier linking PeptideIdentifications and ProteinIdentifications
     String prot_id_;
@@ -296,7 +285,7 @@ private:
     DateTime date_;
 
     /// Mass of a hydrogen atom (monoisotopic/average depending on case)
-    double hydrogen_mass_;
+    double hydrogen_mass_{};
 
     /// The modifications of the current peptide hit (position is 1-based)
     std::vector<std::pair<String, Size> > current_modifications_;

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1019,6 +1019,7 @@ namespace OpenMS
       }
       else
       {
+        //TODO why are we allowing Protein Term here?
         aas.n_term_mod_ = terminalResidueHelper(mod_db, 'n', true, str, mod, String(*next_aa));
         return mod_end;
       }
@@ -1034,6 +1035,7 @@ namespace OpenMS
     else if (specificity == ResidueModification::C_TERM)
     {
       ModificationsDB* mod_db = ModificationsDB::getInstance();
+      //TODO why are we allowing Protein Term here?
       aas.c_term_mod_ = terminalResidueHelper(mod_db, 'c', true, str, mod, res);
       return mod_end;
     }
@@ -1253,7 +1255,9 @@ namespace OpenMS
 
     // ----------------------------------- 
     // Dealing with an unknown modification
-    // ----------------------------------- 
+    // -----------------------------------
+
+    const ResidueModification* new_mod = ResidueModification::createUnknownFromMass(mass, delta_mass, specificity, residue);
 
     // Notes on mass calculation: AASequence::getMonoWeight uses DiffMonoMass
     // for its calculation of C/N-terminal modification mass and it uses
@@ -1261,121 +1265,20 @@ namespace OpenMS
     // set when adding a modification using setModification_
     if (specificity == ResidueModification::N_TERM) 
     {
-      String residue_name = ".[" + mod + "]";
-      String residue_id = ".n[" + mod + "]";
-
-      // Check if it already exists, if not create new modification, transfer
-      // ownership to ModDB
-      if (!mod_db->has(residue_id))
-      {
-        ResidueModification * new_mod = new ResidueModification();
-        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
-        new_mod->setFullName(residue_name); // display name
-        new_mod->setTermSpecificity(ResidueModification::N_TERM);
-
-        // set masses
-        if (delta_mass)
-        {
-          new_mod->setMonoMass(mass + Residue::getInternalToNTerm().getMonoWeight());
-          // new_mod->setAverageMass(mass + residue->getAverageWeight());
-          new_mod->setDiffMonoMass(mass);
-        }
-        else
-        {
-          new_mod->setMonoMass(mass);
-          // new_mod->setAverageMass(mass);
-          new_mod->setDiffMonoMass(mass - Residue::getInternalToNTerm().getMonoWeight());
-        }
-
-        mod_db->addModification(new_mod);
-        aas.n_term_mod_ = new_mod;
-      }
-      else
-      {
-        Size mod_idx = mod_db->findModificationIndex(residue_id);
-        aas.n_term_mod_ = mod_db->getModification(mod_idx);
-      }
+      aas.n_term_mod_ = new_mod;
       return mod_end;
     }
     else if (specificity == ResidueModification::C_TERM)
     {
-      String residue_name = ".[" + mod + "]";
-      String residue_id = ".c[" + mod + "]";
-
-      // Check if it already exists, if not create new modification, transfer
-      // ownership to ModDB
-      if (!mod_db->has(residue_id))
-      {
-        ResidueModification * new_mod = new ResidueModification();
-        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
-        new_mod->setFullName(residue_name); // display name
-        new_mod->setTermSpecificity(ResidueModification::C_TERM);
-
-        // set masses
-        if (delta_mass)
-        {
-          new_mod->setMonoMass(mass + Residue::getInternalToCTerm().getMonoWeight());
-          // new_mod->setAverageMass(mass + residue->getAverageWeight());
-          new_mod->setDiffMonoMass(mass);
-        }
-        else
-        {
-          new_mod->setMonoMass(mass);
-          // new_mod->setAverageMass(mass);
-          new_mod->setDiffMonoMass(mass - Residue::getInternalToCTerm().getMonoWeight());
-        }
-
-        mod_db->addModification(new_mod);
-        aas.c_term_mod_ = new_mod;
-      }
-      else
-      {
-        Size mod_idx = mod_db->findModificationIndex(residue_id);
-        aas.c_term_mod_ = mod_db->getModification(mod_idx);
-      }
+      aas.c_term_mod_ = new_mod;
       return mod_end;
     }
     else
     {
-      String residue_name = aas.peptide_.back()->getOneLetterCode() + "[" + mod + "]"; // e.g. N[12345.6]
-      String modification_name = "[" + mod + "]";
-
-      if (!mod_db->has(residue_name)) 
-      {
-        // create new modification
-        ResidueModification * new_mod = new ResidueModification();
-        new_mod->setFullId(residue_name); // setting FullId but not Id makes it a user-defined mod
-        new_mod->setFullName(modification_name); // display name
-
-        // We will set origin to make sure the same modifcation will be used
-        // for the same AA
-        new_mod->setOrigin(aas.peptide_.back()->getOneLetterCode()[0]);
-
-        // set masses
-        if (delta_mass)
-        {
-          new_mod->setMonoMass(mass + residue->getMonoWeight());
-          new_mod->setAverageMass(mass + residue->getAverageWeight());
-          new_mod->setDiffMonoMass(mass);
-        }
-        else
-        {
-          new_mod->setMonoMass(mass);
-          new_mod->setAverageMass(mass);
-          new_mod->setDiffMonoMass(mass - residue->getMonoWeight());
-        }
-
-        mod_db->addModification(new_mod);
-      }
-
-      // now use the new modification
-      Size mod_idx = mod_db->findModificationIndex(residue_name);
-      const ResidueModification* res_mod = mod_db->getModification(mod_idx);
-
       // Note: this calls setModification_ on a new Residue which changes its
       // weight to the weight of the modification (set above)
       aas.peptide_.back() = ResidueDB::getInstance()->
-        getModifiedResidue(residue, res_mod->getFullId());
+        getModifiedResidue(residue, new_mod->getFullId());
       return mod_end;
     }
   }

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1257,7 +1257,8 @@ namespace OpenMS
     // Dealing with an unknown modification
     // -----------------------------------
 
-    const ResidueModification* new_mod = ResidueModification::createUnknownFromMass(mass, delta_mass, specificity, residue);
+    // local var "mass" might be modified on the way -> parse "mod" string again.
+    const ResidueModification* new_mod = ResidueModification::createUnknownFromMass(String(mod).toDouble();, delta_mass, specificity, residue);
 
     // Notes on mass calculation: AASequence::getMonoWeight uses DiffMonoMass
     // for its calculation of C/N-terminal modification mass and it uses

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1257,8 +1257,11 @@ namespace OpenMS
     // Dealing with an unknown modification
     // -----------------------------------
 
-    // local var "mass" might be modified on the way -> parse "mod" string again.
-    const ResidueModification* new_mod = ResidueModification::createUnknownFromMass(String(mod).toDouble();, delta_mass, specificity, residue);
+    const ResidueModification* new_mod = ResidueModification::createUnknownFromMassString(mod,
+                                                                                          mass,
+                                                                                          delta_mass,
+                                                                                          specificity,
+                                                                                          residue);
 
     // Notes on mass calculation: AASequence::getMonoWeight uses DiffMonoMass
     // for its calculation of C/N-terminal modification mass and it uses

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -34,6 +34,8 @@
 //
 
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
 
@@ -569,4 +571,134 @@ namespace OpenMS
     return id_.empty() && !full_id_.empty();
   }
 
+  const ResidueModification* ResidueModification::createUnknownFromMass(double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue)
+  {
+    ModificationsDB* mod_db = ModificationsDB::getInstance();
+    String mod = String(mass);
+    // -----------------------------------
+    // Dealing with an unknown modification
+    // -----------------------------------
+
+    // Notes on mass calculation: AASequence::getMonoWeight uses DiffMonoMass
+    // for its calculation of C/N-terminal modification mass and it uses
+    // getMonoWeight(Residue::Internal) for each Residue. The Residue weight is
+    // set when adding a modification using setModification_
+    if (specificity == ResidueModification::N_TERM)
+    {
+      String residue_name = ".[" + mod + "]";
+      String residue_id = ".n[" + mod + "]";
+
+      // Check if it already exists, if not create new modification, transfer
+      // ownership to ModDB
+      if (!mod_db->has(residue_id))
+      {
+        auto new_mod = new ResidueModification();
+        new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+        new_mod->setFullName(residue_name); // display name
+        new_mod->setTermSpecificity(ResidueModification::N_TERM);
+
+        // set masses
+        if (delta_mass)
+        {
+          new_mod->setMonoMass(mass + Residue::getInternalToNTerm().getMonoWeight());
+          // new_mod->setAverageMass(mass + residue->getAverageWeight());
+          new_mod->setDiffMonoMass(mass);
+        }
+        else
+        {
+          new_mod->setMonoMass(mass);
+          // new_mod->setAverageMass(mass);
+          new_mod->setDiffMonoMass(mass - Residue::getInternalToNTerm().getMonoWeight());
+        }
+
+        mod_db->addModification(new_mod);
+        return new_mod;
+      }
+      else
+      {
+        Size mod_idx = mod_db->findModificationIndex(residue_id);
+        return mod_db->getModification(mod_idx);
+      }
+    }
+    else
+      if (specificity == ResidueModification::C_TERM)
+      {
+        String residue_name = ".[" + mod + "]";
+        String residue_id = ".c[" + mod + "]";
+
+        // Check if it already exists, if not create new modification, transfer
+        // ownership to ModDB
+        if (!mod_db->has(residue_id))
+        {
+          auto new_mod = new ResidueModification();
+          new_mod->setFullId(residue_id); // setting FullId but not Id makes it a user-defined mod
+          new_mod->setFullName(residue_name); // display name
+          new_mod->setTermSpecificity(ResidueModification::C_TERM);
+
+          // set masses
+          if (delta_mass)
+          {
+            new_mod->setMonoMass(mass + Residue::getInternalToCTerm().getMonoWeight());
+            // new_mod->setAverageMass(mass + residue->getAverageWeight());
+            new_mod->setDiffMonoMass(mass);
+          }
+          else
+          {
+            new_mod->setMonoMass(mass);
+            // new_mod->setAverageMass(mass);
+            new_mod->setDiffMonoMass(mass - Residue::getInternalToCTerm().getMonoWeight());
+          }
+
+          mod_db->addModification(new_mod);
+          return new_mod;
+        }
+        else
+        {
+          Size mod_idx = mod_db->findModificationIndex(residue_id);
+          return mod_db->getModification(mod_idx);
+        }
+      }
+      else
+      {
+        if (residue == nullptr)
+        {
+          throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Cannot create non-terminal mod without origin AA residue.", "nullptr");
+        }
+        String residue_name = String(residue->getOneLetterCode()) + "[" + mod + "]"; // e.g. N[12345.6]
+        String modification_name = "[" + mod + "]";
+
+        if (!mod_db->has(residue_name))
+        {
+          // create new modification
+          auto new_mod = new ResidueModification();
+          new_mod->setFullId(residue_name); // setting FullId but not Id makes it a user-defined mod
+          new_mod->setFullName(modification_name); // display name
+
+          // We will set origin to make sure the same modification will be used
+          // for the same AA
+          new_mod->setOrigin(residue->getOneLetterCode()[0]);
+
+          // set masses
+          if (delta_mass)
+          {
+            new_mod->setMonoMass(mass + residue->getMonoWeight());
+            new_mod->setAverageMass(mass + residue->getAverageWeight());
+            new_mod->setDiffMonoMass(mass);
+          }
+          else
+          {
+            new_mod->setMonoMass(mass);
+            new_mod->setAverageMass(mass);
+            new_mod->setDiffMonoMass(mass - residue->getMonoWeight());
+          }
+          mod_db->addModification(new_mod);
+          return new_mod;
+        }
+        else
+        {
+          Size mod_idx = mod_db->findModificationIndex(residue_name);
+          return mod_db->getModification(mod_idx);
+        }
+      }
+  }
 }

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -571,10 +571,10 @@ namespace OpenMS
     return id_.empty() && !full_id_.empty();
   }
 
-  const ResidueModification* ResidueModification::createUnknownFromMass(double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue)
+  const ResidueModification* ResidueModification::createUnknownFromMassString(const String& mod, double mass, bool delta_mass, TermSpecificity specificity, const Residue* residue)
   {
     ModificationsDB* mod_db = ModificationsDB::getInstance();
-    String mod = String(mass);
+
     // -----------------------------------
     // Dealing with an unknown modification
     // -----------------------------------

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1554,11 +1554,16 @@ namespace OpenMS
         {
           try
           {
-            double mod_mass = mod_split[0].toDouble();
             const Residue* res = &temp_aa_sequence.getResidue(it->second - 1);
-            //TODO check if there can be delta_masses? I dont think so.
-            const ResidueModification* new_mod = ResidueModification::createUnknownFromMass(mod_mass, false,
-                ResidueModification::TermSpecificity::ANYWHERE, res);
+            //TODO check if there can be delta_masses in pepXML? I dont think so.
+            //TODO double-check that the following produces correct results for terminal mods as well
+            //We assume that non-delta masses are internal residue mass (no H2O) + mod. mass.
+            //Internal residue mass will be substracted in the function
+            const ResidueModification* new_mod = ResidueModification::createUnknownFromMassString(mod_split[0],
+                                                                                                  mod_split[0].toDouble(),
+                                                                                                  false,
+                                                                                                  ResidueModification::TermSpecificity::ANYWHERE,
+                                                                                                  res);
             // Note: this calls setModification_ on a new Residue which changes its
             // weight to the weight of the modification (set above)
             temp_aa_sequence.setModification(it->second - 1,ResidueDB::getInstance()->

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -988,9 +988,35 @@ namespace OpenMS
       }
       String protein = attributeAsString_(attributes, "protein");
       pe.setProteinAccession(protein);
-      peptide_hit_.addPeptideEvidence(pe);
+
       ProteinHit hit;
       hit.setAccession(protein);
+
+      if (has_decoys_)
+      {
+        String curr_status("");
+        bool current_prot_is_decoy = protein.hasPrefix(decoy_prefix_);
+        if (peptide_hit_.metaValueExists("target_decoy"))
+        {
+          curr_status = peptide_hit_.getMetaValue("target_decoy");
+        }
+        if (curr_status.empty())
+        {
+          peptide_hit_.setMetaValue("target_decoy", current_prot_is_decoy ? "decoy" : "target");
+        }
+        else if (curr_status == "target" && current_prot_is_decoy)
+        {
+          peptide_hit_.setMetaValue("target_decoy", "target+decoy");
+        }
+        else if (curr_status == "decoy" && !current_prot_is_decoy)
+        {
+          peptide_hit_.setMetaValue("target_decoy", "target+decoy");
+        }
+
+        hit.setMetaValue("target_decoy", current_prot_is_decoy ? "decoy" : "target");
+      }
+      peptide_hit_.addPeptideEvidence(pe);
+
       // depending on the numbering scheme used in the pepXML, "search_id_"
       // may appear to be "out of bounds" - see NOTE above:
       current_proteins_[min(UInt(current_proteins_.size()), search_id_) - 1]->insertHit(hit);
@@ -1106,16 +1132,15 @@ namespace OpenMS
               break;
           }
         }
-        /* TODO support internal decoy searches from e.g. Comet
         else if (name == "decoy_search")
         {
-          contains_decoy_ = attributeAsInt_(attributes, "value");
+          has_decoys_ = attributeAsInt_(attributes, "value");
         }
-        else if (name == "decoy_search")
+        else if (name == "decoy_prefix")
         {
           decoy_prefix_ = attributeAsString_(attributes, "value");
         }
-        */
+
       }
       else
       {
@@ -1204,9 +1229,34 @@ namespace OpenMS
       String protein = attributeAsString_(attributes, "protein");
       PeptideEvidence pe;
       pe.setProteinAccession(protein);
-      peptide_hit_.addPeptideEvidence(pe);
+
       ProteinHit hit;
       hit.setAccession(protein);
+
+      if (has_decoys_)
+      {
+        String curr_status("");
+        bool current_prot_is_decoy = protein.hasPrefix(decoy_prefix_);
+        if (peptide_hit_.metaValueExists("target_decoy"))
+        {
+          curr_status = peptide_hit_.getMetaValue("target_decoy");
+        }
+        if (curr_status.empty())
+        {
+          peptide_hit_.setMetaValue("target_decoy", current_prot_is_decoy ? "decoy" : "target");
+        }
+        else if (curr_status == "target" && current_prot_is_decoy)
+        {
+          peptide_hit_.setMetaValue("target_decoy", "target+decoy");
+        }
+        else if (curr_status == "decoy" && !current_prot_is_decoy)
+        {
+          peptide_hit_.setMetaValue("target_decoy", "target+decoy");
+        }
+        hit.setMetaValue("target_decoy", current_prot_is_decoy ? "decoy" : "target");
+      }
+      peptide_hit_.addPeptideEvidence(pe);
+
       // depending on the numbering scheme used in the pepXML, "search_id_"
       // may appear to be "out of bounds" - see NOTE above:
       current_proteins_[min(UInt(current_proteins_.size()), search_id_) - 1]->

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1140,7 +1140,6 @@ namespace OpenMS
         {
           decoy_prefix_ = attributeAsString_(attributes, "value");
         }
-
       }
       else
       {

--- a/src/tests/topp/IDFileConverter_24_input.pep.xml
+++ b/src/tests/topp/IDFileConverter_24_input.pep.xml
@@ -1442,7 +1442,7 @@
 <alternative_protein protein="DECOY_tr|A0A1S3M7Q4|A0A1S3M7Q4_SALSA" protein_descr="serine\threonine-protein kinase MRCK beta-like isoform X2 OS=Salmo salar GN=LOC106571112 PE=3 SV=1" num_tol_term="0" peptide_prev_aa="D" peptide_next_aa="R"/>
 <alternative_protein protein="DECOY_tr|A0A1S3M863|A0A1S3M863_SALSA" protein_descr="serine\threonine-protein kinase MRCK beta-like isoform X4 OS=Salmo salar GN=LOC106571112 PE=3 SV=1" num_tol_term="0" peptide_prev_aa="D" peptide_next_aa="R"/>
 <alternative_protein protein="DECOY_tr|A0A1S3M8E5|A0A1S3M8E5_SALSA" protein_descr="serine\threonine-protein kinase MRCK beta-like isoform X3 OS=Salmo salar GN=LOC106571112 PE=3 SV=1" num_tol_term="0" peptide_prev_aa="D" peptide_next_aa="R"/>
-<alternative_protein protein="DECOY_tr|A0A060X411|A0A060X411_ONCMY" protein_descr="Uncharacterized protein OS=Oncorhynchus mykiss GN=GSONMT00045548001 PE=3 SV=1" num_tol_term="0" peptide_prev_aa="D" peptide_next_aa="R"/>
+<alternative_protein protein="tr|A0A060X411|A0A060X411_ONCMY" protein_descr="Uncharacterized protein OS=Oncorhynchus mykiss GN=GSONMT00045548001 PE=3 SV=1" num_tol_term="0" peptide_prev_aa="D" peptide_next_aa="R"/>
 <modification_info modified_peptide="QRM[147]ADVKQVAADM[147]EEEKD">
 <mod_aminoacid_mass position="3" mass="147.035385"/>
 <mod_aminoacid_mass position="13" mass="147.035385"/>

--- a/src/tests/topp/IDFileConverter_24_output.idXML
+++ b/src/tests/topp/IDFileConverter_24_output.idXML
@@ -7,80 +7,95 @@
 	</SearchParameters>
 	<IdentificationRun date="2018-02-26T13:26:46" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
-			<ProteinHit id="PH_0" accession="DECOY_tr|A0A1S3S7H0|A0A1S3S7H0_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_0" accession="DECOY_tr|A0A1S3S7H0|A0A1S3S7H0_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_1" accession="DECOY_tr|A0A1S3S7H4|A0A1S3S7H4_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_1" accession="DECOY_tr|A0A1S3S7H4|A0A1S3S7H4_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_2" accession="DECOY_tr|A0A1S3S7G4|A0A1S3S7G4_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_2" accession="DECOY_tr|A0A1S3S7G4|A0A1S3S7G4_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_3" accession="DECOY_tr|A0A1S3S7G5|A0A1S3S7G5_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_3" accession="DECOY_tr|A0A1S3S7G5|A0A1S3S7G5_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_4" accession="DECOY_tr|A0A1S3S7G8|A0A1S3S7G8_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_4" accession="DECOY_tr|A0A1S3S7G8|A0A1S3S7G8_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_5" accession="DECOY_tr|A0A1S3S7G7|A0A1S3S7G7_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_5" accession="DECOY_tr|A0A1S3S7G7|A0A1S3S7G7_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_6" accession="DECOY_tr|A0A1S3M7W0|A0A1S3M7W0_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_6" accession="DECOY_tr|A0A1S3M7W0|A0A1S3M7W0_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_7" accession="DECOY_tr|A0A1S3M7Q4|A0A1S3M7Q4_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_7" accession="DECOY_tr|A0A1S3M7Q4|A0A1S3M7Q4_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_8" accession="DECOY_tr|A0A1S3M863|A0A1S3M863_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_8" accession="DECOY_tr|A0A1S3M863|A0A1S3M863_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_9" accession="DECOY_tr|A0A1S3M8E5|A0A1S3M8E5_SALSA" score="0" sequence="" >
+			<ProteinHit id="PH_9" accession="DECOY_tr|A0A1S3M8E5|A0A1S3M8E5_SALSA" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<ProteinHit id="PH_10" accession="DECOY_tr|A0A060X411|A0A060X411_ONCMY" score="0" sequence="" >
+			<ProteinHit id="PH_10" accession="tr|A0A060X411|A0A060X411_ONCMY" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
-			<ProteinHit id="PH_11" accession="DECOY_DECOY_tr|E9QEY6|E9QEY6_DANRE_UNMAPPED" score="0" sequence="" >
+			<ProteinHit id="PH_11" accession="DECOY_DECOY_tr|E9QEY6|E9QEY6_DANRE_UNMAPPED" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="354.9904475319" RT="75" spectrum_reference="scan=7" >
-			<PeptideHit score="0" sequence="QRM(Oxidation)ADVKKVAADM(Oxidation)EEEKD" charge="6" aa_before="D X X X X X" aa_after="R X X X X X" protein_refs="PH_0 PH_1 PH_2 PH_3 PH_4 PH_5" >
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="354.990447531899974" RT="75.0" spectrum_reference="scan=7" >
+			<PeptideHit score="0.0" sequence="QRM(Oxidation)ADVKKVAADM(Oxidation)EEEKD" charge="6" aa_before="D X X X X X" aa_after="R X X X X X" protein_refs="PH_0 PH_1 PH_2 PH_3 PH_4 PH_5" >
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="170"/>
 				<UserParam type="string" name="num_matched_peptides" value="29030"/>
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="MS:1002252" value="0.998"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
-				<UserParam type="float" name="MS:1002254" value="0.001"/>
-				<UserParam type="float" name="MS:1002255" value="41.8"/>
-				<UserParam type="float" name="MS:1002256" value="84"/>
-				<UserParam type="float" name="MS:1002257" value="27.9"/>
+				<UserParam type="float" name="MS:1002254" value="1.0e-03"/>
+				<UserParam type="float" name="MS:1002255" value="41.799999999999997"/>
+				<UserParam type="float" name="MS:1002256" value="84.0"/>
+				<UserParam type="float" name="MS:1002257" value="27.899999999999999"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
-				<UserParam type="float" name="_ar_0_score" value="0"/>
+				<UserParam type="float" name="_ar_0_score" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-2.3431"/>
-				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0"/>
+				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-0.087"/>
-				<UserParam type="float" name="_ar_0_subscore_nmc" value="0"/>
-				<UserParam type="float" name="_ar_0_subscore_ntt" value="0"/>
+				<UserParam type="float" name="_ar_0_subscore_nmc" value="0.0"/>
+				<UserParam type="float" name="_ar_0_subscore_ntt" value="0.0"/>
 			</PeptideHit>
-			<PeptideHit score="27.9" sequence="QRM(Oxidation)ADVKQVAADM(Oxidation)EEEKD" charge="6" aa_before="D X X X X" aa_after="R X X X X" protein_refs="PH_6 PH_7 PH_8 PH_9 PH_10" >
+			<PeptideHit score="27.899999999999999" sequence="QRM(Oxidation)ADVKQVAADM(Oxidation)EEEKD" charge="6" aa_before="D X X X X" aa_after="R X X X X" protein_refs="PH_6 PH_7 PH_8 PH_9 PH_10" >
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="170"/>
 				<UserParam type="string" name="num_matched_peptides" value="29030"/>
+				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="float" name="MS:1002252" value="0.998"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
-				<UserParam type="float" name="MS:1002254" value="0"/>
-				<UserParam type="float" name="MS:1002255" value="41.8"/>
-				<UserParam type="float" name="MS:1002256" value="84"/>
-				<UserParam type="float" name="MS:1002257" value="27.9"/>
+				<UserParam type="float" name="MS:1002254" value="0.0"/>
+				<UserParam type="float" name="MS:1002255" value="41.799999999999997"/>
+				<UserParam type="float" name="MS:1002256" value="84.0"/>
+				<UserParam type="float" name="MS:1002257" value="27.899999999999999"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="669.0618885319" RT="78" spectrum_reference="scan=9" >
-			<PeptideHit score="0" sequence="LPVLYSSPAALLALRVC(Carbamidomethyl)QGVVKVSAGVSRRGC(Carbamidomethyl)AGAVPVM" charge="6" aa_before="D" aa_after="-" protein_refs="PH_11" >
+		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="669.061888531899967" RT="78.0" spectrum_reference="scan=9" >
+			<PeptideHit score="0.0" sequence="LPVLYSSPAALLALRVC(Carbamidomethyl)QGVVKVSAGVSRRGC(Carbamidomethyl)AGAVPVM" charge="6" aa_before="D" aa_after="-" protein_refs="PH_11" >
 				<UserParam type="string" name="MS:1002258" value="34"/>
 				<UserParam type="string" name="MS:1002259" value="380"/>
 				<UserParam type="string" name="num_matched_peptides" value="10210"/>
+				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="MS:1002252" value="1.474"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
-				<UserParam type="float" name="MS:1002254" value="0"/>
-				<UserParam type="float" name="MS:1002255" value="100.2"/>
-				<UserParam type="float" name="MS:1002256" value="16"/>
+				<UserParam type="float" name="MS:1002254" value="0.0"/>
+				<UserParam type="float" name="MS:1002255" value="100.200000000000003"/>
+				<UserParam type="float" name="MS:1002256" value="16.0"/>
 				<UserParam type="float" name="MS:1002257" value="3.44"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
-				<UserParam type="float" name="_ar_0_score" value="0"/>
+				<UserParam type="float" name="_ar_0_score" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3443"/>
-				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0"/>
+				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="0.129"/>
-				<UserParam type="float" name="_ar_0_subscore_nmc" value="0"/>
-				<UserParam type="float" name="_ar_0_subscore_ntt" value="1"/>
+				<UserParam type="float" name="_ar_0_subscore_nmc" value="0.0"/>
+				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>


### PR DESCRIPTION
AKA Avoid putting terminal modifications to internal AAs when reading pepXML. Instead put them as unknown delta_mass.
Also parses decoys from comet search. (Note: this is not well-tested with downstream tools).
Should fix #4751 though

Limitations: 
1) pepXML only encodes the location of the peptide in the first protein
2) depending on the settings, comet might not report all parent proteins
3) only works for decoys from comet, not pepxml in general

