### PR TITLE
TOPPView: new data tab for DIA/OSW data

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -188,7 +188,7 @@ namespace OpenMS
      */
     String prepareLine(const OpenSwath::LightCompound& /* pep */,
         const OpenSwath::LightTransition* /* transition */,
-        FeatureMap& output, String id) const;
+        const FeatureMap& output, const String& id) const;
 
     /**
      * @brief Write data to disk

--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -42,6 +42,34 @@
 
 namespace OpenMS
 {
+
+    /// hierarchy levels of the OSWData tree
+    struct OPENMS_DLLAPI OSWHierarchy
+    {
+      /// the actual levels
+      enum Level
+      {
+        PROTEIN,
+        PEPTIDE,
+        FEATURE,
+        TRANSITION,
+        SIZE_OF_VALUES
+      };
+      /// strings matching 'Level'
+      static const char* LevelName[SIZE_OF_VALUES];
+    };
+
+    /// Describes a node in the OSWData model tree. 
+    /// If a lower level, e.g. feature, is set, the upper levels need to be set as well.
+    struct OPENMS_DLLAPI OSWIndexTrace
+    {
+      int idx_prot = -1;
+      int idx_pep = -1;
+      int idx_feat = -1;
+      int idx_trans = -1;
+      OSWHierarchy::Level lowest = OSWHierarchy::Level::SIZE_OF_VALUES;
+    };
+
     /// high-level meta data of a transition
     struct OPENMS_DLLAPI OSWTransition
     {

--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -319,6 +319,16 @@ namespace OpenMS
           return transitions_;
         }
 
+        void setSqlSourceFile(const String& filename)
+        {
+          source_file_ = filename;
+        }
+
+        const String& getSqlSourceFile() const
+        {
+          return source_file_;
+        }
+
         /// forget all data
         void clear();
 
@@ -334,6 +344,7 @@ namespace OpenMS
       private:
         std::map<UInt32, OSWTransition> transitions_;
         std::vector<OSWProtein> proteins_;
+        String source_file_;
     };
     
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -216,8 +216,8 @@ namespace OpenMS
 
   String OpenSwathOSWWriter::prepareLine(const OpenSwath::LightCompound& /* pep */,
                                          const OpenSwath::LightTransition* /* transition */,
