### PR TITLE
fix segfault when starting any executable 

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -59,43 +59,6 @@ namespace OpenMS
 
     //--------------------------------------------------------------------------------
 
-    // this cannot be moved into a function as VS2008 does not allow more than 31 static members in a function .. don't ask...
-    const XMLCh* s_value_ = xercesc::XMLString::transcode("value");
-    const XMLCh* s_count_ = xercesc::XMLString::transcode("scanCount");
-    const XMLCh* s_type_ = xercesc::XMLString::transcode("type");
-    const XMLCh* s_name_ = xercesc::XMLString::transcode("name");
-    const XMLCh* s_version_ = xercesc::XMLString::transcode("version");
-    const XMLCh* s_filename_ = xercesc::XMLString::transcode("fileName");
-    const XMLCh* s_filetype_ = xercesc::XMLString::transcode("fileType");
-    const XMLCh* s_filesha1_ = xercesc::XMLString::transcode("fileSha1");
-    const XMLCh* s_completiontime_ = xercesc::XMLString::transcode("completionTime");
-    const XMLCh* s_precision_ = xercesc::XMLString::transcode("precision");
-    const XMLCh* s_byteorder_ = xercesc::XMLString::transcode("byteOrder");
-    const XMLCh* s_contentType_ = xercesc::XMLString::transcode("contentType");
-    const XMLCh* s_compressionType_ = xercesc::XMLString::transcode("compressionType");
-    const XMLCh* s_precursorintensity_ = xercesc::XMLString::transcode("precursorIntensity");
-    const XMLCh* s_precursorcharge_ = xercesc::XMLString::transcode("precursorCharge");
-    const XMLCh* s_windowwideness_ = xercesc::XMLString::transcode("windowWideness");
-    const XMLCh* s_activationMethod_ = xercesc::XMLString::transcode("activationMethod");
-    const XMLCh* s_mslevel_ = xercesc::XMLString::transcode("msLevel");
-    const XMLCh* s_peakscount_ = xercesc::XMLString::transcode("peaksCount");
-    const XMLCh* s_polarity_ = xercesc::XMLString::transcode("polarity");
-    const XMLCh* s_scantype_ = xercesc::XMLString::transcode("scanType");
-    const XMLCh* s_filterline_ = xercesc::XMLString::transcode("filterLine");
-    const XMLCh* s_retentiontime_ = xercesc::XMLString::transcode("retentionTime");
-    const XMLCh* s_startmz_ = xercesc::XMLString::transcode("startMz");
-    const XMLCh* s_endmz_ = xercesc::XMLString::transcode("endMz");
-    const XMLCh* s_first_ = xercesc::XMLString::transcode("first");
-    const XMLCh* s_last_ = xercesc::XMLString::transcode("last");
-    const XMLCh* s_phone_ = xercesc::XMLString::transcode("phone");
-    const XMLCh* s_email_ = xercesc::XMLString::transcode("email");
-    const XMLCh* s_uri_ = xercesc::XMLString::transcode("URI");
-    const XMLCh* s_num_ = xercesc::XMLString::transcode("num");
-    const XMLCh* s_intensitycutoff_ = xercesc::XMLString::transcode("intensityCutoff");
-    const XMLCh* s_centroided_ = xercesc::XMLString::transcode("centroided");
-    const XMLCh* s_deisotoped_ = xercesc::XMLString::transcode("deisotoped");
-    const XMLCh* s_chargedeconvoluted_ = xercesc::XMLString::transcode("chargeDeconvoluted");
-
     void writeKeyValue(std::ostream& os, const String& key, const DataValue& value)
     {
       os << " " << key << "=\"" << value << "\"";
@@ -147,6 +110,41 @@ namespace OpenMS
       const XMLCh* const /*local_name*/, const XMLCh* const qname,
       const xercesc::Attributes& attributes)
     {
+      constexpr XMLCh s_value_[] = {'v', 'a', 'l', 'u', 'e', 0};
+      constexpr XMLCh s_count_[] = {'s', 'c', 'a', 'n', 'C', 'o', 'u', 'n', 't', 0};
+      constexpr XMLCh s_type_[] = {'t', 'y', 'p', 'e', 0};
+      constexpr XMLCh s_name_[] = {'n', 'a', 'm', 'e', 0};
+      constexpr XMLCh s_version_[] = {'v', 'e', 'r', 's', 'i', 'o', 'n', 0};
+      constexpr XMLCh s_filename_[] = {'f', 'i', 'l', 'e', 'N', 'a', 'm', 'e', 0};
+      constexpr XMLCh s_filetype_[] = {'f', 'i', 'l', 'e', 'T', 'y', 'p', 'e', 0};
+      constexpr XMLCh s_filesha1_[] = {'f', 'i', 'l', 'e', 'S', 'h', 'a', '1', 0};
+      constexpr XMLCh s_completiontime_[] = {'c', 'o', 'm', 'p', 'l', 'e', 't', 'i', 'o', 'n', 'T', 'i', 'm', 'e', 0};
+      constexpr XMLCh s_precision_[] = {'p', 'r', 'e', 'c', 'i', 's', 'i', 'o', 'n', 0};
+      constexpr XMLCh s_byteorder_[] = {'b', 'y', 't', 'e', 'O', 'r', 'd', 'e', 'r', 0};
+      constexpr XMLCh s_contentType_[] = {'c', 'o', 'n', 't', 'e', 'n', 't', 'T', 'y', 'p', 'e', 0};
+      constexpr XMLCh s_compressionType_[] = {'c', 'o', 'm', 'p', 'r', 'e', 's', 's', 'i', 'o', 'n', 'T', 'y', 'p', 'e', 0};
+      constexpr XMLCh s_precursorintensity_[] = {'p', 'r', 'e', 'c', 'u', 'r', 's', 'o', 'r', 'I', 'n', 't', 'e', 'n', 's', 'i', 't', 'y', 0};
+      constexpr XMLCh s_precursorcharge_[] = {'p', 'r', 'e', 'c', 'u', 'r', 's', 'o', 'r', 'C', 'h', 'a', 'r', 'g', 'e', 0};
+      constexpr XMLCh s_windowwideness_[] = {'w', 'i', 'n', 'd', 'o', 'w', 'W', 'i', 'd', 'e', 'n', 'e', 's', 's', 0};
+      constexpr XMLCh s_activationMethod_[] = {'a', 'c', 't', 'i', 'v', 'a', 't', 'i', 'o', 'n', 'M', 'e', 't', 'h', 'o', 'd', 0};
+      constexpr XMLCh s_mslevel_[] = {'m', 's', 'L', 'e', 'v', 'e', 'l', 0};
+      constexpr XMLCh s_peakscount_[] = {'p', 'e', 'a', 'k', 's', 'C', 'o', 'u', 'n', 't', 0};
+      constexpr XMLCh s_polarity_[] = {'p', 'o', 'l', 'a', 'r', 'i', 't', 'y', 0};
+      constexpr XMLCh s_scantype_[] = {'s', 'c', 'a', 'n', 'T', 'y', 'p', 'e', 0};
+      constexpr XMLCh s_filterline_[] = {'f', 'i', 'l', 't', 'e', 'r', 'L', 'i', 'n', 'e', 0};
+      constexpr XMLCh s_retentiontime_[] = {'r', 'e', 't', 'e', 'n', 't', 'i', 'o', 'n', 'T', 'i', 'm', 'e', 0};
+      constexpr XMLCh s_startmz_[] = {'s', 't', 'a', 'r', 't', 'M', 'z', 0};
+      constexpr XMLCh s_endmz_[] = {'e', 'n', 'd', 'M', 'z', 0};
+      constexpr XMLCh s_first_[] = {'f', 'i', 'r', 's', 't', 0};
+      constexpr XMLCh s_last_[] = {'l', 'a', 's', 't', 0};
+      constexpr XMLCh s_phone_[] = {'p', 'h', 'o', 'n', 'e', 0};
+      constexpr XMLCh s_email_[] = {'e', 'm', 'a', 'i', 'l', 0};
+      constexpr XMLCh s_uri_[] = {'U', 'R', 'I', 0};
+      constexpr XMLCh s_num_[] = {'n', 'u', 'm', 0};
+      constexpr XMLCh s_intensitycutoff_[] = {'i', 'n', 't', 'e', 'n', 's', 'i', 't', 'y', 'C', 'u', 't', 'o', 'f', 'f', 0};
+      constexpr XMLCh s_centroided_[] = {'c', 'e', 'n', 't', 'r', 'o', 'i', 'd', 'e', 'd', 0};
+      constexpr XMLCh s_deisotoped_[] = {'d', 'e', 'i', 's', 'o', 't', 'o', 'p', 'e', 'd', 0};
+      constexpr XMLCh s_chargedeconvoluted_[] = {'c', 'h', 'a', 'r', 'g', 'e', 'D', 'e', 'c', 'o', 'n', 'v', 'o', 'l', 'u', 't', 'e', 'd', 0};
       OPENMS_PRECONDITION(nesting_level_ >= 0, "Nesting level needs to be zero or more")
 
       String tag = sm_.convert(qname);


### PR DESCRIPTION
# Description

... which was linked with `-flto=auto -ffat-lto-objects` on Linux which results in
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7893f00 in xercesc_3_2::XMLString::transcode(char const*, xercesc_3_2::MemoryManager*) () from /buffer/ag_bsc/build/openms_build/lib/libOpenMS.so

because xercesc::XMLString::transcode is called without being ready internally.

Fixes #5379


# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
