### PR TITLE
NOVORAdapter fixes

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -143,7 +143,7 @@ namespace OpenMS
             map[spectrum_idx].getPeptideIdentifications().push_back(peptide_ids[i]);
             peptides_mapped.insert(i);
           } 
-          catch (const Exception::ElementNotFound& e) 
+          catch (const Exception::ElementNotFound& /*e*/) 
           { // use RT for mapping
             identifications_precursors.insert(make_pair(peptide_ids[i].getRT(), i));
           }

--- a/src/utils/NovorAdapter.cpp
+++ b/src/utils/NovorAdapter.cpp
@@ -52,7 +52,6 @@
 
 #include <OpenMS/SYSTEM/JavaInfo.h>
 
-#include <QProcessEnvironment>
 #include <QFileInfo>
 
 #include <fstream>
@@ -195,15 +194,9 @@ protected:
     //-------------------------------------------------------------
     String in = getStringOption_("in");
     String out = getStringOption_("out");
-    
-    if (out.empty())
-    {
-      writeLog_("Fatal error: no output file given");
-      return ILLEGAL_PARAMETERS;
-    }
 
     //-------------------------------------------------------------
-    // determining the executable
+    // determine the executable
     //-------------------------------------------------------------
     const String java_executable = getStringOption_("java_executable");
     QString java_memory = "-Xmx" + QString::number(getIntOption_("java_memory")) + "m";
@@ -212,17 +205,16 @@ protected:
 
     if (executable.isEmpty())
     {
-      const QProcessEnvironment env;
-      const QString & qnovorpathenv = env.systemEnvironment().value("NOVOR_PATH");
-      if (qnovorpathenv.isEmpty())
+      const char* novor_path_env = getenv("NOVOR_PATH");
+      if (novor_path_env == nullptr || strlen(novor_path_env) == 0)
       {
-        writeLog_( "FATAL: Executable of Novor could not be found. Please either use NOVOR_PATH env variable or provide with -executable");
+        writeLog_( "FATAL: Executable of Novor could not be found. Please either use NOVOR_PATH env variable or provide via '-executable'!");
         return MISSING_PARAMETERS;
       }
-      executable = qnovorpathenv;
+      executable = novor_path_env;
     }
 
-    //Normalize file path
+    // Normalize file path
     QFileInfo file_info(executable);
     executable = file_info.canonicalFilePath();
 
@@ -233,7 +225,7 @@ protected:
     // reading input
     //-------------------------------------------------------------
     
-    //tmp_dir
+    // tmp_dir
     File::TempDir tmp_dir(debug_level_ >= 2);
 
     // parameter file
@@ -242,25 +234,38 @@ protected:
     createParamFile_(os);
 
     // convert mzML to mgf format
+    Size count_written{ 0 };
     String tmp_mgf = tmp_dir.getPath() + "tmp_mgf.mgf";
     {
-      MSDataTransformingConsumer c{};
-      std::ofstream ofs;
-      ofs.open(tmp_mgf, std::ofstream::out);
+      std::ofstream ofs(tmp_mgf, std::ofstream::out);
       MascotGenericFile mgf;
 
-      auto f = [&ofs,&in,&mgf](const MSSpectrum& s)
+      auto f = [&ofs, &in, &mgf, &count_written](const MSSpectrum& spec)
       {
-        UInt lvl = s.getMSLevel();
-        bool centroided = s.getType() == MSSpectrum::SpectrumType::CENTROID;
-        if (lvl == 2 && centroided)
+        if (spec.getType(true) == MSSpectrum::SpectrumType::CENTROID)
         {
-            mgf.writeSpectrum(ofs, s, in, "UNKNOWN");
+          mgf.writeSpectrum(ofs, spec, in, "UNKNOWN");
+          ++count_written;
         }
       };
+      MSDataTransformingConsumer c;
       c.setSpectraProcessingFunc(f);
-      MzMLFile().transform(in, &c, true);
-      ofs.close();
+      MzMLFile mzml_file;
+      mzml_file.getOptions().setMSLevels({2});
+      mzml_file.transform(in, &c, true);
+      OPENMS_LOG_INFO << "Info: " << count_written << " MS2 spectra will be passed to NOVOR\n";
+      if (count_written == 0)
+      {
+        if (getFlag_("force"))
+        {
+          OPENMS_LOG_WARN << "Warning: no MS2 spectra were passed to NOVOR. The result will be empty! To make this an error, remove the '-force' flag!" << std::endl;
+        }
+        else
+        {
+          OPENMS_LOG_ERROR << "Error: no MS2 spectra were passed to NOVOR. This is probably not intentional. Please check the input data '" << in << "'. To make this a warning, set the '-force' flag." << std::endl;
+          return ExitCodes::INPUT_FILE_EMPTY;
+        }
+      }
     }
 
     //-------------------------------------------------------------
