### PR TITLE
[CI] Add --output-on-failure to travis ctest invocations

### DIFF
--- a/tools/travis/lnx-cibuild.sh
+++ b/tools/travis/lnx-cibuild.sh
@@ -85,7 +85,7 @@ export PYTHON_EXE=`which python`
 
 # set os dependent folder for preinstalled libraries
 export OS_PREFIX_PATH=/usr
-timeout 60m ctest -V -S tools/travis/cibuild.cmake
+timeout 60m ctest --output-on-failure -V -S tools/travis/cibuild.cmake
 
 if [ $? -ne 0 ]; then
     echo "Killed build prematurely to store whatever was already built in the cache. Please restart the travis job."

--- a/tools/travis/osx-cibuild.sh
+++ b/tools/travis/osx-cibuild.sh
@@ -68,7 +68,7 @@ export BUILD_NAME=${_build_name}
 
 # set os dependent folder for preinstalled libraries (in this case to homebrew libraries)
 export OS_PREFIX_PATH=/usr/local
-ctest -V -S tools/travis/cibuild.cmake
+ctest --output-on-failure -V -S tools/travis/cibuild.cmake
 
 # tell the user where he can find the results
 echo "Please check the build results at: http://cdash.openms.de/index.php?project=OpenMS&date="$(date +"%y-%m-%d")"#Continuous"


### PR DESCRIPTION
Makes ctest print the tool output when a test fails.