### PR TITLE
[DOC] document that ranks are not stored

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
@@ -99,6 +99,7 @@ public:
         @brief Stores the data in an idXML file
 
         The data is read in and stored in the file 'filename'. PeptideHits are sorted by score.
+        Note that ranks are not stored and need to be reassigned after loading.
 
         @exception Exception::UnableToCreateFile is thrown if the file could not be created
     */


### PR DESCRIPTION
# Description

document that ranks are not stored in idXML files.

Also please:
- Make sure that you are listed in the AUTHORS file
- Add relevant changes and new features to the CHANGELOG file

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes
