### PR TITLE
[FIX] ConsenusID reading from wrong meta data

### DIFF
--- a/src/tests/topp/ConsensusID_7_output.idXML
+++ b/src/tests/topp/ConsensusID_7_output.idXML
@@ -3,8 +3,50 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="ECOlL" db_version="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
+				<UserParam type="string" name="SE:Mascot" value="2.2.04"/>
+				<UserParam type="string" name="Mascot:db" value="ECOlL"/>
+				<UserParam type="string" name="Mascot:db_version" value="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta"/>
+				<UserParam type="string" name="Mascot:taxonomy" value="All entries"/>
+				<UserParam type="string" name="Mascot:charges" value=""/>
+				<UserParam type="string" name="Mascot:fixed_modifications" value=""/>
+				<UserParam type="string" name="Mascot:variable_modifications" value="Oxidation (M)"/>
+				<UserParam type="int" name="Mascot:missed_cleavages" value="1"/>
+				<UserParam type="float" name="Mascot:fragment_mass_tolerance" value="0.5"/>
+				<UserParam type="string" name="Mascot:fragment_mass_tolerance_unit" value="Da"/>
+				<UserParam type="float" name="Mascot:precursor_mass_tolerance" value="10.0"/>
+				<UserParam type="string" name="Mascot:precursor_mass_tolerance_unit" value="Da"/>
+				<UserParam type="string" name="Mascot:digestion_enzyme" value="Trypsin"/>
+				<UserParam type="string" name="Mascot:enzyme_term_specificity" value="unknown"/>
+				<UserParam type="string" name="SE:OMSSA" value="2.1.4"/>
+				<UserParam type="string" name="OMSSA:db" value="/nfs/wsi/bs/share/usr/nahnsen/sequences/Ecoli_K12_TaxID_83333.proteomes.decoy.fasta.psq"/>
+				<UserParam type="string" name="OMSSA:db_version" value=""/>
+				<UserParam type="string" name="OMSSA:taxonomy" value="0"/>
+				<UserParam type="string" name="OMSSA:charges" value="+1-+3"/>
+				<UserParam type="string" name="OMSSA:fixed_modifications" value=""/>
+				<UserParam type="string" name="OMSSA:variable_modifications" value="Oxidation (M)"/>
+				<UserParam type="int" name="OMSSA:missed_cleavages" value="1"/>
+				<UserParam type="float" name="OMSSA:fragment_mass_tolerance" value="0.5"/>
+				<UserParam type="string" name="OMSSA:fragment_mass_tolerance_unit" value="Da"/>
+				<UserParam type="float" name="OMSSA:precursor_mass_tolerance" value="0.01"/>
+				<UserParam type="string" name="OMSSA:precursor_mass_tolerance_unit" value="Da"/>
+				<UserParam type="string" name="OMSSA:digestion_enzyme" value="Trypsin"/>
+				<UserParam type="string" name="OMSSA:enzyme_term_specificity" value="unknown"/>
+				<UserParam type="string" name="SE:XTandem" value=""/>
+				<UserParam type="string" name="XTandem:db" value="/share/usr/nahnsen/sequences/Ecoli_K12_TaxID_83333.proteomes.decoy.fasta.pro"/>
+				<UserParam type="string" name="XTandem:db_version" value=""/>
+				<UserParam type="string" name="XTandem:taxonomy" value=""/>
+				<UserParam type="string" name="XTandem:charges" value="+1-+3"/>
+				<UserParam type="string" name="XTandem:fixed_modifications" value=""/>
+				<UserParam type="string" name="XTandem:variable_modifications" value="Oxidation (M)"/>
+				<UserParam type="int" name="XTandem:missed_cleavages" value="1"/>
+				<UserParam type="float" name="XTandem:fragment_mass_tolerance" value="0.5"/>
+				<UserParam type="string" name="XTandem:fragment_mass_tolerance_unit" value="Da"/>
+				<UserParam type="float" name="XTandem:precursor_mass_tolerance" value="10.0"/>
+				<UserParam type="string" name="XTandem:precursor_mass_tolerance_unit" value="Da"/>
+				<UserParam type="string" name="XTandem:digestion_enzyme" value="unknown_enzyme"/>
+				<UserParam type="string" name="XTandem:enzyme_term_specificity" value="unknown"/>
 	</SearchParameters>
-	<IdentificationRun date="2020-07-17T23:39:59" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.6.0-pre-develop-2020-07-17" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2020-07-28T14:00:27" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.6.0-pre-develop-2020-07-22" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="A" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16,48 +58,6 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
 			<UserParam type="stringList" name="spectra_data" value="[c1.mzML]"/>
