### PR TITLE
[fix] added 3' phosphate gain for unspecific cleavage of nucleotides.…

### DIFF
--- a/share/OpenMS/CHEMISTRY/Enzymes_RNA.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes_RNA.xml
@@ -90,6 +90,8 @@ and what it cuts before. Also be sure to add gains before and after the cut. -->
       <ITEM name="RegExDescription" value="Unspecific cleavage cuts at every site." type="string" />
       <ITEM name="CutsAfter" value=".*" type="string" />
       <ITEM name="CutsBefore" value=".*" type="string" />
+      <ITEM name="ThreePrimeGain" value="p" type="string" />
+      <ITEM name="FivePrimeGain" value="" type="string" />      
     </NODE>
   </NODE>
 </PARAMETERS>

--- a/src/tests/class_tests/openms/source/RNaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/RNaseDigestion_test.cpp
@@ -166,14 +166,14 @@ START_SECTION((void digest(const NASequence& rna, vector<NASequence>& output, Si
   rd.setMissedCleavages(0); // shouldn't matter for the result
   rd.digest(NASequence::fromString("ACGU"), out);
   TEST_EQUAL(out.size(), 10);
-  TEST_STRING_EQUAL(out[0].toString(), "A");
-  TEST_STRING_EQUAL(out[1].toString(), "AC");
-  TEST_STRING_EQUAL(out[2].toString(), "ACG");
+  TEST_STRING_EQUAL(out[0].toString(), "Ap");
+  TEST_STRING_EQUAL(out[1].toString(), "ACp");
+  TEST_STRING_EQUAL(out[2].toString(), "ACGp");
   TEST_STRING_EQUAL(out[3].toString(), "ACGU");
-  TEST_STRING_EQUAL(out[4].toString(), "C");
-  TEST_STRING_EQUAL(out[5].toString(), "CG");
+  TEST_STRING_EQUAL(out[4].toString(), "Cp");
+  TEST_STRING_EQUAL(out[5].toString(), "CGp");
   TEST_STRING_EQUAL(out[6].toString(), "CGU");
-  TEST_STRING_EQUAL(out[7].toString(), "G");
+  TEST_STRING_EQUAL(out[7].toString(), "Gp");
   TEST_STRING_EQUAL(out[8].toString(), "GU");
   TEST_STRING_EQUAL(out[9].toString(), "U");
 }


### PR DESCRIPTION
… This is consistant with AbouHaidar and Ivanov 1999.

# Description

Previously unspecific cleavage of RNA resulted in the loss of the phosphate group at the cleavage site. Per https://www.degruyter.com/document/doi/10.1515/znc-1999-7-813/pdf it appears that the more common behavior is for the phosphate to stay on the 3' end of the "left" fragment.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
