### PR TITLE
TOPPView convenience (commandline, locking) and DIA plotting

### DIFF
--- a/doc/TOPP_tutorial/TOPPView_interface.doxygen
+++ b/doc/TOPP_tutorial/TOPPView_interface.doxygen
@@ -99,12 +99,17 @@
     '+' character between the file names. The following command opens three
     files in three layers of the same window:
     @code TOPPView file1.mzML + file2.mzML + file3.mzML@endcode
-    Without the '+' the files would be opened in three different windows.
+    Without the '+' the files would be opened in three different tabs.
 
     The color gradient used to display a file can be changed by adding one of
     several '@' commands. The following command opens the file with a white-to-black
     gradient:
     @code TOPPView file1.mzML @bw@endcode
+    
+    Automatic annotation of a layer with ID data (.osw files etc) can be performed by using the '!' character.
+    This will treat the next filename as annotation to the previous layer
+    The following command opens two layers in the same tab, with the first layer being annotated:
+    @code TOPPView file1.mzML ! file1.idXML + file2.mzML@endcode
 
     For more information on command line parameters call:
     @code TOPPView --help@endcode

--- a/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/OSWData.h
@@ -387,7 +387,7 @@ namespace OpenMS
         void buildNativeIDResolver(const MSExperiment& chrom_traces);
 
         /// resolve a transition.id (=nativeID) to a simple chromatogram index (.getChromatograms[index]) of the corresponding sqMass file
-///     /// Requires prior call to buildNativeIDResolver(), throws Exception::InvalidValue otherwise (or when nativeID is not known)
+        /// Requires prior call to buildNativeIDResolver(), throws Exception::InvalidValue otherwise (or when nativeID is not known)
         UInt fromNativeID(int transition_id) const;
 
       protected:

--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
@@ -79,11 +79,20 @@ namespace OpenMS
     /// Sets the uppermost position of the line
     void setPosition(const double& x);
     /// Returns the position
-    const double & getPosition() const;
+    const double& getPosition() const;
+
+    /// size of the painted text (width and height of the rectangle)
+    QRectF getTextRect() const;
+
+    /// offset the text by this much downwards (to avoid overlaps etc)
+    void setTextYOffset(int y_offset);
 
   protected:
     /// The position of the vertical line
     double x_ = -1;
+    /// offset in y for the text (to avoid overlaps)
+    int y_text_offset_{0};
+
     /// width of the item (allowing to show a 'band')
     float width_ = 0;
     /// transparency 0...255 of the band (only used when width_ > 0)

--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
@@ -49,7 +49,7 @@ namespace OpenMS
   {
   public:
     /**
-      Constructor for a single vertical line.
+      Constructor for a single vertical line of 1px width.
 
       @param pos X-coordinate as show on the axis
       @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
@@ -57,16 +57,16 @@ namespace OpenMS
     **/ 
     Annotation1DVerticalLineItem(const double x_pos, const QColor& color = QColor("as_before"), const QString& text = "");
     /**
-      Constructor for a single vertical band, with a slightly transparent middle, flanked by two solid vertical lines.
+      Constructor for a single vertical line of 1px width or a broader line (band) with the given width
 
       @param pos X-coordinate of the center as show on the axis
-      @param width Full width of the band
-      @param fill_alpha255 A transparency value from 0 (no visible band), to 255 (fully opaque band)
-      @param dashed_line Should the line (or the two lines of the band) be dashed?
+      @param width Full width of the band; use 0 or 1 for a 1px line.
+      @param alpha255 A transparency value from 0 (not visible), to 255 (fully opaque)
+      @param dashed_line Should the line/band be dashed
       @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
-      @param text Optional text displayed next to the line. Can contain '\n' which will force multiple lines.
+      @param text Optional text displayed next to the line/band. Can contain '\n' which will force multiple lines. Text will be plotted at the very top (modify using setTextYOffset())
     **/
-    Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255 = 128, const bool dashed_line = false, const QColor& color = QColor("as_before"), const QString& text = "");
+    Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int alpha255 = 128, const bool dashed_line = false, const QColor& color = QColor("as_before"), const QString& text = "");
     /// Copy constructor
     Annotation1DVerticalLineItem(const Annotation1DVerticalLineItem& rhs) = default;
     /// Destructor
@@ -85,7 +85,7 @@ namespace OpenMS
     /// size of the painted text (width and height of the rectangle)
     QRectF getTextRect() const;
 
-    /// offset the text by this much downwards (to avoid overlaps etc)
+    /// offset the text by this much downwards in y-direction (to avoid overlaps etc)
     void setTextYOffset(int y_offset);
 
   protected:
@@ -94,11 +94,11 @@ namespace OpenMS
     /// offset in y for the text (to avoid overlaps)
     int y_text_offset_{0};
 
-    /// width of the item (allowing to show a 'band')
-    float width_ = 0;
-    /// transparency 0...255 of the band (only used when width_ > 0)
-    float fill_alpha255_ = 128;
-    /// is the line dashed?
+    /// width of the item (allowing to show a 'band' if > 1)
+    float width_ = 1;
+    /// transparency 0...255 of the band/line
+    float alpha255_ = 128;
+    /// is the band/line dashed?
     bool dashed_{false};
 
     /// The color of the line; if invalid, the current painter color will be used

--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h
@@ -62,10 +62,11 @@ namespace OpenMS
       @param pos X-coordinate of the center as show on the axis
       @param width Full width of the band
       @param fill_alpha255 A transparency value from 0 (no visible band), to 255 (fully opaque band)
+      @param dashed_line Should the line (or the two lines of the band) be dashed?
       @param color Optional color. If invalid (=default), the current painter color will be used when this is painted
       @param text Optional text displayed next to the line. Can contain '\n' which will force multiple lines.
     **/
-    Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255 = 128, const QColor& color = QColor("as_before"), const QString& text = "");
+    Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255 = 128, const bool dashed_line = false, const QColor& color = QColor("as_before"), const QString& text = "");
     /// Copy constructor
     Annotation1DVerticalLineItem(const Annotation1DVerticalLineItem& rhs) = default;
     /// Destructor
@@ -97,6 +98,8 @@ namespace OpenMS
     float width_ = 0;
     /// transparency 0...255 of the band (only used when width_ > 0)
     float fill_alpha255_ = 128;
+    /// is the line dashed?
+    bool dashed_{false};
 
     /// The color of the line; if invalid, the current painter color will be used
     QColor color_ = Qt::black;

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -156,6 +156,16 @@ public:
     ///Destructor
     ~TOPPViewBase() override;
 
+
+    enum class LOAD_RESULT
+    {
+      OK,
+      FILE_NOT_FOUND,       ///< file did not exist
+      FILETYPE_UNKNOWN,     ///< file exists, but type could no be determined                                                
+      FILETYPE_UNSUPPORTED, ///< filetype is known, but the format not supported as layer data
+      LOAD_ERROR            ///< an error occured while loading the file
+    };
+
     /**
       @brief Opens and displays data from a file
 
@@ -168,7 +178,7 @@ public:
       @param window_id in which window the file is opened if opened as a new layer (0 or default equals current window).
       @param spectrum_id determines the spectrum to show in 1D view.
     */
-    void addDataFile(const String& filename, bool show_options, bool add_to_recent, String caption = "", UInt window_id = 0, Size spectrum_id = 0);
+    LOAD_RESULT addDataFile(const String& filename, bool show_options, bool add_to_recent, String caption = "", UInt window_id = 0, Size spectrum_id = 0);
 
     /**
       @brief Adds a peak or feature map to the viewer
@@ -218,6 +228,9 @@ public:
 
     /// Returns the active Layer data (0 if no layer is active)
     const LayerData* getCurrentLayer() const;
+
+    /// Returns the active Layer data (0 if no layer is active)
+    LayerData* getCurrentLayer();
 
     //@name Accessors for the main gui components.
     //@brief The top level enhanced workspace and the EnhancedTabWidgets resing in the EnhancedTabBar.

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/SwathTabWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/SwathTabWidget.h
@@ -40,6 +40,7 @@
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/VISUAL/MISC/ExternalProcessMBox.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
 
 #include <QTabWidget>
 
@@ -65,16 +66,16 @@ namespace OpenMS
     /**
       @brief RAII class to switch to certain TabWidget, disable the GUI and go back to the orignal Tab when this class is destroyed
     */