@@ -300,88 +305,84 @@ protected:
     SpectrumLookup mapping;
     mapping.readSpectra(exp);
 
-    ifstream csvfile(tmp_out);
-    if (csvfile) 
+    if (!File::exists(tmp_out))
     {
-      CsvFile csv(tmp_out, ',');
-
-      std::cout << "file was generated" << std::endl;
-        
-      vector<PeptideIdentification> peptide_ids;
-      for (Size i = 0; i != csv.rowCount(); ++i)
-      {
-        StringList sl;
-        csv.getRow(i, sl);
-        
-        if (sl.empty() || sl[0][0] == '#') { continue; }
-        
-        PeptideIdentification pi;
-        pi.setMetaValue("spectrum_reference", exp[mapping.findByScanNumber(sl[1].toInt())].getNativeID());
-        pi.setScoreType("novorscore");
-        pi.setHigherScoreBetter(true);
-        pi.setRT(sl[2].toDouble());
-        pi.setMZ(sl[3].toDouble());
-
-        PeptideHit ph;
-        ph.setCharge(sl[4].toInt());
-        ph.setScore(sl[8].toDouble());
-
-        // replace PTM name (see http://wiki.rapidnovor.com/wiki/Built-in_PTMs)
-        String sequence = sl[9];
-        sequence.substitute("(Cam)", "(Carbamidomethyl)");
-        sequence.substitute("(O)","(Oxidation)");
-        sequence.substitute("(PyroCam)", "(Pyro-carbamidomethyl)");
-        
-        ph.setSequence(AASequence::fromString(sequence));      
-        ph.setMetaValue("pepMass(denovo)", sl[5].toDouble());
-        ph.setMetaValue("err(data-denovo)", sl[6].toDouble());
-        ph.setMetaValue("ppm(1e6*err/(mz*z))", sl[7].toDouble());
-        ph.setMetaValue("aaScore", sl[10].toQString());
-
-        pi.getHits().push_back(ph);   
-        peptide_ids.emplace_back(pi);
-      } 
-
-      // extract version from comment 
-      // #              v1.06.0634 (stable)
-      // v1.06.0634 (stable)
-      vector<ProteinIdentification> protein_ids;
-      StringList versionrow;
-      csv.getRow(2, versionrow);
-      String version = versionrow[0].substr(versionrow[0].find("v."));
-      
-      protein_ids = vector<ProteinIdentification>(1);
-      protein_ids[0].setDateTime(DateTime::now());
-      protein_ids[0].setSearchEngine("Novor");
-      protein_ids[0].setSearchEngineVersion(version);
-
-      ProteinIdentification::SearchParameters search_parameters;
-      search_parameters.db = "denovo";
-      search_parameters.mass_type = ProteinIdentification::MONOISOTOPIC;
-    
-      // if a parameter file is used the modifications need to be parsed from the novor output csv
-      search_parameters.fixed_modifications = getStringList_("fixed_modifications");
-      search_parameters.variable_modifications = getStringList_("variable_modifications");
-      search_parameters.fragment_mass_tolerance = getDoubleOption_("fragment_mass_tolerance");
-      search_parameters.precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
-      search_parameters.precursor_mass_tolerance_ppm = getStringOption_("precursor_error_units") == "ppm" ? true : false;
-      search_parameters.fragment_mass_tolerance_ppm = false;
-      search_parameters.digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme(getStringOption_("enzyme"));
-     
-      //StringList inputFile;
-      //inputFile[0] = in;
-      //protein_ids[0].setPrimaryMSRunPath(inputFile); 
-      protein_ids[0].setSearchParameters(search_parameters);
-     
-      IdXMLFile().store(out, protein_ids, peptide_ids);
-
+      OPENMS_LOG_ERROR << "Error: NOVOR did not write the output file '" << tmp_out << "' as requested!\n";
+      return ExitCodes::EXTERNAL_PROGRAM_ERROR;
     }
