### PR TITLE
[FIX] Failed to compile with VS2019 MSVC 14.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@
 The following authors contributed to OpenMS at some point. For the 
 authors contributing to a specific piece of code, please refer to
 the authors tag in the respective file header.
+ - Ahmed Khalil
  - Alexandra Scherbart
  - Alexandra Zerck
  - Andreas Bertsch

--- a/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/OPENSWATHALGO/ALGO/Scoring.h>
 #include <OpenMS/OPENSWATHALGO/Macros.h>
 #include <cmath>
+#include <algorithm>
 
 #include <boost/numeric/conversion/cast.hpp>
 


### PR DESCRIPTION
# Description
OpenMS fails to compile with the aforementioned tools, the compiler complains about the missing header algorithm for the OpenSWATHAlgo, namely `Scoring.cpp`. The header was previously present as it's required by `std::sort`. See Issue #5020 .

The exact error is : `~\OpenMS\src\openswathalgo\source\OPENSWATHALGO\ALGO\Scoring.cpp(276,12): error C2039: 'sort': is not a member of 'std' [~\OpenMS\openms_build\src\openswathalgo\OpenSwathAlgo.vcxproj]`

# Changes
- Reinstated `#include <algorithm>` in `OpenMS\src\openswathalgo\source\OPENSWATHALGO\ALGO\Scoring.cpp`.

# Checklist:
- [x ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
