### PR TITLE
[FIX] Add rest of search params during ConsensusID

### DIFF
--- a/src/tests/topp/ConsensusID_7_output.idXML
+++ b/src/tests/topp/ConsensusID_7_output.idXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="ECOlL" db_version="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2020-05-22T11:33:49" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.6.0-pre-fix-scoreCheckSwitchPLFQ-2020-05-22" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2020-07-17T23:39:59" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.6.0-pre-develop-2020-07-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="A" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -371,7 +371,9 @@ protected:
       std::copy(sp.variable_modifications.begin(), sp.variable_modifications.end(), std::inserter(var_mods_set, var_mods_set.end()));
     }
 
-    ProteinIdentification::SearchParameters search_params;
+    // use the first settings as basis (i.e. copy over db and enzyme and tolerance)
+    // we assume that they are the same or similar
+    ProteinIdentification::SearchParameters search_params = get<2>(se_ver_settings[0]);
     std::vector<String> fixed_mods(fixed_mods_set.begin(), fixed_mods_set.end());
     std::vector<String> var_mods(var_mods_set.begin(), var_mods_set.end());
     search_params.fixed_modifications    = fixed_mods;


### PR DESCRIPTION
Important for enzyme when you want to use the new PeptideIndexer auto-detection