### PR TITLE
[PYOPENMS] wrap check_spectrum_type parameter for pphires

### DIFF
--- a/src/pyOpenMS/pxds/PeakPickerHiRes.pxd
+++ b/src/pyOpenMS/pxds/PeakPickerHiRes.pxd
@@ -15,12 +15,17 @@ cdef extern from "<OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>" namespace
 
         PeakPickerHiRes() nogil except +
         PeakPickerHiRes(PeakPickerHiRes &) nogil except + # compiler
+
         void pick(MSSpectrum & input,
                   MSSpectrum & output
                  ) nogil except +
+        void pick(MSChromatogram & input,
+                  MSChromatogram & output
+                 ) nogil except +
 
         void pickExperiment(MSExperiment & input,
-                            MSExperiment & output
+                            MSExperiment & output,
+                            bool check_spectrum_type
                            ) nogil except +
             # wrap-doc:
                 #   Applies the peak-picking algorithm to a map (MSExperiment). This
@@ -30,6 +35,13 @@ cdef extern from "<OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>" namespace
                 #   :param input: Input map in profile mode
                 #   :param output: Output map with picked peaks
                 #   :param check_spectrum_type: If set, checks spectrum type and throws an exception if a centroided spectrum is passed 
+
+        void pickExperiment(MSExperiment & input,
+                            MSExperiment & output,
+                            libcpp_vector[libcpp_vector[PeakBoundary] ]& boundaries_spec,
+                            libcpp_vector[libcpp_vector[PeakBoundary] ]& boundaries_chrom,
+                            bool check_spectrum_type
+                           ) nogil except +
 
 cdef extern from "<OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>" namespace "OpenMS::PeakPickerHiRes":
     


### PR DESCRIPTION
# Description

Wrap the check_spectrum_type parameter to make it accessible from Python

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
