### PR TITLE
Hotfix PRECONDITION after optimization for QTCluster

### DIFF
--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -146,8 +146,6 @@ namespace OpenMS
     OPENMS_PRECONDITION(distance <= data_->max_distance_,
         "Distance cannot be larger than max_distance")
     // collect_annotations_ implies tmp_neighbors_ != NULL, 
-    OPENMS_PRECONDITION(!collect_annotations_ || !tmp_neighbors_.empty(), 
-        "Initialize the cluster first before adding elements")
 
     Size map_index = element->getMapIndex();
 
@@ -462,8 +460,6 @@ namespace OpenMS
 
   void QTCluster::finalizeCluster()
   {
-    OPENMS_PRECONDITION(!data_->tmp_neighbors_.empty(),
-        "Try to finalize QTCluster that was not initialized")
     OPENMS_PRECONDITION(!finalized_,
         "Try to finalize QTCluster that was not initialized")
 

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -145,7 +145,6 @@ namespace OpenMS
     // ensure we only add compatible peptide annotations
     OPENMS_PRECONDITION(distance <= data_->max_distance_,
         "Distance cannot be larger than max_distance")
-    // collect_annotations_ implies tmp_neighbors_ != NULL, 
 
     Size map_index = element->getMapIndex();
 

--- a/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
@@ -74,7 +74,7 @@ START_SECTION((static BaseGroupFinder* create()))
 	BaseGroupFinder* base_ptr = nullptr;
 	base_ptr = QTClusterFinder::create();
   TEST_NOT_EQUAL(base_ptr, base_nullPointer);
-  if (base_ptr != nullptr) delete base_ptr;
+  delete base_ptr;
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
@@ -74,6 +74,7 @@ START_SECTION((static BaseGroupFinder* create()))
 	BaseGroupFinder* base_ptr = nullptr;
 	base_ptr = QTClusterFinder::create();
   TEST_NOT_EQUAL(base_ptr, base_nullPointer);
+  if (base_ptr != nullptr) delete base_ptr;
 }
 END_SECTION
 


### PR DESCRIPTION
### Fixed the FeatureLinkerunlabeledQT after the nightly tests failed.

The reason for the failed test (`OPENMS_PRECONDITION`) was the follwing:

The `tmp_element_mapping` of the `QTCluster` class used to be a pointer to a map. When we implemented the hot-cold-splitting we decided that two indirections were unnecessary. We also wanted to increase the code quality by removing some `new`s and `delete`s. We then changed the `tmp_element_mapping` to be just a map inside the `BulkData` class.

In the preconditions there were a lot of checks whether `tmp_element_mapping` is or isn't a nullptr. This was the case whenever the cluster was in a finalized state (nullptr) or not (pointer to map). We changed these checks to ask whether it is empty (finalized) or not (not finalized). This does not work, because the `tmp_element_mapping` can be empty during a finalized state for certain inputs. In these cases it used to be a pointer to an empty map, but now we don't have the pointer anymore and therefore can't perform this check.

We believe these checks were made because one wanted to make absolutely sure that no nullptr can be dereferenced. The new code does not use a pointer anymore and is less dangerous. Furthermore these checks are redundant, because there is a bool `finalized_` which monitors the exact same functionality with preconditions.

I removed two preconditions at locations where `finalized_` is also checked and I believe the check is not necessary anymore.

I built the DEBUG version on Linux and the tests do not fail anymore. I also fixed a memory leak in the QTClusterFinder_test.cpp.

### Reference

QTCluster.cpp at the last commit before our PR (https://github.com/OpenMS/OpenMS/pull/4721):

https://github.com/OpenMS/OpenMS/blob/94790282ebf0b65932da4a34a03f16eace253f77/src/openms/source/DATASTRUCTURES/QTCluster.cpp