### PR TITLE
Fix/ipf peptidoform gen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,6 +95,7 @@ the authors tag in the respective file header.
  - Volker Mosthaf
  - Witold Wolski
  - Xiao Liang
+ - Justin Sing
  
 
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Adapters/Third-party support:
 
 Further fixes:
 - support for GLPK 5.x (#5127)
+- IPF: add a check for terminal residue modification when generating theoretical peptidoforms
 
 File formats:
 - Exporter for MSP files

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -172,7 +172,9 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is NTerm modifiable
             const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
-            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->searchModifications(modification,"",ResidueModification::N_TERM);
+            OpenMS::ModificationsDB* ptr = ModificationsDB::getInstance();
+            std::set<const ResidueModification*> modifiable_nterm;
+             ptr->searchModifications(modifiable_nterm, modification, "", ResidueModification::N_TERM);
             if ( !modifiable_nterm.empty() || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
@@ -181,7 +183,9 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is CTerm modifiable
             const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
-            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->searchModifications(modification,"",ResidueModification::C_TERM);
+            OpenMS::ModificationsDB* ptr = ModificationsDB::getInstance();
+            std::set<const ResidueModification*> modifiable_cterm;
+            ptr->searchModifications(modifiable_cterm, modification, "", ResidueModification::C_TERM);
             if ( !modifiable_cterm.empty() || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -172,7 +172,7 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is NTerm modifiable
             const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) ) {
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
           }
@@ -180,7 +180,7 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is CTerm modifiable
             const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) ){
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -172,8 +172,8 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is NTerm modifiable
             const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
-            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,temp_sequence[0].getOneLetterCode(),ResidueModification::N_TERM);
-            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
+            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->searchModifications(modification,"",ResidueModification::N_TERM);
+            if ( !modifiable_nterm.empty() || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
           }
@@ -181,8 +181,8 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is CTerm modifiable
             const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
