### PR TITLE
[Internal] Add ParamCTDFile to write Param to CTD File with only standard dependecies

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/ParamValue.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ParamValue.h
@@ -35,6 +35,7 @@
 
 #include <OpenMS/OpenMSConfig.h>
 
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
@@ -2,7 +2,7 @@
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
-// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
 //
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright

--- a/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
@@ -56,8 +56,10 @@ namespace OpenMS
   };
 
   /**
-  @brief The file pendant of the Param class used to load and store the param
+  @brief The file pendant of the Param class used to ( load ) and store the param
          datastructure as paramCTD.
+
+   only storing is possible at this time !
 
 */
   class ParamCTDFile

--- a/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
@@ -1,0 +1,118 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Ruben Grünberg $
+// $Authors: Ruben Grünberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <string>
+
+#include <OpenMS/DATASTRUCTURES/Param.h>
+
+namespace OpenMS
+{
+
+  /**
+   @brief A struct to pass information about the tool as one parameter
+   */
+  struct ToolInfo
+  {
+    const std::string& version_;
+    const std::string& name_;
+    const std::string& docurl_;
+    const std::string& category_;
+    const std::string& description_;
+    const std::string& openms_doi_;
+    const std::vector<std::string>& citations_;
+  };
+
+  /**
+  @brief The file pendant of the Param class used to load and store the param
+         datastructure as paramCTD.
+
+*/
+  class ParamCTDFile
+  {
+  public:
+
+    ///Constructor
+    ParamCTDFile();
+    ///Destructor
+    ~ParamCTDFile() = default;
+
+    /**
+       @brief Write CTD file
+
+       @param filename The name of the file the param data structure should be stored in.
+       @param param The param data structure that should be stored.
+       @param ToolInfo Additional information about the Tool for which the param data should be stored.
+
+       @exception std::ios::failure is thrown if the file could not be created
+     */
+    void store(const std::string& filename, const Param& param, const ToolInfo& tool_info) const;
+
+    /**
+       @brief Write CTD to output stream.
+
+       @param os_ptr The stream to which the param data should be written.
+       @param param The param data structure that should be writte to stream.
+       @param tool_info Additional information about the Tool for which the param data should be written.
+     */
+    void writeCTDToStream(std::ostream* os_ptr, const Param& param, const ToolInfo& tool_info) const;
+
+  private:
+
+    /**
+      @brief Escapes certain characters in a string that are not allowed in XML
+             Escaped characters are: & < > " '
+
+      @param to_escape The string in which the characters should be escaped
+
+      @returns The escaped string
+     */
+    static std::string escapeXML(const std::string& to_escape);
+
+    /**
+      @brief Replace all occurrences of a character in a string with a string
+
+      @param replace_in The string in which the characters should be replaced.
+      @param to_replace The character that should be replaced.
+      @param replace_with The string the character should be replaced with.
+     */
+    static void replace(std::string& replace_in, char to_replace, const std::string& replace_with);
+
+    const std::string schema_location_;
+    const std::string schema_version_;
+
+  };
+
+}

--- a/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
@@ -35,7 +35,6 @@
 #pragma once
 
 #include <string>
-
 #include <OpenMS/DATASTRUCTURES/Param.h>
 
 namespace OpenMS
@@ -62,7 +61,7 @@ namespace OpenMS
    only storing is possible at this time !
 
 */
-  class ParamCTDFile
+  class OPENMS_DLLAPI ParamCTDFile
   {
   public:
 

--- a/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamCTDFile.h
@@ -58,7 +58,7 @@ namespace OpenMS
   @brief The file pendant of the Param class used to ( load ) and store the param
          datastructure as paramCTD.
 
-   only storing is possible at this time !
+   only storing is currently possible !
 
 */
   class OPENMS_DLLAPI ParamCTDFile

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -67,6 +67,7 @@ MzXMLFile.h
 OMSSACSVFile.h
 OMSSAXMLFile.h
 OSWFile.h
+ParamCTDFile.h
 ParamXMLFile.h
 PTMXMLFile.h
 PeakTypeEstimator.h

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2287,17 +2287,8 @@ namespace OpenMS
         citation_dois.push_back(citation.doi);
       }
 
-      paramFile.writeCTDToStream(&ss, default_params,
-                                 {version_, tool_name_, docurl, category, tool_description_, cite_openms_.doi, citation_dois});
-      String ctd_str(ss.str());
-
-      //write to file
-      QFile file(write_ctd_file);
-      if (!file.open(QIODevice::WriteOnly))
-      {
-        return false;
-      }
-      file.write(ctd_str.c_str());
+      paramFile.store(write_ctd_file.toStdString(), default_params,
+                      {version_, tool_name_, docurl, category, tool_description_, cite_openms_.doi, citation_dois});
     }
 
     return true;

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2291,27 +2291,6 @@ namespace OpenMS
                                  {version_, tool_name_, docurl, category, tool_description_, cite_openms_.doi, citation_dois});
       String ctd_str(ss.str());
 
-      /*
-// morph to ctd format
-QStringList lines = ini_file_str.toQString().split("\n", QString::SkipEmptyParts);
-lines.replace(0, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-lines.insert(1, QString("<tool ctdVersion=\"1.7\" version=\"%1\" name=\"%2\" docurl=\"%3\" category=\"%4\" >").arg(version_.toQString(), tool_name_.toQString(), docurl, category));
-lines.insert(2, QString("<description><![CDATA[") + tool_description_.toQString() + "]]></description>");
-lines.insert(3, QString("<manual><![CDATA[") + tool_description_.toQString() + "]]></manual>");
-lines.insert(4, QString("<citations>"));
-lines.insert(5, QString("  <citation doi=\"") + QString::fromStdString(cite_openms_.doi) + "\" url=\"\" />");
-int l = 5;
-for (const Citation& c : citations_)
-{
-  lines.insert(++l, QString("  <citation doi=\"") + QString::fromStdString(c.doi) + "\" url=\"\" />");
-}
-lines.insert(++l, QString("</citations>"));
-
-lines.insert(lines.size(), "</tool>");
-String ctd_str = String(lines.join("\n")) + "\n";
-*/
-
-
       //write to file
       QFile file(write_ctd_file);
       if (!file.open(QIODevice::WriteOnly))

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -2,7 +2,7 @@
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
-// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
 //
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -126,9 +126,13 @@ namespace OpenMS
         ParamValue::ValueType value_type = param_it->value.valueType();
         bool stringParamIsFlag = false;
 
-        if (value_type <= ParamValue::DOUBLE_VALUE)
+        if (value_type < ParamValue::STRING_LIST)
         {
           os << std::string(indentations, ' ') << "<ITEM name=\"" << escapeXML(param_it->name) << R"(" value=")";
+        }
+        else
+        {
+          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name);
         }
 
         switch (value_type)
@@ -169,7 +173,6 @@ namespace OpenMS
           }
         break;
         case ParamValue::STRING_LIST:
-          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name);
           if (tag_list.find("input file") != tag_list.end())
           {
             os << R"(" type="input-file")";
@@ -186,10 +189,10 @@ namespace OpenMS
           }
         break;
         case ParamValue::INT_LIST:
-          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name) << R"(" type="int")";
+          os << R"(" type="int")";
         break;
         case ParamValue::DOUBLE_LIST:
-          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name) << R"(" type="double")";
+          os << R"(" type="double")";
         break;
         default:
         break;
@@ -306,15 +309,11 @@ namespace OpenMS
           }
         }
 
+        os << " />\n";
+
         switch (value_type)
         {
-        case ParamValue::INT_VALUE:
-        case ParamValue::DOUBLE_VALUE:
-        case ParamValue::STRING_VALUE:
-          os << " />\n";
-        break;
         case ParamValue::STRING_LIST:
-          os << ">\n";
           for (auto item : static_cast<std::vector<std::string> >(param_it->value))
           {
             if (item.find('\t') != std::string::npos)
@@ -323,33 +322,34 @@ namespace OpenMS
             }
             os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << escapeXML(item) << "\"/>\n";
           }
-          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
         break;
         case ParamValue::INT_LIST:
-          os << ">\n";
           for (int item : static_cast<std::vector<int> >(param_it->value))
           {
             os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
           }
-          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
         break;
         case ParamValue::DOUBLE_LIST:
-          os << ">\n";
           for (double item : static_cast<std::vector<double> >(param_it->value))
           {
             os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
           }
-          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
         break;
         default:
         break;
         }
+
+        if (value_type > ParamValue::DOUBLE_VALUE && value_type)
+        {
+          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
+        }
+
       }
     }
 
     if (param.begin() != param.end())
     {
-      for(auto& trace : param_it.getTrace())
+      for (auto& trace : param_it.getTrace())
       {
         indentations -= 2;
         os << std::string(indentations, ' ') << "</NODE>\n";

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -302,14 +302,22 @@ namespace OpenMS
                 param_it->tags.find("output file") != param_it->tags.end())
             {
               os << " supported_formats=\"" << escapeXML(restrictions) << "\"";
-            } else
+            }
+            else
             {
               os << " restrictions=\"" << escapeXML(restrictions) << "\"";
             }
           }
         }
 
