### PR TITLE
[gitpod] add python3-pip to use run-clang-tidy

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CLANGDVER=12.0.1
 
 # Install tools for VSCode, Intellisense, JRE for Thirdparties, etc. using apt-get
-RUN apt-get -q update && apt-get install -yq gdb unzip wget php openjdk-11-jre clang-tidy && rm -rf /var/lib/apt/lists/*
+RUN apt-get -q update && apt-get install -yq gdb unzip wget php openjdk-11-jre clang-tidy python3-pip && rm -rf /var/lib/apt/lists/*
 RUN wget https://github.com/clangd/clangd/releases/download/$CLANGDVER/clangd-linux-$CLANGDVER.zip && unzip clangd-linux-$CLANGDVER.zip -d /opt/ && mv /opt/clangd_$CLANGDVER /opt/clangd/ && rm clangd-linux-$CLANGDVER.zip 
 #
 # More information: https://www.gitpod.io/docs/42_config_docker/


### PR DESCRIPTION


# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
