### PR TITLE
make getOpenMSDataPath thread-safe

### DIFF
--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -93,7 +93,7 @@ namespace OpenMS
   {
     // see http://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe/1024937#1024937 for more OS' (if needed)
     // Use immediately evaluated lambda to protect static variable from concurrent access.
-    static String spath = [&]() -> String {
+    const static String spath = [&]() -> String {
         String rpath = "";
 
         char path[1024]; // maximum path length
@@ -459,7 +459,7 @@ namespace OpenMS
   String File::getOpenMSDataPath()
   {
     // Use immediately evaluated lambda to protect static variable from concurrent access.
-    static String path = [&]() -> String {
+    const static String path = [&]() -> String {
       String path;
       bool path_checked = false;
 


### PR DESCRIPTION
# Description

Make getOpenMSDataPath thread-safe

# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
