### PR TITLE
[FIX] rare underflow error in OpenPepXLAlgorithm

### DIFF
--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -555,9 +555,11 @@ using namespace OpenMS;
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentSimple(matched_spec_xlinks_alpha, fragment_mass_tolerance_xlinks_, fragment_mass_tolerance_unit_ppm_, theoretical_spec_xlinks_alpha, xlink_peaks, exp_charges);
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentSimple(matched_spec_xlinks_beta, fragment_mass_tolerance_xlinks_, fragment_mass_tolerance_unit_ppm_, theoretical_spec_xlinks_beta, xlink_peaks, exp_charges);
         }
-        // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2
+        // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
         Size n_xlink_charges = (precursor_charge - 1) - 2;
-        if (n_xlink_charges < 1) n_xlink_charges = 1;
+        // check for reasonable numbers. In case precursor_charge is lower than 4, n_xlink_charges should always be 1
+        // it should never have a number higher than 7 or 8. If it's > 20, that is because of an underflow
+        if (n_xlink_charges < 1 | n_xlink_charges > 20) n_xlink_charges = 1;
 
         // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
         double match_odds_c_alpha = XQuestScores::matchOddsScoreSimpleSpec(theoretical_spec_linear_alpha, matched_spec_linear_alpha.size(), fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm_);

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -555,11 +555,13 @@ using namespace OpenMS;
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentSimple(matched_spec_xlinks_alpha, fragment_mass_tolerance_xlinks_, fragment_mass_tolerance_unit_ppm_, theoretical_spec_xlinks_alpha, xlink_peaks, exp_charges);
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentSimple(matched_spec_xlinks_beta, fragment_mass_tolerance_xlinks_, fragment_mass_tolerance_unit_ppm_, theoretical_spec_xlinks_beta, xlink_peaks, exp_charges);
         }
+
         // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
-        Size n_xlink_charges = (precursor_charge - 1) - 2;
-        // check for reasonable numbers. In case precursor_charge is lower than 4, n_xlink_charges should always be 1
-        // it should never have a number higher than 7 or 8. If it's > 20, that is because of an underflow
-        if (n_xlink_charges < 1 | n_xlink_charges > 20) n_xlink_charges = 1;
+        Size n_xlink_charges = 1;
+        if (precursor_charge > 3)
+        {
+          n_xlink_charges = precursor_charge - 3;
+        }
 
         // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
         double match_odds_c_alpha = XQuestScores::matchOddsScoreSimpleSpec(theoretical_spec_linear_alpha, matched_spec_linear_alpha.size(), fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm_);
@@ -779,10 +781,11 @@ using namespace OpenMS;
           double wTICold = XQuestScores::weightedTICScoreXQuest(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
 
           // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
-          Size n_xlink_charges = (precursor_charge - 1) - 2;
-          // check for reasonable numbers. In case precursor_charge is lower than 4, n_xlink_charges should always be 1
-          // it should never have a number higher than 7 or 8. If it's > 20, that is because of an underflow
-          if (n_xlink_charges < 1 | n_xlink_charges > 20) n_xlink_charges = 1;
+          Size n_xlink_charges = 1;
+          if (precursor_charge > 3)
+          {
+            n_xlink_charges = precursor_charge - 3;
+          }
 
           // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
           double log_occu_c_alpha = XQuestScores::logOccupancyProb(theoretical_spec_linear_alpha, matched_spec_linear_alpha.size(), fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm_);

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -556,7 +556,9 @@ using namespace OpenMS;
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentSimple(matched_spec_xlinks_beta, fragment_mass_tolerance_xlinks_, fragment_mass_tolerance_unit_ppm_, theoretical_spec_xlinks_beta, xlink_peaks, exp_charges);
         }
 
-        // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
+        // the maximal xlink ion charge is (precursor charge - 1) and the minimal xlink ion charge is 2.
+        // we need the difference between min and max here, which is (precursor_charge - 3) in most cases
+        // but we also need a number > 0, we set 1 as the minimum, in case the precursor charge is only 3 or smaller
         Size n_xlink_charges = 1;
         if (precursor_charge > 3)
         {
@@ -779,13 +781,6 @@ using namespace OpenMS;
           // compute wTIC
           double wTIC = XQuestScores::weightedTICScore(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
           double wTICold = XQuestScores::weightedTICScoreXQuest(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
-
-          // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
-          Size n_xlink_charges = 1;
-          if (precursor_charge > 3)
-          {
-            n_xlink_charges = precursor_charge - 3;
-          }
 
           // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
           double log_occu_c_alpha = XQuestScores::logOccupancyProb(theoretical_spec_linear_alpha, matched_spec_linear_alpha.size(), fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm_);

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -778,9 +778,11 @@ using namespace OpenMS;
           double wTIC = XQuestScores::weightedTICScore(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
           double wTICold = XQuestScores::weightedTICScoreXQuest(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
 
-          // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2
+          // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2, we need the difference between min and max here
           Size n_xlink_charges = (precursor_charge - 1) - 2;
-          if (n_xlink_charges < 1) n_xlink_charges = 1;
+          // check for reasonable numbers. In case precursor_charge is lower than 4, n_xlink_charges should always be 1
+          // it should never have a number higher than 7 or 8. If it's > 20, that is because of an underflow
+          if (n_xlink_charges < 1 | n_xlink_charges > 20) n_xlink_charges = 1;
 
           // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
           double log_occu_c_alpha = XQuestScores::logOccupancyProb(theoretical_spec_linear_alpha, matched_spec_linear_alpha.size(), fragment_mass_tolerance_, fragment_mass_tolerance_unit_ppm_);


### PR DESCRIPTION
Fixes a rare underflow error in OpenPepXL.
Same as  #5040, but for the algorithm for isotopically labeled cross-linkers.

# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
