### PR TITLE
ADD: SpectrumLookup - MS_Agilent_MassHunter_nativeID_format

### DIFF
--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -285,6 +285,11 @@ namespace OpenMS
     {
       regexp = std::string("index=(?<GROUP>\\d+)");
     }
+    // "scanId=NUMBER" - MS_Agilent_MassHunter_nativeID_format
+    else if (native_id_type_accession == "MS:1001508")
+    {
+      regexp = std::string("scanId=(?<GROUP>\\d+)");
+    }
     // "spectrum=NUMBER"
     else if (native_id_type_accession == "MS:1000777")
     {

--- a/src/tests/class_tests/openms/source/SpectrumLookup_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumLookup_test.cpp
@@ -175,6 +175,7 @@ START_SECTION((static Int extractScanNumber(const String&,
   TEST_EQUAL(SpectrumLookup::extractScanNumber("file=42", "MS:1000773"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("file=42", "MS:1000775"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("index=42", "MS:1000774"), 42);
+  TEST_EQUAL(SpectrumLookup::extractScanNumber("scanId=42", "MS:1001508"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("spectrum=42", "MS:1000777"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("42", "MS:1001530"), 42);
 }


### PR DESCRIPTION
# Description

Can not extract the scan_number based on the nativeId_accession from MS_Agilent_MassHunter_nativeID_format

# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
