### PR TITLE
Hide IsoSpec using pimpl and add some clang-tidy performance fixes on top

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h
@@ -91,7 +91,7 @@ public:
     ReactionMonitoringTransition & operator=(const ReactionMonitoringTransition & rhs);
 
     /// move assignment operator
-    ReactionMonitoringTransition & operator=(ReactionMonitoringTransition && rhs);
+    ReactionMonitoringTransition & operator=(ReactionMonitoringTransition && rhs) noexcept ;
 
     /** @name Accessors
     */

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
@@ -241,7 +241,7 @@ public:
       **/
     IsoSpecTotalProbGeneratorWrapper(const EmpiricalFormula& formula, double p);
 
-    ~IsoSpecTotalProbGeneratorWrapper() = default;
+    ~IsoSpecTotalProbGeneratorWrapper();
 
     bool nextConf() final;
     Peak1D getConf() final;
@@ -306,7 +306,7 @@ public:
       **/
   IsoSpecThresholdGeneratorWrapper(const EmpiricalFormula& formula, double threshold, bool absolute);
 
-  ~IsoSpecThresholdGeneratorWrapper() = default;
+  ~IsoSpecThresholdGeneratorWrapper();
 
   bool nextConf() final;
   Peak1D getConf() final;
@@ -359,7 +359,7 @@ public:
       **/
   IsoSpecOrderedGeneratorWrapper(const EmpiricalFormula& formula);
 
-  ~IsoSpecOrderedGeneratorWrapper() = default;
+  ~IsoSpecOrderedGeneratorWrapper();
 
   inline bool nextConf() final;
   inline Peak1D getConf() final;

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/Constants.h>
@@ -45,17 +46,21 @@
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
-
 // Override IsoSpec's use of mmap whenever it is available
 #define ISOSPEC_GOT_SYSTEM_MMAN false
 #define ISOSPEC_GOT_MMAN false
 #define ISOSPEC_BUILDING_OPENMS true
 
-#include <OpenMS/../../thirdparty/IsoSpec/IsoSpec/isoSpec++.h>
+// forward declarations
+namespace IsoSpec
+{
+class IsoLayeredGenerator;
+class IsoThresholdGenerator;
+class IsoOrderedGenerator;
+}
 
 namespace OpenMS
 {
-
   /**
     * @brief Interface for the IsoSpec algorithm - a generator of infinitely-resolved theoretical spectra.
     *
@@ -143,7 +148,7 @@ public:
     /**
      * @brief Destructor
      */
-    virtual inline ~IsoSpecGeneratorWrapper() {};
+    virtual ~IsoSpecGeneratorWrapper() = default;
   };
 
   /** @brief A convenience class for the IsoSpec algorithm - easier to use than the IsoSpecGeneratorWrapper classes.
@@ -175,7 +180,7 @@ public:
       **/
     virtual IsotopeDistribution run() = 0;
 
-    virtual inline ~IsoSpecWrapper() {};
+    virtual inline ~IsoSpecWrapper() = default;
   };
 
   //-------------------------------------------------------------------------- 
@@ -236,14 +241,17 @@ public:
       **/
     IsoSpecTotalProbGeneratorWrapper(const EmpiricalFormula& formula, double p);
 
-    inline bool nextConf() final { return ILG.advanceToNextConfiguration(); };
-    inline Peak1D getConf() final { return Peak1D(ILG.mass(), ILG.prob()); };
-    inline double getMass() final { return ILG.mass(); };
-    inline double getIntensity() final { return ILG.prob(); };
-    inline double getLogIntensity() final { return ILG.lprob(); };
+    ~IsoSpecTotalProbGeneratorWrapper() = default;
+
+    bool nextConf() final;
+    Peak1D getConf() final;
+    double getMass() final;
+    double getIntensity() final;
+    double getLogIntensity() final;
 
 protected:
