### PR TITLE
[FIX] pyopenms mac fix dependency order

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -498,7 +498,7 @@ endforeach()
 	
 # fixup these dependencies (i.e. get other dynamic dependencies recursively)
 if (APPLE) ## On APPLE use our script because the executables need to be relinked
-## this is done before setup.py so that we fixup the resulting pyopenms.so's too
+## this is done after "setup.py build_ext" but before setup.py bdist_wheel so that we fixup the resulting pyopenms.so's too
 else()
     ## Assemble common required non-system libraries
     ## Note that we do not need the QT plugins or QTGui libraries since we do not include GUI tools here.
@@ -561,8 +561,8 @@ IF(LINUX AND PY_NO_OUTPUT)
 ELSEIF(APPLE) # We need to still copy libs with our script
   add_custom_command(
             OUTPUT ${PYSOFILES}
-            COMMAND ${CMAKE_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -l ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms -e "@rpath/" -v
             COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext -j ${PY_NUM_THREADS} ${PY_EXTRA_ARGS}
+            COMMAND ${CMAKE_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -l ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms -e "@rpath/" -v
             COMMENT "Compiling and linking pyopenms C++ extension with the chosen C++ compiler"
             DEPENDS compile_pxds prepare_pyopenms_libs
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )


### PR DESCRIPTION
Still a minor error from the CMake restructue.
MacOS fix dependencies has to be run AFTER the pyopenms library build to fixup the DLLs in there too.