### PR TITLE
add missing cachedMzML file type to parameter

### DIFF
--- a/src/topp/OpenSwathAnalyzer.cpp
+++ b/src/topp/OpenSwathAnalyzer.cpp
@@ -150,7 +150,7 @@ protected:
                            "Swath files that were used to extract the transitions. "
                            "If present, SWATH specific scoring will be used.",
                            false);
-    setValidFormats_("swath_files", ListUtils::create<String>("mzML"));
+    setValidFormats_("swath_files", ListUtils::create<String>("mzML,cachedMzML"));
 
     registerDoubleOption_("min_upper_edge_dist", "<double>", 0.0,
                           "[applies only if you have full MS2 spectra maps] "


### PR DESCRIPTION
One question am I right that cachedMzML corresponds to to CML files with root tag the `indexedMzML`.

# Description

Please include a summary of the change and which issue is fixed.

Also please:
- Make sure that you are listed in the AUTHORS file
- Add relevant changes and new features to the CHANGELOG file

# Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
