### PR TITLE
Warn about multiple runs when using PSMFeatureExtractor

### DIFF
--- a/src/utils/PSMFeatureExtractor.cpp
+++ b/src/utils/PSMFeatureExtractor.cpp
@@ -176,6 +176,19 @@ protected:
       }
       //else caught by TOPPBase:registerInput being mandatory mzid or idxml
 
+      //check and warn if merged from multiple runs
+      if (protein_ids.size() > 1)
+      {
+        throw Exception::InvalidValue(
+            __FILE__,
+            __LINE__,
+            OPENMS_PRETTY_FUNCTION,
+            "File '" + in + "' has more than one ProteinIDRun. This is currently not correctly handled."
+            "Please use the merge_proteins_add_psms option if you used IDMerger. Alternatively, pass"
+            " all original single-run idXML inputs as list to this tool.",
+            "# runs: " + String(protein_ids.size()));
+      }
+
       // will check if all ProteinIdentifications have the same search db unless it is the first, in which case all_protein_ids is empty yet.
       if (multiple_search_engines && !skip_db_check && !all_protein_ids.empty())
       {


### PR DESCRIPTION
# Description

The PR is adding a warning about the use of an idXML resulting from multiple merged runs. One should use the Flag merge_proteins_add_psms.

#4825 

Not tested yet, will check once more before merging