### PR TITLE
Addon changes for pyopenms

### DIFF
--- a/src/pyOpenMS/addons/ConvexHull2D.pyx
+++ b/src/pyOpenMS/addons/ConvexHull2D.pyx
@@ -3,15 +3,26 @@ from DPosition cimport DPosition2 as _DPosition2
 from DBoundingBox cimport DBoundingBox2 as _DBoundingBox2
 
 
-    def encloses(self, float x, float y):
-
+    def enclosesXY(self, float x, float y):
+        """
+        Parameters:
+        x (float)
+        y (float)
+        
+        Returns:
+        int
+        """
         cdef _DPosition2 pos
         pos[0] = x
         pos[1] = y
         return self.inst.get().encloses(pos)
 
 
-    def getHullPoints(self):
+    def getHullPointsNPY(self):
+        """
+        Returns:
+        result (np.ndarray[np.float32_t, ndim=2])
+        """
         cdef libcpp_vector[_DPosition2] points = self.inst.get().getHullPoints()
         cdef np.ndarray[np.float32_t, ndim=2] result
         cdef n = points.size()
@@ -25,7 +36,11 @@ from DBoundingBox cimport DBoundingBox2 as _DBoundingBox2
             i += 1
         return result
 
-    def setHullPoints(self, np.ndarray[np.float32_t, ndim=2] points):
+    def setHullPointsNPY(self, np.ndarray[np.float32_t, ndim=2] points):
+        """
+        Parameters:
+        points (np.ndarray[np.float32_t, ndim=2])
+        """
         cdef _ConvexHull2D * hull = self.inst.get()
         cdef int N = points.shape[0]
         cdef int i
@@ -37,19 +52,32 @@ from DBoundingBox cimport DBoundingBox2 as _DBoundingBox2
             vec.push_back(p)
         self.inst.get().setHullPoints(vec)
 
-    def getBoundingBox(self):
+    def getBoundingBox2D(self):
+        """
+        Returns:
+        ((double,double),(double,double))
+        """
         cdef _DBoundingBox2 box = self.inst.get().getBoundingBox()
         cdef _DPosition2 minp = box.minPosition()
         cdef _DPosition2 maxp = box.maxPosition()
         return (minp[0], minp[1]), (maxp[0], maxp[1])
 
-    def addPoint(self, x, y):
+    def addPointXY(self, x, y):
+        """
+        Parameters:
+        x (double)
+        y (double)
+        """
         cdef _DPosition2 p
         p[0] = x
         p[1] = y
         self.inst.get().addPoint(p)
 
-    def addPoints(self, np.ndarray[np.float32_t, ndim=2] points):
+    def addPointsNPY(self, np.ndarray[np.float32_t, ndim=2] points):
+        """
+        Parameters:
+        points (np.ndarray[np.float32_t, ndim=2])
+        """
         cdef _ConvexHull2D * hull = self.inst.get()
         cdef int N = points.shape[0]
         cdef int i
@@ -60,5 +88,4 @@ from DBoundingBox cimport DBoundingBox2 as _DBoundingBox2
             p[1] = points[i,1]
             vec.push_back(p)
         self.inst.get().addPoints(vec)
-
 

--- a/src/pyOpenMS/addons/MapAlignmentAlgorithmIdentification.pyx
+++ b/src/pyOpenMS/addons/MapAlignmentAlgorithmIdentification.pyx
@@ -1,7 +1,17 @@
 
 
-
-    def align(self, list ids , list trafos, int ref_index):
+    # C++ signature: void align(libcpp_vector[MSExperiment] &, libcpp_vector[TransformationDescription] &, int)
+    # C++ signature: void align(libcpp_vector[FeatureMap] &, libcpp_vector[TransformationDescription] &, int)
+    # C++ signature: void align(libcpp_vector[ConsensusMap] &, libcpp_vector[TransformationDescription] &, int)
+    # 
+    # In addition to above overloaded functions adding this new one.
+    def align_4(self, list ids , list trafos, int ref_index):
+        """
+        Parameters:
+        ids (list): list of PeptideIdentification objects
+        trafos (list): list of TransformationDescription objects
+        ref_index (int)
+        """
         assert isinstance(ids, list) and all(isinstance(li, list) and all(isinstance(li_, PeptideIdentification) for li_ in li) for li in ids), 'arg ids wrong type'
         assert isinstance(trafos, list) and all(isinstance(li, TransformationDescription) for li in trafos), 'arg trafos wrong type'
         cdef libcpp_vector[libcpp_vector[_PeptideIdentification]] * v0 = new libcpp_vector[libcpp_vector[_PeptideIdentification]]()

--- a/src/pyOpenMS/addons/MapAlignmentAlgorithmIdentification.pyx
+++ b/src/pyOpenMS/addons/MapAlignmentAlgorithmIdentification.pyx
@@ -8,7 +8,7 @@
     def align_4(self, list ids , list trafos, int ref_index):
         """
         Parameters:
-        ids (list): list of PeptideIdentification objects
+        ids (list): list of lists of PeptideIdentification objects
         trafos (list): list of TransformationDescription objects
         ref_index (int)
         """


### PR DESCRIPTION
# Description

We currently cannot use the addon functions of ConvexHull2D.pyx and MapAlignmentAlgorithmIdentification.pyx. In the pxd files, these functions are declared without "#wrap-ignore" declarative and hence are wrapped by autowrap. The overloaded definitions in addons for these functions seem to be ignored by cython.
Thus, changing the name of these functions is one viable solution for exposing these in pyopenms and eventually the R bindings.

Also please:
- Make sure that you are listed in the AUTHORS file
- Add relevant changes and new features to the CHANGELOG file

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes
