### PR TITLE
MapAlignerPoseClustering: print error message and fall back to identity if no data provided

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h
@@ -67,7 +67,7 @@ public:
     TransformationModelLinear(const DataPoints& data, const Param& params);
 
     /// Destructor
-    ~TransformationModelLinear() override;
+    ~TransformationModelLinear() override = default;
 
     /// Evaluates the model at the given value
     double evaluate(double value) const override;

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
@@ -94,10 +94,6 @@ namespace OpenMS
     }
   }
 
-  TransformationModelLinear::~TransformationModelLinear()
-  {
-  }
-
   double TransformationModelLinear::evaluate(double value) const
   {
     if (!weighting_) 

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -301,7 +301,6 @@ protected:
       {
         plog.setProgress(++progress); // thread safe progress counter
       }
-
     }
 
     plog.endProgress();

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -242,8 +242,25 @@ protected:
         FeatureXMLFile f_fxml_tmp; // do not use OMP-firstprivate, since FeatureXMLFile has no copy c'tor
         f_fxml_tmp.getOptions() = f_fxml.getOptions();
         f_fxml_tmp.load(in_files[i], map);
-        if (i == static_cast<int>(reference_index)) trafo.fitModel("identity");
-        else algorithm.align(map, trafo);
+        if (i == static_cast<int>(reference_index)) 
+        {
+          trafo.fitModel("identity");
+        }
+        else 
+        {
+          try
+          {
+            algorithm.align(map, trafo);
+          }
+          catch (Exception::IllegalArgument& e)
+          {
+            OPENMS_LOG_ERROR << "Aligning " << in_files[i] << " to reference " << in_files[reference_index]
+                             << " failed. No transformation will be applied (RT not changed for this file)." << endl;
+            writeLog_("Illegal argument (" + String(e.getName()) + "): " + String(e.what()) + ".");
+            trafo.fitModel("identity");
+          }
+        }
+
         if (!out_files.empty())
         {
           MapAlignmentTransformer::transformRetentionTimes(map, trafo);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
