### PR TITLE
start to unify traML vs TraML

### DIFF
--- a/src/topp/MRMMapper.cpp
+++ b/src/topp/MRMMapper.cpp
@@ -124,7 +124,7 @@ protected:
     setValidFormats_("in", ListUtils::create<String>("mzML"));
 
     registerInputFile_("tr", "<file>", "", "transition file");
-    setValidFormats_("tr", ListUtils::create<String>("TraML"));
+    setValidFormats_("tr", ListUtils::create<String>("traML"));
 
     registerOutputFile_("out", "<file>", "", "Output file containing mapped chromatograms");
     setValidFormats_("out", ListUtils::create<String>("mzML"));

--- a/src/topp/OpenSwathAnalyzer.cpp
+++ b/src/topp/OpenSwathAnalyzer.cpp
@@ -131,7 +131,7 @@ protected:
     setValidFormats_("in", ListUtils::create<String>("mzML"));
 
     registerInputFile_("tr", "<file>", "", "transition file");
-    setValidFormats_("tr", ListUtils::create<String>("TraML"));
+    setValidFormats_("tr", ListUtils::create<String>("traML"));
 
     registerInputFile_("rt_norm", "<file>", "",
                        "RT normalization file (how to map the RTs of this run to the ones stored in the library)",

--- a/src/utils/OpenSwathDIAPreScoring.cpp
+++ b/src/utils/OpenSwathDIAPreScoring.cpp
@@ -90,7 +90,7 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("tr", "<file>", "", "transition file");
-    setValidFormats_("tr", ListUtils::create<String>("TraML"));
+    setValidFormats_("tr", ListUtils::create<String>("traML"));
 
     registerOutputFile_("out", "<file>", "", "output file");
     setValidFormats_("out", ListUtils::create<String>("tsv"));

--- a/src/utils/SemanticValidator.cpp
+++ b/src/utils/SemanticValidator.cpp
@@ -86,7 +86,7 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input file (any xml file)");
-    setValidFormats_("in", ListUtils::create<String>("analysisXML,mzML,TraML,mzid,mzData,xml"));
+    setValidFormats_("in", ListUtils::create<String>("analysisXML,mzML,traML,mzid,mzData,xml"));
 
     registerInputFile_("mapping_file", "<file>", "", "Mapping file which is used to semantically validate the given XML file against this mapping file (see 'share/OpenMS/MAPPING' for templates).");
     setValidFormats_("mapping_file", ListUtils::create<String>("xml"));

--- a/src/utils/XMLValidator.cpp
+++ b/src/utils/XMLValidator.cpp
@@ -92,7 +92,7 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "file to validate");
-    setValidFormats_("in", ListUtils::create<String>("mzML,mzData,featureXML,mzid,idXML,consensusXML,mzXML,ini,pepXML,TraML,xml"));
+    setValidFormats_("in", ListUtils::create<String>("mzML,mzData,featureXML,mzid,idXML,consensusXML,mzXML,ini,pepXML,traML,xml"));
     registerInputFile_("schema", "<file>", "", "schema to validate against.\nIf no schema is given, the file is validated against the latest schema of the file type.", false);
     setValidFormats_("schema", ListUtils::create<String>("xsd"));
   }


### PR DESCRIPTION
becomes anoying for autoconverters

seemingly traML is less common so I went for the majority

Seems that there are still some places left...


# Description

Please include a summary of the change and which issue is fixed.

Also please:
- Make sure that you are listed in the AUTHORS file
- Add relevant changes and new features to the CHANGELOG file

# Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
