### PR TITLE
Revert changes due to cython 0.29.2

### DIFF
--- a/tools/travis/lnx-cibuild.before.sh
+++ b/tools/travis/lnx-cibuild.before.sh
@@ -33,7 +33,7 @@ if [ "${PYOPENMS}" = "ON" ]; then
   pip install -U nose
   pip install -U numpy
   pip install -U wheel
-  pip install -U Cython==0.29.21
+  pip install -U Cython
   pip install -U autowrap
 fi
 


### PR DESCRIPTION
# Description

Issue:
https://github.com/OpenMS/OpenMS/issues/5188

Autowrap FIX See uweschmitt/autowrap#99
Should work with python 3.6, cython 0.29.22 and autowrap 0.22.2.

# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
