### PR TITLE
[Fix] Remaining memory leaks in tests

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
@@ -232,7 +232,7 @@ protected:
 
       @return A pointer to the trace fitter that should be used.
      */
-    TraceFitter* chooseTraceFitter_(double& tau);
+    std::unique_ptr<TraceFitter> chooseTraceFitter_(double& tau);
 
     double intensityScore_(Size rt_bin, Size mz_bin, double intensity) const;
 
@@ -251,7 +251,7 @@ protected:
       @param traces Original mass traces found in the experiment.
       @param new_traces Mass traces created by cropping the original mass traces.
      */
-    void cropFeature_(TraceFitter* fitter,
+    void cropFeature_(std::shared_ptr<TraceFitter> fitter,
                       const MassTraces& traces,
                       MassTraces& new_traces);
 
@@ -278,7 +278,7 @@ protected:
 
       @return true if the feature is valid
      */
-    bool checkFeatureQuality_(TraceFitter* fitter,
+    bool checkFeatureQuality_(std::shared_ptr<TraceFitter> fitter,
                               MassTraces& feature_traces,
                               const double& seed_mz, const double& min_feature_score,
                               String& error_msg, double& fit_score, double& correlation, double& final_score);
@@ -296,7 +296,7 @@ protected:
       @param peak The Seed Peak
       @param path The path where to put the debug files (default is debug/features)
     */
-    void writeFeatureDebugInfo_(TraceFitter* fitter,
+    void writeFeatureDebugInfo_(std::shared_ptr<TraceFitter> fitter,
                                 const MassTraces& traces,
                                 const MassTraces& new_traces,
                                 bool feature_ok, const String error_msg, const double final_score, const Int plot_nr, const PeakType& peak,

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -141,28 +141,24 @@ namespace OpenMS
     }
 
     MSSpectrum::Chunks chunks(spectrum);
-    PeakSpectrum::StringDataArray* ion_names;
-    PeakSpectrum::IntegerDataArray* charges;
-
-    bool charges_dynamic = false, ion_names_dynamic = false;
+    std::shared_ptr<PeakSpectrum::StringDataArray> ion_names;
+    std::shared_ptr<PeakSpectrum::IntegerDataArray> charges;
 
     if (spectrum.getIntegerDataArrays().empty())
     {
-      charges = new PeakSpectrum::IntegerDataArray();
-      charges_dynamic = true;
+      charges = std::make_shared<PeakSpectrum::IntegerDataArray>();
     }
     else
     {
-      charges = &(spectrum.getIntegerDataArrays()[0]);
+      charges = std::make_shared<PeakSpectrum::IntegerDataArray>(spectrum.getIntegerDataArrays()[0]);
     }
     if (spectrum.getStringDataArrays().empty())
     {
-      ion_names = new PeakSpectrum::StringDataArray();
-      ion_names_dynamic = true;
+      ion_names = std::make_shared<PeakSpectrum::StringDataArray>();
     }
     else
     {
-      ion_names = &(spectrum.getStringDataArrays()[0]);
+      ion_names = std::make_shared<PeakSpectrum::StringDataArray>(spectrum.getStringDataArrays()[0]);
     }
     ion_names->setName("IonNames");
     charges->setName("Charges");
@@ -211,9 +207,6 @@ namespace OpenMS
         spectrum.getStringDataArrays().push_back(std::move(*ion_names));
       }
     }
-
-    if (charges_dynamic) delete charges;
-    if (ion_names_dynamic) delete ion_names;
 
     if (sort_by_position_) spectrum.sortByPositionPresorted(chunks.getChunks());
 

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -126,11 +126,9 @@ namespace OpenMS
     MetaInfoInterface::operator=(source);
     sequence_ = source.sequence_;
     score_ = source.score_;
-    analysis_results_ = nullptr;
+    delete analysis_results_;
     if (source.analysis_results_ != nullptr)
     {
-      // free memory first
-      delete analysis_results_;
       analysis_results_ = new std::vector<PepXMLAnalysisResult>(*source.analysis_results_);
     }
     rank_ = source.rank_;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -678,7 +678,7 @@ namespace OpenMS
 
         // choose fitter
         double egh_tau = 0.0;
-        TraceFitter* fitter = chooseTraceFitter_(egh_tau);
+        std::shared_ptr<TraceFitter> fitter = chooseTraceFitter_(egh_tau);
 
         fitter->setParameters(trace_fitter_params);
         fitter->fit(traces);
@@ -756,10 +756,10 @@ namespace OpenMS
         // Extract some of the model parameters.
         if (egh_tau != 0.0)
         {
-          egh_tau = (static_cast<EGHTraceFitter*>(fitter))->getTau();
+          egh_tau = (std::dynamic_pointer_cast<EGHTraceFitter>(fitter))->getTau();
           f.setMetaValue("EGH_tau", egh_tau);
-          f.setMetaValue("EGH_height", (static_cast<EGHTraceFitter*>(fitter))->getHeight());
-          f.setMetaValue("EGH_sigma", (static_cast<EGHTraceFitter*>(fitter))->getSigma());
+          f.setMetaValue("EGH_height", (std::dynamic_pointer_cast<EGHTraceFitter>(fitter))->getHeight());
+          f.setMetaValue("EGH_sigma", (std::dynamic_pointer_cast<EGHTraceFitter>(fitter))->getSigma());
         }
 
         // Calculate the mass of the feature: maximum, average, monoisotopic
@@ -793,9 +793,6 @@ namespace OpenMS
         // - the model does not include the baseline, so we ignore it here
         // - as we scaled the isotope distribution to
         f.setIntensity(fitter->getArea() / getIsotopeDistribution_(f.getMZ()).max);
-
-        // we do not need the fitter anymore
-        delete fitter;
 
         //add convex hulls of mass traces
         for (Size j = 0; j < traces.size(); ++j)
@@ -1696,19 +1693,19 @@ namespace OpenMS
     return final;
   }
 
