### PR TITLE
[FEATURE] peptide export from feature map for pyOpenMS

### DIFF
--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -218,13 +218,14 @@ class FeatureMapDF(FeatureMap):
             vals = [f.getMetaValue(m) if f.metaValueExists(m) else np.nan for m in meta_values]
             
             if export_peptide_identifications:
-                pep_values = (None, None, None, None)
                 if len(pep) > 0:
                     ID_filename = self.__get_prot_id_filename_from_pep_id(pep[0])
                     hits = pep[0].getHits()
                     if len(hits) > 0:
                         besthit = hits[0]
                         pep_values = (besthit.getSequence().toString(), besthit.getScore(), ID_filename, f.getMetaValue('spectrum_native_id'))
+                else:
+                    pep_values = (None, None, None, None)
             else:
                 pep_values = ()
 
@@ -256,7 +257,7 @@ class FeatureMapDF(FeatureMap):
         A DataFrame from the assigned peptides generated with peptide_identifications_to_df(assigned_peptides) can be
         merged with the FeatureMap DataFrame with:
         merged_df = pd.merge(feature_df, assigned_peptide_df, on=['feature_id', 'ID_native_id', 'ID_filename'])
-        
+
         Returns:
         [PeptideIdentification]: list of PeptideIdentification objects
         """
@@ -269,6 +270,8 @@ class FeatureMapDF(FeatureMap):
                     hit.setMetaValue('ID_filename', self.__get_prot_id_filename_from_pep_id(pep))
                     if f.metaValueExists('spectrum_native_id'):
                         hit.setMetaValue('ID_native_id', f.getMetaValue('spectrum_native_id'))
+                    else:
+                        hit.setMetaValue('ID_native_id', 'unknown')
                     hits.append(hit)
                 pep.setHits(hits)
                 result.append(pep)

--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -239,7 +239,8 @@ class FeatureMapDF(FeatureMap):
                 for hit in pep.getHits():
                     hit.setMetaValue('feature_id', str(f.getUniqueId()))
                     hit.setMetaValue('ID_filename', self.__get_prot_id_filename_from_pep_id(pep))
-                    hit.setMetaValue('ID_native_id', f.getMetaValue('spectrum_native_id'))
+                    if f.metaValueExists('spectrum_native_id'):
+                        hit.setMetaValue('ID_native_id', f.getMetaValue('spectrum_native_id'))
                     hits.append(hit)
                 pep.setHits(hits)
                 result.append(pep)

--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -159,7 +159,7 @@ class FeatureMapDF(FeatureMap):
             if prot.getIdentifier() == pep_id.getIdentifier():
                 filenames = []
                 prot.getPrimaryMSRunPath(filenames)
-                if filenames:
+                if filenames and filenames[0] != '':
                     return filenames[0]
         return 'unknown'
     

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -8,6 +8,7 @@ import os
 
 from pyopenms import String as s
 import numpy as np
+import pandas as pd
 
 print("IMPORTED ", pyopenms.__file__)
 
@@ -2127,11 +2128,22 @@ def testFeatureXMLFile():
     f.setPeptideIdentifications([pep_id])
 
     fm.push_back(f)
+
+    f.setMetaValue('spectrum_native_id', 'spectrum=124')
     fm.push_back(f)
 
     assert len(fm.get_assigned_peptide_identifications()) == 2
     assert fm.get_df(meta_values='all').shape == (2, 16)
     assert fm.get_df(meta_values='all', export_peptide_identifications=False).shape == (2, 12)
+
+    assert pd.merge(fm.get_df(), pyopenms.peptide_identifications_to_df(fm.get_assigned_peptide_identifications()),
+                on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (2,22)
+
+    fm = pyopenms.FeatureMap()
+    pyopenms.FeatureXMLFile().load(os.path.join(os.environ['OPENMS_DATA_PATH'], 'examples/FRACTIONS/BSA1_F1_idmapped.featureXML'), fm)
+
+    assert pd.merge(fm.get_df(), pyopenms.peptide_identifications_to_df(fm.get_assigned_peptide_identifications()),
+                    on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (15,24)
 
     fh = pyopenms.FeatureXMLFile()
     fh.store("test.featureXML", fm)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2121,10 +2121,17 @@ def testFeatureXMLFile():
     f.setMetaValue(b'mv1', 1)
     f.setMetaValue(b'mv2', 2)
 
+    f.setMetaValue('spectrum_native_id', 'spectrum=123')
+    pep_id = pyopenms.PeptideIdentification()
+    pep_id.insertHit(pyopenms.PeptideHit())
+    f.setPeptideIdentifications([pep_id])
+
     fm.push_back(f)
     fm.push_back(f)
 
-    assert fm.get_df(meta_values='all').shape == (2, 12)
+    assert len(fm.get_assigned_peptide_identifications()) == 2
+    assert fm.get_df(meta_values='all').shape == (2, 16)
+    assert fm.get_df(meta_values='all', export_peptide_identifications=False).shape == (2, 12)
 
     fh = pyopenms.FeatureXMLFile()
     fh.store("test.featureXML", fm)


### PR DESCRIPTION
# Description

Peptides assigned to features can be exported together with meta values 'ID_native_id' (feature spectrum id) and 'ID_filename' (primary MS run path of corresponding protein id). Based on these values and feature ID the peptide and feature DataFrames can be merged later. 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