-    class GUILock
+    class SwathGUILock
     {
       public:
-      GUILock(SwathTabWidget* stw);
+        SwathGUILock(SwathTabWidget* stw);
 
-      ~GUILock();
+      ~SwathGUILock();
       private:
         SwathTabWidget* stw_;
         QWidget* old_;
-        bool was_enabled_;
+        GUIHelpers::GUILock glock_;
     };
 
     /// A multi-tabbed widget for the SwathWizard offering setting of parameters, input-file specification and running Swath and more
@@ -83,7 +84,7 @@ namespace OpenMS
       Q_OBJECT
 
     public:
-      friend class GUILock;
+      friend class SwathGUILock;
 
       explicit SwathTabWidget(QWidget *parent = nullptr);
       ~SwathTabWidget();

--- a/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIATreeTab.h
@@ -36,7 +36,7 @@
 
 #include <QtWidgets>
 
-
+#include <OpenMS/VISUAL/DataSelectionTabs.h>
 #include <OpenMS/VISUAL/LayerData.h>
 
 class QLineEdit;
@@ -54,8 +54,8 @@ namespace OpenMS
 
     @ingroup PlotWidgets
   */
-  class DIATreeTab :
-    public QWidget
+  class OPENMS_GUI_DLLAPI DIATreeTab :
+    public QWidget, public DataTabBase
   {
     Q_OBJECT
   public:
@@ -64,9 +64,12 @@ namespace OpenMS
     /// Destructor
     ~DIATreeTab() = default;
 
+    // docu in base class
+    bool hasData(const LayerData* layer) override;
+
     /// refresh the table using data from @p cl
     /// @param cl Layer with OSW data; cannot be const, since we might read missing protein data from source on demand
-    void updateEntries(LayerData& cl);
+    void updateEntries(LayerData* cl) override;
     /// remove all visible data
     void clear();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
@@ -44,12 +44,29 @@
 namespace OpenMS
 {
   class DIATreeTab;
+  class LayerData;
   class SpectraTreeTab;
   class SpectraIDViewTab;
   class TVDIATreeTabController;
   class TVIdentificationViewController;
   class TVSpectraViewController;
   class TOPPViewBase;
+
+  /// all tabs need to implement this interface
+  class OPENMS_GUI_DLLAPI DataTabBase
+  {
+  public:
+    /// given a layer, determine if the tab could use it to show data (useful to decide if the tab should be enabled/disabled)
+    /// If a nullptr is given, it HAS to return false!
+    virtual bool hasData(const LayerData* layer) = 0;
+
+    /// populate the tab using date from @p layer
+    /// Should handle nullptr well (by calling clear())
+    virtual void updateEntries(LayerData* layer) = 0;
+
+    /// explicitly show no data at all
+    virtual void clear() = 0;
+  };
 
   /**
     @brief A tabbed view, to browse lists of spectra or identifications
@@ -66,13 +83,16 @@ namespace OpenMS
       SPECTRA_IDX = 0,  ///< first tab
       IDENT_IDX = 1,    ///< second tab
       DIAOSW_IDX = 2,   ///< third tab
-      AUTO_IDX          ///< automatically decide which tab to show (i.e. prefer IDENT_IDX if it has data)
+      SIZE_OF_TAB_INDEX    
     };
 
     /// Default constructor
     DataSelectionTabs(QWidget* parent, TOPPViewBase* tv);
 
-    /// update items in the two tabs according to the currently selected layer
+    /// Update items in the tabs according to the currently selected layer.
+    /// Tabs which have data to show are automatically enabled. Others are disabled.
+    /// If the currently visible tab would have to data to show, we pick the highest (rightmost) tab
+    /// which has data and show that instead
     void update();
 
     /// invoked when user changes the active tab to @p tab_index
@@ -88,9 +108,6 @@ namespace OpenMS
     /// --> enables it and creates an empty identification structure
     void tabBarDoubleClicked(int tab_index);
 
-    /// enable and show the @p which tab
-    void show(TAB_INDEX which);
-
     SpectraIDViewTab* getSpectraIDViewTab();
   signals:
 
@@ -101,6 +118,7 @@ namespace OpenMS
     SpectraIDViewTab* id_view_widget_;
     DIATreeTab* dia_widget_;
     //@}
+    std::vector< DataTabBase* > tab_ptrs_; ///< holds pointers to all of the above tabs, for iteration purposes
 
     /// TOPPView behavior for the spectra view
     TVSpectraViewController* spectraview_controller_;

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -56,6 +56,8 @@
 #include <vector>
 #include <bitset>
 
+class QWidget;
+
 namespace OpenMS
 {
 
@@ -520,8 +522,9 @@ private:
         
         @param supported_types Which identification data types are allowed to be opened by the user in annotate()
         @param file_dialog_text The header text of the file dialog shown to the user
+        @param gui_lock Optional GUI element which will be locked (disabled) during call to 'annotateWorker_'; can be null_ptr
       **/
-      LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text);
+      LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock);
       
       /// Annotates a @p layer, writing messages to @p log and showing QMessageBoxes on errors.
       /// The input file is selected via a file-dialog which is opened with @p current_path as initial path.
@@ -536,6 +539,7 @@ private:
       
       const FileTypes::FileTypeList supported_types_;
       const String file_dialog_text_;
+      QWidget* gui_lock_ = nullptr; ///< optional widget which will be locked when calling annotateWorker_() in child-classes
   };
 
   /// Annotate a layer with PeptideIdentifications using Layer::annotate(pepIDs, protIDs).
@@ -544,9 +548,9 @@ private:
     : public LayerAnnotatorBase
   {
     public:
-      LayerAnnotatorPeptideID()
+      LayerAnnotatorPeptideID(QWidget* gui_lock)
        : LayerAnnotatorBase(std::vector<FileTypes::Type>{ FileTypes::IDXML, FileTypes::MZIDENTML },
-                            "Select peptide identification data")
+                            "Select peptide identification data", gui_lock)
       {}
 
   protected:
@@ -561,9 +565,9 @@ private:
     : public LayerAnnotatorBase
   {
   public:
-    LayerAnnotatorAMS()
+    LayerAnnotatorAMS(QWidget* gui_lock)
       : LayerAnnotatorBase(std::vector<FileTypes::Type>{ FileTypes::FEATUREXML },
-                           "Select AccurateMassSearch's featureXML file")
+                           "Select AccurateMassSearch's featureXML file", gui_lock)
     {}
 
   protected:
@@ -578,9 +582,9 @@ private:
     : public LayerAnnotatorBase
   {
   public:
-    LayerAnnotatorOSW()
+    LayerAnnotatorOSW(QWidget* gui_lock)
       : LayerAnnotatorBase(std::vector<FileTypes::Type>{ FileTypes::OSW },
-                           "Select OpenSwath/pyProphet output file")
+                           "Select OpenSwath/pyProphet output file", gui_lock)
     {}
 
   protected:

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -514,6 +514,7 @@ private:
   };
 
   /// A base class to annotate layers of specific types with (identification) data
