### PR TITLE
[Feature] Id mapping on open of idXML

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -646,7 +646,7 @@ namespace OpenMS
             QMessageBox msg_box;
             auto spectra_file_name = File::basename(annotate_path);
             msg_box.setText("Spectra data for identification data was found.");
-            msg_box.setInformativeText(String("Annotate spectra using " + spectra_file_name + "?").toQString());
+            msg_box.setInformativeText(String("Annotate spectra in " + spectra_file_name + "?").toQString());
             msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
             msg_box.setDefaultButton(QMessageBox::Yes);
             auto ret = msg_box.exec();

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -561,7 +561,8 @@ namespace OpenMS
 
     vector<PeptideIdentification> peptides;
     // not needed in data but for auto annotation
-    struct annotate_data_t {
+    struct annotate_data_t
+    {
       OpenMS::String path;
       vector<PeptideIdentification> peptide_id;
       vector<ProteinIdentification> protein_id;
@@ -626,12 +627,11 @@ namespace OpenMS
           StringList paths;
           proteins[0].getPrimaryMSRunPath(paths);
 
-          for (StringList::const_iterator it = paths.begin(); it != paths.end(); ++it)
+          for (const String &path : paths)
           {
-
-            if (File::exists(*it) && fh.getType(*it) == FileTypes::MZML)
+            if (File::exists(path) && fh.getType(path) == FileTypes::MZML)
             {
-              annotate_data.path = *it;
+              annotate_data.path = path;
             }
           }
           // annotation could not be found in file reference
@@ -639,7 +639,8 @@ namespace OpenMS
           {
             // try to find file with same path & name but with mzML extension
             auto target = fh.swapExtension(abs_filename, FileTypes::Type::MZML);
-            if (File::exists(target)) {
+            if (File::exists(target))
+            {
               annotate_data.path = target;
             }
           }
@@ -648,16 +649,18 @@ namespace OpenMS
           {
             // open dialog for annotation on load
             QMessageBox msg_box;
-            auto name = File::basename(annotate_data.path);
-            msg_box.setText("An associated Spectra file was found.");
-            msg_box.setInformativeText(String("Annotate spectra using " + name + "?").toQString());
+            auto spectra_file_name = File::basename(annotate_data.path);
+            msg_box.setText("Spectra data for identification data was found.");
+            msg_box.setInformativeText(String("Annotate spectra using " + spectra_file_name + "?").toQString());
             msg_box.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
             msg_box.setDefaultButton(QMessageBox::Yes);
             auto ret = msg_box.exec();
             if (ret == QMessageBox::No)
             { // no annotation performed
               annotate_data.path = "";
-            } else {
+            }
+            else
+            {
               annotate_data.peptide_id = peptides;
               annotate_data.protein_id = proteins;
             }


### PR DESCRIPTION
# Description

Automatically annotates and maps spectra when an idXML file is openend and a reference to its associated mzML file is given in the `spectra_data` meta data or a mzML file with the same name is found in the same folder.  

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
