### PR TITLE
re-implement StopWatch to allow for 'resume()' and querying time while still running

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/StopWatch.h
+++ b/src/openms/include/OpenMS/SYSTEM/StopWatch.h
@@ -50,9 +50,15 @@
 namespace OpenMS
 {
   /**
-      @brief StopWatch Class.
+      @brief This class is used to determine the current process' CPU (user and/or kernel) and wall time.
 
-      This class is used to determine the current process time.
+      CPU time is measured as sum of all threads of the current process.
+
+      To read a time, the stopwatch must be started beforehand, but not necessarily stopped.
+      
+      You can stop() the timer and resume() it later to omit intermediate steps which should not count towards 
+      the measured times.
+
 
       @ingroup System
   */
@@ -72,47 +78,64 @@ public:
     /**	Copy constructor.
             Create a new stop watch from an existing stop watch.
     */
-    StopWatch(const StopWatch & stop_watch);
+    StopWatch(const StopWatch& stop_watch) = default;
+    
+    /**	Assignment operator.
+        Assigns a stop watch from another. The two stop watch will then run
+        synchronously.
+        @return StopWatch <tt>*this</tt>
+    */
+    StopWatch& operator=(const StopWatch& stop_watch) = default;
 
     /**	Destructor.
             Destructs a stop watch object.
     */
-    virtual ~StopWatch();
+    ~StopWatch() = default;
 
     //@}
     /**	Starting, Stopping and Resetting the stop watch
     */
     //@{
 
-    /**	Clear and stop the stop watch.
-            This sets the stop watch to zero and stops it when running.
-            @see	reset
+    /**
+        @brief Start the stop watch.
+        
+        If the watch holds data from previous measurements, these will be reset before starting up,
+        i.e. it is not possible to resume by start(), stop(), start().
+        Use resume(), stop(), resume() instead.
+    
+        @throw Exception::Precondition if the StopWatch is already running
     */
-    void clear();
+    void start();
 
-    /** Start the stop watch.
-            The stop watch is started. If the stop watch is already running, <b>false</b>
-            is returned.
+    /** 
+        @brief Stop the stop watch (can be resumed later).
+        If the stop watch was not running an exception is thrown.
 
-            If the watch holds data from previous measurements, these will be reset before starting up,
-            i.e. it is not possible to resume by start(), stop(), start().
-
-            @return bool <b>false</b> if the stop watch was already running, <b>true</b> otherwise
+        @throw Exception::Precondition if the StopWatch is not running
     */
-    bool start();
+    void stop();
 
-    /** Stop the stop watch.
-            The stop watch is stopped. If the stop watch was not running, <b>false</b>
-            is returned.
-            @return bool <b>false</b> if the was not running, <b>true</b> otherwise
+    /**
+      @brief Resume a stopped StopWatch
+
+      @throw Exception::Precondition if the StopWatch is already running
     */
-    bool stop();
+    void resume();
 
-    /** Clear the stop watch without stopping.
-            The stop watch is cleared, but not stopped (if running).
-            @see clear
+    /** 
+        @brief Clear the stop watch but keep running.
+        
+        The stop watch is reset to 0, but not stopped (if running).
+        @see clear
     */
     void reset();
+
+    /**	Clear and stop the stop watch.
+        This sets the stop watch to zero and stops it when running.
+        @see	reset
+*/
+    void clear();
 
     //@}
 
@@ -121,40 +144,25 @@ public:
     //@{
 
     /**	Get clock time.
-            Return the accumulated clock (real) time in seconds.
+            Return the accumulated wall clock (real) time in seconds.
     */
     double getClockTime() const;
 
     /**	Get user time.
-            Return the accumulated user time in seconds.
+            Return the accumulated user time in seconds across all threads.
     */
     double getUserTime() const;
 
     /**	Get user time.
-            Return the accumulated system time in seconds.
+            Return the accumulated system time in seconds across all threads.
     */
     double getSystemTime() const;
 
     /**	Get CPU time.
             Return the accumulated CPU time in seconds.
-            CPU time is the sum of user time and system time.
+            CPU time is the sum of user time and system time across all threads.
     */
     double getCPUTime() const;
-
-    //@}
-
-    /**	@name	Assignment
-    */
-    //@{
-
-    /**	Assignment operator.
-            Assigns a stop watch from another. The two stop watch will then run
-            synchronously.
-            @return StopWatch <tt>*this</tt>
-    */
-    StopWatch & operator=(const StopWatch & stop_watch);
-
-    //@}
 
     /**	@name	Predicates
     */
@@ -229,45 +237,113 @@ public:
     /**
       custom string formatting of time, using only the minimal number of units required (e.g., does not report hours when seconds suffice).
     */
-    static String toString(const double time);
+    static String toString(const double time_in_seconds);
 
 private:
+  #ifdef OPENMS_WINDOWSPLATFORM
+    static long long StopWatch::SecondsTo100Nano_;  ///< 10 million; convert from 100 nanosecond ticks to seconds (factor of 1 billion/100 = 10 million)
+    typedef OPENMS_UINT64_TYPE TimeType; ///< do not use clock_t on Windows, since its not big enough for larger time intervals
+  #else
+    typedef clock_t TimeType;
+    PointerSizeInt StopWatch::cpu_speed_ = 0L; ///< POSIX API returns clock ticks, so we need to divide by CPU speed
+  #endif
+
+    struct TimeDiff_
+    {
+      TimeType user_ticks{ 0 }; ///< platform dependent value (might be CPU ticks or time intervals)
+      TimeType kernel_ticks{ 0 }; ///< platform dependent value (might be CPU ticks or time intervals)
+      PointerSizeInt start_time{ 0 }; ///< time in seconds (relative or absolute, depending on usage)
+      PointerSizeInt start_time_usec{ 0 }; ///< time in microseconds (relative or absolute, depending on usage)
+
+      double userTime() const
+      {
+        return ticksToSeconds_(user_ticks);
+      }
+      double kernelTime() const
+      {
+        return ticksToSeconds_(kernel_ticks);
+      }
+
+      double getCPUTime() const
+      {
+        return userTime() + kernelTime();
+      }
+
+      double clockTime() const
+      {
+        return (double)start_time + (double)start_time_usec / 1e6;
+      }
+
+      TimeDiff_ operator-(const TimeDiff_ earlier) const
+      {
+        TimeDiff_ diff(*this);
+        diff.kernel_ticks -= earlier.kernel_ticks;
+        diff.user_ticks -= earlier.user_ticks;
+        diff.start_time -= earlier.start_time;
+        diff.start_time_usec -= earlier.start_time_usec;
+
+        /* Adjust for the fact that the usec may be negative.     */
+        /* If they are, take away 1 second and add 1 million      */
+        /* microseconds until they are positive.                  */
+        while (diff.start_time_usec < 0L)
+        {
+          --diff.start_time;
+          diff.start_time_usec += 1000000L;
+        }
+        return diff;
+      }
+
+      TimeDiff_& operator+=(TimeDiff_ other)
+      {
+        user_ticks += other.user_ticks;
+        kernel_ticks += other.kernel_ticks;
+        start_time += other.start_time;
+        start_time_usec += other.start_time_usec;
+
+        while (start_time_usec > 1000000L)
+        {
+          ++start_time;
+          start_time_usec -= 1000000L;
+        }
+
+        return *this;
+      }
+
+      bool operator==(const TimeDiff_ rhs) const
+      {
+        return user_ticks == rhs.user_ticks &&
+               kernel_ticks == rhs.kernel_ticks &&
+               start_time == rhs.start_time &&
+               start_time_usec == rhs.start_time_usec;
+      }
+
+      private:
+        double ticksToSeconds_(TimeType in) const
+        {
+#ifdef OPENMS_WINDOWSPLATFORM
+          return in / double(StopWatch::SecondsTo100Nano_);
+#else
+          return in / double(cpu_speed_); // technically, this is inaccurate since CPU speed may not be constant (turbo-boost)... but finding a better solution is hard...
+#endif
+        }
+    };
+
+
+    /// get the absolute times for current system, user and kernel times
+    TimeDiff_ snapShot_() const;
 
     static PointerSizeInt cpu_speed_;
 
-#ifdef OPENMS_WINDOWSPLATFORM
-    static PointerSizeInt clock_speed_;
-    typedef OPENMS_UINT64_TYPE TimeType; // do not use clock_t on Windows, since its not big enough for larger time intervals
-#else
-    typedef clock_t TimeType;
-#endif
+    /// currently accumulated times between start to stop intervals (initially 0),
+    /// not counting the currently running interval which started at last_start_
+    TimeDiff_ accumulated_times_;
 
-    // state of stop watch, either true(on) or false(off)
-    bool is_running_;
+    /// point in time of last start()
+    TimeDiff_ last_start_;
 
-    // clock seconds value when the stop watch was last started
-    PointerSizeInt start_secs_;
+    /// state of stop watch, either true(on) or false(off)
+    bool is_running_ = false;
 
-    // clock useconds value when the stop watch was last started
-    PointerSizeInt start_usecs_;
-
-    // user time when the stop watch was last started
-    TimeType start_user_time_;
-
-    // system time when the stop watch was last started
-    TimeType start_system_time_;
-
-    // current accumulated clock seconds
-    PointerSizeInt current_secs_;
-
-    // current accumulated clock useconds
-    PointerSizeInt current_usecs_;
-
-    // current accumulated user time
-    TimeType current_user_time_;
-
-    // current accumulated user time
-    TimeType current_system_time_;
   };
 
 }

