### PR TITLE
[FIX] clang format actions

### DIFF
--- a/.github/workflows/openms_clang_format.yml
+++ b/.github/workflows/openms_clang_format.yml
@@ -29,6 +29,4 @@ jobs:
       uses: DoozyX/clang-format-lint-action@v0.12
       with:
         source: ${{ steps.changed-files.outputs.all_modified_files }}
-
-
         clangFormatVersion: 12

--- a/.github/workflows/openms_clang_format_add_and_commit.yml
+++ b/.github/workflows/openms_clang_format_add_and_commit.yml
@@ -11,6 +11,9 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/reformat')
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
 # Get files changed in the PR
       - name: Get changed files
@@ -28,7 +31,6 @@ jobs:
         with:
           source: ${{ steps.changed-files.outputs.all_modified_files }}
           clangFormatVersion: 12
-          extensions: 'h,cpp'
           inplace: True
       - uses: EndBug/add-and-commit@v4
         with:


### PR DESCRIPTION
# Description

An error occurred in PR #5708, when trying to use "/format" 
https://github.com/OpenMS/OpenMS/runs/4537967682?check_suite_focus=true

It seems the issue was that by using the "created" type it is not clear which commits and the branch to use. 
This should be hopefully be fixed by adding the reference to PR and the fetch_depth.

Please see https://github.com/actions/checkout for additional information. 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
