### PR TITLE
[FEATURE] Show utils in ToolsDialog

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ENABLE_DOCS)
   if(WITH_GUI)
     #------------------------------------------------------------------------------
     # QT dependencies
-    find_package(Qt5 COMPONENTS Core Network Svg OpenGL REQUIRED)
+    find_package(Qt5 COMPONENTS Concurrent Core Network Svg OpenGL REQUIRED)
     set(_doc_progs_include ${OpenMS_GUI_INCLUDE_DIRECTORIES})
     set(_doc_progs_link_libraries ${OpenMS_GUI_LIBRARIES})
   else()

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -99,12 +99,11 @@ namespace OpenMS
     static String spath = "";
     static bool path_checked = false;
 
-    mtx.lock();
+    const std::lock_guard<std::mutex> lock(mtx);
 
     // short route. Only inquire the path once. The result will be the same every time.
     if (path_checked) 
     {
-      mtx.unlock();
       return spath;
     }
 
@@ -140,7 +139,6 @@ namespace OpenMS
     }
 
     path_checked = true; // enable short route for next run
-    mtx.unlock();
     return spath;
   }
 

--- a/src/openms_gui/CMakeLists.txt
+++ b/src/openms_gui/CMakeLists.txt
@@ -38,7 +38,7 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 # --------------------------------------------------------------------------
 # Find Qt
 #---------------------------------------------------------------------------
-set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Network Svg)
+set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Network Svg Concurrent)
 
 # On macOS the platform plugin of QT requires PrintSupport. We link
 # so it's packaged via the bundling/dependency tools/scripts
@@ -65,6 +65,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(${Qt5Widgets_DEFINITIONS})
 add_definitions(${Qt5Svg_DEFINITIONS})
 add_definitions(${Qt5Network_DEFINITIONS})
+add_definitions(${Qt5Concurrent_DEFINITIONS})
 
 # Executables fail to build with Qt 5 in the default configuration
 # without -fPIE. We add that here.
@@ -92,6 +93,7 @@ set(OpenMS_GUI_DEP_LIBRARIES OpenMS
                              ${Qt5Widgets_LIBRARIES}
                              ${Qt5Svg_LIBRARIES}
                              ${Qt5Network_LIBRARIES}
+                             ${Qt5Concurrent_LIBRARIES}
                             )
 set(OpenMS_GUI_PRIVATE_DEP_LIBRARIES "")
 
@@ -113,6 +115,7 @@ openms_add_library(TARGET_NAME OpenMS_GUI
                                      ${Qt5Widgets_INCLUDE_DIRS}
 				                     ${Qt5Svg_INCLUDE_DIRS}
 				                     ${Qt5Network_INCLUDE_DIRS}
+                                     ${Qt5Concurrent_INCLUDE_DIRS}
                    LINK_LIBRARIES ${OpenMS_GUI_DEP_LIBRARIES}
                    PRIVATE_LINK_LIBRARIES ${OpenMS_GUI_PRIVATE_DEP_LIBRARIES}
                    DLL_EXPORT_PATH "OpenMS/VISUAL/")

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -47,6 +47,8 @@ class QRadioButton;
 class QString;
 
 #include <QtWidgets/QDialog>
