### PR TITLE
[FIX] Make ProgressLogger destructor virtual

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/ProgressLogger.h
+++ b/src/openms/include/OpenMS/CONCEPT/ProgressLogger.h
@@ -58,7 +58,7 @@ public:
     ProgressLogger();
 
     /// Destructor
-    ~ProgressLogger();
+    virtual ~ProgressLogger();
 
     /// Copy constructor
     ProgressLogger(const ProgressLogger& other);


### PR DESCRIPTION
# Description

Avoid memory leaks in tests where we often create pointers of TOPPBase tools
