### PR TITLE
[FIX] parsing mzid with nonstandard, non-CV-term scores, fixes #4607

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Mathias Walzer $
-// $Authors: Mathias Walzer $
+// $Maintainer: Eugen Netz $
+// $Authors: Mathias Walzer, Eugen Netz $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h>

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2043,7 +2043,7 @@ namespace OpenMS
             break;
           }
         }
-        else if (specific_score_terms.find(scoreit->first) != specific_score_terms.end() || scoreit->first == "MS:1001143")
+        else if (specific_score_terms.find(scoreit->first) != specific_score_terms.end())
         {
           score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(ControlledVocabulary::CVTerm::isHigherBetterScore(cv_.getTerm(scoreit->first)));
@@ -2056,6 +2056,14 @@ namespace OpenMS
           score = scoreit->second.front().getValue().toString().toDouble(); // cast fix needed as DataValue is init with XercesString
           spectrum_identification.setHigherScoreBetter(false);
           spectrum_identification.setScoreType("E-value"); //higherIsBetter = false
+          scoretype = true;
+          break;
+        }
+        else if (scoreit->first == "MS:1001143")
+        {
+          spectrum_identification.setScoreType("PSM-level search engine specific statistic");
+          // TODO this is just an assumption for unknown scores
+          spectrum_identification.setHigherScoreBetter(true);
           scoretype = true;
         }
       }
@@ -2071,11 +2079,15 @@ namespace OpenMS
             {
               hit.setMetaValue(cvs->first, cv->getValue().toString());
             }
+            else if (cvs->first == "MS:1001143") // this is the CV term "PSM-level search engine specific statistic" and it doesn't have a value
+            {
+              continue;
+            }
             else
             {
-            hit.setMetaValue(cvs->first, cv->getValue().toString().toDouble());
+              hit.setMetaValue(cvs->first, cv->getValue().toString().toDouble());
+            }
           }