--- a/src/openms/include/OpenMS/SYSTEM/StopWatch.h
+++ b/src/openms/include/OpenMS/SYSTEM/StopWatch.h
@@ -241,11 +241,11 @@ public:
 
 private:
   #ifdef OPENMS_WINDOWSPLATFORM
-    static long long StopWatch::SecondsTo100Nano_;  ///< 10 million; convert from 100 nanosecond ticks to seconds (factor of 1 billion/100 = 10 million)
+    static long long SecondsTo100Nano_;  ///< 10 million; convert from 100 nanosecond ticks to seconds (factor of 1 billion/100 = 10 million)
     typedef OPENMS_UINT64_TYPE TimeType; ///< do not use clock_t on Windows, since its not big enough for larger time intervals
   #else
     typedef clock_t TimeType;
-    PointerSizeInt StopWatch::cpu_speed_ = 0L; ///< POSIX API returns clock ticks, so we need to divide by CPU speed
+    PointerSizeInt cpu_speed_ = 0L; ///< POSIX API returns clock ticks, so we need to divide by CPU speed
   #endif
 
     struct TimeDiff_
@@ -331,8 +331,6 @@ private:
 
     /// get the absolute times for current system, user and kernel times
     TimeDiff_ snapShot_() const;
-
-    static PointerSizeInt cpu_speed_;
 
     /// currently accumulated times between start to stop intervals (initially 0),
     /// not counting the currently running interval which started at last_start_

