### PR TITLE
fix bug in Epifany introduced by new ParamValue class

### DIFF
--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -309,10 +309,11 @@ namespace OpenMS
           if (debug_lvl_ > 2)
           {
             std::ofstream ofs;
-            ofs.open ("failed_cc_a"+ (std::string)param_.getValue("model_parameters:pep_emission") +
-                "_b" + (std::string)param_.getValue("model_parameters:pep_spurious_emission") + "_g" +
-                (std::string)param_.getValue("model_parameters:prot_prior") + "_c" +
-                (std::string)param_.getValue("model_parameters:pep_prior") + "_p" + String(pnorm) + "_"
+            ofs.open (std::string("failed_cc_a") + 
+                param_.getValue("model_parameters:pep_emission").toString() + "_b" + 
+                param_.getValue("model_parameters:pep_spurious_emission").toString() + "_g" +
+                param_.getValue("model_parameters:prot_prior").toString() + "_c" +
+                param_.getValue("model_parameters:pep_prior").toString() + "_p" + String(pnorm) + "_"
                 + String(idx) + ".dot"
                 , std::ofstream::out);
             IDBoostGraph::printGraph(ofs, fg);


### PR DESCRIPTION
# Description

double param values need to be converted to string

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
