### PR TITLE
[pyOpenMS] convert list [str, ... ] to StringList

### DIFF
--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -181,7 +181,7 @@ def doCythonCompile(arg):
     m_filename = "pyopenms/%s.pyx" % modname
     print ("Cython compile", m_filename)
     # By omitting "compiler_directives": {"language_level": 3} as extra_opt, autowrap will choose the language_level of the used python executable
-    autowrap.Main.run_cython(inc_dirs=autowrap_include_dirs, extra_opts={}, out=m_filename)
+    autowrap.Main.run_cython(inc_dirs=autowrap_include_dirs, extra_opts={"compiler_directives":{"c_string_type": "str"}}, out=m_filename)
 
     if False:
         #

--- a/src/pyOpenMS/pxds/ParamEntry.pxd
+++ b/src/pyOpenMS/pxds/ParamEntry.pxd
@@ -1,5 +1,6 @@
 from Types cimport *
 from libcpp.string cimport string as libcpp_string
+from libcpp.string cimport string as libcpp_utf8_string # triggers input conversion provider for std string
 from libcpp.vector cimport vector as libcpp_vector
 from libcpp.set cimport set as libcpp_set
 from ParamValue cimport *
@@ -20,8 +21,8 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Param.h>" namespace "OpenMS::Param":
 
         ParamEntry() nogil except +
         ParamEntry(ParamEntry) nogil except +
-        ParamEntry(libcpp_string n, ParamValue v, libcpp_string d, libcpp_vector[libcpp_string] t) nogil except +
-        ParamEntry(libcpp_string n, ParamValue v, libcpp_string d) nogil except +
+        ParamEntry(libcpp_string n, ParamValue v, libcpp_utf8_string d, libcpp_vector[libcpp_utf8_string] t) nogil except +
+        ParamEntry(libcpp_string n, ParamValue v, libcpp_utf8_string d) nogil except +
 
         # TODO: wrap bool isValid(libcpp_string & message) maybe as libcpp_pair[bool, libcpp_str] isValid() if possible
         bool operator==(ParamEntry) nogil except +

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -549,9 +549,16 @@ def testModificationDefinitionsSet():
     @tests: ModificationDefinitionsSet
      ModificationDefinitionsSet.__init__
     """
+    # [bytes, ..] to StringList conversion
     empty = pyopenms.ModificationDefinitionsSet()
     fixed = [b"Carbamidomethyl"]
     variable = [b"Oxidation"]
+    full = pyopenms.ModificationDefinitionsSet(fixed, variable)
+
+    # [str, ..] to StringList conversion
+    empty = pyopenms.ModificationDefinitionsSet()
+    fixed = ["Carbamidomethyl"]
+    variable = ["Oxidation", "Phospho"]
     full = pyopenms.ModificationDefinitionsSet(fixed, variable)
 
 @report
@@ -1088,9 +1095,16 @@ def testDataValue():
     assert a.toDoubleList() == [1.0]
     assert a.valueType() == pyopenms.DataType.DOUBLE_LIST
 
+    # StringList with bytes
     a = pyopenms.DataValue([b"1.0"])
     assert not a.isEmpty()
     assert a.toStringList() == [b"1.0"]
+    assert a.valueType() == pyopenms.DataType.STRING_LIST
+
+    # StringList with str
+    a = pyopenms.DataValue(["1.0"])
+    assert not a.isEmpty()
+    assert a.toStringList() == ["1.0"]
     assert a.valueType() == pyopenms.DataType.STRING_LIST
 
     assert pyopenms.MSSpectrum().getMetaValue("nonexisingkey") is None
@@ -5412,3 +5426,11 @@ def testString():
     # assert( isinstance(r, bytes) )
     assert(r.decode("iso8859_15") == u"bläh")
 
+    # TODO: str in map access
+    #ef = pyopenms.EmpiricalFormula("C2H5")
+    #m = ef.getElementalComposition()
+    #assert m["C"] == 2
+    #assert m["H"] == 5
+
+
+ 

--- a/src/tests/class_tests/openms/source/FAIMSHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/FAIMSHelper_test.cpp
@@ -60,14 +60,14 @@ START_SECTION((FAIMSHelper()))
 END_SECTION
 
 START_SECTION((~FAIMSHelper()))
-	delete e_ptr;
+  delete e_ptr;
 END_SECTION
 
 e_ptr = new FAIMSHelper();
 
 START_SECTION((std::set<double> getCompensationVoltages(PeakMap& exp)))
-	delete e_ptr;
-	e_ptr = new FAIMSHelper();
+  delete e_ptr;
+  e_ptr = new FAIMSHelper();
   MzMLFile IM_file;
   PeakMap exp;
   IM_file.load(OPENMS_GET_TEST_DATA_PATH("IM_FAIMS_test.mzML"), exp);
@@ -75,14 +75,13 @@ START_SECTION((std::set<double> getCompensationVoltages(PeakMap& exp)))
   TEST_EQUAL(exp.getSpectra().size(), 19)
 
   std::set<double> CVs = e_ptr->getCompensationVoltages(exp);
-	auto cv_it = CVs.begin();
+  
   TEST_EQUAL(CVs.size(), 3)
-	TEST_EQUAL(CVs.find(-65.0) == CVs.end(), 0)
-	TEST_EQUAL(CVs.find(-55.0) == CVs.end(), 0)
-	TEST_EQUAL(CVs.find(-45.0) == CVs.end(), 0)
+  TEST_EQUAL(CVs.find(-65.0) == CVs.end(), 0)
+  TEST_EQUAL(CVs.find(-55.0) == CVs.end(), 0)
+  TEST_EQUAL(CVs.find(-45.0) == CVs.end(), 0)
 
 END_SECTION
-
 
 delete e_ptr;
 


### PR DESCRIPTION
# Description
Adapted the special_conversion_providers for autowrap.

now StringLists can be passed in python with both bytes and str
[b"string1", b"string2"] and ["string1", "string2"]

More similar to how user could write could before switch to python 3

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
