### PR TITLE
more reduction of test output

### DIFF
--- a/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
@@ -36,6 +36,8 @@
 #include <OpenMS/ANALYSIS/TARGETED/PSProteinInference.h>
 #include <OpenMS/ANALYSIS/TARGETED/PrecursorIonSelectionPreprocessing.h>
 
+#undef DEBUG_OPS
+
 #ifdef DEBUG_OPS
 #include <OpenMS/SYSTEM/StopWatch.h>
 #endif

--- a/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
+++ b/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
@@ -40,6 +40,8 @@
 
 #include <iostream>
 
+#undef DEBUG_FD
+
 namespace OpenMS
 {
 
@@ -276,20 +278,21 @@ namespace OpenMS
       }
     }
 
-
     // sort according to (in-order) net-charge, mass, probability
     std::sort(explanations_.begin(), explanations_.end());
 
     // set Ids of compomers, which allows to uniquely identify them (for later lookup)
     for (size_t i = 0; i < explanations_.size(); ++i)
+    {
       explanations_[i].setID(i);
+    }      
 
-    //#if DEBUG_FD
+    #ifdef DEBUG_FD
     for (size_t ci = 0; ci < explanations_.size(); ++ci)
     {
       std::cerr << explanations_[ci] << " ";
     }
-    //#endif
+    #endif
 
     std::cout << "MassExplainer table size: " << explanations_.size() << "\n";
 

--- a/src/tests/class_tests/openms/source/MetaboliteFeatureDeconvolution_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteFeatureDeconvolution_test.cpp
@@ -69,7 +69,6 @@ namespace OpenMS
 			CHARGEMODE getChargeMode()
       { return q_try_;}
 
-
   };
 
 }


### PR DESCRIPTION
# Description

Some fixes to disable extensive (debug like) test outputs

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