-    else
+    CsvFile csv(tmp_out, ',');
+        
+    vector<PeptideIdentification> peptide_ids;
+    for (Size i = 0; i != csv.rowCount(); ++i)
     {
-      writeLog_("Novor output is empty! No IdXML output was generated.");
+      StringList sl;
+      csv.getRow(i, sl);
+        
+      if (sl.empty() || sl[0][0] == '#') { continue; }
+        
+      PeptideIdentification pi;
+      pi.setMetaValue("spectrum_reference", exp[mapping.findByScanNumber(sl[1].toInt())].getNativeID());
+      pi.setScoreType("novorscore");
+      pi.setHigherScoreBetter(true);
+      pi.setRT(sl[2].toDouble());
+      pi.setMZ(sl[3].toDouble());
+
+      PeptideHit ph;
+      ph.setCharge(sl[4].toInt());
+      ph.setScore(sl[8].toDouble());
+
+      // replace PTM name (see http://wiki.rapidnovor.com/wiki/Built-in_PTMs)
+      String sequence = sl[9];
+      sequence.substitute("(Cam)", "(Carbamidomethyl)");
+      sequence.substitute("(O)","(Oxidation)");
+      sequence.substitute("(PyroCam)", "(Pyro-carbamidomethyl)");
+        
+      ph.setSequence(AASequence::fromString(sequence));      
+      ph.setMetaValue("pepMass(denovo)", sl[5].toDouble());
+      ph.setMetaValue("err(data-denovo)", sl[6].toDouble());
+      ph.setMetaValue("ppm(1e6*err/(mz*z))", sl[7].toDouble());
+      ph.setMetaValue("aaScore", sl[10].toQString());
+
+      pi.getHits().push_back(std::move(ph));   
+      peptide_ids.push_back(std::move(pi));
     } 
 
-   return EXECUTION_OK;
+    // extract version from comment 
+    // #              v1.06.0634 (stable)
+    // v1.06.0634 (stable)
+    vector<ProteinIdentification> protein_ids;
+    StringList versionrow;
+    csv.getRow(2, versionrow);
+    String version = versionrow[0].substr(versionrow[0].find("v."));
+      
+    protein_ids = vector<ProteinIdentification>(1);
+    protein_ids[0].setDateTime(DateTime::now());
+    protein_ids[0].setSearchEngine("Novor");
+    protein_ids[0].setSearchEngineVersion(version);
+
+    ProteinIdentification::SearchParameters search_parameters;
+    search_parameters.db = "denovo";
+    search_parameters.mass_type = ProteinIdentification::MONOISOTOPIC;
+    
+    // if a parameter file is used the modifications need to be parsed from the novor output csv
+    search_parameters.fixed_modifications = getStringList_("fixed_modifications");
+    search_parameters.variable_modifications = getStringList_("variable_modifications");
+    search_parameters.fragment_mass_tolerance = getDoubleOption_("fragment_mass_tolerance");
+    search_parameters.precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
+    search_parameters.precursor_mass_tolerance_ppm = getStringOption_("precursor_error_units") == "ppm" ? true : false;
+    search_parameters.fragment_mass_tolerance_ppm = false;
+    search_parameters.digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme(getStringOption_("enzyme"));
+     
+    //StringList inputFile;
+    //inputFile[0] = in;
+    //protein_ids[0].setPrimaryMSRunPath(inputFile); 
+    protein_ids[0].setSearchParameters(search_parameters);
+     
+    OPENMS_LOG_INFO << "NOVOR created " << peptide_ids.size() << " PSMs from " << count_written << " MS2 spectra (" << (peptide_ids.size() * 100 / count_written) << "% annotated)\n";
+
+    IdXMLFile().store(out, protein_ids, peptide_ids);
+
+    return EXECUTION_OK;
   }
 };
 

--- a/src/utils/NovorAdapter.cpp
+++ b/src/utils/NovorAdapter.cpp
@@ -108,10 +108,10 @@ public:
   TOPPNovorAdapter() :
     TOPPBase("NovorAdapter", "Template for Tool creation", false, 
     {
-      {"Ma Bin",
-       "Novor: Real-Time Peptide de Novo Sequencing Software",
-       "Journal of The American Society for Mass Spectrometry; 30 June 2015",
-       "0.1007/s13361-015-1204-0"}
+      Citation{"Ma Bin",
+               "Novor: Real-Time Peptide de Novo Sequencing Software",
+               "Journal of The American Society for Mass Spectrometry; 30 June 2015",
+               "10.1007/s13361-015-1204-0"}
     })
     {}
 


### PR DESCRIPTION
# Description

fixes #5178 

 - fix NOVOR DOI
 - [FIX] NOVORAdapter: also write MS2 spectra even if their metadata type is not annotated
 - [FIX] NOVORAdapter: error if no MS2 spectra were passed to NOVOR
 - [FEATURE] NOVORAdapter: report MS2 spectra written and annotation rate

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