--- a/src/openms/include/OpenMS/SYSTEM/StopWatch.h
+++ b/src/openms/include/OpenMS/SYSTEM/StopWatch.h
@@ -65,34 +65,6 @@ namespace OpenMS
   class OPENMS_DLLAPI StopWatch
   {
 public:
-
-    /**	@name	Constructors and Destructors
-    */
-    //@{
-
-    /**	Default constructor.
-            Create a new stop watch. The stop watch is stopped.
-    */
-    StopWatch();
-
-    /**	Copy constructor.
-            Create a new stop watch from an existing stop watch.
-    */
-    StopWatch(const StopWatch& stop_watch) = default;
-    
-    /**	Assignment operator.
-        Assigns a stop watch from another. The two stop watch will then run
-        synchronously.
-        @return StopWatch <tt>*this</tt>
-    */
-    StopWatch& operator=(const StopWatch& stop_watch) = default;
-
-    /**	Destructor.
-            Destructs a stop watch object.
-    */
-    ~StopWatch() = default;
-
-    //@}
     /**	Starting, Stopping and Resetting the stop watch
     */
     //@{
@@ -241,11 +213,11 @@ public:
 
 private:
   #ifdef OPENMS_WINDOWSPLATFORM
-    static long long SecondsTo100Nano_;  ///< 10 million; convert from 100 nanosecond ticks to seconds (factor of 1 billion/100 = 10 million)
     typedef OPENMS_UINT64_TYPE TimeType; ///< do not use clock_t on Windows, since its not big enough for larger time intervals
+    static const long long SecondsTo100Nano_;  ///< 10 million; convert from 100 nanosecond ticks to seconds (factor of 1 billion/100 = 10 million)
   #else
     typedef clock_t TimeType;
-    PointerSizeInt cpu_speed_ = 0L; ///< POSIX API returns clock ticks, so we need to divide by CPU speed
+    static const PointerSizeInt cpu_speed_; ///< POSIX API returns clock ticks, so we need to divide by CPU speed
   #endif
 
     struct TimeDiff_
@@ -323,7 +295,7 @@ private:
 #ifdef OPENMS_WINDOWSPLATFORM
           return in / double(StopWatch::SecondsTo100Nano_);
 #else
-          return in / double(cpu_speed_); // technically, this is inaccurate since CPU speed may not be constant (turbo-boost)... but finding a better solution is hard...
+          return in / double(StopWatch::cpu_speed_); // technically, this is inaccurate since CPU speed may not be constant (turbo-boost)... but finding a better solution is hard...
 #endif
         }
     };

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmSpectrumAlignment.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmSpectrumAlignment.cpp
@@ -203,9 +203,6 @@ namespace OpenMS
     Size m = std::min((xend - xbegin), (yend - ybegin)) + 1; //row
     // std::cout<< n << " n " << m << " m " <<  xbegin << " " <<xend<< " " << ybegin << " " << yend <<std::endl;
     //log the Progress of the subaligmnet
-    String temp = "sub-alignment of interval: template sequence " + String(xbegin) + " " + String(xend) + " interval: alignsequence " + String(ybegin) + " " + String(yend);
-    startProgress(0, n, temp);
-
     bool column_row_orientation = false;
     if (n != (xend - xbegin) + 1)
     {
@@ -224,7 +221,6 @@ namespace OpenMS
       traceback.clear();
       for (Size i = 0; i <= n; ++i)
       {
-        setProgress(i);
         for (Size j = 0; j <= m; ++j) //if( j >=1 && (Size)j<=m)
         {
           if (insideBand_(i, j, n, m, k_))
@@ -412,7 +408,6 @@ namespace OpenMS
       }
     }
     //std::cout<< xcoordinate.size()<< std::endl;
-    endProgress();
   }
 
   void MapAlignmentAlgorithmSpectrumAlignment::msFilter_(PeakMap& peakmap, std::vector<MSSpectrum*>& spectrum_pointer_container)
@@ -634,12 +629,12 @@ namespace OpenMS
     //gnuplot of the traceback
     std::ofstream myfile;
     myfile.open("debugtraceback.txt", std::ios::trunc);
-    myfile << "set xrange[0:" << pattern.size() - 1 <<  "]" << "\n set yrange[0:" << aligned.size() - 1 << "] \n plot \'-\' with lines " << std::endl;
+    myfile << "set xrange[0:" << pattern.size() - 1 <<  "]" << "\n set yrange[0:" << aligned.size() - 1 << "] \n plot \'-\' with lines \n";
     std::sort(debugtraceback_.begin(), debugtraceback_.end(), Compare(false));
 
     for (Size i = 0; i < debugtraceback_.size(); ++i)
     {
-      myfile << debugtraceback_[i].first << " " << debugtraceback_[i].second << std::endl;
+      myfile << debugtraceback_[i].first << " " << debugtraceback_[i].second << "\n";
       for (Size p = 0; p < debugscorematrix_.size(); ++p)
       {
         if (debugscorematrix_[p][0] == debugtraceback_[i].first && debugscorematrix_[p][1] == debugtraceback_[i].second)
@@ -649,7 +644,7 @@ namespace OpenMS
         }
       }
     }
-    myfile << "e" << std::endl;
+    myfile << "e\n";
     myfile.close();
     //R heatplot score of both sequence
     // std::map<Size, std::map<Size, float> > debugbuffermatrix;
@@ -690,15 +685,15 @@ namespace OpenMS
     */
     for (Size i = 0; i < debugscorematrix_.size(); ++i)
     {
-      scorefile << debugscorematrix_[i][0] << " " << debugscorematrix_[i][1] << " " << debugscorematrix_[i][2] << " " << debugscorematrix_[i][3] << std::endl;
+      scorefile << debugscorematrix_[i][0] << " " << debugscorematrix_[i][1] << " " << debugscorematrix_[i][2] << " " << debugscorematrix_[i][3] << "\n";
     }
     scorefile.close();
 
     std::ofstream rscript;
     rscript.open("debugRscript.r", std::ios::trunc);
 
