### PR TITLE
overwrite design file names with input file names (as we know those e…

### DIFF
--- a/src/utils/ProteomicsLFQ.cpp
+++ b/src/utils/ProteomicsLFQ.cpp
@@ -1658,12 +1658,6 @@ protected:
     std::map<unsigned int, std::vector<String> > frac2ms = design.getFractionToMSFilesMapping();
 
     // experimental design file could contain URLs etc. that we want to overwrite with the actual input files
-    vector<String> in_basename_vector;
-    for (Size i = 0; i != in.size(); ++i)
-    {
-      in_basename_vector.push_back(File::basename(in[i]));
-    }
-
     for (auto & [fraction, ms_files] : frac2ms)
     {
       for (auto & s : ms_files)
@@ -1671,12 +1665,12 @@ protected:
         // if basename in experimental design matches to basename in input file
         // overwrite experimental design to point to existing file (and only if they were different)
         if (auto it = std::find_if(in.begin(), in.end(), 
-              [&s] (const String& in_filename) { return File::basename(in_filename) == File::basename(s); }); 
-                 it != in_basename_vector.end() && s != *it)
+              [&s] (const String& in_filename) { return File::basename(in_filename) == File::basename(s); }); // basename matches?
+                 it != in.end() && s != *it) // and differ?
         {
           OPENMS_LOG_INFO << "Path of spectra files differ between experimental design (1) and input (2). Using the path of the input file as "
                           << "we know this file exists on the file system: '" << *it << "' vs. '" << s << endl;
-          s = *it;
+          s = *it; // overwrite filename in design with filename in input files
         }
       }
       

--- a/src/utils/ProteomicsLFQ.cpp
+++ b/src/utils/ProteomicsLFQ.cpp
@@ -1654,8 +1654,33 @@ protected:
       throw Exception::InvalidParameter(__FILE__, __LINE__, 
         OPENMS_PRETTY_FUNCTION, "Different number of fractions for different samples provided. This is currently not supported by ProteomicsLFQ.");          
     }
-
+   
     std::map<unsigned int, std::vector<String> > frac2ms = design.getFractionToMSFilesMapping();
+
+    // experimental design file could contain URLs etc. that we want to overwrite with the actual input files
+    vector<String> in_basename_vector;
+    for (Size i = 0; i != in.size(); ++i)
+    {
+      in_basename_vector.push_back(File::basename(in[i]));
+    }
+
+    for (auto & [fraction, ms_files] : frac2ms)
+    {
+      for (auto & s : ms_files)
+      {
+        // if basename in experimental design matches to basename in input file
+        // overwrite experimental design to point to existing file (and only if they were different)
+        if (auto it = std::find_if(in.begin(), in.end(), 
+              [&s] (const String& in_filename) { return File::basename(in_filename) == File::basename(s); }); 
+                 it != in_basename_vector.end() && s != *it)
+        {
+          OPENMS_LOG_INFO << "Path of spectra files differ between experimental design (1) and input (2). Using the path of the input file as "
+                          << "we know this file exists on the file system: '" << *it << "' vs. '" << s << endl;
+          s = *it;
+        }
+      }
+      
+    } 
 
     for (auto & f : frac2ms)
     {


### PR DESCRIPTION
…xist on the filesystem)

# Description

design filenames might be URLs etc. input files are known to exist (e.g., get checked by TOPPBase).
So we overwrite differing design filenames with the input filenames based on their basename.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
