### PR TITLE
[Fix] Prevent crash when TOPP tool/util executable cannot be found

### DIFF
--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -114,7 +114,7 @@ namespace OpenMS
     }
     catch (const Exception::FileNotFound& e)
     {
-      std::cerr <<  e << std::endl;
+      std::cerr << "TOPP tool: " << e << " not found during tool discovery. Skipping." << std::endl;
       return tool_param;
     }
     // Write tool ini to temporary file

--- a/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
+++ b/src/openms_gui/source/VISUAL/TVToolDiscovery.cpp
@@ -40,6 +40,8 @@
 
 #include <QCoreApplication>
 
+#include <iostream>
+
 namespace OpenMS
 {
 
@@ -103,16 +105,27 @@ namespace OpenMS
     String working_dir = path.prefix(path.find_last_of('/'));
     QStringList args{"-write_ini", path.toQString()};
     // Start tool/util to write the ini file
-    String executable = File::findSiblingTOPPExecutable(tool_name);
+    Param tool_param;
+    String executable;
+    // Return empty param if tool executable cannot be found
+    try
+    {
+      executable = File::findSiblingTOPPExecutable(tool_name);
+    }
+    catch (const Exception::FileNotFound& e)
+    {
+      std::cerr <<  e << std::endl;
+      return tool_param;
+    }
+    // Write tool ini to temporary file
     ExternalProcess proc;
     auto return_state = proc.run(executable.toQString(), args, working_dir.toQString(), false, ExternalProcess::IO_MODE::NO_IO);
     // Return empty param if writing the ini file failed
-    Param tool_param;
     if (return_state != ExternalProcess::RETURNSTATE::SUCCESS)
     {
       return tool_param;
     }
-    // Parse ini file to param object and return it
+    // Parse ini file to param object
     ParamXMLFile paramFile;
     paramFile.load((path).c_str(), tool_param);
     return tool_param;


### PR DESCRIPTION
# Description

This PR aims to prevent the crashing of `TVToolDiscovery` when some tool/util executables listed in `ToolHandler` cannot be found as described in issue #5318.This is done by simply catching a `Exception::FileNotFound` error in `TVToolDiscovery::getParamFromIni_` and printing it to stderr. 

I don't know how common the use case of not having all tools/utils build is. Should this be common (especially among regular user)  it might be worth extending this PR. When not all tools are loaded during start, these tool params cannot be written to TOPPView.ini, so that on the next start these tool params are missing again (when loaded from the ini) however without any warning presented to the user. We could add a check to `TOPPViewBase::loadPreferences` which ensures that the tool params in the TOPPView.ini are complete and none are missing compared the number of tools/utils listed in `ToolHandler`. This is not trivial though as I'd have to extend the param class with a functions that somehow counts all direct subnodes of a given node so that the tool params saved in the TOPPView.ini can be counted. 

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
