### PR TITLE
Automatically detected all avialable tools in ToolsDialog

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -117,11 +117,17 @@ private:
     String default_dir_;
     /// name of ini-file
     QString filename_;
+    /// Mapping of file extension to layer type to determine the type of a tool
+    std::map<String, LayerData::DataType> tool_map_;
 
     ///Disables the ok button and input/output comboboxes
     void disable_();
     ///Enables the ok button and input/output comboboxes
     void enable_();
+    /// Generates an .ini file for a given tool name and loads it into a Param object.
+    Param getParamFromIni_(const String& toolName);
+    /// Determine all types a tool is compatible with by mapping each file extensions in a tools param
+    std::vector<LayerData::DataType> getTypesFromParam_(const Param& p) const;
 
 protected slots:
 

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -128,6 +128,8 @@ private:
     Param getParamFromIni_(const String& tool_name);
     /// Determine all types a tool is compatible with by mapping each file extensions in a tools param
     std::vector<LayerData::DataType> getTypesFromParam_(const Param& p) const;
+    // Fill input_combo_ and output_combo_ box with the appropriate entries from the specified param object.
+    void setInputOutputCombo_(const Param& p);
 
 protected slots:
 

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -125,7 +125,7 @@ private:
     ///Enables the ok button and input/output comboboxes
     void enable_();
     /// Generates an .ini file for a given tool name and loads it into a Param object.
-    Param getParamFromIni_(const String& toolName);
+    Param getParamFromIni_(const String& tool_name);
     /// Determine all types a tool is compatible with by mapping each file extensions in a tools param
     std::vector<LayerData::DataType> getTypesFromParam_(const Param& p) const;
 

--- a/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
@@ -221,14 +221,16 @@ namespace OpenMS
   void ToolsDialog::setInputOutputCombo_(const Param &p)
   {
     String str;
-    QStringList input_list;
-    QStringList output_list;
-    for (Param::ParamIterator iter = arg_param_.begin(); iter != arg_param_.end(); ++iter)
+    QStringList input_list("<select>");
+    QStringList output_list("<select>");
+    bool outRequired = false;
+    for (Param::ParamIterator iter = p.begin(); iter != p.end(); ++iter)
     {
-      // iter.getName() is either of form "ToolName:1:ItemName" or "ToolName:1:NodeName:ItemName".
+      // iter.getName() is either of form "ToolName:1:ItemName" or "ToolName:1:NodeName:[...]:ItemName".
       // Cut off "ToolName:1:"
       str = iter.getName().substr(iter.getName().rfind("1:") + 2, iter.getName().size());
-      if (str.size() != 0 && str.find(":") == String::npos)
+      // Only add items and no nodes
+      if (!str.empty() && str.find(":") == String::npos)
       {
         arg_map_.insert(make_pair(str, iter.getName()));
         // Only add to input list if item has "input file" tag.
@@ -240,6 +242,8 @@ namespace OpenMS
         else if (iter->tags.find("output file") != iter->tags.end())
         {
           output_list << QStringList(str.c_str());
+          // Check whether the item has a required tag i.e. is mandatory.
+          outRequired = (outRequired) || (iter->tags.find("required") != iter->tags.end());
         }
       }
     }
@@ -255,7 +259,7 @@ namespace OpenMS
     // Clear and set output combo box
     output_combo_->addItems(output_list);
     pos = output_list.indexOf("out");
-    if (pos != -1 && getTool() != "FileInfo")
+    if (pos != -1 && getTool() != "FileInfo" && outRequired)
     {
       output_combo_->setCurrentIndex(pos);
     }

--- a/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
@@ -214,34 +214,16 @@ namespace OpenMS
 
   void ToolsDialog::createINI_()
   {
-    QStringList args{ "-write_ini", ini_file_.toQString(), "-log", (ini_file_+".log").toQString() };
-    QProcess qp;
-    String executable = File::findSiblingTOPPExecutable(getTool());
-    qp.start(executable.toQString(), args);
-    const bool success = qp.waitForFinished(-1); // wait till job is finished
-    if (qp.error() == QProcess::FailedToStart || success == false || qp.exitStatus() != 0 || qp.exitCode() != 0)
-    {
-      QMessageBox::critical(this, "Error", (String("Could not execute '") + executable + "'!\n\nMake sure the TOPP tools are present in '" + File::getExecutablePath() + "',  that you have permission to write to the temporary file path, and that there is space left in the temporary file path.").c_str());
-      return;
-    }
-    else if (!File::exists(ini_file_))
-    {
-      QMessageBox::critical(this, "Error", (String("Could find requested INI file '") + ini_file_ + "'!").c_str());
-      return;
-    }
-
     enable_();
     if (!arg_param_.empty())
     {
-      tool_desc_->clear();
-      arg_param_.clear();
-      vis_param_.clear();
-      editor_->clear();
-      arg_map_.clear();
+       tool_desc_->clear();
+       arg_param_.clear();
+       vis_param_.clear();
+       editor_->clear();
+       arg_map_.clear();
     }
-
-    ParamXMLFile paramFile;
-    paramFile.load((ini_file_).c_str(), arg_param_);
+    arg_param_ = getParamFromIni_(getTool());
 
     tool_desc_->setText(arg_param_.getSectionDescription(getTool()).toQString());
     vis_param_ = arg_param_.copy(getTool() + ":1:", true);


### PR DESCRIPTION
# Description

This PR adresses issue  ##5117. All available/compatible tools are now being detected automatically instead of being hardcoded for each layer type.

# TODO

Some things still need to be fixed in my opinion but I want to discuss these changes first:

1. Generating an ini file for each tool for each file to determine with which layer types it is compatible with takes a considerable amount of time (~5 seconds). All these IO actions are quite a bottleneck. Maybe there exists a better/faster method?
2. Currently write errors in `getParamFromIni_` are caught but not properly reacted to. In case of an error the param object is still created (line 177, 182).



# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file   **No permission**
- [ ] Add relevant changes and new features to the CHANGELOG file 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

Note: If your PR is failing you can check out http://cdash.openms.de/index.php?project=OpenMS and look for your PR with detailed error messages.