+  /// @hint Add new derived classes to getAnnotatorWhichSupports() to enable automatic annotation in TOPPView 
   class LayerAnnotatorBase
   {
     public:
@@ -530,7 +531,20 @@ private:
       /// The input file is selected via a file-dialog which is opened with @p current_path as initial path.
       /// The filetype is checked to be one of the supported_types_ before the annotateWorker_ function is called
       /// as implemented by the derived classes
-      bool annotate(LayerData& layer, LogWindow& log, const String& current_path) const;
+      bool annotateWithFileDialog(LayerData& layer, LogWindow& log, const String& current_path) const;
+
+      /// Annotates a @p layer, given a filename from which to load the data.
+      /// The filetype is checked to be one of the supported_types_ before the annotateWorker_ function is called
+      /// as implemented by the derived classes
+      bool annotateWithFilename(LayerData& layer, LogWindow& log, const String& filename) const;
+
+      /// get a derived annotator class, which supports annotation of the given filetype.
+      /// If multiple class support this type (currently not the case) an Exception::IllegalSelfOperation will be thrown
+      /// If NO class supports this type, the unique_ptr points to nothing (.get() == nullptr).
+      static std::unique_ptr<LayerAnnotatorBase> getAnnotatorWhichSupports(const FileTypes::Type& type);
+
+      /// see getAnnotatorWhichSupports(const FileTypes::Type& type). Filetype is queried from filename
+      static std::unique_ptr<LayerAnnotatorBase> getAnnotatorWhichSupports(const String& filename);
 
     protected:
       /// abstract virtual worker function to annotate a layer using content from the @p filename

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -47,6 +47,8 @@ class QPoint;
 #include <QCursor>
 #include <QFont>
 
+#include <array>
+
 namespace OpenMS
 {
   /**
@@ -139,6 +141,59 @@ namespace OpenMS
       bool currently_locked_{ false };
       bool was_enabled_{ true };
     };
-  };
 
+    /// color palette for certain purposes
+    /// Currently, only a set of distinct colors is supported
+    class ColorBrewer
+    {
+    public:
+      struct Distinct
+      {
+        enum NAMES
+        {
+          Red,
+          Blue,
+          Green,
+          Brown,
+          Purple,
+          LightGrey,
+          LightGreen,
+          LightBlue,
+          Cyan,
+          Orange,
+          Yellow,
+          Tan,
+          Pink,
+          DarkGrey,
+          SIZE_OF_NAMES
+        };
+
+        const std::array<QColor, NAMES::SIZE_OF_NAMES> values = { Qt::red,
+                                                                  Qt::blue,
+                                                                  Qt::green,
+                                                                  QColor(129, 74, 25) /*brown*/,
+                                                                  QColor(129, 38, 192) /*purple*/,
+                                                                  Qt::lightGray,
+                                                                  QColor(129,197,122) /*lightGreen*/,
+                                                                  QColor(157,175,255) /*lightBlue*/,
+                                                                  Qt::cyan,
+                                                                  QColor(255,146,51) /*orange*/,
+                                                                  Qt::yellow,
+                                                                  QColor(233,222,187) /*tan*/,
+                                                                  QColor(255,205,243) /*pink*/,
+                                                                  Qt::darkGray };
+      };
+
+      /// get a certain color. If @p index is larger than the maximum color, modulo operator will applied (cycling through colors)
+      template<class COLOR_CLASS>
+      static QColor getColor(uint32_t index)
+      {
+        // cycle if neccessary
+        if (index >= COLOR_CLASS::NAMES::SIZE_OF_NAMES) index = index % COLOR_CLASS::NAMES::SIZE_OF_NAMES;
+        return COLOR_CLASS().values[index];
+      }
+
+    }; // ColorBrewer
+
+  }; // GUIHelpers
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -68,6 +68,9 @@ namespace OpenMS
 
     /**
        @brief draw a multi-line text at coordinates XY using a specific font and color
+
+       Internally used getTextDimension() to figure out the size of the text-block/background which needs to be painted.
+
        @param painter Where to draw
        @param text Each item is a new line
        @param where Coordinates where to start drawing (upper left corner of text)
@@ -75,8 +78,14 @@ namespace OpenMS
        @param col_bg Optional background color of bounding rectangle; if invalid (=default) no background will be painted
        @param Optional font; will use Courier by default
     */
-    void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"), QFont f = QFont("Courier"));
+    void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"), const QFont& f = QFont("Courier"));
 
+
+    /**
+      @brief Obtains the bounding rectangle of a text (useful to determine overlaps etc)
+    
+    */
+    QRectF getTextDimension(const QStringList& text, const QFont& font, int& line_spacing);
 
     /**
       @brief RAII class to disable the GUI and set a busy cursor and go back to the orignal state when this class is destroyed

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -87,6 +87,30 @@ namespace OpenMS
     */
     QRectF getTextDimension(const QStringList& text, const QFont& font, int& line_spacing);
 
+
+    /**
+      @brief Given a set of levels (rows), try to add items at to topmost row which does not overlap an already placed item in this row (according to its x-coordinate)
+
+      If a collision occurs, try the row below.
+      If no row is collision-free, pick the one with the smallest overlap.
+
+      X coordinates should always be positive.
+    */
+    class OverlapDetector
+    {
+    public:
+      
+      /// C'tor: number of @p levels must be >=1
+      explicit OverlapDetector(int levels);
+
+      /// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
+      /// @return the smallest row index (starting at 0) which has none (or the least) overlap
+      int placeItem(double x_start, double x_end);
+
+    private:
+      std::vector<double> rows_;
+    };
+
     /**
       @brief RAII class to disable the GUI and set a busy cursor and go back to the orignal state when this class is destroyed
     */

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -37,12 +37,14 @@
 // OpenMS_GUI config
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
-class QString; // declare this OUTSIDE of namespace OpenMS!
+// declare Qt classes OUTSIDE of namespace OpenMS!
+class QString; 
 class QStringList;
 class QPainter;
 class QPoint;
 
 #include <QColor>
+#include <QCursor>
 #include <QFont>
 
 namespace OpenMS
@@ -75,6 +77,34 @@ namespace OpenMS
     */
     void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"), QFont f = QFont("Courier"));
 
+
+    /**
+      @brief RAII class to disable the GUI and set a busy cursor and go back to the orignal state when this class is destroyed
+    */
+    class GUILock
+    {
+    public:
+      /// C'tor receives the widget to lock
+      GUILock(QWidget* gui);
+
+      /// no copy/assignment allowed
+      GUILock(const GUILock& rhs) = delete;
+      GUILock(GUILock&& rhs) = delete;
+      GUILock& operator=(const GUILock& rhs) = delete;
+
+      /// D'tor: unlocks the GUI (does nothing if already unlocked)
+      ~GUILock();
+      
+      /// manually lock the GUI (does nothing if already locked)
+      void lock();
+      /// manually unlock the GUI (does nothing if already unlocked)
+      void unlock();
+
+    private:
+      QWidget* locked_widget_{ nullptr };
+      bool currently_locked_{ false };
+      bool was_enabled_{ true };
+    };
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -106,7 +106,7 @@ namespace OpenMS
 
       /// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
       /// @return the smallest row index (starting at 0) which has none (or the least) overlap
-      int placeItem(double x_start, double x_end);
+      size_t placeItem(double x_start, double x_end);
 
     private:
       std::vector<double> rows_;

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -167,20 +167,20 @@ namespace OpenMS
           SIZE_OF_NAMES
         };
 
-        const std::array<QColor, NAMES::SIZE_OF_NAMES> values = { Qt::red,
-                                                                  Qt::blue,
-                                                                  Qt::green,
-                                                                  QColor(129, 74, 25) /*brown*/,
-                                                                  QColor(129, 38, 192) /*purple*/,
-                                                                  Qt::lightGray,
-                                                                  QColor(129,197,122) /*lightGreen*/,
-                                                                  QColor(157,175,255) /*lightBlue*/,
-                                                                  Qt::cyan,
-                                                                  QColor(255,146,51) /*orange*/,
-                                                                  Qt::yellow,
-                                                                  QColor(233,222,187) /*tan*/,
-                                                                  QColor(255,205,243) /*pink*/,
-                                                                  Qt::darkGray };
+        const std::array<QColor, NAMES::SIZE_OF_NAMES> values = { { Qt::red,
+                                                                    Qt::blue,
+                                                                    Qt::green,
+                                                                    QColor(129, 74, 25) /*brown*/,
+                                                                    QColor(129, 38, 192) /*purple*/,
+                                                                    Qt::lightGray,
+                                                                    QColor(129,197,122) /*lightGreen*/,
+                                                                    QColor(157,175,255) /*lightBlue*/,
+                                                                    Qt::cyan,
+                                                                    QColor(255,146,51) /*orange*/,
+                                                                    Qt::yellow,
+                                                                    QColor(233,222,187) /*tan*/,
+                                                                    QColor(255,205,243) /*pink*/,
+                                                                    Qt::darkGray } };
       };
 
       /// get a certain color. If @p index is larger than the maximum color, modulo operator will applied (cycling through colors)

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -85,6 +85,7 @@ namespace OpenMS
     {
     public:
       /// C'tor receives the widget to lock
+      /// @param gui QWidget to lock(including all children); can be nullptr (nothing will be locked)
       GUILock(QWidget* gui);
 
       /// no copy/assignment allowed

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -101,7 +101,6 @@ namespace OpenMS
     class OverlapDetector
     {
     public:
-      
       /// C'tor: number of @p levels must be >=1
       explicit OverlapDetector(int levels);
 
@@ -192,7 +191,6 @@ namespace OpenMS
         if (index >= COLOR_CLASS::NAMES::SIZE_OF_NAMES) index = index % COLOR_CLASS::NAMES::SIZE_OF_NAMES;
         return COLOR_CLASS().values[index];
       }
-
     }; // ColorBrewer
 
   }; // GUIHelpers

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -602,6 +602,31 @@ public slots:
     ///Updates layer @p i when the data in the corresponding file changes
     virtual void updateLayer(Size i) = 0;
 
+
+    /**
+       @brief converts a distance in axis values to pixel values 
+    */
+    inline void dataToWidgetDistance(double x, double y, QPoint& point)
+    {
+      dataToWidget_(x, y, point);
+      // substract the 'offset'
+      QPoint zero;
+      dataToWidget_(0, 0, zero);
+      point -= zero;
+    }
+
+    /**
+      @brief compute distance in widget coordinates (unit axis as shown) when moving @p x/y px in chart coordinates
+    */
+    inline PointType widgetToDataDistance(double x, double y)
+    {
+      PointType point = widgetToData_(x, y);
+      // substract the 'offset'
+      PointType zero = widgetToData_(0, 0);
+      point -= zero;
+      return point;
+    }
+
 signals:
 
     /// Signal emitted whenever the modification status of a layer changes (editing and storing)

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraIDViewTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraIDViewTab.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <OpenMS/VISUAL/DataSelectionTabs.h>
 #include <OpenMS/VISUAL/LayerData.h>
 #include <OpenMS/VISUAL/TableView.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
@@ -51,9 +52,10 @@ namespace OpenMS
 
     @htmlinclude OpenMS_DigestSimulation.parameters
   */
-  class SpectraIDViewTab :
+  class OPENMS_GUI_DLLAPI SpectraIDViewTab :
     public QWidget,
