### PR TITLE
Tv dia table

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -41,7 +41,7 @@
 #include <OpenMS/DATASTRUCTURES/OSWData.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
+
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
@@ -58,6 +58,8 @@
 
 namespace OpenMS
 {
+
+  class OnDiscMSExperiment;
 
   /**
   @brief Class that stores the data for one layer
@@ -161,34 +163,7 @@ public:
     //@}
 
     /// Default constructor
-    LayerData() :
-      flags(),
-      visible(true),
-      flipped(false),
-      type(DT_UNKNOWN),
-      name_(),
-      filename(),
-      peptides(),
-      param(),
-      gradient(),
-      filters(),
-      annotations_1d(),
-      peak_colors_1d(),
-      modifiable(false),
-      modified(false),
-      label(L_NONE),
-      peptide_id_index(-1),
-      peptide_hit_index(-1),
-      features_(new FeatureMapType()),
-      consensus_map_(new ConsensusMapType()),
-      peak_map_(new ExperimentType()),
-      on_disc_peaks(new OnDiscMSExperiment()),
-      chromatogram_map_(new ExperimentType()),
-      current_spectrum_(0),
-      cached_spectrum_()
-    {
-      annotations_1d.resize(1);
-    }
+    LayerData();
 
     /// no Copy-ctor (should not be needed)
     LayerData(const LayerData& ld) = delete;
@@ -336,20 +311,7 @@ public:
     }
 
     /// Returns a const-copy of the required spectrum which is guaranteed to be populated with raw data
-    const ExperimentType::SpectrumType getSpectrum(Size spectrum_idx) const
-    {
-      if (spectrum_idx == current_spectrum_) return cached_spectrum_;
-
-      if ((*peak_map_)[spectrum_idx].size() > 0)
-      {
-        return (*peak_map_)[spectrum_idx];
-      }
-      else if (!on_disc_peaks->empty())
-      {
-        return on_disc_peaks->getSpectrum(spectrum_idx);
-      }
-      return (*peak_map_)[spectrum_idx];
-    }
+    const ExperimentType::SpectrumType getSpectrum(Size spectrum_idx) const;
       
     /// Get the index of the current spectrum (1D view)
     Size getCurrentSpectrumIndex() const

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
@@ -63,11 +63,7 @@ public:
     void updateEntries(const LayerData & cl);
     /// remove all visible data
     void clear();
-    /// do we have data to show?
-    bool hasData() const
-    {
-      return has_data_;
-    }
+
 signals:
     void spectrumSelected(int);
     void spectrumSelected(std::vector<int> indices);
@@ -77,15 +73,11 @@ signals:
     void showSpectrumAs1D(std::vector<int> indices);
     void showSpectrumMetaData(int);
 private:
-    QLineEdit * spectra_search_box_;
-    QComboBox * spectra_combo_box_;
-    QTreeWidget * spectra_treewidget_;
+    QLineEdit* spectra_search_box_ = nullptr;
+    QComboBox* spectra_combo_box_ = nullptr;
+    QTreeWidget* spectra_treewidget_ = nullptr;
     /// cache to store mapping of chromatogram precursors to chromatogram indices
     std::map<size_t, std::map<Precursor, std::vector<Size>, Precursor::MZLess> > map_precursor_to_chrom_idx_cache_;
-
-    /// do we currently show data? 
-    bool has_data_ = false;
-
     /// remember the last PeakMap that we used to fill the spectra list (and avoid rebuilding it)
     const PeakMap* last_peakmap_ = nullptr;
 

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
@@ -35,11 +35,14 @@
 #pragma once
 
 #include <QtWidgets>
-#include <QLineEdit>
-#include <QComboBox>
-#include <QTreeWidget>
+
 
 #include <OpenMS/VISUAL/LayerData.h>
+
+class QLineEdit;
+class QComboBox;
+class QTreeWidget;
+class QTreeWidgetItem;
 
 namespace OpenMS
 {
@@ -58,11 +61,15 @@ public:
     /// Destructor
     ~SpectraViewWidget() = default;
 
-    QTreeWidget* getTreeWidget();
-    QComboBox* getComboBox();
+    /// refresh the table using data from @p cl
     void updateEntries(const LayerData & cl);
     /// remove all visible data
     void clear();
+
+    /// Return a copy of the currently selected spectrum/chrom (for drag'n'drop to new window)
+    /// and store it either as Spectrum or Chromatogram in @p exp (all other data is cleared)
+    /// If no spectrum/chrom is selected, false is returned and @p exp is empty
+    bool getSelectedScan(MSExperiment& exp) const;
 
 signals:
     void spectrumSelected(int);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -2494,19 +2494,15 @@ namespace OpenMS
       }
       else if (spec_view != nullptr)
       {
-        QTreeWidgetItem* item = spec_view->getTreeWidget()->currentItem();
-        if (item != nullptr)
+        ExperimentSharedPtrType new_exp_sptr(new ExperimentType());
+        if (spec_view->getSelectedScan(*new_exp_sptr))
         {
-          const LayerData& layer = getActiveCanvas()->getCurrentLayer();
-          Size index = (Size)(item->text(3).toInt());       // todo: wtf...
-          const ExperimentType::SpectrumType spectrum = (*layer.getPeakData())[index];
-          ExperimentSharedPtrType new_exp_sptr(new ExperimentType());
-          new_exp_sptr->addSpectrum(spectrum);
           ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
           FeatureMapSharedPtrType f_dummy(new FeatureMapType());
           ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
           vector<PeptideIdentification> p_dummy;
-          addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_CHROMATOGRAM, false, false, true, layer.filename, layer.getName(), new_id);
+          const LayerData& layer = getActiveCanvas()->getCurrentLayer();
+          addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, new_exp_sptr->getNrSpectra() > 0 ? LayerData::DT_PEAK : LayerData::DT_CHROMATOGRAM, false, false, true, layer.filename, layer.getName(), new_id);
         }
       }
       else if (source == nullptr)

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -41,8 +41,8 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
 #include <OpenMS/FORMAT/OSWFile.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
-
 
 //#include <iostream>
 #include <QtWidgets/QFileDialog>
@@ -62,6 +62,38 @@ namespace OpenMS
     os << "number of peaks: " << rhs.getPeakData()->getSize() << std::endl;
     os << "--LayerData END--" << std::endl;
     return os;
+  }
+
+
+  /// Default constructor
+
+  LayerData::LayerData() :
+    flags(),
+    visible(true),
+    flipped(false),
+    type(DT_UNKNOWN),
+    name_(),
+    filename(),
+    peptides(),
+    param(),
+    gradient(),
+    filters(),
+    annotations_1d(),
+    peak_colors_1d(),
+    modifiable(false),
+    modified(false),
+    label(L_NONE),
+    peptide_id_index(-1),
+    peptide_hit_index(-1),
+    features_(new FeatureMapType()),
+    consensus_map_(new ConsensusMapType()),
+    peak_map_(new ExperimentType()),
+    on_disc_peaks(new OnDiscMSExperiment()),
+    chromatogram_map_(new ExperimentType()),
+    current_spectrum_(0),
+    cached_spectrum_()
+  {
+    annotations_1d.resize(1);
   }
 
   const LayerData::ConstExperimentSharedPtrType LayerData::getPeakData() const
@@ -173,9 +205,26 @@ namespace OpenMS
     return true;
   }
 
-  const LayerData::ExperimentType::SpectrumType & LayerData::getCurrentSpectrum() const
+  const LayerData::ExperimentType::SpectrumType& LayerData::getCurrentSpectrum() const
   {
     return cached_spectrum_;
+  }
+
+  /// Returns a const-copy of the required spectrum which is guaranteed to be populated with raw data
+
+  const LayerData::ExperimentType::SpectrumType LayerData::getSpectrum(Size spectrum_idx) const
+  {
+    if (spectrum_idx == current_spectrum_) return cached_spectrum_;
+
+    if ((*peak_map_)[spectrum_idx].size() > 0)
+    {
+      return (*peak_map_)[spectrum_idx];
+    }
+    else if (!on_disc_peaks->empty())
+    {
+      return on_disc_peaks->getSpectrum(spectrum_idx);
+    }
+    return (*peak_map_)[spectrum_idx];
   }
 
   void LayerData::synchronizePeakAnnotations()

--- a/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/DIALOGS/Plot2DGoToDialog.h>
 #include <OpenMS/CONCEPT/UniqueIdInterface.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QGridLayout>

--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -34,21 +34,13 @@
 
 #include <OpenMS/VISUAL/SpectraIdentificationViewWidget.h>
 #include <OpenMS/VISUAL/TableView.h>
-#include <OpenMS/FILTERING/ID/IDFilter.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
 #include <OpenMS/METADATA/MetaInfoInterfaceUtils.h>
 
 #include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QTreeWidget>
-#include <QtWidgets/QComboBox>
-#include <QtWidgets/QLineEdit>
-#include <QtWidgets/QHeaderView>
-#include <QtWidgets/QMenu>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QFileDialog>
-#include <QtCore/QTextStream>
-
 
 #include <vector>
 

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -58,7 +58,7 @@ namespace OpenMS
   QList<QVariant> vecToList(const std::vector<Size>& in)
   {
     QList<QVariant> res;
-    for (auto i : in) res.push_back((unsigned int)i);
+    for (Size i : in) res.push_back((unsigned int)i);
     return res;
   }
 
@@ -92,7 +92,7 @@ namespace OpenMS
 
   struct IndexExtrator
   {
-    IndexExtrator(const QTreeWidgetItem* item)
+    explicit IndexExtrator(const QTreeWidgetItem* item)
       : spectrum_index(item->data(ClmnPeak::SPEC_INDEX, Qt::DisplayRole).toInt()),
         res(item->data(ClmnChrom::TYPE, Qt::UserRole).toList()) // this works, even if the QVariant is invalid (then the list is empty)
     {

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -94,7 +94,7 @@ namespace OpenMS
   {
     IndexExtrator(const QTreeWidgetItem* item)
       : spectrum_index(item->data(ClmnPeak::SPEC_INDEX, Qt::DisplayRole).toInt()),
-        res(item->data(ClmnChrom::TYPE, Qt::UserRole).toList()) // this works, even if the QVariant is invalid. The list will be empty.
+        res(item->data(ClmnChrom::TYPE, Qt::UserRole).toList()) // this works, even if the QVariant is invalid (then the list is empty)
     {
     }
 
@@ -103,8 +103,8 @@ namespace OpenMS
       return !res.empty();
     }
 
-    int spectrum_index;
-    const QList<QVariant>& res;
+    const int spectrum_index;
+    const QList<QVariant> res;
   };
 
 

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -59,7 +59,7 @@ namespace OpenMS
     QWidget(parent)
   {
     setObjectName("Scans");
-    QVBoxLayout * spectra_widget_layout = new QVBoxLayout(this);
+    QVBoxLayout* spectra_widget_layout = new QVBoxLayout(this);
     spectra_treewidget_ = new QTreeWidget(this);
     spectra_treewidget_->setWhatsThis("Spectrum selection bar<BR><BR>Here all spectra of the current experiment are shown. Left-click on a spectrum to show it. "
                                       "Double-clicking might be implemented as well, depending on the data. "
@@ -114,8 +114,8 @@ namespace OpenMS
 
   void SpectraViewWidget::spectrumSearchText_()
   {
-    const QString text = spectra_search_box_->text(); // get text from QLineEdit
-    if (text.size() > 0)
+    const QString& text = spectra_search_box_->text(); // get text from QLineEdit
+    if (!text.isEmpty())
     {
       Qt::MatchFlags matchflags = Qt::MatchFixedString;
       matchflags |=  Qt::MatchRecursive; // match subitems (below top-level)
@@ -161,19 +161,19 @@ namespace OpenMS
   {
     //QTreeWidgetItem* current = spectra_treewidget_->currentItem();
     spectrumSearchText_(); // update selection first (we might be in a new layer)
-    QList<QTreeWidgetItem *> selected = spectra_treewidget_->selectedItems();
+    QList<QTreeWidgetItem*> selected = spectra_treewidget_->selectedItems();
     if (selected.size() > 0) spectrumSelectionChange_(selected.first(), selected.first());
   }
 
-  void SpectraViewWidget::spectrumDoubleClicked_(QTreeWidgetItem * current)
+  void SpectraViewWidget::spectrumDoubleClicked_(QTreeWidgetItem* current)
   {
     if (current == nullptr)
     {
       return;
     }
     int spectrum_index = current->text(1).toInt();
-    const QList<QVariant> & res = current->data(0, 0).toList();
-    if (res.size() == 0)
+    const QList<QVariant>& res = current->data(0, 0).toList();
+    if (res.empty())
     {
       emit spectrumDoubleClicked(spectrum_index);
     }
@@ -196,7 +196,7 @@ namespace OpenMS
       {
         std::vector<int> chrom_indices;
         const QList<QVariant>& res = item->data(0, 0).toList();
-        if (res.size() == 0)
+        if (res.empty())
         {
           emit showSpectrumAs1D(spectrum_index);
         }
@@ -209,7 +209,6 @@ namespace OpenMS
       {
         emit showSpectrumMetaData(spectrum_index);
       });
-      // todo: context_menu->addAction("Center here", [&]() {emit centerHere(spectrum_index); });
 
       context_menu.exec(spectra_treewidget_->mapToGlobal(pos));
     }
@@ -276,8 +275,6 @@ namespace OpenMS
     QTreeWidgetItem* selected_item = nullptr;
     QList<QTreeWidgetItem*> toplevel_items;
     bool more_than_one_spectrum = true;
-
-    has_data_ = true; // for now ...
 
     // Branch if the current layer is a spectrum
     if (cl.type == LayerData::DT_PEAK  && !(cl.chromatogram_flag_set()))
@@ -371,7 +368,7 @@ namespace OpenMS
         for (Size i = 0; i < cl.getPeakData()->size(); ++i)
         {
           const MSSpectrum& current_spec = (*cl.getPeakData())[i];
-          item = new QTreeWidgetItem((QTreeWidget *)nullptr);
+          item = new QTreeWidgetItem((QTreeWidget*)nullptr);
           
           populateRow_(item, i, current_spec);
 
@@ -548,7 +545,6 @@ namespace OpenMS
     {
       spectra_treewidget_->setHeaderLabels(QStringList() << "No peak map");
       spectra_treewidget_->setColumnCount(1); // needed, otherwise old column names for column 2, 3, etc are displayed
-      has_data_ = false;
     }
 
     populateSearchBox_();
@@ -581,7 +577,6 @@ namespace OpenMS
   {
     getTreeWidget()->clear();
     getComboBox()->clear();
-    has_data_ = false;
   }
 
 }

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -479,7 +479,7 @@ namespace OpenMS
       std::map<Precursor, std::vector<Size>, Precursor::MZLess>& map_precursor_to_chrom_idx = map_precursor_to_chrom_idx_cache_[(size_t)(exp.get())];
       if (!was_cached)
       { // create cache: collect all precursor that fall into the mz rt window
-        for (auto it = exp->getChromatograms().begin(); it != exp->getChromatograms().end(); ++it)
+        for (auto it = exp->getChromatograms().cbegin(); it != exp->getChromatograms().cend(); ++it)
         {
           map_precursor_to_chrom_idx[it->getPrecursor()].push_back(it - exp->getChromatograms().begin());
         }

--- a/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
@@ -42,6 +42,7 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 #include <OpenMS/FILTERING/ID/IDFilter.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 #include <OpenMS/KERNEL/ChromatogramTools.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/Plot1DWidget.h>

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -100,8 +100,6 @@ namespace OpenMS
     return chrom_exp_sptr;
   }
 
-  String caption;
-
   void TVSpectraViewController::showSpectrumAs1D(int index)
   {
     // basic behavior 1
@@ -118,7 +116,7 @@ namespace OpenMS
       ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
 
       // fix legend and set layer name
-      caption = layer.getName() + "[" + index + "]";
+      String caption = layer.getName() + "[" + index + "]";
       w->xAxis()->setLegend(PlotWidget::RT_AXIS_TITLE);
 
       // add chromatogram data as peak spectrum
@@ -130,7 +128,7 @@ namespace OpenMS
     }
     else if (layer.type == LayerData::DT_PEAK)
     {
-      caption = layer.getName();
+      String caption = layer.getName();
 
       // add data
       if (!w->canvas()->addLayer(exp_sptr, od_exp_sptr, layer.filename) || (Size)index >= w->canvas()->getCurrentLayer().getPeakData()->size())
@@ -199,7 +197,7 @@ namespace OpenMS
     // string for naming the different chromatogram layers with their index
     String chromatogram_caption;
     // string for naming the tab title with the indices of the chromatograms
-    caption = layer.getName();
+    String caption = layer.getName();
 
     //open new 1D widget
     Plot1DWidget * w = new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget *)tv_->getWorkspace());
@@ -262,30 +260,37 @@ namespace OpenMS
     if (widget_1d == nullptr) return;
     if (widget_1d->canvas()->getLayerCount() == 0) return;
 
-    widget_1d->canvas()->activateSpectrum(index);
-    LayerData& layer = tv_->getActiveCanvas()->getCurrentLayer();
+    LayerData& layer = widget_1d->canvas()->getCurrentLayer();
 
     // If we have a chromatogram, we cannot just simply activate this spectrum.
     // we have to do much more work, e.g. creating a new experiment with the
     // new spectrum.
-    if (layer.chromatogram_flag_set())
+    if (!layer.chromatogram_flag_set())
     {
+      widget_1d->canvas()->activateSpectrum(index);
+    }
+    else 
+    {
+      widget_1d->canvas()->blockSignals(true);
+      RAIICleanup clean([&]() {widget_1d->canvas()->blockSignals(false); });
+
       // first get raw data (the full experiment with all chromatograms), we
       // only need to grab the one with the desired index
       ExperimentSharedPtrType exp_sptr = layer.getChromatogramData();
       auto ondisc_sptr = layer.getOnDiscPeakData();
-
-      String fname = layer.filename;
 
       widget_1d->canvas()->removeLayers();
 
       ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
 
       // fix legend and set layer name
-      caption = fname + "[" + index + "]";
+      String fname = layer.filename;
+      String caption = fname + "[" + index + "]";
 
       // add chromatogram data as peak spectrum and update other controls
       widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, false);
+
+      tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)
     }
   }
 
@@ -312,21 +317,19 @@ namespace OpenMS
       widget_1d->canvas()->removeLayers();
 
       widget_1d->canvas()->blockSignals(true);
-      RAIICleanup clean([&]()
-      {
-        widget_1d->canvas()->blockSignals(false);
-      });
+      RAIICleanup clean([&]() {widget_1d->canvas()->blockSignals(false); });
       String fname = layer.filename;
       for (const auto& index : indices)
       {
         ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
 
         // get caption (either chromatogram idx or peptide sequence, if available)
-        caption = fname + "[" + index + "]";
+        String caption = fname;
         if (chrom_exp_sptr->metaValueExists("peptide_sequence"))
         {
-          caption = String(chrom_exp_sptr->getMetaValue("peptide_sequence")) + "[" + index + "]";
+          caption = String(chrom_exp_sptr->getMetaValue("peptide_sequence"));
         }
+        ((caption += "[") += index) += "]";
         // add chromatogram data as peak spectrum
         widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, true);
       }


### PR DESCRIPTION
# Description

Some fixes, mainly for the spectra tree view widget:
 - avoid useless conversion of numbers to qstring. Name roles properly.
 - fix bug, which caused the LayerMenu not to refresh when clicking a single chrom transition in SpectraView
 - get rid of unneeded and dangerous exposure to internal data
 - allow drag'n'drop of single chromatogram data from SpecView table to new Window
 - properly populate columns via enum indices (fixes wrong layout)
![spec_view_chrom](https://user-images.githubusercontent.com/6008722/98127560-23004200-1eb7-11eb-9e16-e58d64151b2b.png)
