### PR TITLE
make OpenSwathDIAPreScoring outputs mandatory

### DIFF
--- a/src/utils/OpenSwathDIAPreScoring.cpp
+++ b/src/utils/OpenSwathDIAPreScoring.cpp
@@ -101,7 +101,7 @@ protected:
     setValidFormats_("swath_files", ListUtils::create<String>("mzML"));
     registerOutputFileList_("output_files", "<files>", StringList(),
                            "Output files. One per Swath input file.",
-                           false);
+                           true);
     setValidFormats_("output_files", ListUtils::create<String>("tsv"));
 
     registerDoubleOption_("min_upper_edge_dist", "<double>", 0.0,


### PR DESCRIPTION
I think I forgot this in https://github.com/OpenMS/OpenMS/pull/4443

If not given causes a segfault because of the access to `outfile_list[i]`

Alternative would be to check before access

# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