-            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,temp_sequence[temp_sequence.size() - 1].getOneLetterCode(),ResidueModification::C_TERM);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
+            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->searchModifications(modification,"",ResidueModification::C_TERM);
+            if ( !modifiable_cterm.empty() || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -178,8 +178,6 @@ namespace OpenMS
           if (*pos_it == 0)
           {
             // Check first to make sure ending residue is NTerm modifiable
-            //const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
-            //const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::N_TERM);
             if ( !modifiable_nterm.empty() && (temp_sequence[0].getOneLetterCode() == OpenMS::String((*modifiable_nterm.begin())->getOrigin()) || (*modifiable_nterm.begin())->getOrigin() == 'X') ) {
               temp_sequence.setNTerminalModification(modification);
             } else {
@@ -193,8 +191,6 @@ namespace OpenMS
           else if (*pos_it == temp_sequence.size() + 1)
           {
             // Check first to make sure ending residue is CTerm modifiable
-            //const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
-            //const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::C_TERM);
             if ( !modifiable_cterm.empty() && (temp_sequence.toUnmodifiedString().back() == (*modifiable_cterm.begin())->getOrigin() || (*modifiable_cterm.begin())->getOrigin() == 'X') ){
               temp_sequence.setCTerminalModification(modification);
             } else {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -180,7 +180,7 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is CTerm modifiable
             const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ){
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_cterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -161,6 +161,11 @@ namespace OpenMS
     bool multi_mod_switch = false;
     bool skip_invalid_mod_seq = false;
 
+    OpenMS::ModificationsDB* ptr = ModificationsDB::getInstance();
+    std::set<const ResidueModification*> modifiable_nterm;
+    ptr->searchModifications(modifiable_nterm, modification, "", ResidueModification::N_TERM);
+    std::set<const ResidueModification*> modifiable_cterm;
+    ptr->searchModifications(modifiable_cterm, modification, "", ResidueModification::C_TERM);
     for (std::vector<OpenMS::AASequence>::const_iterator sq_it = sequences.begin(); sq_it != sequences.end(); ++sq_it)
     {
       for (std::vector<std::vector<size_t> >::const_iterator mc_it = mods_combs.begin(); mc_it != mods_combs.end(); ++mc_it)
@@ -173,30 +178,30 @@ namespace OpenMS
           if (*pos_it == 0)
           {
             // Check first to make sure ending residue is NTerm modifiable
-            const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
-            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::N_TERM);
-            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
+            //const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
+            //const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::N_TERM);
+            if ( !modifiable_nterm.empty() && (temp_sequence[0].getOneLetterCode() == OpenMS::String((*modifiable_nterm.begin())->getOrigin()) || (*modifiable_nterm.begin())->getOrigin() == 'X') ) {
               temp_sequence.setNTerminalModification(modification);
             } else {
-              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of N-Term " << OpenMS::String(modifiable_nterm->getId()) <<
+              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of N-Term " << OpenMS::String((*modifiable_nterm.begin())->getId()) <<
                                    " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable N-Term residue specificity (" <<
-                                   OpenMS::String(modifiable_nterm->getOrigin()) << ") in ModificationDB." << std::endl;
+                                   OpenMS::String((*modifiable_nterm.begin())->getOrigin()) << ") in ModificationDB." << std::endl;
               skip_invalid_mod_seq = true;
             }
           }
           else if (*pos_it == temp_sequence.size() + 1)
           {
             // Check first to make sure ending residue is CTerm modifiable
-            const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
-            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::C_TERM);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
+            //const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
+            //const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::C_TERM);
+            if ( !modifiable_cterm.empty() && (temp_sequence.toUnmodifiedString().back() == (*modifiable_cterm.begin())->getOrigin() || (*modifiable_cterm.begin())->getOrigin() == 'X') ){
               temp_sequence.setCTerminalModification(modification);
             } else {
-              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String(modifiable_cterm->getId()) <<
-                                   " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
+              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String((*modifiable_cterm.begin())->getId()) <<
+                                   " to last residue (" << temp_sequence.toUnmodifiedString().back() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable C-Term residue specificity (" <<
-                                   OpenMS::String(modifiable_cterm->getOrigin()) << ") in ModificationDB." << std::endl;
+                                   OpenMS::String((*modifiable_cterm.begin())->getOrigin()) << ") in ModificationDB." << std::endl;
               skip_invalid_mod_seq = true;
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -178,9 +178,12 @@ namespace OpenMS
           if (*pos_it == 0)
           {
             // Check first to make sure ending residue is NTerm modifiable
-            if ( !modifiable_nterm.empty() && (temp_sequence[0].getOneLetterCode() == OpenMS::String((*modifiable_nterm.begin())->getOrigin()) || (*modifiable_nterm.begin())->getOrigin() == 'X') ) {
+            if ( !modifiable_nterm.empty() && (temp_sequence[0].getOneLetterCode() == OpenMS::String((*modifiable_nterm.begin())->getOrigin()) || (*modifiable_nterm.begin())->getOrigin() == 'X') ) 
+            {
               temp_sequence.setNTerminalModification(modification);
-            } else {
+            } 
+            else 
+            {
               OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of N-Term " << OpenMS::String((*modifiable_nterm.begin())->getId()) <<
                                    " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable N-Term residue specificity (" <<
@@ -191,9 +194,12 @@ namespace OpenMS
           else if (*pos_it == temp_sequence.size() + 1)
           {
             // Check first to make sure ending residue is CTerm modifiable
-            if ( !modifiable_cterm.empty() && (temp_sequence.toUnmodifiedString().back() == (*modifiable_cterm.begin())->getOrigin() || (*modifiable_cterm.begin())->getOrigin() == 'X') ){
+            if ( !modifiable_cterm.empty() && (temp_sequence.toUnmodifiedString().back() == (*modifiable_cterm.begin())->getOrigin() || (*modifiable_cterm.begin())->getOrigin() == 'X') )
+            {
               temp_sequence.setCTerminalModification(modification);
-            } else {
+            } 
+            else 
+            {
               OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String((*modifiable_cterm.begin())->getId()) <<
                                    " to last residue (" << temp_sequence.toUnmodifiedString().back() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable C-Term residue specificity (" <<

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -171,16 +171,18 @@ namespace OpenMS
           if (*pos_it == 0)
           {
             // Check first to make sure ending residue is NTerm modifiable
-            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ) {
+            const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
+            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,temp_sequence[0].getOneLetterCode(),ResidueModification::N_TERM);
+            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
           }
           else if (*pos_it == temp_sequence.size() + 1)
           {
             // Check first to make sure ending residue is CTerm modifiable
-            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_cterm->getOrigin()) == "X" ){
+            const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
+            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,temp_sequence[temp_sequence.size() - 1].getOneLetterCode(),ResidueModification::C_TERM);
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -170,11 +170,19 @@ namespace OpenMS
         {
           if (*pos_it == 0)
           {
-            temp_sequence.setNTerminalModification(modification);
+            // Check first to make sure ending residue is NTerm modifiable
+            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification);
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) ) {
+              temp_sequence.setNTerminalModification(modification);
+            }
           }
           else if (*pos_it == temp_sequence.size() + 1)
           {
-            temp_sequence.setCTerminalModification(modification);
+            // Check first to make sure ending residue is CTerm modifiable
+            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification);
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) ){
+              temp_sequence.setCTerminalModification(modification);
+            }
           }
           else
           {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -178,10 +178,10 @@ namespace OpenMS
             if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             } else {
-              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String(modifiable_nterm->getId()) <<
+              OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of N-Term " << OpenMS::String(modifiable_nterm->getId()) <<
                                    " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
-                                   " , because it does not match viable C-Term residue specificity (" <<
-                                   OpenMS::String(modifiable_nterm->getOrigin()) << ") in ModificatioDB." << std::endl;
+                                   " , because it does not match viable N-Term residue specificity (" <<
+                                   OpenMS::String(modifiable_nterm->getOrigin()) << ") in ModificationDB." << std::endl;
               skip_invalid_mod_seq = true;
             }
           }
@@ -196,7 +196,7 @@ namespace OpenMS
               OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String(modifiable_cterm->getId()) <<
                                    " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable C-Term residue specificity (" <<
-                                   OpenMS::String(modifiable_cterm->getOrigin()) << ") in ModificatioDB." << std::endl;
+                                   OpenMS::String(modifiable_cterm->getOrigin()) << ") in ModificationDB." << std::endl;
               skip_invalid_mod_seq = true;
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -172,10 +172,8 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is NTerm modifiable
             const ResidueModification* modifiable_any_nterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::N_TERM);
-            OpenMS::ModificationsDB* ptr = ModificationsDB::getInstance();
-            std::set<const ResidueModification*> modifiable_nterm;
-             ptr->searchModifications(modifiable_nterm, modification, "", ResidueModification::N_TERM);
-            if ( !modifiable_nterm.empty() || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
+            const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::N_TERM);
+            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_any_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
           }
@@ -183,10 +181,8 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is CTerm modifiable
             const ResidueModification* modifiable_any_cterm = ModificationsDB::getInstance()->getModification(modification,"X",ResidueModification::C_TERM);
-            OpenMS::ModificationsDB* ptr = ModificationsDB::getInstance();
-            std::set<const ResidueModification*> modifiable_cterm;
-            ptr->searchModifications(modifiable_cterm, modification, "", ResidueModification::C_TERM);
-            if ( !modifiable_cterm.empty() || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
+            const ResidueModification* modifiable_cterm = ModificationsDB::getInstance()->getModification(modification,"",ResidueModification::C_TERM);
+            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_cterm->getOrigin()) || OpenMS::String(modifiable_any_cterm->getOrigin()) == "X" ){
               temp_sequence.setCTerminalModification(modification);
             }
           }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -172,7 +172,7 @@ namespace OpenMS
           {
             // Check first to make sure ending residue is NTerm modifiable
             const ResidueModification* modifiable_nterm = ModificationsDB::getInstance()->getModification(modification);
-            if ( temp_sequence[temp_sequence.size() - 1].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ) {
+            if ( temp_sequence[0].getOneLetterCode() == OpenMS::String(modifiable_nterm->getOrigin()) || OpenMS::String(modifiable_nterm->getOrigin()) == "X" ) {
               temp_sequence.setNTerminalModification(modification);
             }
           }

--- a/src/tests/class_tests/openms/source/MRMAssay_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMAssay_test.cpp
@@ -343,7 +343,7 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
 
   sequences = mrma.addModificationsSequences_test(sequences, mods_combs_p, String("Phospho"));
 
-  TEST_EQUAL(sequences.size(), 13)
+  TEST_EQUAL(sequences.size(), 10)
   TEST_EQUAL(sequences[0].toString(), String("P(Oxidation)EPT(Phospho)DIEK"));
   TEST_EQUAL(sequences[1].toString(), String("P(Oxidation)EPTD(Phospho)IEK"));
   TEST_EQUAL(sequences[2].toString(), String("P(Oxidation)EPTDIEK(Phospho)"));
@@ -354,9 +354,6 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
   TEST_EQUAL(sequences[7].toString(), String("PEPTD(Oxidation)IEK(Phospho)"));
   TEST_EQUAL(sequences[8].toString(), String("PEPT(Phospho)DIEK(Oxidation)"));
   TEST_EQUAL(sequences[9].toString(), String("PEPTD(Phospho)IEK(Oxidation)"));
-  TEST_EQUAL(sequences[10].toString(), String("PEPT(Phospho)DIEK"));
-  TEST_EQUAL(sequences[11].toString(), String("PEPTD(Phospho)IEK"));
-  TEST_EQUAL(sequences[12].toString(), String("PEPTDIEK(Phospho)"));
 }
 
 END_SECTION

--- a/src/tests/class_tests/openms/source/MRMAssay_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMAssay_test.cpp
@@ -328,6 +328,7 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
   no.push_back(3);
   no.push_back(5);
   no.push_back(8);
+  no.push_back(9);
 
   std::vector<std::vector<size_t> > mods_combs_o = mrma.nchoosekcombinations_test(no, 1);
 
@@ -342,7 +343,7 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
 
   sequences = mrma.addModificationsSequences_test(sequences, mods_combs_p, String("Phospho"));
 
-  TEST_EQUAL(sequences.size(), 10)
+  TEST_EQUAL(sequences.size(), 13)
   TEST_EQUAL(sequences[0].toString(), String("P(Oxidation)EPT(Phospho)DIEK"));
   TEST_EQUAL(sequences[1].toString(), String("P(Oxidation)EPTD(Phospho)IEK"));
   TEST_EQUAL(sequences[2].toString(), String("P(Oxidation)EPTDIEK(Phospho)"));
@@ -353,6 +354,9 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
   TEST_EQUAL(sequences[7].toString(), String("PEPTD(Oxidation)IEK(Phospho)"));
   TEST_EQUAL(sequences[8].toString(), String("PEPT(Phospho)DIEK(Oxidation)"));
   TEST_EQUAL(sequences[9].toString(), String("PEPTD(Phospho)IEK(Oxidation)"));
+  TEST_EQUAL(sequences[10].toString(), String("PEPT(Phospho)DIEK"));
+  TEST_EQUAL(sequences[11].toString(), String("PEPTD(Phospho)IEK"));
+  TEST_EQUAL(sequences[12].toString(), String("PEPTDIEK(Phospho)"));
 }
 
 END_SECTION

--- a/src/tests/class_tests/openms/source/MRMAssay_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMAssay_test.cpp
@@ -354,6 +354,16 @@ START_SECTION(std::vector<OpenMS::AASequence> MRMAssay::addModificationsSequence
   TEST_EQUAL(sequences[7].toString(), String("PEPTD(Oxidation)IEK(Phospho)"));
   TEST_EQUAL(sequences[8].toString(), String("PEPT(Phospho)DIEK(Oxidation)"));
   TEST_EQUAL(sequences[9].toString(), String("PEPTD(Phospho)IEK(Oxidation)"));
+
+  std::vector<std::string> sequence_list {};
+  for (std::vector<OpenMS::AASequence>::const_iterator sq_it = sequences.begin(); sq_it != sequences.end(); ++sq_it)
+  {
+	  OpenMS::AASequence temp_sequence = *sq_it;
+	  sequence_list.push_back(temp_sequence.toString());
+  }
+
+  bool check_terminal_mod_present = (std::find(sequence_list.begin(), sequence_list.end(), "PEPT(Phospho)DIEK.(Oxidation)") != sequence_list.end());
+  TEST_EQUAL(check_terminal_mod_present, false)
 }
 
 END_SECTION


### PR DESCRIPTION
# Description

There are certain cases where an error occurs when using `OpenSwathAssayGenerator` to generate theoretical peptidoforms for **IPF**, specifically, an error occurs when [MRMAssay::addModificationsSequences_](https://github.com/OpenMS/OpenMS/blob/d9692da0d410c06b6cdc960f608a5c962360d09c/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp#L158) generates n combinations of peptidoforms which includes a terminal modification on a residue that is not a registered residue with N/C-term specificy in the **ModificationsDB**.  As an example, for peptidoform _**P(Oxidation)EPT(Phospho)DIEK**_, `MRMAssay::addModificationsSequences_` will generate _**PE(Phospho)PTDIEK.(Oxidation)**_ as a potential alternate peptidoform. However, Oxidation can only be a C-term modification on the **G** residue based on the **ModificationsDB**, this raises an unexpected internal error, because the terminal modiciation and residue specifity do not match with the modfication database. 

I added a check in `MRMAssay::addModificationsSequences_` ([MRMAssay.cpp#L178](https://github.com/singjc/OpenMS/blob/bd1e98cc8fb18fba0e62f0e696aed9f8d95876bc/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp#L178) and [MRMAssay.cpp#L193](https://github.com/singjc/OpenMS/blob/bd1e98cc8fb18fba0e62f0e696aed9f8d95876bc/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp#L193)) to first check if the first or last residue is N/C-term modifiable with the assessed modification, before setting the `N/C-TerminalModification` in `AASequence`.

## Example Error
```
~/Development/openms-build/bin/OpenSwathAssayGenerator -in easypqp_lib_test2.tsv -out library_targets.pqp -min_transitions 6 -max_transitions 6 -product_lower_mz_limit 10 -product_upper_mz_limit 1800 -enable_ipf -unimod_file unimod.xml -disable_identification_ms2_precursors -disable_identification_specific_losses -debug 0
Unimod XML: 2928 modification types and residue specificities imported from file: unimod.xml
Loading easypqp_lib_test2.tsv
Progress of 'conversion to internal data representation':
-- done [took 0.00 s (CPU), 0.00 s (Wall)] -- 
Annotating transitions
Progress of 'Annotating transitions':
-- done [took 0.00 s (CPU), 0.00 s (Wall)] -- 
Annotating detecting transitions
Progress of 'Restricting transitions':
-- done [took 0.00 s (CPU), 0.00 s (Wall)] -- 
Generating identifying transitions for IPF
Progress of 'Generation of target in silico peptide map':
-- done [took 0.02 s (CPU), 0.02 s (Wall)] -- 
Progress of 'Generation of target identification transitions':
-- done [took 0.01 s (CPU), 0.01 s (Wall)] -- 
Progress of 'Target-decoy mapping':
Error: Unexpected internal error (the value 'Cannot convert string to peptide modification. No terminal modification matches to term specificity and origin.' was used but is not valid; PE(Phospho)PTDIEK.(Oxidation))

Process finished with exit code 8
```

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)