-                                         FeatureMap& output,
-                                         String id) const
+                                         const FeatureMap& output,
+                                         const String& id) const
   {
     std::stringstream sql, sql_feature, sql_feature_ms1, sql_feature_ms1_precursor, sql_feature_ms2, sql_feature_ms2_transition, sql_feature_uis_transition;
 

--- a/src/openms/source/DATASTRUCTURES/OSWData.cpp
+++ b/src/openms/source/DATASTRUCTURES/OSWData.cpp
@@ -38,7 +38,9 @@
 
 namespace OpenMS
 {
-  void OpenMS::OSWData::addProtein(OSWProtein&& prot)
+  const char* OSWHierarchy::LevelName[] = { "protein", "peptide", "feature/peakgroup", "transition" };
+
+  void OSWData::addProtein(OSWProtein&& prot)
   {
     // check if transitions are known
     checkTransitions_(prot);

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -273,13 +273,15 @@ namespace OpenMS
 
     OSWFile::OSWFile(const String& filename)
       : filename_(filename),
-      conn_(filename)
+        conn_(filename)
     {
       has_SCOREMS2_ = conn_.tableExists("SCORE_MS2");
     }
 
     void OSWFile::readMinimal(OSWData& swath_result)
     {
+      swath_result.setSqlSourceFile(filename_);
+
       readTransitions_(swath_result);
 
       String select_sql = "select PROTEIN.ID as prot_id, PROTEIN_ACCESSION as prot_accession from PROTEIN order by prot_id";
@@ -330,6 +332,7 @@ namespace OpenMS
 
     void OSWFile::read(OSWData& swath_result)
     {
+      swath_result.setSqlSourceFile(filename_);
       readTransitions_(swath_result);
       getFullProteins_(swath_result);      
     }

--- a/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
@@ -47,6 +47,8 @@ class QTreeWidgetItem;
 namespace OpenMS
 {
   class TreeView;
+  struct OSWIndexTrace;
+
   /**
     @brief Hierarchical visualization and selection of spectra.
 
@@ -69,14 +71,17 @@ namespace OpenMS
     void clear();
 
   signals:
-    void transitionSelected(std::vector<int> indices);
+    /// emitted when a protein, peptide, feature or transition was clicked
+    void dataSelected(const OSWIndexTrace& trace);
 
   private:
     QLineEdit* spectra_search_box_ = nullptr;
     QComboBox* spectra_combo_box_ = nullptr;
     TreeView* dia_treewidget_ = nullptr;
 
-    LayerData* current_layer_ = nullptr;
+    /// points to the data which is currently shown
+    /// Useful to avoid useless repaintings, which would loose the open/close state of internal tree nodes and selected items
+    OSWData* current_data_ = nullptr;
 
   private slots:
     /// fill the search-combo-box with current column header names

--- a/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
@@ -34,82 +34,62 @@
 
 #pragma once
 
-// OpenMS_GUI config
-#include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
+#include <QtWidgets>
 
-#include <OpenMS/KERNEL/StandardTypes.h>
 
-#include <QTabWidget>
+#include <OpenMS/VISUAL/LayerData.h>
+
+class QLineEdit;
+class QComboBox;
+class QTreeWidget;
+class QTreeWidgetItem;
 
 namespace OpenMS
 {
-  class DIATreeTab;
-  class SpectraTreeTab;
-  class SpectraIDViewTab;
-  class TVDIATreeTabController;
-  class TVIdentificationViewController;
-  class TVSpectraViewController;
-  class TOPPViewBase;
+  class TreeView;
   /**
-    @brief A tabbed view, to browse lists of spectra or identifications
-    
+    @brief Hierarchical visualization and selection of spectra.
+
+    @ingroup PlotWidgets
   */
-  class OPENMS_GUI_DLLAPI DataSelectionTabs
-    : public QTabWidget
+  class DIATreeTab :
+    public QWidget
   {
     Q_OBJECT
-
   public:
-    enum TAB_INDEX
-    {
-      SPECTRA_IDX = 0,  ///< first tab
-      IDENT_IDX = 1,    ///< second tab
-      DIAOSW_IDX = 2,   ///< third tab
-      AUTO_IDX          ///< automatically decide which tab to show (i.e. prefer IDENT_IDX if it has data)
-    };
+    /// Constructor
+    DIATreeTab(QWidget* parent = nullptr);
+    /// Destructor
+    ~DIATreeTab() = default;
 
-    /// Default constructor
-    DataSelectionTabs(QWidget* parent, TOPPViewBase* tv);
+    /// refresh the table using data from @p cl
+    /// @param cl Layer with OSW data; cannot be const, since we might read missing protein data from source on demand
+    void updateEntries(LayerData& cl);
+    /// remove all visible data
+    void clear();
 
-    /// update items in the two tabs according to the currently selected layer
-    void update();
-
-    /// invoked when user changes the active tab to @p tab_index
-    void currentTabChanged(int tab_index);
-    
-    /// forwards to the TOPPView*Behaviour classes, to show a certain spectrum in 1D
-    void showSpectrumAs1D(int index);
-    
-    /// forwards to the TOPPView*Behaviour classes, to show a certain set of chromatograms in 1D
-    void showSpectrumAs1D(std::vector<int> indices);
-
-    /// double-click on disabled identification view
-    /// --> enables it and creates an empty identification structure
-    void tabBarDoubleClicked(int tab_index);
-
-    /// enable and show the @p which tab
-    void show(TAB_INDEX which);
-
-    SpectraIDViewTab* getSpectraIDViewTab();
   signals:
+    void transitionSelected(std::vector<int> indices);
 
   private:
-    ///@name Spectrum selection widgets
-    //@{
-    SpectraTreeTab* spectra_view_widget_;
-    SpectraIDViewTab* id_view_widget_;
-    DIATreeTab* dia_widget_;
-    //@}
+    QLineEdit* spectra_search_box_ = nullptr;
+    QComboBox* spectra_combo_box_ = nullptr;
+    TreeView* dia_treewidget_ = nullptr;
 
-    /// TOPPView behavior for the spectra view
-    TVSpectraViewController* spectraview_controller_;
-    /// TOPPView behavior for the identification view
-    TVIdentificationViewController* idview_controller_;
-    /// TOPPView behavior for the DIA view
-    TVDIATreeTabController* diatab_controller_;
+    LayerData* current_layer_ = nullptr;
 
-    /// pointer to base class to access some members (going signal/slot would be cleaner)
-    TOPPViewBase* tv_;
+  private slots:
+    /// fill the search-combo-box with current column header names
+    void populateSearchBox_();
+    /// searches for rows containing a search text (from spectra_search_box_); called when text search box is used
+    void spectrumSearchText_();
+    /// emits transitionSelected() for all subitems
+    void rowSelectionChange_(QTreeWidgetItem*, QTreeWidgetItem*);
+    /// emits transitionSelected() for all subitems
+    void rowSelectionChange2_(QTreeWidgetItem*, int col);
+    /// searches using text box and plots the spectrum
+    void searchAndShow_();
+
   };
+}
 
-} //namespace

--- a/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
@@ -89,7 +89,6 @@ namespace OpenMS
     void rowSelectionChange2_(QTreeWidgetItem*, int col);
     /// searches using text box and plots the spectrum
     void searchAndShow_();
-
   };
 }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
@@ -50,6 +50,7 @@ namespace OpenMS
   class TVIdentificationViewController;
   class TVSpectraViewController;
   class TOPPViewBase;
+
   /**
     @brief A tabbed view, to browse lists of spectra or identifications
     

--- a/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
@@ -78,10 +78,10 @@ namespace OpenMS
     void currentTabChanged(int tab_index);
     
     /// forwards to the TOPPView*Behaviour classes, to show a certain spectrum in 1D
-    void showSpectrumAs1D(int index);
+    void showSpectrumAsNew1D(int index);
     
     /// forwards to the TOPPView*Behaviour classes, to show a certain set of chromatograms in 1D
-    void showSpectrumAs1D(std::vector<int> indices);
+    void showChromsAsNew1D(const std::vector<int>& indices);
 
     /// double-click on disabled identification view
     /// --> enables it and creates an empty identification structure

--- a/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
@@ -81,7 +81,7 @@ namespace OpenMS
     void showSpectrumAsNew1D(int index);
     
     /// forwards to the TOPPView*Behaviour classes, to show a certain set of chromatograms in 1D
-    void showChromsAsNew1D(const std::vector<int>& indices);
+    void showChromatogramsAsNew1D(const std::vector<int>& indices);
 
     /// double-click on disabled identification view
     /// --> enables it and creates an empty identification structure

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -263,6 +263,10 @@ public:
     /// Not const, because we might have incomplete data, which needs to be loaded from sql source
     OSWDataSharedPtrType& getChromatogramAnnotation();
 
+    /// get annotation (e.g. to build a hierachical ID View)
+    /// Not actually const (only the pointer, not the data), because we might have incomplete data, which needs to be loaded from sql source
+    const OSWDataSharedPtrType& getChromatogramAnnotation() const;
+
     /// add annotation from an OSW sqlite file.
     void setChromatogramAnnotation(OSWData&& data);
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -256,7 +256,8 @@ public:
     }
 
     /// get annotation (e.g. to build a hierachical ID View)
-    const OSWData& getChromatogramAnnotation()
+    /// Not const, because we might have incomplete data, which needs to be loaded from sql source
+    OSWData& getChromatogramAnnotation()
     {
       return chrom_annotation_;
     }

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -38,7 +38,7 @@
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
 #include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/DATASTRUCTURES/OSWData.h>
+
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
@@ -60,6 +60,7 @@ namespace OpenMS
 {
 
   class OnDiscMSExperiment;
+  class OSWData;
 
   /**
   @brief Class that stores the data for one layer
@@ -160,6 +161,9 @@ public:
     /// SharedPtr on On-Disc MSExperiment
     typedef boost::shared_ptr<OnDiscMSExperiment> ODExperimentSharedPtrType;
 
+    /// SharedPtr on OSWData
+    typedef boost::shared_ptr<OSWData> OSWDataSharedPtrType;
+
     //@}
 
     /// Default constructor
@@ -257,16 +261,10 @@ public:
 
     /// get annotation (e.g. to build a hierachical ID View)
     /// Not const, because we might have incomplete data, which needs to be loaded from sql source
-    OSWData& getChromatogramAnnotation()
-    {
-      return chrom_annotation_;
-    }
+    OSWDataSharedPtrType& getChromatogramAnnotation();
 
     /// add annotation from an OSW sqlite file.
-    void setChromatogramAnnotation(OSWData&& data)
-    {
-      chrom_annotation_ = std::move(data);
-    }
+    void setChromatogramAnnotation(OSWData&& data);
 
     /// add peptide identifications to the layer
     /// Only supported for DT_PEAK, DT_FEATURE and DT_CONSENSUS.
@@ -488,7 +486,7 @@ private:
     ExperimentSharedPtrType chromatogram_map_;
 
     /// Chromatogram annotation data
-    OSWData chrom_annotation_;
+    OSWDataSharedPtrType chrom_annotation_;
 
     /// Index of the current spectrum
     Size current_spectrum_;

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/CommonDefs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/CommonDefs.h
@@ -46,6 +46,7 @@ namespace OpenMS
   #define CONNECTCAST(class,func,args) static_cast<void(class::*)args>(&class::func)
 
 
+  /// Enum to decide which headers(=column) names should be get/set in a table/tree widget
   enum class WidgetHeader
   {
     VISIBLE_ONLY,

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/CommonDefs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/CommonDefs.h
@@ -34,38 +34,22 @@
 
 #pragma once
 
-// OpenMS_GUI config
-#include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
-
-class QString; // declare this OUTSIDE of namespace OpenMS!
-class QStringList;
 
 namespace OpenMS
 {
-  /**
-    @brief Class which holds static GUI-related helper functions.
 
-    Since all methods are static, the c'tor is private.
-    
-    @ingroup Visual
-  */
-  class OPENMS_GUI_DLLAPI GUIHelpers
+  /// Macro for Qt's connect() overload resolution (in case signals/slots are overloaded and we need to tell connect what overload to pick
+  /// without repeating ourselves.
+  /// This can be solved in Qt 5.7 by using qOverload<>
+  /// @note: provide the brackets for 'args' yourself, since there might be multiple arguments, separated by comma
+  /// Example: QObject::connect(spinBox, CONNECTCAST(QSpinBox, valueChanged, (double)), slider, &QSlider::setValue);
+  #define CONNECTCAST(class,func,args) static_cast<void(class::*)args>(&class::func)
+
+
+  enum class WidgetHeader
   {
-  public:
-
-    GUIHelpers() = delete;
-    
-    /// Open a folder in file explorer
-    /// Will show a message box on failure
-    static void openFolder(const QString& folder);
-
-    /// Open TOPPView (e.g. from within TOPPAS)
-    static void startTOPPView(const QStringList& args);
-
-    /// Open a certain URL (in a browser)
-    /// Will show a message box on failure
-    static void openURL(const QString& target);
-    
+    VISIBLE_ONLY,
+    WITH_INVISIBLE,
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -65,7 +65,6 @@ namespace OpenMS
     /// Open a certain URL (in a browser)
     /// Will show a message box on failure
     static void openURL(const QString& target);
-    
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/sources.cmake
@@ -3,6 +3,7 @@ set(directory include/OpenMS/VISUAL/MISC)
 
 ### list all header files of the directory here
 set(sources_list_h
+CommonDefs.h
 ExternalProcessMBox.h
 GUIHelpers.h
 )

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot2DCanvas.h
@@ -107,8 +107,8 @@ signals:
     /// Signal emitted when the projections are to be shown/hidden
     void toggleProjections();
     /// Requests to display the spectrum with index @p index in 1D
-    void showSpectrumAs1D(int index);
-    void showSpectrumAs1D(std::vector<int, std::allocator<int> > indices);
+    void showSpectrumAsNew1D(int index);
+    void showChromsAsNew1D(std::vector<int, std::allocator<int> > indices);
     /// Requests to display all spectra in 3D plot
     void showCurrentPeaksAs3D();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot2DCanvas.h
@@ -108,7 +108,7 @@ signals:
     void toggleProjections();
     /// Requests to display the spectrum with index @p index in 1D
     void showSpectrumAsNew1D(int index);
-    void showChromsAsNew1D(std::vector<int, std::allocator<int> > indices);
+    void showChromatogramsAsNew1D(std::vector<int, std::allocator<int> > indices);
     /// Requests to display all spectra in 3D plot
     void showCurrentPeaksAs3D();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot2DWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot2DWidget.h
@@ -107,7 +107,7 @@ signals:
     void visibleAreaChanged(DRange<2> area);
     /// Requests to display the spectrum with index @p index in 1D
     void showSpectrumAsNew1D(int index);
-    void showChromsAsNew1D(std::vector<int, std::allocator<int> > indices);
+    void showChromatogramsAsNew1D(std::vector<int, std::allocator<int> > indices);
     /// Requests to display all spectra as 1D
     void showCurrentPeaksAs3D();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot2DWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot2DWidget.h
@@ -106,8 +106,8 @@ signals:
     */
     void visibleAreaChanged(DRange<2> area);
     /// Requests to display the spectrum with index @p index in 1D
-    void showSpectrumAs1D(int index);
-    void showSpectrumAs1D(std::vector<int, std::allocator<int> > indices);
+    void showSpectrumAsNew1D(int index);
+    void showChromsAsNew1D(std::vector<int, std::allocator<int> > indices);
     /// Requests to display all spectra as 1D
     void showCurrentPeaksAs3D();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
@@ -77,8 +77,8 @@ signals:
     void spectrumSelected(std::vector<int> indices);
     void spectrumDoubleClicked(int);
     void spectrumDoubleClicked(std::vector<int> indices);
-    void showSpectrumAs1D(int);
-    void showSpectrumAs1D(std::vector<int> indices);
+    void showSpectrumAsNew1D(int);
+    void showChromsAsNew1D(std::vector<int> indices);
     void showSpectrumMetaData(int);
 private:
     QLineEdit* spectra_search_box_ = nullptr;

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
@@ -74,9 +74,9 @@ public:
 
 signals:
     void spectrumSelected(int);
-    void spectrumSelected(std::vector<int> indices);
+    void chromsSelected(std::vector<int> indices);
     void spectrumDoubleClicked(int);
-    void spectrumDoubleClicked(std::vector<int> indices);
+    void chromsDoubleClicked(std::vector<int> indices);
     void showSpectrumAsNew1D(int);
     void showChromsAsNew1D(std::vector<int> indices);
     void showSpectrumMetaData(int);
@@ -94,12 +94,12 @@ private slots:
     void populateSearchBox_();
     /// searches for rows containing a search text (from spectra_search_box_); called when text search box is used
     void spectrumSearchText_();
-    /// emits spectrumSelected() for either PEAK or CHROM data)
-    void spectrumSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
+    /// emits spectrumSelected() for PEAK or chromsSelected() for CHROM data
+    void itemSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
     /// searches using text box and plots the spectrum
     void searchAndShow_(); 
-    /// called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
-    void spectrumDoubleClicked_(QTreeWidgetItem *); 
+    /// called upon double click on an item; emits spectrumDoubleClicked() or chromsDoubleClicked() after some checking
+    void itemDoubleClicked_(QTreeWidgetItem *); 
     /// Display context menu; allows to open metadata window
     void spectrumContextMenu_(const QPoint &);
   };

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
@@ -78,7 +78,7 @@ signals:
     void spectrumDoubleClicked(int);
     void chromsDoubleClicked(std::vector<int> indices);
     void showSpectrumAsNew1D(int);
-    void showChromsAsNew1D(std::vector<int> indices);
+    void showChromatogramsAsNew1D(std::vector<int> indices);
     void showSpectrumMetaData(int);
 private:
     QLineEdit* spectra_search_box_ = nullptr;

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
@@ -46,6 +46,7 @@ class QTreeWidgetItem;
 
 namespace OpenMS
 {
+  class TreeView;
   /**
     @brief Hierarchical visualization and selection of spectra.
 
@@ -82,7 +83,7 @@ signals:
 private:
     QLineEdit* spectra_search_box_ = nullptr;
     QComboBox* spectra_combo_box_ = nullptr;
-    QTreeWidget* spectra_treewidget_ = nullptr;
+    TreeView* spectra_treewidget_ = nullptr;
     /// cache to store mapping of chromatogram precursors to chromatogram indices
     std::map<size_t, std::map<Precursor, std::vector<Size>, Precursor::MZLess> > map_precursor_to_chrom_idx_cache_;
     /// remember the last PeakMap that we used to fill the spectra list (and avoid rebuilding it)
@@ -93,11 +94,13 @@ private slots:
     void populateSearchBox_();
     /// searches for rows containing a search text (from spectra_search_box_); called when text search box is used
     void spectrumSearchText_();
-    /// allows to show/hide columns
-    void spectrumBrowserHeaderContextMenu_(const QPoint &);
+    /// emits spectrumSelected() for either PEAK or CHROM data)
     void spectrumSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
-    void searchAndShow_(); ///< searches using text box and plots the spectrum
-    void spectrumDoubleClicked_(QTreeWidgetItem *); ///< called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
+    /// searches using text box and plots the spectrum
+    void searchAndShow_(); 
+    /// called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
+    void spectrumDoubleClicked_(QTreeWidgetItem *); 
+    /// Display context menu; allows to open metadata window
     void spectrumContextMenu_(const QPoint &);
   };
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
@@ -34,82 +34,35 @@
 
 #pragma once
 
-// OpenMS_GUI config
-#include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
-
-#include <OpenMS/KERNEL/StandardTypes.h>
-
-#include <QTabWidget>
+#include <OpenMS/METADATA/SpectrumSettings.h>
+#include <OpenMS/VISUAL/LayerData.h>
+#include <OpenMS/VISUAL/TVControllerBase.h>
+#include <vector>
 
 namespace OpenMS
 {
-  class DIATreeTab;
-  class SpectraTreeTab;
-  class SpectraIDViewTab;
-  class TVDIATreeTabController;
-  class TVIdentificationViewController;
-  class TVSpectraViewController;
   class TOPPViewBase;
+
   /**
-    @brief A tabbed view, to browse lists of spectra or identifications
-    
+  @brief Behavior of TOPPView in spectra view mode.
   */
-  class OPENMS_GUI_DLLAPI DataSelectionTabs
-    : public QTabWidget
+  class TVDIATreeTabController
+    : public TVControllerBase
   {
     Q_OBJECT
 
-  public:
-    enum TAB_INDEX
-    {
-      SPECTRA_IDX = 0,  ///< first tab
-      IDENT_IDX = 1,    ///< second tab
-      DIAOSW_IDX = 2,   ///< third tab
-      AUTO_IDX          ///< automatically decide which tab to show (i.e. prefer IDENT_IDX if it has data)
-    };
+public:
+    /// Construct the behaviour with its parent
+  TVDIATreeTabController(TOPPViewBase* parent);
 
-    /// Default constructor
-    DataSelectionTabs(QWidget* parent, TOPPViewBase* tv);
+public slots:
+    /// Behavior for showTransitionsAs1D
+    virtual void showTransitionsAs1D(const std::vector<int>& indices);
 
-    /// update items in the two tabs according to the currently selected layer
-    void update();
+    /// Behavior for activate1DTransitions
+    virtual void activate1DTransitions(const std::vector<int>& indices);
 
-    /// invoked when user changes the active tab to @p tab_index
-    void currentTabChanged(int tab_index);
-    
-    /// forwards to the TOPPView*Behaviour classes, to show a certain spectrum in 1D
-    void showSpectrumAs1D(int index);
-    
-    /// forwards to the TOPPView*Behaviour classes, to show a certain set of chromatograms in 1D
-    void showSpectrumAs1D(std::vector<int> indices);
-
-    /// double-click on disabled identification view
-    /// --> enables it and creates an empty identification structure
-    void tabBarDoubleClicked(int tab_index);
-
-    /// enable and show the @p which tab
-    void show(TAB_INDEX which);
-
-    SpectraIDViewTab* getSpectraIDViewTab();
-  signals:
-
-  private:
-    ///@name Spectrum selection widgets
-    //@{
-    SpectraTreeTab* spectra_view_widget_;
-    SpectraIDViewTab* id_view_widget_;
-    DIATreeTab* dia_widget_;
-    //@}
-
-    /// TOPPView behavior for the spectra view
-    TVSpectraViewController* spectraview_controller_;
-    /// TOPPView behavior for the identification view
-    TVIdentificationViewController* idview_controller_;
-    /// TOPPView behavior for the DIA view
-    TVDIATreeTabController* diatab_controller_;
-
-    /// pointer to base class to access some members (going signal/slot would be cleaner)
-    TOPPViewBase* tv_;
+    /// Behavior for deactivate1DTransitions
+    virtual void deactivate1DTransitions(const std::vector<int>& indices);
   };
-
-} //namespace
+}

--- a/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
@@ -43,6 +43,8 @@ namespace OpenMS
 {
   class TOPPViewBase;
 
+  struct OSWIndexTrace;
+
   /**
   @brief Behavior of TOPPView in spectra view mode.
   */
@@ -56,13 +58,7 @@ public:
   TVDIATreeTabController(TOPPViewBase* parent);
 
 public slots:
-    /// Behavior for showTransitionsAs1D
-    virtual void showTransitionsAs1D(const std::vector<int>& indices);
-
-    /// Behavior for activate1DTransitions
-    virtual void activate1DTransitions(const std::vector<int>& indices);
-
-    /// Behavior for deactivate1DTransitions
-    virtual void deactivate1DTransitions(const std::vector<int>& indices);
+    /// shows all transitions from the given subtree
+    virtual void showData(const OSWIndexTrace& trace);
   };
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/TVIdentificationViewController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVIdentificationViewController.h
@@ -58,11 +58,11 @@ namespace OpenMS
     TVIdentificationViewController(TOPPViewBase* parent, SpectraIDViewTab* spec_id_view_);
 
   public slots:
-    /// Behavior for showSpectrumAs1D
-    virtual void showSpectrumAs1D(int spectrum_index, int peptide_id_index, int peptide_hit_index);
+    /// Behavior for showSpectrumAsNew1D
+    virtual void showSpectrumAsNew1D(int spectrum_index, int peptide_id_index, int peptide_hit_index);
 
     /// Show spectrum without selecting an identification
-    virtual void showSpectrumAs1D(int index);
+    virtual void showSpectrumAsNew1D(int index);
 
     /// Behavior for activate1DSpectrum
     virtual void activate1DSpectrum(int spectrum_index, int peptide_id_index, int peptide_hit_index);

--- a/src/openms_gui/include/OpenMS/VISUAL/TVSpectraViewController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVSpectraViewController.h
@@ -59,8 +59,8 @@ public slots:
     /// Behavior for showSpectrumAsNew1D
     virtual void showSpectrumAsNew1D(int index);
 
-    /// Behavior for showChromsAsNew1D
-    virtual void showChromsAsNew1D(const std::vector<int>& indices);
+    /// Behavior for showChromatogramsAsNew1D
+    virtual void showChromatogramsAsNew1D(const std::vector<int>& indices);
 
     /// Behavior for activate1DSpectrum
     virtual void activate1DSpectrum(int index);

--- a/src/openms_gui/include/OpenMS/VISUAL/TVSpectraViewController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVSpectraViewController.h
@@ -56,11 +56,11 @@ public:
     TVSpectraViewController(TOPPViewBase* parent);
 
 public slots:
-    /// Behavior for showSpectrumAs1D
-    virtual void showSpectrumAs1D(int index);
+    /// Behavior for showSpectrumAsNew1D
+    virtual void showSpectrumAsNew1D(int index);
 
-    /// Behavior for showSpectrumAs1D
-    virtual void showSpectrumAs1D(const std::vector<int>& indices);
+    /// Behavior for showChromsAsNew1D
+    virtual void showChromsAsNew1D(const std::vector<int>& indices);
 
     /// Behavior for activate1DSpectrum
     virtual void activate1DSpectrum(int index);

--- a/src/openms_gui/include/OpenMS/VISUAL/TableView.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TableView.h
@@ -36,6 +36,8 @@
 
 #include <QTableWidget>
 
+#include <OpenMS/VISUAL/MISC/CommonDefs.h>
+
 namespace OpenMS
 {
   /**
@@ -78,11 +80,6 @@ namespace OpenMS
     /// @throws Exception::InvalidParameter if a name is not matching the current column names
     void hideColumns(const QStringList& header_names);
 
-    enum class HeaderInfo
-    {
-      VISIBLE_ONLY,
-      WITH_INVISIBLE,
-    };
     /**
        @brief Obtain header names, either from all, or only the visible columns
 
@@ -93,7 +90,7 @@ namespace OpenMS
        @param use_export_name If column has a hidden export name, use that instead of the displayed name 
        @return List of header names 
     */
-    QStringList getHeaderNames(const HeaderInfo which, bool use_export_name = false);
+    QStringList getHeaderNames(const WidgetHeader which, bool use_export_name = false);
     
     /**
       @brief Set the export-name of a column, which will be returned in getHeaderNames() when @p use_export_name it true

--- a/src/openms_gui/include/OpenMS/VISUAL/TreeView.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TreeView.h
@@ -34,38 +34,46 @@
 
 #pragma once
 
-// OpenMS_GUI config
-#include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
+#include <QTreeWidget>
 
-class QString; // declare this OUTSIDE of namespace OpenMS!
-class QStringList;
+#include <OpenMS/VISUAL/MISC/CommonDefs.h>
 
 namespace OpenMS
 {
   /**
-    @brief Class which holds static GUI-related helper functions.
-
-    Since all methods are static, the c'tor is private.
-    
-    @ingroup Visual
+    @brief A better QTreeWidget for TOPPView, which supports header context menu and conveniently adding/getting headers names.
   */
-  class OPENMS_GUI_DLLAPI GUIHelpers
+  class TreeView :
+    public QTreeWidget
   {
+    Q_OBJECT
   public:
+    /// Constructor
+    TreeView(QWidget* parent = nullptr);
+    /// Destructor
+    virtual ~TreeView() = default;
 
-    GUIHelpers() = delete;
-    
-    /// Open a folder in file explorer
-    /// Will show a message box on failure
-    static void openFolder(const QString& folder);
+    /// sets the visible headers (and the number of columns)
+    void setHeaders(const QStringList& headers);
 
-    /// Open TOPPView (e.g. from within TOPPAS)
-    static void startTOPPView(const QStringList& args);
+    /// hides columns with the given names
+    /// @throws Exception::InvalidParameter if a name is not matching the current column names
+    void hideColumns(const QStringList& header_names);
 
-    /// Open a certain URL (in a browser)
-    /// Will show a message box on failure
-    static void openURL(const QString& target);
-    
+    /**
+       @brief Obtain header names, either from all, or only the visible columns
+
+       @param which With or without invisible columns?
+       @return List of header names
+    */
+    QStringList getHeaderNames(const WidgetHeader which) const;
+
+    /// get the displayed name of the header in column with index @p header_column
+    /// @throws Exception::ElementNotFound if header at index @p header_column is not valid
+    QString getHeaderName(const int header_column) const;
+
+  private slots:
+    /// Display header context menu; allows to show/hide columns
+    void headerContextMenu_(const QPoint& pos);
   };
-
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
@@ -52,7 +52,7 @@ TOPPASTreeView.h
 TOPPASVertex.h
 TOPPASWidget.h
 TOPPViewMenu.h
-#TOPPViewPreferences.h
+TreeView.h
 TVControllerBase.h
 TVIdentificationViewController.h
 TVSpectraViewController.h

--- a/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
@@ -8,6 +8,7 @@ AxisPainter.h
 AxisWidget.h
 ColorSelector.h
 DataSelectionTabs.h
+DIATreeTab.h
 EnhancedTabBar.h
 EnhancedTabBarWidgetInterface.h
 EnhancedWorkspace.h
@@ -54,6 +55,7 @@ TOPPASWidget.h
 TOPPViewMenu.h
 TreeView.h
 TVControllerBase.h
+TVDIATreeTabController.h
 TVIdentificationViewController.h
 TVSpectraViewController.h
 )

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1921,7 +1921,7 @@ namespace OpenMS
     {
       return;
     }
-    selection_view_->show(DataSelectionTabs::IDENT_IDX);
+    selection_view_->show(DataSelectionTabs::DIAOSW_IDX);
   }
 
   void TOPPViewBase::showSpectrumGenerationDialog()
@@ -2350,9 +2350,7 @@ namespace OpenMS
       updateMenu();
     }
   }
-
   
-
   void TOPPViewBase::loadFiles(const StringList& list, QSplashScreen* splash_screen)
   {
     static StringList colors = { "@bw", "@bg", "@b", "@r", "@g", "@m" };

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1425,7 +1425,7 @@ namespace OpenMS
     {
       connect(sw2->getHorizontalProjection(), &Plot2DWidget::sendCursorStatus, this, &TOPPViewBase::showCursorStatus);
       connect(sw2->getVerticalProjection(), &Plot2DWidget::sendCursorStatus, this, &TOPPViewBase::showCursorStatusInvert);
-      connect(sw2, CONNECTCAST(Plot2DWidget, showSpectrumAsNew1D, (int)), selection_view_, CONNECTCAST(DataSelectionTabs, showSpectrumAsNew1D, (int)));
+      connect(sw2, &Plot2DWidget::showSpectrumAsNew1D, selection_view_, &DataSelectionTabs::showSpectrumAsNew1D);
       connect(sw2, &Plot2DWidget::showCurrentPeaksAs3D , this, &TOPPViewBase::showCurrentPeaksAs3D);
     }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1425,7 +1425,7 @@ namespace OpenMS
     {
       connect(sw2->getHorizontalProjection(), &Plot2DWidget::sendCursorStatus, this, &TOPPViewBase::showCursorStatus);
       connect(sw2->getVerticalProjection(), &Plot2DWidget::sendCursorStatus, this, &TOPPViewBase::showCursorStatusInvert);
-      connect(sw2, CONNECTCAST(Plot2DWidget, showSpectrumAs1D, (int)), selection_view_, CONNECTCAST(DataSelectionTabs, showSpectrumAs1D, (int)));
+      connect(sw2, CONNECTCAST(Plot2DWidget, showSpectrumAsNew1D, (int)), selection_view_, CONNECTCAST(DataSelectionTabs, showSpectrumAsNew1D, (int)));
       connect(sw2, &Plot2DWidget::showCurrentPeaksAs3D , this, &TOPPViewBase::showCurrentPeaksAs3D);
     }
 

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -168,7 +168,7 @@ namespace OpenMS
       const auto& pep = prot.getPeptidePrecursors()[idx_pep];
       QTreeWidgetItem* item_pep = new QTreeWidgetItem(item_prot);
       item_pep->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::PEPTIDE]);
-      item_pep->setData(Clmn::INDEX, Qt::DisplayRole, idx_pep);
+      item_pep->setData(Clmn::INDEX, Qt::DisplayRole, (int)idx_pep);
       item_pep->setData(Clmn::INDEX, Qt::UserRole, Entity::PEPTIDE); // mark as peptide, so we know how to interpret the display role
       item_pep->setData(Clmn::CHARGE, Qt::DisplayRole, pep.getCharge());
       item_pep->setText(Clmn::FULL_NAME, pep.getSequence().c_str());
@@ -178,7 +178,7 @@ namespace OpenMS
         const auto& feat = pep.getFeatures()[idx_feat];
         QTreeWidgetItem* item_feat = new QTreeWidgetItem(item_pep);
         item_feat->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::FEATURE]);
-        item_feat->setData(Clmn::INDEX, Qt::DisplayRole, idx_feat);
+        item_feat->setData(Clmn::INDEX, Qt::DisplayRole, (int)idx_feat);
         item_feat->setData(Clmn::INDEX, Qt::UserRole, Entity::FEATURE); // mark as feature, so we know how to interpret the display role
         item_feat->setData(Clmn::RT_DELTA, Qt::DisplayRole, feat.getRTDelta());
         item_feat->setData(Clmn::QVALUE, Qt::DisplayRole, feat.getQValue());
@@ -187,7 +187,7 @@ namespace OpenMS
         {
           QTreeWidgetItem* item_trans = new QTreeWidgetItem(item_feat);
           item_trans->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::TRANSITION]);
-          item_trans->setData(Clmn::INDEX, Qt::DisplayRole, idx_trans);
+          item_trans->setData(Clmn::INDEX, Qt::DisplayRole, (int)idx_trans);
           item_trans->setData(Clmn::INDEX, Qt::UserRole, Entity::TRANSITION); // mark as transition, so we know how to interpret the display role
         }
       }

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -56,6 +56,7 @@ namespace OpenMS
       << "entity" << "index" << "charge" << "full name" << "rt delta" << "q-value";
   }
 
+  // hierachy levels of the tree
   namespace Entity
   {
     enum Values
@@ -80,7 +81,7 @@ namespace OpenMS
     Entity::Values lowest = Entity::Values::SIZE_OF_VALUES;
 
     /// CTor which collects all the information
-    IndexTrace(QTreeWidgetItem* current, const OSWData& data)
+    IndexTrace(QTreeWidgetItem* current)
     {
       while (current != nullptr)
       {
@@ -162,7 +163,7 @@ namespace OpenMS
   /// adds a subtree (with peptides ...) to a given protein 
   void fillProt(const OSWProtein& prot, QTreeWidgetItem* item_prot)
   {
-    for (int idx_pep = 0; idx_pep < prot.getPeptidePrecursors().size(); ++idx_pep)
+    for (size_t idx_pep = 0; idx_pep < prot.getPeptidePrecursors().size(); ++idx_pep)
     {
       const auto& pep = prot.getPeptidePrecursors()[idx_pep];
       QTreeWidgetItem* item_pep = new QTreeWidgetItem(item_prot);
@@ -172,7 +173,7 @@ namespace OpenMS
       item_pep->setData(Clmn::CHARGE, Qt::DisplayRole, pep.getCharge());
       item_pep->setText(Clmn::FULL_NAME, pep.getSequence().c_str());
 
-      for (int idx_feat = 0; idx_feat < pep.getFeatures().size(); ++idx_feat)
+      for (size_t idx_feat = 0; idx_feat < pep.getFeatures().size(); ++idx_feat)
       {
         const auto& feat = pep.getFeatures()[idx_feat];
         QTreeWidgetItem* item_feat = new QTreeWidgetItem(item_pep);
@@ -182,9 +183,8 @@ namespace OpenMS
         item_feat->setData(Clmn::RT_DELTA, Qt::DisplayRole, feat.getRTDelta());
         item_feat->setData(Clmn::QVALUE, Qt::DisplayRole, feat.getQValue());
 
-        for (int idx_trans = 0; idx_trans < feat.getTransitionIDs().size(); ++idx_trans)
+        for (size_t idx_trans = 0; idx_trans < feat.getTransitionIDs().size(); ++idx_trans)
         {
-          const uint trid = feat.getTransitionIDs()[idx_trans];
           QTreeWidgetItem* item_trans = new QTreeWidgetItem(item_feat);
           item_trans->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::TRANSITION]);
           item_trans->setData(Clmn::INDEX, Qt::DisplayRole, idx_trans);
@@ -244,7 +244,7 @@ namespace OpenMS
     OSWData& data = *current_layer_->getChromatogramAnnotation().get();
     std::vector<int> transitions_to_show;
 
-    IndexTrace tr(current, data);
+    IndexTrace tr(current);
     switch (tr.lowest)
     {
       case Entity::Values::PROTEIN:
@@ -293,7 +293,7 @@ namespace OpenMS
     emit transitionSelected(transitions_to_show);
   }
 
-  void DIATreeTab::rowSelectionChange2_(QTreeWidgetItem* item, int col)
+  void DIATreeTab::rowSelectionChange2_(QTreeWidgetItem* item, int /*col*/)
   {
     rowSelectionChange_(item, nullptr);
   }
@@ -341,7 +341,7 @@ namespace OpenMS
     }
     else
     {
-      for (int prot_index = 0; prot_index < data->getProteins().size(); ++prot_index)
+      for (size_t prot_index = 0; prot_index < data->getProteins().size(); ++prot_index)
       {
         const auto& prot = data->getProteins()[prot_index];
         auto item_prot = createProt(prot, prot_index);

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -209,7 +209,7 @@ namespace OpenMS
     }
   }
 
-  void DIATreeTab::rowSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* previous)
+  void DIATreeTab::rowSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/)
   {
     if (current == nullptr || current_data_ == nullptr)
     {

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -1,0 +1,384 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/VISUAL/DIATreeTab.h>
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/RAIICleanup.h>
+#include <OpenMS/FORMAT/OSWFile.h>
+#include <OpenMS/VISUAL/TreeView.h>
+
+#include <QtWidgets/QMenu>
+
+namespace OpenMS
+{
+
+
+  // Use a namespace to encapsulate names, yet use c-style 'enum' for fast conversion to int.
+  // So we can write: 'Clmn::MS_LEVEL', but get implicit conversion to int
+  namespace Clmn
+  {
+    enum HeaderNames
+    { // indices into QTableWidget's columns (which start at index 0)
+      ENTITY, INDEX, CHARGE, FULL_NAME, RT_DELTA, QVALUE, /* last entry --> */ SIZE_OF_HEADERNAMES
+    };
+    // keep in SYNC with enum HeaderNames
+    const QStringList HEADER_NAMES = QStringList()
+      << "entity" << "index" << "charge" << "full name" << "rt delta" << "q-value";
+
+  }
+
+  namespace Entity
+  {
+    enum Values
+    {
+      PROTEIN,
+      PEPTIDE,
+      FEATURE,
+      TRANSITION,
+      SIZE_OF_VALUES
+    };
+    const QStringList VALUES = { "protein", "peptide", "feature/peakgroup", "transition" };
+
+  }
+ 
+  /// given an item, goes up the tree to the root and collects indices in to the OSWData for each level
+  struct IndexTrace
+  {
+    int idx_prot = -1;
+    int idx_pep = -1;
+    int idx_feat = -1;
+    int idx_trans = -1;
+    Entity::Values lowest = Entity::Values::SIZE_OF_VALUES;
+
+    /// CTor which collects all the information
+    IndexTrace(QTreeWidgetItem* current, const OSWData& data)
+    {
+      while (current != nullptr)
+      {
+        Entity::Values entity = Entity::Values(current->data(Clmn::INDEX, Qt::UserRole).toInt());
+        int index = current->data(Clmn::INDEX, Qt::DisplayRole).toInt();
+        
+        if (lowest == Entity::Values::SIZE_OF_VALUES)
+        { // set to level of first current
+          lowest = entity;
+        }
+        switch (entity)
+        {
+          case Entity::Values::PROTEIN:
+            idx_prot = index;
+            break;
+          case Entity::Values::PEPTIDE:
+            idx_pep = index;
+            break;
+          case Entity::Values::FEATURE:
+            idx_feat = index;  
+            break;
+          case Entity::Values::TRANSITION:
+            idx_trans = index;
+            break;
+          default:
+            throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+        }
+        // up one level
+        current = current->parent();
+      }
+    }
+  };
+
+
+
+  DIATreeTab::DIATreeTab(QWidget* parent) :
+    QWidget(parent)
+  {
+    setObjectName("DIA OSW View");
+    QVBoxLayout* spectra_widget_layout = new QVBoxLayout(this);
+    dia_treewidget_ = new TreeView(this);
+    dia_treewidget_->setWhatsThis("Protein/Peptide/Transition selection bar<BR><BR>Here all XICs of a DIA experiment are shown. Left-click on a chrom to show it. "
+      "Double-clicking might be implemented as well, depending on the data. "
+      "Context-menus for both the column header and data rows are available by right-clicking.");
+
+    //~ no good for huge experiments - omitted:
+    //~ spectrum_selection_->setSortingEnabled(true);
+    //~ spectrum_selection_->sortByColumn ( 1, Qt::AscendingOrder);
+
+    dia_treewidget_->setDragEnabled(true);
+    dia_treewidget_->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    connect(dia_treewidget_, &QTreeWidget::currentItemChanged, this, &DIATreeTab::rowSelectionChange_);
+
+    connect(dia_treewidget_, &QTreeWidget::itemClicked, this, &DIATreeTab::rowSelectionChange2_);
+
+    spectra_widget_layout->addWidget(dia_treewidget_);
+
+    QHBoxLayout* tmp_hbox_layout = new QHBoxLayout();
+
+    spectra_search_box_ = new QLineEdit(this);
+    spectra_search_box_->setPlaceholderText("<search text>");
+    spectra_search_box_->setWhatsThis("Search in a certain column. Hits are shown as you type. Press <Enter> to display the first hit.");
+    spectra_search_box_->setToolTip(spectra_search_box_->whatsThis());
+
+    spectra_combo_box_ = new QComboBox(this);
+    spectra_combo_box_->setWhatsThis("Sets the column in which to search.");
+    spectra_combo_box_->setToolTip(spectra_combo_box_->whatsThis());
+
+
+    // search whenever text is typed (and highlight the hits)
+    connect(spectra_search_box_, &QLineEdit::textEdited, this, &DIATreeTab::spectrumSearchText_);
+    // .. show hit upon pressing Enter (internally we search again, since the user could have activated another layer with different selections after last search)
+    connect(spectra_search_box_, &QLineEdit::returnPressed, this, &DIATreeTab::searchAndShow_);
+
+    tmp_hbox_layout->addWidget(spectra_search_box_);
+    tmp_hbox_layout->addWidget(spectra_combo_box_);
+    spectra_widget_layout->addLayout(tmp_hbox_layout);
+  }
+
+  /// adds a subtree (with peptides ...) to a given protein 
+  void fillProt(const OSWProtein& prot, QTreeWidgetItem* item_prot)
+  {
+    for (int idx_pep = 0; idx_pep < prot.getPeptidePrecursors().size(); ++idx_pep)
+    {
+      const auto& pep = prot.getPeptidePrecursors()[idx_pep];
+      QTreeWidgetItem* item_pep = new QTreeWidgetItem(item_prot);
+      item_pep->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::PEPTIDE]);
+      item_pep->setData(Clmn::INDEX, Qt::DisplayRole, idx_pep);
+      item_pep->setData(Clmn::INDEX, Qt::UserRole, Entity::PEPTIDE); // mark as peptide, so we know how to interpret the display role
+      item_pep->setData(Clmn::CHARGE, Qt::DisplayRole, pep.getCharge());
+      item_pep->setText(Clmn::FULL_NAME, pep.getSequence().c_str());
+
+      for (int idx_feat = 0; idx_feat < pep.getFeatures().size(); ++idx_feat)
+      {
+        const auto& feat = pep.getFeatures()[idx_feat];
+        QTreeWidgetItem* item_feat = new QTreeWidgetItem(item_pep);
+        item_feat->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::FEATURE]);
+        item_feat->setData(Clmn::INDEX, Qt::DisplayRole, idx_feat);
+        item_feat->setData(Clmn::INDEX, Qt::UserRole, Entity::FEATURE); // mark as feature, so we know how to interpret the display role
+        item_feat->setData(Clmn::RT_DELTA, Qt::DisplayRole, feat.getRTDelta());
+        item_feat->setData(Clmn::QVALUE, Qt::DisplayRole, feat.getQValue());
+
+        for (int idx_trans = 0; idx_trans < feat.getTransitionIDs().size(); ++idx_trans)
+        {
+          const uint trid = feat.getTransitionIDs()[idx_trans];
+          QTreeWidgetItem* item_trans = new QTreeWidgetItem(item_feat);
+          item_trans->setData(Clmn::ENTITY, Qt::DisplayRole, Entity::VALUES[Entity::TRANSITION]);
+          item_trans->setData(Clmn::INDEX, Qt::DisplayRole, idx_trans);
+          item_trans->setData(Clmn::INDEX, Qt::UserRole, Entity::TRANSITION); // mark as transition, so we know how to interpret the display role
+        }
+      }
+      //item_prot->addChild(item_pep);
+    }
+  }
+
+  /// creates a protein subtree (with peptides etc, if available)
+  QTreeWidgetItem* createProt(const OSWProtein& prot, int prot_index)
+  {
+    QTreeWidgetItem* item_prot = new QTreeWidgetItem();
+    item_prot->setData(Clmn::ENTITY, Qt::DisplayRole, "protein");
+    item_prot->setData(Clmn::INDEX, Qt::DisplayRole, prot_index);
+    item_prot->setData(Clmn::INDEX, Qt::UserRole, Entity::PROTEIN); // mark as protein, so we know how to interpret the display role
+    item_prot->setText(Clmn::FULL_NAME, prot.getAccession().c_str());
+
+    // if possible, fill it already
+    fillProt(prot, item_prot);
+    
+    return item_prot;
+  }
+
+  void DIATreeTab::spectrumSearchText_()
+  {
+    const QString& text = spectra_search_box_->text(); // get text from QLineEdit
+    if (!text.isEmpty())
+    {
+      Qt::MatchFlags matchflags = Qt::MatchFixedString;
+      matchflags |= Qt::MatchRecursive; // match subitems (below top-level)
+      matchflags |= Qt::MatchStartsWith;
+
+      QList<QTreeWidgetItem*> searched = dia_treewidget_->findItems(text, matchflags, spectra_combo_box_->currentIndex());
+
+      if (!searched.isEmpty())
+      {
+        dia_treewidget_->clearSelection();
+        searched.first()->setSelected(true);
+        dia_treewidget_->update();
+        dia_treewidget_->scrollToItem(searched.first());
+      }
+    }
+  }
+
+  void DIATreeTab::rowSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* previous)
+  {
+    /*	test for previous == 0 is important - without it,
+        the wrong spectrum will be selected after finishing
+        the execution of a TOPP tool on the whole data */
+    if (current == nullptr || previous == nullptr)
+    {
+      return;
+    }
+
+    OSWData& data = current_layer_->getChromatogramAnnotation();
+    std::vector<int> transitions_to_show;
+
+    IndexTrace tr(current, data);
+    switch (tr.lowest)
+    {
+      case Entity::Values::PROTEIN:
+        if (current->childCount() == 0)
+        { // no peptides... load them
+          OSWFile f(data.getSqlSourceFile());
+          f.readProtein(data, tr.idx_prot);
+        }
+        fillProt(data.getProteins()[tr.idx_prot], current);
+        // do nothing else -- showing all transitions for a protein is overwhelming...      
+        break;
+      case Entity::Values::PEPTIDE:
+        {
+          const auto& prot = data.getProteins()[tr.idx_prot];
+          const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
+          for (const auto& feat : pep.getFeatures())
+          {
+            const auto& trids = feat.getTransitionIDs();
+            transitions_to_show.insert(transitions_to_show.end(), trids.begin(), trids.end());
+          }
+          break;
+        }
+      case Entity::Values::FEATURE:
+        {
+          const auto& prot = data.getProteins()[tr.idx_prot];
+          const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
+          const auto& feat = pep.getFeatures()[tr.idx_feat];
+          const auto& trids = feat.getTransitionIDs();
+          transitions_to_show.insert(transitions_to_show.end(), trids.begin(), trids.end());
+          break;
+        }
+      case Entity::Values::TRANSITION:
+        {
+          const auto& prot = data.getProteins()[tr.idx_prot];
+          const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
+          const auto& feat = pep.getFeatures()[tr.idx_feat];
+          const auto& trid = feat.getTransitionIDs()[tr.idx_trans];
+          transitions_to_show.insert(transitions_to_show.end(), trid);
+          break;
+        }
+      default:
+        throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+    }
+
+    std::cerr << "Showing transitions: " << ListUtils::concatenate(transitions_to_show, ", ") << "\n";
+    emit transitionSelected(transitions_to_show);
+  }
+
+  void DIATreeTab::rowSelectionChange2_(QTreeWidgetItem* item, int col)
+  {
+    rowSelectionChange_(item, nullptr);
+  }
+
+  void DIATreeTab::searchAndShow_()
+  {
+    spectrumSearchText_(); // update selection first (we might be in a new layer)
+    QList<QTreeWidgetItem*> selected = dia_treewidget_->selectedItems();
+    // show the first selected item
+    if (selected.size() > 0) rowSelectionChange_(selected.first(), selected.first());
+  }
+
+
+  void DIATreeTab::updateEntries(LayerData& cl)
+  {
+    if (!dia_treewidget_->isVisible() || dia_treewidget_->signalsBlocked())
+    {
+      return;
+    }
+
+    current_layer_ = &cl;
+
+    dia_treewidget_->blockSignals(true);
+    RAIICleanup clean([&]() { dia_treewidget_->blockSignals(false); });
+
+    QTreeWidgetItem* toplevel_item = nullptr;
+    QTreeWidgetItem* selected_item = nullptr;
+    QList<QTreeWidgetItem*> toplevel_items;
+    bool more_than_one_spectrum = true;
+
+    dia_treewidget_->clear();
+
+    dia_treewidget_->setHeaders(Clmn::HEADER_NAMES);
+
+    const OSWData&  data = cl.getChromatogramAnnotation();
+
+    if (!data.getProteins().empty())
+    {
+      for (int prot_index = 0; prot_index < data.getProteins().size(); ++prot_index)
+      {
+        const auto& prot = data.getProteins()[prot_index];
+        auto item_prot = createProt(prot, prot_index);
+        dia_treewidget_->addTopLevelItem(item_prot);
+      }
+
+      if (selected_item)
+      {
+        // now, select and scroll down to item
+        selected_item->setSelected(true);
+        dia_treewidget_->scrollToItem(selected_item);
+      }
+    }
+    else
+    {
+      dia_treewidget_->setHeaders(QStringList() << "No data");
+    }
+
+    populateSearchBox_();
+
+
+    // automatically set column width, depending on data
+    dia_treewidget_->header()->setStretchLastSection(false);
+    dia_treewidget_->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+  }
+
+  void DIATreeTab::populateSearchBox_()
+  {
+    QStringList headers = dia_treewidget_->getHeaderNames(WidgetHeader::WITH_INVISIBLE);
+    int current_index = spectra_combo_box_->currentIndex(); // when repainting we want the index to stay the same
+    spectra_combo_box_->clear();
+    spectra_combo_box_->addItems(headers);
+    spectra_combo_box_->setCurrentIndex(current_index);
+  }
+
+  void DIATreeTab::clear()
+  {
+    dia_treewidget_->clear();
+    spectra_combo_box_->clear();
+  }
+
+
+
+}

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -337,7 +337,7 @@ namespace OpenMS
 
     dia_treewidget_->setHeaders(Clmn::HEADER_NAMES);
 
-    const OSWData&  data = *cl.getChromatogramAnnotation().get();
+    const OSWData& data = *cl.getChromatogramAnnotation().get();
 
     if (data.getProteins().empty())
     {

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -43,8 +43,6 @@
 
 namespace OpenMS
 {
-
-
   // Use a namespace to encapsulate names, yet use c-style 'enum' for fast conversion to int.
   // So we can write: 'Clmn::MS_LEVEL', but get implicit conversion to int
   namespace Clmn
@@ -56,7 +54,6 @@ namespace OpenMS
     // keep in SYNC with enum HeaderNames
     const QStringList HEADER_NAMES = QStringList()
       << "entity" << "index" << "charge" << "full name" << "rt delta" << "q-value";
-
   }
 
   namespace Entity
@@ -116,8 +113,6 @@ namespace OpenMS
       }
     }
   };
-
-
 
   DIATreeTab::DIATreeTab(QWidget* parent) :
     QWidget(parent)
@@ -353,10 +348,8 @@ namespace OpenMS
         dia_treewidget_->addTopLevelItem(item_prot);
       }
     }
-
     
     populateSearchBox_();
-
 
     // automatically set column width, depending on data
     dia_treewidget_->header()->setStretchLastSection(false);
@@ -377,7 +370,5 @@ namespace OpenMS
     dia_treewidget_->clear();
     spectra_combo_box_->clear();
   }
-
-
 
 }

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -337,17 +337,18 @@ namespace OpenMS
 
     dia_treewidget_->setHeaders(Clmn::HEADER_NAMES);
 
-    const OSWData& data = *cl.getChromatogramAnnotation().get();
+    const OSWData* data = cl.getChromatogramAnnotation().get();
 
-    if (data.getProteins().empty())
+    if (data == nullptr  // DIA tab is active, but the layer has no data to show...
+        || data->getProteins().empty())
     {
       dia_treewidget_->setHeaders(QStringList() << "No data");
     }
     else
     {
-      for (int prot_index = 0; prot_index < data.getProteins().size(); ++prot_index)
+      for (int prot_index = 0; prot_index < data->getProteins().size(); ++prot_index)
       {
-        const auto& prot = data.getProteins()[prot_index];
+        const auto& prot = data->getProteins()[prot_index];
         auto item_prot = createProt(prot, prot_index);
         dia_treewidget_->addTopLevelItem(item_prot);
       }

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -72,11 +72,11 @@ namespace OpenMS
     // Hook-up controller and views for spectra inspection
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumMetaData, tv, &TOPPViewBase::showSpectrumMetaData);
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumAsNew1D, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
-    connect(spectra_view_widget_, &SpectraTreeTab::showChromsAsNew1D, spectraview_controller_, &TVSpectraViewController::showChromsAsNew1D);
+    connect(spectra_view_widget_, &SpectraTreeTab::showChromatogramsAsNew1D, spectraview_controller_, &TVSpectraViewController::showChromatogramsAsNew1D);
     connect(spectra_view_widget_, &SpectraTreeTab::spectrumSelected, spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (int)));
     connect(spectra_view_widget_, &SpectraTreeTab::chromsSelected, spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (const std::vector<int>&)));
     connect(spectra_view_widget_, &SpectraTreeTab::spectrumDoubleClicked, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
-    connect(spectra_view_widget_, &SpectraTreeTab::chromsDoubleClicked, spectraview_controller_, &TVSpectraViewController::showChromsAsNew1D);
+    connect(spectra_view_widget_, &SpectraTreeTab::chromsDoubleClicked, spectraview_controller_, &TVSpectraViewController::showChromatogramsAsNew1D);
 
     // Hook-up controller and views for identification inspection
     connect(id_view_widget_, &SpectraIDViewTab::spectrumDeselected, idview_controller_, &TVIdentificationViewController::deactivate1DSpectrum);
@@ -192,7 +192,7 @@ namespace OpenMS
     }
   }
 
-  void DataSelectionTabs::showChromsAsNew1D(const std::vector<int>& indices)
+  void DataSelectionTabs::showChromatogramsAsNew1D(const std::vector<int>& indices)
   {
     Plot1DWidget* widget_1d = tv_->getActive1DWidget();
     Plot2DWidget* widget_2d = tv_->getActive2DWidget();
@@ -201,14 +201,14 @@ namespace OpenMS
     {
       if (spectra_view_widget_->isVisible())
       {
-        spectraview_controller_->showChromsAsNew1D(indices);
+        spectraview_controller_->showChromatogramsAsNew1D(indices);
       }
     }
     else if (widget_2d)
     {
       if (spectra_view_widget_->isVisible())
       {
-        spectraview_controller_->showChromsAsNew1D(indices);
+        spectraview_controller_->showChromatogramsAsNew1D(indices);
       }
     }
   }

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -71,12 +71,12 @@ namespace OpenMS
   {
     // Hook-up controller and views for spectra inspection
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumMetaData, tv, &TOPPViewBase::showSpectrumMetaData);
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (int)), this, CONNECTCAST(DataSelectionTabs, showSpectrumAs1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (std::vector<int>)), this, CONNECTCAST(DataSelectionTabs, showSpectrumAs1D, (std::vector<int>)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (int)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (const std::vector<int>&)));
     connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (int)));
     connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (const std::vector<int>&)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (int)), this, CONNECTCAST(DataSelectionTabs, showSpectrumAs1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (std::vector<int>)), this, CONNECTCAST(DataSelectionTabs, showSpectrumAs1D, (std::vector<int>)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (int)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (const std::vector<int>&)));
 
     // Hook-up controller and views for identification inspection
     connect(id_view_widget_, &SpectraIDViewTab::spectrumDeselected, idview_controller_, &TVIdentificationViewController::deactivate1DSpectrum);