-    rscript << "#Name: LoadFile \n #transfer data from file into a matrix \n #Input: Filename \n #Output Matrix \n LoadFile<-function(fname){\n temp<-read.table(fname); \n temp<-as.matrix(temp); \n return(temp); \n } " << std::endl;
-    rscript << "#Name: ScoreHeatmapPlot \n #plot the score in a way of a heatmap \n #Input: Scorematrix \n #Output Heatmap \n ScoreHeatmapPlot<-function(matrix) { \n xcord<-as.vector(matrix[,1]); \n ycord<-as.vector(matrix[,2]); \n color<-rgb(as.vector(matrix[,4]),as.vector(matrix[,3]),0);\n  plot(xcord,ycord,col=color, main =\"Heatplot of scores included the traceback\" , xlab= \" Template-sequence \", ylab=\" Aligned-sequence \", type=\"p\" ,phc=22)\n } \n main<-function(filenamea) { \n a<-Loadfile(filenamea) \n X11() \n ScoreHeatmapPlot(a) \n  " << std::endl;
+    rscript << "#Name: LoadFile \n #transfer data from file into a matrix \n #Input: Filename \n #Output Matrix \n LoadFile<-function(fname){\n temp<-read.table(fname); \n temp<-as.matrix(temp); \n return(temp); \n } \n";
+    rscript << "#Name: ScoreHeatmapPlot \n #plot the score in a way of a heatmap \n #Input: Scorematrix \n #Output Heatmap \n ScoreHeatmapPlot<-function(matrix) { \n xcord<-as.vector(matrix[,1]); \n ycord<-as.vector(matrix[,2]); \n color<-rgb(as.vector(matrix[,4]),as.vector(matrix[,3]),0);\n  plot(xcord,ycord,col=color, main =\"Heatplot of scores included the traceback\" , xlab= \" Template-sequence \", ylab=\" Aligned-sequence \", type=\"p\" ,phc=22)\n } \n main<-function(filenamea) { \n a<-Loadfile(filenamea) \n X11() \n ScoreHeatmapPlot(a) \n  \n";
     rscript.close();
     /*
     float matchmaximum=-999.0;

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -210,6 +210,7 @@ namespace OpenMS
     // Execute SQL select statement
     SqliteConnector::prepareStatement(db, &stmt, select_sql);
     sqlite3_step(stmt);
+    endProgress();
 
     Size progress = 0;
     startProgress(0, num_transitions, "reading PQP file");

--- a/src/openms/source/SYSTEM/StopWatch.cpp
+++ b/src/openms/source/SYSTEM/StopWatch.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/SYSTEM/StopWatch.h>
 
+#include <OpenMS/CONCEPT/Exception.h>
+
 #ifdef OPENMS_HAS_UNISTD_H
 #include <unistd.h>
 #endif
@@ -56,22 +58,14 @@
 namespace OpenMS
 {
 
-  PointerSizeInt StopWatch::cpu_speed_ = 0L;
 
 #ifdef OPENMS_WINDOWSPLATFORM
-  PointerSizeInt StopWatch::clock_speed_ = 0L;
+  long long StopWatch::SecondsTo100Nano_ = 10000000LL;
+#else
+  PointerSizeInt StopWatch::cpu_speed_ = 0L;
 #endif
 
-  StopWatch::StopWatch() :
-    is_running_(false),
-    start_secs_(0),
-    start_usecs_(0),
-    start_user_time_(0),
-    start_system_time_(0),
-    current_secs_(0),
-    current_usecs_(0),
-    current_user_time_(0),
-    current_system_time_(0)
+  StopWatch::StopWatch()
   {
 #ifdef OPENMS_HAS_SYSCONF
     if (cpu_speed_ == 0L)
@@ -79,149 +73,48 @@ namespace OpenMS
       cpu_speed_ = sysconf(_SC_CLK_TCK);
     }
 #endif
-
-#ifdef OPENMS_WINDOWSPLATFORM
-    if (cpu_speed_ == 0L)
-    {
-      LARGE_INTEGER ticks;
-      if (QueryPerformanceFrequency(&ticks))
-      {
-        cpu_speed_ = (PointerSizeInt) ticks.QuadPart;
-      }
-      else
-      {
-        cpu_speed_ = 1L;
-      }
-      clock_speed_ = CLOCKS_PER_SEC;
-    }
-#endif
-  }
-
-  StopWatch::StopWatch(const StopWatch & stop_watch) :
-    is_running_(stop_watch.is_running_),
-    start_secs_(stop_watch.start_secs_),
-    start_usecs_(stop_watch.start_usecs_),
-    start_user_time_(stop_watch.start_user_time_),
-    start_system_time_(stop_watch.start_system_time_),
-    current_secs_(stop_watch.current_secs_),
-    current_usecs_(stop_watch.current_usecs_),
-    current_user_time_(stop_watch.current_user_time_),
-    current_system_time_(stop_watch.current_system_time_)
-  {
-  }
-
-  StopWatch::~StopWatch()
-  {
   }
 
   void StopWatch::clear()
-  {
-    is_running_ = false;
-    start_secs_ = 0;
-    start_usecs_ = 0;
-    start_user_time_ = 0;
-    start_system_time_ = 0;
-    current_secs_ = 0L;
-    current_usecs_ = 0L;
-    current_user_time_ = 0L;
-    current_system_time_ = (TimeType)0;
+  { // stopped when running
+    *this = StopWatch(); // default init
   }
 
-  bool StopWatch::start()
+  void StopWatch::start()
   {
-    if (is_running_ == true)
+    if (is_running_)
     {
-      /* tried to start a running stop_watch */
-      return false;
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "StopWatch is already started!");
     }
 
