### PR TITLE
[FIX] preserve native id format in FileHandler

### DIFF
--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -680,7 +680,7 @@ if (first_line.hasSubstring("File	First Scan	Last Scan	Num of Scans	Charge	Monoi
         if (exp.getSourceFiles().size() > 1) 
         {
           OPENMS_LOG_WARN << "Expecting a single source file in mzML. Found " << exp.getSourceFiles().size() 
-                          << " will take only first one as for rewriting." << endl;
+                          << " will take only first one for rewriting." << endl;
         }
         src_file = exp.getSourceFiles()[0];
       }

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -671,6 +671,20 @@ if (first_line.hasSubstring("File	First Scan	Last Scan	Num of Scans	Charge	Monoi
     if (rewrite_source_file)
     {
       SourceFile src_file;
+      if (exp.getSourceFiles().empty()) // copy settings like native ID format
+      {
+        OPENMS_LOG_WARN << "No source file annotated." << endl;
+      }
+      else 
+      {
+        if (exp.getSourceFiles().size() > 1) 
+        {
+          OPENMS_LOG_WARN << "Expecting a single source file in mzML. Found " << exp.getSourceFiles().size() 
+                          << " will take only first one as for rewriting." << endl;
+        }
+        src_file = exp.getSourceFiles()[0];
+      }
+      
       src_file.setNameOfFile(File::basename(filename));
       String path_to_file = File::path(File::absolutePath(filename)); //convert to absolute path and strip file name
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -754,7 +754,14 @@ namespace OpenMS
         String source_file_ref;
         if (optionalAttributeAsString_(source_file_ref, attributes, s_source_file_ref))
         {
-          spec_.setSourceFile(source_files_[source_file_ref]);
+          if (source_files_.has(source_file_ref))
+          {
+            spec_.setSourceFile(source_files_[source_file_ref]);
+          }
+          else
+          {
+            OPENMS_LOG_WARN << "Error: unregistered source file reference " << source_file_ref << "." << std::endl;
+          }
         }
         //native id
         spec_.setNativeID(attributeAsString_(attributes, s_id));

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -454,7 +454,7 @@ namespace OpenMS
     vector<SourceFile> sourcefiles = experiment.getSourceFiles();
     if (sourcefiles.empty())
     {
-      OPENMS_LOG_WARN << "MascatGenericFile: no native ID accession." << endl;
+      OPENMS_LOG_WARN << "MascotGenericFile: no native ID accession." << endl;
       native_id_type_accession = "UNKNOWN";
     }
     else
@@ -462,7 +462,7 @@ namespace OpenMS
       native_id_type_accession = experiment.getSourceFiles()[0].getNativeIDTypeAccession();
       if (native_id_type_accession.empty())
       {
-        OPENMS_LOG_WARN << "MascatGenericFile: empty native ID accession." << endl;
+        OPENMS_LOG_WARN << "MascotGenericFile: empty native ID accession." << endl;
         native_id_type_accession = "UNKNOWN";
       }
     }

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -365,7 +365,7 @@ namespace OpenMS
         }
         else
         {
-                os << "SCANS=" << SpectrumLookup::extractScanNumber(spec.getNativeID(), native_id_type_accession) << "\n";
+          os << "SCANS=" << SpectrumLookup::extractScanNumber(spec.getNativeID(), native_id_type_accession) << "\n";
         }
       }
       else
@@ -451,15 +451,23 @@ namespace OpenMS
 
 
     String native_id_type_accession;
-    vector<SourceFile> sourcefiles = experiment.getExperimentalSettings().getSourceFiles();
+    vector<SourceFile> sourcefiles = experiment.getSourceFiles();
     if (sourcefiles.empty())
     {
+      OPENMS_LOG_WARN << "MascatGenericFile: no native ID accession." << endl;
       native_id_type_accession = "UNKNOWN";
     }
     else
     {
-      native_id_type_accession = experiment.getExperimentalSettings().getSourceFiles()[0].getNativeIDTypeAccession();
+      native_id_type_accession = experiment.getSourceFiles()[0].getNativeIDTypeAccession();
+      if (native_id_type_accession.empty())
+      {
+        OPENMS_LOG_WARN << "MascatGenericFile: empty native ID accession." << endl;
+        native_id_type_accession = "UNKNOWN";
+      }
     }
+
+
     this->startProgress(0, experiment.size(), "storing mascot generic file");
     for (Size i = 0; i < experiment.size(); i++)
     {

--- a/src/tests/topp/FileConverter_23_output.mzML
+++ b/src/tests/topp/FileConverter_23_output.mzML
@@ -14,10 +14,11 @@
 			<cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" />
 		</fileContent>
 		<sourceFileList count="2">
-			<sourceFile id="sf_ru_0" name="FileConverter_23_input.mzML" location="file:///Users/alka/Documents/work/software/openms_dev/OpenMS/src/tests/topp">
+			<sourceFile id="sf_ru_0" name="FileConverter_23_input.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="a262023f28d63389e25eac6007d172b040fde24f" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
+				<userParam name="name" type="xsd:string" value="sourcefile1"/>
 			</sourceFile>
 			<sourceFile id="sf_sp_1" name="tiny1.dta" location="file:///F:/data/Exp01">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="81be39fb2700ab2f3c8b2234b91274968b6899b1" />
@@ -518,16 +519,16 @@
 </mzML>
 <indexList count="2">
 	<index name="spectrum">
-		<offset idRef="index=0">13971</offset>
-		<offset idRef="index=1">18058</offset>
-		<offset idRef="index=2">26944</offset>
-		<offset idRef="index=3">31754</offset>
+		<offset idRef="index=0">14009</offset>
+		<offset idRef="index=1">18096</offset>
+		<offset idRef="index=2">26982</offset>
+		<offset idRef="index=3">31792</offset>
 	</index>
 	<index name="chromatogram">
-		<offset idRef="tic native">33092</offset>
-		<offset idRef="sic native">34471</offset>
+		<offset idRef="tic native">33130</offset>
+		<offset idRef="sic native">34509</offset>
 	</index>
 </indexList>
-<indexListOffset>36052</indexListOffset>
+<indexListOffset>36090</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/tests/topp/FileConverter_28_output.mzML
+++ b/src/tests/topp/FileConverter_28_output.mzML
@@ -13,10 +13,11 @@
 			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
 		</fileContent>
 		<sourceFileList count="1">
-			<sourceFile id="sf_ru_0" name="FileConverter_28_input.mzML" location="file:///home/hr/openmsall/source/OpenMS_trunk/src/tests/topp">
+			<sourceFile id="sf_ru_0" name="FileConverter_28_input.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="fbc7be28bc7bef0b5915f623dba7b35e604fadd2" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
+				<userParam name="name" type="xsd:string" value="sourcefile1"/>
 			</sourceFile>
 		</sourceFileList>
 		<contact>
@@ -205,10 +206,10 @@
 </mzML>
 <indexList count="1">
 	<index name="chromatogram">
-		<offset idRef="tic native">10267</offset>
-		<offset idRef="sic native">11890</offset>
+		<offset idRef="tic native">10320</offset>
+		<offset idRef="sic native">11943</offset>
 	</index>
 </indexList>
-<indexListOffset>13471</indexListOffset>
+<indexListOffset>13524</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/tests/topp/FileMerger_10_output.mzML
+++ b/src/tests/topp/FileMerger_10_output.mzML
@@ -14,15 +14,15 @@
 			<cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" />
 		</fileContent>
 		<sourceFileList count="4">
-			<sourceFile id="sf_ru_0" name="FileMerger_6_input2.mzML" location="file:///Users/pfeuffer/git/OpenMS-inference-src/src/tests/topp">
+			<sourceFile id="sf_ru_0" name="FileMerger_6_input2.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="0e3787759e3b0d2ca8e321527f759879f94a4829" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
 			</sourceFile>
-			<sourceFile id="sf_ru_1" name="FileMerger_6_input2.mzML" location="file:///Users/pfeuffer/git/OpenMS-inference-src/src/tests/topp">
+			<sourceFile id="sf_ru_1" name="FileMerger_6_input2.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="0e3787759e3b0d2ca8e321527f759879f94a4829" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
 			</sourceFile>
 			<sourceFile id="sf_sp_1" name="tiny1.dta" location="file:///F:/data/Exp01">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="81be39fb2700ab2f3c8b2234b91274968b6899b1" />
@@ -257,12 +257,12 @@
 </mzML>
 <indexList count="1">
 	<index name="spectrum">
-		<offset idRef="spectrum=0">8052</offset>
-		<offset idRef="spectrum=1">11875</offset>
-		<offset idRef="spectrum=2">12656</offset>
-		<offset idRef="spectrum=3">16559</offset>
+		<offset idRef="spectrum=0">8020</offset>
+		<offset idRef="spectrum=1">11843</offset>
+		<offset idRef="spectrum=2">12624</offset>
+		<offset idRef="spectrum=3">16527</offset>
 	</index>
 </indexList>
-<indexListOffset>17478</indexListOffset>
+<indexListOffset>17446</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/tests/topp/FileMerger_6_output.mzML
+++ b/src/tests/topp/FileMerger_6_output.mzML
@@ -14,15 +14,15 @@
 			<cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum" />
 		</fileContent>
 		<sourceFileList count="3">
-			<sourceFile id="sf_ru_0" name="FileMerger_6_input2.mzML" location="file:///Users/pfeuffer/git/OpenMS-inference-src/src/tests/topp">
+			<sourceFile id="sf_ru_0" name="FileMerger_6_input2.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="0e3787759e3b0d2ca8e321527f759879f94a4829" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
 			</sourceFile>
-			<sourceFile id="sf_sp_0" name="FileMerger_6_input1.mzML" location="file:///Users/pfeuffer/git/OpenMS-inference-src/src/tests/topp">
+			<sourceFile id="sf_sp_0" name="FileMerger_6_input1.mzML" location="file:///home/sachsenb/OMS/OpenMS/src/tests/topp">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="f5a1cab79a193929ad5b9535e8a792365f5b699b" />
 				<cvParam cvRef="MS" accession="MS:1000584" name="mzML format" />
-				<cvParam cvRef="MS" accession="MS:1000777" name="spectrum identifier nativeID format" />
+				<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format" />
 			</sourceFile>
 			<sourceFile id="sf_sp_2" name="tiny1.dta" location="file:///F:/data/Exp01">
 				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="81be39fb2700ab2f3c8b2234b91274968b6899b1" />
@@ -245,11 +245,11 @@
 </mzML>
 <indexList count="1">
 	<index name="spectrum">
-		<offset idRef="spectrum=0">8821</offset>
-		<offset idRef="spectrum=1">12030</offset>
-		<offset idRef="spectrum=2">15853</offset>
+		<offset idRef="spectrum=0">8789</offset>
+		<offset idRef="spectrum=1">11998</offset>
+		<offset idRef="spectrum=2">15821</offset>
 	</index>
 </indexList>
-<indexListOffset>16692</indexListOffset>
+<indexListOffset>16660</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>


### PR DESCRIPTION
# Description

Using FileHandler to load mzMLs with the flag for automatic filename reannotation
removed the native id format CV term. It is now preserved.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

Note: If your PR is failing you can check out http://cdash.openms.de/index.php?project=OpenMS and look for your PR with detailed error messages.
