### PR TITLE
[Fix] Added missing virtual deconstructor to SiriusAdapterAlgorithm

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
@@ -234,6 +234,8 @@ namespace OpenMS
       SiriusAdapterAlgorithm *enclose;
 
     public:
+      virtual ~ParameterSection() = default;
+
       DataValue getValue(const String &param_name) const
       {
         return enclose->param_.getValue(toFullParameter(param_name));


### PR DESCRIPTION
# Description

Added missing virtual deconstructor to `ParameterSection` class in `SiriusAdapterAlgorithm` whose absence previously caused issues with `SiriusAdapter` and `AssayGeneratorMetabo`.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