-#ifdef OPENMS_WINDOWSPLATFORM
-    LARGE_INTEGER tms;
-    FILETIME kt, ut, ct, et;
-
-    QueryPerformanceCounter(&tms);
-    HANDLE my_id = GetCurrentProcess();
-    GetProcessTimes(my_id, &ct, &et, &kt, &ut);
-    ULARGE_INTEGER kernel_time;
-    kernel_time.HighPart = kt.dwHighDateTime;
-    kernel_time.LowPart = kt.dwLowDateTime;
-    ULARGE_INTEGER user_time;
-    user_time.HighPart = ut.dwHighDateTime;
-    user_time.LowPart = ut.dwLowDateTime;
-
-    start_secs_  = tms.QuadPart / cpu_speed_;
-    start_usecs_ = (PointerSizeInt)((double)(tms.QuadPart - (start_secs_ * cpu_speed_)) / (double)(cpu_speed_) * 1000000.0);
-
-    start_user_time_ = (TimeType) (user_time.QuadPart / 10);
-    start_system_time_ = (TimeType) (kernel_time.QuadPart / 10);
-
-#else
-
-    struct tms tms_buffer;
-    struct timeval timeval_buffer;
-    struct timezone timezone_buffer;
-
-    gettimeofday(&timeval_buffer, &timezone_buffer);
-    times(&tms_buffer);
-
-    start_secs_ = timeval_buffer.tv_sec;
-    start_usecs_ = timeval_buffer.tv_usec;
-    start_user_time_ = tms_buffer.tms_utime;
-    start_system_time_ = tms_buffer.tms_stime;
-#endif
-
+    clear();
+    last_start_ = snapShot_();
     is_running_ = true;
-
-    return true;
   }
 
-  bool StopWatch::stop()
+  void StopWatch::stop()
   {
-    if (is_running_ == false) /* tried to stop a stopped stop_watch */
+    if (!is_running_)
     {
-      return false;
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "StopWatch cannot be stopped if not running!");
     }
-#ifdef OPENMS_WINDOWSPLATFORM
-    LARGE_INTEGER tms;
-
-    QueryPerformanceCounter(&tms);
-    FILETIME kt, ut, ct, et;
-
-    HANDLE my_id = GetCurrentProcess();
-    GetProcessTimes(my_id, &ct, &et, &kt, &ut);
-
-    ULARGE_INTEGER kernel_time;
-    kernel_time.HighPart = kt.dwHighDateTime;
-    kernel_time.LowPart = kt.dwLowDateTime;
-    ULARGE_INTEGER user_time;
-    user_time.HighPart = ut.dwHighDateTime;
-    user_time.LowPart = ut.dwLowDateTime;
-
-    PointerSizeInt secs_to_add = tms.QuadPart / cpu_speed_;
-    current_secs_ += secs_to_add - start_secs_;
-    PointerSizeInt usecs_to_add = (PointerSizeInt)((double)(tms.QuadPart - secs_to_add * cpu_speed_) / (double)(cpu_speed_) * 1000000.0);
-    current_usecs_ += usecs_to_add - start_usecs_;
-
-    current_user_time_ += (TimeType) (user_time.QuadPart / 10 - start_user_time_);
-    current_system_time_ += (TimeType) (kernel_time.QuadPart / 10 - start_system_time_);
-#else
-    struct tms tms_buffer;
-    struct timeval timeval_buffer;
-    struct timezone timezone_buffer;
-
-    gettimeofday(&timeval_buffer, &timezone_buffer);
-    times(&tms_buffer);
-
-    current_secs_ += timeval_buffer.tv_sec - start_secs_;
-    current_usecs_ += timeval_buffer.tv_usec - start_usecs_;
-
-    current_user_time_ += tms_buffer.tms_utime - start_user_time_;
-    current_system_time_ += tms_buffer.tms_stime - start_system_time_;
-#endif
+    
+    TimeDiff_ now = snapShot_();
+    auto diff = now - last_start_;
+    accumulated_times_ += diff;
 
     is_running_ = false;
+  }
 
-    return true;
+  void StopWatch::resume()
+  {
+    if (is_running_)
+    {
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "StopWatch cannot be resumed if already running!");
+    }
+
+    last_start_ = snapShot_();
+    is_running_ = true;
   }
 
   void StopWatch::reset()
@@ -232,10 +125,54 @@ namespace OpenMS
     }
     else
     {
-      stop();
       clear();
       start();
     }
+  }
+
+  StopWatch::TimeDiff_ StopWatch::snapShot_() const
+  {
+    TimeDiff_ t;
+
+#ifdef OPENMS_WINDOWSPLATFORM
+    LARGE_INTEGER lpFrequency; ///< counts of QueryPerformanceCounter per second; fixed at boot time;
+    QueryPerformanceFrequency(&lpFrequency);
+
+    LARGE_INTEGER tms;
+    //QueryPerformanceCounter returns values that represent time in units of 1 / (the frequency of the performance counter obtained from QueryPerformanceFrequency)
+    QueryPerformanceCounter(&tms);
+    t.start_time = tms.QuadPart / lpFrequency.QuadPart;
+    const double secToUsec = 1e6;
+    t.start_time_usec = (PointerSizeInt)((double)(tms.QuadPart - (t.start_time * lpFrequency.QuadPart)) / (double)(lpFrequency.QuadPart) * secToUsec);
+
+    FILETIME ct, et, kt, ut; 
+    // ct is creation time of process, but et is end-time (which is undefined for running processes like ours);
+    // Thus so cannot be used to measure wall time and we need QueryPerformanceCounter from above
+    GetProcessTimes(GetCurrentProcess(), &ct, &et, &kt, &ut);
+    ULARGE_INTEGER kernel_time;
+    kernel_time.HighPart = kt.dwHighDateTime;
+    kernel_time.LowPart = kt.dwLowDateTime;
+    ULARGE_INTEGER user_time;
+    user_time.HighPart = ut.dwHighDateTime;
+    user_time.LowPart = ut.dwLowDateTime;
+    
+    t.user_ticks = (TimeType)user_time.QuadPart;
+    t.kernel_ticks = (TimeType)kernel_time.QuadPart;
+#else
+
+    struct timeval timeval_buffer;
+    struct timezone timezone_buffer;
+    gettimeofday(&timeval_buffer, &timezone_buffer);
+    t.start_time = timeval_buffer.tv_sec; // seconds since 1970-01-01 00:00
+    t.start_time_usec = timeval_buffer.tv_usec; // additional(!) usec 
+
+    struct tms tms_buffer;
+    times(&tms_buffer);
+    t.user_ticks = tms_buffer.tms_utime; // reports value in CPU clock ticks
+    t.kernel_ticks = tms_buffer.tms_stime; // reports value in CPU clock ticks
+#endif
+
+    return t;
   }
 
   //getClockTime returns the current amount of real (clock) time
