### PR TITLE
fix: bug in AbsoluteQuantitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,9 @@ src/.DS_Store
 src/openms/.DS_Store
 .vscode
 contrib-build
+contrib_build
 openms-build
+openms_build
 *.swp
 cmake-build-debug
 cmake-build-release

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -28,7 +28,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Maintainer: Douglas McCloskey $
 // $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
@@ -193,9 +193,9 @@ namespace OpenMS
     TransformationModel::DataPoint point;
     for (size_t i = 0; i < component_concentrations.size(); i++)
     {
-      point.first = component_concentrations[i].actual_concentration/component_concentrations[i].IS_actual_concentration;
+      point.first = component_concentrations[i].actual_concentration / component_concentrations[i].IS_actual_concentration / component_concentrations[i].dilution_factor; // adjust based on the dilution factor
       double ratio = calculateRatio(component_concentrations[i].feature, component_concentrations[i].IS_feature,feature_name);
-      point.second = ratio/component_concentrations[i].dilution_factor; // adjust based on the dilution factor
+      point.second = ratio;
       data.push_back(point);
     }
 
@@ -237,13 +237,13 @@ namespace OpenMS
         transformation_model_params);
 
       double actual_concentration_ratio = component_concentrations[i].actual_concentration/
-        component_concentrations[i].IS_actual_concentration;
+        component_concentrations[i].IS_actual_concentration / component_concentrations[i].dilution_factor;
       concentration_ratios.push_back(component_concentrations[i].actual_concentration);
 
       // extract out the feature amount ratios
       double feature_amount_ratio = calculateRatio(component_concentrations[i].feature,
         component_concentrations[i].IS_feature,
-        feature_name)/component_concentrations[i].dilution_factor;
+        feature_name);
       feature_amounts_ratios.push_back(feature_amount_ratio);
 
       // calculate the bias

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -28,7 +28,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Maintainer: Douglas McCloskey $
 // $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 //

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -406,9 +406,9 @@ START_SECTION((void (
   IS_component.setMetaValue("peak_apex_int",1.0);
   component_concentration.feature = component;
   component_concentration.IS_feature = IS_component;
-  component_concentration.actual_concentration = 1.0;
+  component_concentration.actual_concentration = 2.0;
   component_concentration.IS_actual_concentration = 1.0;
-  component_concentration.dilution_factor = 1.0;
+  component_concentration.dilution_factor = 2.0;
   component_concentrations.push_back(component_concentration);
   // point #2
   component.setMetaValue("native_id","component");
@@ -417,9 +417,9 @@ START_SECTION((void (
   IS_component.setMetaValue("peak_apex_int",1.0);
   component_concentration.feature = component;
   component_concentration.IS_feature = IS_component;
-  component_concentration.actual_concentration = 2.0;
+  component_concentration.actual_concentration = 4.0;
   component_concentration.IS_actual_concentration = 1.0;
-  component_concentration.dilution_factor = 1.0;
+  component_concentration.dilution_factor = 2.0;
   component_concentrations.push_back(component_concentration);
   // point #3
   component.setMetaValue("native_id","component");
@@ -428,9 +428,9 @@ START_SECTION((void (
   IS_component.setMetaValue("peak_apex_int",1.0);
   component_concentration.feature = component;
   component_concentration.IS_feature = IS_component;
-  component_concentration.actual_concentration = 3.0;
+  component_concentration.actual_concentration = 6.0;
   component_concentration.IS_actual_concentration = 1.0;
-  component_concentration.dilution_factor = 1.0;
+  component_concentration.dilution_factor = 2.0;
   component_concentrations.push_back(component_concentration);
 
   String feature_name = "peak_apex_int";
@@ -473,7 +473,7 @@ START_SECTION((Param AbsoluteQuantitation::fitCalibration(
   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
   static const double arry1[] = {1, 1, 1, 1, 1, 1};
   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-  static const double arrz1[] = {-2, -4, -6, 2, 4, 6};
+  static const double arrz1[] = {-4, -8, -12, 4, 8, 12};
   std::vector<double> z1 (arrz1, arrz1 + sizeof(arrz1) / sizeof(arrz1[0]) );
 
   // set-up the features
@@ -490,7 +490,7 @@ START_SECTION((Param AbsoluteQuantitation::fitCalibration(
     component_concentration.IS_feature = IS_component;
     component_concentration.actual_concentration = z1[i];
     component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
+    component_concentration.dilution_factor = 2.0;
     component_concentrations.push_back(component_concentration);
   }
 


### PR DESCRIPTION
# Description

Small fix in `AbsoluteQuantitation`

## Fixes
- change the term that the `dilution_factor` is applied to (i.e., changed to the correct term :))
