### PR TITLE
[Feature] Add info output to MzMLHandler store

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ the authors tag in the respective file header.
  - Peter Kunszt
  - Petra Gutenbrunner
  - Rene Hussong
+ - Ruben Grünberg
  - Samuel Wein
  - Sandro Andreotti
  - Steffen Sass

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3966,6 +3966,8 @@ namespace OpenMS
       const MapType& exp = *(cexp_);
       logger_.startProgress(0, exp.size() + exp.getChromatograms().size(), "storing mzML file");
       int progress = 0;
+      UInt stored_spectra = 0;
+      UInt stored_chromatograms = 0;
       Internal::MzMLValidator validator(mapping_, cv_);
 
       std::vector<std::vector< ConstDataProcessingPtr > > dps;
@@ -4008,6 +4010,7 @@ namespace OpenMS
           logger_.setProgress(progress++);
           const SpectrumType& spec = exp[s_idx];
           writeSpectrum_(os, spec, s_idx, validator, renew_native_ids, dps);
+          ++stored_spectra;
         }
         os << "\t\t</spectrumList>\n";
       }
@@ -4027,11 +4030,15 @@ namespace OpenMS
           logger_.setProgress(progress++);
           const ChromatogramType& chromatogram = exp.getChromatograms()[c_idx];
           writeChromatogram_(os, chromatogram, c_idx, validator);
+          ++stored_chromatograms;
         }
         os << "\t\t</chromatogramList>" << "\n";
       }
 
       MzMLHandlerHelper::writeFooter_(os, options_, spectra_offsets_, chromatograms_offsets_);
+
+      OPENMS_LOG_INFO << stored_spectra << " spectra and " << stored_chromatograms << " chromatograms stored.\n";
+
       logger_.endProgress();
     }
 


### PR DESCRIPTION
# Description

Added counting for the number of spectra and chromatograms that are stored by the MzMLHandler and output it to OPENMS_LOG_INFO. This closes #5061 

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