+#include <QFuture>
+#include <QFutureWatcher>
 
 namespace OpenMS
 {
@@ -92,7 +94,7 @@ public:
     /// to get the currently selected tool-name
     String getTool();
 
-private:
+  private:
     /// ParamEditor for reading ini-files
     ParamEditor * editor_;
     /// tools description label
@@ -120,12 +122,16 @@ private:
     /// Mapping of file extension to layer type to determine the type of a tool
     std::map<String, LayerData::DataType> tool_map_;
 
+    QFuture<Param> param_future_;
+    QFutureWatcher<Param> watcher;
+    LayerData::DataType layer_type;
+
     ///Disables the ok button and input/output comboboxes
     void disable_();
     ///Enables the ok button and input/output comboboxes
     void enable_();
     /// Generates an .ini file for a given tool name and loads it into a Param object.
-    Param getParamFromIni_(const String& tool_name);
+    Param getParamFromIni_(const String& toppExeName);
     /// Determine all types a tool is compatible with by mapping each file extensions in a tools param
     std::vector<LayerData::DataType> getTypesFromParam_(const Param& p) const;
     // Fill input_combo_ and output_combo_ box with the appropriate entries from the specified param object.
@@ -143,6 +149,8 @@ protected slots:
     void loadINI_();
     /// stores an ini-file from the editor_
     void storeINI_();
+
+    void addEntries();
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/ToolsDialog.h
@@ -123,15 +123,15 @@ public:
     std::map<String, LayerData::DataType> tool_map_;
 
     QFuture<Param> param_future_;
-    QFutureWatcher<Param> watcher;
-    LayerData::DataType layer_type;
+    QFutureWatcher<Param> param_watcher_;
+    LayerData::DataType layer_type_;
 
     ///Disables the ok button and input/output comboboxes
     void disable_();
     ///Enables the ok button and input/output comboboxes
     void enable_();
     /// Generates an .ini file for a given tool name and loads it into a Param object.
-    Param getParamFromIni_(const String& toppExeName);
+    static Param getParamFromIni_(const String& name);
     /// Determine all types a tool is compatible with by mapping each file extensions in a tools param
     std::vector<LayerData::DataType> getTypesFromParam_(const Param& p) const;
     // Fill input_combo_ and output_combo_ box with the appropriate entries from the specified param object.
@@ -149,7 +149,7 @@ protected slots:
     void loadINI_();
     /// stores an ini-file from the editor_
     void storeINI_();
-
+    // Adds all tools/utils compatible with the given layer type to the tools_combo_
     void addEntries();
   };
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1636,7 +1636,7 @@ namespace OpenMS
       log_->appendNewHeader(LogWindow::LogState::CRITICAL, "Cannot create temporary file", String("Cannot write to '") + topp_.file_name + "'_ini!");
       return;
     }
-    ToolsDialog tools_dialog(this, topp_.file_name + "_ini", current_path_, layer.type, layer.getName());
+    ToolsDialog tools_dialog(this, log_, topp_.file_name + "_ini", current_path_, layer.type, layer.getName());
 
     if (tools_dialog.exec() == QDialog::Accepted)
     {

--- a/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/ToolsDialog.cpp
@@ -179,8 +179,8 @@ namespace OpenMS
 
   Param ToolsDialog::getParamFromIni_(const String& name)
   {
-    String path = File::getUniqueName();
-    QStringList args{ "-write_ini", path.toQString(), "-log", (path+".log").toQString() };
+    String path = File::getUniqueName() + ".ini";
+    QStringList args{ "-write_ini", path.toQString() };
     QProcess qp;
     Param tool_param;
     String executable = File::findSiblingTOPPExecutable(name);

--- a/src/tests/class_tests/openms_gui/CMakeLists.txt
+++ b/src/tests/class_tests/openms_gui/CMakeLists.txt
@@ -56,7 +56,7 @@ include_directories(${PROJECT_BINARY_DIR})
 add_custom_target(VISUAL_TEST)
 add_dependencies(VISUAL_TEST ${visual_executables_list})
 
-find_package(Qt5 COMPONENTS Core Network Widgets Svg OpenGL REQUIRED)
+find_package(Qt5 COMPONENTS Concurrent Core Network Widgets Svg OpenGL REQUIRED)
 if (NOT Qt5Widgets_FOUND)
   message(STATUS "QtWidgets module not found!")
   message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")

--- a/src/topp/CMakeLists.txt
+++ b/src/topp/CMakeLists.txt
@@ -42,7 +42,7 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 include_directories(SYSTEM ${OpenMS_INCLUDE_DIRECTORIES})
 add_definitions(/DBOOST_ALL_NO_LIB)
 
-find_package(Qt5 COMPONENTS Core Network REQUIRED)
+find_package(Qt5 COMPONENTS Core Network Concurrent REQUIRED)
 
 # add all the tools
 include(executables.cmake)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -42,7 +42,7 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 include_directories(SYSTEM ${OpenMS_INCLUDE_DIRECTORIES})
 add_definitions(/DBOOST_ALL_NO_LIB)
 
-find_package(Qt5 COMPONENTS Core Network REQUIRED)
+find_package(Qt5 COMPONENTS Core Network Concurrent REQUIRED)
 
 # add all the tools
 set(UTILS_executables)


### PR DESCRIPTION
# Description
This focuses on two things:
1. Making utils available for selection in ToolsDialog.
2. Increasing the performance of the compatibility checks (whether a tool or util can be applied to the current layer type) by using `QtConcurrency` i.e. threading `getParamFromIni_` so that IO action can be properly scheduled thus increasing the performance. This also makes sure the main thread isn't blocked and the GUI can still be used. All compatible tools/utils are then later added to the combo box when ready. Failures during the execution of `getParamFromIni_` are signaled to the main thread where they are added to TOPPView's LogWindow via a slot `addEntries_`.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
