### PR TITLE
[FIX] suppress misleading warning messages about unknown parameters

### DIFF
--- a/src/topp/OpenPepXL.cpp
+++ b/src/topp/OpenPepXL.cpp
@@ -231,9 +231,9 @@ protected:
     PeakMap spectra;
 
     OpenPepXLAlgorithm search_algorithm;
-    Param this_param = getParam_().copy("", true);
+    Param this_param = getParam_();
     Param algo_param = search_algorithm.getParameters();
-    algo_param.update(this_param, false, OpenMS_Log_debug); // suppress param. update message
+    algo_param.update(this_param, false, false, false, false, OpenMS_Log_debug); // suppress param. update message
     search_algorithm.setParameters(algo_param);
     search_algorithm.setLogType(this->log_type_);
 

--- a/src/topp/OpenPepXLLF.cpp
+++ b/src/topp/OpenPepXLLF.cpp
@@ -220,9 +220,9 @@ protected:
     PeakMap spectra;
 
     OpenPepXLLFAlgorithm search_algorithm;
-    Param this_param = getParam_().copy("", true);
+    Param this_param = getParam_();
     Param algo_param = search_algorithm.getParameters();
-    algo_param.update(this_param, false, OpenMS_Log_debug); // suppress param. update message
+    algo_param.update(this_param, false, false, false, false, OpenMS_Log_debug); // suppress param. update message
     search_algorithm.setParameters(algo_param);
     search_algorithm.setLogType(this->log_type_);
 

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -69,31 +69,31 @@ using namespace OpenMS;
   PeptideIndexer refreshes target/decoy information and mapping of peptides to proteins.
   The target/decoy information is crucial for the @ref TOPP_FalseDiscoveryRate tool. (For FDR calculations, "target+decoy" peptide hits count as target hits.)
 
-  PeptideIndexer allows for ambiguous amino acids (B|J|Z|X) in the protein database, but not in the peptide sequences. 
+  PeptideIndexer allows for ambiguous amino acids (B|J|Z|X) in the protein database, but not in the peptide sequences.
   For the latter only I/L can be treated as equivalent (see 'IL_equivalent' flag), but 'J' is not allowed.
-  
+
   Enzyme cutting rules and partial specificity can be specified.
 
   Resulting protein hits appear in the order of the FASTA file, except for orphaned proteins, which will appear first with an empty target_decoy metavalue.
   Duplicate protein accessions & sequences will not raise a warning, but create multiple hits (PeptideIndexer scans over the FASTA file once for efficiency
   reasons, and thus might not see all accessions & sequences at once).
 
-  All peptide and protein hits are annotated with target/decoy information, using the meta value "target_decoy". 
-  For proteins the possible values are "target" and "decoy", depending on whether the protein accession contains the decoy pattern (parameter @p decoy_string) 
-  as a suffix or prefix, respectively (see parameter @p prefix). 
-  
+  All peptide and protein hits are annotated with target/decoy information, using the meta value "target_decoy".
+  For proteins the possible values are "target" and "decoy", depending on whether the protein accession contains the decoy pattern (parameter @p decoy_string)
+  as a suffix or prefix, respectively (see parameter @p prefix).
+
   Peptide hits are annotated with metavalue 'protein_references', and if matched to at least one protein also with metavalue 'target_decoy'.
-  The possible values for 'target_decoy' are "target", "decoy" and "target+decoy", 
+  The possible values for 'target_decoy' are "target", "decoy" and "target+decoy",
   depending on whether the peptide sequence is found only in target proteins, only in decoy proteins, or in both. The metavalue is not present, if the peptide is unmatched.
-  
-  Runtime: PeptideIndexer is usually very fast (loading and storing the data takes the most time) and search speed can be further improved (linearly), but using more threads. 
+
+  Runtime: PeptideIndexer is usually very fast (loading and storing the data takes the most time) and search speed can be further improved (linearly), but using more threads.
   Avoid allowing too many (>=4) ambiguous amino acids if your database contains long stretches of 'X' (exponential search space).
 
   PeptideIndexer supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified
   by @p OpenMS.ini:id_db_dir (see @subpage TOPP_advanced).
 
   Further details can be found in the underlying @ref OpenMS::PeptideIndexing implementation.
-  
+
   @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
 
   <B>The command line parameters of this tool are:</B>
@@ -138,9 +138,9 @@ protected:
     String out = getStringOption_("out");
 
     PeptideIndexing indexer;
-    Param param = getParam_().copy("", true);
+    Param param = getParam_();
     Param param_pi = indexer.getParameters();
-    param_pi.update(param, false, OpenMS_Log_debug); // suppress param. update message
+    param_pi.update(param, false, false, false, false, OpenMS_Log_debug); // suppress param. update message
     indexer.setParameters(param_pi);
     indexer.setLogType(this->log_type_);
     String db_name = getStringOption_("fasta");
@@ -178,7 +178,7 @@ protected:
 
     FASTAContainer<TFI_File> proteins(db_name);
     PeptideIndexing::ExitCodes indexer_exit = indexer.run(proteins, prot_ids, pep_ids);
-  
+
     //-------------------------------------------------------------
     // calculate protein coverage
     //-------------------------------------------------------------
@@ -198,7 +198,7 @@ protected:
 
     if (indexer_exit == PeptideIndexing::DATABASE_EMPTY)
     {
-      return INPUT_FILE_EMPTY;       
+      return INPUT_FILE_EMPTY;
     }
     else if (indexer_exit == PeptideIndexing::UNEXPECTED_RESULT)
     {


### PR DESCRIPTION
The OpenPepXL, OpenPepXLLF and PeptideIndexer tools pass all input parameters on to their algorithm classes.
This includes the TOPPBase parameters like `threads` and `test` as well as inout and output file parameters. The algorithm classes don't know about these parameters and a warning about unknown or deprecated parameters is thrown when `debug != 0`.

This PR is a simple workaround that removes those unknown parameters from the `Param` object that is passed to the algorithm.
This method is already used in e.g. `FeatureFinderMultiplex`.

The better option (at least for new tools) would be to add a node to the parameters for each tool that includes all parameters needed for the respective algorithm class, but that would add prefixes to most of their parameters and break all existing `.ini` files and workflows.


Fixes #4546

