### PR TITLE
clang-tidy performance-inefficient-vector/string-operation

### DIFF
--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -260,6 +260,7 @@ namespace OpenMS
         }
 
         vector<PeptideEvidence> newEv;
+        newEv.reserve(evToKeep.size());
         for (const auto& idx : evToKeep)
         {
           newEv.push_back(pepev[idx]);

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -436,6 +436,7 @@ namespace OpenMS
                 indices.end(),
                 [](const SiriusWorkspaceIndex& i, const SiriusWorkspaceIndex& j) { return i.scan_index < j.scan_index; } );
 
+      sorted_subdirs.reserve(indices.size());
       for (const auto& index : indices)
       {
         sorted_subdirs.emplace_back(std::move(subdirs[index.array_index]));

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
@@ -488,6 +488,7 @@ namespace OpenMS
     getNormalized_library_intensities_(transitions, normalized_library_intensity);
 
     std::vector<std::string> native_ids;
+    native_ids.reserve(transitions.size());
     for (const auto& trans : transitions)
     {
       native_ids.push_back(trans.getNativeID());

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -146,6 +146,7 @@ namespace OpenMS
 
     std::vector<String> trgr_ids;
     std::map<std::string, double> pep_im_map;
+    trgr_ids.reserve(transition_group_map.size());
     for (const auto& trgroup_it : transition_group_map)
     {
       trgr_ids.push_back(trgroup_it.first);

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -1181,6 +1181,7 @@ namespace OpenMS
       }
     }
     vector<PeptideIdentification> new_peptide_ids_vector;
+    new_peptide_ids_vector.reserve(new_peptide_ids.size());
     for (pair<String, PeptideIdentification> mit : new_peptide_ids)
     {
       new_peptide_ids_vector.push_back(mit.second);

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -91,6 +91,7 @@ namespace OpenMS
     }
 
     // convert to vector
+    annotated_spectra.reserve(native_ids_annotated_spectra.size());
     for (const auto& it : native_ids_annotated_spectra)
     {
       annotated_spectra.emplace_back(std::move(it.second));

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2918,10 +2918,12 @@ namespace OpenMS
     }
 
     vector<const PeptideIdentification*> pep_ids_ptr;
-    for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
+    pep_ids_ptr.reserve(peptide_identifications.size());
+for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
 
     vector<const ProteinIdentification*> prot_ids_ptr;
-    for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
+    prot_ids_ptr.reserve(protein_identifications.size());
+for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
 
     ofstream tab_file;
     tab_file.open(filename, ios::out | ios::trunc);

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2919,11 +2919,11 @@ namespace OpenMS
 
     vector<const PeptideIdentification*> pep_ids_ptr;
     pep_ids_ptr.reserve(peptide_identifications.size());
-for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
+    for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
 
     vector<const ProteinIdentification*> prot_ids_ptr;
     prot_ids_ptr.reserve(protein_identifications.size());
-for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
+    for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
 
     ofstream tab_file;
     tab_file.open(filename, ios::out | ios::trunc);

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -351,7 +351,7 @@ namespace OpenMS
       {
         std::vector<String> valuesToHash{};
         valuesToHash.reserve(nonRepFacs.size());
-for (const String& fac : nonRepFacs)
+        for (const String& fac : nonRepFacs)
         {
           valuesToHash.emplace_back(sample_section_.getFactorValue(u, fac));
         }

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -289,6 +289,7 @@ namespace OpenMS
       for (unsigned u : sample_section_.getSamples())
       {
         std::vector<String> valuesToHash{};
+        valuesToHash.reserve(factors.size());
         for (const String& fac : factors)
         {
           valuesToHash.emplace_back(sample_section_.getFactorValue(u, fac));
@@ -349,7 +350,8 @@ namespace OpenMS
       for (unsigned u : sample_section_.getSamples())
       {
         std::vector<String> valuesToHash{};
-        for (const String& fac : nonRepFacs)
+        valuesToHash.reserve(nonRepFacs.size());
+for (const String& fac : nonRepFacs)
         {
           valuesToHash.emplace_back(sample_section_.getFactorValue(u, fac));
         }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