-			<UserParam type="string" name="SE:Mascot" value="2.2.04"/>
-			<UserParam type="string" name="Mascot:db" value="ECOlL"/>
-			<UserParam type="string" name="Mascot:db_version" value="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta"/>
-			<UserParam type="string" name="Mascot:taxonomy" value="All entries"/>
-			<UserParam type="string" name="Mascot:charges" value=""/>
-			<UserParam type="string" name="Mascot:fixed_modifications" value=""/>
-			<UserParam type="string" name="Mascot:variable_modifications" value="Oxidation (M)"/>
-			<UserParam type="int" name="Mascot:missed_cleavages" value="1"/>
-			<UserParam type="float" name="Mascot:fragment_mass_tolerance" value="0.5"/>
-			<UserParam type="string" name="Mascot:fragment_mass_tolerance_unit" value="Da"/>
-			<UserParam type="float" name="Mascot:precursor_mass_tolerance" value="10.0"/>
-			<UserParam type="string" name="Mascot:precursor_mass_tolerance_unit" value="Da"/>
-			<UserParam type="string" name="Mascot:digestion_enzyme" value="Trypsin"/>
-			<UserParam type="string" name="Mascot:enzyme_term_specificity" value="unknown"/>
-			<UserParam type="string" name="SE:OMSSA" value="2.1.4"/>
-			<UserParam type="string" name="OMSSA:db" value="/nfs/wsi/bs/share/usr/nahnsen/sequences/Ecoli_K12_TaxID_83333.proteomes.decoy.fasta.psq"/>
-			<UserParam type="string" name="OMSSA:db_version" value=""/>
-			<UserParam type="string" name="OMSSA:taxonomy" value="0"/>
-			<UserParam type="string" name="OMSSA:charges" value="+1-+3"/>
-			<UserParam type="string" name="OMSSA:fixed_modifications" value=""/>
-			<UserParam type="string" name="OMSSA:variable_modifications" value="Oxidation (M)"/>
-			<UserParam type="int" name="OMSSA:missed_cleavages" value="1"/>
-			<UserParam type="float" name="OMSSA:fragment_mass_tolerance" value="0.5"/>
-			<UserParam type="string" name="OMSSA:fragment_mass_tolerance_unit" value="Da"/>
-			<UserParam type="float" name="OMSSA:precursor_mass_tolerance" value="0.01"/>
-			<UserParam type="string" name="OMSSA:precursor_mass_tolerance_unit" value="Da"/>
-			<UserParam type="string" name="OMSSA:digestion_enzyme" value="Trypsin"/>
-			<UserParam type="string" name="OMSSA:enzyme_term_specificity" value="unknown"/>
-			<UserParam type="string" name="SE:XTandem" value=""/>
-			<UserParam type="string" name="XTandem:db" value="/share/usr/nahnsen/sequences/Ecoli_K12_TaxID_83333.proteomes.decoy.fasta.pro"/>
-			<UserParam type="string" name="XTandem:db_version" value=""/>
-			<UserParam type="string" name="XTandem:taxonomy" value=""/>
-			<UserParam type="string" name="XTandem:charges" value="+1-+3"/>
-			<UserParam type="string" name="XTandem:fixed_modifications" value=""/>
-			<UserParam type="string" name="XTandem:variable_modifications" value="Oxidation (M)"/>
-			<UserParam type="int" name="XTandem:missed_cleavages" value="1"/>
-			<UserParam type="float" name="XTandem:fragment_mass_tolerance" value="0.5"/>
-			<UserParam type="string" name="XTandem:fragment_mass_tolerance_unit" value="Da"/>
-			<UserParam type="float" name="XTandem:precursor_mass_tolerance" value="10.0"/>
-			<UserParam type="string" name="XTandem:precursor_mass_tolerance_unit" value="Da"/>
-			<UserParam type="string" name="XTandem:digestion_enzyme" value="unknown_enzyme"/>
-			<UserParam type="string" name="XTandem:enzyme_term_specificity" value="unknown"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0.0" MZ="695.364599999999996" RT="2233.105000000000018" spectrum_reference="index=1" >
 			<PeptideHit score="0.54" sequence="QRESTATDILQK" charge="2" aa_before="K R X" aa_after="N G X" protein_refs="PH_0 PH_0 PH_0" >

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -252,22 +252,24 @@ protected:
   tuple<String, String, ProteinIdentification::SearchParameters> getOriginalSearchEngineSettings_(const ProteinIdentification& prot)
   {
     String engine = prot.getSearchEngine();
+    const ProteinIdentification::SearchParameters& old_sp = prot.getSearchParameters();
     if (engine != "Percolator")
     {
-      return std::tie(engine, prot.getSearchEngineVersion(), prot.getSearchParameters());
+      return std::tie(engine, prot.getSearchEngineVersion(), old_sp);
     }
     else
     {
       String original_SE = "Unknown";
       String original_SE_ver = "0.0";
       vector<String> mvkeys;
-      prot.getKeys(mvkeys);
+      
+      old_sp.getKeys(mvkeys);
       for (const String & mvkey : mvkeys)
       {
         if (mvkey.hasPrefix("SE:"))
         {
           original_SE = mvkey.substr(3);
-          original_SE_ver = prot.getMetaValue(mvkey);
+          original_SE_ver = old_sp.getMetaValue(mvkey);
           break; // multiSE percolator before consensusID not allowed; we take first only
         }
       }
@@ -279,56 +281,56 @@ protected:
         {
           if (mvkey.hasSuffix("db"))
           {
-            sp.db = prot.getMetaValue(mvkey);
+            sp.db = old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("db_version"))
           {
-            sp.db_version = prot.getMetaValue(mvkey);
+            sp.db_version = old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("taxonomy"))
           {
-            sp.taxonomy = prot.getMetaValue(mvkey);
+            sp.taxonomy = old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("charges"))
           {
-            sp.charges = prot.getMetaValue(mvkey);;
+            sp.charges = old_sp.getMetaValue(mvkey);;
           }
           else if (mvkey.hasSuffix("fixed_modifications"))
           {
-            sp.fixed_modifications = prot.getMetaValue(mvkey).toStringList();
+            sp.fixed_modifications = old_sp.getMetaValue(mvkey).toStringList();
           }
           else if (mvkey.hasSuffix("variable_modifications"))
           {
-            sp.variable_modifications = prot.getMetaValue(mvkey).toStringList();
+            sp.variable_modifications = old_sp.getMetaValue(mvkey).toStringList();
           }
           else if (mvkey.hasSuffix("missed_cleavages"))
           {
-            sp.missed_cleavages = (UInt) prot.getMetaValue(mvkey);
+            sp.missed_cleavages = (UInt) old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("fragment_mass_tolerance"))
           {
-            sp.fragment_mass_tolerance = (double) prot.getMetaValue(mvkey);
+            sp.fragment_mass_tolerance = (double) old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("fragment_mass_tolerance_ppm"))
           {
-            sp.fragment_mass_tolerance_ppm = prot.getMetaValue(mvkey).toBool();
+            sp.fragment_mass_tolerance_ppm = old_sp.getMetaValue(mvkey).toBool();
           }
           else if (mvkey.hasSuffix("precursor_mass_tolerance"))
           {
-            sp.precursor_mass_tolerance = (double) prot.getMetaValue(mvkey);
+            sp.precursor_mass_tolerance = (double) old_sp.getMetaValue(mvkey);
           }
           else if (mvkey.hasSuffix("precursor_mass_tolerance_ppm"))
           {
-            sp.precursor_mass_tolerance_ppm = prot.getMetaValue(mvkey).toBool();
+            sp.precursor_mass_tolerance_ppm = old_sp.getMetaValue(mvkey).toBool();
           }
           else if (mvkey.hasSuffix("digestion_enzyme"))
           {
-            Protease p = *(ProteaseDB::getInstance()->getEnzyme(prot.getMetaValue(mvkey)));
+            Protease p = *(ProteaseDB::getInstance()->getEnzyme(old_sp.getMetaValue(mvkey)));
             sp.digestion_enzyme = p;
           }
           else if (mvkey.hasSuffix("enzyme_term_specificity"))
           {
-            sp.enzyme_term_specificity = static_cast<EnzymaticDigestion::Specificity>((int) prot.getMetaValue(mvkey));
+            sp.enzyme_term_specificity = static_cast<EnzymaticDigestion::Specificity>((int) old_sp.getMetaValue(mvkey));
           }
         }
       }
@@ -344,6 +346,9 @@ protected:
 
     //TODO check if settings are same/similar
     bool allsamese = true;
+    // use the first settings as basis (i.e. copy over db and enzyme and tolerance)
+    // we assume that they are the same or similar
+    ProteinIdentification::SearchParameters new_sp = get<2>(se_ver_settings[0]);
     for (const auto& se_ver_setting : se_ver_settings)
     {
       allsamese = allsamese &&
@@ -352,37 +357,35 @@ protected:
 
       const ProteinIdentification::SearchParameters& sp = get<2>(se_ver_setting);
       const String& SE = get<0>(se_ver_setting);
-      prot_id.setMetaValue("SE:" + SE, get<1>(se_ver_setting));
-      prot_id.setMetaValue(SE+":db",sp.db);
-      prot_id.setMetaValue(SE+":db_version",sp.db_version);
-      prot_id.setMetaValue(SE+":taxonomy",sp.taxonomy);
-      prot_id.setMetaValue(SE+":charges",sp.charges);
-      prot_id.setMetaValue(SE+":fixed_modifications",ListUtils::concatenate(sp.fixed_modifications, ","));
-      prot_id.setMetaValue(SE+":variable_modifications",ListUtils::concatenate(sp.variable_modifications, ","));
-      prot_id.setMetaValue(SE+":missed_cleavages",sp.missed_cleavages);
-      prot_id.setMetaValue(SE+":fragment_mass_tolerance",sp.fragment_mass_tolerance);
-      prot_id.setMetaValue(SE+":fragment_mass_tolerance_unit",sp.fragment_mass_tolerance_ppm ? "ppm" : "Da");
-      prot_id.setMetaValue(SE+":precursor_mass_tolerance",sp.precursor_mass_tolerance);
-      prot_id.setMetaValue(SE+":precursor_mass_tolerance_unit",sp.precursor_mass_tolerance_ppm  ? "ppm" : "Da");
-      prot_id.setMetaValue(SE+":digestion_enzyme",sp.digestion_enzyme.getName());
-      prot_id.setMetaValue(SE+":enzyme_term_specificity",EnzymaticDigestion::NamesOfSpecificity[sp.enzyme_term_specificity]);
+      new_sp.setMetaValue("SE:" + SE, get<1>(se_ver_setting));
+      new_sp.setMetaValue(SE+":db",sp.db);
+      new_sp.setMetaValue(SE+":db_version",sp.db_version);
+      new_sp.setMetaValue(SE+":taxonomy",sp.taxonomy);
+      new_sp.setMetaValue(SE+":charges",sp.charges);
+      new_sp.setMetaValue(SE+":fixed_modifications",ListUtils::concatenate(sp.fixed_modifications, ","));
+      new_sp.setMetaValue(SE+":variable_modifications",ListUtils::concatenate(sp.variable_modifications, ","));
+      new_sp.setMetaValue(SE+":missed_cleavages",sp.missed_cleavages);
+      new_sp.setMetaValue(SE+":fragment_mass_tolerance",sp.fragment_mass_tolerance);
+      new_sp.setMetaValue(SE+":fragment_mass_tolerance_unit",sp.fragment_mass_tolerance_ppm ? "ppm" : "Da");
+      new_sp.setMetaValue(SE+":precursor_mass_tolerance",sp.precursor_mass_tolerance);
+      new_sp.setMetaValue(SE+":precursor_mass_tolerance_unit",sp.precursor_mass_tolerance_ppm  ? "ppm" : "Da");
+      new_sp.setMetaValue(SE+":digestion_enzyme",sp.digestion_enzyme.getName());
+      new_sp.setMetaValue(SE+":enzyme_term_specificity",EnzymaticDigestion::NamesOfSpecificity[sp.enzyme_term_specificity]);
 
       std::copy(sp.fixed_modifications.begin(), sp.fixed_modifications.end(), std::inserter(fixed_mods_set, fixed_mods_set.end()));
       std::copy(sp.variable_modifications.begin(), sp.variable_modifications.end(), std::inserter(var_mods_set, var_mods_set.end()));
     }
 
-    // use the first settings as basis (i.e. copy over db and enzyme and tolerance)
-    // we assume that they are the same or similar
-    ProteinIdentification::SearchParameters search_params = get<2>(se_ver_settings[0]);
+
     std::vector<String> fixed_mods(fixed_mods_set.begin(), fixed_mods_set.end());
     std::vector<String> var_mods(var_mods_set.begin(), var_mods_set.end());
-    search_params.fixed_modifications    = fixed_mods;
-    search_params.variable_modifications = var_mods;
+    new_sp.fixed_modifications    = fixed_mods;
+    new_sp.variable_modifications = var_mods;
 
     prot_id.setDateTime(DateTime::now());
     prot_id.setSearchEngine("OpenMS/ConsensusID_" + algorithm_);
     prot_id.setSearchEngineVersion(VersionInfo::getVersion());
-    prot_id.setSearchParameters(search_params);
+    prot_id.setSearchParameters(new_sp);
 
     //TODO for completeness we could in the other algorithms, collect all search engines and put them here
     // or maybe put it in a DataProcessingStep

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -297,11 +297,13 @@ protected:
           }
           else if (mvkey.hasSuffix("fixed_modifications"))
           {
-            sp.fixed_modifications = old_sp.getMetaValue(mvkey).toStringList();
+            const String& s = old_sp.getMetaValue(mvkey);
+            s.split(',', sp.fixed_modifications);
           }
           else if (mvkey.hasSuffix("variable_modifications"))
           {
-            sp.variable_modifications = old_sp.getMetaValue(mvkey).toStringList();
+            const String& s = old_sp.getMetaValue(mvkey);
+            s.split(',', sp.variable_modifications);
           }
           else if (mvkey.hasSuffix("missed_cleavages"))
           {


### PR DESCRIPTION
In the case of a search engine overwritten from Percolator, it read and wrote the wrong meta values (at the ProteinID, not the SearchParams)