-        os << " />\n";
+        if (value_type < ParamValue::STRING_LIST)
+        {
+          os << " />\n";
+        }
+        else
+        {
+          os << " >\n";
+        }
 
         switch (value_type)
         {
@@ -367,7 +375,7 @@ namespace OpenMS
     if(copy.find('&') != std::string::npos) replace(copy, '&', "&amp;");
     if(copy.find('>') != std::string::npos) replace(copy, '>', "&gt;");
     if(copy.find('"') != std::string::npos) replace(copy, '"', "&quot;");
-    if(copy.find('>') != std::string::npos) replace(copy, '>', "&lt;");
+    if(copy.find('<') != std::string::npos) replace(copy, '<', "&lt;");
     if(copy.find('\'') != std::string::npos) replace(copy, '\'', "&apos;");
 
     return copy;

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -1,0 +1,387 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Ruben Grünberg $
+// $Authors: Ruben Grünberg $
+// --------------------------------------------------------------------------
+
+#include <fstream>
+#include <iostream>
+#include <limits>
+
+#include <OpenMS/FORMAT/ParamCTDFile.h>
+
+namespace OpenMS
+{
+  ParamCTDFile::ParamCTDFile() :
+    schema_location_("/SCHEMAS/Param_1_7_0.xsd"),
+    schema_version_("1.7.0")
+  {
+
+  }
+
+  void ParamCTDFile::store(const std::string& filename, const Param& param, const  ToolInfo& tool_info) const
+  {
+    std::ofstream os;
+    std::ostream* os_ptr;
+    if (filename != "-")
+    {
+      os.open(filename.c_str(), std::ofstream::out);
+      if (!os)
+      {
+        //Replace the OpenMS specific exception with a std exception
+        //Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+        throw std::ios::failure("Unable to create file: " + filename);
+      }
+      os_ptr = &os;
+    }
+    else
+    {
+      os_ptr = &std::cout;
+    }
+
+    writeCTDToStream(os_ptr, param, tool_info);
+  }
+
+  void ParamCTDFile::writeCTDToStream(std::ostream *os_ptr, const Param &param, const ToolInfo& tool_info) const
+  {
+
+    std::ostream& os = *os_ptr;
+    os.precision(std::numeric_limits<double>::digits10);
+
+    //write ctd specific stuff
+    os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    os << R"(<tool ctdVersion="1.7" version=")" << tool_info.version_ << R"(" name=")" << tool_info.name_
+       << R"(" docurl=")" << tool_info.docurl_ << R"(" category=")" << tool_info.category_ << "\" >\n";
+    os << "<description><![CDATA[" << tool_info.description_ << "]]></description>\n";
+    os << "<manual><![CDATA[" << tool_info.description_ << "]]></manual>\n";
+    os << "<citations>\n";
+    os << "  <citation doi=\"" << tool_info.openms_doi_ << "\" url=\"\" />\n";
+
+    for (auto& doi : tool_info.citations_)
+    {
+      os << "  <citation doi=\"" << doi << "\" url=\"\" />\n";
+    }
+
+    os << "</citations>\n";
+    os << "<PARAMETERS version=\"" << schema_version_
+       << R"(" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS)"
+       << schema_location_
+       << "\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
+
+    //Write the xml stuff
+    uint32_t indentations = 2;
+    auto param_it = param.begin();
+    for (auto last = param.end(); param_it != last; ++param_it)
+    {
+      for (auto& trace : param_it.getTrace())
+      {
+        if (trace.opened)
+        {
+          std::string d = trace.description;
+          replace(d, '\n', "#br#");
+
+          os << std::string(indentations, ' ') << "<NODE name=\"" << escapeXML(trace.name) << "\" description=\"" << escapeXML(d) << "\">\n";
+          indentations += 2;
+        }
+        else
+        {
+          indentations -= 2;
+          os << std::string(indentations, ' ') << "</NODE>\n";
+        }
+      }
+
+      if (param_it->value.valueType() != ParamValue::EMPTY_VALUE)
+      {
+        // we create a temporary copy of the tag list, since we remove certain tags while writing,
+        // that will be represented differently in the xml
+        std::set<std::string> tag_list = param_it->tags;
+        ParamValue::ValueType value_type = param_it->value.valueType();
+        bool stringParamIsFlag = false;
+
+        if (value_type <= ParamValue::DOUBLE_VALUE)
+        {
+          os << std::string(indentations, ' ') << "<ITEM name=\"" << escapeXML(param_it->name) << R"(" value=")";
+        }
+
+        switch (value_type)
+        {
+        case ParamValue::INT_VALUE:
+          os << param_it->value.toString() << R"(" type="int")";
+        break;
+        case ParamValue::DOUBLE_VALUE:
+          os << param_it->value.toString() << R"(" type="double")";
+        break;
+        case ParamValue::STRING_VALUE:
+          if (tag_list.find("input file") != tag_list.end())
+          {
+            os << escapeXML(param_it->value.toString()) << R"(" type="input-file")";
+            tag_list.erase("input file");
+          }
+          else if (tag_list.find("output file") != tag_list.end())
+          {
+            os << escapeXML(param_it->value.toString()) << R"(" type="output-file")";
+            tag_list.erase("output file");
+          }
+          else if (param_it->valid_strings.size() == 2 &&
+                   param_it->valid_strings[0] == "true" &&
+                   param_it->valid_strings[1] == "false" &&
+                   param_it->value == "false")
+          {
+            stringParamIsFlag = true;
+            os << param_it->value.toString() << R"(" type="bool")";
+          }
+          else
+          {
+            std::string value = param_it->value.toString();
+            if (value.find('\t') != std::string::npos)
+            {
+              replace(value, '\t', "&#x9;");
+            }
+            os << escapeXML(value) << R"(" type="string")";
+          }
+        break;
+        case ParamValue::STRING_LIST:
+          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name);
+          if (tag_list.find("input file") != tag_list.end())
+          {
+            os << R"(" type="input-file")";
+            tag_list.erase("input file");
+          }
+          else if (tag_list.find("output file") != tag_list.end())
+          {
+            os << R"(" type="output-file")";
+            tag_list.erase("output file");
+          }
+          else
+          {
+            os << R"(" type="string")";
+          }
+        break;
+        case ParamValue::INT_LIST:
+          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name) << R"(" type="int")";
+        break;
+        case ParamValue::DOUBLE_LIST:
+          os << std::string(indentations, ' ') << "<ITEMLIST name=\"" << escapeXML(param_it->name) << R"(" type="double")";
+        break;
+        default:
+        break;
+        }
+
+        std::string description = param_it->description;
+        replace(description, '\n', "#br#");
+
+        os << " description=\"" << escapeXML(description) << "\"";
+
+        if (tag_list.find("required") != tag_list.end())
+        {
+          os << R"( required="true")";
+          tag_list.erase("required");
+        }
+        else
+        {
+          os << R"( required="false")";
+        }
+
+        if (tag_list.find("advanced") != tag_list.end())
+        {
+          os << R"( advanced="true")";
+          tag_list.erase("advanced");
+        }
+        else
+        {
+          os << R"( advanced="false")";
+        }
+
+        if (!tag_list.empty())
+        {
+          std::string list;
+          for (auto& tag : tag_list)
+          {
+            if (!list.empty())
+              list += ",";
+            list += tag;
+          }
+          os << " tags=\"" << escapeXML(list) << "\"";
+        }
+
+        if (!stringParamIsFlag)
+        {
+          std::string restrictions;
+          switch (value_type)
+          {
+          case ParamValue::INT_VALUE:
+          case ParamValue::INT_LIST:
+          {
+            bool min_set = (param_it->min_int != -std::numeric_limits<int>::max());
+            bool max_set = (param_it->max_int != std::numeric_limits<int>::max());
+            if (max_set || min_set)
+            {
+              if (min_set)
+              {
+                restrictions += std::to_string(param_it->min_int);
+              }
+              restrictions += ':';
+              if (max_set)
+              {
+                restrictions += std::to_string(param_it->max_int);
+              }
+            }
+          }
+            break;
+
+          case ParamValue::DOUBLE_VALUE:
+          case ParamValue::DOUBLE_LIST:
+          {
+            bool min_set = (param_it->min_float != -std::numeric_limits<double>::max());
+            bool max_set = (param_it->max_float != std::numeric_limits<double>::max());
+            if (max_set || min_set)
+            {
+              if (min_set)
+              {
+                restrictions += std::to_string(param_it->min_float);
+              }
+              restrictions += ':';
+              if (max_set)
+              {
+                restrictions += std::to_string(param_it->max_float);
+              }
+            }
+          }
+            break;
+          case ParamValue::STRING_VALUE:
+          case ParamValue::STRING_LIST:
+            if (!param_it->valid_strings.empty())
+            {
+              restrictions = param_it->valid_strings.front();
+              for (auto it = param_it->valid_strings.begin() + 1, end = param_it->valid_strings.end();
+                   it != end; ++it)
+              {
+                restrictions += ",";
+                restrictions += *it;
+              }
+            }
+            break;
+          default:
+            break;
+          }
+
+          if (!restrictions.empty())
+          {
+            if (param_it->tags.find("input file") != param_it->tags.end() ||
+                param_it->tags.find("output file") != param_it->tags.end())
+            {
+              os << " supported_formats=\"" << escapeXML(restrictions) << "\"";
+            } else
+            {
+              os << " restrictions=\"" << escapeXML(restrictions) << "\"";
+            }
+          }
+        }
+
+        switch (value_type)
+        {
+        case ParamValue::INT_VALUE:
+        case ParamValue::DOUBLE_VALUE:
+        case ParamValue::STRING_VALUE:
+          os << " />\n";
+        break;
+        case ParamValue::STRING_LIST:
+          os << ">\n";
+          for (auto item : static_cast<std::vector<std::string> >(param_it->value))
+          {
+            if (item.find('\t') != std::string::npos)
+            {
+              replace(item, '\t', "&#x9;");
+            }
+            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << escapeXML(item) << "\"/>\n";
+          }
+          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
+        break;
+        case ParamValue::INT_LIST:
+          os << ">\n";
+          for (int item : static_cast<std::vector<int> >(param_it->value))
+          {
+            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
+          }
+          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
+        break;
+        case ParamValue::DOUBLE_LIST:
+          os << ">\n";
+          for (double item : static_cast<std::vector<double> >(param_it->value))
+          {
+            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
+          }
+          os << std::string(indentations, ' ') << "</ITEMLIST>\n";
+        break;
+        default:
+        break;
+        }
+      }
+    }
+
+    if (param.begin() != param.end())
+    {
+      for(auto& trace : param_it.getTrace())
+      {
+        indentations -= 2;
+        os << std::string(indentations, ' ') << "</NODE>\n";
+      }
+    }
+
+    os << "</PARAMETERS>\n";
+    os << "</tool>" << std::endl; //forces a flush
+
+  }
+
+  std::string ParamCTDFile::escapeXML(const std::string &to_escape)
+  {
+    std::string copy = to_escape;
+    if(copy.find('&') != std::string::npos) replace(copy, '&', "&amp;");
+    if(copy.find('>') != std::string::npos) replace(copy, '>', "&gt;");
+    if(copy.find('"') != std::string::npos) replace(copy, '"', "&quot;");
+    if(copy.find('>') != std::string::npos) replace(copy, '>', "&lt;");
+    if(copy.find('\'') != std::string::npos) replace(copy, '\'', "&apos;");
+
+    return copy;
+  }
+
+  void ParamCTDFile::replace(std::string &replace_in, char to_replace, const std::string &replace_with)
+  {
+    for(size_t i = 0; i < replace_in.size(); ++i) {
+      if (replace_in[i] == to_replace)
+      {
+        replace_in = replace_in.substr(0, i) + replace_with + replace_in.substr(i + 1);
+        i += replace_with.size();
+      }
+    }
+  }
+
+}

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
 
   }
 
