### PR TITLE
pass calling process environment to children

### DIFF
--- a/src/openms/source/SYSTEM/ExternalProcess.cpp
+++ b/src/openms/source/SYSTEM/ExternalProcess.cpp
@@ -81,6 +81,10 @@ namespace OpenMS
 
   ExternalProcess::RETURNSTATE ExternalProcess::run(const QString& exe, const QStringList& args, const QString& working_dir, const bool verbose, String& error_msg, IO_MODE io_mode)
   {
+    // pass environment variables to child process
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    qp_->setProcessEnvironment(env);
+
     error_msg.clear();
     if (!working_dir.isEmpty())
     {


### PR DESCRIPTION
# Description

Passing the parent process environment reduces the danger of running a process with e.g. different environment variables set.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
