### PR TITLE
FIX: MSstatsTMTline_ bool operator

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MSstatsFile.h
@@ -268,8 +268,8 @@ namespace OpenMS
         friend bool operator<(const MSstatsTMTLine_ &l,
                               const MSstatsTMTLine_ &r) {
 
-          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_) <
-                  std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_);
+          return std::tie(l.accession_, l.run_, l.condition_, l.bioreplicate_, l.mixture_, l.precursor_charge_, l.sequence_, l.channel_) <
+                  std::tie(r.accession_, r.run_, r.condition_, r.bioreplicate_, r.mixture_, r.precursor_charge_, r.sequence_, r.channel_);
         }
 
 


### PR DESCRIPTION
This fix resolves the issue with skipped channels in the MSstatsConverter.

Thanks at @timosachsenberg and @jpfeuffer.