### PR TITLE
[FIX, GUI] fixes OpenMS#4828, wrong labels in the projections

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
@@ -354,9 +354,9 @@ namespace OpenMS
     LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
 
     // print horizontal (note that m/z in the projection could actually be RT - this only determines the orientation)
-    projection_horz_->canvas()->mzToXAxis(true); 
+    projection_horz_->canvas()->mzToXAxis(true);
     projection_horz_->canvas()->setSwappedAxis(true);
-    
+
     projection_horz_->showLegend(false);
     Spectrum1DCanvas::IntensityModes intensity = projection_horz_->canvas()->getIntensityMode();
     projection_horz_->canvas()->setIntensityMode(intensity);
@@ -379,6 +379,7 @@ namespace OpenMS
       projection_horz_->canvas()->setIntensityMode(SpectrumCanvas::IM_SNAP);
       projection_vert_->canvas()->setDrawMode(Spectrum1DCanvas::DM_PEAKS);
       projection_vert_->canvas()->setIntensityMode(SpectrumCanvas::IM_PERCENTAGE);
+      projection_horz_->canvas()->setSwappedAxis(false);
     }
     projection_horz_->show();
     projection_box_->show();
@@ -388,7 +389,7 @@ namespace OpenMS
   {
     LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     // print vertically (note that m/z in the projection could actually be RT - this only determines the orientation)
-    projection_vert_->canvas()->mzToXAxis(false); 
+    projection_vert_->canvas()->mzToXAxis(false);
     projection_vert_->canvas()->setSwappedAxis(true);
 
     projection_vert_->showLegend(false);
@@ -413,6 +414,7 @@ namespace OpenMS
       projection_horz_->canvas()->setIntensityMode(SpectrumCanvas::IM_SNAP);
       projection_vert_->canvas()->setDrawMode(Spectrum1DCanvas::DM_PEAKS);
       projection_vert_->canvas()->setIntensityMode(SpectrumCanvas::IM_PERCENTAGE);
+      projection_vert_->canvas()->setSwappedAxis(false);
     }
     projection_box_->show();
     projection_vert_->show();


### PR DESCRIPTION
Switched the "m/z" and "RT" labels in `Spectrum1DCanvas.cpp`
This fixes the wrong labels in the projections as reported in #4828.

Previously `projection_horz_->canvas()->setSwappedAxis(true)` and `projection_vert_->canvas()->setSwappedAxis(true)` were always set. This caused the labels to be constant and independent from the orientation of the axes in the main MS1 map.
Now I set these both to `false` for one of the cases and the labels adapt to the MS1 map orientation correctly.