### PR TITLE
Fix race condition in TOPPView

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -349,14 +349,14 @@ private:
     class TemporaryFiles_
     {
       public:
+        TemporaryFiles_(const TemporaryFiles_&) = delete; // copy is forbidden
+        TemporaryFiles_& operator=(const TemporaryFiles_&) = delete;
         TemporaryFiles_();
         /// create a new filename and queue internally for deletion
-        const String& newFile();
+        String newFile();
 
         ~TemporaryFiles_();
       private:
-        TemporaryFiles_(const TemporaryFiles_&) = delete; // copy is forbidden
-        TemporaryFiles_& operator=(const TemporaryFiles_&) = delete;
         StringList filenames_;
         std::mutex mtx_;
     };

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -814,12 +814,13 @@ namespace OpenMS
   {
   }
 
-  const String& File::TemporaryFiles_::newFile()
+  String File::TemporaryFiles_::newFile()
   {
     String s = getTempDirectory().ensureLastChar('/') + getUniqueName();
     std::lock_guard<std::mutex> _(mtx_);
     filenames_.push_back(s);
-    return filenames_.back();
+    // do NOT return filenames_.back() by ref, since another thread might resize the vector and invalidate the reference!
+    return s; // uses RVO, so its efficient
   }
 
   File::TemporaryFiles_::~TemporaryFiles_()

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -138,13 +138,13 @@ namespace OpenMS
           {
             str_list << ti->data(Qt::UserRole).toString();
           }
+          else if (ti->data(Qt::CheckStateRole).isValid()) // Note: item with check box also has a display role, so this test needs to come first
+          {
+            str_list << ti->data(Qt::CheckStateRole).toString();
+          }
           else if (ti->data(Qt::DisplayRole).isValid())
           {
             str_list << ti->data(Qt::DisplayRole).toString();
-          }
-          else if (ti->data(Qt::CheckStateRole).isValid())
-          {
-            str_list << ti->data(Qt::CheckStateRole).toString();
           }
           else
           {


### PR DESCRIPTION
# Description

 fixes a race condition when multiple threads call newFile() and the reference gets invalidated (happened in TOPPView, when requesting a temporary file for INI's)


# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
