### PR TITLE
Disable successful test lines by default

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/ClassTest.h
+++ b/src/openms/include/OpenMS/CONCEPT/ClassTest.h
@@ -477,7 +477,7 @@ namespace TEST = OpenMS::Internal::ClassTest;
     TEST::all_tests = false;                                                              \
     {                                                                                     \
       TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unidentified and unexpected exception - No message."    \
+      stdcout << "Error: Caught unidentified and unexpected exception - No message."      \
                 << std::endl;                                                             \
     }                                                                                     \
   }                                                                                       \
@@ -485,6 +485,10 @@ namespace TEST = OpenMS::Internal::ClassTest;
   if (!TEST::validate(TEST::tmp_file_list))                                               \
   {                                                                                       \
     TEST::all_tests = false;                                                              \
+  }                                                                                       \
+  if (TEST::verbose == 0)                                                                 \
+  {                                                                                       \
+    stdcout << "Output of successful tests were suppressed. Set the environment variable 'OPENMS_TEST_VERBOSE=True' to enable them." << std::endl; \
   }                                                                                       \
   /* check for exit code */                                                               \
   if (!TEST::all_tests)                                                                   \

--- a/src/openms/include/OpenMS/CONCEPT/ClassTest.h
+++ b/src/openms/include/OpenMS/CONCEPT/ClassTest.h
@@ -307,10 +307,13 @@ namespace OpenMS
           initialNewline();
           if (this_test)
           {
-            stdcout << " +  line " << line << ":  TEST_EQUAL("
-                      << expression_1_stringified << ','
-                      << expression_2_stringified << "): got '" << expression_1
-                      << "', expected '" << expression_2 << "'\n";
+            if (verbose > 1)
+            {
+              stdcout << " +  line " << line << ":  TEST_EQUAL("
+                        << expression_1_stringified << ','
+                        << expression_2_stringified << "): got '" << expression_1
+                        << "', expected '" << expression_2 << "'\n";
+            }
           }
           else
           {
@@ -338,10 +341,13 @@ namespace OpenMS
           initialNewline();
           if (this_test)
           {
-            stdcout << " +  line " << line << ":  TEST_NOT_EQUAL("
-                      << expression_1_stringified << ','
-                      << expression_2_stringified << "): got '" << expression_1
-                      << "', forbidden is '" << expression_2 << "'\n";
+            if (verbose > 1)
+            {
+              stdcout << " +  line " << line << ":  TEST_NOT_EQUAL("
+                        << expression_1_stringified << ','
+                        << expression_2_stringified << "): got '" << expression_1
+                        << "', forbidden is '" << expression_2 << "'\n";
+            }
           }
           else
           {
@@ -416,7 +422,7 @@ namespace TEST = OpenMS::Internal::ClassTest;
 #define START_TEST(class_name, version)                                                   \
   int main(int argc, char** argv)                                                         \
   {                                                                                       \
-    TEST::mainInit(version, #class_name, argc, argv[0]);                                        \
+    TEST::mainInit(version, #class_name, argc, argv[0]);                                  \
     try {
 
 /**	@brief End of the test program for a class.  @sa #START_TEST.
@@ -759,25 +765,28 @@ namespace TEST = OpenMS::Internal::ClassTest;
       TEST::initialNewline();                                                             \
       if (TEST::this_test)                                                                \
       {                                                                                   \
-        stdcout << " +  line " << __LINE__                                              \
-                  << ":  TEST_FILE_SIMILAR(" # a "," # b "):  absolute: "                       \
-                  << precisionWrapper(TEST::absdiff)                                            \
-                  << " ("                                                                       \
-                  << precisionWrapper(TEST::absdiff_max_allowed)                                \
-                  << "), relative: "                                                            \
-                  << precisionWrapper(TEST::ratio)                                              \
-                  << " ("                                                                       \
-                  << precisionWrapper(TEST::ratio_max_allowed)                                  \
-                  << ")\n";                                                               \
-        stdcout << "message: \n";                                                       \
-        stdcout << TEST::fuzzy_message;                                                 \
+        if (TEST::verbose > 1)                                                            \
+        {                                                                                 \
+          stdcout << " +  line " << __LINE__                                              \
+                    << ":  TEST_FILE_SIMILAR(" # a "," # b "):  absolute: "               \
+                    << precisionWrapper(TEST::absdiff)                                    \
+                    << " ("                                                               \
+                    << precisionWrapper(TEST::absdiff_max_allowed)                        \
+                    << "), relative: "                                                    \
+                    << precisionWrapper(TEST::ratio)                                      \
+                    << " ("                                                               \
+                    << precisionWrapper(TEST::ratio_max_allowed)                          \
+                    << ")\n";                                                             \
+          stdcout << "message: \n";                                                       \
+          stdcout << TEST::fuzzy_message;                                                 \
+        }                                                                                 \
       }                                                                                   \
       else                                                                                \
       {                                                                                   \
-        stdcout << " -  line " << TEST::test_line <<                                    \
-          ": TEST_FILE_SIMILAR(" # a "," # b ") ...    -\n";                                \
-        stdcout << "message: \n";                                                       \
-        stdcout << TEST::fuzzy_message;                                                 \
+        stdcout << " -  line " << TEST::test_line <<                                      \
+          ": TEST_FILE_SIMILAR(" # a "," # b ") ...    -\n";                              \
+        stdcout << "message: \n";                                                         \
+        stdcout << TEST::fuzzy_message;                                                   \
         TEST::failed_lines_list.push_back(TEST::test_line);                               \
       }                                                                                   \
     }                                                                                     \
@@ -799,9 +808,12 @@ namespace TEST = OpenMS::Internal::ClassTest;
   TEST::ratio_max_allowed = (a);                                                          \
   {                                                                                       \
     TEST::initialNewline();                                                               \
-    stdcout << " +  line " << __LINE__ <<                                               \
-      ":  TOLERANCE_RELATIVE(" <<     TEST::ratio_max_allowed <<                            \
-      ")   (\"" # a "\")\n";                                                     \
+    if (TEST::verbose > 1)                                                                \
+    {                                                                                     \
+      stdcout << " +  line " << __LINE__ <<                                               \
+        ":  TOLERANCE_RELATIVE(" <<     TEST::ratio_max_allowed <<                        \
+        ")   (\"" # a "\")\n";                                                            \
+    }                                                                                     \
   }
 
 /**	@brief Define the absolute tolerance for floating point comparisons.
@@ -819,9 +831,12 @@ namespace TEST = OpenMS::Internal::ClassTest;
   TEST::absdiff_max_allowed = (a);                                                        \
   {                                                                                       \
     TEST::initialNewline();                                                               \
-    stdcout << " +  line " << __LINE__ <<                                               \
-      ":  TOLERANCE_ABSOLUTE(" <<     TEST::absdiff_max_allowed   <<                        \
-      ")   (\"" # a "\")\n";                                                              \
+    if (TEST::verbose > 1)                                                                \
+    {                                                                                     \
+      stdcout << " +  line " << __LINE__ <<                                               \
+        ":  TOLERANCE_ABSOLUTE(" <<     TEST::absdiff_max_allowed   <<                    \
+        ")   (\"" # a "\")\n";                                                            \
+    }                                                                                     \
   }
 
 /** @brief Define the whitelist_ used by #TEST_STRING_SIMILAR and #TEST_FILE_SIMILAR.
@@ -852,11 +867,11 @@ namespace TEST = OpenMS::Internal::ClassTest;
     {                                                                                     \
       command;                                                                            \
     }                                                                                     \
-    catch (exception_type&)                                                                \
+    catch (exception_type&)                                                               \
     {                                                                                     \
       TEST::exception = 1;                                                                \
     }                                                                                     \
-    catch (::OpenMS::Exception::BaseException& e)                                          \
+    catch (::OpenMS::Exception::BaseException& e)                                         \
     {                                                                                     \
       TEST::exception = 2;                                                                \
       TEST::exception_name = e.getName();                                                 \
@@ -879,9 +894,12 @@ namespace TEST = OpenMS::Internal::ClassTest;
         TEST::failed_lines_list.push_back(TEST::test_line);                               \
         break;                                                                            \
       case 1:                                                                             \
-        stdcout << " +  line " << TEST::test_line <<                                    \
-          ":  TEST_EXCEPTION(" # exception_type "," # command                               \
-          "): OK\n";                                                                    \
+        if (TEST::verbose > 1)                                                            \
+        {                                                                                 \
+          stdcout << " +  line " << TEST::test_line <<                                    \
+            ":  TEST_EXCEPTION(" # exception_type "," # command                           \
+            "): OK\n";                                                                    \
+        }                                                                                 \
         break;                                                                            \
       case 2:                                                                             \
         stdcout << " -  line " << TEST::test_line <<                                    \
@@ -992,11 +1010,14 @@ namespace TEST = OpenMS::Internal::ClassTest;
         TEST::failed_lines_list.push_back(TEST::test_line);                               \
         break;                                                                            \
       case 1:                                                                             \
-        /* this is actually what we want to get:  */                                      \
-        stdcout << " +  line " << TEST::test_line <<                                    \
-          ":  TEST_EXCEPTION_WITH_MESSAGE(" # exception_type "," # command ", " # message   \
-          "): OK\n";                                                                      \
-        break;                                                                            \
+        if (TEST::verbose > 1)                                                            \
+        {                                                                                 \
+          /* this is actually what we want to get:  */                                      \
+          stdcout << " +  line " << TEST::test_line <<                                    \
+            ":  TEST_EXCEPTION_WITH_MESSAGE(" # exception_type "," # command ", " # message   \
+            "): OK\n";                                                                      \
+          break;                                                                            \
+        }                                                                                 \
       case 2:                                                                             \
         stdcout << " -  line " << TEST::test_line <<                                    \
           ":  TEST_EXCEPTION_WITH_MESSAGE(" # exception_type "," # command ", " # message   \
@@ -1044,7 +1065,7 @@ namespace TEST = OpenMS::Internal::ClassTest;
     TEST::tmp_file_list.push_back(filename);                                              \
     {                                                                                     \
       TEST::initialNewline();                                                             \
-      stdcout << "    creating new temporary filename '"                                \
+      stdcout << "    creating new temporary filename '"                                  \
                 << filename                                                               \
                 << "' (line "                                                             \
                 << __LINE__                                                               \
@@ -1063,14 +1084,14 @@ namespace TEST = OpenMS::Internal::ClassTest;
   if (condition)                                                                          \
   {                                                                                       \
     {                                                                                     \
-      TEST::test_line = __LINE__;                                                           \
-      TEST::this_test = false;                                                              \
-      TEST::test = TEST::test && TEST::this_test;                                           \
-      TEST::failed_lines_list.push_back(TEST::test_line);                                   \
-      TEST::initialNewline();                                                               \
-      stdcout << " -  line " << TEST::test_line <<                                          \
-        ":  ABORT_IF(" # condition "):  TEST ABORTED\n";                                    \
-    }                                                                                       \
+      TEST::test_line = __LINE__;                                                         \
+      TEST::this_test = false;                                                            \
+      TEST::test = TEST::test && TEST::this_test;                                         \
+      TEST::failed_lines_list.push_back(TEST::test_line);                                 \
+      TEST::initialNewline();                                                             \
+      stdcout << " -  line " << TEST::test_line <<                                        \
+        ":  ABORT_IF(" # condition "):  TEST ABORTED\n";                                  \
+    }                                                                                     \
     break;                                                                                \
   }
 
@@ -1094,7 +1115,7 @@ namespace TEST = OpenMS::Internal::ClassTest;
 #define STATUS(message)                                                                   \
   {                                                                                       \
     TEST::initialNewline();                                                               \
-    stdcout << "    line "                                                              \
+    stdcout << "    line "                                                                \
               <<  __LINE__                                                                \
               << ": status:  "                                                            \
               << message                                                                  \
@@ -1126,4 +1147,3 @@ namespace TEST = OpenMS::Internal::ClassTest;
   TEST::test_count = 1;
 
 //@} // end of ClassTest
-

--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -92,7 +92,13 @@ namespace OpenMS::Internal::ClassTest
 
       void mainInit(const char* version, const char* class_name, int argc, const char* argv0)
       {
-        TEST::verbose = getenv("OPENMS_TEST_SUPPRESS_SUCCESS") ? 0 : 2;
+        // if env var "OPENMS_TEST_VERBOSE=True" enable output of successfull line
+        char* pverbose = std::getenv("OPENMS_TEST_VERBOSE");
+        if (pverbose != nullptr)
+        {
+          if (std::string(pverbose) == "True") TEST::verbose = 2;
+        }
+
         OpenMS::UniqueIdGenerator::setSeed(2453440375);
         TEST::version_string = version;
 
@@ -368,7 +374,7 @@ namespace OpenMS::Internal::ClassTest
             }
           }
         }
-        //output for all files
+        //output for all files        
         if (passed_all)
         {
           std::cout << ": passed" << std::endl << std::endl;

--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -59,7 +59,6 @@
 
 namespace OpenMS::Internal::ClassTest
 {
-
       bool all_tests = true;
       bool equal_files;
       bool newline = false;
@@ -93,6 +92,7 @@ namespace OpenMS::Internal::ClassTest
 
       void mainInit(const char* version, const char* class_name, int argc, const char* argv0)
       {
+        TEST::verbose = getenv("OPENMS_TEST_SUPPRESS_SUCCESS") ? 0 : 2;
         OpenMS::UniqueIdGenerator::setSeed(2453440375);
         TEST::version_string = version;
 
@@ -132,12 +132,10 @@ namespace OpenMS::Internal::ClassTest
             TEST::equal_files &= (TEST_FILE__template_line == TEST_FILE__line);
             if (TEST_FILE__template_line != TEST_FILE__line)
             {
-              {
                 TEST::initialNewline();
                 stdcout << "   TEST_FILE_EQUAL: line mismatch:\n    got:      '"
                         << TEST_FILE__line << "'\n    expected: '"
                         << TEST_FILE__template_line << "'\n";
-              }
             }
           }
         }
@@ -176,13 +174,16 @@ namespace OpenMS::Internal::ClassTest
           TEST::initialNewline();
           if (TEST::this_test)
           {
-            stdcout << " +  line "
-                    << line
-                    << ": TEST_FILE_EQUAL("
-                    << filename_stringified
-                    << ", "
-                    << templatename_stringified
-                    << "): true";
+            if (TEST::verbose > 1)
+            {
+              stdcout << " +  line "
+                      << line
+                      << ": TEST_FILE_EQUAL("
+                      << filename_stringified
+                      << ", "
+                      << templatename_stringified
+                      << "): true";
+            }
           }
           else
           {
@@ -414,11 +415,14 @@ namespace OpenMS::Internal::ClassTest
           {
             if (TEST::this_test)
             {
-              stdcout << " +  line " << line << ":  TEST_REAL_SIMILAR("
-                        << number_1_stringified << ',' << number_2_stringified
-                        << "): got " << std::setprecision(number_1_written_digits)
-                        << number_1 << ", expected "
-                        << std::setprecision(number_2_written_digits) << number_2 << std::endl;
+              if (TEST::verbose > 1)
+              {
+                stdcout << " +  line " << line << ":  TEST_REAL_SIMILAR("
+                          << number_1_stringified << ',' << number_2_stringified
+                          << "): got " << std::setprecision(number_1_written_digits)
+                          << number_1 << ", expected "
+                          << std::setprecision(number_2_written_digits) << number_2 << std::endl;
+              }
             }
             else
             {
@@ -579,12 +583,12 @@ namespace OpenMS::Internal::ClassTest
           initialNewline();
           if (this_test)
           {
-            if (std::getenv("OPENMS_TEST_VERBOSE_SUCCESS"))
+            if (TEST::verbose > 1)
             {
-              stdcout << " +  line " << line << ":  TEST_STRING_EQUAL("
-                        << string_1_stringified << ',' << string_2_stringified
-                        << "): got \"" << string_1 << "\", expected \"" << string_2
-                        << "\"" << std::endl;
+            stdcout << " +  line " << line << ":  TEST_STRING_EQUAL("
+                    << string_1_stringified << ',' << string_2_stringified
+                    << "): got \"" << string_1 << "\", expected \"" << string_2
+                    << "\"" << std::endl;            
             }
           }
           else
@@ -630,16 +634,19 @@ namespace OpenMS::Internal::ClassTest
 
         TEST::initialNewline();
         if (TEST::this_test)
-        {
-          stdcout << " +  line " << line << ":  TEST_STRING_SIMILAR("
-                    << string_1_stringified << ',' << string_2_stringified << "):  "
-                                                                    "absolute: " << TEST::absdiff << " (" << TEST::absdiff_max_allowed
-                    << "), relative: " << TEST::ratio << " ("
-                    << TEST::ratio_max_allowed << ")    +\n";
-          stdcout << "got:\n";
-          TEST::printWithPrefix(string_1, TEST::line_num_1_max);
-          stdcout << "expected:\n";
-          TEST::printWithPrefix(string_2, TEST::line_num_2_max);
+        {          
+          if (TEST::verbose > 1)
+          {
+            stdcout << " +  line " << line << ":  TEST_STRING_SIMILAR("
+                      << string_1_stringified << ',' << string_2_stringified << "):  "
+                                                                      "absolute: " << TEST::absdiff << " (" << TEST::absdiff_max_allowed
+                      << "), relative: " << TEST::ratio << " ("
+                      << TEST::ratio_max_allowed << ")    +\n";
+            stdcout << "got:\n";
+            TEST::printWithPrefix(string_1, TEST::line_num_1_max);
+            stdcout << "expected:\n";
+            TEST::printWithPrefix(string_2, TEST::line_num_2_max);
+          }
         }
         else
         {

--- a/src/tests/class_tests/openms/source/MorphologicalFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MorphologicalFilter_test.cpp
@@ -285,10 +285,10 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
 
     for ( Int struc_length = 3; struc_length <= 2 * data_size + 2; struc_length += 2 )
     {
-      STATUS("data_size: " << data_size);
-      STATUS("struc_elem_length: " << struc_length);
+      //STATUS("data_size: " << data_size);
+      //STATUS("struc_elem_length: " << struc_length);
       {
-        STATUS("erosion");
+        //STATUS("erosion");
         filtered.clear();
         filtered.resize(data_size);
         simple_filtered_1.clear();
@@ -309,13 +309,13 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
                      );
         for ( Int i = 0; i != data_size; ++i )
         {
-          STATUS(i);
+          //STATUS(i);
           TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
         }
       }
 
       {
-        STATUS("dilation");
+        //STATUS("dilation");
         filtered.clear();
         filtered.resize(data_size);
         simple_filtered_1.clear();
@@ -336,11 +336,10 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
                       );
         for ( Int i = 0; i != data_size; ++i )
         {
-          STATUS(i);
+          //STATUS(i);
           TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
         }
       }
-
     }
   }
 
@@ -364,10 +363,10 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
 
     for ( Int struc_length = 3; struc_length <= 2 * data_size + 2; struc_length += 2 )
     {
-      STATUS("data_size: " << data_size);
-      STATUS("struc_elem_length: " << struc_length);
+      //STATUS("data_size: " << data_size);
+      //STATUS("struc_elem_length: " << struc_length);
       {
-        STATUS("erosion");
+        //STATUS("erosion");
         filtered.clear();
         filtered.resize(data_size);
         simple_filtered_1.clear();
@@ -388,13 +387,13 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
                      );
         for ( Int i = 0; i != data_size; ++i )
         {
-          STATUS(i);
+          //STATUS(i);
           TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
         }
       }
 
       {
-        STATUS("dilation");
+        //STATUS("dilation");
         filtered.clear();
         filtered.resize(data_size);
         simple_filtered_1.clear();
@@ -415,7 +414,7 @@ START_SECTION((template < typename InputIterator, typename OutputIterator > void
                       );
         for ( Int i = 0; i != data_size; ++i )
         {
-          STATUS(i);
+          //STATUS(i);
           TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
         }
       }
@@ -446,10 +445,9 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
   MorphologicalFilter mf;
   for ( UInt struc_length = 3; struc_length <= 2 * data_size + 2; struc_length += 2 )
   {
-    STATUS("struc_elem_length: " << struc_length);
-
+    //STATUS("struc_elem_length: " << struc_length);
     {
-      STATUS("erosion");
+      //STATUS("erosion");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_1.clear();
@@ -467,11 +465,11 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
       STHF::erosion(inputf,simple_filtered_1,struc_length);
       for ( UInt i = 0; i != data_size; ++i )
       {
-        STATUS(i);
+        //STATUS(i);
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
       }
 
-      STATUS("erosion_simple");
+      //STATUS("erosion_simple");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_1.clear();
@@ -491,7 +489,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
       }
 
-      STATUS("opening");
+      //STATUS("opening");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_2.clear();
@@ -511,7 +509,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_2[i]);
       }
 
-      STATUS("tophat");
+      //STATUS("tophat");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_3.clear();
@@ -533,7 +531,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
     }
 
     {
-      STATUS("dilation");
+      //STATUS("dilation");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_1.clear();
@@ -554,7 +552,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
       }
 
-      STATUS("dilation_simple");
+      //STATUS("dilation_simple");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_1.clear();
@@ -574,7 +572,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_1[i]);
       }
 
-      STATUS("closing");
+      //STATUS("closing");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_2.clear();
@@ -594,7 +592,7 @@ START_SECTION([EXTRA] (template < typename InputIterator, typename OutputIterato
         TEST_REAL_SIMILAR(filtered[i],simple_filtered_2[i]);
       }
 
-      STATUS("bothat");
+      //STATUS("bothat");
       filtered.clear();
       filtered.resize(data_size);
       simple_filtered_3.clear();
@@ -645,8 +643,8 @@ START_SECTION((template <typename PeakType> void filter(MSSpectrum& spectrum)))
     UInt struc_size_datapoints = UInt ( ceil ( struc_size / spacing ) );
     if ( !Math::isOdd(struc_size_datapoints) ) ++struc_size_datapoints;
     STH::dilation( input, dilation, struc_size_datapoints );
-    STATUS( "struc_size: " << struc_size << "  struc_size_datapoints: " << struc_size_datapoints );
-     for ( UInt i = 0; i != data_size; ++i )
+    //STATUS( "struc_size: " << struc_size << "  struc_size_datapoints: " << struc_size_datapoints );
+    for ( UInt i = 0; i != data_size; ++i )
     {
       STATUS("i: " << i);
       TEST_REAL_SIMILAR(filtered[i].getIntensity(),dilation[i]);
@@ -687,13 +685,13 @@ START_SECTION((template <typename PeakType > void filterExperiment(MSExperiment<
     UInt struc_size_datapoints = UInt ( ceil ( struc_size / spacing ) );
     if ( !Math::isOdd(struc_size_datapoints) ) ++struc_size_datapoints;
     STH::dilation( input, dilation, struc_size_datapoints );
-    STATUS( "struc_size: " << struc_size << "  struc_size_datapoints: " << struc_size_datapoints );
+    //STATUS( "struc_size: " << struc_size << "  struc_size_datapoints: " << struc_size_datapoints );
     for ( UInt scan = 0; scan < 3; ++scan )
     {
       TEST_STRING_EQUAL(mse_raw[scan].getComment(),"Let's see if this comment is copied by the filter.");
       for ( UInt i = 0; i != data_size; ++i )
       {
-        STATUS("i: " << i);
+        //STATUS("i: " << i);
         TEST_REAL_SIMILAR(mse_raw[scan][i].getIntensity(),dilation[i]);
       }
     }


### PR DESCRIPTION
# Description
Previously, test could produce a large outputs (e.g., if many peak positions where tested in a loop).

The new default is omitting line output of successful tests.

To get the old behavior:
Set the environment variable OPENMS_TEST_VERBOSE=True -> will print output of successful tests.


Note that we now inform users that some lines were suppressed (and how they can be printed).
```
83: Output of successful tests were suppressed. Set the env variable 'OPENMS_TEST_VERBOSE=True' to enable them.
83: PASSED
1/1 Test #83: MSSpectrum_test ..................   Passed    0.04 sec
```

Example:
running:  OPENMS_TEST_VERBOSE=True ctest -R MSSpectrum_test -VV
will print all lines (old behavior)
```
83: checking (MSSpectrum()) ... 
83:  +  line 81:  TEST_NOT_EQUAL(ptr,nullPointer): got '0x557102cbca60', forbidden is '0'
83: : passed
83: 
83: checking (~MSSpectrum()) ... : passed
83: Warning: no subtests performed in '(~MSSpectrum())' (line 89)!
83: 
83: checking ([EXTRA] MSSpectrum()) ... 
83:  +  line 97:  TEST_EQUAL(tmp.size(),1): got '1', expected '1'
83:  +  line 98:  TEST_REAL_SIMILAR(tmp[0].getMZ(),47.11): got 47.11, expected 47.11
83: : passed
83: 
83: checking (UInt getMSLevel() const) ... 
83:  +  line 108:  TEST_EQUAL(spec.getMSLevel(),1): got '1', expected '1'
83: : passed
83: 
83: checking (void setMSLevel(UInt ms_level)) ... 
83:  +  line 116:  TEST_EQUAL(spec.getMSLevel(),17): got '17', expected '17'
83: : passed
```

running tests without setting the environment variable - the new default:
```
83: checking (MSSpectrum()) ... 
83: : passed
83: 
83: checking (~MSSpectrum()) ... : passed
83: Warning: no subtests performed in '(~MSSpectrum())' (line 89)!
83: 
83: checking ([EXTRA] MSSpectrum()) ... 
83: : passed
83: 
83: checking (UInt getMSLevel() const) ... 
83: : passed
83: 
83: checking (void setMSLevel(UInt ms_level)) ... 
83: : passed
```

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
