### PR TITLE
PeptideIndexer explicit 'auto' mode

### DIFF
--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -51,20 +51,20 @@ using namespace std;
     defaults_.setValue("missing_decoy_action", "error", "Action to take if NO peptide was assigned to a decoy protein (which indicates wrong database or decoy string): 'error' (exit with error, no output), 'warn' (exit with success, warning message), 'silent' (no action is taken, not even a warning)");
     defaults_.setValidStrings("missing_decoy_action", ListUtils::create<String>("error,warn,silent"));
 
-    defaults_.setValue("enzyme:name", "", "Enzyme which determines valid cleavage sites - e.g. trypsin cleaves after lysine (K) or arginine (R), but not before proline (P). Default: deduce from input");
+    defaults_.setValue("enzyme:name", AUTO_MODE, "Enzyme which determines valid cleavage sites - e.g. trypsin cleaves after lysine (K) or arginine (R), but not before proline (P). Default: deduce from input");
 
     StringList enzymes{};
     ProteaseDB::getInstance()->getAllNames(enzymes);
-    enzymes.emplace_back("");
+    enzymes.emplace(enzymes.begin(), AUTO_MODE); // make it the first item
     defaults_.setValidStrings("enzyme:name", enzymes);
 
-    defaults_.setValue("enzyme:specificity", "", "Specificity of the enzyme. Default: deduce from input."
+    defaults_.setValue("enzyme:specificity", AUTO_MODE, "Specificity of the enzyme. Default: deduce from input."
       "\n  '" + EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_FULL] + "': both internal cleavage sites must match."
       "\n  '" + EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_SEMI] + "': one of two internal cleavage sites must match."
-      "\n  '" + EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_NONE] + "': allow all peptide hits no matter their context."
-                                                            " Therefore, the enzyme chosen does not play a role here");
+      "\n  '" + EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_NONE] + "': allow all peptide hits no matter their context (enzyme is irrelevant).");
 
-    defaults_.setValidStrings("enzyme:specificity", {"",EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_FULL],
+    defaults_.setValidStrings("enzyme:specificity", {AUTO_MODE,
+                                                     EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_FULL],
                                                      EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_SEMI],
                                                      EnzymaticDigestion::NamesOfSpecificity[EnzymaticDigestion::SPEC_NONE]});
 

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -52,19 +52,19 @@ using namespace OpenMS;
 
   @brief Refreshes the protein references for all peptide hits from an idXML file and adds target/decoy information.
 
-<CENTER>
-    <table>
-        <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-            <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ PeptideIndexer \f$ \longrightarrow \f$</td>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
-        </tr>
-        <tr>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_IDFilter or @n any protein/peptide processing tool </td>
-            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_FalseDiscoveryRate </td>
-        </tr>
-    </table>
-</CENTER>
+  <CENTER>
+      <table>
+          <tr>
+              <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+              <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ PeptideIndexer \f$ \longrightarrow \f$</td>
+              <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
+          </tr>
+          <tr>
+              <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_IDFilter or @n any protein/peptide processing tool </td>
+              <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_FalseDiscoveryRate </td>
+          </tr>
+      </table>
+  </CENTER>
 
   PeptideIndexer refreshes target/decoy information and mapping of peptides to proteins.
   The target/decoy information is crucial for the @ref TOPP_FalseDiscoveryRate tool. (For FDR calculations, "target+decoy" peptide hits count as target hits.)
@@ -92,7 +92,7 @@ using namespace OpenMS;
   PeptideIndexer supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified
   by @p OpenMS.ini:id_db_dir (see @subpage TOPP_advanced).
 
-  Further details can be found in the underlying PeptideIndexing implementation.
+  Further details can be found in the underlying @ref OpenMS::PeptideIndexing implementation.
   
   @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
 


### PR DESCRIPTION
 * make 'auto' mode for enzyme choice and specificity more explicit (`auto` instead of empty string)
 * some doc fixes