### PR TITLE
[FEATURE] add python compatible get precursor spectrum

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -520,6 +520,13 @@ public:
     */
     ConstIterator getPrecursorSpectrum(ConstIterator iterator) const;
 
+    /**
+      @brief Returns the index of the precursor spectrum for spectrum at index @p zero_based_index
+
+      If there is no precursor scan -1 is returned.
+    */
+    int getPrecursorSpectrum(int zero_based_index) const;
+
     /// Swaps the content of this map with the content of @p from
     void swap(MSExperiment& from);
 

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -640,6 +640,16 @@ namespace OpenMS
     return spectra_.end();
   }
 
+  // same as above but easier to wrap in python
+  int MSExperiment::getPrecursorSpectrum(int zero_based_index) const
+  {
+    auto spec = spectra_.cbegin();
+    spec += zero_based_index;
+    auto pc_spec = getPrecursorSpectrum(spec);
+    if (pc_spec == spectra_.cend()) return -1;
+    return pc_spec - spectra_.cbegin(); 
+  }
+
   /// Swaps the content of this map with the content of @p from
   void MSExperiment::swap(MSExperiment & from)
   {

--- a/src/pyOpenMS/pxds/MSExperiment.pxd
+++ b/src/pyOpenMS/pxds/MSExperiment.pxd
@@ -105,3 +105,4 @@ cdef extern from "<OpenMS/KERNEL/MSExperiment.h>" namespace "OpenMS":
         void reset() nogil except +
         bool clearMetaDataArrays() nogil except +
 
+        int getPrecursorSpectrum(int zero_based_index) nogil except + # wrap-doc: Returns the index of the precursor spectrum for spectrum at index @p zero_based_index

--- a/src/pyOpenMS/pxds/MSExperiment.pxd
+++ b/src/pyOpenMS/pxds/MSExperiment.pxd
@@ -105,4 +105,5 @@ cdef extern from "<OpenMS/KERNEL/MSExperiment.h>" namespace "OpenMS":
         void reset() nogil except +
         bool clearMetaDataArrays() nogil except +
 
-        int getPrecursorSpectrum(int zero_based_index) nogil except + # wrap-doc: Returns the index of the precursor spectrum for spectrum at index @p zero_based_index
+        int getPrecursorSpectrum(int zero_based_index) nogil except + # wrap-doc:Returns the index of the precursor spectrum for spectrum at index @p zero_based_index
+        

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -1007,27 +1007,57 @@ START_SECTION((ConstIterator getPrecursorSpectrum(ConstIterator iterator) const)
   exp[4].setMSLevel(2);
 
   TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin())==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+1)==exp.begin(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+2)==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+3)==exp.begin()+2,true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+4)==exp.begin()+2,true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.end())==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+1)==exp.begin(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+2)==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+3)==exp.begin()+2,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+4)==exp.begin()+2,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.end())==exp.end(),true)
 
-    exp[0].setMSLevel(2);
+  exp[0].setMSLevel(2);
   exp[1].setMSLevel(1);
   exp[2].setMSLevel(1);
   exp[3].setMSLevel(1);
   exp[4].setMSLevel(1);
 
   TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin())==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+1)==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+2)==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+3)==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+4)==exp.end(),true)
-    TEST_EQUAL(exp.getPrecursorSpectrum(exp.end())==exp.end(),true)
-
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+1)==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+2)==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+3)==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.begin()+4)==exp.end(),true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(exp.end())==exp.end(),true)
 }
 END_SECTION
+
+START_SECTION((int getPrecursorSpectrum(int zero_based_index) const))
+{
+  PeakMap exp;
+  exp.resize(10);
+  exp[0].setMSLevel(1);
+  exp[1].setMSLevel(2);
+  exp[2].setMSLevel(1);
+  exp[3].setMSLevel(2);
+  exp[4].setMSLevel(2);
+
+  TEST_EQUAL(exp.getPrecursorSpectrum(0) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(1) == 0,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(2) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(3) == 2,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(4) == 2,true)
+
+  exp[0].setMSLevel(2);
+  exp[1].setMSLevel(1);
+  exp[2].setMSLevel(1);
+  exp[3].setMSLevel(1);
+  exp[4].setMSLevel(1);
+
+  TEST_EQUAL(exp.getPrecursorSpectrum(0) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(1) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(2) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(3) == -1,true)
+  TEST_EQUAL(exp.getPrecursorSpectrum(4) == -1,true)
+}
+END_SECTION
+
 
 START_SECTION((bool clearMetaDataArrays()))
 {


### PR DESCRIPTION
# Description

Add helper for pyopenms to retrieve the index of the precursor spectrum

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