-  void ParamCTDFile::store(const std::string& filename, const Param& param, const  ToolInfo& tool_info) const
+  void ParamCTDFile::store(const std::string& filename, const Param& param, const ToolInfo& tool_info) const
   {
     std::ofstream os;
     std::ostream* os_ptr;

--- a/src/openms/source/FORMAT/sources.cmake
+++ b/src/openms/source/FORMAT/sources.cmake
@@ -56,6 +56,7 @@ MzXMLFile.cpp
 OMSSACSVFile.cpp
 OMSSAXMLFile.cpp
 OSWFile.cpp
+ParamCTDFile.cpp
 ParamXMLFile.cpp
 PTMXMLFile.cpp
 PeakTypeEstimator.cpp

--- a/src/pyOpenMS/pxds/ParamCTDFile.pxd
+++ b/src/pyOpenMS/pxds/ParamCTDFile.pxd
@@ -1,8 +1,14 @@
 from Param cimport *
+from libcpp.string cimport string as libcpp_utf8_string
+from libcpp.vector cimport vector as libcpp_vector
 
 cdef extern from "<OpenMS/FORMAT/ParamCTDFile.h>" namespace "OpenMS":
+
+    cdef cppclass ToolInfo:
+
+        ToolInfo(ToolInfo) nogil except +
 
     cdef cppclass ParamCTDFile:
 
         ParamCTDFile() nogil except +
-        void store(String, Param &) nogil except+
+        void store(libcpp_utf8_string filename, Param param, ToolInfo tool_info) nogil except +

--- a/src/pyOpenMS/pxds/ParamCTDFile.pxd
+++ b/src/pyOpenMS/pxds/ParamCTDFile.pxd
@@ -1,0 +1,8 @@
+from Param cimport *
+
+cdef extern from "<OpenMS/FORMAT/ParamCTDFile.h>" namespace "OpenMS":
+
+    cdef cppclass ParamCTDFile:
+
+        ParamCTDFile() nogil except +
+        void store(String, Param &) nogil except+

--- a/src/tests/class_tests/openms/data/ParamCTDFile_test_writeCTDToStream.ctd
+++ b/src/tests/class_tests/openms/data/ParamCTDFile_test_writeCTDToStream.ctd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tool ctdVersion="1.7" version="2.6.0-pre-STL-ParamCTD-2021-06-02" name="AccurateMassSearch" docurl="http://www.openms.de/doxygen/nightly/html/UTILS_AccurateMassSearch.html" category="Utilities" >
+<description><![CDATA[Match MS signals to molecules from a database by mass.]]></description>
+<manual><![CDATA[Match MS signals to molecules from a database by mass.]]></manual>
+<citations>
+  <citation doi="10.1038/nmeth.3959" url="" />
+</citations>
+<PARAMETERS version="1.7.0" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/Param_1_7_0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ITEMLIST name="stringlist" type="string" description="StringList Description" required="false" advanced="false" >
+    <LISTITEM value="a"/>
+    <LISTITEM value="bb"/>
+    <LISTITEM value="ccc"/>
+  </ITEMLIST>
+  <ITEMLIST name="intlist" type="int" description="" required="false" advanced="false" >
+    <LISTITEM value="1"/>
+    <LISTITEM value="22"/>
+    <LISTITEM value="333"/>
+  </ITEMLIST>
+  <ITEM name="item" value="bla" type="string" description="" required="false" advanced="false" />
+  <ITEMLIST name="stringlist2" type="string" description="" required="false" advanced="false" >
+  </ITEMLIST>
+  <ITEMLIST name="intlist2" type="int" description="" required="false" advanced="false" >
+  </ITEMLIST>
+  <ITEM name="item1" value="7" type="int" description="" required="false" advanced="false" />
+  <ITEMLIST name="intlist3" type="int" description="" required="false" advanced="false" >
+    <LISTITEM value="1"/>
+  </ITEMLIST>
+  <ITEMLIST name="stringlist3" type="string" description="" required="false" advanced="false" >
+    <LISTITEM value="1"/>
+  </ITEMLIST>
+  <ITEM name="item3" value="7.6" type="double" description="" required="false" advanced="false" />
+  <ITEMLIST name="doublelist" type="double" description="" required="false" advanced="false" >
+    <LISTITEM value="1.22"/>
+    <LISTITEM value="2.33"/>
+    <LISTITEM value="4.55"/>
+  </ITEMLIST>
+  <ITEMLIST name="doublelist3" type="double" description="" required="false" advanced="false" >
+    <LISTITEM value="1.4"/>
+  </ITEMLIST>
+  <ITEM name="file_parameter" value="" type="input-file" description="This is a file parameter." required="false" advanced="false" supported_formats="*.mzML,*.mzXML" />
+  <ITEM name="advanced_parameter" value="" type="string" description="This is an advanced parameter." required="false" advanced="true" />
+  <ITEM name="flag" value="false" type="bool" description="This is a flag i.e. in a command line input it does not need a value." required="false" advanced="false" />
+  <ITEM name="noflagJustTrueFalse" value="true" type="string" description="This is not a flag but has a boolean meaning." required="false" advanced="false" restrictions="true,false" />
+</PARAMETERS>
+</tool>

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -232,6 +232,7 @@ set(format_executables_list
   OMSSAXMLFile_test
   OSWFile_test
   PTMXMLFile_test
+  ParamCTDFile_test
   ParamXMLFile_test
   PeakFileOptions_test
   PeakTypeEstimator_test

--- a/src/tests/class_tests/openms/source/ParamCTDFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamCTDFile_test.cpp
@@ -1,0 +1,401 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2020.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Ruben Grünberg $
+// $Authors: Ruben Grünberg $
+// --------------------------------------------------------------------------
+
+#include <fstream>
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/FORMAT/ParamCTDFile.h>
+#include <OpenMS/FORMAT/ParamXMLFile.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+
+///////////////////////////
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(ParamCTDFile, "$Id")
+
+ParamCTDFile* ptr = nullptr;
+ParamCTDFile* nullPtr = nullptr;
+
+START_SECTION((ParamCTDFile()))
+{
+  ptr = new ParamCTDFile();
+  TEST_NOT_EQUAL(ptr, nullPtr)
+}
+END_SECTION
+
+Param p;
+p.setValue("test:float",17.4f,"floatdesc");
+p.setValue("test:string","test,test,test","stringdesc");
+p.setValue("test:int",17,"intdesc");
+p.setValue("test2:float",17.5f);
+p.setValue("test2:string","test2");
+p.setValue("test2:int",18);
+p.setSectionDescription("test","sectiondesc");
+p.addTags("test:float", {"a","b","c"});
+
+START_SECTION((void store(const String& filename, const Param& param) const))
+  ParamCTDFile paramFile;
+  ParamXMLFile paramXML;
+
+	Param p2(p);
+	p2.setValue("test:a:a1", 47.1,"a1desc\"<>\nnewline");
+	p2.setValue("test:b:b1", 47.1);
+	p2.setSectionDescription("test:b","bdesc\"<>\nnewline");
+	p2.setValue("test2:a:a1", 47.1);
+	p2.setValue("test2:b:b1", 47.1,"",{"advanced"});
+	p2.setSectionDescription("test2:a","adesc");
+
+	//exception
+	Param p300;
+	ToolInfo info = {"a", "a", "a", "a", "a", "a", std::vector<std::string>()};
+	TEST_EXCEPTION(std::ios::failure, paramFile.store("/does/not/exist/FileDoesNotExist.ctd",p300,info))
+
+	String filename;
+	NEW_TMP_FILE(filename);
+	paramFile.store(filename,p2, info);
+	Param p3;
+	paramXML.load(filename,p3);
+	TEST_REAL_SIMILAR(float(p2.getValue("test:float")), float(p3.getValue("test:float")))
+	TEST_EQUAL(p2.getValue("test:string"), p3.getValue("test:string"))
+	TEST_EQUAL(p2.getValue("test:int"), p3.getValue("test:int"))
+	TEST_REAL_SIMILAR(float(p2.getValue("test2:float")), float(p3.getValue("test2:float")))
+	TEST_EQUAL(p2.getValue("test2:string"), p3.getValue("test2:string"))
+	TEST_EQUAL(p2.getValue("test2:int"), p3.getValue("test2:int"))
+
+	TEST_STRING_EQUAL(p2.getDescription("test:float"), p3.getDescription("test:float"))
+	TEST_STRING_EQUAL(p2.getDescription("test:string"), p3.getDescription("test:string"))
+	TEST_STRING_EQUAL(p2.getDescription("test:int"), p3.getDescription("test:int"))
+	TEST_EQUAL(p3.getSectionDescription("test"),"sectiondesc")
+	TEST_EQUAL(p3.getDescription("test:a:a1"),"a1desc\"<>\nnewline")
+	TEST_EQUAL(p3.getSectionDescription("test:b"),"bdesc\"<>\nnewline")
+	TEST_EQUAL(p3.getSectionDescription("test2:a"),"adesc")
+	TEST_EQUAL(p3.hasTag("test2:b:b1","advanced"),true)
+	TEST_EQUAL(p3.hasTag("test2:a:a1","advanced"),false)
+
+	//advanced
+	NEW_TMP_FILE(filename);
+	Param p7;
+	p7.setValue("true",5,"",{"advanced"});
+	p7.setValue("false",5,"");
+
+	paramFile.store(filename,p7, info);
+	Param p8;
+	paramXML.load(filename,p8);
+
+	TEST_EQUAL(p8.getEntry("true").tags.count("advanced")==1, true)
+	TEST_EQUAL(p8.getEntry("false").tags.count("advanced")==1, false)
+
+	//restrictions
+	NEW_TMP_FILE(filename);
+	Param p5;
+	p5.setValue("int",5);
+	p5.setValue("int_min",5);
+	p5.setMinInt("int_min",4);
+	p5.setValue("int_max",5);
+	p5.setMaxInt("int_max",6);
+	p5.setValue("int_min_max",5);
+	p5.setMinInt("int_min_max",0);
+	p5.setMaxInt("int_min_max",10);
+
+	p5.setValue("float",5.1);
+	p5.setValue("float_min",5.1);
+	p5.setMinFloat("float_min",4.1);
+	p5.setValue("float_max",5.1);
+	p5.setMaxFloat("float_max",6.1);
+	p5.setValue("float_min_max",5.1);
+	p5.setMinFloat("float_min_max",0.1);
+	p5.setMaxFloat("float_min_max",10.1);
+
+	vector<std::string> strings;
+	p5.setValue("string","bli");
+	strings.push_back("bla");
+	strings.push_back("bluff");
+	p5.setValue("string_2","bla");
+	p5.setValidStrings("string_2",strings);
+
+		//list restrictions
+	vector<std::string> strings2 = {"xml", "txt"};
+	p5.setValue("stringlist2",std::vector<std::string>{"a.txt","b.xml","c.pdf"});
+	p5.setValue("stringlist",std::vector<std::string>{"aa.C","bb.h","c.doxygen"});
+	p5.setValidStrings("stringlist2",strings2);
+
+	p5.setValue("intlist",ListUtils::create<Int>("2,5,10"));
+	p5.setValue("intlist2",ListUtils::create<Int>("2,5,10"));
+	p5.setValue("intlist3",ListUtils::create<Int>("2,5,10"));
+	p5.setValue("intlist4",ListUtils::create<Int>("2,5,10"));
+	p5.setMinInt("intlist2",1);
+	p5.setMaxInt("intlist3",11);
+	p5.setMinInt("intlist4",0);
+	p5.setMaxInt("intlist4",15);
+
+	p5.setValue("doublelist",ListUtils::create<double>("1.2,3.33,4.44"));
+	p5.setValue("doublelist2",ListUtils::create<double>("1.2,3.33,4.44"));
+	p5.setValue("doublelist3",ListUtils::create<double>("1.2,3.33,4.44"));
+	p5.setValue("doublelist4",ListUtils::create<double>("1.2,3.33,4.44"));
+
+	p5.setMinFloat("doublelist2",1.1);
+	p5.setMaxFloat("doublelist3",4.45);
+	p5.setMinFloat("doublelist4",0.1);
+	p5.setMaxFloat("doublelist4",5.8);
+
+
+	paramFile.store(filename,p5, info);
+	Param p6;
+	paramXML.load(filename,p6);
+
+
+	TEST_EQUAL(p6.getEntry("int").min_int, -numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("int").max_int, numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("int_min").min_int, 4)
+	TEST_EQUAL(p6.getEntry("int_min").max_int, numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("int_max").min_int, -numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("int_max").max_int, 6)
+	TEST_EQUAL(p6.getEntry("int_min_max").min_int, 0)
+	TEST_EQUAL(p6.getEntry("int_min_max").max_int, 10)
+
+	TEST_REAL_SIMILAR(p6.getEntry("float").min_float, -numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("float").max_float, numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("float_min").min_float, 4.1)
+	TEST_REAL_SIMILAR(p6.getEntry("float_min").max_float, numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("float_max").min_float, -numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("float_max").max_float, 6.1)
+	TEST_REAL_SIMILAR(p6.getEntry("float_min_max").min_float, 0.1)
+	TEST_REAL_SIMILAR(p6.getEntry("float_min_max").max_float, 10.1)
+
+	TEST_EQUAL(p6.getEntry("string").valid_strings.size(),0)
+	TEST_EQUAL(p6.getEntry("string_2").valid_strings.size(),2)
+	TEST_EQUAL(p6.getEntry("string_2").valid_strings[0],"bla")
+	TEST_EQUAL(p6.getEntry("string_2").valid_strings[1],"bluff")
+
+
+
+	TEST_EQUAL(p6.getEntry("stringlist").valid_strings.size(),0)
+	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings.size(),2)
+	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[0],"xml")
+	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[1],"txt")
+
+	TEST_EQUAL(p6.getEntry("intlist").min_int, -numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("intlist").max_int, numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("intlist2").min_int, 1)
+	TEST_EQUAL(p6.getEntry("intlist2").max_int, numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("intlist3").min_int, -numeric_limits<Int>::max())
+	TEST_EQUAL(p6.getEntry("intlist3").max_int, 11)
+	TEST_EQUAL(p6.getEntry("intlist4").min_int, 0)
+	TEST_EQUAL(p6.getEntry("intlist4").max_int, 15)
+
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist").min_float, -numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist").max_float, numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist2").min_float, 1.1)
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist2").max_float, numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist3").min_float, -numeric_limits<double>::max())
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist3").max_float, 4.45)
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").min_float, 0.1)
+	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").max_float, 5.8)
+
+END_SECTION
+
+START_SECTION((void writeCTDToStream(std::ostream *os_ptr, const Param &param) const ))
+{
+	Param p;
+  p.setValue("stringlist", std::vector<std::string>{"a","bb","ccc"}, "StringList Description");
+  p.setValue("intlist", ListUtils::create<Int>("1,22,333"));
+  p.setValue("item", String("bla"));
+  p.setValue("stringlist2", std::vector<std::string>());
+  p.setValue("intlist2", ListUtils::create<Int>(""));
+  p.setValue("item1", 7);
+  p.setValue("intlist3", ListUtils::create<Int>("1"));
+  p.setValue("stringlist3", std::vector<std::string>{"1"});
+  p.setValue("item3", 7.6);
+  p.setValue("doublelist", ListUtils::create<double>("1.22,2.33,4.55"));
+  p.setValue("doublelist3", ListUtils::create<double>("1.4"));
+  p.setValue("file_parameter", "", "This is a file parameter.");
+  p.addTag("file_parameter", "input file");
+  p.setValidStrings("file_parameter", std::vector<std::string>{"*.mzML","*.mzXML"});
+  p.setValue("advanced_parameter", "", "This is an advanced parameter.", {"advanced"});
+  p.setValue("flag", "false", "This is a flag i.e. in a command line input it does not need a value.");
+  p.setValidStrings("flag",{"true","false"});
+  p.setValue("noflagJustTrueFalse", "true", "This is not a flag but has a boolean meaning.");
+  p.setValidStrings("noflagJustTrueFalse", {"true","false"});
+
+  String filename;
+  NEW_TMP_FILE(filename)
+  std::ofstream s(filename.c_str(), std::ios::out);
+  ParamCTDFile paramFile;
+  ToolInfo info = {"2.6.0-pre-STL-ParamCTD-2021-06-02",
+                   "AccurateMassSearch",
+                   "http://www.openms.de/doxygen/nightly/html/UTILS_AccurateMassSearch.html",
+                   "Utilities",
+                   "Match MS signals to molecules from a database by mass.",
+                   "10.1038/nmeth.3959",
+                   std::vector<std::string>()};
+  paramFile.writeCTDToStream(&s,p, info);
+  TEST_FILE_EQUAL(filename.c_str(), OPENMS_GET_TEST_DATA_PATH("ParamCTDFile_test_writeCTDToStream.ctd"))
+}
+END_SECTION
+
+START_SECTION([EXTRA] storing of lists)
+  ParamCTDFile paramFile;
+	ParamXMLFile paramXML;
+
+	Param p;
+	p.setValue("stringlist", std::vector<std::string>{"a","bb","ccc"});
+	p.setValue("intlist", ListUtils::create<Int>("1,22,333"));
+	p.setValue("item", String("bla"));
+	p.setValue("stringlist2", std::vector<std::string>());
+	p.setValue("intlist2", ListUtils::create<Int>(""));
+	p.setValue("item1", 7);
+	p.setValue("intlist3", ListUtils::create<Int>("1"));
+	p.setValue("stringlist3", std::vector<std::string>{"1"});
+	p.setValue("item3", 7.6);
+	p.setValue("doublelist", ListUtils::create<double>("1.22,2.33,4.55"));
+	p.setValue("doublelist2", ListUtils::create<double>(""));
+	p.setValue("doublelist3", ListUtils::create<double>("1.4"));
+	//store
+	String filename;
+	NEW_TMP_FILE(filename);
+  ToolInfo info = {"a", "b", "c", "d", "e", "f", std::vector<std::string>()};
+	paramFile.store(filename,p,info);
+	//load
+	Param p2;
+	paramXML.load(filename,p2);
+
+	TEST_EQUAL(p2.size(),12);
+
+	TEST_EQUAL(p2.getValue("stringlist").valueType(), ParamValue::STRING_LIST)
+	std::vector<std::string> list = p2.getValue("stringlist");
+	TEST_EQUAL(list.size(),3)
+	TEST_EQUAL(list[0],"a")
+	TEST_EQUAL(list[1],"bb")
+	TEST_EQUAL(list[2],"ccc")
+
+	TEST_EQUAL(p2.getValue("stringlist2").valueType(), ParamValue::STRING_LIST)
+	list = p2.getValue("stringlist2");
+	TEST_EQUAL(list.size(),0)
+
+	TEST_EQUAL(p2.getValue("stringlist").valueType(), ParamValue::STRING_LIST)
+	list = p2.getValue("stringlist3");
+	TEST_EQUAL(list.size(),1)
+	TEST_EQUAL(list[0],"1")
+
+	TEST_EQUAL(p2.getValue("intlist").valueType(), ParamValue::INT_LIST)
+	IntList intlist = p2.getValue("intlist");
+	TEST_EQUAL(intlist.size(),3);
+	TEST_EQUAL(intlist[0], 1)
+	TEST_EQUAL(intlist[1], 22)
+	TEST_EQUAL(intlist[2], 333)
+
+	TEST_EQUAL(p2.getValue("intlist2").valueType(),ParamValue::INT_LIST)
+	intlist = p2.getValue("intlist2");
+	TEST_EQUAL(intlist.size(),0)
+
+	TEST_EQUAL(p2.getValue("intlist3").valueType(),ParamValue::INT_LIST)
+	intlist = p2.getValue("intlist3");
+	TEST_EQUAL(intlist.size(),1)
+	TEST_EQUAL(intlist[0],1)
+
+	TEST_EQUAL(p2.getValue("doublelist").valueType(), ParamValue::DOUBLE_LIST)
+	DoubleList doublelist = p2.getValue("doublelist");
+	TEST_EQUAL(doublelist.size(),3);
+	TEST_EQUAL(doublelist[0], 1.22)
+	TEST_EQUAL(doublelist[1], 2.33)
+	TEST_EQUAL(doublelist[2], 4.55)
+
+	TEST_EQUAL(p2.getValue("doublelist2").valueType(),ParamValue::DOUBLE_LIST)
+	doublelist = p2.getValue("doublelist2");
+	TEST_EQUAL(doublelist.size(),0)
+
+	TEST_EQUAL(p2.getValue("doublelist3").valueType(),ParamValue::DOUBLE_LIST)
+	doublelist = p2.getValue("doublelist3");
+	TEST_EQUAL(doublelist.size(),1)
+	TEST_EQUAL(doublelist[0],1.4)
+
+END_SECTION
+
+
+START_SECTION(([EXTRA] Escaping of characters))
+	Param p;
+  ParamCTDFile paramFile;
+  ParamXMLFile paramXML;
+
+	p.setValue("string",String("bla"),"string");
+	p.setValue("string_with_ampersand", String("bla2&blubb"), "string with ampersand");
+	p.setValue("string_with_ampersand_in_descr", String("blaxx"), "String with & in description");
+	p.setValue("string_with_single_quote", String("bla'xxx"), "String with single quotes");
+	p.setValue("string_with_single_quote_in_descr", String("blaxxx"), "String with ' quote in description");
+	p.setValue("string_with_double_quote", String("bla\"xxx"), "String with double quote");
+	p.setValue("string_with_double_quote_in_descr", String("bla\"xxx"), "String with \" description");
+	p.setValue("string_with_greater_sign", String("bla>xxx"), "String with greater sign");
+	p.setValue("string_with_greater_sign_in_descr", String("bla greater xxx"), "String with >");
+	p.setValue("string_with_less_sign", String("bla<xxx"), "String with less sign");
+	p.setValue("string_with_less_sign_in_descr", String("bla less sign_xxx"), "String with less sign <");
+
+
+	String filename;
+	NEW_TMP_FILE(filename)
+  ToolInfo info = {"a", "a", "a", "a", "a", "a", std::vector<std::string>()};
+	paramFile.store(filename,p,info);
+
+	Param p2;
+	paramXML.load(filename,p2);
+
+	TEST_STRING_EQUAL(p2.getDescription("string"), "string")
+
+  TEST_STRING_EQUAL(p.getValue("string_with_ampersand"), String("bla2&blubb"))
+  TEST_STRING_EQUAL(p.getDescription("string_with_ampersand_in_descr"), "String with & in description")
+  TEST_STRING_EQUAL(p.getValue("string_with_single_quote"), String("bla'xxx"))
+  TEST_STRING_EQUAL(p.getDescription("string_with_single_quote_in_descr"), "String with ' quote in description")
+  TEST_STRING_EQUAL(p.getValue("string_with_double_quote"), String("bla\"xxx"))
+  TEST_STRING_EQUAL(p.getDescription("string_with_double_quote_in_descr"), "String with \" description")
+  TEST_STRING_EQUAL(p.getValue("string_with_greater_sign"), String("bla>xxx"))
+  TEST_STRING_EQUAL(p.getDescription("string_with_greater_sign_in_descr"), "String with >")
+  TEST_STRING_EQUAL(p.getValue("string_with_less_sign"), String("bla<xxx"))
+  TEST_STRING_EQUAL(p.getDescription("string_with_less_sign_in_descr"), "String with less sign <")
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST
+
+#pragma clang diagnostic pop
+


### PR DESCRIPTION
# Description

Added the new class ParamCTDFile that allows to write the Param datastructure to a CTD file (similar to ParamXMLFile).
Additionally ParamCTDFile has only standard dependecies.
Prior to this, writing the CTD file was directly done in TOPPBase.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