-    public DefaultParamHandler
+    public DefaultParamHandler,
+    public DataTabBase
   {
     Q_OBJECT
   public:
@@ -62,20 +64,23 @@ namespace OpenMS
     /// Destructor
     ~SpectraIDViewTab() override = default;
 
-    /// set layer data and create table anew
-    void setLayer(LayerData* model);
+    // docu in base class
+    bool hasData(const LayerData* layer) override;
+
+    /// set layer data and create table anew; if given a nullptr, behaves as clear()
+    void updateEntries(LayerData* model) override;
     /// get layer data
     LayerData* getLayer();
 
-    /// clears all visible data from table widget and void the layer
-    void clear();
+    /// clears all visible data from table widget and voids the layer
+    void clear() override;
 
     /// Helper member to block outgoing signals
     bool ignore_update = false; 
   
   protected slots:
     /// Rebuild table entries
-    void updateEntries();
+    void updateEntries_();
   signals:
     /// request to show a specific spectrum, and (if available) a specific pepId + pepHit in there (otherwise -1, -1)
     void spectrumSelected(int spectrum_index, int pep_id_index, int pep_hit_index);

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraTreeTab.h
@@ -37,6 +37,7 @@
 #include <QtWidgets>
 
 
+#include <OpenMS/VISUAL/DataSelectionTabs.h>
 #include <OpenMS/VISUAL/LayerData.h>
 
 class QLineEdit;
@@ -52,8 +53,9 @@ namespace OpenMS
 
     @ingroup PlotWidgets
   */
-  class SpectraTreeTab :
-    public QWidget
+  class OPENMS_GUI_DLLAPI SpectraTreeTab :
+    public QWidget,
+    public DataTabBase
   {
     Q_OBJECT
 public:
@@ -62,10 +64,13 @@ public:
     /// Destructor
     ~SpectraTreeTab() = default;
 
+    // docu in base class
+    bool hasData(const LayerData* layer);
+
     /// refresh the table using data from @p cl
-    void updateEntries(const LayerData & cl);
+    void updateEntries(LayerData* cl) override;
     /// remove all visible data
-    void clear();
+    void clear() override;
 
     /// Return a copy of the currently selected spectrum/chrom (for drag'n'drop to new window)
     /// and store it either as Spectrum or Chromatogram in @p exp (all other data is cleared)

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
@@ -44,6 +44,8 @@ using namespace std;
 namespace OpenMS
 {
 
+  QFont default_text_font = QFont("Courier");
+
   Annotation1DVerticalLineItem::Annotation1DVerticalLineItem(const double x_pos, const QColor& color, const QString& text) :
       Annotation1DItem(text),
       x_(x_pos),
@@ -107,8 +109,7 @@ namespace OpenMS
     // 5 pixel to x() was added to give some space between the line and the text
     if (!text_.isEmpty())
     {
-      // randomize the y-coordinate to avoid overlaps
-      GUIHelpers::drawText(painter, text_.split('\n'), { end_p_right.x() + 5, 20 }, Qt::black);
+      GUIHelpers::drawText(painter, text_.split('\n'), { start_p_left.x() + 5, 20 + y_text_offset_ }, Qt::black, "invalid", default_text_font);
     }
 
     if (color_.isValid())
@@ -130,6 +131,17 @@ namespace OpenMS
   const double & Annotation1DVerticalLineItem::getPosition() const
   {
     return x_;
+  }
+
+  QRectF Annotation1DVerticalLineItem::getTextRect() const
+  {
+    int dummy;
+    return GUIHelpers::getTextDimension(getText().split('\n'), default_text_font, dummy);
+  }
+
+  void Annotation1DVerticalLineItem::setTextYOffset(int y_offset)
+  {
+    y_text_offset_ = y_offset;
   }
 
   void Annotation1DVerticalLineItem::ensureWithinDataRange(Plot1DCanvas* const)

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.cpp
@@ -53,69 +53,62 @@ namespace OpenMS
   {
   }
 
-  Annotation1DVerticalLineItem::Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255, const QColor& color, const QString& text) :
+  Annotation1DVerticalLineItem::Annotation1DVerticalLineItem(const double x_center_pos, const double width, const int fill_alpha255, const bool dashed_line, const QColor& color, const QString& text) :
     Annotation1DItem(text),
     x_(x_center_pos),
     width_(width),
     fill_alpha255_(fill_alpha255),
+    dashed_(dashed_line),
     color_(color)
   {
   }
 
   void Annotation1DVerticalLineItem::draw(Plot1DCanvas* const canvas, QPainter& painter, bool flipped)
   {
+    painter.save();
+    auto pen = painter.pen();
+
+    QColor col = pen.color();
     if (color_.isValid())
     {
-      painter.save();
-      auto pen = painter.pen();
-      pen.setColor(color_);
-      painter.setPen(pen);
+      col = color_;
+    }
+    col.setAlpha(fill_alpha255_);
+    pen.setColor(col);
+    if (dashed_)
+    {
+      pen.setDashPattern({ 5, 5, 1, 5 });
     }
 
-    //translate mz/intensity to pixel coordinates
-    QPoint start_p_left, start_p_right, end_p_left, end_p_right;
-    if (width_ == 0)
-    { // draw a single stick
-      canvas->dataToWidget(x_, 0, start_p_left, flipped, true);
-      canvas->dataToWidget(x_, canvas->getDataRange().maxY(), end_p_right, flipped, true);
-      painter.drawLine(start_p_left, end_p_right);
+    // translate mz/intensity to pixel coordinates
+    float width_px = 0;
+    if (width_ != 0)
+    { // prepare to draw a band
+      QPoint left, right;
+      canvas->dataToWidget(x_ - width_ / 2, 0, left, flipped, true);
+      canvas->dataToWidget(x_ + width_ / 2, 0, right, flipped, true);
+      width_px = right.x() - left.x();
+      pen.setWidth(width_px);
     }
-    else
-    { // draw a band
-      canvas->dataToWidget(x_ - width_ / 2, 0, start_p_left, flipped, true);
-      canvas->dataToWidget(x_ - width_ / 2, canvas->getDataRange().maxY(), end_p_left, flipped, true);
-      canvas->dataToWidget(x_ + width_ / 2, 0, start_p_right, flipped, true);
-      canvas->dataToWidget(x_ + width_ / 2, canvas->getDataRange().maxY(), end_p_right, flipped, true);
-      
-      QPainterPath path;
-      auto w = start_p_right.x() - start_p_left.x();
-      auto h = end_p_left.y() - start_p_left.y();
-      path.addRect(start_p_left.x(), start_p_left.y(), w, h);
-      auto color = painter.pen().color();
-      color.setAlpha(fill_alpha255_);
-      painter.fillPath(path, color);
-      painter.drawPath(path);
-
-      painter.drawLine(start_p_left, end_p_left);
-      painter.drawLine(start_p_right, end_p_right);
-    }
+    painter.setPen(pen);
+    QPoint start_low, end_high;
+    canvas->dataToWidget(x_, 0, start_low, flipped, true);
+    canvas->dataToWidget(x_, canvas->getDataRange().maxY(), end_high, flipped, true);
+    painter.drawLine(start_low, end_high);
 
     // compute bounding box on the specified painter
     // TODO: implement proper bounding box calculation
     // currently not needed as we don't support selection or moving
-    bounding_box_ = QRectF(QPointF(start_p_left), QPointF(end_p_right));
+    bounding_box_ = QRectF(QPointF(start_low), QPointF(end_high));
 
     // TODO: draw according to proper bounding box to support switching axis and flipping
     // 5 pixel to x() was added to give some space between the line and the text
     if (!text_.isEmpty())
     {
-      GUIHelpers::drawText(painter, text_.split('\n'), { start_p_left.x() + 5, 20 + y_text_offset_ }, Qt::black, "invalid", default_text_font);
+      GUIHelpers::drawText(painter, text_.split('\n'), { start_low.x() + 5 - (int)width_px / 2, 20 + y_text_offset_ }, Qt::black, "invalid", default_text_font);
     }
 
-    if (color_.isValid())
-    {
-      painter.restore();
-    }
+    painter.restore();
   }
 
   void Annotation1DVerticalLineItem::move(const PointType& delta)

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1895,7 +1895,7 @@ namespace OpenMS
   void TOPPViewBase::annotateWithAMS()
   { // this should only be callable if current layer's type is of type DT_PEAK
     LayerData& layer = getActiveCanvas()->getCurrentLayer();
-    LayerAnnotatorAMS annotator;
+    LayerAnnotatorAMS annotator(this);
     assert(log_ != nullptr);
     if (!annotator.annotate(layer, *log_, current_path_))
     {
@@ -1907,7 +1907,7 @@ namespace OpenMS
   void TOPPViewBase::annotateWithID()
   { // this should only be callable if current layer's type is one of DT_PEAK, DT_FEATURE, DT_CONSENSUS
     LayerData& layer = getActiveCanvas()->getCurrentLayer();
-    LayerAnnotatorPeptideID annotator;
+    LayerAnnotatorPeptideID annotator(this);
     assert(log_ != nullptr);
     if (!annotator.annotate(layer, *log_, current_path_))
     {
@@ -1919,7 +1919,7 @@ namespace OpenMS
   void TOPPViewBase::annotateWithOSW()
   { // this should only be callable if current layer's type is of type DT_CHROMATOGRAM
     LayerData& layer = getActiveCanvas()->getCurrentLayer();
-    LayerAnnotatorOSW annotator;
+    LayerAnnotatorOSW annotator(this);
     assert(log_ != nullptr);
     if (!annotator.annotate(layer, *log_, current_path_))
     {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -522,9 +522,6 @@ namespace OpenMS
 
   void TOPPViewBase::addDataFile(const String& filename, bool show_options, bool add_to_recent, String caption, UInt window_id, Size spectrum_id)
   {
-    setCursor(Qt::WaitCursor);
-    RAIICleanup cl([&]() { setCursor(Qt::ArrowCursor); }); // revert to ArrowCursor on exit
-
     String abs_filename = File::absolutePath(filename);
 
     // check if the file exists
@@ -566,6 +563,9 @@ namespace OpenMS
     LayerData::DataType data_type;
 
     ODExperimentSharedPtrType on_disc_peaks(new OnDiscMSExperiment);
+
+    // lock the GUI - no interaction possible when loading...
+    GUIHelpers::GUILock glock(this);
 
     bool cache_ms2_on_disc = ((String)param_.getValue("preferences:use_cached_ms2") == "true");
     bool cache_ms1_on_disc = ((String)param_.getValue("preferences:use_cached_ms1") == "true");
@@ -732,6 +732,8 @@ namespace OpenMS
     {
       abs_filename = "";
     }
+
+    glock.unlock();
 
     addData(feature_map_sptr, 
       consensus_map_sptr, 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1913,7 +1913,6 @@ namespace OpenMS
     {
       return;
     }
-    selection_view_->show(DataSelectionTabs::IDENT_IDX);
   }
 
   void TOPPViewBase::annotateWithID()
@@ -1925,7 +1924,6 @@ namespace OpenMS
     {
       return;
     }
-    selection_view_->show(DataSelectionTabs::IDENT_IDX);
   }
 
   void TOPPViewBase::annotateWithOSW()
@@ -1937,7 +1935,6 @@ namespace OpenMS
     {
       return;
     }
-    selection_view_->show(DataSelectionTabs::DIAOSW_IDX);
   }
 
   void TOPPViewBase::showSpectrumGenerationDialog()
@@ -2439,11 +2436,7 @@ namespace OpenMS
           }
           else
           { // we have an annotator ...
-            if (annotator->annotateWithFilename(*l, *log_, *it))
-            { // enable ID tabs (we don't know which one because the annotator cannot know ... so do both for now)
-              selection_view_->show(DataSelectionTabs::IDENT_IDX);
-              selection_view_->show(DataSelectionTabs::DIAOSW_IDX);
-            }
+            annotator->annotateWithFilename(*l, *log_, *it); // ID tabs are automatically enabled
           }
         }
       }        

--- a/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
@@ -59,20 +59,19 @@ namespace OpenMS
   namespace Internal
   {
 
-    GUILock::GUILock(SwathTabWidget* stw)
+    SwathGUILock::SwathGUILock(SwathTabWidget* stw)
       : 
       stw_(stw),
       old_(stw->currentWidget()),
-      was_enabled_(stw->isEnabled())
+      glock_(stw)
     {
       stw->setCurrentWidget(stw->ui->tab_log);
-      stw->setEnabled(false);
+      
     }
 
-    GUILock::~GUILock()
+    SwathGUILock::~SwathGUILock()
     {
       stw_->setCurrentWidget(old_);
-      stw_->setEnabled(was_enabled_);
     }
 
     String getOSWExe()
@@ -174,7 +173,7 @@ namespace OpenMS
     {
       if (!checkOSWInputReady_()) return;
       
-      GUILock lock(this); // forbid user interaction
+      SwathGUILock lock(this); // forbid user interaction
 
       updateSwathParamFromWidgets_();
       Param tmp_param;
@@ -449,7 +448,7 @@ namespace OpenMS
         QMessageBox::warning(this, "Error", "Could not find all requirements for 'pyprophet & tric' (see 'Config' tab). Install modules via 'pip install <modulename>' and make sure it's available in $PATH");
         return;
       }
-      GUILock lock(this); // forbid user interaction
+      SwathGUILock lock(this); // forbid user interaction
 
       auto inputs = getPyProphetInputFiles();
       if (inputs.empty())

--- a/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
@@ -66,7 +66,6 @@ namespace OpenMS
       glock_(stw)
     {
       stw->setCurrentWidget(stw->ui->tab_log);
-      
     }
 
     SwathGUILock::~SwathGUILock()

--- a/src/openms_gui/source/VISUAL/DIATreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/DIATreeTab.cpp
@@ -269,13 +269,27 @@ namespace OpenMS
   }
 
 
-  void DIATreeTab::updateEntries(LayerData& cl)
+  bool DIATreeTab::hasData(const LayerData* layer)
   {
+    if (layer == nullptr) return false;
+    OSWData* data = layer->getChromatogramAnnotation().get();
+    return (data != nullptr && !data->getProteins().empty());
+  }
+
+  void DIATreeTab::updateEntries(LayerData* layer)
+  {
+    if (layer == nullptr)
+    {
+      clear();
+      return;
+    }
+
     if (!dia_treewidget_->isVisible() || dia_treewidget_->signalsBlocked())
     {
       return;
     }
- 
+    LayerData& cl = *layer;
+
     OSWData* data = cl.getChromatogramAnnotation().get();
 
     if (current_data_ == data)

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -152,7 +152,6 @@ namespace OpenMS
 
     // update the currently visible tab (might be disabled if no data is shown)
     tab_ptrs_[current_index]->updateEntries(layer_ptr);
-
   }
 
   void DataSelectionTabs::currentTabChanged(int tab_index)

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -107,7 +107,7 @@ namespace OpenMS
   {
     PlotCanvas* cc = tv->getActiveCanvas();
     if (cc == nullptr) return nullptr;
-    if (cc->getCurrentLayerIndex() == -1) return nullptr;
+    if (cc->getCurrentLayerIndex() == Size(-1)) return nullptr;
     return &(cc->getCurrentLayer());
   }
 

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -64,6 +64,7 @@ namespace OpenMS
     spectra_view_widget_(new SpectraTreeTab(this)),
     id_view_widget_(new SpectraIDViewTab(Param(), this)),
     dia_widget_(new DIATreeTab(this)),
+    tab_ptrs_{ spectra_view_widget_, id_view_widget_, dia_widget_ },   // make sure to add new tabs here!
     spectraview_controller_(new TVSpectraViewController(tv)),
     idview_controller_(new TVIdentificationViewController(tv, id_view_widget_)),
     diatab_controller_(new TVDIATreeTabController(tv)),
@@ -94,15 +95,24 @@ namespace OpenMS
     if (index != IDENT_IDX) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Tab index is expected to be 1");
     index = addTab(dia_widget_, dia_widget_->objectName());
     if (index != DIAOSW_IDX) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Tab index is expected to be 2");
-    setTabEnabled(SPECTRA_IDX, true);
-    setTabEnabled(IDENT_IDX, false);
-    setTabEnabled(DIAOSW_IDX, false);
+    // make sure initialization was correct
+    assert(tabBar()->count() == tab_ptrs_.size());
 
     // switch between different view tabs
     connect(this, &QTabWidget::currentChanged, this, &DataSelectionTabs::currentTabChanged);
     connect(this, &QTabWidget::tabBarDoubleClicked, this, &DataSelectionTabs::tabBarDoubleClicked);
   }
 
+  LayerData* getCurrentLayerData(TOPPViewBase* tv)
+  {
+    PlotCanvas* cc = tv->getActiveCanvas();
+    if (cc == nullptr) return nullptr;
+    if (cc->getCurrentLayerIndex() == -1) return nullptr;
+    return &(cc->getCurrentLayer());
+  }
+
+  // called externally
+  // and internally by signals
   void DataSelectionTabs::update()
   {
     // prevent infinite loop when calling 'setTabEnabled' -> currentTabChanged() -> update()
@@ -112,38 +122,37 @@ namespace OpenMS
       this->blockSignals(false);
     });
 
-    PlotCanvas* cc = tv_->getActiveCanvas();
-    Size layer_row = (cc == nullptr 
-                          ? -1 
-                          : cc->getCurrentLayerIndex() /* may return -1 as well */);
+    auto layer_ptr = getCurrentLayerData(tv_); // can be nullptr
 
-    if (layer_row == (Size)-1)
+    // becomes true if the currently visible tab has no data
+    bool auto_select = false; 
+    // the order is important here. On auto-select, we will pick the highest one which has data to show!
+    Size highest_data_index = 0; // will pick spectra_view_widget_ if layer_ptr==nullptr
+    for (Size i = 0; i < tab_ptrs_.size(); ++i)
     {
-      spectra_view_widget_->clear();
-      id_view_widget_->clear();
-      setTabEnabled(SPECTRA_IDX, true);
-      setTabEnabled(IDENT_IDX, false);
-      return;
-    }
-
-
-    if (spectra_view_widget_->isVisible())
-    {
-      spectra_view_widget_->updateEntries(cc->getCurrentLayer());
-    }
-
-    if (id_view_widget_->isVisible())
-    {
-      if (&cc->getCurrentLayer() != id_view_widget_->getLayer())
+      auto widget = dynamic_cast<QWidget*>(tab_ptrs_[i]);
+      bool has_data = tab_ptrs_[i]->hasData(layer_ptr);
+      setTabEnabled(i, has_data); // enable/disable depending on data
+      if (has_data)
       {
-        id_view_widget_->setLayer(&cc->getCurrentLayer());
+        highest_data_index = i;
+      }
+      if (!has_data && // the currently visible tab has no data --> select a new tab
+          widget->isVisible())
+      {
+        auto_select = true;
       }
     }
-
-    if (dia_widget_->isVisible())
-    {
-      dia_widget_->updateEntries(cc->getCurrentLayer());
+    // pick the highest tab which has data
+    if (auto_select)
+    { 
+      setCurrentIndex(highest_data_index);
     }
+    Size current_index = currentIndex();
+
+    // update the currently visible tab (might be disabled if no data is shown)
+    tab_ptrs_[current_index]->updateEntries(layer_ptr);
+
   }
 
   void DataSelectionTabs::currentTabChanged(int tab_index)
@@ -244,12 +253,6 @@ namespace OpenMS
     }
 
     // update here?
-  }
-
-  void DataSelectionTabs::show(TAB_INDEX which)
-  {
-    setTabEnabled(which, true);
-    setCurrentIndex(which);
   }
 
   SpectraIDViewTab* DataSelectionTabs::getSpectraIDViewTab()

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -44,6 +44,7 @@
 #include <OpenMS/FORMAT/OSWFile.h>
 #include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
 
 //#include <iostream>
 #include <QtWidgets/QFileDialog>
@@ -485,9 +486,10 @@ namespace OpenMS
     if (annotations_changed) { hit.setPeakAnnotations(fas); }
   }
 
