### PR TITLE
[FIX] add parameter to disable output of warnings in GaussFilter

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/SMOOTHING/GaussFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/SMOOTHING/GaussFilter.h
@@ -76,7 +76,7 @@ public:
     GaussFilter();
 
     /// Destructor
-    ~GaussFilter() override;
+    ~GaussFilter() override = default;
 
     /**
       @brief Smoothes an MSSpectrum containing profile data.
@@ -102,6 +102,8 @@ protected:
 
     /// The spacing of the pre-tabulated kernel coefficients
     double spacing_;
+
+    bool write_log_messages_ = false;
 
     // Docu in base class
     void updateMembers_() override;

--- a/src/openms/source/FILTERING/SMOOTHING/GaussFilter.cpp
+++ b/src/openms/source/FILTERING/SMOOTHING/GaussFilter.cpp
@@ -52,28 +52,28 @@ namespace OpenMS
     defaults_.setValue("ppm_tolerance", 10.0, "Gaussian width, depending on the m/z position.\nThe higher the value, the wider the peak and therefore the wider the gaussian.");
     defaults_.setValue("use_ppm_tolerance", "false", "If true, instead of the gaussian_width value, the ppm_tolerance is used. The gaussian is calculated in each step anew, so this is much slower.");
     defaults_.setValidStrings("use_ppm_tolerance", {"true","false"});
+    defaults_.setValue("write_log_messages", "false", "true: Warn if no signal was found by the Gauss filter algorithm.");
     defaultsToParam_();
-  }
-
-  GaussFilter::~GaussFilter()
-  {
   }
 
   void GaussFilter::updateMembers_()
   {
-    gauss_algo_.initialize((double)param_.getValue("gaussian_width"), spacing_,
-            (double)param_.getValue("ppm_tolerance"), param_.getValue("use_ppm_tolerance").toBool());
+    gauss_algo_.initialize(
+      (double)param_.getValue("gaussian_width"), 
+      spacing_,
+      (double)param_.getValue("ppm_tolerance"), 
+      param_.getValue("use_ppm_tolerance").toBool());
+
+    write_log_messages_ = param_.getValue("write_log_messages").toBool();
   }
 
   void GaussFilter::filter(MSSpectrum & spectrum)
   {
-    typedef std::vector<double> ContainerT;
-
     // make sure the right data type is set
     spectrum.setType(SpectrumSettings::PROFILE);
     bool found_signal = false;
     const Size data_size = spectrum.size();
-    ContainerT mz_in(data_size), int_in(data_size), mz_out(data_size), int_out(data_size);
+    std::vector<double> mz_in(data_size), int_in(data_size), mz_out(data_size), int_out(data_size);
 
     // copy spectrum to container
     for (Size p = 0; p < spectrum.size(); ++p)
@@ -83,26 +83,26 @@ namespace OpenMS
     }
 
     // apply filter
-    ContainerT::iterator mz_out_it = mz_out.begin();
-    ContainerT::iterator int_out_it = int_out.begin();
+    auto mz_out_it = mz_out.begin();
+    auto int_out_it = int_out.begin();
     found_signal = gauss_algo_.filter(mz_in.begin(), mz_in.end(), int_in.begin(), mz_out_it, int_out_it);
 
     // If all intensities are zero in the scan and the scan has a reasonable size, throw an exception.
     // This is the case if the Gaussian filter is smaller than the spacing of raw data
-    if (!found_signal && spectrum.size() >= 3)
+    if (!found_signal && write_log_messages_ && spectrum.size() >= 3)
     {
       String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your profile data. Try to use a bigger width.";
       if (spectrum.getRT() > 0.0)
       {
         error_message += String(" The error occurred in the spectrum with retention time ") + spectrum.getRT() + ".";
       }
-      OPENMS_LOG_ERROR << error_message << std::endl;
+      OPENMS_LOG_WARN << error_message << std::endl;
     }
     else
     {
       // copy the new data into the spectrum
-      ContainerT::iterator mz_it = mz_out.begin();
-      ContainerT::iterator int_it = int_out.begin();
+      auto mz_it = mz_out.begin();
+      auto int_it = int_out.begin();
       for (Size p = 0; mz_it != mz_out.end(); mz_it++, int_it++, p++)
       {
         spectrum[p].setIntensity(*int_it);
@@ -113,8 +113,6 @@ namespace OpenMS
 
   void GaussFilter::filter(MSChromatogram & chromatogram)
   {
-    typedef std::vector<double> ContainerT;
-
     if (param_.getValue("use_ppm_tolerance").toBool())
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
@@ -123,7 +121,7 @@ namespace OpenMS
 
     bool found_signal = false;
     const Size data_size = chromatogram.size();
-    ContainerT rt_in(data_size), int_in(data_size), rt_out(data_size), int_out(data_size);
+    std::vector<double> rt_in(data_size), int_in(data_size), rt_out(data_size), int_out(data_size);
 
     // copy spectrum to container
     for (Size p = 0; p < chromatogram.size(); ++p)
@@ -133,13 +131,13 @@ namespace OpenMS
     }
 
     // apply filter
-    ContainerT::iterator mz_out_it = rt_out.begin();
-    ContainerT::iterator int_out_it = int_out.begin();
+    auto mz_out_it = rt_out.begin();
+    auto int_out_it = int_out.begin();
     found_signal = gauss_algo_.filter(rt_in.begin(), rt_in.end(), int_in.begin(), mz_out_it, int_out_it);
 
     // If all intensities are zero in the scan and the scan has a reasonable size, throw an exception.
     // This is the case if the Gaussian filter is smaller than the spacing of raw data
-    if (!found_signal && chromatogram.size() >= 3)
+    if (!found_signal && write_log_messages_ && chromatogram.size() >= 3)
     {
       String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your chromatogram data. Try to use a bigger width.";
       if (chromatogram.getMZ() > 0.0)
@@ -151,8 +149,8 @@ namespace OpenMS
     else
     {
       // copy the new data into the spectrum
-      ContainerT::iterator mz_it = rt_out.begin();
-      ContainerT::iterator int_it = int_out.begin();
+      auto mz_it = rt_out.begin();
+      auto int_it = int_out.begin();
       for (Size p = 0; mz_it != rt_out.end(); mz_it++, int_it++, p++)
       {
         chromatogram[p].setIntensity(*int_it);
@@ -170,6 +168,7 @@ namespace OpenMS
       filter(map[i]);
       setProgress(++progress);
     }
+
     for (Size i = 0; i < map.getChromatograms().size(); ++i)
     {
       filter(map.getChromatogram(i));

--- a/src/openms/source/FILTERING/SMOOTHING/GaussFilter.cpp
+++ b/src/openms/source/FILTERING/SMOOTHING/GaussFilter.cpp
@@ -89,14 +89,17 @@ namespace OpenMS
 
     // If all intensities are zero in the scan and the scan has a reasonable size, throw an exception.
     // This is the case if the Gaussian filter is smaller than the spacing of raw data
-    if (!found_signal && write_log_messages_ && spectrum.size() >= 3)
+    if (!found_signal && spectrum.size() >= 3)
     {
-      String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your profile data. Try to use a bigger width.";
-      if (spectrum.getRT() > 0.0)
+      if (write_log_messages_)
       {
-        error_message += String(" The error occurred in the spectrum with retention time ") + spectrum.getRT() + ".";
+        String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your profile data. Try to use a bigger width.";
+        if (spectrum.getRT() > 0.0)
+        {
+          error_message += String(" The error occurred in the spectrum with retention time ") + spectrum.getRT() + ".";
+        }
+        OPENMS_LOG_WARN << error_message << std::endl;
       }
-      OPENMS_LOG_WARN << error_message << std::endl;
     }
     else
     {
@@ -137,14 +140,17 @@ namespace OpenMS
 
     // If all intensities are zero in the scan and the scan has a reasonable size, throw an exception.
     // This is the case if the Gaussian filter is smaller than the spacing of raw data
-    if (!found_signal && write_log_messages_ && chromatogram.size() >= 3)
+    if (!found_signal && chromatogram.size() >= 3)
     {
-      String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your chromatogram data. Try to use a bigger width.";
-      if (chromatogram.getMZ() > 0.0)
+      if (write_log_messages_)
       {
-        error_message += String(" The error occurred in the chromatogram with m/z time ") + chromatogram.getMZ() + ".";
+        String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your chromatogram data. Try to use a bigger width.";
+        if (chromatogram.getMZ() > 0.0)
+        {
+          error_message += String(" The error occurred in the chromatogram with m/z time ") + chromatogram.getMZ() + ".";
+        }
+        OPENMS_LOG_ERROR << error_message << std::endl;
       }
-      OPENMS_LOG_ERROR << error_message << std::endl;
     }
     else
     {


### PR DESCRIPTION

# Description

Reduces warning in high throughput data.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
