### PR TITLE
[FEATURE] combine SE settings during ConsensusID (instead of taking 1st)

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -55,6 +55,10 @@ namespace OpenMS
                        "true",
                        "If true, adds a map_index MetaValue to the PeptideIDs to annotate the IDRun they came from.");
     defaults_.setValidStrings("annotate_origin", ListUtils::create<String>("true,false"));
+    defaults_.setValue("allow_disagreeing_settings",
+                       "false",
+                       "Force merging of disagreeing runs. Use at your own risk.");
+    defaults_.setValidStrings("allow_disagreeing_settings", ListUtils::create<String>("true,false"));
     defaultsToParam_();
     prot_result_.setIdentifier(getNewIdentifier_());
   }
@@ -411,7 +415,7 @@ namespace OpenMS
       // collect warnings and throw at the end if at least one failed
       ok = ok && ref.peptideIDsMergeable(idRun, experiment_type);
     }
-    if (!ok /*&& TODO and no force flag*/)
+    if (!ok && !param_.getValue("allow_disagreeing_settings").toBool())
     {
       throw Exception::MissingInformation(__FILE__,
                                           __LINE__,

--- a/src/tests/topp/ConsensusID_7_output.idXML
+++ b/src/tests/topp/ConsensusID_7_output.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="ECOlL" db_version="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="ECOlL" db_version="Ecoli_K12_TaxID_83333.proteomes.decoy.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="1-3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 				<UserParam type="string" name="SE:Mascot" value="2.2.04"/>
 				<UserParam type="string" name="Mascot:db" value="ECOlL"/>

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -736,6 +736,8 @@ protected:
     // TODO let this be parsed by the pepXML parser if this info is present there.
     protein_identifications[0].getSearchParameters().enzyme_term_specificity =
         static_cast<EnzymaticDigestion::Specificity>(num_enzyme_termini[getStringOption_("num_enzyme_termini")]);
+    protein_identifications[0].getSearchParameters().charges = getStringOption_("precursor_charge");
+    protein_identifications[0].getSearchParameters().db = getStringOption_("database");
     IdXMLFile().store(out, protein_identifications, peptide_identifications);
 
     //-------------------------------------------------------------

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -464,7 +464,8 @@ protected:
     String final_db_bn = final_db;
     final_db_bn.substitute("\\","/");
     final_db_bn = File::basename(final_db_bn);
-    for (auto db : dbs)
+    // we need to copy to substitute anyway
+    for (auto db : dbs) // OMS_CODING_TEST_EXCLUDE
     {
       db.substitute("\\","/");
       if (File::basename(db) != final_db_bn)

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -345,13 +345,13 @@ protected:
     // modification params are necessary for further analysis tools (e.g. LuciPHOr2)
     set<String> fixed_mods_set;
     set<String> var_mods_set;
+    set<EnzymaticDigestion::Specificity> specs;
     double prec_tol = 0.;
     double frag_tol = 0.;
     int min_chg = 10000;
     int max_chg = -10000;
     Size mc = 0;
     String enz;
-    String spec;
 
     //TODO check if settings are same/similar
     bool allsamese = true;
@@ -392,24 +392,32 @@ protected:
       {
         enz = sp.digestion_enzyme.getName();
       }
-      if (spec.empty())
-      {
-        spec = EnzymaticDigestion::NamesOfSpecificity[sp.enzyme_term_specificity];
-      }
-      //TODO does not handle no-cterm and no-nterm
-      else if (spec == "full" && (sp.enzyme_term_specificity == EnzymaticDigestion::SPEC_SEMI || sp.enzyme_term_specificity == EnzymaticDigestion::SPEC_NONE))
-      {
-        spec = EnzymaticDigestion::NamesOfSpecificity[sp.enzyme_term_specificity];
-      }
-      else if (spec == "semi" && sp.enzyme_term_specificity == EnzymaticDigestion::SPEC_NONE)
-      {
-        spec = EnzymaticDigestion::NamesOfSpecificity[sp.enzyme_term_specificity];
-      }
+      specs.insert(sp.enzyme_term_specificity);
 
       std::copy(sp.fixed_modifications.begin(), sp.fixed_modifications.end(), std::inserter(fixed_mods_set, fixed_mods_set.end()));
       std::copy(sp.variable_modifications.begin(), sp.variable_modifications.end(), std::inserter(var_mods_set, var_mods_set.end()));
     }
 
+    if (specs.find(EnzymaticDigestion::SPEC_NONE) != specs.end())
+    {
+      new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NONE;
+    }
+    else if (specs.find(EnzymaticDigestion::SPEC_SEMI) != specs.end())
+    {
+      new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_SEMI;
+    }
+    else if (specs.find(EnzymaticDigestion::SPEC_NONTERM) != specs.end())
+    {
+      new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NONTERM;
+    }
+    else if (specs.find(EnzymaticDigestion::SPEC_NOCTERM) != specs.end())
+    {
+      new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_NOCTERM;
+    }
+    else if (specs.find(EnzymaticDigestion::SPEC_FULL) != specs.end())
+    {
+      new_sp.enzyme_term_specificity = EnzymaticDigestion::SPEC_FULL;
+    }
 
     std::vector<String> fixed_mods(fixed_mods_set.begin(), fixed_mods_set.end());
     std::vector<String> var_mods(var_mods_set.begin(), var_mods_set.end());
@@ -421,7 +429,6 @@ protected:
     new_sp.fragment_mass_tolerance = frag_tol;
     new_sp.precursor_mass_tolerance = prec_tol;
     new_sp.missed_cleavages = mc;
-    new_sp.enzyme_term_specificity = EnzymaticDigestion::getSpecificityByName(spec);
 
     prot_id.setDateTime(DateTime::now());
     prot_id.setSearchEngine("OpenMS/ConsensusID_" + algorithm_);


### PR DESCRIPTION
# Description

Important to have the same settings outcome, when executing ConsID on files in a different order. Before it was just taking first, now it takes the loosest settings.

Also please:
- Make sure that you are listed in the AUTHORS file
- Add relevant changes and new features to the CHANGELOG file

# Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes
