### PR TITLE
TOPPView DIA data browsing

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -61,6 +61,7 @@ namespace OpenMS
 
     /// Describes a node in the OSWData model tree. 
     /// If a lower level, e.g. feature, is set, the upper levels need to be set as well.
+    /// The lowest level which is set, must be indicated by setting @p lowest.
     struct OPENMS_DLLAPI OSWIndexTrace
     {
       int idx_prot = -1;
@@ -68,6 +69,13 @@ namespace OpenMS
       int idx_feat = -1;
       int idx_trans = -1;
       OSWHierarchy::Level lowest = OSWHierarchy::Level::SIZE_OF_VALUES;
+
+      /// is the trace default constructed (=false), or does it point somewhere (=true)?
+      bool isSet() const
+      {
+        return lowest != OSWHierarchy::Level::SIZE_OF_VALUES;
+      }
+
     };
 
     /// high-level meta data of a transition

--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -305,7 +305,6 @@ namespace OpenMS
     class OPENMS_DLLAPI OSWData
     {
       public:
-
         /// Adds a transition; do this before adding Proteins
         void addTransition(const OSWTransition& tr)
         {

--- a/src/openms/source/DATASTRUCTURES/OSWData.cpp
+++ b/src/openms/source/DATASTRUCTURES/OSWData.cpp
@@ -79,7 +79,7 @@ namespace OpenMS
       {
         throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Transition with nativeID " + (String(nid)) + " not found in OSW data. Make sure the OSW data was loaded!");
       }
-      transID_to_index_[nid] = i;
+      transID_to_index_[nid] = (UInt32)i;
     }
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -104,8 +104,11 @@ namespace OpenMS
       // perform first step
       sqlite3_step(stmt);
 
-      std::vector<int> cont_data; cont_data.resize(containers.size());
+      std::vector<int> cont_data;
+      cont_data.resize(containers.size());
       std::map<Size,Size> sql_container_map;
+      std::vector<double> data;
+      String stemp;
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
       {
         Size id_orig = sqlite3_column_int( stmt, 0 );
@@ -140,14 +143,14 @@ namespace OpenMS
 
         // data_type is one of 0 = mz, 1 = int, 2 = rt
         // compression is one of 0 = no, 1 = zlib, 2 = np-linear, 3 = np-slof, 4 = np-pic, 5 = np-linear + zlib, 6 = np-slof + zlib, 7 = np-pic + zlib
-        std::vector<double> data;
+        data.clear();
+        stemp.clear();
         if (compression == 1)
         {
-          std::string uncompressed;
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, uncompressed);
+          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
 
-          void* byte_buffer = reinterpret_cast<void *>(&uncompressed[0]);
-          Size buffer_size = uncompressed.size();
+          void* byte_buffer = reinterpret_cast<void *>(&stemp[0]);
+          Size buffer_size = stemp.size();
           const double* float_buffer = reinterpret_cast<const double *>(byte_buffer);
           if (buffer_size % sizeof(double) != 0)
           {
@@ -159,19 +162,17 @@ namespace OpenMS
         }
         else if (compression == 5)
         {
-          std::string uncompressed;
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, uncompressed);
+          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
           MSNumpressCoder::NumpressConfig config;
           config.setCompression("linear");
-          MSNumpressCoder().decodeNPRaw(uncompressed, data, config);
+          MSNumpressCoder().decodeNPRaw(stemp, data, config);
         }
         else if (compression == 6)
         {
-          std::string uncompressed;
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, uncompressed);
+          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
           MSNumpressCoder::NumpressConfig config;
           config.setCompression("slof");
-          MSNumpressCoder().decodeNPRaw(uncompressed, data, config);
+          MSNumpressCoder().decodeNPRaw(stemp, data, config);
         }
         else
         {
@@ -257,7 +258,7 @@ namespace OpenMS
     {
     }
 
-    void MzMLSqliteHandler::readExperiment(MSExperiment & exp, bool meta_only) const
+    void MzMLSqliteHandler::readExperiment(MSExperiment& exp, bool meta_only) const
     {
       SqliteConnector conn(filename_);
       sqlite3 *db = conn.getDB();
@@ -558,8 +559,7 @@ namespace OpenMS
                                            const std::vector<int>& indices) const
     {
       sqlite3_stmt* stmt;
-      std::string select_sql;
-      select_sql = "SELECT " \
+      std::string select_sql = "SELECT " \
                     "CHROMATOGRAM.ID as chrom_id," \
                     "CHROMATOGRAM.NATIVE_ID as chrom_native_id," \
                     "PRECURSOR.CHARGE as precursor_charge," \
@@ -597,9 +597,10 @@ namespace OpenMS
       String tmp;
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
       {
-        MSChromatogram chrom;
-        OpenMS::Precursor precursor;
-        OpenMS::Product product;
+        chromatograms.resize(chromatograms.size()+1);
+        MSChromatogram& chrom = chromatograms.back();
+        OpenMS::Precursor& precursor = chrom.getPrecursor();
+        OpenMS::Product& product = chrom.getProduct();
 
         if (Sql::extractValue(&tmp, stmt, 1)) chrom.setNativeID(tmp);
         if (sqlite3_column_type(stmt, 2) != SQLITE_NULL) precursor.setCharge(sqlite3_column_int(stmt, 2));
@@ -619,10 +620,6 @@ namespace OpenMS
         }
         if (sqlite3_column_type(stmt, 13) != SQLITE_NULL) precursor.setActivationEnergy(sqlite3_column_double(stmt, 13));
 
-        chrom.setPrecursor(precursor);
-        chrom.setProduct(product);
-        chromatograms.push_back(chrom);
-
         sqlite3_step( stmt );
       }
 
@@ -635,8 +632,7 @@ namespace OpenMS
                                             const std::vector<int> & indices) const
     {
       sqlite3_stmt * stmt;
-      std::string select_sql;
-      select_sql = "SELECT " \
+      std::string select_sql = "SELECT " \
                     "SPECTRUM.ID as spec_id," \
                     "SPECTRUM.NATIVE_ID as spec_native_id," \
                     "SPECTRUM.MSLEVEL as spec_mslevel," \
@@ -677,7 +673,8 @@ namespace OpenMS
       OpenMS::String tmp;
       while (sqlite3_column_type(stmt, 0) != SQLITE_NULL)
       {
-        MSSpectrum spec;
+        spectra.resize(spectra.size() + 1);
+        MSSpectrum& spec = spectra.back();
         OpenMS::Precursor precursor;
         OpenMS::Product product;
         if (Sql::extractValue(&tmp, stmt, 1)) spec.setNativeID(tmp);
@@ -706,9 +703,8 @@ namespace OpenMS
         }
         if (sqlite3_column_type(stmt, 16) != SQLITE_NULL) precursor.setActivationEnergy(sqlite3_column_double(stmt, 16));
 
-        if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) spec.getPrecursors().push_back(precursor);
-        if (sqlite3_column_type(stmt, 11) != SQLITE_NULL) spec.getProducts().push_back(product);
-        spectra.push_back(spec);
+        if (sqlite3_column_type(stmt, 6) != SQLITE_NULL) spec.getPrecursors().push_back(std::move(precursor));
+        if (sqlite3_column_type(stmt, 11) != SQLITE_NULL) spec.getProducts().push_back(std::move(product));
 
         sqlite3_step( stmt );
       }

--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
@@ -53,7 +53,7 @@ namespace OpenMS
 
       @param pos X-coordinate as show on the axis
       @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
-      @param text Optional text displayed next to the line
+      @param text Optional text displayed next to the line. Can contain '\n' which will force multiple lines.
     **/ 
     Annotation1DVerticalLineItem(const double x_pos, const QColor& color = QColor("as_before"), const QString& text = "");
     /**
@@ -63,7 +63,7 @@ namespace OpenMS
       @param width Full width of the band
       @param fill_alpha255 A transparency value from 0 (no visible band), to 255 (fully opaque band)
       @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
-      @param text Optional text displayed next to the line
+      @param text Optional text displayed next to the line. Can contain '\n' which will force multiple lines.
     **/
     Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255 = 128, const QColor& color = QColor("as_before"), const QString& text = "");
     /// Copy constructor

--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
@@ -48,8 +48,24 @@ namespace OpenMS
       public Annotation1DItem
   {
   public:
-    /// Constructor
-    Annotation1DVerticalLineItem(const double& x, const QColor& color, const QString& text="");
+    /**
+      Constructor for a single vertical line.
+
+      @param pos X-coordinate as show on the axis
+      @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
+      @param text Optional text displayed next to the line
+    **/ 
+    Annotation1DVerticalLineItem(const double x_pos, const QColor& color = QColor("as_before"), const QString& text = "");
+    /**
+      Constructor for a single vertical band, with a slightly transparent middle, flanked by two solid vertical lines.
+
+      @param pos X-coordinate of the center as show on the axis
+      @param width Full width of the band
+      @param fill_alpha255 A transparency value from 0 (no visible band), to 255 (fully opaque band)
+      @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
+      @param text Optional text displayed next to the line
+    **/
+    Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255 = 128, const QColor& color = QColor("as_before"), const QString& text = "");
     /// Copy constructor
     Annotation1DVerticalLineItem(const Annotation1DVerticalLineItem& rhs) = default;
     /// Destructor
@@ -67,9 +83,13 @@ namespace OpenMS
 
   protected:
     /// The position of the vertical line
-    double x_;
+    double x_ = -1;
+    /// width of the item (allowing to show a 'band')
+    float width_ = 0;
+    /// transparency 0...255 of the band (only used when width_ > 0)
+    float fill_alpha255_ = 128;
 
-    /// The color of the line
-    QColor color_;
+    /// The color of the line; if invalid, the current painter color will be used
+    QColor color_ = Qt::black;
   };
 } // namespace OpenMS

--- a/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
@@ -71,8 +71,10 @@ namespace OpenMS
     void clear();
 
   signals:
-    /// emitted when a protein, peptide, feature or transition was clicked
-    void dataSelected(const OSWIndexTrace& trace);
+    /// emitted when a protein, peptide, feature or transition was selected
+    void entityClicked(const OSWIndexTrace& trace);
+    /// emitted when a protein, peptide, feature or transition was double-clicked
+    void entityDoubleClicked(const OSWIndexTrace& trace);
 
   private:
     QLineEdit* spectra_search_box_ = nullptr;
@@ -83,15 +85,25 @@ namespace OpenMS
     /// Useful to avoid useless repaintings, which would loose the open/close state of internal tree nodes and selected items
     OSWData* current_data_ = nullptr;
 
+    /** 
+      @brief convert a tree item to a pointer into an OSWData structure
+
+      @param item The tree item (protein, peptide,...) that was clicked
+      @return The index into the current OSWData @p current_data_
+    **/
+    OSWIndexTrace prepareSignal_(QTreeWidgetItem* item);
+
   private slots:
     /// fill the search-combo-box with current column header names
     void populateSearchBox_();
     /// searches for rows containing a search text (from spectra_search_box_); called when text search box is used
     void spectrumSearchText_();
-    /// emits transitionSelected() for all subitems
+    /// emits entityClicked() for all subitems
     void rowSelectionChange_(QTreeWidgetItem*, QTreeWidgetItem*);
-    /// emits transitionSelected() for all subitems
-    void rowSelectionChange2_(QTreeWidgetItem*, int col);
+    /// emits entityClicked() for all subitems
+    void rowClicked_(QTreeWidgetItem*, int col);
+    /// emits entityDoubleClicked() for all subitems
+    void rowDoubleClicked_(QTreeWidgetItem*, int col);
     /// searches using text box and plots the spectrum
     void searchAndShow_();
   };

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -329,6 +329,18 @@ public:
       updateCache_();
     }
 
+
+    /// get the full chromExperiment
+    /// Could be backed up in layer.getChromatogramData() (if layer.getPeakDataMuteable() shows converted chroms already)
+    /// ... or layer.getChromatogramData() is empty and thus layer.getPeakDataMuteable() is the original chrom data
+    ExperimentSharedPtrType getFullChromData()
+    {
+      ExperimentSharedPtrType exp_sptr(getChromatogramData().get() == nullptr ||
+          getChromatogramData().get()->getNrChromatograms() == 0
+             ? getPeakDataMuteable() : getChromatogramData());
+      return exp_sptr;
+    }
+
     /// Check whether the current layer should be represented as ion mobility
     bool isIonMobilityData() const
     {

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -39,32 +39,42 @@
 
 class QString; // declare this OUTSIDE of namespace OpenMS!
 class QStringList;
+class QPainter;
+class QPoint;
+
+#include <QColor>
+#include <QFont>
 
 namespace OpenMS
 {
   /**
-    @brief Class which holds static GUI-related helper functions.
-
-    Since all methods are static, the c'tor is private.
-    
-    @ingroup Visual
+    Namespace which holds static GUI-related helper functions.
   */
-  class OPENMS_GUI_DLLAPI GUIHelpers
+  namespace GUIHelpers
   {
-  public:
-
-    GUIHelpers() = delete;
     
     /// Open a folder in file explorer
     /// Will show a message box on failure
-    static void openFolder(const QString& folder);
+    void openFolder(const QString& folder);
 
     /// Open TOPPView (e.g. from within TOPPAS)
-    static void startTOPPView(const QStringList& args);
+    void startTOPPView(const QStringList& args);
 
     /// Open a certain URL (in a browser)
     /// Will show a message box on failure
-    static void openURL(const QString& target);
+    void openURL(const QString& target);
+
+    /**
+       @brief draw a multi-line text at coordinates XY using a specific font and color
+       @param painter Where to draw
+       @param text Each item is a new line
+       @param where Coordinates where to start drawing (upper left corner of text)
+       @param col_fg Optional text color; if invalid (=default) will use the current painter's color
+       @param col_bg Optional background color of bounding rectangle; if invalid (=default) no background will be painted
+       @param Optional font; will use Courier by default
+    */
+    void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"), QFont f = QFont("Courier"));
+
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
@@ -88,13 +88,21 @@ public:
     ~Plot1DCanvas() override;
 
     /// add a chromatogram layer
+    /// @param chrom_exp_sptr An MSExperiment with chromatograms
+    /// @param ondisc_sptr OnDisk experiment, as fallback to read the chromatogram from, should @p chrom_exp_sptr.getChromatograms(index) be empty
+    /// @param OSWDataSharedPtrType If OSWData was loaded, pass the shared_pointer from the LayerData. Otherwise leave empty.
+    /// @param index Index of the chromatogram to show
+    /// @param filename For file change watcher (can be empty, if need be)
+    /// @param caption Name of layer
+    /// @param multiple_select .... not sure ...
+    /// @return true on success, false if data was missing etc
     /// @note: this does NOT trigger layerActivated signal for efficiency-reasons. Do it manually afterwards!
     bool addChromLayer(ExperimentSharedPtrType chrom_exp_sptr,
                        ODExperimentSharedPtrType ondisc_sptr, 
+                       OSWDataSharedPtrType chrom_annotation,
+                       const int index,
                        const String& filename, 
                        const String& caption, 
-                       ExperimentSharedPtrType exp_sptr,
-                       const int index,
                        const bool multiple_select);
 
     

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -146,6 +146,7 @@ public:
     typedef LayerData::ExperimentSharedPtrType ExperimentSharedPtrType;
     typedef LayerData::ConstExperimentSharedPtrType ConstExperimentSharedPtrType;
     typedef LayerData::ODExperimentSharedPtrType ODExperimentSharedPtrType;
+    typedef LayerData::OSWDataSharedPtrType OSWDataSharedPtrType;
     /// Main data type (features)
     typedef LayerData::FeatureMapType FeatureMapType;
     /// Main managed data type (features)

--- a/src/openms_gui/include/OpenMS/VISUAL/TVControllerBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVControllerBase.h
@@ -49,7 +49,7 @@ namespace OpenMS
   {
     Q_OBJECT
 
-protected:
+public:
     ///@name Type definitions
     //@{
     /// Feature map type
@@ -69,8 +69,6 @@ protected:
     /// Peak spectrum type
     typedef ExperimentType::SpectrumType SpectrumType;
     //@}
-
-public:
     TVControllerBase() = delete;
 
     virtual ~TVControllerBase() = default;

--- a/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TVDIATreeTabController.h
@@ -42,7 +42,8 @@
 namespace OpenMS
 {
   class TOPPViewBase;
-
+  class Plot1DWidget;
+  struct MiniLayer;
   struct OSWIndexTrace;
 
   /**
@@ -59,6 +60,12 @@ public:
 
 public slots:
     /// shows all transitions from the given subtree
-    virtual void showData(const OSWIndexTrace& trace);
+    virtual void showChromatograms(const OSWIndexTrace& trace);
+
+    /// shows all transitions from the given subtree in a new 1D canvas
+    virtual void showChromatogramsAsNew1D(const OSWIndexTrace& trace);
+    
+private:    
+    bool showChromatogramsInCanvas_(const OSWIndexTrace& trace, MiniLayer& ml, Plot1DWidget* w);
   };
 }

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h>
 #include <OpenMS/VISUAL/Plot1DCanvas.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
 
 #include <QtCore/QPoint>
 #include <QtGui/QPainter>
@@ -106,7 +107,8 @@ namespace OpenMS
     // 5 pixel to x() was added to give some space between the line and the text
     if (!text_.isEmpty())
     {
-      painter.drawText(end_p_right.x() + 5, 20.0, text_);
+      // randomize the y-coordinate to avoid overlaps
+      GUIHelpers::drawText(painter, text_.split('\n'), { end_p_right.x() + 5, 20 }, Qt::black);
     }
 
     if (color_.isValid())

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1317,7 +1317,9 @@ namespace OpenMS
       if (getActiveCanvas()->getLayerCount() != 0) 
       {
         fs |= TV_STATUS::HAS_LAYER;
-        layer_type = getCurrentLayer()->type;
+        layer_type = getCurrentLayer()->getChromatogramData().get()->getNrChromatograms() > 0
+                             ? LayerData::DT_CHROMATOGRAM // chrom data in 1D view is shown as DT_PEAK...
+                             : getCurrentLayer()->type;
       }
     }
     // is this a 1D view

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -111,8 +111,8 @@ namespace OpenMS
     dia_treewidget_->setContextMenuPolicy(Qt::CustomContextMenu);
 
     connect(dia_treewidget_, &QTreeWidget::currentItemChanged, this, &DIATreeTab::rowSelectionChange_);
-
-    connect(dia_treewidget_, &QTreeWidget::itemClicked, this, &DIATreeTab::rowSelectionChange2_);
+    connect(dia_treewidget_, &QTreeWidget::itemClicked, this, &DIATreeTab::rowClicked_);
+    connect(dia_treewidget_, &QTreeWidget::itemDoubleClicked, this, &DIATreeTab::rowDoubleClicked_);
 
     spectra_widget_layout->addWidget(dia_treewidget_);
 
@@ -188,6 +188,7 @@ namespace OpenMS
     return item_prot;
   }
 
+
   void DIATreeTab::spectrumSearchText_()
   {
     const QString& text = spectra_search_box_->text(); // get text from QLineEdit
@@ -209,38 +210,54 @@ namespace OpenMS
     }
   }
 
-  void DIATreeTab::rowSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/)
+
+  OSWIndexTrace DIATreeTab::prepareSignal_(QTreeWidgetItem* item)
   {
-    if (current == nullptr || current_data_ == nullptr)
+    OSWIndexTrace tr;
+    if (item == nullptr || current_data_ == nullptr)
     {
-      return;
+      return tr;
     }
 
-    OSWIndexTrace tr = getTrace(current);
+    tr = getTrace(item);
     switch (tr.lowest)
     {
-      case OSWHierarchy::Level::PROTEIN:
-        if (current->childCount() == 0)
-        { // no peptides... load them
-          OSWFile f(current_data_->getSqlSourceFile());
-          f.readProtein(*current_data_, tr.idx_prot);
-        }
-        fillProt(current_data_->getProteins()[tr.idx_prot], current);
-        // do nothing else -- showing all transitions for a protein is overwhelming...      
-        break;
-      case OSWHierarchy::Level::PEPTIDE:
-      case OSWHierarchy::Level::FEATURE:
-      case OSWHierarchy::Level::TRANSITION:
-        break;
-      default:
-        throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+    case OSWHierarchy::Level::PROTEIN:
+      if (item->childCount() == 0)
+      { // no peptides... load them
+        OSWFile f(current_data_->getSqlSourceFile());
+        f.readProtein(*current_data_, tr.idx_prot);
+      }
+      fillProt(current_data_->getProteins()[tr.idx_prot], item);
+      // do nothing else -- showing all transitions for a protein is overwhelming...      
+      break;
+    case OSWHierarchy::Level::PEPTIDE:
+    case OSWHierarchy::Level::FEATURE:
+    case OSWHierarchy::Level::TRANSITION:
+      break;
+    default:
+      throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
-    emit dataSelected(tr);
+
+    return tr;
   }
 
-  void DIATreeTab::rowSelectionChange2_(QTreeWidgetItem* item, int /*col*/)
+  void DIATreeTab::rowSelectionChange_(QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/)
   {
-    rowSelectionChange_(item, nullptr);
+    auto tr = prepareSignal_(current);
+    if (tr.isSet()) emit entityClicked(tr);
+  }
+
+  void DIATreeTab::rowClicked_(QTreeWidgetItem* item, int /*col*/)
+  {
+    auto tr = prepareSignal_(item);
+    if (tr.isSet()) emit entityClicked(tr);
+  }
+
+  void DIATreeTab::rowDoubleClicked_(QTreeWidgetItem* item, int /*col*/)
+  {
+    auto tr = prepareSignal_(item);
+    if (tr.isSet()) entityDoubleClicked(tr);
   }
 
   void DIATreeTab::searchAndShow_()

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -227,8 +227,8 @@ namespace OpenMS
       { // no peptides... load them
         OSWFile f(current_data_->getSqlSourceFile());
         f.readProtein(*current_data_, tr.idx_prot);
+        fillProt(current_data_->getProteins()[tr.idx_prot], item);
       }
-      fillProt(current_data_->getProteins()[tr.idx_prot], item);
       // do nothing else -- showing all transitions for a protein is overwhelming...      
       break;
     case OSWHierarchy::Level::PEPTIDE:

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -84,7 +84,8 @@ namespace OpenMS
     connect(id_view_widget_, &SpectraIDViewTab::requestVisibleArea1D, idview_controller_, &TVIdentificationViewController::setVisibleArea1D);
 
     // Hook-up controller and views for DIA
-    connect(dia_widget_, &DIATreeTab::dataSelected, diatab_controller_, &TVDIATreeTabController::showData);
+    connect(dia_widget_, &DIATreeTab::entityClicked, diatab_controller_, &TVDIATreeTabController::showChromatograms);
+    connect(dia_widget_, &DIATreeTab::entityDoubleClicked, diatab_controller_, &TVDIATreeTabController::showChromatogramsAsNew1D);
 
     int index;
     index = addTab(spectra_view_widget_, spectra_view_widget_->objectName());

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -573,14 +573,16 @@ namespace OpenMS
     return false;
   }
 
-  bool LayerAnnotatorOSW::annotateWorker_(LayerData &layer,
-                                          const String &filename,
-                                          LogWindow &log) const
+  bool LayerAnnotatorOSW::annotateWorker_(LayerData& layer,
+                                          const String& filename,
+                                          LogWindow& log) const
   {
     OSWFile oswf(filename);
     OSWData data;
     log.appendNewHeader(LogWindow::LogState::NOTICE, "Note", "Reading OSW data ...");
     oswf.readMinimal(data);
+    // allow data to map from transition.id (=native.id) to a chromatogram index
+    data.buildNativeIDResolver(*layer.getFullChromData().get());
     layer.setChromatogramAnnotation(std::move(data));
     log.appendText(" done");
     return true;

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -43,6 +43,8 @@
 #include <QMessageBox>
 #include <QString>
 #include <QStringList>
+#include <QPainter>
+#include <QPoint>
 #include <QProcess>
 
 namespace OpenMS
@@ -141,6 +143,45 @@ namespace OpenMS
                            QObject::tr("Unable to open\n") + target + 
                            QObject::tr("\n\nPossible reason: security settings or misconfigured Operating System"));
     }
+  }
+
+  /**
+  @brief draw a multi-line text at coordinates XY using a specific font and color
+  @param painter Where to draw
+  @param text Each item is a new line
+  @param where Coordinates where to start drawing (upper left corner of text)
+  @param col_fg Optional text color; if invalid (=default) will use the current painter's color
+  @param col_bg Optional background color of bounding rectangle; if invalid (=default) no background will be painted
+  @param Optional font; will use Courier by default
+  */
+  void GUIHelpers::drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg, const QColor col_bg, QFont f)
+  {
+    painter.save();
+
+    // font
+    painter.setFont(f);
+
+    //d etermine width and height of the box we need
+    QFontMetrics metrics(painter.font());
+    int line_spacing = metrics.lineSpacing();
+    int height = 6 + text.size() * line_spacing;
+    int width = 4;
+    for (int i = 0; i < text.size(); ++i)
+    {
+      width = std::max(width, 4 + metrics.width(text[i]));
+    }
+
+    // draw background for text
+    if (col_bg.isValid()) painter.fillRect(where.x(), where.y(), width, height, col_bg);
+
+    // draw text
+    if (col_fg.isValid()) painter.setPen(col_fg);
+
+    for (int i = 0; i < text.size(); ++i)
+    {
+      painter.drawText(where.x() + 1, where.y() + (i + 1) * line_spacing, text[i]);
+    }
+    painter.restore();
   }
 
 } //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -49,6 +49,7 @@
 #include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignmentScore.h>
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/SYSTEM/FileWatcher.h>
 #include <OpenMS/VISUAL/Plot1DCanvas.h>
@@ -81,6 +82,49 @@ namespace OpenMS
   using namespace Math;
   using namespace Internal;
 
+  /// returns an MSExp with a single spec (converted from @p exp_sptr's chromatograms at index  @p index (or ondisc_sptr, if that should be empty)
+  Plot1DCanvas::ExperimentSharedPtrType prepareChromatogram(Size index, Plot1DCanvas::ExperimentSharedPtrType exp_sptr, Plot1DCanvas::ODExperimentSharedPtrType ondisc_sptr)
+  {
+    // create a managed pointer fill it with a spectrum containing the chromatographic data
+    LayerData::ExperimentSharedPtrType chrom_exp_sptr(new LayerData::ExperimentType());
+    chrom_exp_sptr->setMetaValue("is_chromatogram", "true"); //this is a hack to store that we have chromatogram data
+    LayerData::ExperimentType::SpectrumType spectrum;
+
+    // retrieve chromatogram (either from in-memory or on-disc representation)
+    MSChromatogram current_chrom = exp_sptr->getChromatograms()[index];
+    if (current_chrom.empty())
+    {
+      current_chrom = ondisc_sptr->getChromatogram(index);
+    }
+
+    // fill "dummy" spectrum with chromatogram data
+    for (const ChromatogramPeak& cpeak : current_chrom)
+    {
+      spectrum.emplace_back(cpeak.getRT(), cpeak.getIntensity());
+    }
+
+    spectrum.getFloatDataArrays() = current_chrom.getFloatDataArrays();
+    spectrum.getIntegerDataArrays() = current_chrom.getIntegerDataArrays();
+    spectrum.getStringDataArrays() = current_chrom.getStringDataArrays();
+
+    // Add at least one data point to the chromatogram, otherwise
+    // "addLayer" will fail and a segfault occurs later
+    if (current_chrom.empty())
+    {
+      spectrum.emplace_back(-1, 0);
+    }
+    chrom_exp_sptr->addSpectrum(spectrum);
+
+    // store peptide_sequence if available
+    if (current_chrom.getPrecursor().metaValueExists("peptide_sequence"))
+    {
+      chrom_exp_sptr->setMetaValue("peptide_sequence", current_chrom.getPrecursor().getMetaValue("peptide_sequence"));
+    }
+
+    return chrom_exp_sptr;
+  }
+
+
   Plot1DCanvas::Plot1DCanvas(const Param& preferences, QWidget* parent) :
     PlotCanvas(preferences, parent),
     mirror_mode_(false),
@@ -111,11 +155,13 @@ namespace OpenMS
   {
   }
 
-  bool Plot1DCanvas::addChromLayer(ExperimentSharedPtrType chrom_exp_sptr, ODExperimentSharedPtrType ondisc_sptr, const String& filename,
-                                       const String& caption,
-                                       ExperimentSharedPtrType exp_sptr,
-                                       const int index,
-                                       const bool multiple_select)
+  bool Plot1DCanvas::addChromLayer(ExperimentSharedPtrType chrom_exp_sptr,
+                                   ODExperimentSharedPtrType ondisc_sptr,
+                                   OSWDataSharedPtrType chrom_annotation,
+                                   const int index,
+                                   const String& filename,
+                                   const String& caption,
+                                   const bool multiple_select)
   {
     // we do not want addLayer to trigger repaint, since we have not set the chromatogram data!
     this->blockSignals(true);
@@ -124,8 +170,11 @@ namespace OpenMS
       this->blockSignals(false);
     });
 
+    // convert from chromatogram to spectrum --- hacky!!!
+    ExperimentSharedPtrType converted_spec = prepareChromatogram(index, chrom_exp_sptr, ondisc_sptr);
+
     // add chromatogram data as peak spectrum
-    if (!addLayer(chrom_exp_sptr, ondisc_sptr, filename))
+    if (!addLayer(converted_spec, ondisc_sptr, filename))
     {
       return false;
     }
@@ -134,7 +183,8 @@ namespace OpenMS
     setIntensityMode(Plot1DCanvas::IM_NONE);
 
     getCurrentLayer().setName(caption);
-    getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
+    getCurrentLayer().getChromatogramData() = chrom_exp_sptr; // save the original chromatogram data so that we can access it later
+    getCurrentLayer().getChromatogramAnnotation() = chrom_annotation; // copy over shared-ptr to OSW-sql data (if available)
     //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
     getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");
     getCurrentLayer().getPeakDataMuteable()->setMetaValue("multiple_select", multiple_select ? "true" : "false");

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/SYSTEM/FileWatcher.h>
 #include <OpenMS/VISUAL/MetaDataBrowser.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
 
 // QT
 #include <QPainter>
@@ -964,32 +965,7 @@ namespace OpenMS
 
   void PlotCanvas::drawText_(QPainter & painter, QStringList text)
   {
-    painter.save();
-
-    //font
-    QFont font("Courier");
-    painter.setFont(font);
-
-    //determine width and height of the box we need
-    QFontMetrics metrics(painter.font());
-    int line_spacing = metrics.lineSpacing();
-    int height = 6 + text.size() * line_spacing;
-    int width = 4;
-    for (int i = 0; i < text.size(); ++i)
-    {
-      width = max(width, 4 + metrics.width(text[i]));
-    }
-
-    //draw background for text
-    painter.fillRect(2, 3, width, height, QColor(255, 255, 255, 200));
-
-    //draw text
-    painter.setPen(Qt::black);
-    for (int i = 0; i < text.size(); ++i)
-    {
-      painter.drawText(3, 3 + (i + 1) * line_spacing, text[i]);
-    }
-    painter.restore();
+    GUIHelpers::drawText(painter, text, {2, 3}, Qt::black, QColor(255, 255, 255, 200));
   }
 
   double PlotCanvas::getIdentificationMZ_(const Size layer_index,

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -71,7 +71,7 @@ namespace OpenMS
     String filename;
     String layername;
 
-    MiniLayer(LayerData& layer)
+    explicit MiniLayer(LayerData& layer)
     : full_chrom_exp_sptr(layer.getFullChromData()),
       ondisc_sptr(layer.getOnDiscPeakData()),
       annot_sptr(layer.getChromatogramAnnotation()),
@@ -153,7 +153,6 @@ namespace OpenMS
 
   bool TVDIATreeTabController::showChromatogramsInCanvas_(const OSWIndexTrace& trace, MiniLayer& ml, Plot1DWidget* w)
   {
-
     OSWData* data = ml.annot_sptr.get();
     if (data == nullptr)
     { // no OSWData available ... strange...

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -36,11 +36,15 @@
 
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 #include <OpenMS/DATASTRUCTURES/OSWData.h>
+#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/ChromatogramTools.h>
 #include <OpenMS/KERNEL/OnDiscMSExperiment.h>
+#include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/Plot1DWidget.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h>
+
 
 #include <QtWidgets/QMessageBox>
 #include <QtCore/QString>
@@ -50,90 +54,189 @@ using namespace std;
 
 namespace OpenMS
 {
+
+
+  typedef LayerData::ExperimentSharedPtrType ExperimentSharedPtrType;
+  typedef LayerData::ConstExperimentSharedPtrType ConstExperimentSharedPtrType;
+  typedef LayerData::ODExperimentSharedPtrType ODExperimentSharedPtrType;
+  typedef LayerData::OSWDataSharedPtrType OSWDataSharedPtrType;
+
+  /// represents all the information we need from a layer
+  /// We cannot use a full layer, because the original layer might get destroyed in the process...
+  struct MiniLayer
+  {
+    ExperimentSharedPtrType full_chrom_exp_sptr;
+    ODExperimentSharedPtrType ondisc_sptr;
+    OSWDataSharedPtrType annot_sptr;
+    String filename;
+    String layername;
+
+    MiniLayer(LayerData& layer)
+    : full_chrom_exp_sptr(getFullChromData(layer)),
+      ondisc_sptr(layer.getOnDiscPeakData()),
+      annot_sptr(layer.getChromatogramAnnotation()),
+      filename(layer.filename),
+      layername(layer.getName())
+    {
+    }
+
+    /// get the full chromExperiment
+    /// Could be backed up in layer.getChromatogramData() (if layer.getPeakDataMuteable() shows converted chroms already; as we will do below)
+    /// ... or layer.getChromatogramData() is empty and thus layer.getPeakDataMuteable() is the original chrom data
+    static ExperimentSharedPtrType getFullChromData(LayerData& layer)
+    {
+      ExperimentSharedPtrType exp_sptr(layer.getChromatogramData().get() == nullptr ||
+                                       layer.getChromatogramData().get()->getNrChromatograms() == 0
+                                       ? layer.getPeakDataMuteable() : layer.getChromatogramData());
+      return exp_sptr;
+    }
+  };
+
+  
+
   TVDIATreeTabController::TVDIATreeTabController(TOPPViewBase* parent):
     TVControllerBase(parent)
   {  
   }
 
-  void TVDIATreeTabController::showData(const OSWIndexTrace& /*trace*/)
+  bool addTransitionAsLayer(Plot1DWidget* w, 
+                            MiniLayer ml,
+                            const int chrom_index,
+                            const OSWPeakGroup* feature = nullptr)
   {
-  /*
-    // basic behavior 1
+    String chrom_caption = FileHandler::stripExtension(File::basename(ml.filename)) + "[" + chrom_index + "]";
 
-    // show multiple spectra together is only used for chromatograms directly
-    // where multiple (SRM) traces are shown together
-    LayerData& layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
-    ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
-
-    OSWData* data = layer.getChromatogramAnnotation().get();
-    if (data == nullptr)
-    { // no OSWData available ... strange...
-      return;
+    // add data and return if something went wrong
+    if (!w->canvas()->addChromLayer(ml.full_chrom_exp_sptr, ml.ondisc_sptr, ml.annot_sptr, chrom_index, ml.filename, chrom_caption, false))
+    {
+      return false;
+    }
+    // add boundaries
+    if (feature)
+    {
+      double width = feature->getRTRightWidth() - feature->getRTLeftWidth();
+      double center = feature->getRTLeftWidth() + width / 2;
+      Annotation1DItem* item = new Annotation1DVerticalLineItem(center, width, 30);
+      item->setSelected(false);
+      w->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
     }
 
-    //open new 1D widget
-    Plot1DWidget* w = new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget*)tv_->getWorkspace());
 
-    // string for naming the different chromatogram layers with their index
-    String chromatogram_caption;
-    // string for naming the tab title with the indices of the chromatograms
-    String caption = layer.getName();
+    w->canvas()->activateSpectrum(0, false);
+    return true;
+  }
+
+
+  void TVDIATreeTabController::showChromatogramsAsNew1D(const OSWIndexTrace& trace)
+  {
+    LayerData& layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
+    MiniLayer ml(layer);
+    // create new 1D widget; if we return due to error, the widget will be cleaned up
+    unique_ptr<Plot1DWidget> w(new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget*)tv_->getWorkspace()));
+
+    if (showChromatogramsInCanvas_(trace, ml, w.get()))
+    { // success!
+      tv_->showPlotWidgetInWindow(w.get(), ml.layername);
+      w.release(); // do NOT delete the widget; tv_ owns it now ...
+      tv_->updateBarsAndMenus();
+    }
+  }
+
+  void TVDIATreeTabController::showChromatograms(const OSWIndexTrace& trace)
+  {
+    Plot1DWidget* w = tv_->getActive1DWidget();
+    if (w == nullptr)
+    { // currently not a 1d widget... ignore the signal
+      return;
+    }
+    MiniLayer ml(w->canvas()->getCurrentLayer());
+    // clear all layers
+    w->canvas()->removeLayers();
+    // add new layers
+    if (showChromatogramsInCanvas_(trace, ml, w))
+    {
+      tv_->updateBarsAndMenus();
+    }
+  }
+
+  bool TVDIATreeTabController::showChromatogramsInCanvas_(const OSWIndexTrace& trace, MiniLayer& ml, Plot1DWidget* w)
+  {
+
+    OSWData* data = ml.annot_sptr.get();
+    if (data == nullptr)
+    { // no OSWData available ... strange...
+      return false;
+    }
+
     switch (trace.lowest)
     {
     case OSWHierarchy::Level::PROTEIN:
-      // do nothing else -- showing all transitions for a protein is overwhelming...      
-      break;
-    case OSWHierarchy::Level::PEPTIDE:
     {
-      const auto& prot = data.getProteins()[tr.idx_prot];
-      const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
+      const auto& prot = data->getProteins()[trace.idx_prot];
+      // show only the first peptide for now...
+      const auto& pep = prot.getPeptidePrecursors()[0];
       for (const auto& feat : pep.getFeatures())
       {
         const auto& trids = feat.getTransitionIDs();
-        transitions_to_show.insert(transitions_to_show.end(), trids.begin(), trids.end());
+        for (UInt trid : trids)
+        {
+          if (!addTransitionAsLayer(w, ml, (Size)trid, &feat))
+          { // something went wrong. abort
+            return false;
+          }
+        }
+      }
+      break;
+    }
+    case OSWHierarchy::Level::PEPTIDE:
+    {
+      const auto& prot = data->getProteins()[trace.idx_prot];
+      const auto& pep = prot.getPeptidePrecursors()[trace.idx_pep];
+      for (const auto& feat : pep.getFeatures())
+      {
+        const auto& trids = feat.getTransitionIDs();
+        for (UInt trid : trids)
+        {
+          if (!addTransitionAsLayer(w, ml, (Size)trid, &feat))
+          { // something went wrong. abort
+            return false;
+          }
+        }
       }
       break;
     }
     case OSWHierarchy::Level::FEATURE:
     {
-      const auto& prot = data.getProteins()[tr.idx_prot];
-      const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
-      const auto& feat = pep.getFeatures()[tr.idx_feat];
+      const auto& prot = data->getProteins()[trace.idx_prot];
+      const auto& pep = prot.getPeptidePrecursors()[trace.idx_pep];
+      const auto& feat = pep.getFeatures()[trace.idx_feat];
       const auto& trids = feat.getTransitionIDs();
-      transitions_to_show.insert(transitions_to_show.end(), trids.begin(), trids.end());
+      for (UInt trid : trids)
+      {
+        if (!addTransitionAsLayer(w, ml, (Size)trid, &feat))
+        { // something went wrong. abort
+          return false;
+        }
+      }
       break;
     }
     case OSWHierarchy::Level::TRANSITION:
     {
-      const auto& prot = data.getProteins()[tr.idx_prot];
-      const auto& pep = prot.getPeptidePrecursors()[tr.idx_pep];
-      const auto& feat = pep.getFeatures()[tr.idx_feat];
-      const auto& trid = feat.getTransitionIDs()[tr.idx_trans];
-      transitions_to_show.insert(transitions_to_show.end(), trid);
+      const auto& prot = data->getProteins()[trace.idx_prot];
+      const auto& pep = prot.getPeptidePrecursors()[trace.idx_pep];
+      const auto& feat = pep.getFeatures()[trace.idx_feat];
+      const auto& trid = feat.getTransitionIDs()[trace.idx_trans];
+      if (!addTransitionAsLayer(w, ml, (Size)trid, &feat))
+      { // something went wrong. abort
+        return false;
+      }
       break;
     }
     default:
       throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
-    // add data and return if something went wrong
-    if (!w->canvas()->addLayer(exp_sptr, od_exp_sptr, layer.filename)
-      || (Size)spectrum_index >= w->canvas()->getCurrentLayer().getPeakData()->size())
-    {
-      return;
-    }
 
-    
-    // fix legend if its a chromatogram
-    w->xAxis()->setLegend(PlotWidget::RT_AXIS_TITLE);
-
-
-    // set relative (%) view of visible area
-    w->canvas()->setIntensityMode(PlotCanvas::IM_SNAP);
-
-    tv_->showPlotWidgetInWindow(w, caption);
-    tv_->updateBarsAndMenus();
-
-    */
+    return true;
   }
 
 

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -116,7 +116,8 @@ namespace OpenMS
     {
       double width = feature->getRTRightWidth() - feature->getRTLeftWidth();
       double center = feature->getRTLeftWidth() + width / 2;
-      Annotation1DItem* item = new Annotation1DVerticalLineItem(center, width, 30);
+      String ann = String("RT: ") + String(feature->getRTExperimental(), false) + "\ndRT: " + String(feature->getRTDelta(), false) + "\nQ-Value: " + String(feature->getQValue(), false);
+      Annotation1DItem* item = new Annotation1DVerticalLineItem(center, width, 30, QColor("invalid"), ann.toQString());
       item->setSelected(false);
       w->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
     }

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -72,26 +72,14 @@ namespace OpenMS
     String layername;
 
     MiniLayer(LayerData& layer)
-    : full_chrom_exp_sptr(getFullChromData(layer)),
+    : full_chrom_exp_sptr(layer.getFullChromData()),
       ondisc_sptr(layer.getOnDiscPeakData()),
       annot_sptr(layer.getChromatogramAnnotation()),
       filename(layer.filename),
       layername(layer.getName())
     {
     }
-
-    /// get the full chromExperiment
-    /// Could be backed up in layer.getChromatogramData() (if layer.getPeakDataMuteable() shows converted chroms already; as we will do below)
-    /// ... or layer.getChromatogramData() is empty and thus layer.getPeakDataMuteable() is the original chrom data
-    static ExperimentSharedPtrType getFullChromData(LayerData& layer)
-    {
-      ExperimentSharedPtrType exp_sptr(layer.getChromatogramData().get() == nullptr ||
-                                       layer.getChromatogramData().get()->getNrChromatograms() == 0
-                                       ? layer.getPeakDataMuteable() : layer.getChromatogramData());
-      return exp_sptr;
-    }
   };
-
   
 
   TVDIATreeTabController::TVDIATreeTabController(TOPPViewBase* parent):
@@ -100,11 +88,14 @@ namespace OpenMS
   }
 
   bool addTransitionAsLayer(Plot1DWidget* w, 
-                            MiniLayer ml,
-                            const int chrom_index,
+                            const MiniLayer& ml,
+                            const int transition_id,
                             const OSWPeakGroup* feature = nullptr)
   {
-    String chrom_caption = FileHandler::stripExtension(File::basename(ml.filename)) + "[" + chrom_index + "]";
+    String chrom_caption = FileHandler::stripExtension(File::basename(ml.filename)) + "[" + transition_id + "]";
+
+    // convert from native id to chrom_index
+    int chrom_index = ml.annot_sptr->fromNativeID(transition_id);
 
     // add data and return if something went wrong
     if (!w->canvas()->addChromLayer(ml.full_chrom_exp_sptr, ml.ondisc_sptr, ml.annot_sptr, chrom_index, ml.filename, chrom_caption, false))

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -54,53 +54,6 @@ namespace OpenMS
   {  
   }
 
-  LayerData::ExperimentSharedPtrType prepareChromatogram(Size index, LayerData::ExperimentSharedPtrType exp_sptr, LayerData::ODExperimentSharedPtrType ondisc_sptr)
-  {
-    // create a managed pointer fill it with a spectrum containing the chromatographic data
-    LayerData::ExperimentSharedPtrType chrom_exp_sptr(new LayerData::ExperimentType());
-    chrom_exp_sptr->setMetaValue("is_chromatogram", "true"); //this is a hack to store that we have chromatogram data
-    LayerData::ExperimentType::SpectrumType spectrum;
-
-    // retrieve chromatogram (either from in-memory or on-disc representation)
-    MSChromatogram current_chrom;
-    current_chrom = exp_sptr->getChromatograms()[index];
-    if (current_chrom.empty() )
-    {
-      current_chrom = ondisc_sptr->getChromatogram(index);
-    }
-
-    // fill "dummy" spectrum with chromatogram data
-    for (Size i = 0; i != current_chrom.size(); ++i)
-    {
-      const ChromatogramPeak & cpeak = current_chrom[i];
-      Peak1D peak1d;
-      peak1d.setMZ(cpeak.getRT());
-      peak1d.setIntensity(cpeak.getIntensity());
-      spectrum.push_back(peak1d);
-    }
-
-    spectrum.getFloatDataArrays() = current_chrom.getFloatDataArrays();
-    spectrum.getIntegerDataArrays() = current_chrom.getIntegerDataArrays();
-    spectrum.getStringDataArrays() = current_chrom.getStringDataArrays();
-
-    // Add at least one data point to the chromatogram, otherwise
-    // "addLayer" will fail and a segfault occurs later
-    if (current_chrom.empty()) 
-    {
-      Peak1D peak1d(-1, 0);
-      spectrum.push_back(peak1d);
-    }
-
-    // store peptide_sequence if available
-    if (current_chrom.getPrecursor().metaValueExists("peptide_sequence"))
-    {
-      chrom_exp_sptr->setMetaValue("peptide_sequence", current_chrom.getPrecursor().getMetaValue("peptide_sequence"));
-    }
-
-    chrom_exp_sptr->addSpectrum(spectrum);
-    return chrom_exp_sptr;
-  }
-
   void TVSpectraViewController::showSpectrumAsNew1D(int index)
   {
     // basic behavior 1
@@ -109,19 +62,18 @@ namespace OpenMS
     LayerData::ODExperimentSharedPtrType od_exp_sptr = layer.getOnDiscPeakData();
     auto ondisc_sptr = layer.getOnDiscPeakData();
 
-    // open new 1D widget
-    Plot1DWidget * w = new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget *)tv_->getWorkspace());
+    // create new 1D widget; if we return due to error, the widget will be cleaned up automatically
+    unique_ptr<Plot1DWidget> wp(new Plot1DWidget(tv_->getSpectrumParameters(1), (QWidget*)tv_->getWorkspace()));
+    Plot1DWidget* w = wp.get();
 
     if (layer.type == LayerData::DT_CHROMATOGRAM)
     {
-      ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
-
       // fix legend and set layer name
       String caption = layer.getName() + "[" + index + "]";
       w->xAxis()->setLegend(PlotWidget::RT_AXIS_TITLE);
 
       // add chromatogram data as peak spectrum
-      if (!w->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, layer.filename, caption, exp_sptr, index, false))
+      if (!w->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, layer.filename, caption, false))
       {
         return;
       }
@@ -178,6 +130,8 @@ namespace OpenMS
     w->canvas()->setLayerName(w->canvas()->getCurrentLayerIndex(), caption);
 
     tv_->showPlotWidgetInWindow(w, caption);
+    wp.release();
+
     tv_->updateLayerBar();
     tv_->updateViewBar();
     tv_->updateFilterBar();
@@ -209,27 +163,15 @@ namespace OpenMS
     {
       if (layer.type == LayerData::DT_CHROMATOGRAM)
       {
-        ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
-
         // fix legend and set layer name
         caption += String(" [") + index + "];";
         chromatogram_caption = layer.getName() + "[" + index + "]";
 
         // add chromatogram data as peak spectrum
-        if (!w->canvas()->addLayer(chrom_exp_sptr, ondisc_sptr, layer.filename))
+        if (!w->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, layer.filename, chromatogram_caption, true))
         {
           return;
         }
-        w->canvas()->setLayerName(w->canvas()->getCurrentLayerIndex(), chromatogram_caption);
-        w->canvas()->setDrawMode(Plot1DCanvas::DM_CONNECTEDLINES);
-
-        w->canvas()->getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
-        w->canvas()->getCurrentLayer().getChromatogramAnnotation() = layer.getChromatogramAnnotation(); // copy over shared-ptr to OSW-sql data (if available)
-
-        //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
-        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");
-        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("multiple_select", "true");
-        w->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("selected_chromatogram", index);
 
         // set visible area to visible area in 2D view
         // switch X/Y because now we want to have RT on the x-axis and not m/z
@@ -283,14 +225,12 @@ namespace OpenMS
 
       widget_1d->canvas()->removeLayers();
 
-      ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
-
       // fix legend and set layer name
       String fname = layer.filename;
       String caption = fname + "[" + index + "]";
 
       // add chromatogram data as peak spectrum and update other controls
-      widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, false);
+      widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, fname, caption, false);
 
       tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)
     }
@@ -323,17 +263,15 @@ namespace OpenMS
       String fname = layer.filename;
       for (const auto& index : indices)
       {
-        ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
-
         // get caption (either chromatogram idx or peptide sequence, if available)
         String caption = fname;
-        if (chrom_exp_sptr->metaValueExists("peptide_sequence"))
+        if (exp_sptr->metaValueExists("peptide_sequence"))
         {
-          caption = String(chrom_exp_sptr->getMetaValue("peptide_sequence"));
+          caption = String(exp_sptr->getMetaValue("peptide_sequence"));
         }
         ((caption += "[") += index) += "]";
         // add chromatogram data as peak spectrum
-        widget_1d->canvas()->addChromLayer(chrom_exp_sptr, ondisc_sptr, fname, caption, exp_sptr, index, true);
+        widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, fname, caption, true);
       }
 
       tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -171,8 +171,8 @@ public:
 protected:
   void registerOptionsAndFlags_() override
   {
-    StringList in_types = { "mzData", "mzXML", "mzML", "dta", "dta2d", "mgf", "featureXML", "consensusXML", "idXML", "pepXML", "fid", "mzid", "trafoXML", "fasta", "pqp" };
-    registerInputFile_("in", "<file>", "", "input file ");
+    StringList in_types = { "mzData", "mzXML", "mzML", "sqMass", "dta", "dta2d", "mgf", "featureXML", "consensusXML", "idXML", "pepXML", "fid", "mzid", "trafoXML", "fasta", "pqp" };
+    registerInputFile_("in", "<file>", "", "input file");
     setValidFormats_("in", in_types);
     registerStringOption_("in_type", "<type>", "", "input file type -- default: determined from file extension or content", false);
     setValidStrings_("in_type", in_types);


### PR DESCRIPTION
# Description


- extend VerticalLineItem for 1D plot to show a band
- move data conversion for chomatogram to spectrum for 1D widget to a better place
- reduce redundant code (this is still not ideal)
 - show the correct menu entries when chromatogram data is present
 - enable double/single clicking of rows in DIA view
 - show the transitions with bands marking the feature-groups
 - faster sqMass reading (7%)
 - allow Annotation1DVerticalItem to be a band (and actually use its color member)
 - annotate OSW features using a band
 - fix bug (peptides get repeatedly added when browing data)
 - fix: map native IDs to chrom indices 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