@@ -157,7 +157,7 @@ namespace OpenMS
       diatab_controller_->deactivateBehavior();
       if (tv_->getActive2DWidget()) // currently 2D window is open
       {
-        showSpectrumAs1D(0);
+        idview_controller_->showSpectrumAs1D(0);
       }
       idview_controller_->activateBehavior();
       break;
@@ -227,7 +227,7 @@ namespace OpenMS
         spectraview_controller_->deactivateBehavior();
         if (tv_->getActive2DWidget()) // currently 2D window is open
         {
-          showSpectrumAs1D(0);
+          idview_controller_->showSpectrumAs1D(0);
         }
         idview_controller_->activateBehavior();
 

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -71,12 +71,12 @@ namespace OpenMS
   {
     // Hook-up controller and views for spectra inspection
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumMetaData, tv, &TOPPViewBase::showSpectrumMetaData);
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAsNew1D, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAsNew1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showChromsAsNew1D, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showChromsAsNew1D, (const std::vector<int>&)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (const std::vector<int>&)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAsNew1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showChromsAsNew1D, (const std::vector<int>&)));
+    connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumAsNew1D, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
+    connect(spectra_view_widget_, &SpectraTreeTab::showChromsAsNew1D, spectraview_controller_, &TVSpectraViewController::showChromsAsNew1D);
+    connect(spectra_view_widget_, &SpectraTreeTab::spectrumSelected, spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (int)));
+    connect(spectra_view_widget_, &SpectraTreeTab::chromsSelected, spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (const std::vector<int>&)));
+    connect(spectra_view_widget_, &SpectraTreeTab::spectrumDoubleClicked, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
+    connect(spectra_view_widget_, &SpectraTreeTab::chromsDoubleClicked, spectraview_controller_, &TVSpectraViewController::showChromsAsNew1D);
 
     // Hook-up controller and views for identification inspection
     connect(id_view_widget_, &SpectraIDViewTab::spectrumDeselected, idview_controller_, &TVIdentificationViewController::deactivate1DSpectrum);

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -71,12 +71,12 @@ namespace OpenMS
   {
     // Hook-up controller and views for spectra inspection
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumMetaData, tv, &TOPPViewBase::showSpectrumMetaData);
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAs1D, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (const std::vector<int>&)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showSpectrumAsNew1D, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAsNew1D, (int)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, showChromsAsNew1D, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showChromsAsNew1D, (const std::vector<int>&)));
     connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (int)));
     connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumSelected, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, activate1DSpectrum, (const std::vector<int>&)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (int)));
-    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAs1D, (const std::vector<int>&)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (int)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showSpectrumAsNew1D, (int)));
+    connect(spectra_view_widget_, CONNECTCAST(SpectraTreeTab, spectrumDoubleClicked, (std::vector<int>)), spectraview_controller_, CONNECTCAST(TVSpectraViewController, showChromsAsNew1D, (const std::vector<int>&)));
 
     // Hook-up controller and views for identification inspection
     connect(id_view_widget_, &SpectraIDViewTab::spectrumDeselected, idview_controller_, &TVIdentificationViewController::deactivate1DSpectrum);
@@ -157,7 +157,7 @@ namespace OpenMS
       diatab_controller_->deactivateBehavior();
       if (tv_->getActive2DWidget()) // currently 2D window is open
       {
-        idview_controller_->showSpectrumAs1D(0);
+        idview_controller_->showSpectrumAsNew1D(0);
       }
       idview_controller_->activateBehavior();
       break;
@@ -173,7 +173,7 @@ namespace OpenMS
     update();
   }
 
-  void DataSelectionTabs::showSpectrumAs1D(int index)
+  void DataSelectionTabs::showSpectrumAsNew1D(int index)
   {
     Plot1DWidget* widget_1d = tv_->getActive1DWidget();
     Plot2DWidget* widget_2d = tv_->getActive2DWidget();
@@ -182,17 +182,17 @@ namespace OpenMS
     {
       if (spectra_view_widget_->isVisible())
       {
-        spectraview_controller_->showSpectrumAs1D(index);
+        spectraview_controller_->showSpectrumAsNew1D(index);
       }
 
       if (id_view_widget_->isVisible())
       {
-        idview_controller_->showSpectrumAs1D(index);
+        idview_controller_->showSpectrumAsNew1D(index);
       }
     }
   }
 
-  void DataSelectionTabs::showSpectrumAs1D(std::vector<int> indices)
+  void DataSelectionTabs::showChromsAsNew1D(const std::vector<int>& indices)
   {
     Plot1DWidget* widget_1d = tv_->getActive1DWidget();
     Plot2DWidget* widget_2d = tv_->getActive2DWidget();
@@ -201,14 +201,14 @@ namespace OpenMS
     {
       if (spectra_view_widget_->isVisible())
       {
-        spectraview_controller_->showSpectrumAs1D(indices);
+        spectraview_controller_->showChromsAsNew1D(indices);
       }
     }
     else if (widget_2d)
     {
       if (spectra_view_widget_->isVisible())
       {
-        spectraview_controller_->showSpectrumAs1D(indices);
+        spectraview_controller_->showChromsAsNew1D(indices);
       }
     }
   }
@@ -227,7 +227,7 @@ namespace OpenMS
         spectraview_controller_->deactivateBehavior();
         if (tv_->getActive2DWidget()) // currently 2D window is open
         {
-          idview_controller_->showSpectrumAs1D(0);
+          idview_controller_->showSpectrumAsNew1D(0);
         }
         idview_controller_->activateBehavior();
 

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -69,7 +69,7 @@ namespace OpenMS
     diatab_controller_(new TVDIATreeTabController(tv)),
     tv_(tv)
   {
-    // Hook-up controller and views for spectra inspection
+    // Hook-up controller and views for spectra
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumMetaData, tv, &TOPPViewBase::showSpectrumMetaData);
     connect(spectra_view_widget_, &SpectraTreeTab::showSpectrumAsNew1D, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
     connect(spectra_view_widget_, &SpectraTreeTab::showChromatogramsAsNew1D, spectraview_controller_, &TVSpectraViewController::showChromatogramsAsNew1D);
@@ -78,10 +78,13 @@ namespace OpenMS
     connect(spectra_view_widget_, &SpectraTreeTab::spectrumDoubleClicked, spectraview_controller_, &TVSpectraViewController::showSpectrumAsNew1D);
     connect(spectra_view_widget_, &SpectraTreeTab::chromsDoubleClicked, spectraview_controller_, &TVSpectraViewController::showChromatogramsAsNew1D);
 
-    // Hook-up controller and views for identification inspection
+    // Hook-up controller and views for identification
     connect(id_view_widget_, &SpectraIDViewTab::spectrumDeselected, idview_controller_, &TVIdentificationViewController::deactivate1DSpectrum);
     connect(id_view_widget_, &SpectraIDViewTab::spectrumSelected, idview_controller_, CONNECTCAST(TVIdentificationViewController, activate1DSpectrum, (int, int, int)));
     connect(id_view_widget_, &SpectraIDViewTab::requestVisibleArea1D, idview_controller_, &TVIdentificationViewController::setVisibleArea1D);
+
+    // Hook-up controller and views for DIA
+    connect(dia_widget_, &DIATreeTab::dataSelected, diatab_controller_, &TVDIATreeTabController::showData);
 
     int index;
     index = addTab(spectra_view_widget_, spectra_view_widget_->objectName());

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -189,6 +189,11 @@ namespace OpenMS
     return chrom_annotation_;
   }
 
+  const LayerData::OSWDataSharedPtrType& LayerData::getChromatogramAnnotation() const
+  {
+    return chrom_annotation_;
+  }
+
   void LayerData::setChromatogramAnnotation(OSWData&& data)
   {
     chrom_annotation_ = OSWDataSharedPtrType(new OSWData(std::move(data)));

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h> // for AMS annotation
 #include <OpenMS/ANALYSIS/ID/IDMapper.h>
+#include <OpenMS/DATASTRUCTURES/OSWData.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
@@ -174,6 +175,23 @@ namespace OpenMS
     {
       cached_spectrum_ = on_disc_peaks->getSpectrum(current_spectrum_);
     }
+  }
+
+
+  /// add annotation from an OSW sqlite file.
+
+
+  /// get annotation (e.g. to build a hierachical ID View)
+  /// Not const, because we might have incomplete data, which needs to be loaded from sql source
+
+  LayerData::OSWDataSharedPtrType& LayerData::getChromatogramAnnotation()
+  {
+    return chrom_annotation_;
+  }
+
+  void LayerData::setChromatogramAnnotation(OSWData&& data)
+  {
+    chrom_annotation_ = OSWDataSharedPtrType(new OSWData(std::move(data)));
   }
 
   bool LayerData::annotate(const vector<PeptideIdentification>& identifications,

--- a/src/openms_gui/source/VISUAL/MISC/CommonDefs.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/CommonDefs.cpp
@@ -32,40 +32,12 @@
 // $Authors: Chris Bielow $
 // --------------------------------------------------------------------------
 
-#pragma once
+#include <OpenMS/VISUAL/MISC/CommonDefs.h>
 
-// OpenMS_GUI config
-#include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
-
-class QString; // declare this OUTSIDE of namespace OpenMS!
-class QStringList;
 
 namespace OpenMS
 {
-  /**
-    @brief Class which holds static GUI-related helper functions.
 
-    Since all methods are static, the c'tor is private.
-    
-    @ingroup Visual
-  */
-  class OPENMS_GUI_DLLAPI GUIHelpers
-  {
-  public:
+  // nothing to see here (yet)
 
-    GUIHelpers() = delete;
-    
-    /// Open a folder in file explorer
-    /// Will show a message box on failure
-    static void openFolder(const QString& folder);
-
-    /// Open TOPPView (e.g. from within TOPPAS)
-    static void startTOPPView(const QStringList& args);
-
-    /// Open a certain URL (in a browser)
-    /// Will show a message box on failure
-    static void openURL(const QString& target);
-    
-  };
-
-}
+} //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/MISC/sources.cmake
+++ b/src/openms_gui/source/VISUAL/MISC/sources.cmake
@@ -3,6 +3,7 @@ set(directory source/VISUAL/MISC)
 
 ### list all filenames of the directory here
 set(sources_list
+CommonDefs.cpp
 ExternalProcessMBox.cpp
 GUIHelpers.cpp
 )

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -2503,7 +2503,7 @@ namespace OpenMS
               chrom_indices.push_back(res[i].toInt());
               cout << "chrom_indices: " << res[i].toInt() << std::endl;
             }
-            emit showChromsAsNew1D(chrom_indices);
+            emit showChromatogramsAsNew1D(chrom_indices);
           }
           else   // Show single chromatogram
           {

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -2294,7 +2294,7 @@ namespace OpenMS
       {
         if (result->parent() == ms1_scans  || result->parent() == msn_scans)
         {
-          emit showSpectrumAs1D(result->data().toInt());
+          emit showSpectrumAsNew1D(result->data().toInt());
         }
         else if (result->parent() == ms1_meta || result->parent() == msn_meta)
         {
@@ -2503,12 +2503,12 @@ namespace OpenMS
               chrom_indices.push_back(res[i].toInt());
               cout << "chrom_indices: " << res[i].toInt() << std::endl;
             }
-            emit showSpectrumAs1D(chrom_indices);
+            emit showChromsAsNew1D(chrom_indices);
           }
           else   // Show single chromatogram
           {
             //cout << "Chromatogram result " << result->data().toInt() << endl;
-            emit showSpectrumAs1D(result->data().toInt());
+            emit showSpectrumAsNew1D(result->data().toInt());
           }
         }
         else if (result->parent() == msn_chromatogram_meta)

--- a/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
@@ -105,8 +105,8 @@ namespace OpenMS
     connect(canvas(), SIGNAL(toggleProjections()), this, SLOT(toggleProjections()));
     connect(canvas(), SIGNAL(visibleAreaChanged(DRange<2>)), this, SLOT(autoUpdateProjections()));
     // delegate signals from canvas
