### PR TITLE
[FEATURE] Export isotope errors when reading pepXML

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,9 +3,10 @@ FROM openms/contrib:latest
 #USER gitpod
 # Avoid user input
 ARG DEBIAN_FRONTEND=noninteractive
+ARG CLANGDVER=12.0.1
 
 # Install tools for VSCode, Intellisense, JRE for Thirdparties, etc. using apt-get
 RUN apt-get -q update && apt-get install -yq gdb unzip wget php openjdk-11-jre clang-tidy && rm -rf /var/lib/apt/lists/*
-RUN wget https://github.com/clangd/clangd/releases/download/12.0.1/clangd-linux-12.0.1.zip && unzip clangd-linux-12.0.1.zip -d /usr/ && rm clangd-linux-12.0.1.zip 
+RUN wget https://github.com/clangd/clangd/releases/download/$CLANGDVER/clangd-linux-$CLANGDVER.zip && unzip clangd-linux-$CLANGDVER.zip -d /opt/ && mv /opt/clangd_$CLANGDVER /opt/clangd/ && rm clangd-linux-$CLANGDVER.zip 
 #
 # More information: https://www.gitpod.io/docs/42_config_docker/

--- a/.vscode-gitpod/cmake-kits.json
+++ b/.vscode-gitpod/cmake-kits.json
@@ -1,3 +1,9 @@
 [
-
+  {
+    "name": "Default",
+    "compilers": {
+        "C": "/usr/bin/gcc",
+        "CXX": "/usr/bin/g++"
+    }
+  }
 ]

--- a/.vscode-gitpod/settings.json
+++ b/.vscode-gitpod/settings.json
@@ -15,7 +15,7 @@
     ],
     "cmake.skipConfigureIfCachePresent": true,
     "cmake.buildDirectory": "${workspaceFolder}/build",
-    "clangd.path": "/usr/bin/clangd",
+    "clangd.path": "/opt/clangd/bin/clangd",
     "clangd.arguments": [
       "-background-index=0"
     ]

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -296,9 +296,6 @@ private:
     /// RT and m/z of current PeptideIdentification (=spectrum)  
     double rt_{}, mz_{};
 
-    /// possible isotopes to consider and annotate
-    //std::vector<int> potential_isotopeerrors_;
-
     /// 1-based scan nr. of current PeptideIdentification (=spectrum). Scannr is usually from the start_scan attribute
     Size scannr_{};
 

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -296,6 +296,9 @@ private:
     /// RT and m/z of current PeptideIdentification (=spectrum)  
     double rt_{}, mz_{};
 
+    /// possible isotopes to consider and annotate
+    //std::vector<int> potential_isotopeerrors_;
+
     /// 1-based scan nr. of current PeptideIdentification (=spectrum). Scannr is usually from the start_scan attribute
     Size scannr_{};
 
@@ -341,5 +344,7 @@ private:
     bool lookupAddFromHeader_(double modification_mass,
                               Size modification_position,
                               std::vector<AminoAcidModification> const& header_mods);
+
+    //static std::vector<int> getIsotopeErrorsFromIntSetting_(int intSetting);
   };
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -124,6 +124,7 @@ namespace OpenMS
     
     void PercolatorFeatureSetHelper::addXTANDEMFeatures(vector<PeptideIdentification>& peptide_ids, StringList& feature_set)
     {
+      //TODO annotate isotope error in Adapter and add here as well.
       // Find out which ions are in XTandem-File and take only these as features
       StringList ion_types = ListUtils::create<String>("a,b,c,x,y,z");
       StringList ion_types_found;
@@ -168,11 +169,13 @@ namespace OpenMS
       feature_set.push_back("MS:1001330"); // expect_score
       feature_set.push_back("hyperscore");
       feature_set.push_back("nextscore");
+      feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
     }
 
     void PercolatorFeatureSetHelper::addCOMETFeatures(vector<PeptideIdentification>& peptide_ids, StringList& feature_set)
     {
 
+      feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR); // to use
       feature_set.push_back("COMET:deltCn"); // recalculated deltCn = (current_XCorr - 2nd_best_XCorr) / max(current_XCorr, 1)
       feature_set.push_back("COMET:deltLCn"); // deltLCn = (current_XCorr - worst_XCorr) / max(current_XCorr, 1)
       feature_set.push_back("COMET:lnExpect"); // log(E-value)

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -175,7 +175,7 @@ namespace OpenMS
     void PercolatorFeatureSetHelper::addCOMETFeatures(vector<PeptideIdentification>& peptide_ids, StringList& feature_set)
     {
 
-      feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR); // to use
+      feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
       feature_set.push_back("COMET:deltCn"); // recalculated deltCn = (current_XCorr - 2nd_best_XCorr) / max(current_XCorr, 1)
       feature_set.push_back("COMET:deltLCn"); // deltLCn = (current_XCorr - worst_XCorr) / max(current_XCorr, 1)
       feature_set.push_back("COMET:lnExpect"); // log(E-value)

--- a/src/tests/class_tests/openms/data/combined.concat.perco.in.idXML
+++ b/src/tests/class_tests/openms/data/combined.concat.perco.in.idXML
@@ -599,6 +599,7 @@
 				<UserParam type="string" name="MS:1002258" value="4"/>
 				<UserParam type="string" name="MS:1002259" value="38"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.449"/>
 				<UserParam type="float" name="MS:1002253" value="0.052"/>
 				<UserParam type="float" name="MS:1002255" value="34"/>
@@ -614,6 +615,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="48"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.426"/>
 				<UserParam type="float" name="MS:1002253" value="0.073"/>
 				<UserParam type="float" name="MS:1002255" value="12.2"/>
@@ -629,6 +631,7 @@
 				<UserParam type="string" name="MS:1002258" value="5"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.395"/>
 				<UserParam type="float" name="MS:1002253" value="0.466"/>
 				<UserParam type="float" name="MS:1002255" value="40.4"/>
@@ -644,6 +647,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.211"/>
 				<UserParam type="float" name="MS:1002253" value="0.037"/>
 				<UserParam type="float" name="MS:1002255" value="1.7"/>
@@ -659,6 +663,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.203"/>
 				<UserParam type="float" name="MS:1002253" value="0.001"/>
 				<UserParam type="float" name="MS:1002255" value="1.9"/>
@@ -676,6 +681,7 @@
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.256"/>
 				<UserParam type="float" name="MS:1002253" value="0.093"/>
 				<UserParam type="float" name="MS:1002255" value="703.3"/>
@@ -691,6 +697,7 @@
 				<UserParam type="string" name="MS:1002258" value="10"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.14"/>
 				<UserParam type="float" name="MS:1002253" value="0.031"/>
 				<UserParam type="float" name="MS:1002255" value="201.6"/>
@@ -706,6 +713,7 @@
 				<UserParam type="string" name="MS:1002258" value="12"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.104"/>
 				<UserParam type="float" name="MS:1002253" value="0.03"/>
 				<UserParam type="float" name="MS:1002255" value="251.4"/>
@@ -721,6 +729,7 @@
 				<UserParam type="string" name="MS:1002258" value="11"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.017"/>
 				<UserParam type="float" name="MS:1002255" value="144.2"/>
@@ -733,9 +742,11 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="CONCAT:lnEvalue" value="2.95491027903374"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="10"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.053"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002255" value="170.8"/>
@@ -753,6 +764,7 @@
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="2.028"/>
 				<UserParam type="float" name="MS:1002253" value="0.057"/>
 				<UserParam type="float" name="MS:1002255" value="476.7"/>
@@ -768,6 +780,7 @@
 				<UserParam type="string" name="MS:1002258" value="15"/>
 				<UserParam type="string" name="MS:1002259" value="48"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.913"/>
 				<UserParam type="float" name="MS:1002253" value="0.097"/>
 				<UserParam type="float" name="MS:1002255" value="342.3"/>
@@ -783,6 +796,7 @@
 				<UserParam type="string" name="MS:1002258" value="17"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.728"/>
 				<UserParam type="float" name="MS:1002253" value="0.011"/>
 				<UserParam type="float" name="MS:1002255" value="320.5"/>
@@ -798,6 +812,7 @@
 				<UserParam type="string" name="MS:1002258" value="23"/>
 				<UserParam type="string" name="MS:1002259" value="72"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.708"/>
 				<UserParam type="float" name="MS:1002253" value="0.055"/>
 				<UserParam type="float" name="MS:1002255" value="503.4"/>
@@ -813,6 +828,7 @@
 				<UserParam type="string" name="MS:1002258" value="16"/>
 				<UserParam type="string" name="MS:1002259" value="52"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.615"/>
 				<UserParam type="float" name="MS:1002253" value="0.007"/>
 				<UserParam type="float" name="MS:1002255" value="356.8"/>

--- a/src/tests/class_tests/openms/data/comet.topperc.idXML
+++ b/src/tests/class_tests/openms/data/comet.topperc.idXML
@@ -64,6 +64,7 @@
 				<UserParam type="float" name="MS:1002257" value="15.1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="19.7" sequence="PSGNGADEDEDEGSGDDEDEEAGNG" charge="2" aa_before="S" aa_after="K" start="245" end="269" protein_refs="PH_1" >
 				<UserParam type="string" name="MS:1002258" value="3"/>
@@ -76,6 +77,7 @@
 				<UserParam type="float" name="MS:1002257" value="19.7"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="28" sequence="FCCRCCCNCGCCRRRCCCCRI" charge="2" aa_before="C" aa_after="T" start="102" end="122" protein_refs="PH_11" >
 				<UserParam type="string" name="MS:1002258" value="5"/>
@@ -88,6 +90,7 @@
 				<UserParam type="float" name="MS:1002257" value="28"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="223" sequence="SDDDEDEDDEEDHDIMEADLD" charge="2" aa_before="E" aa_after="K" start="581" end="601" protein_refs="PH_0" >
 				<UserParam type="string" name="MS:1002258" value="1"/>
@@ -100,6 +103,7 @@
 				<UserParam type="float" name="MS:1002257" value="223"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="244" sequence="DLDAEMIDHDEEDDEDEDDDS" charge="2" aa_before="K" aa_after="E" start="215" end="235" protein_refs="PH_7" >
 				<UserParam type="string" name="MS:1002258" value="1"/>
@@ -112,6 +116,7 @@
 				<UserParam type="float" name="MS:1002257" value="244"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="434.918547698567" RT="983.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=344" >
@@ -126,6 +131,7 @@
 				<UserParam type="float" name="MS:1002257" value="4.59"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="10.4" sequence="PTLLERSLNFI" charge="3" aa_before="Q" aa_after="A" start="2449" end="2459" protein_refs="PH_10" >
 				<UserParam type="string" name="MS:1002258" value="10"/>
@@ -138,6 +144,7 @@
 				<UserParam type="float" name="MS:1002257" value="10.4"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="13.4" sequence="PLTVEKKQTMK" charge="3" aa_before="F" aa_after="V" start="547" end="557" protein_refs="PH_12" >
 				<UserParam type="string" name="MS:1002258" value="12"/>
@@ -150,6 +157,7 @@
 				<UserParam type="float" name="MS:1002257" value="13.4"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="16.9" sequence="ASVEKARKALTE" charge="3" aa_before="Y" aa_after="R" start="333" end="344" protein_refs="PH_3" >
 				<UserParam type="string" name="MS:1002258" value="11"/>
@@ -162,6 +170,7 @@
 				<UserParam type="float" name="MS:1002257" value="16.9"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="19.2" sequence="PTISRPLICRF" charge="3" aa_before="Y" aa_after="G" start="104" end="114" protein_refs="PH_2" >
 				<UserParam type="string" name="MS:1002258" value="10"/>
@@ -174,6 +183,7 @@
 				<UserParam type="float" name="MS:1002257" value="19.2"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="547.9460440319" RT="986.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=348" >
@@ -188,6 +198,7 @@
 				<UserParam type="float" name="MS:1002257" value="0.328"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="0.786" sequence="M(Oxidation)EEMKQKVQAYLK" charge="3" aa_before="Q" aa_after="H" start="112" end="124" protein_refs="PH_6" >
 				<UserParam type="string" name="MS:1002258" value="15"/>
@@ -200,6 +211,7 @@
 				<UserParam type="float" name="MS:1002257" value="0.786"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="3.23" sequence="QLSAVIECADSAHGLK" charge="3" aa_before="P" aa_after="G" start="197" end="212" protein_refs="PH_4" >
 				<UserParam type="string" name="MS:1002258" value="17"/>
@@ -212,6 +224,7 @@
 				<UserParam type="float" name="MS:1002257" value="3.23"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="3.76" sequence="ALGSSVPGAQVSGGAQGAQ" charge="3" aa_before="L" aa_after="V" start="257" end="275" protein_refs="PH_9" >
 				<UserParam type="string" name="MS:1002258" value="23"/>
@@ -224,6 +237,7 @@
 				<UserParam type="float" name="MS:1002257" value="3.76"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="7.65" sequence="QQPQPPQPQQQPLQ" charge="3" aa_before="Q" aa_after="S" start="255" end="268" protein_refs="PH_14" >
 				<UserParam type="string" name="MS:1002258" value="16"/>
@@ -236,6 +250,7 @@
 				<UserParam type="float" name="MS:1002257" value="7.65"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/class_tests/openms/data/comet.topperc_check.idXML
+++ b/src/tests/class_tests/openms/data/comet.topperc_check.idXML
@@ -17,7 +17,7 @@
 				<UserParam type="string" name="Comet:precursor_mass_tolerance_unit" value="ppm"/>
 				<UserParam type="string" name="Comet:digestion_enzyme" value="unspecific cleavage"/>
 				<UserParam type="string" name="feature_extractor" value="TOPP_PSMFeatureExtractor"/>
-				<UserParam type="string" name="extra_features" value="COMET:deltCn,COMET:deltLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
+				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltCn,COMET:deltLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 	</SearchParameters>
 	<IdentificationRun date="2017-03-25T18:21:07" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
@@ -70,6 +70,7 @@
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="1233.9196160319" RT="974.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=334" >
 			<PeptideHit score="15.1" sequence="HYSEEEYDSEFDDADDDEEQ" charge="2" aa_before="L" aa_after="S" start="733" end="752" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="4"/>
 				<UserParam type="string" name="MS:1002259" value="38"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
@@ -88,6 +89,7 @@
 			</PeptideHit>
 			<PeptideHit score="19.7" sequence="PSGNGADEDEDEGSGDDEDEEAGNG" charge="2" aa_before="S" aa_after="K" start="245" end="269" protein_refs="PH_12" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="48"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
@@ -106,6 +108,7 @@
 			</PeptideHit>
 			<PeptideHit score="28" sequence="FCCRCCCNCGCCRRRCCCCRI" charge="2" aa_before="C" aa_after="T" start="102" end="122" protein_refs="PH_11" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="5"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
@@ -124,6 +127,7 @@
 			</PeptideHit>
 			<PeptideHit score="223" sequence="SDDDEDEDDEEDHDIMEADLD" charge="2" aa_before="E" aa_after="K" start="581" end="601" protein_refs="PH_7" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
@@ -142,6 +146,7 @@
 			</PeptideHit>
 			<PeptideHit score="244" sequence="DLDAEMIDHDEEDDEDEDDDS" charge="2" aa_before="K" aa_after="E" start="215" end="235" protein_refs="PH_8" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
@@ -162,6 +167,7 @@
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="434.918547698567" RT="983.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=344" >
 			<PeptideHit score="4.59" sequence="TPLIDRVVVAGY" charge="3" aa_before="L" aa_after="S" start="1051" end="1062" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
@@ -180,6 +186,7 @@
 			</PeptideHit>
 			<PeptideHit score="10.4" sequence="PTLLERSLNFI" charge="3" aa_before="Q" aa_after="A" start="2449" end="2459" protein_refs="PH_10" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="10"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
@@ -198,6 +205,7 @@
 			</PeptideHit>
 			<PeptideHit score="13.4" sequence="PLTVEKKQTMK" charge="3" aa_before="F" aa_after="V" start="547" end="557" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="12"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
@@ -216,6 +224,7 @@
 			</PeptideHit>
 			<PeptideHit score="16.9" sequence="ASVEKARKALTE" charge="3" aa_before="Y" aa_after="R" start="333" end="344" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="11"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
@@ -234,6 +243,7 @@
 			</PeptideHit>
 			<PeptideHit score="19.2" sequence="PTISRPLICRF" charge="3" aa_before="Y" aa_after="G" start="104" end="114" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="10"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="20394"/>
@@ -254,6 +264,7 @@
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="547.9460440319" RT="986.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=348" >
 			<PeptideHit score="0.328" sequence="PSGASIDLDGKEKIPD" charge="3" aa_before="Q" aa_after="T" start="6" end="21" protein_refs="PH_6" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
@@ -272,6 +283,7 @@
 			</PeptideHit>
 			<PeptideHit score="0.786" sequence="M(Oxidation)EEMKQKVQAYLK" charge="3" aa_before="Q" aa_after="H" start="112" end="124" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="15"/>
 				<UserParam type="string" name="MS:1002259" value="48"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
@@ -290,6 +302,7 @@
 			</PeptideHit>
 			<PeptideHit score="3.23" sequence="QLSAVIECADSAHGLK" charge="3" aa_before="P" aa_after="G" start="197" end="212" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="17"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
@@ -308,6 +321,7 @@
 			</PeptideHit>
 			<PeptideHit score="3.76" sequence="ALGSSVPGAQVSGGAQGAQ" charge="3" aa_before="L" aa_after="V" start="257" end="275" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="23"/>
 				<UserParam type="string" name="MS:1002259" value="72"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>
@@ -326,6 +340,7 @@
 			</PeptideHit>
 			<PeptideHit score="7.65" sequence="QQPQPPQPQQQPLQ" charge="3" aa_before="Q" aa_after="S" start="255" end="268" protein_refs="PH_9" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="MS:1002258" value="16"/>
 				<UserParam type="string" name="MS:1002259" value="52"/>
 				<UserParam type="string" name="num_matched_peptides" value="39994"/>

--- a/src/tests/topp/IDFileConverter_10_output.idXML
+++ b/src/tests/topp/IDFileConverter_10_output.idXML
@@ -29,7 +29,8 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="804.383175031900009" RT="383.87700000000001" spectrum_reference="scan=1671" >
-			<PeptideHit score="0.7911" sequence=".(Dimethyl:2H(4)13C(2))TGSESSQTGTSTTSSR" charge="2" aa_before="R" aa_after="N" protein_refs="PH_0" >
+			<PeptideHit score="0.7911" sequence=".(Dimethyl:2H(4)13C(2))TGSESSQTGTSTTSSR.(MOD:00266)" charge="2" aa_before="R" aa_after="N" protein_refs="PH_0" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="19.399999999999999"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="float" name="MS:1001330" value="0.033"/>
@@ -47,7 +48,8 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="863.492925031899972" RT="4120.789999999999964" spectrum_reference="scan=30513" >
-			<PeptideHit score="0.9938" sequence=".(Dimethyl:2H(4)13C(2))DLADELALVDVIEDK(Dimethyl:2H(4)13C(2))" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+			<PeptideHit score="0.9938" sequence=".(Dimethyl:2H(4)13C(2))DLADELALVDVIEDK(Dimethyl:2H(4)13C(2)).(MOD:00266)" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="28.800000000000001"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 				<UserParam type="float" name="MS:1001330" value="2.0e-04"/>
@@ -73,7 +75,8 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="587.947991698566625" RT="374.115999999999985" spectrum_reference="scan=1594" >
-			<PeptideHit score="1.0" sequence=".(Dimethyl)GDTPGHATPGHGGATSSAR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_2" >
+			<PeptideHit score="1.0" sequence=".(Dimethyl)GDTPGHATPGHGGATSSAR.(MOD:00266)" charge="3" aa_before="R" aa_after="K" protein_refs="PH_2" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="34.200000000000003"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 				<UserParam type="float" name="MS:1001330" value="1.0e-04"/>
@@ -91,7 +94,8 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="853.11645836523337" RT="4131.050000000000182" spectrum_reference="scan=30586" >
-			<PeptideHit score="1.0" sequence=".(Dimethyl)TLVLSNLSYSATEETLQEVFEK(Dimethyl)" charge="3" aa_before="K" aa_after="A" protein_refs="PH_3" >
+			<PeptideHit score="1.0" sequence=".(Dimethyl)TLVLSNLSYSATEETLQEVFEK(Dimethyl).(MOD:00266)" charge="3" aa_before="K" aa_after="A" protein_refs="PH_3" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="27.100000000000001"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 				<UserParam type="float" name="MS:1001330" value="1.3e-07"/>

--- a/src/tests/topp/IDFileConverter_16_output.idXML
+++ b/src/tests/topp/IDFileConverter_16_output.idXML
@@ -29,6 +29,7 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="436.210339680337484" RT="0.0" spectrum_reference="scan=6" >
 			<PeptideHit score="0.806668" sequence="HEEIDTK" charge="2" aa_before="K X" aa_after="N X" protein_refs="PH_0 PH_1" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.9208"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.434"/>
@@ -47,6 +48,7 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="360.700329914712484" RT="0.0" spectrum_reference="scan=2770" >
 			<PeptideHit score="0.0" sequence="GLVC(Carbamidomethyl)GSK" charge="2" aa_before="A" aa_after="F" protein_refs="PH_2" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-3.5466"/>
@@ -65,6 +67,7 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="350.530489419920002" RT="0.0" spectrum_reference="scan=2999" >
 			<PeptideHit score="0.0223989" sequence="LIWTM(Oxidation)IGIS" charge="3" aa_before="R" aa_after="F" protein_refs="PH_3" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.217"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="0.801"/>
@@ -83,6 +86,7 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="566.770337238929983" RT="0.0" spectrum_reference="scan=3084" >
 			<PeptideHit score="0.0505509" sequence=".(Glu-&gt;pyro-Glu)EAGIVDELAYA" charge="2" aa_before="K" aa_after="V" protein_refs="PH_4" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.07"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3114"/>
@@ -101,6 +105,7 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="608.957491373046651" RT="0.0" spectrum_reference="scan=3905" >
 			<PeptideHit score="0.999999" sequence=".(Acetyl)SASAQHSQAQQQQQQK" charge="3" aa_before="M" aa_after="S" protein_refs="PH_5" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="1.0"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="4.795"/>
@@ -119,6 +124,7 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="681.293347492839985" RT="0.0" spectrum_reference="scan=7319" >
 			<PeptideHit score="2.01282e-05" sequence=".(Ammonia-loss)C(Carbamidomethyl)LPGPATASIYQT" charge="2" aa_before="K" aa_after="L" protein_refs="PH_6" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="7.0e-04"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3658"/>

--- a/src/tests/topp/IDFileConverter_24_output.idXML
+++ b/src/tests/topp/IDFileConverter_24_output.idXML
@@ -50,6 +50,7 @@
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="170"/>
 				<UserParam type="string" name="num_matched_peptides" value="29030"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="MS:1002252" value="0.998"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
@@ -69,6 +70,7 @@
 				<UserParam type="string" name="MS:1002258" value="20"/>
 				<UserParam type="string" name="MS:1002259" value="170"/>
 				<UserParam type="string" name="num_matched_peptides" value="29030"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="float" name="MS:1002252" value="0.998"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
@@ -83,6 +85,7 @@
 				<UserParam type="string" name="MS:1002258" value="34"/>
 				<UserParam type="string" name="MS:1002259" value="380"/>
 				<UserParam type="string" name="num_matched_peptides" value="10210"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="MS:1002252" value="1.474"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>

--- a/src/tests/topp/IDFileConverter_2_output.idXML
+++ b/src/tests/topp/IDFileConverter_2_output.idXML
@@ -58,54 +58,63 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="538.605091698566639" RT="1.3653" spectrum_reference="scan=2" >
 			<PeptideHit score="8.0" sequence=".(Glu-&gt;pyro-Glu)ELNKEMAAEKAKAAAG" charge="3" aa_before="R X X" aa_after="E X X" protein_refs="PH_0 PH_1 PH_2" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="329.0"/>
 				<UserParam type="float" name="nextscore" value="323.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="637.885175031899962" RT="1.719" spectrum_reference="scan=3" >
 			<PeptideHit score="7.7" sequence=".(Gln-&gt;pyro-Glu)QLPGVNIKPVVK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_3" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="173.0"/>
 				<UserParam type="float" name="nextscore" value="167.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="678.384725031899961" RT="2.0436" spectrum_reference="scan=4" >
 			<PeptideHit score="4.9" sequence="IFQAALYAAPYK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_4" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="274.0"/>
 				<UserParam type="float" name="nextscore" value="250.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="762.728391698566725" RT="2.7843" spectrum_reference="scan=6" >
 			<PeptideHit score="9.1e-04" sequence="EISPDTTLLDLQNNDISELR" charge="3" aa_before="K X X X" aa_after="K X X X" protein_refs="PH_5 PH_6 PH_7 PH_8" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="807.0"/>
 				<UserParam type="float" name="nextscore" value="446.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="1143.595525031900024" RT="3.085" spectrum_reference="scan=7" >
 			<PeptideHit score="7.9e-05" sequence="EISPDTTLLDLQNNDISELR" charge="2" aa_before="K X X X" aa_after="K X X X" protein_refs="PH_5 PH_6 PH_7 PH_8" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="705.0"/>
 				<UserParam type="float" name="nextscore" value="309.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="770.055225031900022" RT="3.4018" spectrum_reference="scan=8" >
 			<PeptideHit score="14.0" sequence="RSHTILNSSQSFAKGC(Carbamidomethyl)VQC(Carbamidomethyl)K" charge="3" aa_before="K X X" aa_after="H X X" protein_refs="PH_9 PH_10 PH_11" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="350.0"/>
 				<UserParam type="float" name="nextscore" value="349.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="757.412291698566719" RT="4.4573" spectrum_reference="scan=10" >
 			<PeptideHit score="0.65" sequence="VSLPNYPAIPSDATLEVQSLR" charge="3" aa_before="K X X" aa_after="S X X" protein_refs="PH_12 PH_13 PH_14" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="463.0"/>
 				<UserParam type="float" name="nextscore" value="431.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="807.394125031899989" RT="4.8288" spectrum_reference="scan=11" >
 			<PeptideHit score="4.6e-03" sequence="NALWHTGDTESQVR" charge="2" aa_before="R X X" aa_after="L X X" protein_refs="PH_15 PH_16 PH_17" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="478.0"/>
 				<UserParam type="float" name="nextscore" value="278.0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="512.784525031899989" RT="5.1785" spectrum_reference="scan=12" >
 			<PeptideHit score="1.1" sequence="SSLKNYANK" charge="2" aa_before="R X" aa_after="I X" protein_refs="PH_18 PH_19" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="hyperscore" value="266.0"/>
 				<UserParam type="float" name="nextscore" value="228.0"/>
 			</PeptideHit>
@@ -132,46 +141,55 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="1143.590525031899915" RT="3.1" spectrum_reference="scan=7" >
 			<PeptideHit score="5.136" sequence="EISPDTTLLDLQNNDISELR" charge="2" aa_before="K" aa_after="K" protein_refs="PH_20" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="5.136"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="637.885525031899988" RT="1.7" spectrum_reference="scan=3" >
 			<PeptideHit score="1.024" sequence="LLTAQEQPVYI" charge="2" aa_before="R" aa_after="-" protein_refs="PH_21" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.024"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="538.605558365233378" RT="1.4" spectrum_reference="scan=2" >
 			<PeptideHit score="1.641" sequence="HEVVIWLGDLNYR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_22" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.641"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="770.055558365233424" RT="3.4" spectrum_reference="scan=8" >
 			<PeptideHit score="1.606" sequence="LDGNYLKPPIPLDLM(Oxidation)MC(Carbamidomethyl)FR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+				<UserParam type="int" name="isotope_error" value="-1"/>
 				<UserParam type="float" name="MS:1001155" value="1.606"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="512.784525031899989" RT="5.2" spectrum_reference="scan=12" >
 			<PeptideHit score="1.288" sequence="EHVQLRDK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_24" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.288"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="678.384525031900012" RT="2.0" spectrum_reference="scan=4" >
 			<PeptideHit score="3.986" sequence="FSDGAFLGVTTLK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_25" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="3.986"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="807.394525031900002" RT="4.8" spectrum_reference="scan=11" >
 			<PeptideHit score="2.831" sequence="NALWHTGDTESQVR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_26" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="2.831"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="757.412558365233394" RT="4.5" spectrum_reference="scan=10" >
 			<PeptideHit score="2.197" sequence="VSLPNYPAIPSDATLEVQSLR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_27" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="2.197"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="762.728558365233425" RT="2.8" spectrum_reference="scan=6" >
 			<PeptideHit score="5.638" sequence="EISPDTTLLDLQNNDISELR" charge="3" aa_before="K" aa_after="K" protein_refs="PH_20" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="5.638"/>
 			</PeptideHit>
 		</PeptideIdentification>

--- a/src/tests/topp/IDFileConverter_6_output.idXML
+++ b/src/tests/topp/IDFileConverter_6_output.idXML
@@ -39,18 +39,23 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="484.305389031900006" RT="673.395899999999983" >
 			<PeptideHit score="9.5e-03" sequence="IHSEILKK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_0" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="0.89" sequence="VPIGVANVAK" charge="2" aa_before="K X X" aa_after="K X X" protein_refs="PH_1 PH_2 PH_3" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="403.554869031899955" RT="679.558800000000019" >
 			<PeptideHit score="6.9e-03" sequence="SATPAQAQAVHK" charge="3" aa_before="K X X" aa_after="F X X" protein_refs="PH_4 PH_5 PH_6" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="516.267699031899951" RT="687.714600000000019" >
 			<PeptideHit score="0.013" sequence="AVQAVVHHNETADR" charge="3" aa_before="K X X" aa_after="A X X" protein_refs="PH_7 PH_8 PH_9" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 			<PeptideHit score="1.4" sequence="GKGVVTISVAEC(Carbamidomethyl)GNR" charge="3" aa_before="K X X" aa_after="V X X" protein_refs="PH_10 PH_11 PH_12" >
+				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="3" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.50025" peak_mass_tolerance_ppm="false" >
-				<UserParam type="string" name="CometAdapter:1:in" value="C:/Development/OpenMS/src/tests/topp/THIRDPARTY/spectra_comet.mzML"/>
+	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="3" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.50025" peak_mass_tolerance_ppm="false" >
+				<UserParam type="string" name="CometAdapter:1:in" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/spectra_comet.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_1_out1.tmp"/>
 				<UserParam type="string" name="CometAdapter:1:database" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/proteins.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="C:/Development/OpenMS/THIRDPARTY/Windows/64bit/Comet/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/workspace/OpenMS/THIRDPARTY/Linux/64bit/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_1_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="3.0"/>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="CometAdapter:1:test" value="true"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2020-03-27T19:09:09" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2021-09-30T16:38:22" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 			</ProteinHit>
@@ -70,6 +70,7 @@
 				<UserParam type="string" name="MS:1002258" value="26"/>
 				<UserParam type="string" name="MS:1002259" value="52"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="3.734"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -83,6 +84,7 @@
 				<UserParam type="string" name="MS:1002258" value="34"/>
 				<UserParam type="string" name="MS:1002259" value="88"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="5.268"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_2_in.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="3" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.50025" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_2_in.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="3" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.50025" peak_mass_tolerance_ppm="false" >
 				<UserParam type="string" name="CometAdapter:1:in" value="CometAdapter_2_prepared.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_2_out1.tmp"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="C:/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_2_in.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_2_in.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/workspace/OpenMS/THIRDPARTY/Linux/64bit/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_2_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="3.0"/>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="CometAdapter:1:test" value="true"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2020-03-27T19:10:22" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2021-09-30T16:38:24" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="prot1" score="0.0" sequence="" >
 			</ProteinHit>
@@ -80,6 +80,7 @@
 				<UserParam type="string" name="MS:1002258" value="10"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="1"/>
 				<UserParam type="float" name="MS:1002252" value="1.145"/>
 				<UserParam type="float" name="MS:1002253" value="0.466"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -91,6 +92,7 @@
 				<UserParam type="string" name="MS:1002258" value="4"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="-1"/>
 				<UserParam type="float" name="MS:1002252" value="0.612"/>
 				<UserParam type="float" name="MS:1002253" value="0.031"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -102,6 +104,7 @@
 				<UserParam type="string" name="MS:1002258" value="5"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="-2"/>
 				<UserParam type="float" name="MS:1002252" value="0.592"/>
 				<UserParam type="float" name="MS:1002253" value="0.074"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -113,6 +116,7 @@
 				<UserParam type="string" name="MS:1002258" value="5"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.548"/>
 				<UserParam type="float" name="MS:1002253" value="0.251"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -124,6 +128,7 @@
 				<UserParam type="string" name="MS:1002258" value="4"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="-1"/>
 				<UserParam type="float" name="MS:1002252" value="0.411"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -137,6 +142,7 @@
 				<UserParam type="string" name="MS:1002258" value="9"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.326"/>
 				<UserParam type="float" name="MS:1002253" value="0.226"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -148,6 +154,7 @@
 				<UserParam type="string" name="MS:1002258" value="11"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="2"/>
 				<UserParam type="float" name="MS:1002252" value="1.026"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/Users/pfeuffer/git/OpenMS-fixes-src/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="3" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="3" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Phospho (S)" />
 		<VariableModification name="Phospho (T)" />
 		<VariableModification name="Phospho (Y)" />
 		<VariableModification name="Acetyl (Protein N-term)" />
 		<VariableModification name="Carbamidomethyl (N-term)" />
-				<UserParam type="string" name="CometAdapter:1:in" value="/Users/pfeuffer/git/OpenMS-fixes-src/src/tests/topp/THIRDPARTY/CometAdapter_3.mzML"/>
+				<UserParam type="string" name="CometAdapter:1:in" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_3_out1.tmp"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="/Users/pfeuffer/git/OpenMS-fixes-src/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/Users/pfeuffer/git/OpenMS-fixes-src/THIRDPARTY/MacOS/64bit/Comet/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/workspace/OpenMS/THIRDPARTY/Linux/64bit/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_3_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="5.0"/>
@@ -63,7 +63,7 @@
 				<UserParam type="string" name="CometAdapter:1:test" value="true"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2020-12-18T20:05:30" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2021-09-30T16:38:25" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_tr|Q5QTS3|Q5QTS3_HUMAN" score="0.0" sequence="" >
 			</ProteinHit>
@@ -71,13 +71,14 @@
 			</ProteinHit>
 			<ProteinHit id="PH_2" accession="sp|P84103|SRSF3_HUMAN" score="0.0" sequence="" >
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[/Users/pfeuffer/git/OpenMS-fixes-src/src/tests/topp/THIRDPARTY/CometAdapter_3.mzML]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/workspace/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="633.705382698566723" RT="1821.299999999999955" spectrum_reference="controllerType=0 controllerNumber=1 scan=6304" >
 			<PeptideHit score="107.0" sequence=".(Acetyl)VLLGHTKLVETYKDIK" charge="3" aa_before="-" aa_after="K" protein_refs="PH_0" >
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.377"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -91,6 +92,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.276"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -104,6 +106,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="132"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.291"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -117,6 +120,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.068"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -130,6 +134,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="68"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.134"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/Users/pfeuffer/git/OpenMS-fixes-src/share/OpenMS/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="3" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/workspace/OpenMS/share/OpenMS/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="trypsin" missed_cleavages="3" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Met-loss (Protein N-term M)" />
-				<UserParam type="string" name="CometAdapter:1:in" value="/Users/pfeuffer/git/OpenMS-fixes-src/share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML"/>
+				<UserParam type="string" name="CometAdapter:1:in" value="/workspace/OpenMS/share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_4_out1.tmp"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="/Users/pfeuffer/git/OpenMS-fixes-src/share/OpenMS/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/Users/pfeuffer/git/OpenMS-fixes-src/THIRDPARTY/MacOS/64bit/Comet/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/workspace/OpenMS/share/OpenMS/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/workspace/OpenMS/THIRDPARTY/Linux/64bit/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value=""/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="5.0"/>
@@ -59,7 +59,7 @@
 				<UserParam type="string" name="CometAdapter:1:test" value="true"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2020-08-20T00:14:39" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2021-09-30T16:38:26" search_engine="Comet" search_engine_version="# comet_version 2019.01 rev. 5" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="tr|A9GFE2|A9GFE2_SORC5_rev" score="0.0" sequence="" >
 			</ProteinHit>
@@ -1147,13 +1147,14 @@
 			</ProteinHit>
 			<ProteinHit id="PH_542" accession="tr|A9G4J0|A9G4J0_SORC5_rev" score="0.0" sequence="" >
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[/Users/pfeuffer/git/OpenMS-fixes-src/share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/workspace/OpenMS/share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="457.724517031900007" RT="1504.0" spectrum_reference="spectrum=2442" >
 			<PeptideHit score="8.23" sequence="IAQHIDSM" charge="2" aa_before="K" aa_after="-" protein_refs="PH_0" >
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="26"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.312"/>
 				<UserParam type="float" name="MS:1002253" value="0.772"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1165,6 +1166,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="26"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.857"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1176,6 +1178,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="26"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.01"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1189,6 +1192,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.035"/>
 				<UserParam type="float" name="MS:1002253" value="0.213"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1200,6 +1204,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.028"/>
 				<UserParam type="float" name="MS:1002253" value="0.129"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1211,6 +1216,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.024"/>
 				<UserParam type="float" name="MS:1002253" value="0.049"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1222,6 +1228,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.023"/>
 				<UserParam type="float" name="MS:1002253" value="0.02"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1233,6 +1240,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.023"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1246,6 +1254,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="234"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.478"/>
 				<UserParam type="float" name="MS:1002253" value="0.139"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1257,6 +1266,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="234"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.411"/>
 				<UserParam type="float" name="MS:1002253" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1268,6 +1278,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="234"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.41"/>
 				<UserParam type="float" name="MS:1002253" value="0.1"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1279,6 +1290,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="234"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.369"/>
 				<UserParam type="float" name="MS:1002253" value="3.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1290,6 +1302,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="234"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.367"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1303,6 +1316,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.202"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1314,6 +1328,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.101"/>
 				<UserParam type="float" name="MS:1002253" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1325,6 +1340,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="9.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1336,6 +1352,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.099"/>
 				<UserParam type="float" name="MS:1002253" value="0.251"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1347,6 +1364,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.074"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1360,6 +1378,7 @@
 				<UserParam type="string" name="MS:1002258" value="4"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.787"/>
 				<UserParam type="float" name="MS:1002253" value="0.575"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1371,6 +1390,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.334"/>
 				<UserParam type="float" name="MS:1002253" value="0.414"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1382,6 +1402,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.196"/>
 				<UserParam type="float" name="MS:1002253" value="0.369"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1393,6 +1414,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.124"/>
 				<UserParam type="float" name="MS:1002253" value="0.207"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1404,6 +1426,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1417,6 +1440,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.073"/>
 				<UserParam type="float" name="MS:1002253" value="0.053"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1428,6 +1452,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1439,6 +1464,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="0.195"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1450,6 +1476,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.056"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1461,6 +1488,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1474,6 +1502,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="99"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="0.126"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1485,6 +1514,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="99"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.103"/>
 				<UserParam type="float" name="MS:1002253" value="0.021"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1496,6 +1526,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="99"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.101"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1507,6 +1538,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="99"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="0.019"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1518,6 +1550,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="99"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1531,6 +1564,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="162"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.146"/>
 				<UserParam type="float" name="MS:1002253" value="0.392"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1542,6 +1576,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="162"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="0.041"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1553,6 +1588,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="162"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="0.109"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1564,6 +1600,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="162"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="0.044"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1575,6 +1612,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="162"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.073"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1588,6 +1626,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.143"/>
 				<UserParam type="float" name="MS:1002253" value="0.527"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1599,6 +1638,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.12"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1610,6 +1650,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.059"/>
 				<UserParam type="float" name="MS:1002253" value="0.382"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1621,6 +1662,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.037"/>
 				<UserParam type="float" name="MS:1002253" value="0.226"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1632,6 +1674,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.028"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1645,6 +1688,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.0"/>
 				<UserParam type="float" name="MS:1002253" value="0.987"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1658,6 +1702,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.15"/>
 				<UserParam type="float" name="MS:1002253" value="0.356"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1669,6 +1714,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1682,6 +1728,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="86"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.154"/>
 				<UserParam type="float" name="MS:1002253" value="0.57"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1693,6 +1740,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="86"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.066"/>
 				<UserParam type="float" name="MS:1002253" value="0.044"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1704,6 +1752,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="86"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.063"/>
 				<UserParam type="float" name="MS:1002253" value="0.144"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1715,6 +1764,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="86"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.054"/>
 				<UserParam type="float" name="MS:1002253" value="0.401"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1726,6 +1776,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="86"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.032"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1739,6 +1790,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.239"/>
 				<UserParam type="float" name="MS:1002253" value="0.624"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1750,6 +1802,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.09"/>
 				<UserParam type="float" name="MS:1002253" value="0.524"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1761,6 +1814,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="0.311"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1772,6 +1826,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.029"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1785,6 +1840,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.266"/>
 				<UserParam type="float" name="MS:1002253" value="0.447"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1796,6 +1852,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.147"/>
 				<UserParam type="float" name="MS:1002253" value="0.275"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1807,6 +1864,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="0.852"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1818,6 +1876,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.016"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1831,6 +1890,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.146"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1842,6 +1902,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.14"/>
 				<UserParam type="float" name="MS:1002253" value="0.213"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1853,6 +1914,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.11"/>
 				<UserParam type="float" name="MS:1002253" value="0.191"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1864,6 +1926,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1875,6 +1938,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.088"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1888,6 +1952,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="48"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.29"/>
 				<UserParam type="float" name="MS:1002253" value="0.22"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1899,6 +1964,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="48"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.226"/>
 				<UserParam type="float" name="MS:1002253" value="0.142"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1910,6 +1976,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="48"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.194"/>
 				<UserParam type="float" name="MS:1002253" value="0.023"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1921,6 +1988,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="48"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.189"/>
 				<UserParam type="float" name="MS:1002253" value="0.032"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1932,6 +2000,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="48"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.183"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1945,6 +2014,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.242"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1956,6 +2026,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.242"/>
 				<UserParam type="float" name="MS:1002253" value="0.031"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1967,6 +2038,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.234"/>
 				<UserParam type="float" name="MS:1002253" value="0.531"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1978,6 +2050,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.11"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -1989,6 +2062,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.11"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2002,6 +2076,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.081"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2015,6 +2090,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.119"/>
 				<UserParam type="float" name="MS:1002253" value="0.281"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2026,6 +2102,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="0.441"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2037,6 +2114,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="0.027"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2048,6 +2126,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.046"/>
 				<UserParam type="float" name="MS:1002253" value="0.373"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2059,6 +2138,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.029"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2072,6 +2152,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="22"/>
 				<UserParam type="string" name="num_matched_peptides" value="66"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.18"/>
 				<UserParam type="float" name="MS:1002253" value="0.303"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2083,6 +2164,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="66"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.279"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2094,6 +2176,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="66"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.091"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2105,6 +2188,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="22"/>
 				<UserParam type="string" name="num_matched_peptides" value="66"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.091"/>
 				<UserParam type="float" name="MS:1002253" value="0.234"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2116,6 +2200,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="66"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2129,6 +2214,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.329"/>
 				<UserParam type="float" name="MS:1002253" value="0.144"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2140,6 +2226,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.282"/>
 				<UserParam type="float" name="MS:1002253" value="3.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2151,6 +2238,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.281"/>
 				<UserParam type="float" name="MS:1002253" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2162,6 +2250,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.28"/>
 				<UserParam type="float" name="MS:1002253" value="0.343"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2173,6 +2262,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.184"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2186,6 +2276,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2199,6 +2290,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="17"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.292"/>
 				<UserParam type="float" name="MS:1002253" value="0.037"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2210,6 +2302,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="17"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.281"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2221,6 +2314,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="17"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.281"/>
 				<UserParam type="float" name="MS:1002253" value="0.698"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2232,6 +2326,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="17"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="0.103"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2243,6 +2338,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="17"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2256,6 +2352,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="55"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.075"/>
 				<UserParam type="float" name="MS:1002253" value="0.083"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2267,6 +2364,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="55"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="0.359"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2278,6 +2376,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="55"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2289,6 +2388,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="55"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="0.126"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2300,6 +2400,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="55"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.038"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2313,6 +2414,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="322"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.361"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2324,6 +2426,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="322"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.361"/>
 				<UserParam type="float" name="MS:1002253" value="0.016"/>
 				<UserParam type="float" name="MS:1002254" value="9.0e-03"/>
@@ -2335,6 +2438,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="322"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.358"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2346,6 +2450,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="322"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.355"/>
 				<UserParam type="float" name="MS:1002253" value="0.174"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2357,6 +2462,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="322"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.293"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2370,6 +2476,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="106"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.355"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2381,6 +2488,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="106"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.353"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2392,6 +2500,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="106"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.352"/>
 				<UserParam type="float" name="MS:1002253" value="0.348"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2403,6 +2512,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="106"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.23"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2414,6 +2524,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="106"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.229"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2427,6 +2538,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.329"/>
 				<UserParam type="float" name="MS:1002253" value="0.098"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2438,6 +2550,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.296"/>
 				<UserParam type="float" name="MS:1002253" value="0.052"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2449,6 +2562,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.281"/>
 				<UserParam type="float" name="MS:1002253" value="0.131"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2460,6 +2574,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.244"/>
 				<UserParam type="float" name="MS:1002253" value="0.05"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2471,6 +2586,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.232"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2484,6 +2600,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="207"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.153"/>
 				<UserParam type="float" name="MS:1002253" value="0.053"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2495,6 +2612,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="207"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.145"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2506,6 +2624,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="207"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.145"/>
 				<UserParam type="float" name="MS:1002253" value="0.015"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2517,6 +2636,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="207"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.143"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2528,6 +2648,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="207"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.143"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2541,6 +2662,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="69"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.229"/>
 				<UserParam type="float" name="MS:1002253" value="8.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2552,6 +2674,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="69"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.227"/>
 				<UserParam type="float" name="MS:1002253" value="0.231"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2563,6 +2686,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="69"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.174"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2574,6 +2698,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="69"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.174"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2585,6 +2710,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="69"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.174"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2598,6 +2724,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="67"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.238"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2609,6 +2736,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="67"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.235"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2620,6 +2748,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="67"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.232"/>
 				<UserParam type="float" name="MS:1002253" value="8.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2631,6 +2760,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="67"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.23"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2642,6 +2772,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="67"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.23"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2655,6 +2786,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.042"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2668,6 +2800,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="84"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2679,6 +2812,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="84"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="0.338"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2690,6 +2824,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="84"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.066"/>
 				<UserParam type="float" name="MS:1002253" value="0.02"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2701,6 +2836,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="84"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="0.101"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2712,6 +2848,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="84"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.058"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2725,6 +2862,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="0.407"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2736,6 +2874,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.046"/>
 				<UserParam type="float" name="MS:1002253" value="0.436"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2747,6 +2886,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.026"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2760,6 +2900,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.026"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2773,6 +2914,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.182"/>
 				<UserParam type="float" name="MS:1002253" value="0.061"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2784,6 +2926,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.171"/>
 				<UserParam type="float" name="MS:1002253" value="0.248"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2795,6 +2938,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.128"/>
 				<UserParam type="float" name="MS:1002253" value="0.338"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2806,6 +2950,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="0.028"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2817,6 +2962,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.083"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2830,6 +2976,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="0.673"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2841,6 +2988,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.032"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2854,6 +3002,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.01"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2865,6 +3014,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.113"/>
 				<UserParam type="float" name="MS:1002253" value="0.229"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2876,6 +3026,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.087"/>
 				<UserParam type="float" name="MS:1002253" value="0.248"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2887,6 +3038,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2898,6 +3050,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2911,6 +3064,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.5"/>
 				<UserParam type="float" name="MS:1002253" value="0.225"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2922,6 +3076,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.388"/>
 				<UserParam type="float" name="MS:1002253" value="0.082"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2933,6 +3088,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.356"/>
 				<UserParam type="float" name="MS:1002253" value="9.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2944,6 +3100,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.353"/>
 				<UserParam type="float" name="MS:1002253" value="0.686"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2955,6 +3112,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2968,6 +3126,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.169"/>
 				<UserParam type="float" name="MS:1002253" value="0.333"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2979,6 +3138,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.113"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -2990,6 +3150,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3001,6 +3162,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="0.039"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3012,6 +3174,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3025,6 +3188,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="23"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.219"/>
 				<UserParam type="float" name="MS:1002253" value="0.192"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3036,6 +3200,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="23"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.176"/>
 				<UserParam type="float" name="MS:1002253" value="0.515"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3047,6 +3212,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="23"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.086"/>
 				<UserParam type="float" name="MS:1002253" value="0.011"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3058,6 +3224,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="23"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3071,6 +3238,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.644"/>
 				<UserParam type="float" name="MS:1002253" value="0.43"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3082,6 +3250,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.367"/>
 				<UserParam type="float" name="MS:1002253" value="0.354"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3093,6 +3262,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.237"/>
 				<UserParam type="float" name="MS:1002253" value="0.384"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3104,6 +3274,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.146"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3117,6 +3288,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.025"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3130,6 +3302,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.092"/>
 				<UserParam type="float" name="MS:1002253" value="0.036"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3141,6 +3314,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3154,6 +3328,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.124"/>
 				<UserParam type="float" name="MS:1002253" value="0.07"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3165,6 +3340,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.115"/>
 				<UserParam type="float" name="MS:1002253" value="0.067"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3176,6 +3352,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="0.172"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3187,6 +3364,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3198,6 +3376,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.088"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3211,6 +3390,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="0.496"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3222,6 +3402,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.045"/>
 				<UserParam type="float" name="MS:1002253" value="0.306"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3233,6 +3414,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.031"/>
 				<UserParam type="float" name="MS:1002253" value="0.699"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3244,6 +3426,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="9.0e-03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3257,6 +3440,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="0.397"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3268,6 +3452,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.303"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3279,6 +3464,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.05"/>
 				<UserParam type="float" name="MS:1002253" value="0.254"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3290,6 +3476,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.037"/>
 				<UserParam type="float" name="MS:1002253" value="0.296"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3301,6 +3488,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="33"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.026"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3314,6 +3502,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="60"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.198"/>
 				<UserParam type="float" name="MS:1002253" value="0.27"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3325,6 +3514,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="60"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.145"/>
 				<UserParam type="float" name="MS:1002253" value="0.206"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3336,6 +3526,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="60"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.115"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3347,6 +3538,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="60"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.113"/>
 				<UserParam type="float" name="MS:1002253" value="0.056"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3358,6 +3550,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="60"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3371,6 +3564,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.268"/>
 				<UserParam type="float" name="MS:1002253" value="0.916"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3382,6 +3576,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.022"/>
 				<UserParam type="float" name="MS:1002253" value="0.925"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3393,6 +3588,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3406,6 +3602,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.174"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3419,6 +3616,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.018"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3432,6 +3630,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.216"/>
 				<UserParam type="float" name="MS:1002253" value="0.215"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3443,6 +3642,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.169"/>
 				<UserParam type="float" name="MS:1002253" value="0.026"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3454,6 +3654,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.165"/>
 				<UserParam type="float" name="MS:1002253" value="0.026"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3465,6 +3666,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.161"/>
 				<UserParam type="float" name="MS:1002253" value="0.124"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3476,6 +3678,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.141"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3489,6 +3692,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.323"/>
 				<UserParam type="float" name="MS:1002253" value="0.085"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3500,6 +3704,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.296"/>
 				<UserParam type="float" name="MS:1002253" value="0.128"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3511,6 +3716,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.258"/>
 				<UserParam type="float" name="MS:1002253" value="0.015"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3522,6 +3728,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.254"/>
 				<UserParam type="float" name="MS:1002253" value="0.166"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3533,6 +3740,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.212"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3546,6 +3754,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.034"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3559,6 +3768,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="37"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.128"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3570,6 +3780,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="37"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.127"/>
 				<UserParam type="float" name="MS:1002253" value="0.141"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3581,6 +3792,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="37"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="0.303"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3592,6 +3804,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="22"/>
 				<UserParam type="string" name="num_matched_peptides" value="37"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="0.338"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3603,6 +3816,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="37"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.05"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3616,6 +3830,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.094"/>
 				<UserParam type="float" name="MS:1002253" value="0.04"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3627,6 +3842,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.09"/>
 				<UserParam type="float" name="MS:1002253" value="0.155"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3638,6 +3854,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="0.125"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3649,6 +3866,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.255"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3660,6 +3878,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.05"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3673,6 +3892,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.17"/>
 				<UserParam type="float" name="MS:1002253" value="0.07"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3684,6 +3904,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.158"/>
 				<UserParam type="float" name="MS:1002253" value="0.654"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3695,6 +3916,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="0.657"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3706,6 +3928,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.019"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3719,6 +3942,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.356"/>
 				<UserParam type="float" name="MS:1002253" value="0.752"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3730,6 +3954,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.088"/>
 				<UserParam type="float" name="MS:1002253" value="0.24"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3741,6 +3966,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.182"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3752,6 +3978,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="6.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3763,6 +3990,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="64"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3776,6 +4004,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.102"/>
 				<UserParam type="float" name="MS:1002253" value="0.505"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3787,6 +4016,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.05"/>
 				<UserParam type="float" name="MS:1002253" value="0.385"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3798,6 +4028,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.031"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3811,6 +4042,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.21"/>
 				<UserParam type="float" name="MS:1002253" value="0.294"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3822,6 +4054,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.148"/>
 				<UserParam type="float" name="MS:1002253" value="0.032"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3833,6 +4066,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.143"/>
 				<UserParam type="float" name="MS:1002253" value="0.084"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3844,6 +4078,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.131"/>
 				<UserParam type="float" name="MS:1002253" value="0.182"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3855,6 +4090,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3868,6 +4104,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.072"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3881,6 +4118,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.405"/>
 				<UserParam type="float" name="MS:1002253" value="0.149"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3892,6 +4130,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.345"/>
 				<UserParam type="float" name="MS:1002253" value="0.916"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3903,6 +4142,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.029"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3916,6 +4156,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.302"/>
 				<UserParam type="float" name="MS:1002253" value="0.78"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3927,6 +4168,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.168"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3938,6 +4180,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="0.212"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3949,6 +4192,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3960,6 +4204,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="58"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3973,6 +4218,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.407"/>
 				<UserParam type="float" name="MS:1002253" value="0.627"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3984,6 +4230,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.152"/>
 				<UserParam type="float" name="MS:1002253" value="0.129"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -3995,6 +4242,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.132"/>
 				<UserParam type="float" name="MS:1002253" value="9.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4006,6 +4254,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.131"/>
 				<UserParam type="float" name="MS:1002253" value="0.021"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4017,6 +4266,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.128"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4030,6 +4280,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.488"/>
 				<UserParam type="float" name="MS:1002253" value="0.462"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4041,6 +4292,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.262"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4052,6 +4304,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.259"/>
 				<UserParam type="float" name="MS:1002253" value="0.5"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4063,6 +4316,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.129"/>
 				<UserParam type="float" name="MS:1002253" value="0.157"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4074,6 +4328,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4087,6 +4342,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.344"/>
 				<UserParam type="float" name="MS:1002253" value="0.146"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4098,6 +4354,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.294"/>
 				<UserParam type="float" name="MS:1002253" value="0.336"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4109,6 +4366,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.196"/>
 				<UserParam type="float" name="MS:1002253" value="0.341"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4120,6 +4378,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.129"/>
 				<UserParam type="float" name="MS:1002253" value="0.225"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4131,6 +4390,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4144,6 +4404,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="42"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.238"/>
 				<UserParam type="float" name="MS:1002253" value="0.497"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4155,6 +4416,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="42"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.12"/>
 				<UserParam type="float" name="MS:1002253" value="0.078"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4166,6 +4428,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="42"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="0.034"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4177,6 +4440,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="42"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="0.677"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4188,6 +4452,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="42"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.035"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4201,6 +4466,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.217"/>
 				<UserParam type="float" name="MS:1002253" value="0.541"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4212,6 +4478,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.099"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4225,6 +4492,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.186"/>
 				<UserParam type="float" name="MS:1002253" value="0.742"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4236,6 +4504,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4249,6 +4518,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4262,6 +4532,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.101"/>
 				<UserParam type="float" name="MS:1002253" value="0.144"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4273,6 +4544,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.086"/>
 				<UserParam type="float" name="MS:1002253" value="0.429"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4284,6 +4556,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.049"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4295,6 +4568,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="0.095"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4306,6 +4580,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="44"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4319,6 +4594,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="117"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.268"/>
 				<UserParam type="float" name="MS:1002253" value="0.085"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4330,6 +4606,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="117"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.245"/>
 				<UserParam type="float" name="MS:1002253" value="0.229"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4341,6 +4618,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="117"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.189"/>
 				<UserParam type="float" name="MS:1002253" value="0.334"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4352,6 +4630,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="117"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.045"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4363,6 +4642,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="117"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.12"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4376,6 +4656,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.364"/>
 				<UserParam type="float" name="MS:1002253" value="0.24"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4387,6 +4668,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.277"/>
 				<UserParam type="float" name="MS:1002253" value="0.498"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4398,6 +4680,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.139"/>
 				<UserParam type="float" name="MS:1002253" value="0.247"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4409,6 +4692,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.105"/>
 				<UserParam type="float" name="MS:1002253" value="0.068"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4420,6 +4704,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4433,6 +4718,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.367"/>
 				<UserParam type="float" name="MS:1002253" value="0.464"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4444,6 +4730,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.197"/>
 				<UserParam type="float" name="MS:1002253" value="0.094"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4455,6 +4742,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.178"/>
 				<UserParam type="float" name="MS:1002253" value="0.068"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4466,6 +4754,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.166"/>
 				<UserParam type="float" name="MS:1002253" value="0.105"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4477,6 +4766,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.149"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4490,6 +4780,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="0.161"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4501,6 +4792,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.093"/>
 				<UserParam type="float" name="MS:1002253" value="0.492"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4512,6 +4804,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.047"/>
 				<UserParam type="float" name="MS:1002253" value="0.068"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4523,6 +4816,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="0.261"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4534,6 +4828,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.033"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4547,6 +4842,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4560,6 +4856,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="54"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="0.104"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4571,6 +4868,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="54"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.061"/>
 				<UserParam type="float" name="MS:1002253" value="0.203"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4582,6 +4880,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="54"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.049"/>
 				<UserParam type="float" name="MS:1002253" value="0.027"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4593,6 +4892,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="54"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="0.037"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4604,6 +4904,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="54"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.046"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4617,6 +4918,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.12"/>
 				<UserParam type="float" name="MS:1002253" value="0.576"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4628,6 +4930,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.051"/>
 				<UserParam type="float" name="MS:1002253" value="0.552"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4639,6 +4942,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.023"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4652,6 +4956,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.188"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4665,6 +4970,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="10"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.102"/>
 				<UserParam type="float" name="MS:1002253" value="0.058"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4676,6 +4982,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="10"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.096"/>
 				<UserParam type="float" name="MS:1002253" value="0.435"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4687,6 +4994,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="10"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.054"/>
 				<UserParam type="float" name="MS:1002253" value="0.111"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4698,6 +5006,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="10"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="0.644"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4709,6 +5018,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="10"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.017"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4722,6 +5032,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="486"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.264"/>
 				<UserParam type="float" name="MS:1002253" value="3.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4733,6 +5044,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="486"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.263"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4744,6 +5056,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="486"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.263"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4755,6 +5068,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="486"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.263"/>
 				<UserParam type="float" name="MS:1002253" value="0.011"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4766,6 +5080,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="486"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.26"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4779,6 +5094,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.04"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4790,6 +5106,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="0.374"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4801,6 +5118,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="0.08"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4812,6 +5130,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.063"/>
 				<UserParam type="float" name="MS:1002253" value="0.254"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4823,6 +5142,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.047"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4836,6 +5156,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.073"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4849,6 +5170,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="0.161"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4860,6 +5182,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="0.134"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4871,6 +5194,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="0.126"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4882,6 +5206,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.068"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4895,6 +5220,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.201"/>
 				<UserParam type="float" name="MS:1002253" value="0.096"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4906,6 +5232,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.182"/>
 				<UserParam type="float" name="MS:1002253" value="0.287"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4917,6 +5244,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.13"/>
 				<UserParam type="float" name="MS:1002253" value="0.208"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4928,6 +5256,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.103"/>
 				<UserParam type="float" name="MS:1002253" value="0.048"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4939,6 +5268,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="41"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4952,6 +5282,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.235"/>
 				<UserParam type="float" name="MS:1002253" value="0.057"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4963,6 +5294,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.221"/>
 				<UserParam type="float" name="MS:1002253" value="6.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4974,6 +5306,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.22"/>
 				<UserParam type="float" name="MS:1002253" value="0.021"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4985,6 +5318,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.216"/>
 				<UserParam type="float" name="MS:1002253" value="0.751"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -4996,6 +5330,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.054"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5009,6 +5344,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.183"/>
 				<UserParam type="float" name="MS:1002253" value="0.632"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5020,6 +5356,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.559"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5031,6 +5368,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5044,6 +5382,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.092"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5057,6 +5396,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.205"/>
 				<UserParam type="float" name="MS:1002253" value="0.625"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5068,6 +5408,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="0.078"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5079,6 +5420,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.081"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5090,6 +5432,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="0.013"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5101,6 +5444,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.064"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5114,6 +5458,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.412"/>
 				<UserParam type="float" name="MS:1002253" value="0.338"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5125,6 +5470,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.273"/>
 				<UserParam type="float" name="MS:1002253" value="0.046"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5136,6 +5482,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.26"/>
 				<UserParam type="float" name="MS:1002253" value="0.244"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5147,6 +5494,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.197"/>
 				<UserParam type="float" name="MS:1002253" value="0.071"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5158,6 +5506,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="63"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.183"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5171,6 +5520,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.184"/>
 				<UserParam type="float" name="MS:1002253" value="0.256"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5182,6 +5532,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.137"/>
 				<UserParam type="float" name="MS:1002253" value="0.129"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5193,6 +5544,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.119"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5204,6 +5556,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.119"/>
 				<UserParam type="float" name="MS:1002253" value="0.011"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5215,6 +5568,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="14"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5228,6 +5582,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.25"/>
 				<UserParam type="float" name="MS:1002253" value="0.806"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5239,6 +5594,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="7"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.048"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5252,6 +5608,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.201"/>
 				<UserParam type="float" name="MS:1002253" value="0.279"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5263,6 +5620,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.145"/>
 				<UserParam type="float" name="MS:1002253" value="0.397"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5274,6 +5632,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.087"/>
 				<UserParam type="float" name="MS:1002253" value="0.109"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5285,6 +5644,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.078"/>
 				<UserParam type="float" name="MS:1002253" value="0.308"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5296,6 +5656,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.054"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5309,6 +5670,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.123"/>
 				<UserParam type="float" name="MS:1002253" value="0.145"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5320,6 +5682,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.105"/>
 				<UserParam type="float" name="MS:1002253" value="0.029"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5331,6 +5694,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.102"/>
 				<UserParam type="float" name="MS:1002253" value="0.415"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5342,6 +5706,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.06"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5355,6 +5720,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.166"/>
 				<UserParam type="float" name="MS:1002253" value="0.647"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5366,6 +5732,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.059"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5379,6 +5746,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.552"/>
 				<UserParam type="float" name="MS:1002253" value="0.37"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5390,6 +5758,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.348"/>
 				<UserParam type="float" name="MS:1002253" value="0.215"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5401,6 +5770,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.273"/>
 				<UserParam type="float" name="MS:1002253" value="0.021"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5412,6 +5782,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.267"/>
 				<UserParam type="float" name="MS:1002253" value="0.119"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5423,6 +5794,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.236"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5436,6 +5808,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.264"/>
 				<UserParam type="float" name="MS:1002253" value="0.026"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5447,6 +5820,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.257"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5458,6 +5832,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.257"/>
 				<UserParam type="float" name="MS:1002253" value="0.037"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5469,6 +5844,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.247"/>
 				<UserParam type="float" name="MS:1002253" value="8.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5480,6 +5856,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.245"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5493,6 +5870,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.235"/>
 				<UserParam type="float" name="MS:1002253" value="0.08"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5504,6 +5882,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.217"/>
 				<UserParam type="float" name="MS:1002253" value="0.37"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5515,6 +5894,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.136"/>
 				<UserParam type="float" name="MS:1002253" value="0.281"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5526,6 +5906,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="0.01"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5537,6 +5918,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5550,6 +5932,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="473"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.454"/>
 				<UserParam type="float" name="MS:1002253" value="0.495"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5561,6 +5944,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="473"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.229"/>
 				<UserParam type="float" name="MS:1002253" value="0.316"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5572,6 +5956,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="473"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.157"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5583,6 +5968,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="473"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.156"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5594,6 +5980,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="473"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.155"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5607,6 +5994,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.237"/>
 				<UserParam type="float" name="MS:1002253" value="0.218"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5618,6 +6006,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.185"/>
 				<UserParam type="float" name="MS:1002253" value="0.103"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5629,6 +6018,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.166"/>
 				<UserParam type="float" name="MS:1002253" value="0.457"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5640,6 +6030,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.09"/>
 				<UserParam type="float" name="MS:1002253" value="0.145"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5651,6 +6042,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="31"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5664,6 +6056,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="52"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.244"/>
 				<UserParam type="float" name="MS:1002253" value="0.012"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5675,6 +6068,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="52"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.241"/>
 				<UserParam type="float" name="MS:1002253" value="0.446"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5686,6 +6080,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="52"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.134"/>
 				<UserParam type="float" name="MS:1002253" value="0.112"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5697,6 +6092,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="52"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.119"/>
 				<UserParam type="float" name="MS:1002253" value="0.438"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5708,6 +6104,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="52"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5721,6 +6118,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.44"/>
 				<UserParam type="float" name="MS:1002253" value="0.063"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5732,6 +6130,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.413"/>
 				<UserParam type="float" name="MS:1002253" value="0.696"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5743,6 +6142,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.086"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5754,6 +6154,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.115"/>
 				<UserParam type="float" name="MS:1002253" value="3.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5765,6 +6166,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5778,6 +6180,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5791,6 +6194,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.176"/>
 				<UserParam type="float" name="MS:1002253" value="0.212"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5802,6 +6206,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.139"/>
 				<UserParam type="float" name="MS:1002253" value="0.157"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5813,6 +6218,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.117"/>
 				<UserParam type="float" name="MS:1002253" value="0.024"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5824,6 +6230,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.625"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5835,6 +6242,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5848,6 +6256,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.308"/>
 				<UserParam type="float" name="MS:1002253" value="0.323"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5859,6 +6268,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.208"/>
 				<UserParam type="float" name="MS:1002253" value="0.13"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5870,6 +6280,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.181"/>
 				<UserParam type="float" name="MS:1002253" value="0.048"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5881,6 +6292,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.173"/>
 				<UserParam type="float" name="MS:1002253" value="0.135"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5892,6 +6304,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.149"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5905,6 +6318,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.056"/>
 				<UserParam type="float" name="MS:1002253" value="0.398"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5916,6 +6330,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.034"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5929,6 +6344,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5942,6 +6358,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="70"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.078"/>
 				<UserParam type="float" name="MS:1002253" value="0.09"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5953,6 +6370,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="70"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="9.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5964,6 +6382,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="70"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.07"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5975,6 +6394,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="70"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.07"/>
 				<UserParam type="float" name="MS:1002253" value="0.449"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5986,6 +6406,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="70"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.038"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -5999,6 +6420,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="113"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.67"/>
 				<UserParam type="float" name="MS:1002253" value="0.279"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6010,6 +6432,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="113"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.483"/>
 				<UserParam type="float" name="MS:1002253" value="0.043"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6021,6 +6444,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="113"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.462"/>
 				<UserParam type="float" name="MS:1002253" value="0.079"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6032,6 +6456,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="113"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.426"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6043,6 +6468,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="8"/>
 				<UserParam type="string" name="num_matched_peptides" value="113"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.425"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6056,6 +6482,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.102"/>
 				<UserParam type="float" name="MS:1002253" value="0.077"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6067,6 +6494,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.094"/>
 				<UserParam type="float" name="MS:1002253" value="0.01"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6078,6 +6506,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.093"/>
 				<UserParam type="float" name="MS:1002253" value="0.219"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6089,6 +6518,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.073"/>
 				<UserParam type="float" name="MS:1002253" value="0.059"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6100,6 +6530,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.068"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6113,6 +6544,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.069"/>
 				<UserParam type="float" name="MS:1002253" value="0.434"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6124,6 +6556,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.039"/>
 				<UserParam type="float" name="MS:1002253" value="0.054"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6135,6 +6568,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.037"/>
 				<UserParam type="float" name="MS:1002253" value="0.441"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6146,6 +6580,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.021"/>
 				<UserParam type="float" name="MS:1002253" value="0.07"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6157,6 +6592,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.019"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6170,6 +6606,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="56"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.225"/>
 				<UserParam type="float" name="MS:1002253" value="0.025"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6181,6 +6618,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="56"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.219"/>
 				<UserParam type="float" name="MS:1002253" value="0.056"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6192,6 +6630,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="56"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.207"/>
 				<UserParam type="float" name="MS:1002253" value="0.312"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6203,6 +6642,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="56"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.142"/>
 				<UserParam type="float" name="MS:1002253" value="0.124"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6214,6 +6654,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="56"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.125"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6227,6 +6668,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.273"/>
 				<UserParam type="float" name="MS:1002253" value="0.16"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6238,6 +6680,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.229"/>
 				<UserParam type="float" name="MS:1002253" value="0.223"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6249,6 +6692,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.178"/>
 				<UserParam type="float" name="MS:1002253" value="0.386"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6260,6 +6704,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="0.011"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6271,6 +6716,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.108"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6284,6 +6730,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.229"/>
 				<UserParam type="float" name="MS:1002253" value="0.665"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6295,6 +6742,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="0.442"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6306,6 +6754,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="0.052"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6317,6 +6766,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.04"/>
 				<UserParam type="float" name="MS:1002253" value="0.11"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6328,6 +6778,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.036"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6341,6 +6792,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.129"/>
 				<UserParam type="float" name="MS:1002253" value="0.706"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6352,6 +6804,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.038"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6365,6 +6818,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.41"/>
 				<UserParam type="float" name="MS:1002253" value="0.619"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6376,6 +6830,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.156"/>
 				<UserParam type="float" name="MS:1002253" value="0.224"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6387,6 +6842,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.121"/>
 				<UserParam type="float" name="MS:1002253" value="0.028"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6398,6 +6854,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6409,6 +6866,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.116"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6422,6 +6880,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="81"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.117"/>
 				<UserParam type="float" name="MS:1002253" value="0.297"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6433,6 +6892,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="81"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.082"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6446,6 +6906,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.357"/>
 				<UserParam type="float" name="MS:1002253" value="0.057"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6457,6 +6918,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.337"/>
 				<UserParam type="float" name="MS:1002253" value="0.048"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6468,6 +6930,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.32"/>
 				<UserParam type="float" name="MS:1002253" value="0.241"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6479,6 +6942,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.243"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6490,6 +6954,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.242"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6503,6 +6968,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.202"/>
 				<UserParam type="float" name="MS:1002253" value="0.418"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6514,6 +6980,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="0.632"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6525,6 +6992,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="0.354"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6536,6 +7004,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.028"/>
 				<UserParam type="float" name="MS:1002253" value="0.429"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6547,6 +7016,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.016"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6560,6 +7030,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.465"/>
 				<UserParam type="float" name="MS:1002253" value="0.225"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6571,6 +7042,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.36"/>
 				<UserParam type="float" name="MS:1002253" value="0.359"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6582,6 +7054,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.231"/>
 				<UserParam type="float" name="MS:1002253" value="0.013"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6593,6 +7066,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.228"/>
 				<UserParam type="float" name="MS:1002253" value="0.248"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6604,6 +7078,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.171"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6617,6 +7092,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.1"/>
 				<UserParam type="float" name="MS:1002253" value="0.056"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6628,6 +7104,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.095"/>
 				<UserParam type="float" name="MS:1002253" value="0.643"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6639,6 +7116,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.034"/>
 				<UserParam type="float" name="MS:1002253" value="0.052"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6650,6 +7128,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.032"/>
 				<UserParam type="float" name="MS:1002253" value="0.027"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6661,6 +7140,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.031"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6674,6 +7154,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.173"/>
 				<UserParam type="float" name="MS:1002253" value="0.109"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6685,6 +7166,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.154"/>
 				<UserParam type="float" name="MS:1002253" value="0.027"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6696,6 +7178,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.15"/>
 				<UserParam type="float" name="MS:1002253" value="0.349"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6707,6 +7190,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="0.272"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6718,6 +7202,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6731,6 +7216,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.078"/>
 				<UserParam type="float" name="MS:1002253" value="0.024"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6742,6 +7228,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="0.17"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6753,6 +7240,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.063"/>
 				<UserParam type="float" name="MS:1002253" value="0.18"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6764,6 +7252,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.052"/>
 				<UserParam type="float" name="MS:1002253" value="0.028"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6775,6 +7264,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.051"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6788,6 +7278,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.108"/>
 				<UserParam type="float" name="MS:1002253" value="0.033"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6799,6 +7290,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.104"/>
 				<UserParam type="float" name="MS:1002253" value="0.569"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6810,6 +7302,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.045"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6823,6 +7316,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.354"/>
 				<UserParam type="float" name="MS:1002253" value="0.18"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6834,6 +7328,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.291"/>
 				<UserParam type="float" name="MS:1002253" value="0.184"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6845,6 +7340,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.237"/>
 				<UserParam type="float" name="MS:1002253" value="0.227"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6856,6 +7352,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.183"/>
 				<UserParam type="float" name="MS:1002253" value="0.266"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6867,6 +7364,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="43"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.135"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6880,6 +7378,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.194"/>
 				<UserParam type="float" name="MS:1002253" value="0.12"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6891,6 +7390,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.171"/>
 				<UserParam type="float" name="MS:1002253" value="0.109"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6902,6 +7402,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.152"/>
 				<UserParam type="float" name="MS:1002253" value="0.031"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6913,6 +7414,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.147"/>
 				<UserParam type="float" name="MS:1002253" value="0.037"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6924,6 +7426,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.142"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6937,6 +7440,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.305"/>
 				<UserParam type="float" name="MS:1002253" value="0.162"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6948,6 +7452,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.255"/>
 				<UserParam type="float" name="MS:1002253" value="0.663"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6959,6 +7464,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.086"/>
 				<UserParam type="float" name="MS:1002253" value="0.064"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6970,6 +7476,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.08"/>
 				<UserParam type="float" name="MS:1002253" value="0.04"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6981,6 +7488,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.077"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -6994,6 +7502,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="6"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.075"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7007,6 +7516,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="159"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.426"/>
 				<UserParam type="float" name="MS:1002253" value="0.398"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7018,6 +7528,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="159"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.256"/>
 				<UserParam type="float" name="MS:1002253" value="0.059"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7029,6 +7540,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="159"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.241"/>
 				<UserParam type="float" name="MS:1002253" value="0.159"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7040,6 +7552,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="159"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.203"/>
 				<UserParam type="float" name="MS:1002253" value="0.097"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7051,6 +7564,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="159"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.183"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7064,6 +7578,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.221"/>
 				<UserParam type="float" name="MS:1002253" value="0.132"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7075,6 +7590,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.192"/>
 				<UserParam type="float" name="MS:1002253" value="0.677"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7086,6 +7602,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.062"/>
 				<UserParam type="float" name="MS:1002253" value="0.086"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7097,6 +7614,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.057"/>
 				<UserParam type="float" name="MS:1002253" value="0.085"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7108,6 +7626,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="15"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.052"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7121,6 +7640,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.559"/>
 				<UserParam type="float" name="MS:1002253" value="0.796"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7132,6 +7652,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.381"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7143,6 +7664,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.697"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7154,6 +7676,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.021"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7165,6 +7688,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.021"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7178,6 +7702,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7191,6 +7716,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="32"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.098"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7202,6 +7728,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="32"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.012"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7213,6 +7740,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="32"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="0.025"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7224,6 +7752,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="32"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="0.45"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7235,6 +7764,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="32"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.06"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7248,6 +7778,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.179"/>
 				<UserParam type="float" name="MS:1002253" value="0.076"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7259,6 +7790,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.166"/>
 				<UserParam type="float" name="MS:1002253" value="0.413"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7270,6 +7802,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="0.759"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7281,6 +7814,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.023"/>
 				<UserParam type="float" name="MS:1002253" value="0.815"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7292,6 +7826,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7305,6 +7840,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.244"/>
 				<UserParam type="float" name="MS:1002253" value="0.203"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7316,6 +7852,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.194"/>
 				<UserParam type="float" name="MS:1002253" value="0.137"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7327,6 +7864,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.168"/>
 				<UserParam type="float" name="MS:1002253" value="0.207"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7338,6 +7876,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.133"/>
 				<UserParam type="float" name="MS:1002253" value="0.051"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7349,6 +7888,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="59"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7362,6 +7902,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.054"/>
 				<UserParam type="float" name="MS:1002253" value="0.209"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7373,6 +7914,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="2"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.043"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7386,6 +7928,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.216"/>
 				<UserParam type="float" name="MS:1002253" value="0.188"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7397,6 +7940,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.175"/>
 				<UserParam type="float" name="MS:1002253" value="0.276"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7408,6 +7952,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.127"/>
 				<UserParam type="float" name="MS:1002253" value="0.123"/>
 				<UserParam type="float" name="MS:1002254" value="0.018"/>
@@ -7419,6 +7964,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.125"/>
 				<UserParam type="float" name="MS:1002253" value="0.107"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7430,6 +7976,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="49"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7443,6 +7990,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.187"/>
 				<UserParam type="float" name="MS:1002253" value="0.27"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7454,6 +8002,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.137"/>
 				<UserParam type="float" name="MS:1002253" value="0.139"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7465,6 +8014,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="0.105"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7476,6 +8026,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.105"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7487,6 +8038,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.105"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7500,6 +8052,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.427"/>
 				<UserParam type="float" name="MS:1002253" value="0.207"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7511,6 +8064,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.339"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7522,6 +8076,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.338"/>
 				<UserParam type="float" name="MS:1002253" value="0.026"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7533,6 +8088,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.329"/>
 				<UserParam type="float" name="MS:1002253" value="0.273"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7544,6 +8100,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="80"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.239"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7557,6 +8114,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="22"/>
 				<UserParam type="string" name="num_matched_peptides" value="8"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.103"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7570,6 +8128,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.144"/>
 				<UserParam type="float" name="MS:1002253" value="0.409"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7581,6 +8140,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.085"/>
 				<UserParam type="float" name="MS:1002253" value="0.039"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7592,6 +8152,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.082"/>
 				<UserParam type="float" name="MS:1002253" value="6.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7603,6 +8164,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.081"/>
 				<UserParam type="float" name="MS:1002253" value="0.17"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7614,6 +8176,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7627,6 +8190,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.24"/>
 				<UserParam type="float" name="MS:1002253" value="0.324"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7638,6 +8202,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.162"/>
 				<UserParam type="float" name="MS:1002253" value="0.397"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7649,6 +8214,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.098"/>
 				<UserParam type="float" name="MS:1002253" value="0.23"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7660,6 +8226,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.075"/>
 				<UserParam type="float" name="MS:1002253" value="0.107"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7671,6 +8238,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7684,6 +8252,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="61"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.345"/>
 				<UserParam type="float" name="MS:1002253" value="0.318"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7695,6 +8264,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="61"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.235"/>
 				<UserParam type="float" name="MS:1002253" value="0.013"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7706,6 +8276,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="61"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.232"/>
 				<UserParam type="float" name="MS:1002253" value="6.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7717,6 +8288,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="61"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.231"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7728,6 +8300,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="61"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.228"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7741,6 +8314,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.245"/>
 				<UserParam type="float" name="MS:1002253" value="0.062"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7752,6 +8326,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.23"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7763,6 +8338,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.227"/>
 				<UserParam type="float" name="MS:1002253" value="0.305"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7774,6 +8350,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.158"/>
 				<UserParam type="float" name="MS:1002253" value="0.326"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7785,6 +8362,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.106"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7798,6 +8376,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.238"/>
 				<UserParam type="float" name="MS:1002253" value="0.756"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7809,6 +8388,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.058"/>
 				<UserParam type="float" name="MS:1002253" value="0.061"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7820,6 +8400,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.055"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7833,6 +8414,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.351"/>
 				<UserParam type="float" name="MS:1002253" value="0.579"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7844,6 +8426,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.148"/>
 				<UserParam type="float" name="MS:1002253" value="0.167"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7855,6 +8438,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.123"/>
 				<UserParam type="float" name="MS:1002253" value="0.213"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7866,6 +8450,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="0.061"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7877,6 +8462,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.091"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7890,6 +8476,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="146"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.489"/>
 				<UserParam type="float" name="MS:1002253" value="0.077"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7901,6 +8488,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="146"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.451"/>
 				<UserParam type="float" name="MS:1002253" value="0.142"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7912,6 +8500,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="146"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.387"/>
 				<UserParam type="float" name="MS:1002253" value="0.061"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7923,6 +8512,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="146"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.364"/>
 				<UserParam type="float" name="MS:1002253" value="7.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7934,6 +8524,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="146"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.361"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7947,6 +8538,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.198"/>
 				<UserParam type="float" name="MS:1002253" value="0.186"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7958,6 +8550,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.161"/>
 				<UserParam type="float" name="MS:1002253" value="0.46"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7969,6 +8562,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.087"/>
 				<UserParam type="float" name="MS:1002253" value="0.234"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7980,6 +8574,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.067"/>
 				<UserParam type="float" name="MS:1002253" value="0.338"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -7991,6 +8586,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.044"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8004,6 +8600,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.058"/>
 				<UserParam type="float" name="MS:1002253" value="0.567"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8015,6 +8612,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="30"/>
 				<UserParam type="string" name="num_matched_peptides" value="5"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.025"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8028,6 +8626,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="4"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.089"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8041,6 +8640,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.313"/>
 				<UserParam type="float" name="MS:1002253" value="0.519"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8052,6 +8652,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.151"/>
 				<UserParam type="float" name="MS:1002253" value="0.255"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8063,6 +8664,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="0.014"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8074,6 +8676,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.111"/>
 				<UserParam type="float" name="MS:1002253" value="0.069"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8085,6 +8688,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.103"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8098,6 +8702,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.206"/>
 				<UserParam type="float" name="MS:1002253" value="0.502"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8109,6 +8714,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.103"/>
 				<UserParam type="float" name="MS:1002253" value="0.226"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8120,6 +8726,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.08"/>
 				<UserParam type="float" name="MS:1002253" value="0.04"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8131,6 +8738,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.076"/>
 				<UserParam type="float" name="MS:1002253" value="0.258"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8142,6 +8750,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.057"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8155,6 +8764,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.203"/>
 				<UserParam type="float" name="MS:1002253" value="0.321"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8166,6 +8776,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.138"/>
 				<UserParam type="float" name="MS:1002253" value="0.334"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8177,6 +8788,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.092"/>
 				<UserParam type="float" name="MS:1002253" value="6.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8188,6 +8800,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.091"/>
 				<UserParam type="float" name="MS:1002253" value="0.074"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8199,6 +8812,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.084"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8212,6 +8826,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.07"/>
 				<UserParam type="float" name="MS:1002253" value="0.932"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8223,6 +8838,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8236,6 +8852,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="19"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.107"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8249,6 +8866,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.35"/>
 				<UserParam type="float" name="MS:1002253" value="0.247"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8260,6 +8878,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.264"/>
 				<UserParam type="float" name="MS:1002253" value="0.353"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8271,6 +8890,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.17"/>
 				<UserParam type="float" name="MS:1002253" value="0.343"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8282,6 +8902,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="0.307"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8293,6 +8914,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.078"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8306,6 +8928,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="128"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.217"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8317,6 +8940,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="128"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.213"/>
 				<UserParam type="float" name="MS:1002253" value="0.283"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8328,6 +8952,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="128"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.153"/>
 				<UserParam type="float" name="MS:1002253" value="5.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8339,6 +8964,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="128"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.152"/>
 				<UserParam type="float" name="MS:1002253" value="0.082"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8350,6 +8976,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="128"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.14"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8363,6 +8990,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.22"/>
 				<UserParam type="float" name="MS:1002253" value="0.077"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8374,6 +9002,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.203"/>
 				<UserParam type="float" name="MS:1002253" value="0.244"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8385,6 +9014,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.154"/>
 				<UserParam type="float" name="MS:1002253" value="0.047"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8396,6 +9026,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.146"/>
 				<UserParam type="float" name="MS:1002253" value="0.257"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8407,6 +9038,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="35"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8420,6 +9052,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.366"/>
 				<UserParam type="float" name="MS:1002253" value="0.201"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8431,6 +9064,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.292"/>
 				<UserParam type="float" name="MS:1002253" value="0.214"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8442,6 +9076,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.23"/>
 				<UserParam type="float" name="MS:1002253" value="0.065"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8453,6 +9088,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.215"/>
 				<UserParam type="float" name="MS:1002253" value="0.161"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8464,6 +9100,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.18"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8477,6 +9114,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="40"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.019"/>
 				<UserParam type="float" name="MS:1002253" value="0.954"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8488,6 +9126,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="60"/>
 				<UserParam type="string" name="num_matched_peptides" value="3"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8501,6 +9140,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.272"/>
 				<UserParam type="float" name="MS:1002253" value="0.408"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8512,6 +9152,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.161"/>
 				<UserParam type="float" name="MS:1002253" value="0.066"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8523,6 +9164,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.15"/>
 				<UserParam type="float" name="MS:1002253" value="0.182"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8534,6 +9176,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.123"/>
 				<UserParam type="float" name="MS:1002253" value="0.092"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8545,6 +9188,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="47"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.112"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8558,6 +9202,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="139"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.17"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8569,6 +9214,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="139"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.169"/>
 				<UserParam type="float" name="MS:1002253" value="0.237"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8580,6 +9226,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="139"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.129"/>
 				<UserParam type="float" name="MS:1002253" value="0.012"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8591,6 +9238,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="139"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.128"/>
 				<UserParam type="float" name="MS:1002253" value="0.047"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8602,6 +9250,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="139"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.122"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8615,6 +9264,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="20"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.01"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8628,6 +9278,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.221"/>
 				<UserParam type="float" name="MS:1002253" value="0.542"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8639,6 +9290,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="10"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.101"/>
 				<UserParam type="float" name="MS:1002253" value="0.196"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8650,6 +9302,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.081"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8663,6 +9316,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.245"/>
 				<UserParam type="float" name="MS:1002253" value="0.266"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8674,6 +9328,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.18"/>
 				<UserParam type="float" name="MS:1002253" value="0.609"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8685,6 +9340,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.07"/>
 				<UserParam type="float" name="MS:1002253" value="0.098"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8696,6 +9352,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.064"/>
 				<UserParam type="float" name="MS:1002253" value="0.414"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8707,6 +9364,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.037"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8720,6 +9378,7 @@
 				<UserParam type="string" name="MS:1002258" value="3"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.603"/>
 				<UserParam type="float" name="MS:1002253" value="0.423"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8731,6 +9390,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.348"/>
 				<UserParam type="float" name="MS:1002253" value="0.24"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8742,6 +9402,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.264"/>
 				<UserParam type="float" name="MS:1002253" value="0.162"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8753,6 +9414,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.222"/>
 				<UserParam type="float" name="MS:1002253" value="0.151"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8764,6 +9426,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="24"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.188"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8777,6 +9440,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.126"/>
 				<UserParam type="float" name="MS:1002253" value="0.077"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8788,6 +9452,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.116"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8799,6 +9464,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.114"/>
 				<UserParam type="float" name="MS:1002253" value="0.165"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8810,6 +9476,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.095"/>
 				<UserParam type="float" name="MS:1002253" value="0.054"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8821,6 +9488,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="46"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.09"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8834,6 +9502,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.24"/>
 				<UserParam type="float" name="MS:1002253" value="0.132"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8845,6 +9514,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.208"/>
 				<UserParam type="float" name="MS:1002253" value="0.483"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8856,6 +9526,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.108"/>
 				<UserParam type="float" name="MS:1002253" value="0.391"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8867,6 +9538,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.066"/>
 				<UserParam type="float" name="MS:1002253" value="0.039"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8878,6 +9550,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="12"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.063"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8891,6 +9564,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="9"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.226"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8904,6 +9578,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.378"/>
 				<UserParam type="float" name="MS:1002253" value="0.538"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8915,6 +9590,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.174"/>
 				<UserParam type="float" name="MS:1002253" value="0.029"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8926,6 +9602,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.169"/>
 				<UserParam type="float" name="MS:1002253" value="0.405"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8937,6 +9614,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.101"/>
 				<UserParam type="float" name="MS:1002253" value="0.042"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8948,6 +9626,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="13"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.097"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8961,6 +9640,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.123"/>
 				<UserParam type="float" name="MS:1002253" value="0.195"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8972,6 +9652,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.099"/>
 				<UserParam type="float" name="MS:1002253" value="0.345"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8983,6 +9664,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="3.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -8994,6 +9676,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9005,6 +9688,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="14"/>
 				<UserParam type="string" name="num_matched_peptides" value="28"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.065"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9018,6 +9702,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.295"/>
 				<UserParam type="float" name="MS:1002253" value="2.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9029,6 +9714,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.295"/>
 				<UserParam type="float" name="MS:1002253" value="0.074"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9040,6 +9726,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.273"/>
 				<UserParam type="float" name="MS:1002253" value="0.116"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9051,6 +9738,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.242"/>
 				<UserParam type="float" name="MS:1002253" value="0.374"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9062,6 +9750,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="50"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.151"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9075,6 +9764,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.241"/>
 				<UserParam type="float" name="MS:1002253" value="0.221"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9086,6 +9776,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.188"/>
 				<UserParam type="float" name="MS:1002253" value="0.621"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9097,6 +9788,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.071"/>
 				<UserParam type="float" name="MS:1002253" value="0.532"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9108,6 +9800,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="21"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.033"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9121,6 +9814,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.236"/>
 				<UserParam type="float" name="MS:1002253" value="0.346"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9132,6 +9826,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="20"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.154"/>
 				<UserParam type="float" name="MS:1002253" value="0.031"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9143,6 +9838,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="24"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.15"/>
 				<UserParam type="float" name="MS:1002253" value="0.212"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9154,6 +9850,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.118"/>
 				<UserParam type="float" name="MS:1002253" value="4.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9165,6 +9862,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="87"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.117"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9178,6 +9876,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="16"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.213"/>
 				<UserParam type="float" name="MS:1002253" value="0.399"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9189,6 +9888,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="16"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.128"/>
 				<UserParam type="float" name="MS:1002253" value="0.153"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9200,6 +9900,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="36"/>
 				<UserParam type="string" name="num_matched_peptides" value="16"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.108"/>
 				<UserParam type="float" name="MS:1002253" value="0.431"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9211,6 +9912,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="32"/>
 				<UserParam type="string" name="num_matched_peptides" value="16"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.062"/>
 				<UserParam type="float" name="MS:1002253" value="0.196"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9222,6 +9924,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="28"/>
 				<UserParam type="string" name="num_matched_peptides" value="16"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.05"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9235,6 +9938,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="25"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.173"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9246,6 +9950,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="25"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.173"/>
 				<UserParam type="float" name="MS:1002253" value="1.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9257,6 +9962,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="18"/>
 				<UserParam type="string" name="num_matched_peptides" value="25"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.173"/>
 				<UserParam type="float" name="MS:1002253" value="0.37"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9268,6 +9974,7 @@
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="16"/>
 				<UserParam type="string" name="num_matched_peptides" value="25"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.109"/>
 				<UserParam type="float" name="MS:1002253" value="8.0e-03"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9279,6 +9986,7 @@
 				<UserParam type="string" name="MS:1002258" value="1"/>
 				<UserParam type="string" name="MS:1002259" value="22"/>
 				<UserParam type="string" name="num_matched_peptides" value="25"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.108"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9292,6 +10000,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="141"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.565"/>
 				<UserParam type="float" name="MS:1002253" value="0.018"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9303,6 +10012,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="141"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.554"/>
 				<UserParam type="float" name="MS:1002253" value="0.091"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9314,6 +10024,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="141"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.504"/>
 				<UserParam type="float" name="MS:1002253" value="0.126"/>
 				<UserParam type="float" name="MS:1002254" value="0.126"/>
@@ -9325,6 +10036,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="141"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.441"/>
 				<UserParam type="float" name="MS:1002253" value="0.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>
@@ -9336,6 +10048,7 @@
 				<UserParam type="string" name="MS:1002258" value="2"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>
 				<UserParam type="string" name="num_matched_peptides" value="141"/>
+				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1002252" value="0.441"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="MS:1002254" value="0.0"/>

--- a/src/tests/topp/THIRDPARTY/MyriMatchAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MyriMatchAdapter_1_out.idXML
@@ -38,7 +38,7 @@
 				<UserParam type="string" name="MyriMatchAdapter:1:force" value="false"/>
 				<UserParam type="string" name="MyriMatchAdapter:1:test" value="true"/>
 	</SearchParameters>
-	<IdentificationRun date="2021-09-22T18:58:47" search_engine="MyriMatch" search_engine_version="2.1.132" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2021-10-01T15:40:00" search_engine="MyriMatch" search_engine_version="2.1.132" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 			</ProteinHit>
@@ -51,16 +51,19 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="mvh" higher_score_better="true" significance_threshold="0.0" MZ="520.263365947831971" RT="2655.095703124979991" spectrum_reference="spectrum=0" >
 			<PeptideHit score="39.267901895785002" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" protein_refs="PH_0" >
+				<UserParam type="int" name="isotope_error" value="1"/>
 				<UserParam type="float" name="MS:1001155" value="3.778751259224015"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="mvh" higher_score_better="true" significance_threshold="0.0" MZ="1063.210387432209927" RT="4587.668945312520009" spectrum_reference="spectrum=1" >
 			<PeptideHit score="55.310076424030001" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
+				<UserParam type="int" name="isotope_error" value="2"/>
 				<UserParam type="float" name="MS:1001155" value="7.638644124345921"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="mvh" higher_score_better="true" significance_threshold="0.0" MZ="775.38775559627004" RT="4923.777343750020009" spectrum_reference="spectrum=2" >
 			<PeptideHit score="66.092927029473998" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="int" name="isotope_error" value="1"/>
 				<UserParam type="float" name="MS:1001155" value="5.093466068553372"/>
 			</PeptideHit>
 		</PeptideIdentification>

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -788,6 +788,7 @@ protected:
         for (PeptideHit& psm : pid.getHits())
         {
           auto v = psm.getMetaValue("IsotopeError");
+          // TODO cast to Int!
           psm.setMetaValue(Constants::UserParam::ISOTOPE_ERROR, v);
           psm.removeMetaValue("IsotopeError");
         }


### PR DESCRIPTION
# Description

For use in Percolator, parse isotope error with round(neutralmassdiff/C12C13diff).
Also contains various fixes for terminal modifications once again.

Contains another try to make clangd work out of the box on Gitpod.