### PR TITLE
[pyopenms] use np.empty instead of np.zeros

### DIFF
--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -1,6 +1,8 @@
 cimport numpy as np
 import numpy as np
 
+
+
     def get_peaks(self):
         """Cython signature: numpy_vector, numpy_vector get_peaks()
         


### PR DESCRIPTION
for a little bit of speed. We know we will initialize everything.