-        }
         }
         for (map<String, DataValue>::const_iterator up = params.second.begin(); up != params.second.end(); ++up)
         {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -992,8 +992,10 @@ set_tests_properties("TOPP_IDFileConverter_29_out1" PROPERTIES DEPENDS "TOPP_IDF
 add_test("TOPP_IDFileConverter_30" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_27_input.idXML -out IDFileConverter_30_output.tmp -out_type FASTA -concatenate_peptides -number_of_hits 2)
 add_test("TOPP_IDFileConverter_30_out1" ${DIFF} -in1 IDFileConverter_30_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_30_output.fasta)
 set_tests_properties("TOPP_IDFileConverter_30_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_30")
-
-
+# Test MzIdentML files with unofficial (non CV-term) scores
+add_test("TOPP_IDFileConverter_31" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_31_input.mzid -out IDFileConverter_31_output.tmp -out_type idXML)
+add_test("TOPP_IDFileConverter_31_out1" ${DIFF} -in1 IDFileConverter_31_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_31_output.idXML)
+set_tests_properties("TOPP_IDFileConverter_31_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_31")
 
 #------------------------------------------------------------------------------
 # IDFilter tests

--- a/src/tests/topp/IDFileConverter_31_input.mzid
+++ b/src/tests/topp/IDFileConverter_31_input.mzid
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.1.0.xsd"
+	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
+	version="1.1.0"
+	id="OpenMS_11115414975438642789"
+	creationDate="2019-07-30T12:13:41">
+<cvList>
+	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
+ 	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
+	<cv id="UO"     fullName="UNIT-ONTOLOGY" uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"></cv>
+</cvList>
+<AnalysisSoftwareList>
+	<AnalysisSoftware version="2.1.0" name="Mascot" id="SOF_17749660155506638460">
+		<SoftwareName>
+			<cvParam accession="MS:1001207" cvRef="PSI-MS" name="Mascot"/>
+		</SoftwareName>
+	</AnalysisSoftware>
+	<AnalysisSoftware version="OpenMS TOPP v2.4.0-feature-XLMS-Percolator-2019-07-29" name="TOPP software" id="SOF_14509930621887606273">
+		<SoftwareName>
+			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
+		</SoftwareName>
+	</AnalysisSoftware>
+</AnalysisSoftwareList>
+<SequenceCollection>
+	<DBSequence accession="PROT1" searchDatabase_ref="SDB_15916652588957785155" length="7" id="PROT_15157403601844400700">
+	<Seq>ABCDEFG</Seq>
+		<cvParam accession="MS:1001088" cvRef="PSI-MS" name="protein description" value="PROT1"/>
+	</DBSequence>
+	<DBSequence accession="PROT2" searchDatabase_ref="SDB_15916652588957785155" length="7" id="PROT_6408859317243173796">
+	<Seq>ABCDEFG</Seq>
+		<cvParam accession="MS:1001088" cvRef="PSI-MS" name="protein description" value="PROT2"/>
+	</DBSequence>
+	<DBSequence accession="PROT3" searchDatabase_ref="SDB_15916652588957785155" id="PROT_2927519776102075938">
+		<cvParam accession="MS:1001088" cvRef="PSI-MS" name="protein description" value="PROT3"/>
+	</DBSequence>
+	<Peptide id="PEP_10306100746905639127" name="PEPTIDER">
+		<PeptideSequence>PEPTIDER</PeptideSequence>
+	</Peptide>
+ 	<Peptide id="PEP_15050004366391181853" name="N[3899.350028191399815]PEPTIDEK">
+		<PeptideSequence>NPEPTIDEK</PeptideSequence>
+		<Modification location="1" residues="N" monoisotopicMassDelta="3785.307099999999991">
+			<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification"/>
+		</Modification>
+	</Peptide>
+ 	<Peptide id="PEP_16177748921272733768" name="PEPTIDERRRRR">
+		<PeptideSequence>PEPTIDERRRRR</PeptideSequence>
+	</Peptide>
+ 	<Peptide id="PEP_2684106197423007927" name="PEPTIDERR">
+		<PeptideSequence>PEPTIDERR</PeptideSequence>
+	</Peptide>
+ 	<Peptide id="PEP_3023658190814908261" name="PEPTIDERRR">
+		<PeptideSequence>PEPTIDERRR</PeptideSequence>
+	</Peptide>
+ 	<PeptideEvidence id="PEV_12524258085768770586" peptide_ref="PEP_10306100746905639127" dBSequence_ref="PROT_15157403601844400700" post="B" pre="A"/>
+	<PeptideEvidence id="PEV_1755235105885170967" peptide_ref="PEP_10306100746905639127" dBSequence_ref="PROT_6408859317243173796"/>
+	<PeptideEvidence id="PEV_7276556891837796968" peptide_ref="PEP_16177748921272733768" dBSequence_ref="PROT_2927519776102075938"/>
+</SequenceCollection>
+<AnalysisCollection>
+	<SpectrumIdentification id="SI_Mascot_2006-01-12T12:13:14_5233264595117471314" spectrumIdentificationProtocol_ref="SIP_15004869347769368353" spectrumIdentificationList_ref="SIL_7804704400743266335" activityDate="2006-01-12T12:13:14">
+		<InputSpectra spectraData_ref="SDAT_13440783915218733453"/>
+		<SearchDatabaseRef searchDatabase_ref="SDB_15916652588957785155"/>
+	</SpectrumIdentification>
+	<SpectrumIdentification id="SI_Mascot_2007-01-12T12:13:14_4835329514588776807" spectrumIdentificationProtocol_ref="SIP_12999979801269632061" spectrumIdentificationList_ref="SIL_474525871221756682" activityDate="2007-01-12T12:13:14">
+		<InputSpectra spectraData_ref="SDAT_13440783915218733453"/>
+		<SearchDatabaseRef searchDatabase_ref="SDB_15916652588957785155"/>
+	</SpectrumIdentification>
+</AnalysisCollection>
+<AnalysisProtocolCollection>
+	<SpectrumIdentificationProtocol id="SIP_12999979801269632061" analysisSoftware_ref="SOF_17749660155506638460">
+		<SearchType>
+			<cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/>
+		</SearchType>
+		<AdditionalSearchParams>
+			<userParam name="charges" unitName="xsd:string" value="+1, +2, +3"/>
+		</AdditionalSearchParams>
+		<ModificationParams>
+			<SearchModification fixedMod="true" massDelta="57.021464000000002" residues="C">
+				<cvParam accession="UNIMOD:4" cvRef="PSI-MS" name="Carbamidomethyl"/>
+			</SearchModification>
+			<SearchModification fixedMod="true" massDelta="176.032087999999987" residues="S">
+				<cvParam accession="UNIMOD:54" cvRef="PSI-MS" name="Glucuronyl"/>
+			</SearchModification>
+			<SearchModification fixedMod="false" massDelta="15.994915000000001" residues="M">
+				<cvParam accession="UNIMOD:35" cvRef="PSI-MS" name="Oxidation"/>
+			</SearchModification>
+			<SearchModification fixedMod="false" massDelta="0.984016" residues="Q">
+				<cvParam accession="UNIMOD:7" cvRef="PSI-MS" name="Deamidated"/>
+			</SearchModification>
+		</ModificationParams>
+		<Enzymes independent="false">
+			<Enzyme missedCleavages="0" id="ENZ_17413765565443951891">
+				<EnzymeName>
+					<cvParam accession="MS:1001044" cvRef="PSI-MS" name="cleavage agent details"/>
+				</EnzymeName>
+			</Enzyme>
+		</Enzymes>
+		<FragmentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+		</FragmentTolerance>
+		<ParentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1.0"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1.0"/>
+		</ParentTolerance>
+		<Threshold>
+			<cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
+		</Threshold>
+	</SpectrumIdentificationProtocol>
+	<SpectrumIdentificationProtocol id="SIP_15004869347769368353" analysisSoftware_ref="SOF_17749660155506638460">
+		<SearchType>
+			<cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/>
+		</SearchType>
+		<AdditionalSearchParams>
+			<userParam name="charges" unitName="xsd:string" value="+1, +2"/>
+		</AdditionalSearchParams>
+		<ModificationParams>
+			<SearchModification fixedMod="true" massDelta="3785.307099999999991" residues="N">
+				<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification"/>
+			</SearchModification>
+		</ModificationParams>
+		<Enzymes independent="false">
+			<Enzyme missedCleavages="0" id="ENZ_3332699010107892018">
+				<EnzymeName>
+					<cvParam accession="MS:1001251" cvRef="PSI-MS" name="Trypsin"/>
+				</EnzymeName>
+			</Enzyme>
+		</Enzymes>
+		<FragmentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+		</FragmentTolerance>
+		<ParentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1.0"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1.0"/>
+		</ParentTolerance>
+		<Threshold>
+			<cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
+		</Threshold>
+	</SpectrumIdentificationProtocol>
+</AnalysisProtocolCollection>
+<DataCollection>
+	<Inputs>
+		<SearchDatabase location="MSDB" version="1.0" id="SDB_15916652588957785155">
+			<FileFormat>
+				<cvParam accession="MS:1001348" cvRef="PSI-MS" name="FASTA format"/>
+			</FileFormat>
+			<DatabaseName>
+				<userParam name="MSDB"/>
+			</DatabaseName>
+		</SearchDatabase>
+		<SpectraData location="UNKNOWN" id="SDAT_13440783915218733453">
+			<FileFormat>
+				<cvParam accession="MS:1000584" cvRef="PSI-MS" name="mzML format"/>
+			</FileFormat>
+			<SpectrumIDFormat>
+				<cvParam accession="MS:1001530" cvRef="PSI-MS" name="mzML unique identifier"/>
+			</SpectrumIDFormat>
+		</SpectraData>
+	</Inputs>
+	<AnalysisData>
+		<SpectrumIdentificationList id="SIL_474525871221756682">
+			<FragmentationTable>
+				<Measure id="Measure_mz">
+					<cvParam accession="MS:1001225" cvRef="PSI-MS" unitCvRef="PSI-MS" unitName="m/z" unitAccession="MS:1000040" name="product ion m/z"/>
+				</Measure>
+				<Measure id="Measure_int">
+					<cvParam cvRef="PSI-MS" accession="MS:1001226" name="product ion intensity" unitAccession="MS:1000131" unitCvRef="UO" unitName="number of detector counts"/>
+				</Measure>
+				<Measure id="Measure_error">
+					<cvParam cvRef="PSI-MS" accession="MS:1001227" name="product ion m/z error" unitAccession="MS:1000040" unitCvRef="PSI-MS" unitName="m/z"/>
+				</Measure>
+			</FragmentationTable>
+			<SpectrumIdentificationResult spectraData_ref="SDAT_13440783915218733453" spectrumID="MZ:nan@RT:nan" id="SIR_16250062551099875712">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_16177748921272733768" calculatedMassToCharge="1580.872803071470571" experimentalMassToCharge="nan" chargeState="1" id="SII_1147219038608936718">
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_7276556891837796968"/>
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
+					<userParam name="MOWSE" unitName="xsd:double" value="1.4"/>
+				</SpectrumIdentificationItem>
+			</SpectrumIdentificationResult>
+		</SpectrumIdentificationList>
+		<SpectrumIdentificationList id="SIL_7804704400743266335">
+			<FragmentationTable>
+				<Measure id="Measure_mz">
+					<cvParam accession="MS:1001225" cvRef="PSI-MS" unitCvRef="PSI-MS" unitName="m/z" unitAccession="MS:1000040" name="product ion m/z"/>
+				</Measure>
+				<Measure id="Measure_int">
+					<cvParam cvRef="PSI-MS" accession="MS:1001226" name="product ion intensity" unitAccession="MS:1000131" unitCvRef="UO" unitName="number of detector counts"/>
+				</Measure>
+				<Measure id="Measure_error">
+					<cvParam cvRef="PSI-MS" accession="MS:1001227" name="product ion m/z error" unitAccession="MS:1000040" unitCvRef="PSI-MS" unitName="m/z"/>
+				</Measure>
+			</FragmentationTable>
+			<SpectrumIdentificationResult spectraData_ref="SDAT_13440783915218733453" spectrumID="17" id="SIR_16907355690727166316">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_10306100746905639127" calculatedMassToCharge="956.468357540270972" experimentalMassToCharge="675.899999999999977" chargeState="1" id="SII_14811341817612382122">
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_12524258085768770586"/>
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_1755235105885170967"/>
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
+					<userParam name="MOWSE" unitName="xsd:double" value="0.9"/>
+					<userParam name="name" unitName="xsd:string" value="PeptideHit"/>
+				</SpectrumIdentificationItem>
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_2684106197423007927" calculatedMassToCharge="1112.569468923070872" experimentalMassToCharge="675.899999999999977" chargeState="1" id="SII_8119044117483804262">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
+					<userParam name="MOWSE" unitName="xsd:double" value="1.4"/>
+				</SpectrumIdentificationItem>
+				<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="1234.5" unitAccession="UO:0000010" unitCvRef="UO"/>
+			</SpectrumIdentificationResult>
+			<SpectrumIdentificationResult spectraData_ref="SDAT_13440783915218733453" spectrumID="MZ:nan@RT:nan" id="SIR_17314619952666245179">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_3023658190814908261" calculatedMassToCharge="634.838928386320959" experimentalMassToCharge="nan" chargeState="2" id="SII_7898004582401008768">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
+					<userParam name="MOWSE" unitName="xsd:double" value="44.399999999999999"/>
+				</SpectrumIdentificationItem>
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_15050004366391181853" calculatedMassToCharge="2414.409757099221224" experimentalMassToCharge="nan" chargeState="2" id="SII_17716858074023296841">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
+					<userParam name="MOWSE" unitName="xsd:double" value="33.299999999999997"/>
+				</SpectrumIdentificationItem>
+			</SpectrumIdentificationResult>
+		</SpectrumIdentificationList>
+	</AnalysisData>
+</DataCollection>
+</MzIdentML>

--- a/src/tests/topp/IDFileConverter_31_output.idXML
+++ b/src/tests/topp/IDFileConverter_31_output.idXML
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="MSDB" db_version="1.0" taxonomy="" mass_type="monoisotopic" charges="+1, +2" enzyme="trypsin" missed_cleavages="0" precursor_peak_tolerance="1" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<SearchParameters id="SP_1" db="MSDB" db_version="1.0" taxonomy="" mass_type="monoisotopic" charges="+1, +2, +3" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="1" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+		<FixedModification name="Carbamidomethyl (C)" />
+		<FixedModification name="Glucuronyl (S)" />
+		<VariableModification name="Oxidation (M)" />
+		<VariableModification name="Deamidated (Q)" />
+	</SearchParameters>
+	<IdentificationRun date="2006-01-12T12:13:14" search_engine="Mascot" search_engine_version="2.1.0" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="PROT2" score="0.0" sequence="ABCDEFG" >
+				<UserParam type="string" name="isDecoy" value="false"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="PROT1" score="0.0" sequence="ABCDEFG" >
+				<UserParam type="string" name="isDecoy" value="false"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[UNKNOWN]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="PSM-level search engine specific statistic" higher_score_better="true" significance_threshold="0.0" MZ="675.899999999999977" RT="1234.5" spectrum_reference="17" >
+			<PeptideHit score="0.0" sequence="PEPTIDER" charge="1" aa_before="A X" aa_after="B X" protein_refs="PH_1 PH_0" >
+				<UserParam type="string" name="MOWSE" value="0.9"/>
+				<UserParam type="float" name="calcMZ" value="956.468357540270972"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="name" value="PeptideHit"/>
+			</PeptideHit>
+			<PeptideHit score="0.0" sequence="PEPTIDERR" charge="1" >
+				<UserParam type="string" name="MOWSE" value="1.4"/>
+				<UserParam type="float" name="calcMZ" value="1112.569468923070872"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="PSM-level search engine specific statistic" higher_score_better="true" significance_threshold="0.0" spectrum_reference="MZ:nan@RT:nan" >
+			<PeptideHit score="0.0" sequence="PEPTIDERRR" charge="2" >
+				<UserParam type="string" name="MOWSE" value="44.399999999999999"/>
+				<UserParam type="float" name="calcMZ" value="634.838928386320845"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+			</PeptideHit>
+			<PeptideHit score="0.0" sequence="N[3785.307099999999991]PEPTIDEK" charge="2" >
+				<UserParam type="string" name="MOWSE" value="33.299999999999997"/>
+				<UserParam type="float" name="calcMZ" value="2414.409757099220769"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+	<IdentificationRun date="2007-01-12T12:13:14" search_engine="Mascot" search_engine_version="2.1.0" search_parameters_ref="SP_1" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_2" accession="PROT3" score="0.0" sequence="" >
+				<UserParam type="string" name="isDecoy" value="false"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[UNKNOWN]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="PSM-level search engine specific statistic" higher_score_better="true" significance_threshold="0.0" spectrum_reference="MZ:nan@RT:nan" >
+			<PeptideHit score="0.0" sequence="PEPTIDERRRRR" charge="1" protein_refs="PH_2" >
+				<UserParam type="string" name="MOWSE" value="1.4"/>
+				<UserParam type="float" name="calcMZ" value="1580.872803071470571"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>


### PR DESCRIPTION
This PR addresses #4607.

When writing an mzid that from PeptideHits that use a score that does not have a CV-term,
we add this CV-term without a value instead:
`<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>`
and then add the score as a `userParam`.
This will technically make an invalid mzid, but at least it still contains all the data. Previously this type of mzid could also not be parsed by OpenMS. The cvParam without a value caused an error.

This PR fixes the parsing somewhat. It generates PeptideHits with a score of 0.0 and the score type
`PSM-level search engine specific statistic`. The actual score is (most likely) automatically stored as a metaValue, like all other mzid userParams.
This way the mzid can be converted into an equivalent idXML without a usable `score` attribute, but all the data still there.
If it is known which userParam is the score, it could be updated manually using the IDScoreSwitcher.

Also a test was added that reads in this type of mzid and writes out an idXML.

As a future update, we can add a userParam that says which userParam is the main score to this type of mzid.
Then the mzid Parser can look it up and set that metaValue as the score in the PeptideHit.
This could also be done for the "higher score is better" attribute. Right know it is assumed to be `true` for this type of score.