### PR TITLE
FDR filtering in DBSuitability Tool

### DIFF
--- a/src/tests/topp/DatabaseSuitability_out_1.tsv
+++ b/src/tests/topp/DatabaseSuitability_out_1.tsv
@@ -1,7 +1,7 @@
 key	value
-#top_db_hits	438
+#top_db_hits	430
 #top_novo_hits	1
-db_suitability	0.997722095671982
+db_suitability	0.997679814385151
 #total_novo_seqs	1118
 #unique_novo_seqs	1111
 #ms2_spectra	1120

--- a/src/tests/topp/DatabaseSuitability_out_2.tsv
+++ b/src/tests/topp/DatabaseSuitability_out_2.tsv
@@ -1,7 +1,7 @@
 key	value
-#top_db_hits	437
+#top_db_hits	429
 #top_novo_hits	2
-db_suitability	0.995444191343964
+db_suitability	0.995359628770302
 #total_novo_seqs	1118
 #unique_novo_seqs	1111
 #ms2_spectra	1120

--- a/src/tests/topp/DatabaseSuitability_out_3.tsv
+++ b/src/tests/topp/DatabaseSuitability_out_3.tsv
@@ -1,7 +1,7 @@
 key	value
-#top_db_hits	436
+#top_db_hits	428
 #top_novo_hits	3
-db_suitability	0.993166287015945
+db_suitability	0.993039443155452
 #total_novo_seqs	1118
 #unique_novo_seqs	1111
 #ms2_spectra	1120


### PR DESCRIPTION
- added FDR input option

- tool now only counts hits with q-value less than or equal to given FDR

- changed test output files accordingly