@@ -244,51 +181,19 @@ namespace OpenMS
   //accumulated time + the time since the stop_watch was last started.
   double StopWatch::getClockTime() const
   {
-    PointerSizeInt elapsed_seconds = 0;
-    PointerSizeInt elapsed_useconds = 0;
-
     if (is_running_ == false)
     {
       /* stop_watch is currently off, so just return accumulated time */
-      elapsed_seconds = current_secs_;
-      elapsed_useconds = current_usecs_;
-    }
-    else
-    {
-      /* stop_watch is currently running, so add the elapsed time since */
-      /* the stop_watch was last started to the accumulated time        */
-#ifdef OPENMS_WINDOWSPLATFORM
-      LARGE_INTEGER tms;
-      if (QueryPerformanceCounter(&tms))
-      {
-        PointerSizeInt secs_to_add = tms.QuadPart / cpu_speed_;
-        elapsed_seconds = current_secs_ + secs_to_add - start_secs_;
-        PointerSizeInt usecs_to_add = (PointerSizeInt)((double)(tms.QuadPart - secs_to_add * cpu_speed_) / (double)(cpu_speed_) * 1000000.0);
-        elapsed_useconds  = current_usecs_ + usecs_to_add - start_usecs_;
-      }
-#else
-      struct timeval timeval_buffer;
-      struct timezone timezone_buffer;
-
-      gettimeofday(&timeval_buffer, &timezone_buffer);
-
-      elapsed_seconds = current_secs_ + timeval_buffer.tv_sec - start_secs_;
-      elapsed_useconds = current_usecs_ + timeval_buffer.tv_usec - start_usecs_;
-#endif
+      return accumulated_times_.clockTime();
     }
 
-
-    /* Adjust for the fact that the useconds may be negative. */
-    /* If they are, take away 1 second and add 1 million      */
-    /* microseconds until they are positive.                  */
-    while (elapsed_useconds < 0L)
-    {
-      elapsed_useconds += 1000000L;
-      --elapsed_seconds;
-    }
-
+    /* stop_watch is currently running, so add the elapsed time since */
+    /* the stop_watch was last started to the accumulated time        */
+    auto now = snapShot_();
+    auto diff = now - last_start_;
+       
     /* convert into floating point number of seconds */
-    return (double)((double)elapsed_seconds + (double)elapsed_useconds / 1000000.0);
+    return accumulated_times_.clockTime() + diff.clockTime();
   }
 
   //getUserTime reports the current amount of user cpu time
@@ -297,44 +202,19 @@ namespace OpenMS
   //is the accumulated time plus the time since the stop_watch was last started.
   double StopWatch::getUserTime() const
   {
-    double temp_value(0.0);
     if (is_running_ == false)
     {
-      /* stop_watch is off, just return accumulated time */
-      temp_value = (double)current_user_time_;
-    }
-    else
-    {
-      /* stop_watch is on, add current running time to accumulated time */
-#ifdef OPENMS_WINDOWSPLATFORM
-      FILETIME kt, ut, ct, et;
-      HANDLE my_id = GetCurrentProcess();
-      GetProcessTimes(my_id, &ct, &et, &kt, &ut);
-
-      ULARGE_INTEGER kernel_time;
-      kernel_time.HighPart = kt.dwHighDateTime;
-      kernel_time.LowPart = kt.dwLowDateTime;
-      ULARGE_INTEGER user_time;
-      user_time.HighPart = ut.dwHighDateTime;
-      user_time.LowPart = ut.dwLowDateTime;
-
-      temp_value = (double)(current_user_time_ - start_user_time_ + user_time.QuadPart / 10.0);
-#else
-      struct tms tms_buffer;
-      times(&tms_buffer);
-      temp_value = (double)(current_user_time_ - start_user_time_ + tms_buffer.tms_utime);
-#endif
+      /* stop_watch is currently off, so just return accumulated time */
+      return accumulated_times_.userTime();
     }
 
-#ifdef OPENMS_WINDOWSPLATFORM
-    return (double)(temp_value / 1000000.0);
+    /* stop_watch is currently running, so add the elapsed time since */
+    /* the stop_watch was last started to the accumulated time        */
+    auto now = snapShot_();
+    auto diff = now - last_start_;
 
-#else
-    /* convert from clock ticks to seconds using the */
-    /* cpu-speed value obtained in the constructor   */
-    return (double)(temp_value / (double)cpu_speed_);
-
-#endif
+    /* convert into floating point number of seconds */
+    return accumulated_times_.userTime() + diff.userTime();
   }
 
   // system_time reports the current amount of system cpu time