-    connect(canvas(), SIGNAL(showSpectrumAs1D(int)), this, SIGNAL(showSpectrumAs1D(int)));
-    connect(canvas(), SIGNAL(showSpectrumAs1D(std::vector<int, std::allocator<int> >)), this, SIGNAL(showSpectrumAs1D(std::vector<int, std::allocator<int> >)));
+    connect(canvas(), SIGNAL(showSpectrumAsNew1D(int)), this, SIGNAL(showSpectrumAsNew1D(int)));
+    connect(canvas(), SIGNAL(showChromsAsNew1D(std::vector<int, std::allocator<int> >)), this, SIGNAL(showChromsAsNew1D(std::vector<int, std::allocator<int> >)));
     connect(canvas(), SIGNAL(showCurrentPeaksAs3D()), this, SIGNAL(showCurrentPeaksAs3D()));
     // add projections box
     projection_box_ = new QGroupBox("Projections", this);

--- a/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
@@ -106,7 +106,7 @@ namespace OpenMS
     connect(canvas(), SIGNAL(visibleAreaChanged(DRange<2>)), this, SLOT(autoUpdateProjections()));
     // delegate signals from canvas
     connect(canvas(), SIGNAL(showSpectrumAsNew1D(int)), this, SIGNAL(showSpectrumAsNew1D(int)));
-    connect(canvas(), SIGNAL(showChromsAsNew1D(std::vector<int, std::allocator<int> >)), this, SIGNAL(showChromsAsNew1D(std::vector<int, std::allocator<int> >)));
+    connect(canvas(), SIGNAL(showChromatogramsAsNew1D(std::vector<int, std::allocator<int> >)), this, SIGNAL(showChromatogramsAsNew1D(std::vector<int, std::allocator<int> >)));
     connect(canvas(), SIGNAL(showCurrentPeaksAs3D()), this, SIGNAL(showCurrentPeaksAs3D()));
     // add projections box
     projection_box_ = new QGroupBox("Projections", this);

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -75,7 +75,7 @@ namespace OpenMS
     setObjectName("Identifications");
 
     // make sure they are in sync
-    assert(HEADER_NAMES.size() == HeaderNames::SIZE_OF_HEADERNAMES);
+    assert(Clmn::HEADER_NAMES.size() == Clmn::HeaderNames::SIZE_OF_HEADERNAMES);
 
     // id view
     defaults_.setValue("a_intensity", 1.0, "Default intensity of a-ions");

--- a/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
@@ -128,8 +128,8 @@ namespace OpenMS
     spectra_treewidget_->setDragEnabled(true);
     spectra_treewidget_->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    connect(spectra_treewidget_, &QTreeWidget::currentItemChanged, this, &SpectraTreeTab::spectrumSelectionChange_);
-    connect(spectra_treewidget_, &QTreeWidget::itemDoubleClicked, this, &SpectraTreeTab::spectrumDoubleClicked_);
+    connect(spectra_treewidget_, &QTreeWidget::currentItemChanged, this, &SpectraTreeTab::itemSelectionChange_);
+    connect(spectra_treewidget_, &QTreeWidget::itemDoubleClicked, this, &SpectraTreeTab::itemDoubleClicked_);
     connect(spectra_treewidget_, &QTreeWidget::customContextMenuRequested, this, &SpectraTreeTab::spectrumContextMenu_);
 
     spectra_widget_layout->addWidget(spectra_treewidget_);
@@ -182,7 +182,7 @@ namespace OpenMS
     }
   }
 
-  void SpectraTreeTab::spectrumSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* previous)
+  void SpectraTreeTab::itemSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* previous)
   {
     /*	test for previous == 0 is important - without it,
         the wrong spectrum will be selected after finishing
@@ -199,7 +199,7 @@ namespace OpenMS
     }
     else
     { // open several chromatograms at once
-      emit spectrumSelected(listToVec(ie.res));
+      emit chromsSelected(listToVec(ie.res));
     }
   }
 
@@ -208,10 +208,10 @@ namespace OpenMS
     spectrumSearchText_(); // update selection first (we might be in a new layer)
     QList<QTreeWidgetItem*> selected = spectra_treewidget_->selectedItems();
     // show the first selected item
-    if (selected.size() > 0) spectrumSelectionChange_(selected.first(), selected.first());
+    if (selected.size() > 0) itemSelectionChange_(selected.first(), selected.first());
   }
 
-  void SpectraTreeTab::spectrumDoubleClicked_(QTreeWidgetItem* current)
+  void SpectraTreeTab::itemDoubleClicked_(QTreeWidgetItem* current)
   {
     if (current == nullptr)
     {
@@ -224,7 +224,7 @@ namespace OpenMS
     }
     else
     { // open several chromatograms at once
-      emit spectrumDoubleClicked(listToVec(ie.res));
+      emit chromsDoubleClicked(listToVec(ie.res));
     }
   }
 

--- a/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
@@ -240,11 +240,11 @@ namespace OpenMS
       {
         if (!ie.hasChromIndices())
         {
-          emit showSpectrumAs1D(ie.spectrum_index);
+          emit showSpectrumAsNew1D(ie.spectrum_index);
         }
         else
         { // open several chromatograms at once
-          emit showSpectrumAs1D(listToVec(ie.res));
+          emit showChromsAsNew1D(listToVec(ie.res));
         }
       });
       context_menu.addAction("Meta data", [&]() 

--- a/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
@@ -244,7 +244,7 @@ namespace OpenMS
         }
         else
         { // open several chromatograms at once
-          emit showChromsAsNew1D(listToVec(ie.res));
+          emit showChromatogramsAsNew1D(listToVec(ie.res));
         }
       });
       context_menu.addAction("Meta data", [&]() 

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -103,7 +103,6 @@ namespace OpenMS
 
   void TVDIATreeTabController::showTransitionsAs1D(const std::vector<int>& indices)
   {
-
     // basic behavior 1
 
     // show multiple spectra together is only used for chromatograms directly

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -179,20 +179,12 @@ namespace OpenMS
     if (widget_1d->canvas()->getLayerCount() == 0) return;
 
     const LayerData& layer = widget_1d->canvas()->getCurrentLayer();
-    // If we have a chromatogram, we cannot just simply activate this spectrum.
-    // we have to do much more work, e.g. creating a new experiment with the
-    // new spectrum.
-    if (layer.chromatogram_flag_set())
+    if (layer.getChromatogramAnnotation().get())
     {
-      // first get raw data (the full experiment with all chromatograms), we
-      // only need to grab the ones with the desired indices
-      ExperimentSharedPtrType exp_sptr = layer.getChromatogramData();
-      auto ondisc_sptr = layer.getOnDiscPeakData();
-
       widget_1d->canvas()->removeLayers();
-
       widget_1d->canvas()->blockSignals(true);
       RAIICleanup clean([&]() {widget_1d->canvas()->blockSignals(false); });
+      /*
       String fname = layer.filename;
       for (const auto& index : indices)
       {
@@ -208,7 +200,7 @@ namespace OpenMS
         // add chromatogram data as peak spectrum
         widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, true);
       }
-
+           */
       tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)
     }
   }

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -1,0 +1,222 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/VISUAL/TVDIATreeTabController.h>
+
+#include <OpenMS/CONCEPT/RAIICleanup.h>
+#include <OpenMS/KERNEL/ChromatogramTools.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
+#include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
+#include <OpenMS/VISUAL/AxisWidget.h>
+#include <OpenMS/VISUAL/Plot1DWidget.h>
+
+#include <QtWidgets/QMessageBox>
+#include <QtCore/QString>
+
+using namespace OpenMS;
+using namespace std;
+
+namespace OpenMS
+{
+  TVDIATreeTabController::TVDIATreeTabController(TOPPViewBase* parent):
+    TVControllerBase(parent)
+  {  
+  }
+
+  LayerData::ExperimentSharedPtrType prepareChromatogram(Size index, LayerData::ExperimentSharedPtrType exp_sptr, LayerData::ODExperimentSharedPtrType ondisc_sptr)
+  {
+    // create a managed pointer fill it with a spectrum containing the chromatographic data
+    LayerData::ExperimentSharedPtrType chrom_exp_sptr(new LayerData::ExperimentType());
+    chrom_exp_sptr->setMetaValue("is_chromatogram", "true"); //this is a hack to store that we have chromatogram data
+    LayerData::ExperimentType::SpectrumType spectrum;
+
+    // retrieve chromatogram (either from in-memory or on-disc representation)
+    MSChromatogram current_chrom;
+    current_chrom = exp_sptr->getChromatograms()[index];
+    if (current_chrom.empty() )
+    {
+      current_chrom = ondisc_sptr->getChromatogram(index);
+    }
+
+    // fill "dummy" spectrum with chromatogram data
+    for (Size i = 0; i != current_chrom.size(); ++i)
+    {
+      const ChromatogramPeak & cpeak = current_chrom[i];
+      Peak1D peak1d;
+      peak1d.setMZ(cpeak.getRT());
+      peak1d.setIntensity(cpeak.getIntensity());
+      spectrum.push_back(peak1d);
+    }
+
+    spectrum.getFloatDataArrays() = current_chrom.getFloatDataArrays();
+    spectrum.getIntegerDataArrays() = current_chrom.getIntegerDataArrays();
+    spectrum.getStringDataArrays() = current_chrom.getStringDataArrays();
+
+    // Add at least one data point to the chromatogram, otherwise
+    // "addLayer" will fail and a segfault occurs later
+    if (current_chrom.empty()) 
+    {
+      Peak1D peak1d(-1, 0);
+      spectrum.push_back(peak1d);
+    }
+
+    // store peptide_sequence if available
+    if (current_chrom.getPrecursor().metaValueExists("peptide_sequence"))
+    {
+      chrom_exp_sptr->setMetaValue("peptide_sequence", current_chrom.getPrecursor().getMetaValue("peptide_sequence"));
+    }
+
+    chrom_exp_sptr->addSpectrum(spectrum);
+    return chrom_exp_sptr;
+  }
+
+  void TVDIATreeTabController::showTransitionsAs1D(const std::vector<int>& indices)
+  {
+
+    // basic behavior 1
+
+    // show multiple spectra together is only used for chromatograms directly
+    // where multiple (SRM) traces are shown together
+    LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
+    ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
+    auto ondisc_sptr = layer.getOnDiscPeakData();
+
+    // string for naming the different chromatogram layers with their index
+    String chromatogram_caption;
+    // string for naming the tab title with the indices of the chromatograms
+    String caption = layer.getName();
+
+    //open new 1D widget
+    Plot1DWidget * w = new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget *)tv_->getWorkspace());
+    // fix legend if its a chromatogram
+    w->xAxis()->setLegend(PlotWidget::RT_AXIS_TITLE);
+
+    for (const auto& index : indices)
+    {
+      if (layer.type == LayerData::DT_CHROMATOGRAM)
+      {
+        ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
+
+        // fix legend and set layer name
+        caption += String(" [") + index + "];";
+        chromatogram_caption = layer.getName() + "[" + index + "]";
+
+        // add chromatogram data as peak spectrum
+        if (!w->canvas()->addLayer(chrom_exp_sptr, ondisc_sptr, layer.filename))
+        {
+          return;
+        }
+        w->canvas()->setLayerName(w->canvas()->getCurrentLayerIndex(), chromatogram_caption);
+        w->canvas()->setDrawMode(Plot1DCanvas::DM_CONNECTEDLINES);
+
+        w->canvas()->getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
+
+        //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
+        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");
+        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("multiple_select", "true");
+        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("selected_chromatogram", index);
+
+        // set visible area to visible area in 2D view
+        // switch X/Y because now we want to have RT on the x-axis and not m/z
+        DRange<2> visible_area = tv_->getActiveCanvas()->getVisibleArea();
+        int tmp_x1 = visible_area.minX();
+        int tmp_x2 = visible_area.maxX();
+        visible_area.setMinX(visible_area.minY());
+        visible_area.setMaxX(visible_area.maxY());
+        visible_area.setMinY(tmp_x1);
+        visible_area.setMaxY(tmp_x2);
+        w->canvas()->setVisibleArea(visible_area);
+      }
+    }
+
+    // set relative (%) view of visible area
+    w->canvas()->setIntensityMode(PlotCanvas::IM_SNAP);
+
+    // basic behavior 2
+
+    tv_->showPlotWidgetInWindow(w, caption);
+    tv_->updateBarsAndMenus();
+  }
+
+  // called by SpectraTreeTab::spectrumSelected()
+  void TVDIATreeTabController::activate1DTransitions(const std::vector<int>& indices)
+  {
+    Plot1DWidget * widget_1d = tv_->getActive1DWidget();
+
+    // return if no active 1D widget is present or no layers are present (e.g. the addLayer call failed)
+    if (widget_1d == nullptr) return;
+    if (widget_1d->canvas()->getLayerCount() == 0) return;
+
+    const LayerData& layer = widget_1d->canvas()->getCurrentLayer();
+    // If we have a chromatogram, we cannot just simply activate this spectrum.
+    // we have to do much more work, e.g. creating a new experiment with the
+    // new spectrum.
+    if (layer.chromatogram_flag_set())
+    {
+      // first get raw data (the full experiment with all chromatograms), we
+      // only need to grab the ones with the desired indices
+      ExperimentSharedPtrType exp_sptr = layer.getChromatogramData();
+      auto ondisc_sptr = layer.getOnDiscPeakData();
+
+      widget_1d->canvas()->removeLayers();
+
+      widget_1d->canvas()->blockSignals(true);
+      RAIICleanup clean([&]() {widget_1d->canvas()->blockSignals(false); });
+      String fname = layer.filename;
+      for (const auto& index : indices)
+      {
+        ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
+
+        // get caption (either chromatogram idx or peptide sequence, if available)
+        String caption = fname;
+        if (chrom_exp_sptr->metaValueExists("peptide_sequence"))
+        {
+          caption = String(chrom_exp_sptr->getMetaValue("peptide_sequence"));
+        }
+        ((caption += "[") += index) += "]";
+        // add chromatogram data as peak spectrum
+        widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, true);
+      }
+
+      tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)
+    }
+  }
+
+  void TVDIATreeTabController::deactivate1DTransitions(const std::vector<int>& /*indices*/)
+  {
+    // no special handling of spectrum deactivation needed
+  }
+
+} // OpenMS
+

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
   {  
   }
 