-    IsoSpec::IsoLayeredGenerator ILG;
+    IsoSpecTotalProbGeneratorWrapper(const IsoSpecTotalProbGeneratorWrapper&) = delete;
+    std::unique_ptr<IsoSpec::IsoLayeredGenerator> ILG;
   };
 
   /**
@@ -298,15 +306,18 @@ public:
       **/
   IsoSpecThresholdGeneratorWrapper(const EmpiricalFormula& formula, double threshold, bool absolute);
 
-  inline bool nextConf() final { return ITG.advanceToNextConfiguration(); };
-  inline Peak1D getConf() final { return Peak1D(ITG.mass(), ITG.prob()); };
-  inline double getMass() final { return ITG.mass(); };
-  inline double getIntensity() final { return ITG.prob(); };
-  inline double getLogIntensity() final { return ITG.lprob(); };
+  ~IsoSpecThresholdGeneratorWrapper() = default;
+
+  bool nextConf() final;
+  Peak1D getConf() final;
+  double getMass() final;
+  double getIntensity() final;
+  double getLogIntensity() final;
 
 
 protected:
-  IsoSpec::IsoThresholdGenerator ITG;
+  IsoSpecThresholdGeneratorWrapper(const IsoSpecThresholdGeneratorWrapper&) = delete;
+  std::unique_ptr<IsoSpec::IsoThresholdGenerator> ITG;
   };
 
   /**
@@ -348,14 +359,17 @@ public:
       **/
   IsoSpecOrderedGeneratorWrapper(const EmpiricalFormula& formula);
 
-  inline bool nextConf() final { return IOG.advanceToNextConfiguration(); };
-  inline Peak1D getConf() final { return Peak1D(IOG.mass(), IOG.prob()); };
-  inline double getMass() final { return IOG.mass(); };
-  inline double getIntensity() final { return IOG.prob(); };
-  inline double getLogIntensity() final { return IOG.lprob(); };
+  ~IsoSpecOrderedGeneratorWrapper() = default;
+
+  inline bool nextConf() final;
+  inline Peak1D getConf() final;
+  inline double getMass() final;
+  inline double getIntensity() final;
+  inline double getLogIntensity() final;
 
 protected:
-  IsoSpec::IsoOrderedGenerator IOG;
+  IsoSpecOrderedGeneratorWrapper(const IsoSpecOrderedGeneratorWrapper&) = delete;
+  std::unique_ptr<IsoSpec::IsoOrderedGenerator> IOG;
   };
 
   //-------------------------------------------------------------------------- 
@@ -413,10 +427,13 @@ public:
       **/
     IsoSpecTotalProbWrapper(const EmpiricalFormula& formula, double p, bool do_p_trim = false);
 
+    ~IsoSpecTotalProbWrapper();
+
     IsotopeDistribution run() final;
 
 protected:
-    IsoSpec::IsoLayeredGenerator ILG;
+    IsoSpecTotalProbWrapper(const IsoSpecTotalProbWrapper&) = delete;
+    std::unique_ptr<IsoSpec::IsoLayeredGenerator> ILG;
     const double target_prob;
     const bool do_p_trim;
   };
@@ -472,10 +489,13 @@ public:
       **/
     IsoSpecThresholdWrapper(const EmpiricalFormula& formula, double threshold, bool absolute);
 
+    ~IsoSpecThresholdWrapper();
+
     IsotopeDistribution run() final;
 
 protected:
-    IsoSpec::IsoThresholdGenerator ITG;
+    IsoSpecThresholdWrapper(const IsoSpecThresholdWrapper&) = delete;
+    std::unique_ptr<IsoSpec::IsoThresholdGenerator> ITG;
 
   };
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
@@ -46,10 +46,6 @@
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
-// Override IsoSpec's use of mmap whenever it is available
-#define ISOSPEC_GOT_SYSTEM_MMAN false
-#define ISOSPEC_GOT_MMAN false
-#define ISOSPEC_BUILDING_OPENMS true
 
 // forward declarations
 namespace IsoSpec
@@ -235,6 +231,8 @@ public:
              const std::vector<std::vector<double> >& isotopeProbabilities,
              double p);
 
