### PR TITLE
Correct a-B fragment masses for DNA

### DIFF
--- a/share/OpenMS/CHEMISTRY/Modomics.tsv
+++ b/share/OpenMS/CHEMISTRY/Modomics.tsv
@@ -175,3 +175,8 @@ uridine 5-oxyacetic acid	cmo5U	502U	U	V	V	C11O9N2H14	318.0699	318.2403
 uridine 5-oxyacetic acid methyl ester	mcmo5U	503U	U	υ	&upsilon;	C12O9N2H16	332.0856	332.2672
 wybutosine	yW	3483G	G	Y	Y	C21O9N6H28	508.1918	508.4892
 wyosine	imG	34G	G	€	&euro;	C14H17N5O5	335.123	335.3202
+deoxyadenosine	dA	dA	A			C10O3N5H13	251.1018	251.2424
+deoxycytidine	dC	dC	C			C9O4N3H13	227.0906	227.2176
+deoxyguanosine	dG	dG	G			C10O4N5H13	267.0968	267.2418
+deoxyuridine	dU	dU	U			C9O5N2H12	228.0746	228.2024
+thymidine	dT	dT	U			C10O5N2H14	242.0903	242.2290

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -216,11 +216,11 @@ namespace OpenMS
       {
         if (parts[1].back() == 'm')
         {
-          ribo->setBaselossFormula(EmpiricalFormula("C6H12O4");
+          ribo->setBaselossFormula(EmpiricalFormula("C6H12O4"));
         }
         else
         {
-          ribo->setBaselossFormula(EmpiricalFormula("C5H10O4");
+          ribo->setBaselossFormula(EmpiricalFormula("C5H10O4"));
         }
       }
     }

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -190,7 +190,7 @@ namespace OpenMS
     }
     else // default specificity is "ANYWHERE"; now set formula after base loss:
     {
-      if (parts[1].back() == 'm') // mod. attached to the ribose, not base
+      if (parts[1].back() == 'm' || parts[1].front() != 'd') // mod. attached to the ribose, not base, and not deoxy
       {
         ribo->setBaselossFormula(EmpiricalFormula("C6H12O5"));
       }
@@ -211,6 +211,17 @@ namespace OpenMS
       else if ((parts[1] == "Ar(p)") || (parts[1] == "Gr(p)"))
       {
         ribo->setBaselossFormula(EmpiricalFormula("C10H19O21P"));
+      }
+      else if (parts[1].front() == 'd') // handle deoxyribose, possibly with methyl mod
+      {
+        if (parts[1].back() == 'm')
+        {
+          ribo->setBaselossFormula(EmpiricalFormula("C6H12O4");
+        }
+        else
+        {
+          ribo->setBaselossFormula(EmpiricalFormula("C5H10O4");
+        }
       }
     }
 

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -190,7 +190,18 @@ namespace OpenMS
     }
     else // default specificity is "ANYWHERE"; now set formula after base loss:
     {
-      if (parts[1].back() == 'm' || parts[1].front() != 'd') // mod. attached to the ribose, not base, and not deoxy
+      if (parts[1].front() == 'd') // handle deoxyribose, possibly with methyl mod
+      {
+        if (parts[1].back() == 'm') // do we have both a methylation and a deoxylation?
+        {
+          ribo->setBaselossFormula(EmpiricalFormula("C6H12O4"));
+        }
+        else  // Otherwise we have just the O difference
+        {
+          ribo->setBaselossFormula(EmpiricalFormula("C5H10O4"));
+        }
+      }
+      else if (parts[1].back() == 'm') // mod. attached to the ribose, not base
       {
         ribo->setBaselossFormula(EmpiricalFormula("C6H12O5"));
       }
@@ -212,17 +223,7 @@ namespace OpenMS
       {
         ribo->setBaselossFormula(EmpiricalFormula("C10H19O21P"));
       }
-      else if (parts[1].front() == 'd') // handle deoxyribose, possibly with methyl mod
-      {
-        if (parts[1].back() == 'm')
-        {
-          ribo->setBaselossFormula(EmpiricalFormula("C6H12O4"));
-        }
-        else
-        {
-          ribo->setBaselossFormula(EmpiricalFormula("C5H10O4"));
-        }
-      }
+
     }
 
     return ribo;

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -223,9 +223,7 @@ namespace OpenMS
       {
         ribo->setBaselossFormula(EmpiricalFormula("C10H19O21P"));
       }
-
     }
-
     return ribo;
   }
 

--- a/src/tests/class_tests/openms/source/RibonucleotideDB_test.cpp
+++ b/src/tests/class_tests/openms/source/RibonucleotideDB_test.cpp
@@ -95,6 +95,16 @@ START_SECTION((const Ribonucleotide& getRibonucleotidePrefix(const String& seq))
 }
 END_SECTION
 
+START_SECTION(EmpiricalFormula getBaselossFormula())
+{
+  const Ribonucleotide* dna = ptr->getRibonucleotide("dT");
+  TEST_EQUAL(EmpiricalFormula("C5H10O4") == dna->getBaselossFormula(), true);
+  const Ribonucleotide* rnam = ptr->getRibonucleotide("Um");
+  TEST_EQUAL(EmpiricalFormula("C6H12O5") == rnam->getBaselossFormula(), true);
+
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/RibonucleotideDB_test.cpp
+++ b/src/tests/class_tests/openms/source/RibonucleotideDB_test.cpp
@@ -101,7 +101,6 @@ START_SECTION(EmpiricalFormula getBaselossFormula())
   TEST_EQUAL(EmpiricalFormula("C5H10O4") == dna->getBaselossFormula(), true);
   const Ribonucleotide* rnam = ptr->getRibonucleotide("Um");
   TEST_EQUAL(EmpiricalFormula("C6H12O5") == rnam->getBaselossFormula(), true);
-
 }
 END_SECTION
 


### PR DESCRIPTION
# Description

Fixes an existing issue where custom deoxyribose mods (with the naming convention [d*]) were not producing the correct masses for base loses.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