-  LayerAnnotatorBase::LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text)
+  LayerAnnotatorBase::LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock)
     : supported_types_(supported_types),
-      file_dialog_text_(file_dialog_text)
+      file_dialog_text_(file_dialog_text),
+      gui_lock_(gui_lock)
   {
   }
 
@@ -515,6 +517,7 @@ namespace OpenMS
       return false;
     }
 
+    GUIHelpers::GUILock glock(gui_lock_);
     bool success = annotateWorker_(layer, fname, log);
     
     if (success) log.appendNewHeader(LogWindow::LogState::NOTICE, "Done", "Annotation finished. Open identification view to see results!");
@@ -581,7 +584,7 @@ namespace OpenMS
     OSWData data;
     log.appendNewHeader(LogWindow::LogState::NOTICE, "Note", "Reading OSW data ...");
     oswf.readMinimal(data);
-    // allow data to map from transition.id (=native.id) to a chromatogram index
+    // allow data to map from transition.id (=native.id) to a chromatogram index in MSExperiment
     data.buildNativeIDResolver(*layer.getFullChromData().get());
     layer.setChromatogramAnnotation(std::move(data));
     log.appendText(" done");

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -38,15 +38,15 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <QDesktopServices>
-#include <QGUIApplication>
 #include <QDir>
