### PR TITLE
[FIX] Decoding ontology in PeptideIdentification df conversion

### DIFF
--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -294,7 +294,7 @@ def peptide_identifications_to_df(peps: List[PeptideIdentification], decode_onto
     clearMVs = [cv.getTerm(m).name if m.startswith("MS:") else m for m in decodedMVs]
     #cols = ["id", "RT", "mz", "score", "charge"] + decodedMVs
     clearcols = ["id", "RT", "mz", mainscorename, "charge", "protein_accession", "start", "end"] + clearMVs
-    coltypes = ['U100', 'f', 'f', 'f', 'i','U100', 'U100', 'U100'] + types
+    coltypes = ['U100', 'f', 'f', 'f', 'i','U1000', 'U1000', 'U1000'] + types
     dt = list(zip(clearcols, coltypes))
 
     def extract(pep):

--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -293,20 +293,26 @@ def peptide_identifications_to_df(peps: List[PeptideIdentification], decode_onto
     cv.loadFromOBO("psims", File.getOpenMSDataPath() + "/CV/psi-ms.obo")
     clearMVs = [cv.getTerm(m).name if m.startswith("MS:") else m for m in decodedMVs]
     #cols = ["id", "RT", "mz", "score", "charge"] + decodedMVs
-    clearcols = ["id", "RT", "mz", mainscorename, "charge"] + clearMVs
-    coltypes = ['U100', 'f', 'f', 'f', 'i'] + types
+    clearcols = ["id", "RT", "mz", mainscorename, "charge", "protein_accession", "start", "end"] + clearMVs
+    coltypes = ['U100', 'f', 'f', 'f', 'i','U100', 'U100', 'U100'] + types
     dt = list(zip(clearcols, coltypes))
 
     def extract(pep):
         hits = pep.getHits()
         if not hits:
             if export_unidentified:
-                return (pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), default_missing_values[float], default_missing_values[int], *dmv)
+                return (pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), default_missing_values[float], default_missing_values[int],
+                        default_missing_values[str], default_missing_values[str], default_missing_values[str], *dmv)
             else:
                 return
 
         besthit = hits[0]
-        ret = [pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), besthit.getScore(), besthit.getCharge()]
+        ret = [pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), besthit.getScore(), besthit.getCharge()] 
+        # add accession, start and end positions of peptide evidences as comma separated str (like in mzTab)
+        evs = besthit.getPeptideEvidences()
+        ret += [','.join(v) if v else default_missing_values[str] for v in ([e.getProteinAccession() for e in evs],
+                                                                            [str(e.getStart()) for e in evs],
+                                                                            [str(e.getEnd()) for e in evs])]
         for k in metavals:
             if besthit.metaValueExists(k):
                 val = besthit.getMetaValue(k)

--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -301,7 +301,7 @@ def peptide_identifications_to_df(peps: List[PeptideIdentification], decode_onto
         hits = pep.getHits()
         if not hits:
             if export_unidentified:
-                return tuple(pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), default_missing_values[float], default_missing_values[int], *dmv)
+                return (pep.getIdentifier().encode('utf-8'), pep.getRT(), pep.getMZ(), default_missing_values[float], default_missing_values[int], *dmv)
             else:
                 return
 

--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -288,11 +288,14 @@ def peptide_identifications_to_df(peps: List[PeptideIdentification], decode_onto
                 return key
     dmv = [default_missing_values[get_key(t)] for t in types]
 
-    decodedMVs = [m.decode("utf-8") for m in metavals] if decode_ontology else metavals
-    cv = ControlledVocabulary()
-    cv.loadFromOBO("psims", File.getOpenMSDataPath() + "/CV/psi-ms.obo")
-    clearMVs = [cv.getTerm(m).name if m.startswith("MS:") else m for m in decodedMVs]
-    #cols = ["id", "RT", "mz", "score", "charge"] + decodedMVs
+    decodedMVs = [m.decode("utf-8") for m in metavals]
+    if decode_ontology:
+        cv = ControlledVocabulary()
+        cv.loadFromOBO("psims", File.getOpenMSDataPath() + "/CV/psi-ms.obo")
+        clearMVs = [cv.getTerm(m).name if m.startswith("MS:") else m for m in decodedMVs]
+    else:
+        clearMVs = decodedMVs
+
     clearcols = ["id", "RT", "mz", mainscorename, "charge", "protein_accession", "start", "end"] + clearMVs
     coltypes = ['U100', 'f', 'f', 'f', 'i','U1000', 'U1000', 'U1000'] + types
     dt = list(zip(clearcols, coltypes))

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2255,11 +2255,15 @@ def test_peptide_identifications_to_df():
     h.setCharge(2)
     h.setMetaValue("StringMetaValue", "Value")
     h.setMetaValue("IntMetaValue", 2)
-    e = pyopenms.PeptideEvidence()
-    e.setProteinAccession("sp|MyAccession")
-    e.setStart(123)
-    e.setEnd(141)
-    h.setPeptideEvidences([e, e])
+    e1 = pyopenms.PeptideEvidence()
+    e1.setProteinAccession("sp|Accession1")
+    e1.setStart(123)
+    e1.setEnd(141)
+    e2 = pyopenms.PeptideEvidence()
+    e2.setProteinAccession("sp|Accession2")
+    e2.setStart(12)
+    e2.setEnd(24)
+    h.setPeptideEvidences([e1, e2])
     p.insertHit(h)
 
     peps.append(p)
@@ -2274,6 +2278,7 @@ def test_peptide_identifications_to_df():
     peps.append(p1)
 
     assert pyopenms.peptide_identifications_to_df(peps).shape == (2,10)
+    assert pyopenms.peptide_identifications_to_df(peps)['protein_accession'][0] == 'sp|Accession1,sp|Accession2'
     assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,10)
 
 @report

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2255,12 +2255,26 @@ def test_peptide_identifications_to_df():
     h.setCharge(2)
     h.setMetaValue("StringMetaValue", "Value")
     h.setMetaValue("IntMetaValue", 2)
+    e = pyopenms.PeptideEvidence()
+    e.setProteinAccession("sp|MyAccession")
+    e.setStart(123)
+    e.setEnd(141)
+    h.setPeptideEvidences([e, e])
     p.insertHit(h)
 
     peps.append(p)
-    peps.append(p)
 
-    assert pyopenms.peptide_identifications_to_df(peps).shape == (2,7)
+    p1 = pyopenms.PeptideIdentification()
+    p1.setRT(1243.56)
+    p1.setMZ(240.0)
+    p1.setScoreType("ScoreType")
+    p1.setHigherScoreBetter(False)
+    p1.setIdentifier("IdentificationRun2")
+
+    peps.append(p1)
+
+    assert pyopenms.peptide_identifications_to_df(peps).shape == (2,10)
+    assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,10)
 
 @report
 def testPepXMLFile():

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2278,6 +2278,7 @@ def test_peptide_identifications_to_df():
     peps.append(p1)
 
     assert pyopenms.peptide_identifications_to_df(peps).shape == (2,10)
+    assert pyopenms.peptide_identifications_to_df(peps, decode_ontology=False).shape == (2,10)
     assert pyopenms.peptide_identifications_to_df(peps)['protein_accession'][0] == 'sp|Accession1,sp|Accession2'
     assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,10)
 


### PR DESCRIPTION
Function peptide_identifications_to_df() crashed when decode_ontology was set False. Because meta values were not decoded to strings, checking meta values in the CV failed when calling startswith().

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