-  TraceFitter* FeatureFinderAlgorithmPicked::chooseTraceFitter_(double& tau)
+  std::unique_ptr<TraceFitter> FeatureFinderAlgorithmPicked::chooseTraceFitter_(double& tau)
   {
     // choose fitter
     if (param_.getValue("feature:rt_shape") == "asymmetric")
     {
       OPENMS_LOG_DEBUG << "use asymmetric rt peak shape" << std::endl;
       tau = -1.0;
-      return new EGHTraceFitter();
+      return std::make_unique<EGHTraceFitter>();
     }
     else // if (param_.getValue("feature:rt_shape") == "symmetric")
     {
       OPENMS_LOG_DEBUG << "use symmetric rt peak shape" << std::endl;
-      return new GaussTraceFitter();
+      return std::make_unique<GaussTraceFitter>();
     }
   }
 
@@ -1746,7 +1743,7 @@ namespace OpenMS
     return final;
   }
 
-  void FeatureFinderAlgorithmPicked::cropFeature_(TraceFitter* fitter,
+  void FeatureFinderAlgorithmPicked::cropFeature_(std::shared_ptr<TraceFitter> fitter,
                                                   const MassTraces& traces,
                                                   MassTraces& new_traces)
   {
@@ -1825,7 +1822,7 @@ namespace OpenMS
     new_traces.baseline = traces.baseline;
   }
 
-  bool FeatureFinderAlgorithmPicked::checkFeatureQuality_(TraceFitter* fitter,
+  bool FeatureFinderAlgorithmPicked::checkFeatureQuality_(std::shared_ptr<TraceFitter> fitter,
                                                           MassTraces& feature_traces,
                                                           const double& seed_mz, const double& min_feature_score,
                                                           String& error_msg, double& fit_score, double& correlation, double& final_score)
@@ -1907,7 +1904,7 @@ namespace OpenMS
     return true;
   }
 
-  void FeatureFinderAlgorithmPicked::writeFeatureDebugInfo_(TraceFitter* fitter,
+  void FeatureFinderAlgorithmPicked::writeFeatureDebugInfo_(std::shared_ptr<TraceFitter> fitter,
                                                             const MassTraces& traces,
                                                             const MassTraces& new_traces,
                                                             bool feature_ok, const String error_msg, const double final_score, const Int plot_nr, const PeakType& peak,


### PR DESCRIPTION
# Description
I had a look at the [remaining memory leaks](http://cdash.openms.de/viewTest.php?onlyfailed&buildid=170763) in the tests. Sadly almost all have them are due to leaks in third party dependencies and therefore hardly fixable.

| Name | Memory Leak source | Description |
|---|---|---|
| DetectabilitySimulation_test | libsvm | Unresolvable |
| FeatureFinderAlgorithmPicked_test | Raw pointer | Fixed by using a `std::shared_ptr`. Not sure if this introduces a relevant performance penalty. Thoughts? |
| FeatureFinderMetabo_test | libsvm | Unresolvable |
| LibSVMEncoder_test | libsvm | Unresolvable |
| MzMLFile_test | `xercesc_3_2::MemoryManagerImpl::allocate(unsigned long)` | Unresolvable |
| MzMLSpectrumDecoder_test | `xercesc_3_2::MemoryManagerImpl::allocate(unsigned long)`, ... | Unresolvable |
| OfflinePrecursorIonSelection_test | libsvm | Unresolvable |
| OSWFile_test | libsqlite | Unresolvable |
| PepXMLFile_test | probably a false positiv | Allocation [here](https://github.com/OpenMS/OpenMS/blob/bf46a11720e76a406addbaafdddaff9f6a48515f/src/openms/source/METADATA/PeptideHit.cpp#L94) and deletion [here](https://github.com/OpenMS/OpenMS/blob/bf46a11720e76a406addbaafdddaff9f6a48515f/src/openms/source/METADATA/PeptideHit.cpp#L116). Should be fine.  |
| PrecursorIonSelectionPreprocessing_test | libsvm | Unresolvable |
| PSLPFormulation_test | libsvm | Unresolvable |
| SimpleSVM_test | libsvm | Unresolvable |
| SVMWrapper_test | libsvm | Unresolvable |
| TheoreticalSpectrumGenerator_test | probably a false positiv | Allocation [here](https://github.com/OpenMS/OpenMS/blob/bf46a11720e76a406addbaafdddaff9f6a48515f/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp#L151) and deletion [here](https://github.com/OpenMS/OpenMS/blob/bf46a11720e76a406addbaafdddaff9f6a48515f/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp#L215). Should be fine. |
| TOPP_ExecutePipeline_1 | Qt | Unresolvable |
| TOPP_FeatureFinderCentroided_1 | Raw pointer in `FeatureFinderAlgorithmPicked` | Fixed. See prior entry `FeatureFinderAlgorithmPicked_test` |
| TOPP_PTModel_1 | libsvm | Unresolvable |
| TOPP_RTModel_1 | libsvm | Unresolvable |
| TOPP_RTModel_2 | libsvm | Unresolvable |
| TOPP_RTModel_3 | libsvm | Unresolvable |
| TOPP_RTModel_4 | libsvm | Unresolvable |
| TOPPView_test | Qt | Unresolvable |
| UnimodXMLFile_test | `xercesc_3_2::DefaultHandler` | Unresolvable |

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
