### PR TITLE
[fix] Elution peak detection: rare segfault if no features were detected (e.g., in blanks)

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.h
@@ -230,7 +230,7 @@ protected:
   std::map<String, double> isotope_probs_; ///< isotope probabilities of transitions
   std::map<String, double> target_rts_; ///< RTs of targets (assays)
   
-  size_t n_shared_;
+  size_t n_shared_ = 0;
 };
 
 } // namespace OpenMS

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ElutionModelFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ElutionModelFitter.cpp
@@ -199,6 +199,11 @@ void ElutionModelFitter::fitAndValidateModel_(
 
 void ElutionModelFitter::fitElutionModels(FeatureMap& features)
 {
+  if (features.empty())
+  {
+    throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No features provided.");
+  }
+
   bool asymmetric = param_.getValue("asymmetric").toBool();
   double add_zeros = param_.getValue("add_zeros");
   bool weighted = !param_.getValue("unweighted_fit").toBool();

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -272,7 +272,14 @@ namespace OpenMS
                << " features left after resolving overlaps (involving "
                << n_overlap_features << " features in " << n_overlap_groups
                << " groups)." << endl;
+      if (features.empty())
+      {
+        OPENMS_LOG_INFO << "No features left after filtering." << endl;
+      }    
     }
+
+    if (features.empty()) return;
+
     n_shared_ = addTargetAnnotations_(features);
 
     if (elution_model_ != "none")


### PR DESCRIPTION


# Description

- Elution model fit now throws if no features provided (before segfault in median calculation)
- FFMetaboIdent now only calls fitting if at least one feature was found

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
