### PR TITLE
Update PythonExtensionChecker.py

### DIFF
--- a/src/pyOpenMS/tests/unittests/test_DIAScoring.py
+++ b/src/pyOpenMS/tests/unittests/test_DIAScoring.py
@@ -11,18 +11,23 @@ class TestDIAScoring(unittest.TestCase):
     def test_spectrum(self):
 
           intensity = [
-            100, 100, 100, 100,
-            100, 100, 100]
+                        100,
+                        100,
+                        100,
+                        100,
+                        100,
+                        100
+                      ]
           mz = [
-                #// four of the naked b/y ions 
-                #// as well as one of the modified b and y ions ion each
-                350.17164, #// b
-                421.20875, #// b
-                421.20875 + 79.9657, #// b + P
-                547.26291, #// y
-                646.33133, #// y
-                809.39466 + 79.9657 #// y + P
-          ]
+                 #// four of the naked b/y ions
+                 #// as well as one of the modified b and y ions ion each
+                 350.17164, #// b
+                 421.20875, #// b
+                 421.20875 + 79.9657, #// b + P
+                 547.26291, #// y
+                 646.33133, #// y
+                 809.39466 + 79.9657 #// y + P
+               ]
 
           spectrum = pyopenms.OSSpectrum()
           spectrum.setMZArray(mz)

--- a/tools/PythonExtensionChecker.py
+++ b/tools/PythonExtensionChecker.py
@@ -134,7 +134,7 @@ def handle_member_definition(mdef, pxd_class, cnt):
             enumr += '    cdef enum %s %s:\n' % (mdef.get_name(), true_cppname)
             for val in mdef.get_enumvalue():
                 enumr += "        %s\n" % val.get_name()
-            tres.setMessage(tres.what() + enumr)
+            tres.setMessage(tres.getMessage() + enumr)
         elif len(klass[0].items) != len(mdef.get_enumvalue()):
             tres.setPassed(False)
             tres.setMessage("TODO: Found enum in C++ with %s members but in Cython there are %s members: " % (
@@ -911,8 +911,8 @@ class TestResultHandler:
       ) )
                 xml_output.append(" " * 6 + '<Measurement>\n')
                 xml_output.append(" " * 8 + '<Value>\n')
-                if not tres.what() is None:
-                    xml_output.append(" " * 10 +  xml_escape(tres.what() ) + "\n")
+                if not tres.getMessage() is None:
+                    xml_output.append(" " * 10 +  xml_escape(tres.getMessage() ) + "\n")
                 xml_output.append(" " * 8 + '</Value>\n')
                 xml_output.append(" " * 6 + '</Measurement>\n')
 


### PR DESCRIPTION
# Description

change what() to getMessage()
tool failed using what()

Edit:
Somehow only seems to fail locally? 
MacOS 10.15.7
```
test 9
    Start 9: pyopenms_unittest_test_DIAScoring.py

9: Test command: /usr/local/miniconda3/envs/build_pyopenms_39/bin/python3.9 "-c" "import nose; nose.run_exit()" "/Users/alka/Documents/work/software/openms_pyopenms/20210224_test/pyOpenMS/tests/unittests/test_DIAScoring.py" "-s" "-v"
9: Environment variables: 
9:  LD_LIBRARY_PATH=/Users/alka/Documents/work/software/openms_pyopenms/20210224_test/lib
9: Test timeout computed to be: 1500
9: Determination of memory status is not supported on this 
9:  platform, measuring for memoryleaks will never fail
9: test_spectrum (unittests.test_DIAScoring.TestDIAScoring) ... ERROR
9: 
9: ======================================================================
9: ERROR: test_spectrum (unittests.test_DIAScoring.TestDIAScoring)
9: ----------------------------------------------------------------------
9: Traceback (most recent call last):
9:   File "/Users/alka/Documents/work/software/openms_pyopenms/20210224_test/pyOpenMS/tests/unittests/test_DIAScoring.py", line 48, in test_spectrum
9:     bseries_score, yseries_score = diascoring.dia_by_ion_score(spectrum, a, charge, bseries_score, yseries_score)
9:   File "pyopenms/pyopenms_1.pyx", line 2688, in pyopenms.pyopenms_1.DIAScoring.dia_by_ion_score
9:     self.inst.get().dia_by_ion_score(input_spectrum, (deref(sequence.inst.get())), (<int>charge), input_bseries_score, input_yseries_score)
9: RuntimeError: spectrum->getMZArray()->data.size() == spectrum->getIntensityArray()->data.size() "MZ and Intensity array need to have the same length."
9: 
9: ----------------------------------------------------------------------
9: Ran 1 test in 0.010s
9: 
9: FAILED (errors=1)
1/1 Test #9: pyopenms_unittest_test_DIAScoring.py ...***Failed    0.67 sec
```