@@ -343,82 +223,34 @@ namespace OpenMS
   // is the accumulated time plus the time since the stop_watch was last started
   double StopWatch::getSystemTime() const
   {
-    double temp_value(0.0);
-
     if (is_running_ == false)
     {
-      /* stop_watch is off, just return accumulated time */
-      temp_value = (double)current_system_time_;
+      /* stop_watch is currently off, so just return accumulated time */
+      return accumulated_times_.kernelTime();
     }
-    else
-    {
-        /* stop_watch is on, return accumulated plus current */
-#ifdef OPENMS_WINDOWSPLATFORM
-        FILETIME kt, ut, ct, et;
-        
-        HANDLE my_id = GetCurrentProcess();
-        GetProcessTimes(my_id, &ct, &et, &kt, &ut);
 
-        ULARGE_INTEGER kernel_time;
-        kernel_time.HighPart = kt.dwHighDateTime;
-        kernel_time.LowPart = kt.dwLowDateTime;
-        ULARGE_INTEGER user_time;
-        user_time.HighPart = ut.dwHighDateTime;
-        user_time.LowPart = ut.dwLowDateTime;
-        temp_value = (double)((double)(current_system_time_ - start_system_time_) + kernel_time.QuadPart / 10.0);
-#else
-        struct tms tms_buffer;
-        times(&tms_buffer);
-        temp_value = (double)(current_system_time_ - start_system_time_ + tms_buffer.tms_stime);
-#endif
-    }
-#ifdef OPENMS_WINDOWSPLATFORM
-      return (double)(temp_value / 1000000.0);
-#else
-      /* convert from clock ticks to seconds using the */
-      /* cpu-speed value obtained in the constructor   */
-      return (double)(temp_value / (double)cpu_speed_);
-#endif
+    /* stop_watch is currently running, so add the elapsed time since */
+    /* the stop_watch was last started to the accumulated time        */
+    auto now = snapShot_();
+    auto diff = now - last_start_;
+
+    /* convert into floating point number of seconds */
+    return accumulated_times_.kernelTime() + diff.kernelTime();
   }
 
-  StopWatch & StopWatch::operator=(const StopWatch & stop_watch)
+  bool StopWatch::operator==(const StopWatch& rhs) const
   {
-    if (this == &stop_watch)
-    {
-      return *this;
-    }
-
-    is_running_ = stop_watch.is_running_;
-    start_secs_ = stop_watch.start_secs_;
-    start_usecs_ = stop_watch.start_usecs_;
-    start_user_time_ = stop_watch.start_user_time_;
-    start_system_time_ = stop_watch.start_system_time_;
-    current_secs_ = stop_watch.current_secs_;
-    current_usecs_ = stop_watch.current_usecs_;
-    current_user_time_ = stop_watch.current_user_time_;
-    current_system_time_ = stop_watch.current_system_time_;
-
-    return *this;
-  }
-
-  bool StopWatch::operator==(const StopWatch & stop_watch) const
-  {
-    return start_secs_ == stop_watch.start_secs_
-           && start_usecs_ == stop_watch.start_usecs_
-           && start_user_time_ == stop_watch.start_user_time_
-           && start_system_time_ == stop_watch.start_system_time_
-           && current_secs_ == stop_watch.current_secs_
-           && current_usecs_ == stop_watch.current_usecs_
-           && current_user_time_ == stop_watch.current_user_time_
-           && current_system_time_ == stop_watch.current_system_time_;
+    return accumulated_times_ == rhs.accumulated_times_
+           && last_start_ == rhs.last_start_
+           && is_running_ == rhs.is_running_;
   }
 
 
-  String StopWatch::toString(const double time)
+  String StopWatch::toString(const double time_in_seconds)
   {
     int d(0), h(0), m(0), s(0);
 
-    TimeType time_i = (TimeType) time; // trunc to integer
+    TimeType time_i = (TimeType)time_in_seconds; // trunc to integer
 
     // compute days
     d = int(time_i / (3600*24));
@@ -443,7 +275,7 @@ namespace OpenMS
     return ( (d>0 ? s_d + "d " + s_h + s_m + s_s + " h" :
              (h>0 ?              s_h + s_m + s_s + " h" :
              (m>0 ?                    s_m + s_s + " m" :
-             (      String::number(time, 2) + " s"))))); // second (shown by itself with no minutes) has two digits after decimal
+             (      String::number(time_in_seconds, 2) + " s"))))); // second (shown by itself with no minutes) has two digits after decimal
 
   }
 

