### PR TITLE
Require OPENMS_TEST_VERBOSE_SUCCESS env variable set if output of successful test executions should be printed

### DIFF
--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -579,10 +579,13 @@ namespace OpenMS::Internal::ClassTest
           initialNewline();
           if (this_test)
           {
-            stdcout << " +  line " << line << ":  TEST_STRING_EQUAL("
-                      << string_1_stringified << ',' << string_2_stringified
-                      << "): got \"" << string_1 << "\", expected \"" << string_2
-                      << "\"" << std::endl;
+            if (std::getenv("OPENMS_TEST_VERBOSE_SUCCESS"))
+            {
+              stdcout << " +  line " << line << ":  TEST_STRING_EQUAL("
+                        << string_1_stringified << ',' << string_2_stringified
+                        << "): got \"" << string_1 << "\", expected \"" << string_2
+                        << "\"" << std::endl;
+            }
           }
           else
           {

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -81,7 +81,6 @@ endif()
 foreach(_class_test ${TEST_executables})
   add_executable(${_class_test} source/${_class_test}.cpp)
   target_link_libraries(${_class_test} ${OpenMS_LIBRARIES})
-  set_property(TEST ${_class_test} APPEND PROPERTY ENVIRONMENT "OPENMS_TEST_VERBOSE_SUCCESS=1")
   add_test(${_class_test} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_class_test})
   # only add OPENMP flags to gcc linker (except Mac OS X, due to compiler bug
   # see https://sourceforge.net/apps/trac/open-ms/ticket/280 for details)

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 foreach(_class_test ${TEST_executables})
   add_executable(${_class_test} source/${_class_test}.cpp)
   target_link_libraries(${_class_test} ${OpenMS_LIBRARIES})
+  set_property(${_class_test} APPEND PROPERTY ENVIRONMENT "OPENMS_TEST_VERBOSE_SUCCESS")
   add_test(${_class_test} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_class_test})
   # only add OPENMP flags to gcc linker (except Mac OS X, due to compiler bug
   # see https://sourceforge.net/apps/trac/open-ms/ticket/280 for details)

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 foreach(_class_test ${TEST_executables})
   add_executable(${_class_test} source/${_class_test}.cpp)
   target_link_libraries(${_class_test} ${OpenMS_LIBRARIES})
-  set_property(${_class_test} APPEND PROPERTY ENVIRONMENT "OPENMS_TEST_VERBOSE_SUCCESS")
+  set_property(TEST ${_class_test} APPEND PROPERTY ENVIRONMENT "OPENMS_TEST_VERBOSE_SUCCESS=1")
   add_test(${_class_test} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${_class_test})
   # only add OPENMP flags to gcc linker (except Mac OS X, due to compiler bug
   # see https://sourceforge.net/apps/trac/open-ms/ticket/280 for details)


### PR DESCRIPTION
# Description

Output from successful tests clutter the log. In most cases this information is not needed. Optionally can now be enabled by setting the OPENMS_TEST_VERBOSE_SUCCESS environment variable

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
