### PR TITLE
Extends precondition check bounds to equality

### DIFF
--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -311,12 +311,12 @@ namespace OpenMS
 
     double MassTrace::linearInterpolationAtY_(double xA, double xB, double yA, double yB, double y_eval) const
     {
-      OPENMS_PRECONDITION(yA < y_eval && y_eval < yB, "y_eval is not between yA and yB")
+      OPENMS_PRECONDITION(yA <= y_eval && y_eval <= yB, "y_eval is not between yA and yB")
       // no solution -> return an estimate
       if (std::fabs(xA - xB) == 0 || std::fabs(yA - yB) == 0)  { return xA; }
 
       double xC = (xA + ((y_eval - yA) * (xB - xA) / (yB - yA)));
-      OPENMS_POSTCONDITION(xA < xC && xC < xB, "xC is not between xA and xB");
+      OPENMS_POSTCONDITION(xA <= xC && xC <= xB, "xC is not between xA and xB");
 
       return xC;
     }


### PR DESCRIPTION
# Description

This refers to Issue #5164

When running FeaturefinderMetabo with our data, we run into an exception, an OPENMS_PRECONDITION that is not satisfied in MassTrace::linearInterpolationAtY_:

```
OPENMS_PRECONDITION(yA < y_eval && y_eval < yB, "y_eval is not between yA and yB")
```

However, the values for yA and y_eval are equals: 284.00000000 (screenshot attached). 

![image](https://user-images.githubusercontent.com/1705849/108240172-e0533480-714a-11eb-997f-cb2b05227aba.png)

The assertion passes by changing conditions to <= and everything gets executed until the end. 

On the issue discussion, it is suggested only to check yB > yA to avoid division per 0, however, this situation seems to be already handled in that method.

An even better precondition would be to test for the then needed more dangerous yB > yA so that it is not dividing by zero
we are launching FeatureFinderMetabo in a simple way:
FeatureFinderMetabo -in data.mzML -out out.featureXML


# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
**-> This very minor fix, should I do a change in CHANGELOG?**
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)


