### PR TITLE
[FIX] colliding ProteinIDRun  IDs

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -394,6 +394,11 @@ namespace OpenMS
       if (debug_level_ < 1) OpenMS_Log_info.insert(cout); // revert logging change
       chrom_data_.clear(true);
       library_.clear(true);
+      // since chrom_data_ here is just a container for the chromatograms and identifications will be empty,
+      // pickExperiment above will only add empty ProteinIdentification runs with colliding identifiers.
+      // Usually we could sanitize the identifiers or merge the runs, but since they are empty and we add the
+      // "real" proteins later -> just clear them
+      features.getProteinIdentifications().clear();
     }
 
     OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -291,7 +291,7 @@ add_test("TOPP_FeatureFinderIdentification_4_out1" ${DIFF} -whitelist "spectra_d
 set_tests_properties("TOPP_FeatureFinderIdentification_4_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_4")
 
 ## with batch extraction size smaller than the nr of peptides (we need to whitelist feature ids, since they might be generated differently)
-add_test("TOPP_FeatureFinderIdentification_4" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out FeatureFinderIdentification_4.tmp -extract:mz_window 0.1 -extract:batch_size 10 -detect:peak_width 60 -model:type none)
+add_test("TOPP_FeatureFinderIdentification_4" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out FeatureFinderIdentification_4.tmp -candidates_out FeatureFinderIdentification_4_candidates.tmp -extract:mz_window 0.1 -extract:batch_size 10 -detect:peak_width 60 -model:type none)
 add_test("TOPP_FeatureFinderIdentification_4_out1" ${DIFF} -whitelist "feature id" "spectra_data" "featureMap" -in1 FeatureFinderIdentification_4.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_output.featureXML)
 set_tests_properties("TOPP_FeatureFinderIdentification_4_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_4")
 


### PR DESCRIPTION
Fixes 
```
unable to read file (<filename) ProteinIdentifications are not unique, which leads to loss of unique peptide assignment. Duplicated Protein-Id is: unique_run_identifier.
```

when adding the "candidates_out" option and chunking.