### PR TITLE
[FIX] Correctly setup c17 for pyopenms

### DIFF
--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -195,21 +195,18 @@ elif sys.platform == "darwin":
 if IS_DEBUG:
     extra_compile_args.append("-g2")
 
-# Note: we use -std=gnu++11 in Linux by default, also reduce some warnings
 if not iswin:
-    if isosx: # MacOS c++11
-        extra_link_args.append("-stdlib=libc++") # MacOS libstdc++ does not include c++11 lib support.
+    extra_link_args.append("-std=c++17")
+    extra_compile_args.append("-std=c++17")
+    if isosx: # MacOS
+        extra_link_args.append("-stdlib=libc++") # MacOS libstdc++ does not include c++11+ lib support.
         extra_link_args.append("-mmacosx-version-min=10.7") # due to libc++
-        extra_link_args.append("-std=c++17")
-    if isosx: # MacOS c++11
-        extra_compile_args.append("-stdlib=libc++")
-        extra_compile_args.append("-mmacosx-version-min=10.7")
-        extra_compile_args.append("-std=c++17")
         if (osx_ver >= "10.14.0" and SYSROOT_OSX_PATH): # since macOS Mojave
             extra_compile_args.append("-isysroot" + SYSROOT_OSX_PATH)
     extra_compile_args.append("-Wno-redeclared-class-member")
     extra_compile_args.append("-Wno-unused-local-typedefs")
     extra_compile_args.append("-Wno-deprecated-register") # caused by seqan on gcc
+    extra_compile_args.append("-Wno-misleading-indentation") # caused by seqan on gcc
     extra_compile_args.append("-Wno-register") #caused by seqan on clang c17
     extra_compile_args.append("-Wdeprecated-declarations")
     extra_compile_args.append("-Wno-sign-compare")


### PR DESCRIPTION
It had a weird logic before. Leading to non-c17 builds on Linux gcc before.