### PR TITLE
Clang tidy performance type-promotion-in-math-fn,move-const-arg,unnecessary-copy-initialization

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -692,13 +692,13 @@ private:
   {
     if (transition_exp_used.hasPeptide(id))
     {
-      const TargetedExperiment::Peptide p = transition_exp_used.getPeptideByRef(id);
+      const TargetedExperiment::Peptide& p = transition_exp_used.getPeptideByRef(id);
       if (p.hasCharge()) {prec_charge = p.getChargeState();}
       return p.sequence;
     }
     else if (transition_exp_used.hasCompound(id))
     {
-      const TargetedExperiment::Compound c = transition_exp_used.getCompoundByRef(id);
+      const TargetedExperiment::Compound& c = transition_exp_used.getCompoundByRef(id);
       if (c.hasCharge()) {prec_charge = c.getChargeState();}
       return c.id;
     }

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -172,7 +172,7 @@ public:
 
       bool operator()(const HitType& hit) const
       {
-        DataValue found = hit.getMetaValue(key);
+        const DataValue& found = hit.getMetaValue(key);
         if (found.isEmpty()) return false; // meta value "key" not set
         if (value.isEmpty()) return true; // "key" is set, value doesn't matter
         return found == value;
@@ -195,7 +195,7 @@ public:
 
       bool operator()(const HitType& hit) const
       {
-        DataValue found = hit.getMetaValue(key);
+        const DataValue& found = hit.getMetaValue(key);
         if (found.isEmpty()) return false; // meta value "key" not set
         return double(found) <= value;
       }

--- a/src/openms/include/OpenMS/MATH/MISC/MathFunctions.h
+++ b/src/openms/include/OpenMS/MATH/MISC/MathFunctions.h
@@ -141,11 +141,11 @@ namespace OpenMS
     {
       if (x >= T(0))
       {
-        return T(floor(x + T(0.5)));
+        return T(std::floor(x + T(0.5)));
       }
       else
       {
-        return T(ceil(x - T(0.5)));
+        return T(std::ceil(x - T(0.5)));
       }
     }
 

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -199,7 +199,7 @@ namespace OpenMS
       identified_oligos_(std::move(other.identified_oligos_)),
       query_matches_(std::move(other.query_matches_)),
       query_match_groups_(std::move(other.query_match_groups_)),
-      current_step_ref_(std::move(other.current_step_ref_)),
+      current_step_ref_(other.current_step_ref_),
       // look-up tables:
       data_query_lookup_(std::move(other.data_query_lookup_)),
       parent_molecule_lookup_(std::move(other.parent_molecule_lookup_)),

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/ContinuousWaveletTransformNumIntegration.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/ContinuousWaveletTransformNumIntegration.h
@@ -98,7 +98,7 @@ public:
 #ifdef DEBUG_PEAK_PICKING
       std::cout << "ContinuousWaveletTransformNumIntegration::transform: start " << begin_input->getMZ() << " until " << (end_input - 1)->getMZ() << std::endl;
 #endif
-      if (fabs(resolution - 1) < 0.0001)
+      if (std::fabs(resolution - 1) < 0.0001)
       {
         // resolution = 1 corresponds to the cwt at supporting points which have a distance corresponding to the minimal spacing in [begin_input,end_input)
         SignedSize n = distance(begin_input, end_input);

--- a/src/openms/source/ANALYSIS/DENOVO/CompNovoIdentificationBase.cpp
+++ b/src/openms/source/ANALYSIS/DENOVO/CompNovoIdentificationBase.cpp
@@ -650,7 +650,7 @@ for (set<Size>::const_iterator it = used_pos.begin(); it != used_pos.end(); ++it
 
     // now handle the modifications
     ModificationDefinitionsSet mod_set(ListUtils::toStringList<std::string>(param_.getValue("fixed_modifications")), ListUtils::toStringList<std::string>(param_.getValue("variable_modifications")));
-    set<ModificationDefinition> fixed_mods = mod_set.getFixedModifications();
+    const set<ModificationDefinition>& fixed_mods = mod_set.getFixedModifications();
 
     for (set<ModificationDefinition>::const_iterator it = fixed_mods.begin(); it != fixed_mods.end(); ++it)
     {
@@ -692,7 +692,7 @@ for (set<Size>::const_iterator it = used_pos.begin(); it != used_pos.end(); ++it
 
     const StringList mod_names(ListUtils::create<String>("a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"));
     vector<String>::const_iterator actual_mod_name = mod_names.begin();
-    set<ModificationDefinition> var_mods = mod_set.getVariableModifications();
+    const set<ModificationDefinition>& var_mods = mod_set.getVariableModifications();
     for (set<ModificationDefinition>::const_iterator it = var_mods.begin(); it != var_mods.end(); ++it)
     {
       ResidueModification mod = it->getModification();

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -750,7 +750,7 @@ namespace OpenMS
 
     // collect meta data:
     // intensities for all maps as given in handles; 0 if no handle is present for a map
-    ConsensusFeature::HandleSetType ind_feats(cfeat.getFeatures()); // sorted by MapIndices
+    const ConsensusFeature::HandleSetType& ind_feats(cfeat.getFeatures()); // sorted by MapIndices
     ConsensusFeature::const_iterator f_it = ind_feats.begin();
     std::vector<double> tmp_f_ints;
     for (Size map_idx = 0; map_idx < number_of_maps; ++map_idx)

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -505,7 +505,7 @@ namespace OpenMS
           new_hits.push_back(std::move(hit));
         }
       }
-      it->setHits(std::move(new_hits));
+      it->setHits(new_hits);
     }
   }
 

--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -330,7 +330,7 @@ namespace OpenMS
       if (!hits.empty())
       {
         PeptideHit best_hit = hits[0];
-        const vector<PeptideEvidence> pepev = best_hit.getPeptideEvidences();
+        const vector<PeptideEvidence>& pepev = best_hit.getPeptideEvidences();
 
         for (vector<PeptideEvidence>::const_iterator pepev_it = pepev.begin();
              pepev_it != pepev.end(); ++pepev_it)

--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -260,6 +260,7 @@ namespace OpenMS
         }
 
         vector<PeptideEvidence> newEv;
+        newEv.reserve(evToKeep.size());
         for (const auto& idx : evToKeep)
         {
           newEv.push_back(pepev[idx]);

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -436,6 +436,7 @@ namespace OpenMS
                 indices.end(),
                 [](const SiriusWorkspaceIndex& i, const SiriusWorkspaceIndex& j) { return i.scan_index < j.scan_index; } );
 
+      sorted_subdirs.reserve(indices.size());
       for (const auto& index : indices)
       {
         sorted_subdirs.emplace_back(std::move(subdirs[index.array_index]));

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentEvaluationAlgorithm.cpp
@@ -40,6 +40,8 @@
 
 #include <OpenMS/CONCEPT/Factory.h>
 
+#include <cmath>
+
 namespace OpenMS
 {
   //register products here
@@ -60,7 +62,7 @@ namespace OpenMS
     if (fabs(lhs.getMZ() - rhs.getMZ()) > mz_dev)
       return false; // TODO MAGIC_ALERT
 
-    if (fabs(lhs.getIntensity() - rhs.getIntensity()) > int_dev)
+    if (std::fabs(lhs.getIntensity() - rhs.getIntensity()) > int_dev)
       return false; // TODO MAGIC_ALERT
 
     if (use_charge && (lhs.getCharge() != rhs.getCharge()))

--- a/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
+++ b/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
@@ -89,15 +89,15 @@ namespace OpenMS
     name_(std::move(rhs.name_)),
     peptide_ref_(std::move(rhs.peptide_ref_)),
     compound_ref_(std::move(rhs.compound_ref_)),
-    library_intensity_(std::move(rhs.library_intensity_)),
-    decoy_type_(std::move(rhs.decoy_type_)),
-    precursor_mz_(std::move(rhs.precursor_mz_)),
-    precursor_cv_terms_(std::move(rhs.precursor_cv_terms_)),
+    library_intensity_(rhs.library_intensity_),
+    decoy_type_(rhs.decoy_type_),
+    precursor_mz_(rhs.precursor_mz_),
+    precursor_cv_terms_(rhs.precursor_cv_terms_),
     product_(std::move(rhs.product_)),
     intermediate_products_(std::move(rhs.intermediate_products_)),
     rts(std::move(rhs.rts)),
-    prediction_(std::move(rhs.prediction_)),
-    transition_flags_(std::move(rhs.transition_flags_))
+    prediction_(rhs.prediction_),
+    transition_flags_(rhs.transition_flags_)
   {
     rhs.precursor_cv_terms_ = nullptr;
     rhs.prediction_ = nullptr;
@@ -152,13 +152,13 @@ namespace OpenMS
       name_ = std::move(rhs.name_);
       peptide_ref_ = std::move(rhs.peptide_ref_);
       compound_ref_ = std::move(rhs.compound_ref_);
-      precursor_mz_ = std::move(rhs.precursor_mz_);
+      precursor_mz_ = rhs.precursor_mz_;
       intermediate_products_ = std::move(rhs.intermediate_products_);
       product_ = std::move(rhs.product_);
       rts = std::move(rhs.rts);
-      library_intensity_ = std::move(rhs.library_intensity_);
-      decoy_type_ = std::move(rhs.decoy_type_);
-      transition_flags_ = std::move(rhs.transition_flags_);
+      library_intensity_ = rhs.library_intensity_;
+      decoy_type_ = rhs.decoy_type_;
+      transition_flags_ = rhs.transition_flags_;
 
       // Move the ptr-based objects to the current objects and delete them in the rhs
       delete precursor_cv_terms_;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -663,7 +663,7 @@ namespace OpenMS
     for (const auto & decoy_pep_it : DecoyPeptideMap)
     {
       setProgress(progress++);
-      TargetedExperiment::Peptide target_peptide = exp.getPeptideByRef(decoy_pep_it.first);
+      const TargetedExperiment::Peptide& target_peptide = exp.getPeptideByRef(decoy_pep_it.first);
       int precursor_charge = 1;
       if (target_peptide.hasCharge()) 
       {
@@ -839,7 +839,7 @@ namespace OpenMS
       setProgress(++progress);
       ReactionMonitoringTransition tr = exp.getTransitions()[i];
 
-      const TargetedExperiment::Peptide target_peptide = exp.getPeptideByRef(tr.getPeptideRef());
+      const TargetedExperiment::Peptide& target_peptide = exp.getPeptideByRef(tr.getPeptideRef());
       OpenMS::AASequence target_peptide_sequence = TargetedExperimentHelper::getAASequence(target_peptide);
 
       // Check annotation for unannotated interpretations

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -507,9 +507,9 @@ namespace OpenMS
       String peptide_ref = pep_it->first;
       String decoy_peptide_ref = decoy_tag + pep_it->first; // see above, the decoy peptide id is computed deterministically from the target id
       if (!dec.hasPeptide(decoy_peptide_ref)) {continue;}
-      const TargetedExperiment::Peptide target_peptide = exp.getPeptideByRef(peptide_ref);
+      const TargetedExperiment::Peptide& target_peptide = exp.getPeptideByRef(peptide_ref);
 
-      const TargetedExperiment::Peptide decoy_peptide = dec.getPeptideByRef(decoy_peptide_ref);
+      const TargetedExperiment::Peptide& decoy_peptide = dec.getPeptideByRef(decoy_peptide_ref);
       OpenMS::AASequence target_peptide_sequence = TargetedExperimentHelper::getAASequence(target_peptide);
       OpenMS::AASequence decoy_peptide_sequence = TargetedExperimentHelper::getAASequence(decoy_peptide);
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
@@ -488,6 +488,7 @@ namespace OpenMS
     getNormalized_library_intensities_(transitions, normalized_library_intensity);
 
     std::vector<std::string> native_ids;
+    native_ids.reserve(transitions.size());
     for (const auto& trans : transitions)
     {
       native_ids.push_back(trans.getNativeID());

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -492,7 +492,7 @@ namespace OpenMS
       FeatureMap featureFile;
       boost::shared_ptr<MSExperiment> empty_exp = boost::shared_ptr<MSExperiment>(new MSExperiment);
 
-      OpenSwath::LightTargetedExperiment transition_exp_used = transition_exp;
+      const OpenSwath::LightTargetedExperiment& transition_exp_used = transition_exp;
       scoreAllChromatograms_(std::vector<MSChromatogram>(), ms1_chromatograms, swath_maps, transition_exp_used, 
                             feature_finder_param, trafo,
                             cp.rt_extraction_window, featureFile, tsv_writer, osw_writer, ms1_isotopes, true);

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -146,6 +146,7 @@ namespace OpenMS
 
     std::vector<String> trgr_ids;
     std::map<std::string, double> pep_im_map;
+    trgr_ids.reserve(transition_group_map.size());
     for (const auto& trgroup_it : transition_group_map)
     {
       trgr_ids.push_back(trgroup_it.first);

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -1181,6 +1181,7 @@ namespace OpenMS
       }
     }
     vector<PeptideIdentification> new_peptide_ids_vector;
+    new_peptide_ids_vector.reserve(new_peptide_ids.size());
     for (pair<String, PeptideIdentification> mit : new_peptide_ids)
     {
       new_peptide_ids_vector.push_back(mit.second);

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -957,7 +957,7 @@ namespace OpenMS
       throw ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, name);
     }
 
-    StringList valids = strings;
+    const StringList& valids = strings;
     StringList defaults;
 
     if (p.type == ParameterInformation::STRING)

--- a/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/MassDecompositionAlgorithm.cpp
+++ b/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/MassDecompositionAlgorithm.cpp
@@ -112,7 +112,7 @@ namespace OpenMS
 
     // now handle the modifications
     ModificationDefinitionsSet mod_set(ListUtils::toStringList<std::string>(param_.getValue("fixed_modifications")), ListUtils::toStringList<std::string>(param_.getValue("variable_modifications")));
-    set<ModificationDefinition> fixed_mods = mod_set.getFixedModifications();
+    const set<ModificationDefinition>& fixed_mods = mod_set.getFixedModifications();
     for (set<ModificationDefinition>::const_iterator it = fixed_mods.begin(); it != fixed_mods.end(); ++it)
     {
       const ResidueModification& mod = it->getModification();
@@ -147,7 +147,7 @@ namespace OpenMS
 
     const StringList mod_names(ListUtils::create<String>("a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z"));
     vector<String>::const_iterator actual_mod_name = mod_names.begin();
-    set<ModificationDefinition> var_mods = mod_set.getVariableModifications();
+    const set<ModificationDefinition>& var_mods = mod_set.getVariableModifications();
     for (set<ModificationDefinition>::const_iterator it = var_mods.begin(); it != var_mods.end(); ++it)
     {
       ResidueModification mod = it->getModification();

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -196,7 +196,7 @@ namespace OpenMS
   {
     const ResidueModification* mod(nullptr);
 
-    String mod_name = mod_in.getFullId();
+    const String& mod_name = mod_in.getFullId();
 
     #pragma omp critical(OpenMS_ModificationsDB)
     {

--- a/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
@@ -63,7 +63,7 @@ namespace OpenMS
     ModifiedPeptideGenerator::MapToResidueType m;
     for (auto const & r : mods)
     {
-      String name = r->getFullId();
+      const String& name = r->getFullId();
       bool is_terminal = r->getTermSpecificity() == ResidueModification::N_TERM || r->getTermSpecificity() == ResidueModification::C_TERM || r->getTermSpecificity() == ResidueModification::PROTEIN_N_TERM || r->getTermSpecificity() == ResidueModification::PROTEIN_C_TERM;
       if (!is_terminal)
       {

--- a/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
+++ b/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
@@ -148,7 +148,7 @@ namespace OpenMS
         error_annotations[it->second] = std::fabs(spec[it->second].getMZ() - theoretical_spec[it->first].getMZ());
         type_annotations[it->second] = theo_annot[it->first];
     }
-    Param sap = sa.getParameters();
+    const Param& sap = sa.getParameters();
     spec.setMetaValue("fragment_mass_tolerance", sap.getValue("tolerance"));
     spec.setMetaValue("fragment_mass_tolerance_ppm", false);
     spec.setStringDataArrays(PeakSpectrum::StringDataArrays(1, type_annotations));
@@ -394,7 +394,7 @@ namespace OpenMS
         }
         //TODO add "FragmentArray"s
 
-        Param sap = sa.getParameters();
+        const Param& sap = sa.getParameters();
         pi.setMetaValue("fragment_match_tolerance", (double)sap.getValue("tolerance"));
       }
     }

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
@@ -269,11 +269,11 @@ namespace OpenMS
 
     double fragment_mass = (fragment.getMonoWeight(res_type, charge) - loss.getMonoWeight());
 
-    Residue res_n = peptide.getResidue(position);
-    Residue res_c = peptide.getResidue(position + 1);
+    const Residue& res_n = peptide.getResidue(position);
+    const Residue& res_c = peptide.getResidue(position + 1);
 
-    String res_n_string = res_n.getOneLetterCode();
-    String res_c_string = res_c.getOneLetterCode();
+    const String& res_n_string = res_n.getOneLetterCode();
+    const String& res_c_string = res_c.getOneLetterCode();
 
     Size num_aa = aa_to_index_.size();
     Int index = 1;

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -236,10 +236,10 @@ namespace OpenMS
   }
 
   DataValue::DataValue(DataValue&& rhs) noexcept :
-    value_type_(std::move(rhs.value_type_)),
-    unit_type_(std::move(rhs.unit_type_)),
-    unit_(std::move(rhs.unit_)),
-    data_(std::move(rhs.data_))
+    value_type_(rhs.value_type_),
+    unit_type_(rhs.unit_type_),
+    unit_(rhs.unit_),
+    data_(rhs.data_)
   {
     // clean up rhs, take ownership of data_
     // NOTE: value_type_ == EMPTY_VALUE implies data_ is empty and can be reset

--- a/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
+++ b/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/DATASTRUCTURES/Compomer.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
+#include <cmath>
 #include <iostream>
 
 namespace OpenMS
@@ -340,10 +341,10 @@ namespace OpenMS
     }
 #endif
 
-    Compomer cmp_low(net_charge, static_cast<double>(mass_to_explain) - fabs(mass_delta), 1);
+    Compomer cmp_low(net_charge, static_cast<double>(mass_to_explain) - std::fabs(mass_delta), 1);
     firstExplanation = lower_bound(explanations_.begin(), explanations_.end(), cmp_low);
 
-    Compomer cmp_high(net_charge, static_cast<double>(mass_to_explain) + fabs(mass_delta), static_cast<double>(thresh_log_p));
+    Compomer cmp_high(net_charge, static_cast<double>(mass_to_explain) + std::fabs(mass_delta), static_cast<double>(thresh_log_p));
     lastExplanation  = lower_bound(explanations_.begin(), explanations_.end(), cmp_high);
 
     return std::distance(firstExplanation, lastExplanation);

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -630,7 +630,7 @@ namespace OpenMS
         if (real_pathname != "")
         {
           std::string description_old = getSectionDescription(prefix + real_pathname);
-          std::string description_new = defaults.getSectionDescription(real_pathname);
+          const std::string& description_new = defaults.getSectionDescription(real_pathname);
           if (description_old == "")
           {
             //std::cerr << "## Setting description of " << prefix+real_pathname << " to"<< std::endl;
@@ -911,10 +911,10 @@ namespace OpenMS
   void Param::parseCommandLine(const int argc, const char** argv, const std::map<std::string, std::string>& options_with_one_argument, const std::map<std::string, std::string>& options_without_argument, const std::map<std::string, std::string>& options_with_multiple_argument, const std::string& misc, const std::string& unknown)
   {
     //determine misc key
-    std::string misc_key = misc;
+    const std::string& misc_key = misc;
 
     //determine unknown key
-    std::string unknown_key = unknown;
+    const std::string& unknown_key = unknown;
 
     //parse arguments
     std::string arg, arg1;
@@ -1410,7 +1410,7 @@ OPENMS_THREAD_CRITICAL(oms_log)
         if (real_pathname != "")
         {
           std::string description_old = getSectionDescription(prefix + real_pathname);
-          std::string description_new = toMerge.getSectionDescription(real_pathname);
+          const std::string& description_new = toMerge.getSectionDescription(real_pathname);
           if (description_old == "")
           {
             setSectionDescription(real_pathname, description_new);

--- a/src/openms/source/DATASTRUCTURES/ParamValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/ParamValue.cpp
@@ -180,8 +180,8 @@ namespace OpenMS
   }
 
   ParamValue::ParamValue(ParamValue&& rhs) noexcept :
-    value_type_(std::move(rhs.value_type_)),
-    data_(std::move(rhs.data_))
+    value_type_(rhs.value_type_),
+    data_(rhs.data_)
   {
     // clean up rhs, take ownership of data_
     // NOTE: value_type_ == EMPTY_VALUE implies data_ is empty and can be reset

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -91,6 +91,7 @@ namespace OpenMS
     }
 
     // convert to vector
+    annotated_spectra.reserve(native_ids_annotated_spectra.size());
     for (const auto& it : native_ids_annotated_spectra)
     {
       annotated_spectra.emplace_back(std::move(it.second));

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -94,7 +94,7 @@ namespace OpenMS
     annotated_spectra.reserve(native_ids_annotated_spectra.size());
     for (const auto& it : native_ids_annotated_spectra)
     {
-      annotated_spectra.emplace_back(std::move(it.second));
+      annotated_spectra.emplace_back(it.second);
     }
 
     return annotated_spectra;

--- a/src/openms/source/FORMAT/EDTAFile.cpp
+++ b/src/openms/source/FORMAT/EDTAFile.cpp
@@ -328,7 +328,7 @@ namespace OpenMS
       // consensus
       String entry = String(f.getRT()) + "\t" + f.getMZ() + "\t" + f.getIntensity() + "\t" + f.getCharge();
       // sub-features
-      ConsensusFeature::HandleSetType handle = f.getFeatures();
+      const ConsensusFeature::HandleSetType& handle = f.getFeatures();
       for (ConsensusFeature::HandleSetType::const_iterator it = handle.begin(); it != handle.end(); ++it)
       {
         entry += String("\t") + it->getRT() + "\t" + it->getMZ() + "\t" + it->getIntensity() + "\t" + it->getCharge();

--- a/src/openms/source/FORMAT/FASTAFile.cpp
+++ b/src/openms/source/FORMAT/FASTAFile.cpp
@@ -198,9 +198,9 @@ namespace OpenMS
     }
     ++entries_read_;
 
-    protein.identifier = std::move(id_);
-    protein.description = std::move(description_);
-    protein.sequence = std::move(seq_);
+    protein.identifier = id_;
+    protein.description = description_;
+    protein.sequence = seq_;
 
     return true;
   }

--- a/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
@@ -273,7 +273,7 @@ namespace OpenMS::Internal
   {
     // delete the actual data for all spectra and chromatograms, leave only metadata
     // TODO : remove copy
-    ExperimentalSettings qq = exp;
+    const ExperimentalSettings& qq = exp;
     MSExperiment out_exp;
     out_exp = qq;
     // std::vector<MSChromatogram > chromatograms = exp.getChromatograms(); // copy

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -258,7 +258,7 @@ namespace OpenMS::Internal
             act_index_tuple.setCharge(charge);
           }
 
-          act_cons_element_.insert(std::move(act_index_tuple));
+          act_cons_element_.insert(act_index_tuple);
         }
       }
       act_cons_element_.getPosition() = pos_;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -989,7 +989,7 @@ namespace OpenMS::Internal
         {
           s += String(indent, '\t') + "<userParam name=\"" + keys[i] + "\" unitName=\"";
 
-          DataValue d = meta.getMetaValue(keys[i]);
+          const DataValue& d = meta.getMetaValue(keys[i]);
           //determine type
           if (d.valueType() == DataValue::INT_VALUE)
           {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -837,7 +837,7 @@ namespace OpenMS::Internal
 
       // prepare streams and set required precision (default is 6 digits)
       std::stringstream insert_run_sql;
-      std::string native_id = exp.getLoadedFilePath(); // TODO escape stuff like ' (SQL inject)
+      const std::string& native_id = exp.getLoadedFilePath(); // TODO escape stuff like ' (SQL inject)
       insert_run_sql << "INSERT INTO RUN (ID, FILENAME, NATIVE_ID) VALUES (" <<
             run_id_ << ",'" << native_id << "','" << native_id << "'); ";
       conn.executeStatement("BEGIN TRANSACTION");

--- a/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
@@ -1300,7 +1300,7 @@ namespace OpenMS::Internal
       {
         s += String(indent, '\t') + "<userParam name=\"" + keys[i] + "\" unitName=\"";
 
-        DataValue d = meta.getMetaValue(keys[i]);
+        const DataValue& d = meta.getMetaValue(keys[i]);
         //determine type
         if (d.valueType() == DataValue::INT_VALUE)
         {

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -1127,7 +1127,7 @@ namespace OpenMS::Internal
     void TraMLHandler::handleCVParam_(const String& parent_parent_tag, const String& parent_tag, const CVTerm& cv_term)
     {
       //Error checks of CV values
-      String accession = cv_term.getAccession();
+      const String& accession = cv_term.getAccession();
       if (cv_.exists(accession))
       {
         const ControlledVocabulary::CVTerm& term = cv_.getTerm(accession);

--- a/src/openms/source/FORMAT/IBSpectraFile.cpp
+++ b/src/openms/source/FORMAT/IBSpectraFile.cpp
@@ -293,7 +293,7 @@ namespace OpenMS
 
         // extract channel intensities and positions
         std::map<Int, double> intensityMap;
-        ConsensusFeature::HandleSetType features = cFeature.getFeatures();
+        const ConsensusFeature::HandleSetType& features = cFeature.getFeatures();
 
         for (ConsensusFeature::HandleSetType::const_iterator fIt = features.begin();
              fIt != features.end();

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -603,7 +603,7 @@ namespace OpenMS
       // sequence
       String tmp;
       optionalAttributeAsString_(tmp, attributes, "sequence");
-      prot_hit_.setSequence(std::move(tmp));
+      prot_hit_.setSequence(tmp);
 
       last_meta_ = &prot_hit_;
 

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -455,7 +455,7 @@ namespace OpenMS
 
 
     String native_id_type_accession;
-    vector<SourceFile> sourcefiles = experiment.getSourceFiles();
+    const vector<SourceFile>& sourcefiles = experiment.getSourceFiles();
     if (sourcefiles.empty())
     {
       OPENMS_LOG_WARN << "MascotGenericFile: no native ID accession." << endl;

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2918,10 +2918,12 @@ namespace OpenMS
     }
 
     vector<const PeptideIdentification*> pep_ids_ptr;
-    for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
+    pep_ids_ptr.reserve(peptide_identifications.size());
+for (const PeptideIdentification& pi : peptide_identifications) { pep_ids_ptr.push_back(&pi); }
 
     vector<const ProteinIdentification*> prot_ids_ptr;
-    for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
+    prot_ids_ptr.reserve(protein_identifications.size());
+for (const ProteinIdentification& pi : protein_identifications) { prot_ids_ptr.push_back(&pi); }
 
     ofstream tab_file;
     tab_file.open(filename, ios::out | ios::trunc);

--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -304,7 +304,7 @@ namespace OpenMS
       {
         int id = Sql::extractInt(stmt, I_PROTID);
         accession = Sql::extractString(stmt, I_ACCESSION);
-        swath_result.addProtein(OSWProtein(std::move(accession), id, {}));
+        swath_result.addProtein(OSWProtein(accession, id, {}));
         rc = Sql::nextRow(stmt, rc); // next row
       }
     }
@@ -672,7 +672,7 @@ namespace OpenMS
           Sql::extractFloat(stmt, COLIDs::PRODUCT_MZ),
           Sql::extractChar(stmt, COLIDs::TYPE),
           Sql::extractInt(stmt, COLIDs::DECOY));
-        swath_result.addTransition(std::move(tr));
+        swath_result.addTransition(tr);
         rc = Sql::nextRow(stmt);
       }
       sqlite3_finalize(stmt);

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -576,7 +576,7 @@ namespace OpenMS
       }
       for (const PeptideHit& hit : pep.getHits())
       {
-        PeptideHit h = hit;
+        const PeptideHit& h = hit;
         const AASequence& seq = h.getSequence();
         double precursor_neutral_mass = seq.getMonoWeight();
 

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -1737,7 +1737,7 @@ namespace OpenMS
             }
             for (const Residue& z : tmp.getSequence())
             {
-              Residue res = z;
+              const Residue& res = z;
               String temp;
               if (res.isModified() && res.getModificationName() != "Carbamidomethyl")
               {

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -348,7 +348,7 @@ namespace OpenMS
             throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
               "Found SWATH scan (MS level 2 scan) without a precursor. Cannot determine SWATH window.");
           }
-          const std::vector<Precursor> prec = s.getPrecursors();
+          const std::vector<Precursor>& prec = s.getPrecursors();
           double center = prec[0].getMZ();
           bool found = false;
           for (Size j = 0; j < known_window_boundaries.size(); j++)

--- a/src/openms/source/FORMAT/TransformationXMLFile.cpp
+++ b/src/openms/source/FORMAT/TransformationXMLFile.cpp
@@ -93,7 +93,7 @@ namespace OpenMS
        << "\">\n";
 
     // write parameters
-    Param params = transformation.getModelParameters();
+    const Param& params = transformation.getModelParameters();
     for (Param::ParamIterator it = params.begin(); it != params.end(); ++it)
     {
       if (it->value.valueType() != ParamValue::EMPTY_VALUE)

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
     // fill up the PeakMaps by moving spectra from the input PeakMap
     for (const MSSpectrum& it : exp)
     {
-      split_peakmap[cv2index[it.getDriftTime()]].addSpectrum(std::move(it));
+      split_peakmap[cv2index[it.getDriftTime()]].addSpectrum(it);
     }
 
     return split_peakmap;

--- a/src/openms/source/KERNEL/Feature.cpp
+++ b/src/openms/source/KERNEL/Feature.cpp
@@ -67,7 +67,7 @@ namespace OpenMS
   Feature::Feature(Feature&& feature) noexcept :
     BaseFeature(std::move(feature)),
     convex_hulls_(std::move(feature.convex_hulls_)),
-    convex_hulls_modified_(std::move(feature.convex_hulls_modified_)),
+    convex_hulls_modified_(feature.convex_hulls_modified_),
     convex_hull_(std::move(feature.convex_hull_)),
     subordinates_(std::move(feature.subordinates_))
   {
@@ -204,7 +204,7 @@ namespace OpenMS
     BaseFeature::operator=(std::move(rhs));
     std::copy(rhs.qualities_, rhs.qualities_ + 2, qualities_);
     convex_hulls_           = std::move(rhs.convex_hulls_);
-    convex_hulls_modified_  = std::move(rhs.convex_hulls_modified_);
+    convex_hulls_modified_  = rhs.convex_hulls_modified_;
     convex_hull_            = std::move(rhs.convex_hull_);
     subordinates_           = std::move(rhs.subordinates_);
 

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -563,8 +563,8 @@ namespace OpenMS
     for (const SourceFile& ss : sfs)
     {
       // assemble a single location string from the URI (path to file) and file name
-      String path = ss.getPathToFile();
-      String filename = ss.getNameOfFile();
+      const String& path = ss.getPathToFile();
+      const String& filename = ss.getNameOfFile();
 
       if (path.empty() || filename.empty())
       {

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -72,7 +72,7 @@ namespace OpenMS
       mda_tmp_float.reserve(float_data_arrays_[i].size());
       for (Size j = 0; j < snew; ++j)
       {
-        mda_tmp_float.push_back(std::move(float_data_arrays_[i][indices[j]]));
+        mda_tmp_float.push_back(float_data_arrays_[i][indices[j]]);
       }
       std::swap(float_data_arrays_[i], mda_tmp_float);
     }
@@ -116,7 +116,7 @@ namespace OpenMS
       mda_tmp_int.reserve(integer_data_arrays_[i].size());
       for (Size j = 0; j < snew; ++j)
       {
-        mda_tmp_int.push_back(std::move(integer_data_arrays_[i][indices[j]]));
+        mda_tmp_int.push_back(integer_data_arrays_[i][indices[j]]);
       }
       std::swap(integer_data_arrays_[i], mda_tmp_int);
     }

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -289,6 +289,7 @@ namespace OpenMS
       for (unsigned u : sample_section_.getSamples())
       {
         std::vector<String> valuesToHash{};
+        valuesToHash.reserve(factors.size());
         for (const String& fac : factors)
         {
           valuesToHash.emplace_back(sample_section_.getFactorValue(u, fac));
@@ -349,7 +350,8 @@ namespace OpenMS
       for (unsigned u : sample_section_.getSamples())
       {
         std::vector<String> valuesToHash{};
-        for (const String& fac : nonRepFacs)
+        valuesToHash.reserve(nonRepFacs.size());
+for (const String& fac : nonRepFacs)
         {
           valuesToHash.emplace_back(sample_section_.getFactorValue(u, fac));
         }

--- a/src/openms/source/METADATA/MetaInfoInterface.cpp
+++ b/src/openms/source/METADATA/MetaInfoInterface.cpp
@@ -58,7 +58,7 @@ namespace OpenMS
 
   /// Move constructor
   MetaInfoInterface::MetaInfoInterface(MetaInfoInterface&& rhs) noexcept :
-    meta_(std::move(rhs.meta_))
+    meta_(rhs.meta_)
   {
     // take ownership
     rhs.meta_ = nullptr;

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -100,7 +100,7 @@ namespace OpenMS
     MetaInfoInterface(std::move(source)), // NOTE: rhs itself is an lvalue
     sequence_(std::move(source.sequence_)),
     score_(source.score_),
-    analysis_results_(std::move(source.analysis_results_)),
+    analysis_results_(source.analysis_results_),
     rank_(source.rank_),
     charge_(source.charge_),
     peptide_evidences_(std::move(source.peptide_evidences_)),

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -1328,7 +1328,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1346,7 +1346,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1364,7 +1364,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1384,7 +1384,7 @@ namespace OpenMS
 
   void TOPPASBase::updateTOPPOutputLog(const QString& out)
   {
-    QString text = out; // shortened version for now (if we reintroduce simultaneous tool execution,
+    const QString& text = out; // shortened version for now (if we reintroduce simultaneous tool execution,
                         // we need to rethink this (probably only trigger this slot when tool 100% finished)
 
 

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -260,7 +260,7 @@ namespace OpenMS
 
       const PeakMap& exp = *layer.getPeakData();
       float mz_origin = 0.0;
-      auto rt_area = area; // check overlap with chrom's RT
+      const auto& rt_area = area; // check overlap with chrom's RT
 
       int count {-1};
       for (const auto& chrom : exp.getChromatograms())
@@ -863,7 +863,7 @@ namespace OpenMS
       {
         //paint hull points
         ConvexHull2D hull = i->getConvexHull();
-        ConvexHull2D::PointArrayType ch_points = hull.getHullPoints();
+        const ConvexHull2D::PointArrayType& ch_points = hull.getHullPoints();
         QPolygon points;
         points.resize((int)ch_points.size());
 

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -1381,7 +1381,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1403,7 +1403,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1425,7 +1425,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";
@@ -1447,7 +1447,7 @@ namespace OpenMS
     if (tv)
     {
       String text = tv->getName();
-      String type = tv->getType();
+      const String& type = tv->getType();
       if (type != "")
       {
         text += " (" + type + ")";

--- a/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
@@ -931,7 +931,7 @@ namespace OpenMS
     LayerData& current_layer = current_canvas->getCurrentLayer();
     const SpectrumType& current_spectrum = current_layer.getCurrentSpectrum();
 
-    AASequence aa_sequence = ph.getSequence();
+    const AASequence& aa_sequence = ph.getSequence();
 
     // get measured spectrum indices and spectrum
     Size current_spectrum_layer_index = current_canvas->getCurrentLayerIndex();

--- a/src/tests/class_tests/openms/source/AreaIterator_test.cpp
+++ b/src/tests/class_tests/openms/source/AreaIterator_test.cpp
@@ -128,7 +128,7 @@ START_SECTION((AreaIterator(const AreaIterator &rhs)))
 	AI a1;
 	AI a2(exp.begin(),exp.RTBegin(0), exp.RTEnd(10), 500, 600);
 
-	AI a3(a2);
+	const AI& a3(a2);
 	TEST_EQUAL(a3==a1, false)
 	TEST_EQUAL(a3==a2, true)
 	

--- a/src/tests/class_tests/openms/source/ChargePair_test.cpp
+++ b/src/tests/class_tests/openms/source/ChargePair_test.cpp
@@ -83,7 +83,7 @@ END_SECTION
 START_SECTION((ChargePair(const ChargePair &rhs)))
 {
 	ChargePair cp2(34,45, 4,5, cmp, 12.34, false);
-	ChargePair cp (cp2);
+	const ChargePair& cp (cp2);
 	TEST_EQUAL(cp.getElementIndex(0), 34);
 	TEST_EQUAL(cp.getElementIndex(1), 45);	
 	TEST_EQUAL(cp.getCharge(0), 4);
@@ -98,7 +98,7 @@ END_SECTION
 START_SECTION((ChargePair& operator=(const ChargePair &rhs)))
 {
 	ChargePair cp2(34,45, 4,5, cmp, 12.34, false);
-	ChargePair cp = cp2;
+	const ChargePair& cp = cp2;
 	TEST_EQUAL(cp.getElementIndex(0), 34);
 	TEST_EQUAL(cp.getElementIndex(1), 45);	
 	TEST_EQUAL(cp.getCharge(0), 4);

--- a/src/tests/class_tests/openms/source/ChromatogramTools_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramTools_test.cpp
@@ -66,7 +66,7 @@ END_SECTION
 START_SECTION((ChromatogramTools(const ChromatogramTools &)))
 {
   ChromatogramTools tmp;
-	ChromatogramTools tmp2(tmp);
+	const ChromatogramTools& tmp2(tmp);
 	NOT_TESTABLE
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ClusterProxyKD_test.cpp
+++ b/src/tests/class_tests/openms/source/ClusterProxyKD_test.cpp
@@ -68,7 +68,7 @@ ClusterProxyKD proxy_1(10, 0.01, 4);
 ClusterProxyKD proxy_2(9, 0.001, 3);
 ClusterProxyKD proxy_3(9, 0.01, 2);
 ClusterProxyKD proxy_4(9, 0.01, 1);
-ClusterProxyKD proxy_5 = proxy_1;
+const ClusterProxyKD& proxy_5 = proxy_1;
 
 START_SECTION((ClusterProxyKD(const ClusterProxyKD& rhs)))
   ptr = new ClusterProxyKD(proxy_1);
@@ -80,7 +80,7 @@ START_SECTION((ClusterProxyKD(const ClusterProxyKD& rhs)))
 END_SECTION
 
 START_SECTION((ClusterProxyKD& operator=(const ClusterProxyKD& rhs)))
-  ClusterProxyKD proxy_5 = proxy_1;
+  const ClusterProxyKD& proxy_5 = proxy_1;
   TEST_EQUAL(proxy_5.getSize(), proxy_1.getSize());
   TEST_REAL_SIMILAR(proxy_5.getAvgDistance(), proxy_1.getAvgDistance());
   TEST_EQUAL(proxy_5.getCenterIndex(), proxy_1.getCenterIndex());

--- a/src/tests/class_tests/openms/source/CompNovoIdentificationBase_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentificationBase_test.cpp
@@ -91,7 +91,7 @@ END_SECTION
 
 START_SECTION([CompNovoIdentificationBase::Permut] Permut(const Permut &rhs))
 	CompNovoIdentificationBase::Permut perm(it, 50.0);
-	CompNovoIdentificationBase::Permut copy(perm);
+	const CompNovoIdentificationBase::Permut& copy(perm);
 	TEST_EQUAL(perm.getScore(), copy.getScore())
 	TEST_EQUAL(*perm.getPermut(), *copy.getPermut())
 END_SECTION

--- a/src/tests/class_tests/openms/source/ConsensusFeature_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusFeature_test.cpp
@@ -388,7 +388,7 @@ START_SECTION((const HandleSetType& getFeatures() const))
   cons.insert(2,tmp_feature);
   const ConsensusFeature cons_copy(cons);
 
-  ConsensusFeature::HandleSetType group = cons_copy.getFeatures();
+  const ConsensusFeature::HandleSetType& group = cons_copy.getFeatures();
 
   ConsensusFeature::HandleSetType::const_iterator it = group.begin();
   TEST_EQUAL(it->getMapIndex(),2)

--- a/src/tests/class_tests/openms/source/ConstRefVector_test.cpp
+++ b/src/tests/class_tests/openms/source/ConstRefVector_test.cpp
@@ -864,13 +864,13 @@ START_SECTION((template <class InputIterator> ConstRefVector(InputIterator f, In
 END_SECTION
 
 START_SECTION((bool operator==(const ConstRefVector &array) const))
-  ConstRefVector<PeakArrayType> pl2(pl);
+  const ConstRefVector<PeakArrayType>& pl2(pl);
   TEST_EQUAL(pl.size(), pl2.size())
   TEST_EQUAL(pl == pl2 , true)
 END_SECTION
 
 START_SECTION((bool operator!=(const ConstRefVector &array) const))
-  ConstRefVector<PeakArrayType> pl2(pl);
+  const ConstRefVector<PeakArrayType>& pl2(pl);
   TEST_EQUAL(pl.size(), pl2.size())
   TEST_EQUAL(pl != pl2 , false)
 END_SECTION

--- a/src/tests/class_tests/openms/source/ControlledVocabulary_test.cpp
+++ b/src/tests/class_tests/openms/source/ControlledVocabulary_test.cpp
@@ -161,7 +161,7 @@ START_SECTION(bool isChildOf(const String& child, const String& parent) const)
 END_SECTION
 
 START_SECTION((const Map<String, CVTerm>& getTerms() const))
-	Map<String, ControlledVocabulary::CVTerm> terms = cv.getTerms();
+	const Map<String, ControlledVocabulary::CVTerm>& terms = cv.getTerms();
 	TEST_EQUAL(terms.size(), 6)
 	TEST_EQUAL(terms.has("OpenMS:1"), true)
 	TEST_EQUAL(terms.has("OpenMS:2"), true)

--- a/src/tests/class_tests/openms/source/DBoundingBox_test.cpp
+++ b/src/tests/class_tests/openms/source/DBoundingBox_test.cpp
@@ -87,7 +87,7 @@ END_SECTION
 
 START_SECTION(DBoundingBox(const DBoundingBox &rhs))
 	BB2 bb(DPosition<2>(1,2),DPosition<2>(3,4));
-	BB2 bb_copy(bb);
+	const BB2& bb_copy(bb);
 	TEST_REAL_SIMILAR(bb.minPosition()[0],bb_copy.minPosition()[0]);
 	TEST_REAL_SIMILAR(bb.minPosition()[1],bb_copy.minPosition()[1]);
 	TEST_REAL_SIMILAR(bb.maxPosition()[0],bb_copy.maxPosition()[0]);

--- a/src/tests/class_tests/openms/source/DIntervalBase_test.cpp
+++ b/src/tests/class_tests/openms/source/DIntervalBase_test.cpp
@@ -148,7 +148,7 @@ END_SECTION
 
 START_SECTION((DIntervalBase(const DIntervalBase& rhs)))
 	I2 tmp(p1,p2);
-	I2 tmp2(tmp);
+	const I2& tmp2(tmp);
 	TEST_EQUAL(tmp==tmp2,true);
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/DRange_test.cpp
+++ b/src/tests/class_tests/openms/source/DRange_test.cpp
@@ -90,7 +90,7 @@ DRange<2> r(p1,p2);
 //do not modify this range, it is used in many tests
 
 START_SECTION(DRange(const DRange& range))
-	DRange<2> r2(r);
+	const DRange<2>& r2(r);
 	TEST_REAL_SIMILAR(r2.minPosition()[0],-1.0f);
 	TEST_REAL_SIMILAR(r2.minPosition()[1],-2.0f);
 	TEST_REAL_SIMILAR(r2.maxPosition()[0],3.0f);
@@ -98,7 +98,7 @@ START_SECTION(DRange(const DRange& range))
 END_SECTION
 
 START_SECTION(DRange(const Base& range))
-	Internal::DIntervalBase<2> ib(r);
+	const Internal::DIntervalBase<2>& ib(r);
 	DRange<2> r2(ib);
 	TEST_REAL_SIMILAR(r2.minPosition()[0],-1.0f);
 	TEST_REAL_SIMILAR(r2.minPosition()[1],-2.0f);
@@ -107,7 +107,7 @@ START_SECTION(DRange(const Base& range))
 END_SECTION
 
 START_SECTION(DRange& operator=(const Base& rhs))
-	Internal::DIntervalBase<2> ib(r);
+	const Internal::DIntervalBase<2>& ib(r);
 	DRange<2> r2;
 	r2 = ib;
 	TEST_REAL_SIMILAR(r2.minPosition()[0],-1.0f);

--- a/src/tests/class_tests/openms/source/DataValue_test.cpp
+++ b/src/tests/class_tests/openms/source/DataValue_test.cpp
@@ -223,16 +223,16 @@ START_SECTION((DataValue(const DataValue&)))
   DataValue p9;
   DataValue p10(ListUtils::create<Int>("1,2,3,4,5"));
   DataValue p11(ListUtils::create<double>("1.2,2.3,3.4"));
-  DataValue copy_of_p1(p1);
-  DataValue copy_of_p3(p3);
-  DataValue copy_of_p4(p4);
-  DataValue copy_of_p5(p5);
-  DataValue copy_of_p6(p6);
-  DataValue copy_of_p7(p7);
-  DataValue copy_of_p8(p8);
-  DataValue copy_of_p9(p9);
-  DataValue copy_of_p10(p10);
-  DataValue copy_of_p11(p11);
+  const DataValue& copy_of_p1(p1);
+  const DataValue& copy_of_p3(p3);
+  const DataValue& copy_of_p4(p4);
+  const DataValue& copy_of_p5(p5);
+  const DataValue& copy_of_p6(p6);
+  const DataValue& copy_of_p7(p7);
+  const DataValue& copy_of_p8(p8);
+  const DataValue& copy_of_p9(p9);
+  const DataValue& copy_of_p10(p10);
+  const DataValue& copy_of_p11(p11);
   TEST_REAL_SIMILAR( (double) copy_of_p1, 1.23)
   TEST_REAL_SIMILAR( (float) copy_of_p3, 1.23)
   TEST_EQUAL( (Int) copy_of_p4, -3)

--- a/src/tests/class_tests/openms/source/DocumentIDTagger_test.cpp
+++ b/src/tests/class_tests/openms/source/DocumentIDTagger_test.cpp
@@ -76,7 +76,7 @@ END_SECTION
 START_SECTION((DocumentIDTagger(const DocumentIDTagger &source)))
 {
   DocumentIDTagger tagme("SomeTOPPTool");
-  DocumentIDTagger tagme2(tagme);
+  const DocumentIDTagger& tagme2(tagme);
 
   TEST_EQUAL(tagme==tagme2, true)
 }
@@ -85,7 +85,7 @@ END_SECTION
 START_SECTION((DocumentIDTagger& operator=(const DocumentIDTagger &source)))
 {
   DocumentIDTagger tagme("SomeTOPPTool");
-	DocumentIDTagger tagme2 = tagme;
+	const DocumentIDTagger& tagme2 = tagme;
 	TEST_EQUAL(tagme==tagme2,true)
 }
 END_SECTION
@@ -93,9 +93,9 @@ END_SECTION
 START_SECTION((bool operator==(const DocumentIDTagger &source) const ))
 {
   DocumentIDTagger tagme("SomeTOPPTool");
-	DocumentIDTagger tagme2 = tagme;
+	const DocumentIDTagger& tagme2 = tagme;
 	TEST_EQUAL(tagme==tagme2, true)
-	DocumentIDTagger tagme3(tagme);
+	const DocumentIDTagger& tagme3(tagme);
 	TEST_EQUAL(tagme==tagme3, true)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/EGHTraceFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/EGHTraceFitter_test.cpp
@@ -280,7 +280,7 @@ END_SECTION
 
 START_SECTION((EGHTraceFitter(const EGHTraceFitter& other)))
 {
-  EGHTraceFitter egh1(egh_trace_fitter);
+  const EGHTraceFitter& egh1(egh_trace_fitter);
 
   TEST_EQUAL(egh1.getCenter(),egh_trace_fitter.getCenter())
   TEST_EQUAL(egh1.getHeight(),egh_trace_fitter.getHeight())

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -95,7 +95,7 @@ START_SECTION(EmpiricalFormula(EmpiricalFormula&&) = default)
   EmpiricalFormula e = EmpiricalFormula("C4");
 
   EmpiricalFormula ef(e);
-  EmpiricalFormula ef2(e);
+  const EmpiricalFormula& ef2(e);
 
   TEST_NOT_EQUAL(ef, ef_empty)
 
@@ -154,7 +154,7 @@ START_SECTION(EmpiricalFormula& operator=(EmpiricalFormula&&) & = default)
   EmpiricalFormula e = EmpiricalFormula("C4");
 
   EmpiricalFormula ef(e);
-  EmpiricalFormula ef2(e);
+  const EmpiricalFormula& ef2(e);
   TEST_NOT_EQUAL(ef, ef_empty)
 
   // the move target should be equal, while the move source should be empty

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -99,7 +99,7 @@ END_SECTION
 
 START_SECTION((const MSFileSection& getMSFileSection() const ))
 {
-  ExperimentalDesign::MSFileSection fs = labelfree_unfractionated_design.getMSFileSection();
+  const ExperimentalDesign::MSFileSection& fs = labelfree_unfractionated_design.getMSFileSection();
 }
 END_SECTION
 
@@ -113,7 +113,7 @@ END_SECTION
 
 START_SECTION((const ExperimentalDesign::SampleSection& getSampleSection() const ))
 {
-  ExperimentalDesign::SampleSection ss = labelfree_unfractionated_design.getSampleSection();
+  const ExperimentalDesign::SampleSection& ss = labelfree_unfractionated_design.getSampleSection();
 }
 END_SECTION
 
@@ -288,9 +288,9 @@ START_SECTION((String SampleSection::getFactorValue(const unsigned sample, const
   // Note: Factors are the same (correctness tested in ExperimentalDesign::SampleSection::getFactors())
   const auto lns = labelfree_unfractionated_design.getNumberOfSamples();
 
-  auto lss_tt = labelfree_unfractionated_design.getSampleSection();
-  auto lss_st = labelfree_unfractionated_single_table_design.getSampleSection();
-  auto lss_stns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection();
+  const auto& lss_tt = labelfree_unfractionated_design.getSampleSection();
+  const auto& lss_st = labelfree_unfractionated_single_table_design.getSampleSection();
+  const auto& lss_stns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection();
 
   // 12 samples (see getNumberOfSamples test)
   for (size_t sample = 1; sample <= lns; ++sample)
@@ -308,8 +308,8 @@ START_SECTION((String SampleSection::getFactorValue(const unsigned sample, const
   }    
 
   const auto fns = fourplex_fractionated_design.getNumberOfSamples();
-  auto fss_tt = fourplex_fractionated_design.getSampleSection();
-  auto fss_st = fourplex_fractionated_single_table_design.getSampleSection();
+  const auto& fss_tt = fourplex_fractionated_design.getSampleSection();
+  const auto& fss_st = fourplex_fractionated_single_table_design.getSampleSection();
   // 8 samples (see getNumberOfSamples test)
   for (size_t sample = 1; sample <= fns; ++sample)
   {

--- a/src/tests/class_tests/openms/source/FeatureFinderAlgorithmMRM_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderAlgorithmMRM_test.cpp
@@ -78,7 +78,7 @@ START_SECTION((virtual void run()))
 	MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("FeatureFinderAlgorithmMRM_input.mzML"), exp);
 
 	FeatureMap features, seeds;
-	Param ff_param(ptr->getParameters());
+	const Param& ff_param(ptr->getParameters());
 	ff.run("mrm", exp, features, ff_param, seeds);
 
 	TEST_EQUAL(exp.getChromatograms().size(), 3)

--- a/src/tests/class_tests/openms/source/GaussTraceFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/GaussTraceFitter_test.cpp
@@ -278,7 +278,7 @@ END_SECTION
 
 START_SECTION((GaussTraceFitter(const GaussTraceFitter& other)))
 {
-  GTF gtf2(gaussian_trace_fitter);
+  const GTF& gtf2(gaussian_trace_fitter);
 
   TEST_REAL_SIMILAR(gaussian_trace_fitter.getCenter(), gtf2.getCenter())
   TEST_REAL_SIMILAR(gaussian_trace_fitter.getHeight(), gtf2.getHeight())
@@ -289,7 +289,7 @@ END_SECTION
 
 START_SECTION((GaussTraceFitter& operator=(const GaussTraceFitter& source)))
 {
-  GTF gtf3 = gaussian_trace_fitter;
+  const GTF& gtf3 = gaussian_trace_fitter;
 
   TEST_REAL_SIMILAR(gaussian_trace_fitter.getCenter(), gtf3.getCenter())
   TEST_REAL_SIMILAR(gaussian_trace_fitter.getHeight(), gtf3.getHeight())

--- a/src/tests/class_tests/openms/source/Histogram_test.cpp
+++ b/src/tests/class_tests/openms/source/Histogram_test.cpp
@@ -66,7 +66,7 @@ END_SECTION
 Histogram<float,float> d(0, 10, 1);
 
 START_SECTION((Histogram(const Histogram& histogram)))
-	Histogram<float, float> d2(d);
+	const Histogram<float, float>& d2(d);
 	TEST_EQUAL(d == d2, true)
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/IDFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/IDFilter_test.cpp
@@ -1030,7 +1030,7 @@ START_SECTION((template<class PeakT> static void keepHitsMatchingProteins(MSExpe
 {
   PeakMap experiment;
   vector<FASTAFile::FASTAEntry> proteins;
-  vector<PeptideIdentification> peptides = global_peptides;
+  const vector<PeptideIdentification>& peptides = global_peptides;
 
   proteins.push_back(FASTAFile::FASTAEntry("Q824A5", "first desription",
                                            "LHASGITVTEIPVTATNFK"));

--- a/src/tests/class_tests/openms/source/IMSAlphabet_test.cpp
+++ b/src/tests/class_tests/openms/source/IMSAlphabet_test.cpp
@@ -113,7 +113,7 @@ IMSAlphabet alphabet(elements);
 
 START_SECTION((IMSAlphabet(const IMSAlphabet &alphabet)))
 {
-  IMSAlphabet alphabet_copy(alphabet);
+  const IMSAlphabet& alphabet_copy(alphabet);
 
   TEST_EQUAL(alphabet_copy.size(), 3)
   TEST_EQUAL(alphabet_copy.getName(0), "hydrogen")

--- a/src/tests/class_tests/openms/source/ITRAQLabeler_test.cpp
+++ b/src/tests/class_tests/openms/source/ITRAQLabeler_test.cpp
@@ -213,7 +213,7 @@ START_SECTION((void postRawTandemMSHook(SimTypes::FeatureMapSimVector &, SimType
   DoubleList elution_bounds(eb);
   elution_bounds[0] = 100; elution_bounds[1] = 509.2; elution_bounds[2] = 120; elution_bounds[3] = 734.3;
   std::vector<double> ei(5, 0.5); // 50% elution profile
-  DoubleList elution_ints(ei);
+  const DoubleList& elution_ints(ei);
   Feature f;
   f.setMetaValue("elution_profile_bounds", elution_bounds);
   f.setMetaValue("elution_profile_intensities", elution_ints);

--- a/src/tests/class_tests/openms/source/InterpolationModel_test.cpp
+++ b/src/tests/class_tests/openms/source/InterpolationModel_test.cpp
@@ -279,7 +279,7 @@ END_SECTION
 START_SECTION( const LinearInterpolation& getInterpolation() const )
 	TestModel tm;
 	InterpolationModel::LinearInterpolation interpol1;
-	InterpolationModel::LinearInterpolation interpol2 = tm.getInterpolation();
+	const InterpolationModel::LinearInterpolation& interpol2 = tm.getInterpolation();
 
 	// compare models
 	TEST_REAL_SIMILAR(interpol1.getScale(), interpol2.getScale());

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -142,7 +142,7 @@ END_SECTION
 START_SECTION(void set(const ContainerType &distribution))
   IsotopeDistribution iso1(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11))), iso2;
   TEST_EQUAL(iso1 == iso2, false)
-  IsotopeDistribution::ContainerType container = iso1.getContainer();
+  const IsotopeDistribution::ContainerType& container = iso1.getContainer();
   iso2.set(container);
   TEST_EQUAL(iso1.getContainer() == iso2.getContainer(), true)
   TEST_EQUAL(iso1 == iso2, true)

--- a/src/tests/class_tests/openms/source/KDTreeFeatureMaps_test.cpp
+++ b/src/tests/class_tests/openms/source/KDTreeFeatureMaps_test.cpp
@@ -100,7 +100,7 @@ START_SECTION((KDTreeFeatureMaps(const KDTreeFeatureMaps& rhs)))
 END_SECTION
 
 START_SECTION((KDTreeFeatureMaps& operator=(const KDTreeFeatureMaps& rhs)))
-  KDTreeFeatureMaps kd_data_2 = kd_data_1;
+  const KDTreeFeatureMaps& kd_data_2 = kd_data_1;
   TEST_EQUAL(kd_data_2.size(), kd_data_1.size())
   TEST_EQUAL(kd_data_2.size(), 2)
   TEST_EQUAL(kd_data_2.mz(0), kd_data_1.mz(0))

--- a/src/tests/class_tests/openms/source/KDTreeFeatureNode_test.cpp
+++ b/src/tests/class_tests/openms/source/KDTreeFeatureNode_test.cpp
@@ -97,7 +97,7 @@ START_SECTION((KDTreeFeatureNode(const KDTreeFeatureNode& rhs)))
 END_SECTION
 
 START_SECTION((KDTreeFeatureNode& operator=(KDTreeFeatureNode const& rhs)))
-  KDTreeFeatureNode node_2 = node_1;
+  const KDTreeFeatureNode& node_2 = node_1;
   TEST_EQUAL(node_2.getIndex(), node_1.getIndex())
   TEST_REAL_SIMILAR(node_2[0], node_1[0])
   TEST_REAL_SIMILAR(node_2[1], node_1[1])

--- a/src/tests/class_tests/openms/source/MQEvidenceExporter_test.cpp
+++ b/src/tests/class_tests/openms/source/MQEvidenceExporter_test.cpp
@@ -51,7 +51,7 @@ using namespace OpenMS;
 /////////////////////////////////////////////////////////////
 
 File::TempDir dir;
-const String path = dir.getPath();
+const String& path = dir.getPath();
 
 START_SECTION(MQEvidence())
 {

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -1206,7 +1206,7 @@ const MSSpectrum spec_test = [](){
 
 START_SECTION((Size findNearest(CoordinateType mz) const))
 {
-  MSSpectrum tmp = spec_test;
+  const MSSpectrum& tmp = spec_test;
 
   //test outside mass range
   TEST_EQUAL(tmp.findNearest(400.0),0);

--- a/src/tests/class_tests/openms/source/MassDecomposition_test.cpp
+++ b/src/tests/class_tests/openms/source/MassDecomposition_test.cpp
@@ -68,7 +68,7 @@ START_SECTION((MassDecomposition(const MassDecomposition &deco)))
 	TEST_EQUAL(md.getNumberOfMaxAA(), 200)
 	TEST_STRING_EQUAL(md.toString(), "C3 M4 S200")
 
-	MassDecomposition md2(md);
+	const MassDecomposition& md2(md);
 	TEST_EQUAL(md2.getNumberOfMaxAA(), 200)
 	TEST_STRING_EQUAL(md2.toString(), "C3 M4 S200")
 }

--- a/src/tests/class_tests/openms/source/MassTrace_test.cpp
+++ b/src/tests/class_tests/openms/source/MassTrace_test.cpp
@@ -182,7 +182,7 @@ END_SECTION
 
 START_SECTION((const PeakType& operator[](const Size &mt_idx) const ))
 {
-  const MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
 
   double rt1 = test_mt_const[1].getRT();
   double mz1 = test_mt_const[1].getMZ();
@@ -340,7 +340,7 @@ END_SECTION
 
 START_SECTION((double getCentroidMZ() const ))
 {
-  MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
   double test_mt_cent_mz = test_mt_const.getCentroidMZ();
   TEST_REAL_SIMILAR(test_mt_cent_mz, 230.10188);
 }
@@ -349,7 +349,7 @@ END_SECTION
 /////
 START_SECTION((double getCentroidRT() const ))
 {
-  MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
   double test_mt_cent_rt = test_mt_const.getCentroidRT();
   TEST_REAL_SIMILAR(test_mt_cent_rt, 155.319906426507);
 }
@@ -393,7 +393,7 @@ END_SECTION
                           
 START_SECTION((double getCentroidSD() const ))
 {
-  MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
   double test_mt_sd = test_mt_const.getCentroidSD();
   TEST_REAL_SIMILAR(test_mt_sd, 0.0004594);
 }
@@ -404,7 +404,7 @@ END_SECTION
 
 START_SECTION((double getTraceLength() const ))
 {
-  const MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
 
   double mt_length = test_mt_const.getTraceLength();
 
@@ -439,7 +439,7 @@ END_SECTION
 
 START_SECTION((std::vector<double> getSmoothedIntensities()))
 {
-  std::vector<double> smoothed_vec = test_mt.getSmoothedIntensities();
+  const std::vector<double>& smoothed_vec = test_mt.getSmoothedIntensities();
 
   TEST_EQUAL(smoothed_vec.empty(), false);
   TEST_EQUAL(smoothed_vec.size(), smoothed_ints.size());
@@ -478,7 +478,7 @@ END_SECTION
 
 START_SECTION((double getMaxIntensity(bool) const ))
 {
-  const MassTrace test_mt_const(test_mt);
+  const MassTrace& test_mt_const(test_mt);
   double smoothed_maxint = test_mt_const.getMaxIntensity(true);
   TEST_REAL_SIMILAR(smoothed_maxint, 33000000.0);
 
@@ -491,7 +491,7 @@ END_SECTION
 
 START_SECTION((const std::vector<double>& getSmoothedIntensities() const))
 {
-  std::vector<double> smoothed_vec = test_mt.getSmoothedIntensities();
+  const std::vector<double>& smoothed_vec = test_mt.getSmoothedIntensities();
 
   TEST_EQUAL(smoothed_vec.empty(), false);
   TEST_EQUAL(smoothed_vec.size(), smoothed_ints.size());

--- a/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
@@ -144,7 +144,7 @@ START_SECTION((String getUnit(const String& name) const))
 END_SECTION
 
 START_SECTION((MetaInfoRegistry(const MetaInfoRegistry& rhs)))
-	MetaInfoRegistry mir2(mir);
+	const MetaInfoRegistry& mir2(mir);
   TEST_EQUAL(mir2.getIndex("testname"), 1024)
   TEST_EQUAL(mir2.getIndex("retention time"), 1025)
 	TEST_STRING_EQUAL(mir2.getName(1), "isotopic_range")

--- a/src/tests/class_tests/openms/source/MetaInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfo_test.cpp
@@ -111,7 +111,7 @@ START_SECTION((bool empty() const))
 END_SECTION
 
 START_SECTION((MetaInfo(const MetaInfo& rhs)))
-	MetaInfo mi3(mi);
+	const MetaInfo& mi3(mi);
 	TEST_REAL_SIMILAR(double(mi3.getValue("cluster_id")),double(mi.getValue("cluster_id")))
 	TEST_STRING_EQUAL(mi3.getValue("testname"),"testtesttest2")
 END_SECTION

--- a/src/tests/class_tests/openms/source/ModificationDefinitionsSet_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionsSet_test.cpp
@@ -232,7 +232,7 @@ START_SECTION(const std::set<ModificationDefinition>& getFixedModifications() co
   fixed_mods.insert("Phospho (T)");
   fixed_mods.insert("Phospho (Y)");
 
-  set<ModificationDefinition> mod_defs = mod_set1.getFixedModifications();
+  const set<ModificationDefinition>& mod_defs = mod_set1.getFixedModifications();
   TEST_EQUAL(mod_defs.size(), 3)
   for (set<ModificationDefinition>::const_iterator it = mod_defs.begin(); it != mod_defs.end(); ++it)
   {
@@ -249,7 +249,7 @@ START_SECTION(const std::set<ModificationDefinition>& getVariableModifications()
   mods.insert("Phospho (S)");
   mods.insert("Carbamidomethyl (C)");
 
-  set<ModificationDefinition> mod_defs = mod_set1.getVariableModifications();
+  const set<ModificationDefinition>& mod_defs = mod_set1.getVariableModifications();
   TEST_EQUAL(mod_defs.size(), 2)
   for (set<ModificationDefinition>::const_iterator it = mod_defs.begin(); it != mod_defs.end(); ++it)
   {

--- a/src/tests/class_tests/openms/source/NASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/NASequence_test.cpp
@@ -72,7 +72,7 @@ START_SECTION((NASequence(const NASequence&) = default))
 {
   // test Copy Constructor
   NASequence aaa = NASequence::fromString("AAA");
-  NASequence aaa2(aaa);
+  const NASequence& aaa2(aaa);
 
   TEST_EQUAL(aaa.size(), 3);
   TEST_EQUAL(aaa2.size(), 3);
@@ -127,7 +127,7 @@ END_SECTION
 START_SECTION((bool operator==(const NASequence& rhs) const))
 {
   NASequence aaa = NASequence::fromString("AAA");
-  NASequence aaa2(aaa);
+  const NASequence& aaa2(aaa);
   TEST_EQUAL(aaa.operator==(aaa2), true);
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/Normalizer_test.cpp
+++ b/src/tests/class_tests/openms/source/Normalizer_test.cpp
@@ -108,7 +108,7 @@ START_SECTION((void filterPeakMap(PeakMap& exp) const))
 	delete e_ptr;
 	e_ptr = new Normalizer();
 
-  PeakSpectrum spec = spec_ref;
+  const PeakSpectrum& spec = spec_ref;
 
 	PeakMap pm;
 	pm.addSpectrum(spec);

--- a/src/tests/class_tests/openms/source/ParamValue_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamValue_test.cpp
@@ -200,16 +200,16 @@ START_TEST(ParamValue, "$Id$")
                     ParamValue p9;
                     ParamValue p10(vector<int>{1,2,3,4,5});
                     ParamValue p11(vector<double>{1.2,2.3,3.4});
-                    ParamValue copy_of_p1(p1);
-                    ParamValue copy_of_p3(p3);
-                    ParamValue copy_of_p4(p4);
-                    ParamValue copy_of_p5(p5);
-                    ParamValue copy_of_p6(p6);
-                    ParamValue copy_of_p7(p7);
-                    ParamValue copy_of_p8(p8);
-                    ParamValue copy_of_p9(p9);
-                    ParamValue copy_of_p10(p10);
-                    ParamValue copy_of_p11(p11);
+                    const ParamValue& copy_of_p1(p1);
+                    const ParamValue& copy_of_p3(p3);
+                    const ParamValue& copy_of_p4(p4);
+                    const ParamValue& copy_of_p5(p5);
+                    const ParamValue& copy_of_p6(p6);
+                    const ParamValue& copy_of_p7(p7);
+                    const ParamValue& copy_of_p8(p8);
+                    const ParamValue& copy_of_p9(p9);
+                    const ParamValue& copy_of_p10(p10);
+                    const ParamValue& copy_of_p11(p11);
                     TEST_REAL_SIMILAR( (double) copy_of_p1, 1.23)
                     TEST_REAL_SIMILAR( (float) copy_of_p3, 1.23)
                     TEST_EQUAL( (Int) copy_of_p4, -3)

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -934,7 +934,7 @@ p_src.setSectionDescription("test","sectiondesc");
 p_src.addTags("test:float", {"a", "b", "c"});
 
 START_SECTION((Param(const Param& rhs)))
-	Param p2(p_src);
+	const Param& p2(p_src);
 	TEST_REAL_SIMILAR(float(p2.getValue("test:float")), 17.4)
 	TEST_STRING_EQUAL(p_src.getDescription("test:float"), "floatdesc")
 	TEST_EQUAL(p2.getValue("test:string"), "test,test,test")

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -190,7 +190,7 @@ ptr = new PeakIntegrator();
 
 START_SECTION(getParameters())
 {
-  Param params = ptr->getParameters();
+  const Param& params = ptr->getParameters();
   TEST_EQUAL(params.getValue("integration_type"), INTEGRATION_TYPE_INTENSITYSUM)
   TEST_EQUAL(params.getValue("baseline_type"), BASELINE_TYPE_BASETOBASE)
 }

--- a/src/tests/class_tests/openms/source/PrecursorCorrection_test.cpp
+++ b/src/tests/class_tests/openms/source/PrecursorCorrection_test.cpp
@@ -180,7 +180,7 @@ END_SECTION
 
 START_SECTION((static void getPrecursors(const MSExperiment &exp, std::vector< Precursor > &precursors, std::vector< double > &precursors_rt, std::vector< Size > &precursor_scan_index)))
 {
-  MSExperiment getP_exp = exp;
+  const MSExperiment& getP_exp = exp;
   vector<Precursor> precursor;
   vector<double> rt;
   vector<Size> index;

--- a/src/tests/class_tests/openms/source/PrecursorIonSelectionPreprocessing_test.cpp
+++ b/src/tests/class_tests/openms/source/PrecursorIonSelectionPreprocessing_test.cpp
@@ -84,7 +84,7 @@ ptr->setParameters(param);
 ptr->dbPreprocessing(OPENMS_GET_TEST_DATA_PATH("PrecursorIonSelectionPreprocessing_db.fasta"),true);
 
 START_SECTION((const std::map<String,std::vector<double> >& getProtMasses() const))
-	std::map<String,std::vector<double> > prot_map = ptr->getProtMasses();
+	const std::map<String,std::vector<double> >& prot_map = ptr->getProtMasses();
 	TEST_EQUAL(prot_map.size(), 3)
 END_SECTION
 
@@ -99,7 +99,7 @@ END_SECTION
 
 
 START_SECTION(void dbPreprocessing(String db_path, bool save=true))
-	std::map<String,std::vector<double> > prot_map = ptr->getProtMasses();
+	const std::map<String,std::vector<double> >& prot_map = ptr->getProtMasses();
 	TEST_EQUAL(prot_map.size(), 3)
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Ribonucleotide_test.cpp
+++ b/src/tests/class_tests/openms/source/Ribonucleotide_test.cpp
@@ -63,7 +63,7 @@ END_SECTION
 Ribonucleotide test_ribo("test", "T");
 
 START_SECTION(Ribonucleotide(const Ribonucleotide& ribonucleotide))
-  Ribonucleotide copy(test_ribo);
+  const Ribonucleotide& copy(test_ribo);
   TEST_EQUAL(copy, test_ribo)
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/StringListUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/StringListUtils_test.cpp
@@ -219,7 +219,7 @@ END_SECTION
 
 START_SECTION((static ConstIterator searchPrefix(const ConstIterator &start, const ConstIterator &end, const String &text, bool trim=false)))
 {
-	const StringList list(tmp_list);
+	const StringList& list(tmp_list);
 
 	TEST_EQUAL(StringListUtils::searchPrefix(list.begin(), list.end(), "first_line") == list.begin(), true)
 	TEST_EQUAL(StringListUtils::searchPrefix(list.begin(), list.end(), "middle_line") == (list.begin()+3), true)
@@ -240,7 +240,7 @@ START_SECTION((static ConstIterator searchPrefix(const ConstIterator &start, con
 	TEST_EQUAL(StringListUtils::searchPrefix(list.begin() + 1, list.end(), "first_line",true) == list.end(), true)
 
 	//Try it on the same file (but trimmed)
-	const StringList list2 = tmp_list2;
+	const StringList& list2 = tmp_list2;
 
 	TEST_EQUAL(StringListUtils::searchPrefix(list2.begin(), list2.end(), "first_line") == list2.begin(), true)
 	TEST_EQUAL(StringListUtils::searchPrefix(list2.begin(), list2.end(), "middle_line") == (list2.begin()+3), true)
@@ -261,7 +261,7 @@ END_SECTION
 
 START_SECTION((static ConstIterator searchPrefix(const StringList &container, const String &text, bool trim=false)))
 {
-	const StringList list(tmp_list);
+	const StringList& list(tmp_list);
 
 	TEST_EQUAL(StringListUtils::searchPrefix(list, "first_line") == list.begin(), true)
 	TEST_EQUAL(StringListUtils::searchPrefix(list, "middle_line") == (list.begin()+3), true)
@@ -279,7 +279,7 @@ START_SECTION((static ConstIterator searchPrefix(const StringList &container, co
 	TEST_EQUAL(StringListUtils::searchPrefix(list, "invented_line",true) == list.end(), true)
 
 	//Try it on the same file (but trimmed)
-	const StringList list2 = tmp_list2;
+	const StringList& list2 = tmp_list2;
 
 	TEST_EQUAL(StringListUtils::searchPrefix(list2, "first_line") == list2.begin(), true)
 	TEST_EQUAL(StringListUtils::searchPrefix(list2, "middle_line") == (list2.begin()+3), true)
@@ -298,7 +298,7 @@ END_SECTION
 
 START_SECTION((static ConstIterator searchSuffix(const ConstIterator &start, const ConstIterator &end, const String &text, bool trim=false)))
 {
-	const StringList list(tmp_list);
+	const StringList& list(tmp_list);
 
 	TEST_EQUAL(StringListUtils::searchSuffix(list.begin(), list.end(), "invented_line",true) == list.end(), true)
 	TEST_EQUAL(StringListUtils::searchSuffix(list.begin(), list.end(), "back_space_line",true) == list.begin()+7, true)
@@ -313,7 +313,7 @@ END_SECTION
 
 START_SECTION((static ConstIterator searchSuffix(const StringList &container, const String &text, bool trim=false)))
 {
-	const StringList list(tmp_list);
+	const StringList& list(tmp_list);
 
 	TEST_EQUAL(StringListUtils::searchSuffix(list, "invented_line",true) == list.end(), true)
 	TEST_EQUAL(StringListUtils::searchSuffix(list, "back_space_line",true) == list.begin()+7, true)

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -757,7 +757,7 @@ START_SECTION(([EXTRA] const Param& getParam_()))
 	test_param.setValidStrings("param_flag", {"true","false"});
 
 	TOPPBaseTestParam temp(test_param);
-	Param result = temp.getParam(); // contains "test_param" + some default stuff
+	const Param& result = temp.getParam(); // contains "test_param" + some default stuff
 	for (Param::ParamIterator it = test_param.begin(); it != test_param.end(); ++it)
 	{
 		TEST_EQUAL(*it == result.getEntry(it.getName()), true);

--- a/src/tests/class_tests/openms/source/TransformationDescription_test.cpp
+++ b/src/tests/class_tests/openms/source/TransformationDescription_test.cpp
@@ -279,7 +279,7 @@ START_SECTION((TransformationDescription(const TransformationDescription& rhs)))
 	TEST_EQUAL(td.getModelType(), td2.getModelType());
 	TEST_EQUAL(td.getDataPoints() == td2.getDataPoints(), true);
 	Param params = td.getModelParameters();
-	Param params2 = td2.getModelParameters();
+	const Param& params2 = td2.getModelParameters();
 	TEST_EQUAL(params, params2);
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/TransformationModel_test.cpp
+++ b/src/tests/class_tests/openms/source/TransformationModel_test.cpp
@@ -97,7 +97,7 @@ END_SECTION
 START_SECTION((void getParameters(Param& params) const))
 {
   TransformationModel tm;
-  Param p = tm.getParameters();
+  const Param& p = tm.getParameters();
   TEST_EQUAL(p.empty(), true)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/UniqueIdInterface_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdInterface_test.cpp
@@ -65,7 +65,7 @@ END_SECTION
 START_SECTION((UniqueIdInterface(const UniqueIdInterface &rhs)))
 {
   UniqueIdInterface uii1;
-  UniqueIdInterface uii2(uii1);
+  const UniqueIdInterface& uii2(uii1);
   // to be continued further below
   NOT_TESTABLE
 }

--- a/src/tests/class_tests/openms/source/WeightWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/WeightWrapper_test.cpp
@@ -74,7 +74,7 @@ END_SECTION
 START_SECTION((WeightWrapper(const WeightWrapper &source)))
 {
   WeightWrapper ww(WeightWrapper::AVERAGE);
-  WeightWrapper ww2(ww);
+  const WeightWrapper& ww2(ww);
 
   TEST_EQUAL(ww.getWeightMode(), ww2.getWeightMode())
 }

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -763,7 +763,7 @@ protected:
               auto acciter_inserted = iter_inserted.first->second.emplace(hit.getAccession());
               if (acciter_inserted.second)
               {
-                prot_ids[mzml_to_new_run_idx[original_file]].getHits().emplace_back(std::move(hit));
+                prot_ids[mzml_to_new_run_idx[original_file]].getHits().emplace_back(hit);
               }
             }
           }
@@ -855,7 +855,7 @@ protected:
 
         for (PeptideIdentification& pep : pep_ids)
         {
-          String run_id = pep.getIdentifier();
+          const String& run_id = pep.getIdentifier();
           if (!pep.hasRT() || !pep.hasMZ())
           {
             OPENMS_LOG_FATAL_ERROR << "Peptide ID without RT and/or m/z information found in identification run '" + run_id + "'.\nMake sure that this information is included for all IDs when generating/converting search results. Aborting!" << endl;

--- a/src/topp/CruxAdapter.cpp
+++ b/src/topp/CruxAdapter.cpp
@@ -363,7 +363,7 @@ protected:
       }
       params += debug_args;
 
-      String extra_args = concat;
+      const String& extra_args = concat;
       params += extra_args;
 
       params += " --mzid-output T --decoy-xml-output T ";

--- a/src/topp/FidoAdapter.cpp
+++ b/src/topp/FidoAdapter.cpp
@@ -255,7 +255,7 @@ protected:
     for (const ProteinHit& hit : protein.getHits())
     {
       String target_decoy = hit.getMetaValue("target_decoy").toString();
-      String accession = hit.getAccession();
+      const String& accession = hit.getAccession();
       String sanitized = sanitized_accessions_.left.find(accession)->second;
       if (target_decoy == "target")
       {

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -455,7 +455,7 @@ protected:
     {
       return true; // not having the meta value means passing the test
     }
-    DataValue v_data = mi.getMetaValue(meta_info[0]);
+    const DataValue& v_data = mi.getMetaValue(meta_info[0]);
     DataValue v_user;
     if (v_data.valueType() == DataValue::STRING_VALUE)
     {

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -671,7 +671,7 @@ protected:
       auto checkMVs = [this, &meta_info](PeptideHit& ph)->bool
       {
         if (!ph.metaValueExists(meta_info[0])) return true; // not having the meta value means passing the test
-        DataValue v_data = ph.getMetaValue(meta_info[0]);
+        const DataValue& v_data = ph.getMetaValue(meta_info[0]);
         DataValue v_user;
         switch (v_data.valueType())
         {

--- a/src/topp/IDMapper.cpp
+++ b/src/topp/IDMapper.cpp
@@ -141,7 +141,7 @@ protected:
 
     addEmptyLine_();
     IDMapper mapper;
-    Param p = mapper.getParameters();
+    const Param& p = mapper.getParameters();
     registerDoubleOption_("rt_tolerance", "<value>", p.getValue("rt_tolerance"), "RT tolerance (in seconds) for the matching of peptide identifications and (consensus) features.\nTolerance is understood as 'plus or minus x', so the matching range increases by twice the given value.", false);
     setMinFloat_("rt_tolerance", 0.0);
     registerDoubleOption_("mz_tolerance", "<value>", p.getValue("mz_tolerance"), "m/z tolerance (in ppm or Da) for the matching of peptide identifications and (consensus) features.\nTolerance is understood as 'plus or minus x', so the matching range increases by twice the given value.", false);

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -268,7 +268,7 @@ protected:
   String modifyNTermAASpecificSequence_(const String& seq)
   {
     String swap;
-    string modifiedSequence = seq;
+    const string& modifiedSequence = seq;
     vector<pair<String, char> > massShiftList;
 
     massShiftList.push_back(make_pair("-18.011", 'E'));

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -280,12 +280,12 @@ protected:
       if (separate)
       {
         OPENMS_LOG_INFO << "Writing only decoys to file: " << out << std::endl;
-        targeted_merged = std::move(targeted_decoy);
+        targeted_merged = targeted_decoy;
       }
       else
       {
         OPENMS_LOG_INFO << "Writing targets and decoys to file: " << out << std::endl;
-        targeted_merged = std::move(targeted_exp);
+        targeted_merged = targeted_exp;
         targeted_merged += std::move(targeted_decoy);
       }
 

--- a/src/topp/ProteinResolver.cpp
+++ b/src/topp/ProteinResolver.cpp
@@ -617,7 +617,7 @@ protected:
 
       for (int i = 0; i < list.size(); ++i)
       {
-        QFileInfo fileInfo = list.at(i);
+        const QFileInfo& fileInfo = list.at(i);
         input_list.push_back(fileInfo.absoluteFilePath());
       }
     }

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -373,7 +373,7 @@ namespace OpenMS
     // locale setting
     out << pid.getDateTime().toString() << pid.getSearchEngineVersion();
     // search parameters
-    ProteinIdentification::SearchParameters sp = pid.getSearchParameters();
+    const ProteinIdentification::SearchParameters& sp = pid.getSearchParameters();
     out << sp << nl;
     for (const ProteinHit& hit : pid.getHits())
     {

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -228,7 +228,7 @@ protected:
     // write input xml file
     File::TempDir dir(debug_level_ >= 2);
     String input_filename = dir.getPath() + "tandem_input.xml";
-    String tandem_input_filename = in;
+    const String& tandem_input_filename = in;
     String tandem_output_filename = dir.getPath() + "tandem_output.xml";
     String tandem_taxonomy_filename = dir.getPath() + "tandem_taxonomy.xml";
 

--- a/src/utils/MSstatsConverter.cpp
+++ b/src/utils/MSstatsConverter.cpp
@@ -159,7 +159,7 @@ protected:
         // Experimental Design file
         const String arg_in_design = getStringOption_(param_in_design);
         const ExperimentalDesign design = ExperimentalDesignFile::load(arg_in_design, false);
-        ExperimentalDesign::SampleSection sampleSection = design.getSampleSection();
+        const ExperimentalDesign::SampleSection& sampleSection = design.getSampleSection();
 
         ConsensusMap consensus_map;
         ConsensusXMLFile().load(arg_in, consensus_map);

--- a/src/utils/MultiplexResolver.cpp
+++ b/src/utils/MultiplexResolver.cpp
@@ -160,7 +160,7 @@ private:
     if (section == "labels")
     {     
       MultiplexDeltaMassesGenerator generator;
-      Param p = generator.getParameters();
+      const Param& p = generator.getParameters();
       
       for (Param::ParamIterator it = p.begin(); it != p.end(); ++it)
       {

--- a/src/utils/TriqlerConverter.cpp
+++ b/src/utils/TriqlerConverter.cpp
@@ -129,7 +129,7 @@ protected:
         // Experimental Design file
         const String arg_in_design = getStringOption_(param_in_design);
         const ExperimentalDesign design = ExperimentalDesignFile::load(arg_in_design, false);
-        ExperimentalDesign::SampleSection sampleSection = design.getSampleSection();
+        const ExperimentalDesign::SampleSection& sampleSection = design.getSampleSection();
 
         ConsensusMap consensus_map;
         ConsensusXMLFile().load(arg_in, consensus_map);


### PR DESCRIPTION
# Description

performance-type-promotion-in-math-fn
performance-move-const-arg

Valuable check but could bring up race conditions that got hidden by copying:
performance-unnecessary-copy-initialization

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
