### PR TITLE
[FIX] bug introduced when trying to reuse vector

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -1036,6 +1036,7 @@ namespace OpenMS
         // if a pep does not belong to a cluster it didnt have multiple parents and
         // therefore does not need to be resolved
       {
+        accs_to_remove.clear();
         q.push(*ui);
         getUpstreamNodesNonRecursive(q, fg, 1, true, groups_or_singles);
 
@@ -1089,6 +1090,7 @@ namespace OpenMS
             peptidePtr->setPeptideEvidences(std::move(newev));
             newev.clear();
           }
+          singles.clear();
         }
       }
     }


### PR DESCRIPTION
Was not cleared correctly and sometimes led to type mismatch during get.