-#include <QUrl>
+#include <QGuiApplication>
 #include <QMessageBox>
-#include <QString>
-#include <QStringList>
 #include <QPainter>
 #include <QPoint>
 #include <QProcess>
+#include <QString>
+#include <QStringList>
+#include <QUrl>
 
 namespace OpenMS
 {

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -146,34 +146,18 @@ namespace OpenMS
     }
   }
 
-  /**
-  @brief draw a multi-line text at coordinates XY using a specific font and color
-  @param painter Where to draw
-  @param text Each item is a new line
-  @param where Coordinates where to start drawing (upper left corner of text)
-  @param col_fg Optional text color; if invalid (=default) will use the current painter's color
-  @param col_bg Optional background color of bounding rectangle; if invalid (=default) no background will be painted
-  @param Optional font; will use Courier by default
-  */
-  void GUIHelpers::drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg, const QColor col_bg, QFont f)
+  void GUIHelpers::drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg, const QColor col_bg, const QFont& f)
   {
     painter.save();
 
     // font
     painter.setFont(f);
 
-    //d etermine width and height of the box we need
-    QFontMetrics metrics(painter.font());
-    int line_spacing = metrics.lineSpacing();
-    int height = 6 + text.size() * line_spacing;
-    int width = 4;
-    for (int i = 0; i < text.size(); ++i)
-    {
-      width = std::max(width, 4 + metrics.width(text[i]));
-    }
+    int line_spacing;
+    QRectF dim = getTextDimension(text, painter.font(), line_spacing);
 
     // draw background for text
-    if (col_bg.isValid()) painter.fillRect(where.x(), where.y(), width, height, col_bg);
+    if (col_bg.isValid()) painter.fillRect(where.x(), where.y(), dim.width(), dim.height(), col_bg);
 
     // draw text
     if (col_fg.isValid()) painter.setPen(col_fg);
@@ -185,6 +169,19 @@ namespace OpenMS
     painter.restore();
   }
 
+  QRectF GUIHelpers::getTextDimension(const QStringList& text, const QFont& f, int& line_spacing)
+  {
+    // determine width and height of the box we need
+    QFontMetrics metrics(f);
+    line_spacing = metrics.lineSpacing();
+    int height = 6 + text.size() * line_spacing;
+    int width = 4;
+    for (int i = 0; i < text.size(); ++i)
+    {
+      width = std::max(width, 4 + metrics.width(text[i]));
+    }
+    return QRectF(0, 0, width, height);
+  }
 
   GUIHelpers::GUILock::GUILock(QWidget* gui)
     : locked_widget_(gui)

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -228,14 +228,14 @@ OpenMS::GUIHelpers::OverlapDetector::OverlapDetector(int levels)
 /// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
 /// @return the smallest row index (starting at 0) which has none (or the least) overlap
 
-int OpenMS::GUIHelpers::OverlapDetector::placeItem(double x_start, double x_end)
+size_t OpenMS::GUIHelpers::OverlapDetector::placeItem(double x_start, double x_end)
 {
   if (x_start < 0) OPENMS_LOG_WARN << "Warning: x coordinates should be positive!\n";
   if (x_start > x_end) OPENMS_LOG_WARN << "Warning: x-end is larger than x-start!\n";
 
-  int best_index = 0;
+  size_t best_index = 0;
   double best_distance = -std::numeric_limits<double>::max();
-  for (int i = 0; i < rows_.size(); ++i)
+  for (size_t i = 0; i < rows_.size(); ++i)
   {
     if (rows_[i] < x_start)
     { // easy win; row[i] does not overlap; take it

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -204,7 +204,6 @@ namespace OpenMS
     was_enabled_ = locked_widget_->isEnabled();
     locked_widget_->setEnabled(false);
     QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-    locked_widget_->setCursor(Qt::WaitCursor);
     currently_locked_ = true;
   }
 

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <QDesktopServices>
+#include <QGUIApplication>
 #include <QDir>
 #include <QUrl>
 #include <QMessageBox>
@@ -184,4 +185,37 @@ namespace OpenMS
     painter.restore();
   }
 
+
+  GUIHelpers::GUILock::GUILock(QWidget* gui)
+    : locked_widget_(gui)
+  {
+    lock();
+  }
+
+  GUIHelpers::GUILock::~GUILock()
+  {
+    unlock();
+  }
+
+  void GUIHelpers::GUILock::lock()
+  {
+    if (currently_locked_) return;
+
+    was_enabled_ = locked_widget_->isEnabled();
+    locked_widget_->setEnabled(false);
+    QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+    locked_widget_->setCursor(Qt::WaitCursor);
+    currently_locked_ = true;
+  }
+
+  void GUIHelpers::GUILock::unlock()
+  {
+    if (!currently_locked_) return;
+
+    locked_widget_->setEnabled(was_enabled_);
+    QGuiApplication::restoreOverrideCursor(); 
+    currently_locked_ = false;
+  }
+
 } //namespace OpenMS
+

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -200,6 +200,7 @@ namespace OpenMS
   void GUIHelpers::GUILock::lock()
   {
     if (currently_locked_) return;
+    if (locked_widget_ == nullptr) return;
 
     was_enabled_ = locked_widget_->isEnabled();
     locked_widget_->setEnabled(false);
@@ -210,6 +211,7 @@ namespace OpenMS
   void GUIHelpers::GUILock::unlock()
   {
     if (!currently_locked_) return;
+    if (locked_widget_ == nullptr) return;
 
     locked_widget_->setEnabled(was_enabled_);
     QGuiApplication::restoreOverrideCursor(); 

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -217,3 +217,38 @@ namespace OpenMS
 
 } //namespace OpenMS
 
+  /// C'tor: number of @p levels must be >=1
+
+OpenMS::GUIHelpers::OverlapDetector::OverlapDetector(int levels)
+{
+  if (levels <= 0) throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, levels);
+  rows_.resize(levels, 0);
+}
+
+/// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
+/// @return the smallest row index (starting at 0) which has none (or the least) overlap
+
+int OpenMS::GUIHelpers::OverlapDetector::placeItem(double x_start, double x_end)
+{
+  if (x_start < 0) OPENMS_LOG_WARN << "Warning: x coordinates should be positive!\n";
+  if (x_start > x_end) OPENMS_LOG_WARN << "Warning: x-end is larger than x-start!\n";
+
+  int best_index = 0;
+  double best_distance = -std::numeric_limits<double>::max();
+  for (int i = 0; i < rows_.size(); ++i)
+  {
+    if (rows_[i] < x_start)
+    { // easy win; row[i] does not overlap; take it
+      rows_[i] = x_end; // update space for next call
+      return i;
+    }
+    // x_start is smaller than row's end...
+    if ((rows_[i] - x_start) < best_distance)
+    {
+      best_distance = rows_[i] - x_start;
+      best_index = i;
+    }
+  }
+
+  return best_index;
+}

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -378,7 +378,6 @@ namespace OpenMS
       const Size id_count = pi.size();
       const vector<Precursor> & precursors = spectrum.getPrecursors();
 
-
       // allow only MS2 OR MS1 with peptideIDs (from Mass Fingerprinting)
       if (ms_level != 2 && id_count == 0) { continue; }
 

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -135,7 +135,7 @@ namespace OpenMS
   void SpectraIDViewTab::clear()
   {
     table_widget_->clear();
-    layer_ == nullptr;
+    layer_ = nullptr;
   }
 
   void SpectraIDViewTab::currentCellChanged_(int row, int column, int /*old_row*/, int /*old_column*/)

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -127,15 +127,15 @@ namespace OpenMS
 
     connect(table_widget_, &QTableWidget::currentCellChanged, this, &SpectraIDViewTab::currentCellChanged_);
     connect(table_widget_, &QTableWidget::itemChanged, this, &SpectraIDViewTab::updatedSingleCell_);