-  void TVDIATreeTabController::showTransitionsAs1D(const std::vector<int>& indices)
+  void TVDIATreeTabController::showTransitionsAs1D(const std::vector<int>& /*indices*/)
   {
     // basic behavior 1
 

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -169,7 +169,7 @@ namespace OpenMS
   }
 
   // called by SpectraTreeTab::chromsSelected()
-  void TVDIATreeTabController::activate1DTransitions(const std::vector<int>& indices)
+  void TVDIATreeTabController::activate1DTransitions(const std::vector<int>& /*indices*/)
   {
     Plot1DWidget * widget_1d = tv_->getActive1DWidget();
 

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -169,7 +169,7 @@ namespace OpenMS
     tv_->updateBarsAndMenus();
   }
 
-  // called by SpectraTreeTab::spectrumSelected()
+  // called by SpectraTreeTab::chromsSelected()
   void TVDIATreeTabController::activate1DTransitions(const std::vector<int>& indices)
   {
     Plot1DWidget * widget_1d = tv_->getActive1DWidget();

--- a/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
@@ -177,14 +177,9 @@ namespace OpenMS
 
     // mass precision to match a peak's m/z to a feature m/z
     // m/z values of features are usually an average over multiple scans...
-    double ppm = 0.5;
+    constexpr double ppm = 0.5;
 
-    vector<QColor> cols;
-    cols.push_back(Qt::blue);
-    cols.push_back(Qt::green);
-    cols.push_back(Qt::red);
-    cols.push_back(Qt::gray);
-    cols.push_back(Qt::darkYellow);
+    vector<QColor> cols{ Qt::blue, Qt::green, Qt::red, Qt::gray, Qt::darkYellow };
 
     if (!current_layer.getCurrentSpectrum().isSorted())
     {

--- a/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
@@ -70,13 +70,13 @@ namespace OpenMS
   {
   }
 
-  void TVIdentificationViewController::showSpectrumAs1D(int index)
+  void TVIdentificationViewController::showSpectrumAsNew1D(int index)
   {
     // Show spectrum "index" without selecting an identification
-    showSpectrumAs1D(index, -1, -1);
+    showSpectrumAsNew1D(index, -1, -1);
   }
 
-  void TVIdentificationViewController::showSpectrumAs1D(int spectrum_index, int peptide_id_index, int peptide_hit_index)
+  void TVIdentificationViewController::showSpectrumAsNew1D(int spectrum_index, int peptide_id_index, int peptide_hit_index)
   {
     // basic behavior 1
     LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -224,6 +224,7 @@ namespace OpenMS
         w->canvas()->setDrawMode(Plot1DCanvas::DM_CONNECTEDLINES);
 
         w->canvas()->getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
+        w->canvas()->getCurrentLayer().getChromatogramAnnotation() = layer.getChromatogramAnnotation(); // copy over shared-ptr to OSW-sql data (if available)
 
         //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
         w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -184,7 +184,7 @@ namespace OpenMS
     tv_->updateMenu();
   }
 
-  void TVSpectraViewController::showChromsAsNew1D(const std::vector<int>& indices)
+  void TVSpectraViewController::showChromatogramsAsNew1D(const std::vector<int>& indices)
   {
 
     // basic behavior 1

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -101,7 +101,7 @@ namespace OpenMS
     return chrom_exp_sptr;
   }
 
-  void TVSpectraViewController::showSpectrumAs1D(int index)
+  void TVSpectraViewController::showSpectrumAsNew1D(int index)
   {
     // basic behavior 1
     LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
@@ -184,7 +184,7 @@ namespace OpenMS
     tv_->updateMenu();
   }
 
-  void TVSpectraViewController::showSpectrumAs1D(const std::vector<int>& indices)
+  void TVSpectraViewController::showChromsAsNew1D(const std::vector<int>& indices)
   {
 
     // basic behavior 1

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -296,7 +296,7 @@ namespace OpenMS
     }
   }
 
-  // called by SpectraTreeTab::spectrumSelected()
+  // called by SpectraTreeTab::chromsSelected()
   void TVSpectraViewController::activate1DSpectrum(const std::vector<int>& indices)
   {
     Plot1DWidget * widget_1d = tv_->getActive1DWidget();

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -105,7 +105,7 @@ namespace OpenMS
     QStringList str_list;
 
     // write header
-    ts << getHeaderNames(HeaderInfo::VISIBLE_ONLY, true).join("\t") + "\n";
+    ts << getHeaderNames(WidgetHeader::VISIBLE_ONLY, true).join("\t") + "\n";
 
     // write entries
     for (int r = 0; r < rowCount(); ++r)
@@ -212,13 +212,13 @@ namespace OpenMS
     setItem(rowCount() - 1, (int)column_index, item);
   }
  
-  QStringList TableView::getHeaderNames(const HeaderInfo which, bool use_export_name)
+  QStringList TableView::getHeaderNames(const WidgetHeader which, bool use_export_name)
   {
     QStringList header_labels;
     for (int i = 0; i != columnCount(); ++i)
     {
       // do not export hidden columns
-      if (which == HeaderInfo::VISIBLE_ONLY && isColumnHidden(i))
+      if (which == WidgetHeader::VISIBLE_ONLY && isColumnHidden(i))
       {
         continue;
       }

--- a/src/openms_gui/source/VISUAL/TreeView.cpp
+++ b/src/openms_gui/source/VISUAL/TreeView.cpp
@@ -54,7 +54,6 @@ namespace OpenMS
 
     this->header()->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this->header(), &QHeaderView::customContextMenuRequested, this, &TreeView::headerContextMenu_);
-
   }
 
 

--- a/src/openms_gui/source/VISUAL/TreeView.cpp
+++ b/src/openms_gui/source/VISUAL/TreeView.cpp
@@ -1,0 +1,132 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/VISUAL/TreeView.h>
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+
+#include <QHeaderView>
+#include <QMenu>
+
+using namespace std;
+
+///@improvement write the visibility-status of the columns in toppview.ini and read at start
+
+
+namespace OpenMS
+{
+  TreeView::TreeView(QWidget* parent) :
+    QTreeWidget(parent)
+  {
+    this->setObjectName("tree_widget");
+
+    this->header()->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(this->header(), &QHeaderView::customContextMenuRequested, this, &TreeView::headerContextMenu_);
+
+  }
+
+
+  void TreeView::headerContextMenu_(const QPoint& pos)
+  {
+    // allows to hide/show columns
+    QMenu context_menu(this->header());
+    const auto& header = this->headerItem();
+
+    for (int i = 0; i < header->columnCount(); ++i)
+    {
+      auto action = context_menu.addAction(header->text(i), [i, this]() {
+        this->setColumnHidden(i, !this->isColumnHidden(i));
+        });
+      action->setCheckable(true);
+      action->setChecked(!this->isColumnHidden(i));
+    }
+
+    // show and execute menu
+    context_menu.exec(this->mapToGlobal(pos));
+  }
+
+  void TreeView::setHeaders(const QStringList& headers)
+  {
+    setColumnCount(headers.size());
+    setHeaderLabels(headers);
+  }
+
+  void TreeView::hideColumns(const QStringList& header_names)
+  {
+    auto hset = header_names.toSet();
+    // add actions which show/hide columns
+    const auto& header = this->headerItem();
+
+    for (int i = 0; i < header->columnCount(); ++i)
+    {
+      if (hset.contains(header->text(i)))
+      {
+        setColumnHidden(i, true);
+        hset.remove(header->text(i));
+      }
+    }
+    if (!hset.empty())
+    {
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "header_names contains a column name which is unknown: " + String(hset.toList().join(", ")));
+    }
+  }
+
+  QStringList TreeView::getHeaderNames(const WidgetHeader which) const
+  {
+    QStringList header_labels;
+    for (int i = 0; i != columnCount(); ++i)
+    {
+      // do not export hidden columns
+      if (which == WidgetHeader::VISIBLE_ONLY && isColumnHidden(i))
+      {
+        continue;
+      }
+      header_labels << getHeaderName(i);
+    }
+    return header_labels;
+  }
+
+  /// get the displayed name of the header in column with index @p header_column
+  /// @throws Exception::ElementNotFound if header at index @p header_column is not valid
+
+  QString TreeView::getHeaderName(const int header_column) const
+  {
+    const auto& header = this->headerItem();
+    if (header->columnCount() <= header_column) throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Header index " + String(header_column) + " is too large. There are only " + String(header->columnCount()) + " columns!");
+
+    return header->text(header_column);
+  }
+
+}

--- a/src/openms_gui/source/VISUAL/sources.cmake
+++ b/src/openms_gui/source/VISUAL/sources.cmake
@@ -8,6 +8,7 @@ AxisTickCalculator.cpp
 AxisWidget.cpp
 ColorSelector.cpp
 DataSelectionTabs.cpp
+DIATreeTab.cpp
 EnhancedTabBar.cpp
 EnhancedTabBarWidgetInterface.cpp
 EnhancedWorkspace.cpp
@@ -59,6 +60,7 @@ TOPPASVertex.cpp
 TOPPASWidget.cpp
 TOPPViewMenu.cpp
 TreeView.cpp
+TVDIATreeTabController.cpp
 TVIdentificationViewController.cpp
 TVSpectraViewController.cpp
 TVControllerBase.cpp

--- a/src/openms_gui/source/VISUAL/sources.cmake
+++ b/src/openms_gui/source/VISUAL/sources.cmake
@@ -58,7 +58,7 @@ TOPPASTreeView.cpp
 TOPPASVertex.cpp
 TOPPASWidget.cpp
 TOPPViewMenu.cpp
-#TOPPViewPreferences.cpp
+TreeView.cpp
 TVIdentificationViewController.cpp
 TVSpectraViewController.cpp
 TVControllerBase.cpp


### PR DESCRIPTION
# Description

The new tab can currently show the protein/peptide/feature/transition tree
(not yet reacting to clicks, i.e. showing the chromatograms -- to come)

Also renames some signal/slots to more meaningful names, i.e.
`showSpectrumAs1D` was used for single spectra AND (wrongly) for multiple chromatograms, and it always meant opening a new Window/PlottingWidget.
Thus renamed to showSpectrumAsNew1D and showChromsAsNew1D.

Some other minor refactorings to increase shared code.