### PR TITLE
Doc extra

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
@@ -300,7 +300,6 @@ namespace OpenMS
   private:
     CalibrationData cal_data_;
 
-
   }; // class InternalCalibration
   
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
@@ -299,7 +299,6 @@ namespace OpenMS
 
   private:
     CalibrationData cal_data_;
-
   }; // class InternalCalibration
   
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
@@ -241,6 +241,31 @@ namespace OpenMS
     static void applyTransformation(PeakMap& exp, const IntList& target_mslvl, const MZTrafoModel& trafo);
   
   protected:
+
+    /// statistics when adding peptide calibrants
+    struct CalibrantStats_
+    {
+      CalibrantStats_(const double tol_ppm)
+        : tol_ppm_(tol_ppm)
+      {};
+      Size cnt_empty = 0; ///< cases of empty PepIDs (no hits)
+      Size cnt_nomz = 0; ///< cases of no m/z value
+      Size cnt_nort = 0; ///< cases of no RT value
+      Size cnt_decal = 0; ///< cases of large gap (>tol_ppm) between theoretical peptide weight (from sequence) and precursor mass
+      Size cnt_total = 0; ///< total number of cases
+
+      void print() const
+      {
+        if (cnt_empty > 0) OPENMS_LOG_WARN << "Warning: " << cnt_empty << "/" << cnt_total << " calibrations points were skipped, since they have no peptide sequence!" << std::endl;
+        if (cnt_nomz > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nomz << "/" << cnt_total << " calibrations points were skipped, since they have no m/z value!" << std::endl;
+        if (cnt_nort > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nort << "/" << cnt_total << " calibrations points were skipped, since they have no RT value!" << std::endl;
+        if (cnt_decal > 0) OPENMS_LOG_WARN << "Warning: " << cnt_decal << "/" << cnt_total << " calibrations points were skipped, since their theoretical weight is more than " << tol_ppm_ << " ppm away from their measured mass!" << std::endl;
+      }
+
+      private:
+      const double tol_ppm_; ///< tolerance used for counting cnt_decal
+    };
+
     /**
       @brief Add(no prior clear) calibrants to internal list.
       
@@ -252,11 +277,18 @@ namespace OpenMS
       Since precursor masses could be annotated wrongly (e.g. isotope peak instead of mono),
       larger outliers are removed before accepting an ID as calibrant.
 
-      @param pep_ids Peptide ids (e.g. from an idXML file)
+      @param pep_id A single PeptideID (e.g. from an idXML file); only the top peptide hit is used
       @param tol_ppm Only accept ID's whose theoretical mass deviates at most this much from annotated
+      @param stats Update stats, if calibrant cannot be used (no RT, no MZ, no sequence, out-of tolerance)
 
     */
-    void fillIDs_( const std::vector<PeptideIdentification>& pep_ids, double tol_ppm );
+    void fillID_( const PeptideIdentification& pep_id, const double tol_ppm, CalibrantStats_& stats);
+
+    /// calls fillID_ on all PeptideIDs
+    void fillIDs_(const std::vector<PeptideIdentification>& pep_ids, const double tol_ppm, CalibrantStats_& stats);
+
+    /// determine if sequence is within tol_ppm and update stats; fills mz_ref with the theoretical m/z of the sequence
+    bool isDecalibrated_(const PeptideIdentification& pep_id, const double mz_obs, const double tol_ppm, CalibrantStats_& stats, double& mz_ref);
 
     /*
      @brief Calibrate m/z of a spectrum, ignoring precursors!

--- a/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
@@ -185,22 +185,23 @@ namespace OpenMS
   Size InternalCalibration::fillCalibrants( const FeatureMap& fm, double tol_ppm )
   {
     cal_data_.clear();
-    for (FeatureMap::ConstIterator it = fm.begin(); it != fm.end(); ++it)
-    {
-      const std::vector<PeptideIdentification>& ids = it->getPeptideIdentifications();
-      if (ids.empty() || ids[0].empty()) continue;
+    CalibrantStats_ stats(tol_ppm);
+    stats.cnt_total = fm.size() + fm.getUnassignedPeptideIdentifications().size();
 
-      PeptideIdentification pid = ids[0];
-      pid.sort();
-      double mz_ref = pid.getHits()[0].getSequence().getMonoWeight(OpenMS::Residue::Full, pid.getHits()[0].getCharge());
-      if (tol_ppm < Math::getPPMAbs(it->getMZ(), mz_ref)) continue;
-      cal_data_.insertCalibrationPoint(it->getRT(), it->getMZ(), it->getIntensity(), mz_ref, log(it->getIntensity()));
+    for (const auto& f : fm)
+    {
+      const std::vector<PeptideIdentification>& ids = f.getPeptideIdentifications();
+      double mz_ref;
+      if (ids.empty()) continue;
+      if (isDecalibrated_(ids[0], f.getMZ(), tol_ppm, stats, mz_ref)) continue;
+      cal_data_.insertCalibrationPoint(f.getRT(), f.getMZ(), f.getIntensity(), mz_ref, log(f.getIntensity()));
     }
 
     // unassigned peptide IDs
-    fillIDs_(fm.getUnassignedPeptideIdentifications(), tol_ppm);
+    fillIDs_(fm.getUnassignedPeptideIdentifications(), tol_ppm, stats);
 
     OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants (incl. unassigned) in FeatureMap." << std::endl;
+    stats.print();
 
     // sort CalData by RT
     cal_data_.sortByRT();
@@ -208,46 +209,69 @@ namespace OpenMS
     return cal_data_.size();
   }
 
-  void InternalCalibration::fillIDs_( const std::vector<PeptideIdentification>& pep_ids, double tol_ppm )
+  void InternalCalibration::fillID_(const PeptideIdentification& pep_id, const double tol_ppm, CalibrantStats_& stats)
   {
-    Size cnt_nomz(0);
-    Size cnt_nort(0);
-
-    for (std::vector<PeptideIdentification>::const_iterator it = pep_ids.begin(); it != pep_ids.end(); ++it)
+    if (pep_id.empty())
     {
-      if (it->empty()) continue;
-      if (!it->hasMZ())
-      {
-        ++cnt_nomz;
-        continue;
-      }
-      if (!it->hasRT())
-      {
-        ++cnt_nort;
-        continue;
-      }
-      PeptideIdentification pid = *it;
-      pid.sort();
-      int q = pid.getHits()[0].getCharge();
-      double mz_ref = pid.getHits()[0].getSequence().getMonoWeight(OpenMS::Residue::Full, q) / q;
-
-      // Only use ID if precursor m/z and theoretical mass don't deviate too much.
-      // as they may occur due to isotopic peak misassignments
-      if (tol_ppm < Math::getPPMAbs(it->getMZ(), mz_ref)) continue;
-
-      const double weight = 1.0;
-      const double intensity = 1.0;
-      cal_data_.insertCalibrationPoint(it->getRT(), it->getMZ(), intensity, mz_ref, weight);
+      ++stats.cnt_empty;
+      return;
     }
-    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << std::endl;
-    if (cnt_nomz > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nomz << "/" << pep_ids.size() << " were skipped, since they have no m/z value set! They cannot be used as calibration point." << std::endl;
-    if (cnt_nort > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nort << "/" << pep_ids.size() << " were skipped, since they have no RT value set! They cannot be used as calibration point." << std::endl;
+    if (!pep_id.hasMZ())
+    {
+      ++stats.cnt_nomz;
+      return;
+    }
+    if (!pep_id.hasRT())
+    {
+      ++stats.cnt_nort;
+      return;
+    }
+    double mz_ref;
+    if (isDecalibrated_(pep_id, pep_id.getMZ(), tol_ppm, stats, mz_ref))
+    {
+      return;
+    }
+
+    cal_data_.insertCalibrationPoint(pep_id.getRT(), pep_id.getMZ(), 1.0, mz_ref, 1.0);
+  }
+
+  void InternalCalibration::fillIDs_( const std::vector<PeptideIdentification>& pep_ids, const double tol_ppm, CalibrantStats_& stats)
+  {
+    for (const auto& id : pep_ids)
+    {
+      fillID_(id, tol_ppm, stats);
+    }
+ }
+
+  bool InternalCalibration::isDecalibrated_(const PeptideIdentification& pep_id, const double mz_obs, const double tol_ppm, CalibrantStats_& stats, double& mz_ref)
+  {
+    PeptideIdentification pid = pep_id;
+    pid.sort();
+    int q = pid.getHits()[0].getCharge();
+    mz_ref = pid.getHits()[0].getSequence().getMonoWeight(OpenMS::Residue::Full, q) / q;
+
+    // Only use ID if precursor m/z and theoretical mass don't deviate too much.
+    // as they may occur due to isotopic peak misassignments
+    double delta = Math::getPPMAbs(mz_obs, mz_ref);
+    if (tol_ppm < delta)
+    {
+      if (stats.cnt_decal < 10) OPENMS_LOG_INFO << "Peptide " << pid.getHits()[0].getSequence().toString() << " is " << delta << " (>" << tol_ppm << ") ppm away from theoretical mass and is omitted as calibration point.\n";
+      else if (stats.cnt_decal == 10) OPENMS_LOG_INFO << "More than 10 peptides are at least " << tol_ppm << " ppm away from theoretical mass and are omitted as calibration point.";
+      ++stats.cnt_decal;
+      return true;
+    }
+    return false;
   }
 
   Size InternalCalibration::fillCalibrants( const std::vector<PeptideIdentification>& pep_ids, double tol_ppm )
   {
     cal_data_.clear();
-    fillIDs_(pep_ids, tol_ppm);
+    CalibrantStats_ stats(tol_ppm);
+    stats.cnt_total = pep_ids.size();
+    fillIDs_(pep_ids, tol_ppm, stats);
+    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << std::endl;
+    stats.print();
+
     // sort CalData by RT
     cal_data_.sortByRT();
 

--- a/src/tests/topp/FileInfo_10_output.txt
+++ b/src/tests/topp/FileInfo_10_output.txt
@@ -1,8 +1,10 @@
 
 -- General information --
 
-File name: /home/sachsenb/OpenMS/src/tests/topp/FileInfo_10_input.idXML
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_10_input.idXML
 File type: idXML
+Search Engine(s):
+  Unknown (version: 0)
 Number of:
   runs:                       1
   protein hits:               0

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -763,6 +763,7 @@ protected:
           }
         }
       }
+      set<pair<String, String>> search_engines;
       for (Size i = 0; i < id_data.proteins.size(); ++i)
       {
         ++runs_count;
@@ -772,12 +773,19 @@ protected:
         {
           proteins.insert(temp_hits[j].getAccession());
         }
+        // collect all search engines which generated the data
+        search_engines.emplace(id_data.proteins[i].getSearchEngine(), id_data.proteins[i].getSearchEngineVersion());
       }
       if (peptide_length.empty())
       { // avoid invalid-range exception when computing mean()
         peptide_length.push_back(0);
       }
-
+      
+      os << "Search Engine(s):\n";
+      for (const auto& se : search_engines)
+      {
+        os << "  " << se.first << " (version: " << se.second << ")\n";
+      }
       os << "Number of:"
          << "\n";
       os << "  runs:                       " << runs_count << "\n";

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -608,8 +608,8 @@ protected:
       // we determine the size of a consensus feature we would obtain if we would link just be sequence and charge
       // and we sum up all sub features for these consensus feature that has at least one id
       // (as we assume that the ID is transfered to all sub features)
-      map<Size, UInt> num_aggregated_consfeat_of_size_with_id;
-      map<Size, UInt> num_aggregated_feat_of_size_with_id;
+      map<Size, Size> num_aggregated_consfeat_of_size_with_id;
+      map<Size, Size> num_aggregated_feat_of_size_with_id;
       for (auto & a : seq_charge2map_occurence)
       {
         const vector<int>& occurences = a.second;
@@ -642,16 +642,16 @@ protected:
         Size number_features{0};
         Size number_cons_features_with_id{0};
         Size number_features_with_id{0};
-        for (map<Size, UInt>::reverse_iterator i = num_consfeat_of_size.rbegin(); i != num_consfeat_of_size.rend(); ++i)
+        for (auto it = num_consfeat_of_size.rbegin(); it != num_consfeat_of_size.rend(); ++it)
         {
-          const Size csize = i->first;
-          const Size nfeatures = i->first * i->second;
-          const Size nc_with_id = num_consfeat_of_size_with_id[i->first];
+          const Size csize = it->first;
+          const Size nfeatures = it->first * it->second;
+          const Size nc_with_id = num_consfeat_of_size_with_id[it->first];
           number_features += nfeatures;
           number_features_with_id += csize * nc_with_id;
           number_cons_features_with_id += nc_with_id;
 
-          os << "  of size " << setw(field_width) << csize << ": " << i->second 
+          os << "  of size " << setw(field_width) << csize << ": " << it->second 
              << "\t (features: " << nfeatures << " )"
              << "\t with at least one ID: " << nc_with_id
              << "\t (features: " << csize * nc_with_id << " )"
@@ -659,8 +659,8 @@ protected:
 
         }
 
-        map<Size, UInt>::reverse_iterator ci = num_aggregated_consfeat_of_size_with_id.rbegin();
-        map<Size, UInt>::reverse_iterator fi = num_aggregated_feat_of_size_with_id.rbegin();
+        auto ci = num_aggregated_consfeat_of_size_with_id.rbegin();
+        auto fi = num_aggregated_feat_of_size_with_id.rbegin();
         for (; ci != num_aggregated_consfeat_of_size_with_id.rend(); ++ci, ++fi)
         {
           const Size csize = ci->first;
@@ -733,7 +733,7 @@ protected:
              << "\t" << id_data.proteins[0].getSearchParameters().taxonomy << "\n";
 
       // calculations
-      UInt average_peptide_hits{0}; // average number of hits per spectrum (ignoring the empty ones)
+      Size average_peptide_hits{0}; // average number of hits per spectrum (ignoring the empty ones)
       for (Size i = 0; i < id_data.peptides.size(); ++i)
       {
         if (!id_data.peptides[i].empty())
@@ -1637,40 +1637,35 @@ protected:
     String out = getStringOption_("out");
     String out_tsv = getStringOption_("out_tsv");
 
-    TOPPBase::ExitCodes ret;
-    if (!out.empty() && !out_tsv.empty())
+    ofstream os;
+    ofstream os_tsv;
+    boost::iostreams::filtering_ostream os_filt;
+    boost::iostreams::filtering_ostream os_tsv_filt;
+
+
+    if (out.empty())
     {
-      ofstream os(out.c_str());
-      ofstream os_tsv(out_tsv.c_str());
-      ret = outputTo_(os, os_tsv);
-      os.close();
-      os_tsv.close();
-    }
-    else if (!out.empty() && out_tsv.empty())
-    {
-      ofstream os(out.c_str());
-      // Output stream with null output
-      boost::iostreams::filtering_ostream os_tsv;
-      os_tsv.push(boost::iostreams::null_sink());
-      ret = outputTo_(os, os_tsv);
-      os.close();
-    }
-    else if (out.empty() && !out_tsv.empty())
-    {
-      ofstream os_tsv(out_tsv.c_str());
-      // directly use OpenMS_Log_info (no need for protecting output stream in non-parallel section)
-      ret = outputTo_(OpenMS_Log_info, os_tsv);
-      os_tsv.close();
+      os_filt.push(OpenMS_Log_info);
     }
     else
     {
-      // Output stream with null output
-      boost::iostreams::filtering_ostream os_tsv;
-      os_tsv.push(boost::iostreams::null_sink());
-      // directly use OpenMS_Log_info (no need for protecting output stream in non-parallel section)
-      ret = outputTo_(OpenMS_Log_info, os_tsv);
+      os.open(out);
+      if (!os) throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, out);
+      os_filt.push(os);
     }
-    return ret;
+
+    if (out_tsv.empty())
+    {
+      os_tsv_filt.push(boost::iostreams::null_sink());
+    }
+    else
+    {
+      os_tsv.open(out_tsv);
+      if (!os_tsv) throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, out_tsv);
+      os_tsv_filt.push(os_tsv);
+    }
+
+    return outputTo_(os_filt, os_tsv_filt);
   }
 };
 

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -77,17 +77,28 @@
 </CENTER>
 
     MS-GF+ must be installed before this wrapper can be used. Please make sure that Java and MS-GF+ are working.@n
-    The following MS-GF+ version is required: MS-GF+ 2019/07/03. At the time of writing, it could be downloaded from https://github.com/MSGFPlus/msgfplus/releases. Older versions will not work properly.
+    The following MS-GF+ version is required: MS-GF+ 2019/07/03. At the time of writing, it could be downloaded 
+    from https://github.com/MSGFPlus/msgfplus/releases. Older versions will not work properly.
 
     Input spectra for MS-GF+ have to be centroided; profile spectra are ignored.
 
-    The first time MS-GF+ is applied to a database (FASTA file), it will index the file contents and generate a number of auxiliary files in the same directory as the database (e.g. for "db.fasta": "db.canno", "db.cnlap", "db.csarr" and "db.cseq" will be generated). It is advisable to keep these files for future MS-GF+ searches, to save the indexing step.@n
+    The first time MS-GF+ is applied to a database (FASTA file), it will index the file contents and
+    generate a number of auxiliary files in the same directory as the database (e.g. for "db.fasta": "db.canno", "db.cnlap", "db.csarr" and "db.cseq" will be generated).
+    It is advisable to keep these files for future MS-GF+ searches, to save the indexing step.@n
 
-    @note When a new database is used for the first time, make sure to run only one MS-GF+ search against it! Otherwise one process will start the indexing and the others will crash due to incomplete index files. After a database has been indexed, multiple MS-GF+ processes can use it in parallel.
+    @note When a new database is used for the first time, make sure to run only one MS-GF+ search against it! Otherwise one process will start the 
+    indexing and the others will crash due to incomplete index files. After a database has been indexed, multiple MS-GF+ processes can use it in parallel.
 
-    This adapter supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified by 'OpenMS.ini:id_db_dir' (see @subpage TOPP_advanced).
+    This adapter supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified 
+    by 'OpenMS.ini:id_db_dir' (see @subpage TOPP_advanced).
 
-    The adapter works in three steps to generate an idXML file: First MS-GF+ is run on the input MS data and the sequence database, producing an mzIdentML (.mzid) output file containing the search results. This file is then converted to a text file (.tsv) using MS-GF+' "MzIDToTsv" tool. Finally, the .tsv file is parsed and a result in idXML format is generated.
+    The adapter works in three steps to generate an idXML file: First MS-GF+ is run on the input MS data and the sequence database, 
+    producing an mzIdentML (.mzid) output file containing the search results. This file is then converted to a text file (.tsv) using MS-GF+' "MzIDToTsv" tool.
+    Finally, the .tsv file is parsed and a result in idXML format is generated.
+
+    An optional MSGF+ configuration file can be added via '-conf' parameter (e.g. to support custom AA masses).
+    See https://github.com/MSGFPlus/msgfplus/blob/master/docs/examples/MSGFPlus_Params.txt for 
+    an example and consult the MSGF+ documentation for further details.
 
     <B>The command line parameters of this tool are:</B>
     @verbinclude TOPP_MSGFPlusAdapter.cli
@@ -207,6 +218,8 @@ protected:
     setValidStrings_("variable_modifications", all_mods);
 
     registerFlag_("legacy_conversion", "Use the indirect conversion of MS-GF+ results to idXML via export to TSV. Try this only if the default conversion takes too long or uses too much memory.", true);
+
+    registerInputFile_("conf", "<file>", "", "Optional MSGF+ configuration file (passed as -conf <file> to MSGF+). See documentation for examples.", false, false);
 
     registerInputFile_("java_executable", "<file>", "java", "The Java executable. Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java", false, false, {"is_executable"});
     registerIntOption_("java_memory", "<num>", 3500, "Maximum Java heap size (in MB)", false);
@@ -524,6 +537,9 @@ protected:
                    << "-addFeatures" << QString::number(int((getParam_().getValue("add_features") == "true")))
                    << "-tasks" << QString::number(getIntOption_("tasks"))
                    << "-thread" << QString::number(getIntOption_("threads"));
+    String conf = getStringOption_("conf");
+    if (!conf.empty()) process_params << "-conf" << conf.toQString();
+
 
     if (!mod_file.empty())
     {

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -75,21 +75,26 @@ using namespace std;
     </table>
 </CENTER>
 
-    @em X! Tandem must be installed before this wrapper can be used.
-    This wrapper has been successfully tested with several versions of X! Tandem.
+    @em X!Tandem must be installed before this wrapper can be used.
+    This wrapper has been successfully tested with several versions of @em X!Tandem.
     The earliest version known to work is "PILEDRIVER" (2015-04-01). The latest is "ALANINE" (2017-02-01).
 
-    To speed up computations, FASTA databases can be compressed using the fasta_pro.exe tool of @em X! Tandem.
-    It is contained in the "bin" folder of the @em X! Tandem installation.
-    Refer to the documentation of @em X! Tandem for further information about settings.
+    @note @em X!Tandem only support uncompressed mzML files (e.g. no zlib compression or other fancy things like numpress) may be used internally!
+    This converter only forwards the mzML filename and you will get an error like 'Fatal error: unsupported CODEC used for mzML peak data (CODEC type=zlib compression)'.
+    If this happens, preprocess the mzML files using OpenMS' @ref TOPP_FileConverter to write a plain mzML which @em X!Tandem understands.
+
+    To speed up computations, FASTA databases can be compressed using the fasta_pro.exe tool of @em X!Tandem.
+    It is contained in the "bin" folder of the @em X!Tandem installation.
+    Refer to the documentation of @em X!Tandem for further information about settings.
 
     This adapter supports relative database filenames.
     If a database is not found in the current working directory, it is looked up in the directories specified by 'OpenMS.ini:id_db_dir' (see @subpage TOPP_advanced).
 
-    @em X! Tandem settings not exposed by this adapter (especially refinement settings) can be directly adjusted using an XML configuration file.
+    @em X!Tandem settings not exposed by this adapter (especially refinement settings) can be directly adjusted using an XML configuration file.
     By default, all (!) parameters available explicitly via this wrapper take precedence over the XML configuration file.
     The parameter @p default_config_file can be used to specify such a custom configuration.
-    An example of a configuration file (named "default_input.xml") is contained in the "bin" folder of the @em X! Tandem installation and in the OpenMS installation under OpenMS/share/CHEMISTRY/XTandem_default_input.xml.
+    An example of a configuration file (named "default_input.xml") is contained in the "bin" folder of the @em X!Tandem installation and in the OpenMS installation
+    under OpenMS/share/CHEMISTRY/XTandem_default_input.xml.
     If you want to use the XML configuration file and @em ignore most of the parameters set via this adapter, use the @p ignore_adapter_param flag.
     Then, the config given via @p default_config_file is used exclusively and only the values for the paramters @p in, @p out, @p database and @p xtandem_executable are taken from this adapter.
 


### PR DESCRIPTION
this PR adds some extra information for the user in multiple places:

1) amend our docs, for the zlib error of X!Tandem in #4817
2) write the search engine used in idXML files when calling FileInfo
3) some more stats when calling InternalCalibration (which calibration points were excluded and why)
4) allow MSGF+Adapter to pass a `conf` file with additional parameters