### PR TITLE
[FIX] QWidget::grab()

### DIFF
--- a/src/openms_gui/source/VISUAL/Plot1DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DWidget.cpp
@@ -366,7 +366,7 @@ namespace OpenMS
     }
     else // raster graphics formats
     {
-      QPixmap pixmap = QPixmap::grabWidget(this);
+      QPixmap pixmap = this->grab();
       x_scrollbar_->setVisible(x_visible);
       y_scrollbar_->setVisible(y_visible);
       pixmap.save(file_name);

--- a/src/openms_gui/source/VISUAL/PlotWidget.cpp
+++ b/src/openms_gui/source/VISUAL/PlotWidget.cpp
@@ -231,7 +231,7 @@ namespace OpenMS
     bool y_visible = y_scrollbar_->isVisible();
     x_scrollbar_->hide();
     y_scrollbar_->hide();
-    QPixmap pixmap = QPixmap::grabWidget(this);
+    QPixmap pixmap = this->grab();
     x_scrollbar_->setVisible(x_visible);
     y_scrollbar_->setVisible(y_visible);
     pixmap.save(file_name);


### PR DESCRIPTION
# Description

Stumbled over a deprecated warning, when exporting from TOPPView.

`QPixmap::grabWidget is deprecated, use QWidget::grab() instead`

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