+    // delete copy constructor
+    IsoSpecTotalProbGeneratorWrapper(const IsoSpecTotalProbGeneratorWrapper&) = delete;
     /**
       * @brief Setup the algorithm to run on an EmpiricalFormula
       *
@@ -250,7 +248,6 @@ public:
     double getLogIntensity() final;
 
 protected:
-    IsoSpecTotalProbGeneratorWrapper(const IsoSpecTotalProbGeneratorWrapper&) = delete;
     std::unique_ptr<IsoSpec::IsoLayeredGenerator> ILG;
   };
 
@@ -300,6 +297,9 @@ public:
              double threshold,
              bool absolute);
 
+  // delete copy constructor
+  IsoSpecThresholdGeneratorWrapper(const IsoSpecThresholdGeneratorWrapper&) = delete;
+
     /**
       * @brief Setup the algorithm to run on an EmpiricalFormula
       *
@@ -316,7 +316,6 @@ public:
 
 
 protected:
-  IsoSpecThresholdGeneratorWrapper(const IsoSpecThresholdGeneratorWrapper&) = delete;
   std::unique_ptr<IsoSpec::IsoThresholdGenerator> ITG;
   };
 
@@ -353,6 +352,8 @@ public:
              const std::vector<std::vector<double> >& isotopeMasses,
              const std::vector<std::vector<double> >& isotopeProbabilities);
 
+  // delete copy constructor
+  IsoSpecOrderedGeneratorWrapper(const IsoSpecOrderedGeneratorWrapper&) = delete;
     /**
       * @brief Setup the algorithm to run on an EmpiricalFormula
       *
@@ -368,7 +369,6 @@ public:
   inline double getLogIntensity() final;
 
 protected:
-  IsoSpecOrderedGeneratorWrapper(const IsoSpecOrderedGeneratorWrapper&) = delete;
   std::unique_ptr<IsoSpec::IsoOrderedGenerator> IOG;
   };
 
@@ -420,6 +420,9 @@ public:
              const std::vector<std::vector<double> >& isotopeProbabilities,
              double p,
              bool do_p_trim = false);
+    
+    // delete copy constructor
+    IsoSpecTotalProbWrapper(const IsoSpecTotalProbWrapper&) = delete;
 
     /**
       * @brief Setup the algorithm to run on an EmpiricalFormula
@@ -432,7 +435,6 @@ public:
     IsotopeDistribution run() final;
 
 protected:
-    IsoSpecTotalProbWrapper(const IsoSpecTotalProbWrapper&) = delete;
     std::unique_ptr<IsoSpec::IsoLayeredGenerator> ILG;
     const double target_prob;
     const bool do_p_trim;
@@ -482,7 +484,9 @@ public:
              const std::vector<std::vector<double> >& isotopeProbabilities,
              double threshold,
              bool absolute);
-
+    
+    // delelte copy constructor
+    IsoSpecThresholdWrapper(const IsoSpecThresholdWrapper&) = delete;
     /**
       * @brief Setup the algorithm to run on an EmpiricalFormula
       *
@@ -494,7 +498,6 @@ public:
     IsotopeDistribution run() final;
 
 protected:
-    IsoSpecThresholdWrapper(const IsoSpecThresholdWrapper&) = delete;
     std::unique_ptr<IsoSpec::IsoThresholdGenerator> ITG;
 
   };

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -184,7 +184,7 @@ namespace OpenMS
     IdentificationData(const IdentificationData& other) = delete;
 
     /// Move constructor
-    IdentificationData(IdentificationData&& other):
+    IdentificationData(IdentificationData&& other) noexcept :
       input_files_(std::move(other.input_files_)),
       processing_softwares_(std::move(other.processing_softwares_)),
       processing_steps_(std::move(other.processing_steps_)),

--- a/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
+++ b/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
@@ -144,7 +144,7 @@ namespace OpenMS
     return *this;
   }
 
-  ReactionMonitoringTransition & ReactionMonitoringTransition::operator=(ReactionMonitoringTransition && rhs)
+  ReactionMonitoringTransition & ReactionMonitoringTransition::operator=(ReactionMonitoringTransition && rhs) noexcept
   {
     if (&rhs != this)
     {

--- a/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
+++ b/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
@@ -145,7 +145,7 @@ namespace OpenMS
   }
 
   ReactionMonitoringTransition & ReactionMonitoringTransition::operator=(ReactionMonitoringTransition && rhs)
-  {
+ noexcept   {
     if (&rhs != this)
     {
       CVTermList::operator=(std::move(rhs));

--- a/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
+++ b/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
@@ -145,7 +145,7 @@ namespace OpenMS
   }
 
   ReactionMonitoringTransition & ReactionMonitoringTransition::operator=(ReactionMonitoringTransition && rhs)
- noexcept   {
+  {
     if (&rhs != this)
     {
       CVTermList::operator=(std::move(rhs));

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
@@ -47,6 +47,8 @@
 #define ISOSPEC_GOT_MMAN false
 #define ISOSPEC_BUILDING_OPENMS true
 
+#include <OpenMS/../../thirdparty/IsoSpec/IsoSpec/isoSpec++.h>
+
 #include "IsoSpec/allocator.cpp"
 #include "IsoSpec/dirtyAllocator.cpp"
 #include "IsoSpec/isoSpec++.cpp"
@@ -128,23 +130,29 @@ namespace OpenMS
     return _OMS_IsoFromParameters(isotopeNumbers, atomCounts, isotopeMasses, isotopeProbabilities);
   }
 
-
-
-
   IsoSpecThresholdGeneratorWrapper::IsoSpecThresholdGeneratorWrapper(const std::vector<int>& isotopeNr,
                     const std::vector<int>& atomCounts,
                     const std::vector<std::vector<double> >& isotopeMasses,
                     const std::vector<std::vector<double> >& isotopeProbabilities,
                     double threshold,
                     bool absolute) :
-  ITG(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), threshold, absolute)
+  ITG(std::make_unique<IsoSpec::IsoThresholdGenerator>(
+    _OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 
+    threshold, 
+    absolute))
   {};
 
   IsoSpecThresholdGeneratorWrapper::IsoSpecThresholdGeneratorWrapper(const EmpiricalFormula& formula,
                     double threshold,
                     bool absolute) :
-  ITG(_OMS_IsoFromEmpiricalFormula(formula), threshold, absolute)
+  ITG(std::make_unique<IsoSpec::IsoThresholdGenerator>(_OMS_IsoFromEmpiricalFormula(formula), threshold, absolute))
   {};
+
+  bool IsoSpecThresholdGeneratorWrapper::nextConf() { return ITG->advanceToNextConfiguration(); };
+  Peak1D IsoSpecThresholdGeneratorWrapper::getConf() { return Peak1D(ITG->mass(), ITG->prob()); };
+  double IsoSpecThresholdGeneratorWrapper::getMass() { return ITG->mass(); };
+  double IsoSpecThresholdGeneratorWrapper::getIntensity() { return ITG->prob(); };
+  double IsoSpecThresholdGeneratorWrapper::getLogIntensity() { return ITG->lprob(); };
 
 
 //  --------------------------------------------------------------------------------
@@ -156,14 +164,19 @@ namespace OpenMS
                     const std::vector<std::vector<double> >& isotopeMasses,
                     const std::vector<std::vector<double> >& isotopeProbabilities,
                     double total_prob_hint) :
-  ILG(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 1024, 1024, true, total_prob_hint)
+  ILG(std::make_unique<IsoSpec::IsoLayeredGenerator>(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 1024, 1024, true, total_prob_hint))
   {};
 
   IsoSpecTotalProbGeneratorWrapper::IsoSpecTotalProbGeneratorWrapper(const EmpiricalFormula& formula,
                     double total_prob_hint) :
-  ILG(_OMS_IsoFromEmpiricalFormula(formula), 1024, 1024, true, total_prob_hint)
+  ILG(std::make_unique<IsoSpec::IsoLayeredGenerator>(_OMS_IsoFromEmpiricalFormula(formula), 1024, 1024, true, total_prob_hint))
   {};
 
+  bool IsoSpecTotalProbGeneratorWrapper::nextConf() { return ILG->advanceToNextConfiguration(); };
+  Peak1D IsoSpecTotalProbGeneratorWrapper::getConf() { return Peak1D(ILG->mass(), ILG->prob()); };
+  double IsoSpecTotalProbGeneratorWrapper::getMass() { return ILG->mass(); };
+  double IsoSpecTotalProbGeneratorWrapper::getIntensity() { return ILG->prob(); };
+  double IsoSpecTotalProbGeneratorWrapper::getLogIntensity() { return ILG->lprob(); };
 
 //  --------------------------------------------------------------------------------
 
@@ -172,12 +185,18 @@ namespace OpenMS
                     const std::vector<int>& atomCounts,
                     const std::vector<std::vector<double> >& isotopeMasses,
                     const std::vector<std::vector<double> >& isotopeProbabilities) :
-  IOG(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities))
+   IOG(std::make_unique<IsoSpec::IsoOrderedGenerator>(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities)))
   {};
 
   IsoSpecOrderedGeneratorWrapper::IsoSpecOrderedGeneratorWrapper(const EmpiricalFormula& formula) :
-  IOG(_OMS_IsoFromEmpiricalFormula(formula))
+    IOG(std::make_unique<IsoSpec::IsoOrderedGenerator>(_OMS_IsoFromEmpiricalFormula(formula)))
   {};
+
+  bool IsoSpecOrderedGeneratorWrapper::nextConf() { return IOG->advanceToNextConfiguration(); };
+  Peak1D IsoSpecOrderedGeneratorWrapper::getConf() { return Peak1D(IOG->mass(), IOG->prob()); };
+  double IsoSpecOrderedGeneratorWrapper::getMass() { return IOG->mass(); };
+  double IsoSpecOrderedGeneratorWrapper::getIntensity() { return IOG->prob(); };
+  double IsoSpecOrderedGeneratorWrapper::getLogIntensity() { return IOG->lprob(); };
 
 //  --------------------------------------------------------------------------------
 
@@ -187,25 +206,31 @@ namespace OpenMS
                     const std::vector<std::vector<double> >& isotopeProbabilities,
                     double threshold,
                     bool absolute) :
-  ITG(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), threshold, absolute)
-  {};
+  ITG(std::make_unique<IsoSpec::IsoThresholdGenerator>(
+    _OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 
+    threshold, 
+    absolute))
+  {}
 
   IsoSpecThresholdWrapper::IsoSpecThresholdWrapper(const EmpiricalFormula& formula,
                     double threshold,
-                    bool absolute) :
-  ITG(_OMS_IsoFromEmpiricalFormula(formula), threshold, absolute)
+                    bool absolute) :                    
+  ITG(std::make_unique<IsoSpec::IsoThresholdGenerator>(
+    _OMS_IsoFromEmpiricalFormula(formula), 
+    threshold, 
+    absolute))
   {};
 
 
   IsotopeDistribution IsoSpecThresholdWrapper::run()
   {
     std::vector<Peak1D> distribution;
-    distribution.reserve(ITG.count_confs());
+    distribution.reserve(ITG->count_confs());
 
-    ITG.reset();
+    ITG->reset();
 
-    while (ITG.advanceToNextConfiguration())
-        distribution.emplace_back(Peak1D(ITG.mass(), ITG.prob()));
+    while (ITG->advanceToNextConfiguration())
+        distribution.emplace_back(Peak1D(ITG->mass(), ITG->prob()));
 
     IsotopeDistribution ID;
 
@@ -214,6 +239,7 @@ namespace OpenMS
     return ID;
   }
 
+  IsoSpecThresholdWrapper::~IsoSpecThresholdWrapper() = default;
 //  --------------------------------------------------------------------------------
 
 
@@ -223,7 +249,12 @@ namespace OpenMS
                     const std::vector<std::vector<double> >& isotopeProbabilities,
                     double _total_prob,
                     bool _do_p_trim) :
-  ILG(_OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 1024, 1024, true, _total_prob),
+  ILG(std::make_unique<IsoSpec::IsoLayeredGenerator>(
+    _OMS_IsoFromParameters(isotopeNr, atomCounts, isotopeMasses, isotopeProbabilities), 
+    1024, 
+    1024, 
+    true, 
+    _total_prob)),
   target_prob(_total_prob),
   do_p_trim(_do_p_trim)
   {};
@@ -231,11 +262,12 @@ namespace OpenMS
   IsoSpecTotalProbWrapper::IsoSpecTotalProbWrapper(const EmpiricalFormula& formula,
                     double _total_prob,
                     bool _do_p_trim) :
-  ILG(_OMS_IsoFromEmpiricalFormula(formula), 1024, 1024, true, _total_prob),
+  ILG(std::make_unique<IsoSpec::IsoLayeredGenerator>(_OMS_IsoFromEmpiricalFormula(formula), 1024, 1024, true, _total_prob)),
   target_prob(_total_prob),
   do_p_trim(_do_p_trim)
   {};
 
+  IsoSpecTotalProbWrapper::~IsoSpecTotalProbWrapper() = default;
 
   IsotopeDistribution IsoSpecTotalProbWrapper::run()
   {
@@ -245,19 +277,19 @@ namespace OpenMS
 
     double acc_prob = 0.0;
 
-    while (acc_prob < target_prob && ILG.advanceToNextConfiguration())
+    while (acc_prob < target_prob && ILG->advanceToNextConfiguration())
     {
-        double p = ILG.prob();
+        double p = ILG->prob();
         acc_prob += p;
-        distribution.emplace_back(Peak1D(ILG.mass(), p));
+        distribution.emplace_back(Peak1D(ILG->mass(), p));
     }
 
     if (do_p_trim)
     {
         // the p_trim: extract the rest of the last layer, and perform quickselect
 
-        while (ILG.advanceToNextConfigurationWithinLayer())
-            distribution.emplace_back(Peak1D(ILG.mass(), ILG.prob()));
+        while (ILG->advanceToNextConfigurationWithinLayer())
+            distribution.emplace_back(Peak1D(ILG->mass(), ILG->prob()));
 
         size_t start = 0;
         size_t end = distribution.size();

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
@@ -64,8 +64,6 @@ using namespace IsoSpec;
 
 namespace OpenMS
 {
-
-
   Iso _OMS_IsoFromParameters(const std::vector<int>& isotopeNr,
                     const std::vector<int>& atomCounts,
                     const std::vector<std::vector<double> >& isotopeMasses,
@@ -154,10 +152,10 @@ namespace OpenMS
   double IsoSpecThresholdGeneratorWrapper::getIntensity() { return ITG->prob(); };
   double IsoSpecThresholdGeneratorWrapper::getLogIntensity() { return ITG->lprob(); };
 
+  // in this special case it needs to go in cpp file (see e.g., https://stackoverflow.com/questions/38242200/where-should-a-default-destructor-c11-style-go-header-or-cpp)
+  IsoSpecThresholdGeneratorWrapper::~IsoSpecThresholdGeneratorWrapper() = default; 
 
 //  --------------------------------------------------------------------------------
-
-
 
   IsoSpecTotalProbGeneratorWrapper::IsoSpecTotalProbGeneratorWrapper(const std::vector<int>& isotopeNr,
                     const std::vector<int>& atomCounts,
@@ -172,6 +170,8 @@ namespace OpenMS
   ILG(std::make_unique<IsoSpec::IsoLayeredGenerator>(_OMS_IsoFromEmpiricalFormula(formula), 1024, 1024, true, total_prob_hint))
   {};
 
+  IsoSpecTotalProbGeneratorWrapper::~IsoSpecTotalProbGeneratorWrapper() = default;
+
   bool IsoSpecTotalProbGeneratorWrapper::nextConf() { return ILG->advanceToNextConfiguration(); };
   Peak1D IsoSpecTotalProbGeneratorWrapper::getConf() { return Peak1D(ILG->mass(), ILG->prob()); };
   double IsoSpecTotalProbGeneratorWrapper::getMass() { return ILG->mass(); };
@@ -179,7 +179,6 @@ namespace OpenMS
   double IsoSpecTotalProbGeneratorWrapper::getLogIntensity() { return ILG->lprob(); };
 
 //  --------------------------------------------------------------------------------
-
 
   IsoSpecOrderedGeneratorWrapper::IsoSpecOrderedGeneratorWrapper(const std::vector<int>& isotopeNr,
                     const std::vector<int>& atomCounts,
@@ -191,6 +190,8 @@ namespace OpenMS
   IsoSpecOrderedGeneratorWrapper::IsoSpecOrderedGeneratorWrapper(const EmpiricalFormula& formula) :
     IOG(std::make_unique<IsoSpec::IsoOrderedGenerator>(_OMS_IsoFromEmpiricalFormula(formula)))
   {};
+
+  IsoSpecOrderedGeneratorWrapper::~IsoSpecOrderedGeneratorWrapper() = default; // needs to be in cpp file because of incomplete types!
 
   bool IsoSpecOrderedGeneratorWrapper::nextConf() { return IOG->advanceToNextConfiguration(); };
   Peak1D IsoSpecOrderedGeneratorWrapper::getConf() { return Peak1D(IOG->mass(), IOG->prob()); };
@@ -221,7 +222,6 @@ namespace OpenMS
     absolute))
   {};
 
-
   IsotopeDistribution IsoSpecThresholdWrapper::run()
   {
     std::vector<Peak1D> distribution;
@@ -240,6 +240,7 @@ namespace OpenMS
   }
 
   IsoSpecThresholdWrapper::~IsoSpecThresholdWrapper() = default;
+  
 //  --------------------------------------------------------------------------------
 
 

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
@@ -43,6 +43,7 @@
 #include <string>
 #include <utility>
 
+// Override IsoSpec's use of mmap whenever it is available
 #define ISOSPEC_GOT_SYSTEM_MMAN false
 #define ISOSPEC_GOT_MMAN false
 #define ISOSPEC_BUILDING_OPENMS true

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/isoSpec++.cpp
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/isoSpec++.cpp
@@ -137,7 +137,7 @@ marginals(nullptr)
     }
 }
 
-Iso::Iso(Iso&& other) :
+Iso::Iso(Iso&& other) noexcept :
 disowned(other.disowned),
 dimNumber(other.dimNumber),
 isotopeNumbers(other.isotopeNumbers),

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/isoSpec++.h
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/isoSpec++.h
@@ -113,7 +113,7 @@ class ISOSPEC_EXPORT_SYMBOL Iso {
     static inline Iso FromFASTA(const std::string& fasta, bool use_nominal_masses = false, bool add_water = true) { return FromFASTA(fasta.c_str(), use_nominal_masses, add_water); }
 
     //! The move constructor.
-    Iso(Iso&& other);
+    Iso(Iso&& other) noexcept ;
 
     /* We're not exactly following standard copy and assign semantics with Iso objects, so delete the default assign constructor just in case, so noone tries to use it. Copy ctor declared below. */
     Iso& operator=(const Iso& other) = delete;

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
@@ -201,7 +201,7 @@ loggamma_nominator(other.loggamma_nominator)
 
 
 // the move-constructor: used in the specialization of the marginal.
-Marginal::Marginal(Marginal&& other) :
+Marginal::Marginal(Marginal&& other) noexcept :
 disowned(other.disowned),
 isotopeNo(other.isotopeNo),
 atomCnt(other.atomCnt),

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.h
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.h
@@ -74,7 +74,7 @@ class Marginal
     Marginal(const Marginal& other);
 
     //! Move constructor.
-    Marginal(Marginal&& other);
+    Marginal(Marginal&& other) noexcept ;
 
     //! Destructor.
     virtual ~Marginal();


### PR DESCRIPTION
# Description
clang-tidy fixes
cppcoreguidelines-virtual-class-destructor
misc-redundant-expression,
performance-trivially-destructible
performance-noexcept-move-constructor

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