--- a/src/openms/source/SYSTEM/StopWatch.cpp
+++ b/src/openms/source/SYSTEM/StopWatch.cpp
@@ -57,23 +57,11 @@
 
 namespace OpenMS
 {
-
-
 #ifdef OPENMS_WINDOWSPLATFORM
-  long long StopWatch::SecondsTo100Nano_ = 10000000LL;
+  const long long StopWatch::SecondsTo100Nano_ = 10000000LL;
 #else
-  PointerSizeInt StopWatch::cpu_speed_ = 0L;
+  const PointerSizeInt StopWatch::cpu_speed_ = sysconf(_SC_CLK_TCK);
 #endif
-
-  StopWatch::StopWatch()
-  {
-#ifdef OPENMS_HAS_SYSCONF
-    if (cpu_speed_ == 0L)
-    {
-      cpu_speed_ = sysconf(_SC_CLK_TCK);
-    }
-#endif
-  }
 
   void StopWatch::clear()
   { // stopped when running

--- a/src/tests/class_tests/openms/source/StopWatch_test.cpp
+++ b/src/tests/class_tests/openms/source/StopWatch_test.cpp
@@ -98,10 +98,11 @@ END_SECTION
 
 START_SECTION((bool isRunning() const))
   StopWatch w;
-
+  TEST_EQUAL(w.isRunning(), false);
   w.start();
   TEST_EQUAL(w.isRunning(), true);
   w.stop();
+  TEST_EQUAL(w.isRunning(), false); 
 END_SECTION
 
 START_SECTION((bool operator != (const StopWatch& stop_watch) const))
@@ -129,15 +130,23 @@ START_SECTION((bool operator >= (const StopWatch& stop_watch) const))
 END_SECTION
 
 START_SECTION((bool start()))
-  NOT_TESTABLE; // see below
+  StopWatch s1;
+  s1.start();
+  TEST_EXCEPTION(Exception::Precondition, s1.start()); // cannot start twice
 END_SECTION
 
 START_SECTION((bool stop()))
   const double t_wait = 0.2;
-  StopWatch s;
+  const double t_wait_more = 0.1;
+  StopWatch s, s_nostop, s_reset, s_resume;
   s.start();
+  s_nostop.start();
+  s_reset.start();
+  s_resume.resume();
   wait(t_wait);
   s.stop();
+  s_resume.stop();
+  TEST_EXCEPTION(Exception::Precondition, s.stop()); // cannot stop twice
 
   TEST_EQUAL(s.getClockTime() > 0.1, true)
   TEST_EQUAL(s.getClockTime() < 0.3, true)
@@ -146,8 +155,11 @@ START_SECTION((bool stop()))
   double t2 = s.getClockTime();
   double t3 = s.getSystemTime();
   double t4 = s.getUserTime();
+  s_reset.reset();
+  TEST_EQUAL(s_reset.isRunning(), true); // keeps on running
+  s_resume.resume();
   // wait some more
-  wait(0.1);
+  wait(t_wait_more);
   // ... and see if time is still the old one
   TEST_EQUAL(s.getCPUTime(), t1)
   TEST_EQUAL(s.getClockTime(), t2)
@@ -162,6 +174,41 @@ START_SECTION((bool stop()))
   TEST_EQUAL(s.getUserTime() < t_wait * 2, true)
   TEST_EQUAL(s.getSystemTime() < t_wait, true) // and usually quite few system time
                                                //(not guaranteed on VMs, therefore do a trivial check)
+
+  // the watch that never stopped should be ahead...
+  TEST_EQUAL(s.getCPUTime() < s_nostop.getCPUTime(), true) 
+  TEST_EQUAL(s.getClockTime() < s_nostop.getClockTime(), true)
+  TEST_EQUAL(s.getUserTime() < s_nostop.getUserTime(), true)
+  TEST_EQUAL(s.getSystemTime() <= s_nostop.getSystemTime(), true)
+
+  s.reset(); // was stopped, so remains stopped
+  TEST_EQUAL(s.isRunning(), false);
+  TEST_EQUAL(s == StopWatch(), true);
+
+  // kept on running the whole time after reset above .. should accumulate time
+  TEST_EQUAL(s_reset.getCPUTime() > 0, true);
+
+  // don't stop the timer.. just keep running and query on the fly
+  TEST_EQUAL(s_resume.getCPUTime() > (t_wait_more + t_wait) / 2, true) // waiting costs CPU time in our implementation... just not sure how much...
+  TEST_EQUAL(s_resume.getClockTime() > (t_wait_more + t_wait) * 0.95, true) //  must consume wall time
+END_SECTION
+
+START_SECTION((void clear()))
+  StopWatch s;
+  s.start();
+  s.clear();
+  TEST_EQUAL(s.isRunning(), false);
+  TEST_EQUAL(s == StopWatch(), true);
+  END_SECTION
+
+START_SECTION((void reset()))
+  NOT_TESTABLE; // done above to save Test time
+END_SECTION
+
+START_SECTION((void resume()))
+  StopWatch s1;
+  s1.start();
+  TEST_EXCEPTION(Exception::Precondition, s1.resume()); // cannot start twice
 END_SECTION
 
 START_SECTION((double getCPUTime() const ))
@@ -177,14 +224,6 @@ START_SECTION((double getSystemTime() const ))
 END_SECTION
 
 START_SECTION((double getUserTime() const ))
-  NOT_TESTABLE; // done above
-END_SECTION
-
-START_SECTION((void clear()))
-  NOT_TESTABLE; // done above
-END_SECTION
-
-START_SECTION((void reset()))
   NOT_TESTABLE; // done above
 END_SECTION
 

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -2275,8 +2275,6 @@ protected:
 
     vector<PeptideIdentification> peptide_ids;
     vector<ProteinIdentification> protein_ids;
-    progresslogger.startProgress(0, 1, "Post-processing PSMs...");
-
     // Localization
     //
 
@@ -2288,7 +2286,7 @@ protected:
     // for post scoring don't convert fragments to single charge. Annotate charge instead to every peak.
     preprocessSpectra_(spectra, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, false, true); // no single charge (false), annotate charge (true)
 
-    progresslogger.startProgress(0, 1, "localization...");
+    progresslogger.startProgress(0, 1, "Post-processing PSMs...localization...");
 
     // create spectrum generator. For convenience we add more peak types here.
     Param param(total_loss_spectrum_generator.getParameters());
@@ -2311,6 +2309,7 @@ protected:
                    partial_loss_spectrum_generator,
                    fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm,
                    all_feasible_fragment_adducts);
+    progresslogger.endProgress();
 
     progresslogger.startProgress(0, 1, "Post-processing and annotation...");
     postProcessHits_(spectra,


### PR DESCRIPTION
Cleans up the implementation and fixes a bug (querying a stopwatch without stop() would yield arbitrary numbers -- at least on Windows)

Also allows to `start()` ... `stop()` `<do not time this>` `resume()`  to allow for more fine-grained measurements (e.g. benchmarking).

It also prevents accidental wrong usage (e.g. stop()'ing twice) by throwing exceptions.