### PR TITLE
[FEATURE] White BG during 2D export in TOPPView.

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
@@ -240,8 +240,6 @@ protected:
     QScrollBar * x_scrollbar_;
     /// Vertical scrollbar
     QScrollBar * y_scrollbar_;
-
-
   };
 }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
@@ -225,6 +225,7 @@ protected:
     void dragEnterEvent(QDragEnterEvent * event) override;
     void dragMoveEvent(QDragMoveEvent * event) override;
     void dropEvent(QDropEvent * event) override;
+    /// make our subclassed QWidget listen to things like stylesheet changes
     void paintEvent(QPaintEvent * /*event*/) override;
     //@}
 

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
@@ -225,6 +225,7 @@ protected:
     void dragEnterEvent(QDragEnterEvent * event) override;
     void dragMoveEvent(QDragMoveEvent * event) override;
     void dropEvent(QDropEvent * event) override;
+    void paintEvent(QPaintEvent * /*event*/) override;
     //@}
 
     /// Pointer to the canvas widget
@@ -239,6 +240,8 @@ protected:
     QScrollBar * x_scrollbar_;
     /// Vertical scrollbar
     QScrollBar * y_scrollbar_;
+
+
   };
 }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1891,7 +1891,7 @@ namespace OpenMS
   {
     LayerData& layer = getActiveCanvas()->getCurrentLayer();
     LayerAnnotatorAMS annotator;
-    assert(log != nullptr);
+    assert(log_ != nullptr);
     if (!annotator.annotate(layer, *log_, current_path_))
     {
       return;
@@ -1903,7 +1903,7 @@ namespace OpenMS
   { // this should only be callable if current layer's type is one of PEAK, FEATURE, CONSENSUS
     LayerData& layer = getActiveCanvas()->getCurrentLayer();
     LayerAnnotatorPeptideID annotator;
-    assert(log != nullptr);
+    assert(log_ != nullptr);
     if (!annotator.annotate(layer, *log_, current_path_))
     {
       return;

--- a/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
@@ -224,6 +224,7 @@ namespace OpenMS
   void SpectrumWidget::saveAsImage()
   {
     QString file_name = QFileDialog::getSaveFileName(this, "Save File", "", "Images (*.bmp *.png *.jpg *.gif)");
+    this->setStyleSheet("background: white");
     bool x_visible = x_scrollbar_->isVisible();
     bool y_visible = y_scrollbar_->isVisible();
     x_scrollbar_->hide();
@@ -232,6 +233,7 @@ namespace OpenMS
     x_scrollbar_->setVisible(x_visible);
     y_scrollbar_->setVisible(y_visible);
     pixmap.save(file_name);
+    this->setStyleSheet("");
   }
 
   void SpectrumWidget::updateAxes()
@@ -352,6 +354,14 @@ namespace OpenMS
   {
     emit dropReceived(event->mimeData(), dynamic_cast<QWidget*>(event->source()), this->getWindowId());
     event->acceptProposedAction();
+  }
+
+  void SpectrumWidget::paintEvent(QPaintEvent * /*event*/)
+  {
+    QStyleOption opt;
+    opt.init(this);
+    QPainter p(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
   }
 
 } //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
@@ -224,6 +224,8 @@ namespace OpenMS
   void SpectrumWidget::saveAsImage()
   {
     QString file_name = QFileDialog::getSaveFileName(this, "Save File", "", "Images (*.bmp *.png *.jpg *.gif)");
+    QString old_stylesheet = this->styleSheet();
+    // Make the whole widget (including the usually natively styled AxisWidgets) white
     this->setStyleSheet("background: white");
     bool x_visible = x_scrollbar_->isVisible();
     bool y_visible = y_scrollbar_->isVisible();
@@ -233,7 +235,7 @@ namespace OpenMS
     x_scrollbar_->setVisible(x_visible);
     y_scrollbar_->setVisible(y_visible);
     pixmap.save(file_name);
-    this->setStyleSheet("");
+    this->setStyleSheet(old_stylesheet);
   }
 
   void SpectrumWidget::updateAxes()

--- a/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
@@ -363,6 +363,7 @@ namespace OpenMS
     QStyleOption opt;
     opt.init(this);
     QPainter p(this);
+    // apply style options and draw the widget using current stylesheets
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
   }
 


### PR DESCRIPTION
# Description

White BG during 2D export in TOPPView.
![test](https://user-images.githubusercontent.com/8102638/94468864-60d9be80-01c5-11eb-8e8e-b1ce163c1f5f.png)

Also, fixes assert errors introduced in recent TOPPView

# Checklist:
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