-    connect(hide_no_identification_, &QCheckBox::toggled, this, &SpectraIDViewTab::updateEntries);
-    connect(create_rows_for_commmon_metavalue_, &QCheckBox::toggled, this, &SpectraIDViewTab::updateEntries);
+    connect(hide_no_identification_, &QCheckBox::toggled, this, &SpectraIDViewTab::updateEntries_);
+    connect(create_rows_for_commmon_metavalue_, &QCheckBox::toggled, this, &SpectraIDViewTab::updateEntries_);
     connect(export_table, &QPushButton::clicked, table_widget_, &TableView::exportEntries);
   }
 
   void SpectraIDViewTab::clear()
   {
-    // remove all entries
-    setLayer(nullptr);
+    table_widget_->clear();
+    layer_ == nullptr;
   }
 
   void SpectraIDViewTab::currentCellChanged_(int row, int column, int /*old_row*/, int /*old_column*/)
@@ -256,12 +256,23 @@ namespace OpenMS
     } // PeakAnnotation cell clicked
   }
 
-  void SpectraIDViewTab::setLayer(LayerData* cl)
+  bool SpectraIDViewTab::hasData(const LayerData* layer)
+  {
+    // this is a very easy check.
+    // We do not check for PeptideIdentifications attached to Spectra, because the user could just 
+    // want the list of unidentified MS2 spectra (obtained by unchecking the 'just hits' button).
+    bool no_data = (layer == nullptr
+                || (layer->type == LayerData::DT_PEAK && layer->getPeakData()->empty())
+                || (layer->type == LayerData::DT_CHROMATOGRAM && layer->getChromatogramData()->empty()));
+    return !no_data;
+  }
+
+  void SpectraIDViewTab::updateEntries(LayerData* cl)
   {
     // do not try to be smart and check if layer_ == cl; to return early
     // since the layer content might have changed, e.g. pepIDs were added
     layer_ = cl;
-    updateEntries();
+    updateEntries_(); // we need this extra function since its an internal slot
   }
 
   LayerData* SpectraIDViewTab::getLayer()
@@ -281,14 +292,12 @@ namespace OpenMS
     };
   }
 
-  void SpectraIDViewTab::updateEntries()
+  void SpectraIDViewTab::updateEntries_()
   {
     // no valid peak layer attached
-    if (layer_ == nullptr
-        || (layer_->type == LayerData::DT_PEAK && layer_->getPeakData()->empty())
-        || (layer_->type == LayerData::DT_CHROMATOGRAM && layer_->getChromatogramData()->empty()))
+    if (!hasData(layer_))
     {
-      table_widget_->clear();
+      clear();
       return;
     }
 
@@ -297,7 +306,6 @@ namespace OpenMS
     if (!isVisible()) { return; }
 
     int restore_spec_index = layer_->getCurrentSpectrumIndex();
-    std::cout << "spec index selected:" << restore_spec_index << '\n';
 
     set<String> common_keys;
     bool has_peak_annotations(false);

--- a/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraTreeTab.cpp
@@ -285,12 +285,28 @@ namespace OpenMS
     item->setText(ClmnPeak::ZOOM, (spec.getInstrumentSettings().getZoomScan() ? "yes" : "no"));
   }
 
-  void SpectraTreeTab::updateEntries(const LayerData& cl)
+  bool SpectraTreeTab::hasData(const LayerData* layer)
   {
+    if (layer == nullptr) return false;
+
+    bool is_peak = layer->type == LayerData::DT_PEAK && !(layer->chromatogram_flag_set());
+    bool is_chrom = layer->type == LayerData::DT_CHROMATOGRAM || layer->chromatogram_flag_set();
+    return is_peak || is_chrom;
+  }
+
+  void SpectraTreeTab::updateEntries(LayerData* layer)
+  {
+    if (layer == nullptr)
+    {
+      clear();
+      return;
+    }
+
     if (!spectra_treewidget_->isVisible() || spectra_treewidget_->signalsBlocked())
     {
       return;
     }
+    LayerData& cl = *layer;
 
     spectra_treewidget_->blockSignals(true);
     RAIICleanup clean([&](){ spectra_treewidget_->blockSignals(false); });

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -144,7 +144,7 @@ namespace OpenMS
       auto text_size = item->getTextRect(); // this is in px units (Qt widget coordinates)
       // translate to axis units (our native 'data'):
       auto p_text = w->canvas()->widgetToDataDistance(text_size.width(), 0);
-      int chunk = od.placeItem(feature.getRTLeftWidth(), feature.getRTLeftWidth() + p_text.getX());
+      auto chunk = od.placeItem(feature.getRTLeftWidth(), feature.getRTLeftWidth() + p_text.getX());
       item->setTextYOffset(chunk * text_size.height());
 
       w->canvas()->getCurrentLayer().getCurrentAnnotations().push_back(item);

--- a/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
+++ b/src/openms_gui/source/VISUAL/TVDIATreeTabController.cpp
@@ -118,10 +118,11 @@ namespace OpenMS
       return a.getRTLeftWidth() < b.getRTLeftWidth();
     });
     const OSWPeakGroup* best_feature = &features[0];
-    auto findBestFeature = [&features, &best_feature](const OSWPeakGroup& f)
+    auto findBestFeature = [&best_feature](const OSWPeakGroup& f)
     {
       if (best_feature->getQValue() > f.getQValue()) best_feature = &f;
     };
+    std::for_each(features.begin(), features.end(), findBestFeature);
     if (best_feature->getQValue() == -1)
     { // no q-values are annotated. make them all grey.
       best_feature = nullptr;
@@ -132,8 +133,8 @@ namespace OpenMS
     // show feature boundaries
     for (const auto& feature : features)
     {
-      double width = feature.getRTRightWidth() - feature.getRTLeftWidth();
-      double center = feature.getRTLeftWidth() + width / 2;
+      auto width = feature.getRTRightWidth() - feature.getRTLeftWidth();
+      auto center = feature.getRTLeftWidth() + width / 2;
       String ann = String("RT:\n ") + String(feature.getRTExperimental(), false) + "\ndRT:\n " + String(feature.getRTDelta(), false) + "\nQ:\n " + String(feature.getQValue(), false);
       QColor col = GUIHelpers::ColorBrewer::Distinct().values[(best_feature == &feature) 
                           ? GUIHelpers::ColorBrewer::Distinct::LightGreen
@@ -149,13 +150,10 @@ namespace OpenMS
       w->canvas()->getCurrentLayer().getCurrentAnnotations().push_back(item);
     }
     // paint the expected RT once
-    if (!features.empty())
-    {
-      double expected_RT = features[0].getRTExperimental() - features[0].getRTDelta();
-      Annotation1DItem* item = new Annotation1DVerticalLineItem(expected_RT, 3, 200, true, Qt::darkGreen, "");
-      item->setSelected(false);
-      w->canvas()->getCurrentLayer().getCurrentAnnotations().push_back(item);
-    }
+    auto expected_RT = features[0].getRTExperimental() - features[0].getRTDelta();
+    Annotation1DItem* item = new Annotation1DVerticalLineItem(expected_RT, 3, 200, true, Qt::darkGreen, "");
+    item->setSelected(false);
+    w->canvas()->getCurrentLayer().getCurrentAnnotations().push_back(item);
   }
 
 


### PR DESCRIPTION
# Description

- add nicer plotting to sqMass + OSW id view
![image](https://user-images.githubusercontent.com/6008722/100618172-c1978b80-331b-11eb-9f3f-58bfbdbe7739.png)
    - this includes a basic overlap detection algorithm which avoids overlapping text blocks
- lock TOPPView GUI when large data is loaded, so the user gets feedback why nothing is responding
- automatically select the appropriate ID tab, depending on what data is available
- support ID annotation from commandline via the new `!` operator, e.g. `TOPPView BSA.mzML ! BSA.idXML` (or for any other annotation data we support, e.g. sqMass + osw)

