### PR TITLE
[FIX] github actions pyopenms whl release 2.6.0 (macOS)

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -179,6 +179,11 @@ jobs:
               lnknm=$(basename "${f%/*}" ".framework")
               ln -s $f $lnknm
             done
+            for f in $Qt5_Dir/lib/*.framework/Versions/5/Qt*
+            do
+              install_name_tool -id $f $f
+            done
+            otool -L /Users/runner/work/OpenMS/Qt/5.12.7/clang_64/lib/QtCore.framework/Versions/5/QtCore
           popd
           mkdir bld
           pushd bld
@@ -254,8 +259,8 @@ jobs:
 
     - name: Build on manylinux2014 
       run: |
-            # fixes some issues with empty pxd files
-            rm -rf /OpenMS/src/pyOpenMS/pxds/SwathMapMassCorrection.pxd
+            ## Do not load shared objects from root folder oft he package at import. Auditwheel handles dependencies.
+            patch -p0 $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/pyopenms/__init__.py < $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/dist-scripts/manylinux.patch
 
             # install Python deps
             for PYBIN in /opt/python/cp3*; do
@@ -399,7 +404,9 @@ jobs:
           pip install $CURRENT_WHL
 
           python -c "import importlib.util; p_name = 'pyopenms'; package = importlib.util.find_spec(p_name); print(p_name + ' was sucessfully installed! Nice one!') if package is not None else print('Something seems to be wrong!')"
-
+          ## at least test the import
+          ## TODO run test suite?
+          python -c "import pyopenms"
           conda deactivate
 
           # clean up


### PR DESCRIPTION
# Description

Cheery picked (missed in 2.6.0)
PR should fix QT import error

```
ImportError: dlopen(/usr/local/miniconda3/envs/build_pyopenms_36/lib/python3.6/site-packages/pyopenms/pyopenms_1.cpython-36m-darwin.so, 2): Library not loaded: @rpath/QtNetwork.framework/Versions/5/QtNetwork
  Referenced from: /usr/local/miniconda3/envs/build_pyopenms_36/lib/python3.6/site-packages/pyopenms/libOpenMS.dylib
  Reason: image not found
```

QtCore.framework
QtNetwork.framework
are missing in the pyopenms directory. 


# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
