### PR TITLE
[Fix] MS3 TMT IdMapping

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -322,41 +322,22 @@ namespace OpenMS
           //check if we compare distance from centroid or subelements
           if (!measure_from_subelements)
           {
+            String ref_mv = "";
             if (map[cm_index].metaValueExists("id_scan_id")) // MS3 TMT
             {
-              if (ids[i].metaValueExists("spectrum_reference"))
-              {
-                if (ids[i].getMetaValue("spectrum_reference") == map[cm_index].getMetaValue("id_scan_id"))
-                {
-                  id_mapped = true;
-                  was_added = true;
-                  map[cm_index].getPeptideIdentifications().push_back(ids[i]);
-                  ++assigned_ids[i];
-                }
-              }
+              ref_mv = "id_scan_id";
             }
-            else if (map[cm_index].metaValueExists("scan_id")) // MS2 TMT
+            else if (map[cm_index].metaValueExists("scan_id"))
             {
-              if (ids[i].metaValueExists("spectrum_reference"))
-              {
-                if (ids[i].getMetaValue("spectrum_reference") == map[cm_index].getMetaValue("scan_id"))
-                {
-                  id_mapped = true;
-                  was_added = true;
-                  map[cm_index].getPeptideIdentifications().push_back(ids[i]);
-                  ++assigned_ids[i];
-                }
-              }
+              ref_mv = "scan_id";
             }
-            else
+            if ((!ref_mv.empty() && ids[i].metaValueExists("spectrum_reference") && (ids[i].getMetaValue("spectrum_reference") == map[cm_index].getMetaValue(ref_mv))) ||
+                (isMatch_(rt_pep - map[cm_index].getRT(), mz_pep, map[cm_index].getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, map[cm_index].getCharge()))))
             {
-              if (isMatch_(rt_pep - map[cm_index].getRT(), mz_pep, map[cm_index].getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, map[cm_index].getCharge())))
-              {
-                id_mapped = true;
-                was_added = true;
-                map[cm_index].getPeptideIdentifications().push_back(ids[i]);
-                ++assigned_ids[i];
-              }
+              id_mapped = true;
+              was_added = true;
+              map[cm_index].getPeptideIdentifications().push_back(ids[i]);
+              ++assigned_ids[i];
             }
           }
           else

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -249,7 +249,7 @@ namespace OpenMS
     annotate(map, peptide_ids, protein_ids, clear_ids, map_ms1);
   }
 
-  bool isMatchByNativeID(const String& reference_id, const PeptideIdentification& id, ConsensusFeature& cf)
+  bool isMatchByNativeID(const PeptideIdentification& id, ConsensusFeature& cf)
   {
     // check if the native id of an identifying spectrum is annotated            
     String ref_mv;
@@ -339,7 +339,7 @@ namespace OpenMS
           //check if we compare distance from centroid or subelements
           if (!measure_from_subelements)
           {
-            if (isMatchByNativeID(ref_mv, ids[i], map[cm_index]) || // can we match by native ids? if not, match by rt/mz
+            if (isMatchByNativeID(ids[i], map[cm_index]) || // can we match by native ids? if not, match by rt/mz
                (isMatch_(rt_pep - map[cm_index].getRT(), mz_pep, map[cm_index].getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, map[cm_index].getCharge()))))
             {
               id_mapped = true;

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -253,17 +253,17 @@ namespace OpenMS
   {
     // check if the native id of an identifying spectrum is annotated            
     String ref_mv;
-    if (map[cm_index].metaValueExists("id_scan_id")) // identifying MS2 spectrum in MS3 TMT
+    if (cf.metaValueExists("id_scan_id")) // identifying MS2 spectrum in MS3 TMT
     {
       ref_mv = "id_scan_id";
     }
-    else if (map[cm_index].metaValueExists("scan_id")) // identifying MS2 spectrum in standard TMT
+    else if (cf.metaValueExists("scan_id")) // identifying MS2 spectrum in standard TMT
     {
       ref_mv = "scan_id";
     }
 
     // return if no meta info to match ids between spectra and consensus features?
-    if (reference_id.empty() || !id.metaValueExists("spectrum_reference")) return false;
+    if (ref_mv.empty() || !id.metaValueExists("spectrum_reference")) return false;
     return id.getMetaValue("spectrum_reference") == cf.getMetaValue(ref_mv);
   }
 

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -322,12 +322,41 @@ namespace OpenMS
           //check if we compare distance from centroid or subelements
           if (!measure_from_subelements)
           {
-            if (isMatch_(rt_pep - map[cm_index].getRT(), mz_pep, map[cm_index].getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, map[cm_index].getCharge())))
+            if (map[cm_index].metaValueExists("id_scan_id")) // MS3 TMT
             {
-              id_mapped = true;
-              was_added = true;
-              map[cm_index].getPeptideIdentifications().push_back(ids[i]);
-              ++assigned_ids[i];
+              if (ids[i].metaValueExists("spectrum_reference"))
+              {
+                if (ids[i].getMetaValue("spectrum_reference") == map[cm_index].getMetaValue("id_scan_id"))
+                {
+                  id_mapped = true;
+                  was_added = true;
+                  map[cm_index].getPeptideIdentifications().push_back(ids[i]);
+                  ++assigned_ids[i];
+                }
+              }
+            }
+            else if (map[cm_index].metaValueExists("scan_id")) // MS2 TMT
+            {
+              if (ids[i].metaValueExists("spectrum_reference"))
+              {
+                if (ids[i].getMetaValue("spectrum_reference") == map[cm_index].getMetaValue("scan_id"))
+                {
+                  id_mapped = true;
+                  was_added = true;
+                  map[cm_index].getPeptideIdentifications().push_back(ids[i]);
+                  ++assigned_ids[i];
+                }
+              }
+            }
+            else
+            {
+              if (isMatch_(rt_pep - map[cm_index].getRT(), mz_pep, map[cm_index].getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, map[cm_index].getCharge())))
+              {
+                id_mapped = true;
+                was_added = true;
+                map[cm_index].getPeptideIdentifications().push_back(ids[i]);
+                ++assigned_ids[i];
+              }
             }
           }
           else
@@ -336,7 +365,7 @@ namespace OpenMS
                  it_handle != map[cm_index].getFeatures().end();
                  ++it_handle)
             {
-              if (isMatch_(rt_pep - it_handle->getRT(), mz_pep, it_handle->getMZ())  && (ignore_charge_ || ListUtils::contains(current_charges, it_handle->getCharge())))
+              if (isMatch_(rt_pep - it_handle->getRT(), mz_pep, it_handle->getMZ()) && (ignore_charge_ || ListUtils::contains(current_charges, it_handle->getCharge())))
               {
                 id_mapped = true;
                 was_added = true;

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -528,7 +528,7 @@ namespace OpenMS
     Size number_of_channels = quant_method_->getNumberOfChannels();
 
     PeakMap::ConstIterator it_last_MS2 = ms_exp_data.end(); // remember last MS2 spec, to get precursor in MS1 (also if quant is in MS3)
-
+    bool ms3 = false;
     for (PeakMap::ConstIterator it = ms_exp_data.begin(); it != ms_exp_data.end(); ++it)
     {
       // remember the last MS1 spectra as we assume it to be the precursor spectrum
@@ -578,6 +578,7 @@ namespace OpenMS
 
       if (it->getMSLevel() == 3)
       {
+        ms3 = true;
         // we cannot save just the last MS2 but need to compare to the precursor info stored in the (potential MS3 spectrum)
         it_last_MS2 = ms_exp_data.getPrecursorSpectrum(it);
 
@@ -682,10 +683,16 @@ namespace OpenMS
 
       // embed the id of the scan from which the quantitative information was extracted
       cf.setMetaValue("scan_id", it->getNativeID());
+      // embed the id of the scan from which the ID information should be extracted
+      // helpful for mapping later
+      if (ms3)
+      {
+        cf.setMetaValue("id_scan_id", it_last_MS2->getNativeID());
+      }
       // ...as well as additional meta information
       cf.setMetaValue("precursor_intensity", it->getPrecursors()[0].getIntensity());
 
-      cf.setCharge(it->getPrecursors()[0].getCharge());
+      cf.setCharge(it_last_MS2->getPrecursors()[0].getCharge());
       cf.setIntensity(overall_intensity);
       consensus_map.push_back(cf);
 

--- a/src/tests/topp/MS3TMT10Plex_test.consensusXML
+++ b/src/tests/topp/MS3TMT10Plex_test.consensusXML
@@ -81,26 +81,27 @@
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_5233264595117471314" quality="0.0" charge="1">
+		<consensusElement id="e_5233264595117471314" quality="0.0" charge="2">
 			<centroid rt="1742.439688272000012" mz="614.330261230468977" it="2.730841e05"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1742.783019904019966" mz="126.127725999999996" it="25684.339844"/>
-				<element map="1" id="0" rt="1742.783019904019966" mz="127.124761000000007" it="29396.761719"/>
-				<element map="2" id="0" rt="1742.783019904019966" mz="127.131080999999995" it="49474.910156"/>
-				<element map="3" id="0" rt="1742.783019904019966" mz="128.128116000000006" it="16671.869141"/>
-				<element map="4" id="0" rt="1742.783019904019966" mz="128.134435999999994" it="31941.115234"/>
-				<element map="5" id="0" rt="1742.783019904019966" mz="129.131471000000005" it="20037.552734"/>
-				<element map="6" id="0" rt="1742.783019904019966" mz="129.137789999999995" it="24973.181641"/>
-				<element map="7" id="0" rt="1742.783019904019966" mz="130.134825000000006" it="24619.080078"/>
-				<element map="8" id="0" rt="1742.783019904019966" mz="130.141144999999995" it="11245.0"/>
-				<element map="9" id="0" rt="1742.783019904019966" mz="131.138180000000006" it="39040.300781"/>
+				<element map="0" id="0" rt="1742.783019904019966" mz="126.127725999999996" it="2.568434e04"/>
+				<element map="1" id="0" rt="1742.783019904019966" mz="127.124761000000007" it="2.939676e04"/>
+				<element map="2" id="0" rt="1742.783019904019966" mz="127.131080999999995" it="4.947491e04"/>
+				<element map="3" id="0" rt="1742.783019904019966" mz="128.128116000000006" it="1.667187e04"/>
+				<element map="4" id="0" rt="1742.783019904019966" mz="128.134435999999994" it="3.194112e04"/>
+				<element map="5" id="0" rt="1742.783019904019966" mz="129.131471000000005" it="2.003755e04"/>
+				<element map="6" id="0" rt="1742.783019904019966" mz="129.137789999999995" it="2.497318e04"/>
+				<element map="7" id="0" rt="1742.783019904019966" mz="130.134825000000006" it="2.461908e04"/>
+				<element map="8" id="0" rt="1742.783019904019966" mz="130.141144999999995" it="1.1245e04"/>
+				<element map="9" id="0" rt="1742.783019904019966" mz="131.138180000000006" it="3.90403e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3250"/>
-			<UserParam type="float" name="precursor_intensity" value="20394.580078125"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3248"/>
+			<UserParam type="float" name="precursor_intensity" value="2.0394580078125e04"/>
 		</consensusElement>
 		<consensusElement id="e_17749660155506638460" quality="0.0" charge="3">
-			<centroid rt="1742.80122123197998" mz="564.247802734375" it="48407.238281"/>
+			<centroid rt="1742.80122123197998" mz="564.247802734375" it="4.840724e04"/>
 			<groupedElementList>
 				<element map="0" id="2" rt="1743.51680611200004" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="2" rt="1743.51680611200004" mz="127.124761000000007" it="3399.125"/>
@@ -110,21 +111,22 @@
 				<element map="5" id="2" rt="1743.51680611200004" mz="129.131471000000005" it="0.0"/>
 				<element map="6" id="2" rt="1743.51680611200004" mz="129.137789999999995" it="5042.988281"/>
 				<element map="7" id="2" rt="1743.51680611200004" mz="130.134825000000006" it="0.0"/>
-				<element map="8" id="2" rt="1743.51680611200004" mz="130.141144999999995" it="37662.335938"/>
+				<element map="8" id="2" rt="1743.51680611200004" mz="130.141144999999995" it="3.766234e04"/>
 				<element map="9" id="2" rt="1743.51680611200004" mz="131.138180000000006" it="0.0"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3254"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3251"/>
 			<UserParam type="float" name="precursor_intensity" value="688.47332763671875"/>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="0.0">
-			<centroid rt="1743.185043775979921" mz="524.272521972656023" it="30526.712891"/>
+		<consensusElement id="e_7804704400743266335" quality="0.0" charge="3">
+			<centroid rt="1743.185043775979921" mz="524.272521972656023" it="3.052671e04"/>
 			<groupedElementList>
 				<element map="0" id="3" rt="1743.866057296020017" mz="126.127725999999996" it="2268.391113"/>
 				<element map="1" id="3" rt="1743.866057296020017" mz="127.124761000000007" it="2742.512207"/>
 				<element map="2" id="3" rt="1743.866057296020017" mz="127.131080999999995" it="1655.295166"/>
 				<element map="3" id="3" rt="1743.866057296020017" mz="128.128116000000006" it="0.0"/>
-				<element map="4" id="3" rt="1743.866057296020017" mz="128.134435999999994" it="16617.236328"/>
+				<element map="4" id="3" rt="1743.866057296020017" mz="128.134435999999994" it="1.661724e04"/>
 				<element map="5" id="3" rt="1743.866057296020017" mz="129.131471000000005" it="2297.929932"/>
 				<element map="6" id="3" rt="1743.866057296020017" mz="129.137789999999995" it="2514.262695"/>
 				<element map="7" id="3" rt="1743.866057296020017" mz="130.134825000000006" it="780.874695"/>
@@ -133,28 +135,30 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3256"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3253"/>
 			<UserParam type="float" name="precursor_intensity" value="1663.202880859375"/>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="0.0" charge="2">
+		<consensusElement id="e_15004869347769368353" quality="0.0" charge="3">
 			<centroid rt="1743.534788592000041" mz="627.64599609375" it="1.703809e05"/>
 			<groupedElementList>
-				<element map="0" id="4" rt="1744.218051088020047" mz="126.127725999999996" it="10494.09375"/>
-				<element map="1" id="4" rt="1744.218051088020047" mz="127.124761000000007" it="21049.962891"/>
-				<element map="2" id="4" rt="1744.218051088020047" mz="127.131080999999995" it="14122.788086"/>
-				<element map="3" id="4" rt="1744.218051088020047" mz="128.128116000000006" it="13522.242188"/>
-				<element map="4" id="4" rt="1744.218051088020047" mz="128.134435999999994" it="12161.426758"/>
-				<element map="5" id="4" rt="1744.218051088020047" mz="129.131471000000005" it="31433.351563"/>
-				<element map="6" id="4" rt="1744.218051088020047" mz="129.137789999999995" it="19105.160156"/>
-				<element map="7" id="4" rt="1744.218051088020047" mz="130.134825000000006" it="15312.146484"/>
+				<element map="0" id="4" rt="1744.218051088020047" mz="126.127725999999996" it="1.049409e04"/>
+				<element map="1" id="4" rt="1744.218051088020047" mz="127.124761000000007" it="2.104996e04"/>
+				<element map="2" id="4" rt="1744.218051088020047" mz="127.131080999999995" it="1.412279e04"/>
+				<element map="3" id="4" rt="1744.218051088020047" mz="128.128116000000006" it="1.352224e04"/>
+				<element map="4" id="4" rt="1744.218051088020047" mz="128.134435999999994" it="1.216143e04"/>
+				<element map="5" id="4" rt="1744.218051088020047" mz="129.131471000000005" it="3.143335e04"/>
+				<element map="6" id="4" rt="1744.218051088020047" mz="129.137789999999995" it="1.910516e04"/>
+				<element map="7" id="4" rt="1744.218051088020047" mz="130.134825000000006" it="1.531215e04"/>
 				<element map="8" id="4" rt="1744.218051088020047" mz="130.141144999999995" it="7206.324219"/>
-				<element map="9" id="4" rt="1744.218051088020047" mz="131.138180000000006" it="25973.359375"/>
+				<element map="9" id="4" rt="1744.218051088020047" mz="131.138180000000006" it="2.597336e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3258"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3255"/>
 			<UserParam type="float" name="precursor_intensity" value="6422.115234375"/>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="0.0" charge="1">
-			<centroid rt="1743.883907536019933" mz="863.882080078125" it="31638.671875"/>
+		<consensusElement id="e_3332699010107892018" quality="0.0" charge="2">
+			<centroid rt="1743.883907536019933" mz="863.882080078125" it="3.163867e04"/>
 			<groupedElementList>
 				<element map="0" id="5" rt="1744.567793184000038" mz="126.127725999999996" it="6361.843262"/>
 				<element map="1" id="5" rt="1744.567793184000038" mz="127.124761000000007" it="5062.328125"/>
@@ -169,10 +173,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3260"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3257"/>
 			<UserParam type="float" name="precursor_intensity" value="2302.14306640625"/>
 		</consensusElement>
-		<consensusElement id="e_13440783915218733453" quality="0.0">
-			<centroid rt="1744.235910527999977" mz="657.315246582031023" it="28118.347656"/>
+		<consensusElement id="e_13440783915218733453" quality="0.0" charge="4">
+			<centroid rt="1744.235910527999977" mz="657.315246582031023" it="2.811835e04"/>
 			<groupedElementList>
 				<element map="0" id="6" rt="1744.768806304020018" mz="126.127725999999996" it="1110.639526"/>
 				<element map="1" id="6" rt="1744.768806304020018" mz="127.124761000000007" it="2367.315186"/>
@@ -187,64 +192,68 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3261"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3259"/>
 			<UserParam type="float" name="precursor_intensity" value="1717.0133056640625"/>
 		</consensusElement>
-		<consensusElement id="e_15916652588957785155" quality="0.0" charge="1">
+		<consensusElement id="e_15916652588957785155" quality="0.0" charge="2">
 			<centroid rt="1742.395947647999947" mz="544.301025390625" it="1.552087e05"/>
 			<groupedElementList>
-				<element map="0" id="7" rt="1744.969057360020088" mz="126.127725999999996" it="18936.099609"/>
-				<element map="1" id="7" rt="1744.969057360020088" mz="127.124761000000007" it="15760.194336"/>
-				<element map="2" id="7" rt="1744.969057360020088" mz="127.131080999999995" it="13647.632813"/>
-				<element map="3" id="7" rt="1744.969057360020088" mz="128.128116000000006" it="20805.716797"/>
-				<element map="4" id="7" rt="1744.969057360020088" mz="128.134435999999994" it="19356.787109"/>
-				<element map="5" id="7" rt="1744.969057360020088" mz="129.131471000000005" it="18101.605469"/>
-				<element map="6" id="7" rt="1744.969057360020088" mz="129.137789999999995" it="14504.352539"/>
-				<element map="7" id="7" rt="1744.969057360020088" mz="130.134825000000006" it="16371.303711"/>
+				<element map="0" id="7" rt="1744.969057360020088" mz="126.127725999999996" it="1.89361e04"/>
+				<element map="1" id="7" rt="1744.969057360020088" mz="127.124761000000007" it="1.576019e04"/>
+				<element map="2" id="7" rt="1744.969057360020088" mz="127.131080999999995" it="1.364763e04"/>
+				<element map="3" id="7" rt="1744.969057360020088" mz="128.128116000000006" it="2.080572e04"/>
+				<element map="4" id="7" rt="1744.969057360020088" mz="128.134435999999994" it="1.935679e04"/>
+				<element map="5" id="7" rt="1744.969057360020088" mz="129.131471000000005" it="1.810161e04"/>
+				<element map="6" id="7" rt="1744.969057360020088" mz="129.137789999999995" it="1.450435e04"/>
+				<element map="7" id="7" rt="1744.969057360020088" mz="130.134825000000006" it="1.63713e04"/>
 				<element map="8" id="7" rt="1744.969057360020088" mz="130.141144999999995" it="5294.603516"/>
-				<element map="9" id="7" rt="1744.969057360020088" mz="131.138180000000006" it="12430.387695"/>
+				<element map="9" id="7" rt="1744.969057360020088" mz="131.138180000000006" it="1.243039e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3262"/>
-			<UserParam type="float" name="precursor_intensity" value="13224.0595703125"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3247"/>
+			<UserParam type="float" name="precursor_intensity" value="1.32240595703125e04"/>
 		</consensusElement>
-		<consensusElement id="e_15157403601844400700" quality="0.0" charge="2">
-			<centroid rt="1745.271144271979892" mz="576.257751464843977" it="88494.703125"/>
+		<consensusElement id="e_15157403601844400700" quality="0.0" charge="3">
+			<centroid rt="1745.271144271979892" mz="576.257751464843977" it="8.84947e04"/>
 			<groupedElementList>
-				<element map="0" id="8" rt="1745.622064576019966" mz="126.127725999999996" it="13479.118164"/>
-				<element map="1" id="8" rt="1745.622064576019966" mz="127.124761000000007" it="11226.704102"/>
-				<element map="2" id="8" rt="1745.622064576019966" mz="127.131080999999995" it="17374.246094"/>
-				<element map="3" id="8" rt="1745.622064576019966" mz="128.128116000000006" it="14156.112305"/>
+				<element map="0" id="8" rt="1745.622064576019966" mz="126.127725999999996" it="1.347912e04"/>
+				<element map="1" id="8" rt="1745.622064576019966" mz="127.124761000000007" it="1.12267e04"/>
+				<element map="2" id="8" rt="1745.622064576019966" mz="127.131080999999995" it="1.737425e04"/>
+				<element map="3" id="8" rt="1745.622064576019966" mz="128.128116000000006" it="1.415611e04"/>
 				<element map="4" id="8" rt="1745.622064576019966" mz="128.134435999999994" it="6243.678711"/>
 				<element map="5" id="8" rt="1745.622064576019966" mz="129.131471000000005" it="971.983704"/>
-				<element map="6" id="8" rt="1745.622064576019966" mz="129.137789999999995" it="12477.426758"/>
+				<element map="6" id="8" rt="1745.622064576019966" mz="129.137789999999995" it="1.247743e04"/>
 				<element map="7" id="8" rt="1745.622064576019966" mz="130.134825000000006" it="5609.756836"/>
 				<element map="8" id="8" rt="1745.622064576019966" mz="130.141144999999995" it="0.0"/>
 				<element map="9" id="8" rt="1745.622064576019966" mz="131.138180000000006" it="6955.669434"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3267"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3265"/>
 			<UserParam type="float" name="precursor_intensity" value="3107.503662109375"/>
 		</consensusElement>
-		<consensusElement id="e_6408859317243173796" quality="0.0">
+		<consensusElement id="e_6408859317243173796" quality="0.0" charge="4">
 			<centroid rt="1745.338042735980025" mz="449.479064941406023" it="2.634313e05"/>
 			<groupedElementList>
-				<element map="0" id="9" rt="1745.998533055980033" mz="126.127725999999996" it="22678.580078"/>
-				<element map="1" id="9" rt="1745.998533055980033" mz="127.124761000000007" it="30900.388672"/>
-				<element map="2" id="9" rt="1745.998533055980033" mz="127.131080999999995" it="33509.222656"/>
-				<element map="3" id="9" rt="1745.998533055980033" mz="128.128116000000006" it="14566.374023"/>
-				<element map="4" id="9" rt="1745.998533055980033" mz="128.134435999999994" it="26641.728516"/>
-				<element map="5" id="9" rt="1745.998533055980033" mz="129.131471000000005" it="43079.8125"/>
-				<element map="6" id="9" rt="1745.998533055980033" mz="129.137789999999995" it="27302.205078"/>
-				<element map="7" id="9" rt="1745.998533055980033" mz="130.134825000000006" it="22439.707031"/>
-				<element map="8" id="9" rt="1745.998533055980033" mz="130.141144999999995" it="13340.897461"/>
-				<element map="9" id="9" rt="1745.998533055980033" mz="131.138180000000006" it="28972.427734"/>
+				<element map="0" id="9" rt="1745.998533055980033" mz="126.127725999999996" it="2.267858e04"/>
+				<element map="1" id="9" rt="1745.998533055980033" mz="127.124761000000007" it="3.090039e04"/>
+				<element map="2" id="9" rt="1745.998533055980033" mz="127.131080999999995" it="3.350922e04"/>
+				<element map="3" id="9" rt="1745.998533055980033" mz="128.128116000000006" it="1.456637e04"/>
+				<element map="4" id="9" rt="1745.998533055980033" mz="128.134435999999994" it="2.664173e04"/>
+				<element map="5" id="9" rt="1745.998533055980033" mz="129.131471000000005" it="4.307981e04"/>
+				<element map="6" id="9" rt="1745.998533055980033" mz="129.137789999999995" it="2.730221e04"/>
+				<element map="7" id="9" rt="1745.998533055980033" mz="130.134825000000006" it="2.243971e04"/>
+				<element map="8" id="9" rt="1745.998533055980033" mz="130.141144999999995" it="1.33409e04"/>
+				<element map="9" id="9" rt="1745.998533055980033" mz="131.138180000000006" it="2.897243e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3269"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3266"/>
 			<UserParam type="float" name="precursor_intensity" value="1.21468015625e05"/>
 		</consensusElement>
-		<consensusElement id="e_474525871221756682" quality="0.0" charge="1">
-			<centroid rt="1745.640142255979981" mz="940.965698242187955" it="17759.492188"/>
+		<consensusElement id="e_474525871221756682" quality="0.0" charge="2">
+			<centroid rt="1745.640142255979981" mz="940.965698242187955" it="1.775949e04"/>
 			<groupedElementList>
 				<element map="0" id="10" rt="1746.351754207980093" mz="126.127725999999996" it="743.268921"/>
 				<element map="1" id="10" rt="1746.351754207980093" mz="127.124761000000007" it="3373.173096"/>
@@ -259,17 +268,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3271"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3268"/>
 			<UserParam type="float" name="precursor_intensity" value="4147.79443359375"/>
 		</consensusElement>
-		<consensusElement id="e_12999979801269632061" quality="0.0">
-			<centroid rt="1746.016506288000073" mz="711.35693359375" it="46648.304688"/>
+		<consensusElement id="e_12999979801269632061" quality="0.0" charge="3">
+			<centroid rt="1746.016506288000073" mz="711.35693359375" it="4.664831e04"/>
 			<groupedElementList>
 				<element map="0" id="11" rt="1746.700889839979936" mz="126.127725999999996" it="514.180603"/>
 				<element map="1" id="11" rt="1746.700889839979936" mz="127.124761000000007" it="5108.108398"/>
 				<element map="2" id="11" rt="1746.700889839979936" mz="127.131080999999995" it="2538.865967"/>
 				<element map="3" id="11" rt="1746.700889839979936" mz="128.128116000000006" it="2183.846191"/>
 				<element map="4" id="11" rt="1746.700889839979936" mz="128.134435999999994" it="4267.595703"/>
-				<element map="5" id="11" rt="1746.700889839979936" mz="129.131471000000005" it="13882.43457"/>
+				<element map="5" id="11" rt="1746.700889839979936" mz="129.131471000000005" it="1.388243e04"/>
 				<element map="6" id="11" rt="1746.700889839979936" mz="129.137789999999995" it="5107.131836"/>
 				<element map="7" id="11" rt="1746.700889839979936" mz="130.134825000000006" it="4345.013672"/>
 				<element map="8" id="11" rt="1746.700889839979936" mz="130.141144999999995" it="3996.955322"/>
@@ -277,10 +287,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3273"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3270"/>
 			<UserParam type="float" name="precursor_intensity" value="2980.733154296875"/>
 		</consensusElement>
-		<consensusElement id="e_17413765565443951891" quality="0.0">
-			<centroid rt="1746.369623040000079" mz="500.755645751953011" it="11566.614258"/>
+		<consensusElement id="e_17413765565443951891" quality="0.0" charge="4">
+			<centroid rt="1746.369623040000079" mz="500.755645751953011" it="1.156661e04"/>
 			<groupedElementList>
 				<element map="0" id="12" rt="1747.050020704019971" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="12" rt="1747.050020704019971" mz="127.124761000000007" it="1111.064453"/>
@@ -295,10 +306,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3275"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3272"/>
 			<UserParam type="float" name="precursor_intensity" value="475.63946533203125"/>
 		</consensusElement>
-		<consensusElement id="e_16907355690727166316" quality="0.0">
-			<centroid rt="1747.06775126399998" mz="771.358215332031023" it="27245.1875"/>
+		<consensusElement id="e_16907355690727166316" quality="0.0" charge="2">
+			<centroid rt="1747.06775126399998" mz="771.358215332031023" it="2.724519e04"/>
 			<groupedElementList>
 				<element map="0" id="14" rt="1747.597911424019912" mz="126.127725999999996" it="3069.997314"/>
 				<element map="1" id="14" rt="1747.597911424019912" mz="127.124761000000007" it="2623.657471"/>
@@ -313,52 +325,55 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3278"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3276"/>
 			<UserParam type="float" name="precursor_intensity" value="231.818145751953125"/>
 		</consensusElement>
-		<consensusElement id="e_10306100746905639127" quality="0.0" charge="1">
+		<consensusElement id="e_10306100746905639127" quality="0.0" charge="2">
 			<centroid rt="1745.223908128019957" mz="660.3642578125" it="4.761588e05"/>
 			<groupedElementList>
-				<element map="0" id="15" rt="1747.799210736000077" mz="126.127725999999996" it="51444.011719"/>
-				<element map="1" id="15" rt="1747.799210736000077" mz="127.124761000000007" it="51356.289063"/>
-				<element map="2" id="15" rt="1747.799210736000077" mz="127.131080999999995" it="19712.246094"/>
-				<element map="3" id="15" rt="1747.799210736000077" mz="128.128116000000006" it="25564.410156"/>
+				<element map="0" id="15" rt="1747.799210736000077" mz="126.127725999999996" it="5.144401e04"/>
+				<element map="1" id="15" rt="1747.799210736000077" mz="127.124761000000007" it="5.135629e04"/>
+				<element map="2" id="15" rt="1747.799210736000077" mz="127.131080999999995" it="1.971225e04"/>
+				<element map="3" id="15" rt="1747.799210736000077" mz="128.128116000000006" it="2.556441e04"/>
 				<element map="4" id="15" rt="1747.799210736000077" mz="128.134435999999994" it="1.904606e05"/>
-				<element map="5" id="15" rt="1747.799210736000077" mz="129.131471000000005" it="43167.046875"/>
-				<element map="6" id="15" rt="1747.799210736000077" mz="129.137789999999995" it="46249.527344"/>
-				<element map="7" id="15" rt="1747.799210736000077" mz="130.134825000000006" it="11344.793945"/>
-				<element map="8" id="15" rt="1747.799210736000077" mz="130.141144999999995" it="24098.683594"/>
-				<element map="9" id="15" rt="1747.799210736000077" mz="131.138180000000006" it="12761.145508"/>
+				<element map="5" id="15" rt="1747.799210736000077" mz="129.131471000000005" it="4.316705e04"/>
+				<element map="6" id="15" rt="1747.799210736000077" mz="129.137789999999995" it="4.624953e04"/>
+				<element map="7" id="15" rt="1747.799210736000077" mz="130.134825000000006" it="1.134479e04"/>
+				<element map="8" id="15" rt="1747.799210736000077" mz="130.141144999999995" it="2.409868e04"/>
+				<element map="9" id="15" rt="1747.799210736000077" mz="131.138180000000006" it="1.276115e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3279"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3264"/>
 			<UserParam type="float" name="precursor_intensity" value="6874.3466796875"/>
 		</consensusElement>
-		<consensusElement id="e_12524258085768770586" quality="0.0">
+		<consensusElement id="e_12524258085768770586" quality="0.0" charge="3">
 			<centroid rt="1748.064848543999915" mz="493.280548095703011" it="1.260554e05"/>
 			<groupedElementList>
 				<element map="0" id="16" rt="1748.412916048019952" mz="126.127725999999996" it="9449.94043"/>
-				<element map="1" id="16" rt="1748.412916048019952" mz="127.124761000000007" it="15202.529297"/>
-				<element map="2" id="16" rt="1748.412916048019952" mz="127.131080999999995" it="12038.678711"/>
-				<element map="3" id="16" rt="1748.412916048019952" mz="128.128116000000006" it="14848.02832"/>
-				<element map="4" id="16" rt="1748.412916048019952" mz="128.134435999999994" it="10666.711914"/>
-				<element map="5" id="16" rt="1748.412916048019952" mz="129.131471000000005" it="10252.626953"/>
-				<element map="6" id="16" rt="1748.412916048019952" mz="129.137789999999995" it="11324.256836"/>
-				<element map="7" id="16" rt="1748.412916048019952" mz="130.134825000000006" it="11251.865234"/>
+				<element map="1" id="16" rt="1748.412916048019952" mz="127.124761000000007" it="1.520253e04"/>
+				<element map="2" id="16" rt="1748.412916048019952" mz="127.131080999999995" it="1.203868e04"/>
+				<element map="3" id="16" rt="1748.412916048019952" mz="128.128116000000006" it="1.484803e04"/>
+				<element map="4" id="16" rt="1748.412916048019952" mz="128.134435999999994" it="1.066671e04"/>
+				<element map="5" id="16" rt="1748.412916048019952" mz="129.131471000000005" it="1.025263e04"/>
+				<element map="6" id="16" rt="1748.412916048019952" mz="129.137789999999995" it="1.132426e04"/>
+				<element map="7" id="16" rt="1748.412916048019952" mz="130.134825000000006" it="1.125187e04"/>
 				<element map="8" id="16" rt="1748.412916048019952" mz="130.141144999999995" it="6626.402344"/>
-				<element map="9" id="16" rt="1748.412916048019952" mz="131.138180000000006" it="24394.398438"/>
+				<element map="9" id="16" rt="1748.412916048019952" mz="131.138180000000006" it="2.43944e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3284"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3282"/>
 			<UserParam type="float" name="precursor_intensity" value="5805.478515625"/>
 		</consensusElement>
-		<consensusElement id="e_1755235105885170967" quality="0.0">
-			<centroid rt="1748.133118111979911" mz="693.674133300781023" it="30743.289063"/>
+		<consensusElement id="e_1755235105885170967" quality="0.0" charge="3">
+			<centroid rt="1748.133118111979911" mz="693.674133300781023" it="3.074329e04"/>
 			<groupedElementList>
 				<element map="0" id="17" rt="1748.793026304000023" mz="126.127725999999996" it="3140.464355"/>
 				<element map="1" id="17" rt="1748.793026304000023" mz="127.124761000000007" it="4685.476563"/>
 				<element map="2" id="17" rt="1748.793026304000023" mz="127.131080999999995" it="673.353638"/>
 				<element map="3" id="17" rt="1748.793026304000023" mz="128.128116000000006" it="714.181519"/>
-				<element map="4" id="17" rt="1748.793026304000023" mz="128.134435999999994" it="16585.4375"/>
+				<element map="4" id="17" rt="1748.793026304000023" mz="128.134435999999994" it="1.658544e04"/>
 				<element map="5" id="17" rt="1748.793026304000023" mz="129.131471000000005" it="1667.682495"/>
 				<element map="6" id="17" rt="1748.793026304000023" mz="129.137789999999995" it="3276.694336"/>
 				<element map="7" id="17" rt="1748.793026304000023" mz="130.134825000000006" it="0.0"/>
@@ -367,10 +382,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3286"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3283"/>
 			<UserParam type="float" name="precursor_intensity" value="2668.87939453125"/>
 		</consensusElement>
-		<consensusElement id="e_14811341817612382122" quality="0.0" charge="1">
-			<centroid rt="1748.431172959979904" mz="755.8583984375" it="58417.175781"/>
+		<consensusElement id="e_14811341817612382122" quality="0.0" charge="2">
+			<centroid rt="1748.431172959979904" mz="755.8583984375" it="5.841718e04"/>
 			<groupedElementList>
 				<element map="0" id="18" rt="1749.347614272000101" mz="126.127725999999996" it="1918.554932"/>
 				<element map="1" id="18" rt="1749.347614272000101" mz="127.124761000000007" it="6824.422852"/>
@@ -381,14 +397,15 @@
 				<element map="6" id="18" rt="1749.347614272000101" mz="129.137789999999995" it="6354.091797"/>
 				<element map="7" id="18" rt="1749.347614272000101" mz="130.134825000000006" it="4433.185547"/>
 				<element map="8" id="18" rt="1749.347614272000101" mz="130.141144999999995" it="3291.654053"/>
-				<element map="9" id="18" rt="1749.347614272000101" mz="131.138180000000006" it="16191.258789"/>
+				<element map="9" id="18" rt="1749.347614272000101" mz="131.138180000000006" it="1.619126e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3288"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3285"/>
 			<UserParam type="float" name="precursor_intensity" value="1526.4462890625"/>
 		</consensusElement>
-		<consensusElement id="e_2684106197423007927" quality="0.0" charge="1">
-			<centroid rt="1748.810964863999971" mz="409.889221191406023" it="35841.644531"/>
+		<consensusElement id="e_2684106197423007927" quality="0.0" charge="3">
+			<centroid rt="1748.810964863999971" mz="409.889221191406023" it="3.584164e04"/>
 			<groupedElementList>
 				<element map="0" id="19" rt="1749.697349152020024" mz="126.127725999999996" it="3632.499023"/>
 				<element map="1" id="19" rt="1749.697349152020024" mz="127.124761000000007" it="3834.286621"/>
@@ -403,17 +420,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3290"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3287"/>
 			<UserParam type="float" name="precursor_intensity" value="446.383819580078125"/>
 		</consensusElement>
-		<consensusElement id="e_8119044117483804262" quality="0.0" charge="2">
-			<centroid rt="1749.365601583979924" mz="598.969177246093977" it="85591.054688"/>
+		<consensusElement id="e_8119044117483804262" quality="0.0" charge="3">
+			<centroid rt="1749.365601583979924" mz="598.969177246093977" it="8.559106e04"/>
 			<groupedElementList>
 				<element map="0" id="20" rt="1750.045111679999991" mz="126.127725999999996" it="6271.069824"/>
-				<element map="1" id="20" rt="1750.045111679999991" mz="127.124761000000007" it="10725.62793"/>
-				<element map="2" id="20" rt="1750.045111679999991" mz="127.131080999999995" it="10745.322266"/>
+				<element map="1" id="20" rt="1750.045111679999991" mz="127.124761000000007" it="1.072563e04"/>
+				<element map="2" id="20" rt="1750.045111679999991" mz="127.131080999999995" it="1.074532e04"/>
 				<element map="3" id="20" rt="1750.045111679999991" mz="128.128116000000006" it="5472.896973"/>
 				<element map="4" id="20" rt="1750.045111679999991" mz="128.134435999999994" it="7519.975098"/>
-				<element map="5" id="20" rt="1750.045111679999991" mz="129.131471000000005" it="15354.292969"/>
+				<element map="5" id="20" rt="1750.045111679999991" mz="129.131471000000005" it="1.535429e04"/>
 				<element map="6" id="20" rt="1750.045111679999991" mz="129.137789999999995" it="9710.601563"/>
 				<element map="7" id="20" rt="1750.045111679999991" mz="130.134825000000006" it="7019.637695"/>
 				<element map="8" id="20" rt="1750.045111679999991" mz="130.141144999999995" it="4949.558594"/>
@@ -421,9 +439,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3292"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3289"/>
 			<UserParam type="float" name="precursor_intensity" value="2456.42138671875"/>
 		</consensusElement>
-		<consensusElement id="e_17314619952666245179" quality="0.0" charge="1">
+		<consensusElement id="e_17314619952666245179" quality="0.0" charge="2">
 			<centroid rt="1749.715223328000093" mz="758.899291992187955" it="1161.5271"/>
 			<groupedElementList>
 				<element map="0" id="21" rt="1750.24887379200004" mz="126.127725999999996" it="0.0"/>
@@ -439,46 +458,49 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3293"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3291"/>
 			<UserParam type="float" name="precursor_intensity" value="1119.497802734375"/>
 		</consensusElement>
-		<consensusElement id="e_3023658190814908261" quality="0.0" charge="2">
+		<consensusElement id="e_3023658190814908261" quality="0.0" charge="3">
 			<centroid rt="1748.041490032019965" mz="506.269653320313012" it="4.043755e05"/>
 			<groupedElementList>
-				<element map="0" id="22" rt="1750.556580960000019" mz="126.127725999999996" it="42813.445313"/>
-				<element map="1" id="22" rt="1750.556580960000019" mz="127.124761000000007" it="44921.140625"/>
-				<element map="2" id="22" rt="1750.556580960000019" mz="127.131080999999995" it="48444.714844"/>
-				<element map="3" id="22" rt="1750.556580960000019" mz="128.128116000000006" it="30186.185547"/>
-				<element map="4" id="22" rt="1750.556580960000019" mz="128.134435999999994" it="49107.214844"/>
-				<element map="5" id="22" rt="1750.556580960000019" mz="129.131471000000005" it="40688.175781"/>
-				<element map="6" id="22" rt="1750.556580960000019" mz="129.137789999999995" it="39613.632813"/>
-				<element map="7" id="22" rt="1750.556580960000019" mz="130.134825000000006" it="29296.875"/>
-				<element map="8" id="22" rt="1750.556580960000019" mz="130.141144999999995" it="14345.223633"/>
-				<element map="9" id="22" rt="1750.556580960000019" mz="131.138180000000006" it="64958.863281"/>
+				<element map="0" id="22" rt="1750.556580960000019" mz="126.127725999999996" it="4.281344e04"/>
+				<element map="1" id="22" rt="1750.556580960000019" mz="127.124761000000007" it="4.492114e04"/>
+				<element map="2" id="22" rt="1750.556580960000019" mz="127.131080999999995" it="4.844471e04"/>
+				<element map="3" id="22" rt="1750.556580960000019" mz="128.128116000000006" it="3.018619e04"/>
+				<element map="4" id="22" rt="1750.556580960000019" mz="128.134435999999994" it="4.910721e04"/>
+				<element map="5" id="22" rt="1750.556580960000019" mz="129.131471000000005" it="4.068818e04"/>
+				<element map="6" id="22" rt="1750.556580960000019" mz="129.137789999999995" it="3.961363e04"/>
+				<element map="7" id="22" rt="1750.556580960000019" mz="130.134825000000006" it="2.929688e04"/>
+				<element map="8" id="22" rt="1750.556580960000019" mz="130.141144999999995" it="1.434522e04"/>
+				<element map="9" id="22" rt="1750.556580960000019" mz="131.138180000000006" it="6.495886e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3295"/>
-			<UserParam type="float" name="precursor_intensity" value="73779.4375"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3281"/>
+			<UserParam type="float" name="precursor_intensity" value="7.37794375e04"/>
 		</consensusElement>
-		<consensusElement id="e_7898004582401008768" quality="0.0" charge="1">
+		<consensusElement id="e_7898004582401008768" quality="0.0" charge="3">
 			<centroid rt="1750.267099200000075" mz="458.903747558593977" it="1.135281e05"/>
 			<groupedElementList>
 				<element map="0" id="23" rt="1750.757877151979983" mz="126.127725999999996" it="8560.217773"/>
-				<element map="1" id="23" rt="1750.757877151979983" mz="127.124761000000007" it="11263.487305"/>
-				<element map="2" id="23" rt="1750.757877151979983" mz="127.131080999999995" it="13218.292969"/>
-				<element map="3" id="23" rt="1750.757877151979983" mz="128.128116000000006" it="10634.291016"/>
-				<element map="4" id="23" rt="1750.757877151979983" mz="128.134435999999994" it="12890.871094"/>
-				<element map="5" id="23" rt="1750.757877151979983" mz="129.131471000000005" it="11206.921875"/>
-				<element map="6" id="23" rt="1750.757877151979983" mz="129.137789999999995" it="11166.698242"/>
-				<element map="7" id="23" rt="1750.757877151979983" mz="130.134825000000006" it="10789.436523"/>
+				<element map="1" id="23" rt="1750.757877151979983" mz="127.124761000000007" it="1.126349e04"/>
+				<element map="2" id="23" rt="1750.757877151979983" mz="127.131080999999995" it="1.321829e04"/>
+				<element map="3" id="23" rt="1750.757877151979983" mz="128.128116000000006" it="1.063429e04"/>
+				<element map="4" id="23" rt="1750.757877151979983" mz="128.134435999999994" it="1.289087e04"/>
+				<element map="5" id="23" rt="1750.757877151979983" mz="129.131471000000005" it="1.120692e04"/>
+				<element map="6" id="23" rt="1750.757877151979983" mz="129.137789999999995" it="1.11667e04"/>
+				<element map="7" id="23" rt="1750.757877151979983" mz="130.134825000000006" it="1.078944e04"/>
 				<element map="8" id="23" rt="1750.757877151979983" mz="130.141144999999995" it="7805.259766"/>
-				<element map="9" id="23" rt="1750.757877151979983" mz="131.138180000000006" it="15992.598633"/>
+				<element map="9" id="23" rt="1750.757877151979983" mz="131.138180000000006" it="1.59926e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3296"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3294"/>
 			<UserParam type="float" name="precursor_intensity" value="7760.8623046875"/>
 		</consensusElement>
-		<consensusElement id="e_15050004366391181853" quality="0.0" charge="1">
-			<centroid rt="1751.071194112020066" mz="456.237396240233977" it="86863.34375"/>
+		<consensusElement id="e_15050004366391181853" quality="0.0" charge="2">
+			<centroid rt="1751.071194112020066" mz="456.237396240233977" it="8.686335e04"/>
 			<groupedElementList>
 				<element map="0" id="24" rt="1751.419240896000019" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="24" rt="1751.419240896000019" mz="127.124761000000007" it="4241.079102"/>
@@ -488,14 +510,15 @@
 				<element map="5" id="24" rt="1751.419240896000019" mz="129.131471000000005" it="0.0"/>
 				<element map="6" id="24" rt="1751.419240896000019" mz="129.137789999999995" it="2592.562744"/>
 				<element map="7" id="24" rt="1751.419240896000019" mz="130.134825000000006" it="0.0"/>
-				<element map="8" id="24" rt="1751.419240896000019" mz="130.141144999999995" it="79584.78125"/>
+				<element map="8" id="24" rt="1751.419240896000019" mz="130.141144999999995" it="7.958478e04"/>
 				<element map="9" id="24" rt="1751.419240896000019" mz="131.138180000000006" it="0.0"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3301"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3299"/>
 			<UserParam type="float" name="precursor_intensity" value="705.9500732421875"/>
 		</consensusElement>
-		<consensusElement id="e_17716858074023296841" quality="0.0" charge="1">
+		<consensusElement id="e_17716858074023296841" quality="0.0" charge="2">
 			<centroid rt="1751.143064143979927" mz="734.86572265625" it="7414.572754"/>
 			<groupedElementList>
 				<element map="0" id="25" rt="1751.794069663980054" mz="126.127725999999996" it="666.003174"/>
@@ -511,9 +534,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3303"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3300"/>
 			<UserParam type="float" name="precursor_intensity" value="265.4268798828125"/>
 		</consensusElement>
-		<consensusElement id="e_16250062551099875712" quality="0.0" charge="1">
+		<consensusElement id="e_16250062551099875712" quality="0.0" charge="2">
 			<centroid rt="1751.437341376019958" mz="611.34375" it="1329.875"/>
 			<groupedElementList>
 				<element map="0" id="26" rt="1752.145556303999911" mz="126.127725999999996" it="0.0"/>
@@ -529,10 +553,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3305"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3302"/>
 			<UserParam type="float" name="precursor_intensity" value="573.2122802734375"/>
 		</consensusElement>
-		<consensusElement id="e_16177748921272733768" quality="0.0" charge="2">
-			<centroid rt="1751.811936511980093" mz="514.905639648437955" it="22928.363281"/>
+		<consensusElement id="e_16177748921272733768" quality="0.0" charge="3">
+			<centroid rt="1751.811936511980093" mz="514.905639648437955" it="2.292836e04"/>
 			<groupedElementList>
 				<element map="0" id="27" rt="1752.494935535999957" mz="126.127725999999996" it="1235.434082"/>
 				<element map="1" id="27" rt="1752.494935535999957" mz="127.124761000000007" it="3686.738281"/>
@@ -547,9 +572,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3307"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3304"/>
 			<UserParam type="float" name="precursor_intensity" value="725.303466796875"/>
 		</consensusElement>
-		<consensusElement id="e_7276556891837796968" quality="0.0" charge="2">
+		<consensusElement id="e_7276556891837796968" quality="0.0" charge="3">
 			<centroid rt="1752.163414687980094" mz="647.64599609375" it="8470.817383"/>
 			<groupedElementList>
 				<element map="0" id="28" rt="1752.84356515200011" mz="126.127725999999996" it="0.0"/>
@@ -565,46 +591,49 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3309"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3306"/>
 			<UserParam type="float" name="precursor_intensity" value="2725.87060546875"/>
 		</consensusElement>
-		<consensusElement id="e_1147219038608936718" quality="0.0" charge="1">
+		<consensusElement id="e_1147219038608936718" quality="0.0" charge="3">
 			<centroid rt="1752.51281032001998" mz="528.601379394531023" it="4.88186e05"/>
 			<groupedElementList>
-				<element map="0" id="29" rt="1753.193800207980075" mz="126.127725999999996" it="54564.203125"/>
-				<element map="1" id="29" rt="1753.193800207980075" mz="127.124761000000007" it="51194.226563"/>
-				<element map="2" id="29" rt="1753.193800207980075" mz="127.131080999999995" it="51435.902344"/>
-				<element map="3" id="29" rt="1753.193800207980075" mz="128.128116000000006" it="26031.632813"/>
+				<element map="0" id="29" rt="1753.193800207980075" mz="126.127725999999996" it="5.45642e04"/>
+				<element map="1" id="29" rt="1753.193800207980075" mz="127.124761000000007" it="5.119422e04"/>
+				<element map="2" id="29" rt="1753.193800207980075" mz="127.131080999999995" it="5.14359e04"/>
+				<element map="3" id="29" rt="1753.193800207980075" mz="128.128116000000006" it="2.603163e04"/>
 				<element map="4" id="29" rt="1753.193800207980075" mz="128.134435999999994" it="1.795369e05"/>
-				<element map="5" id="29" rt="1753.193800207980075" mz="129.131471000000005" it="14993.750977"/>
-				<element map="6" id="29" rt="1753.193800207980075" mz="129.137789999999995" it="44680.664063"/>
-				<element map="7" id="29" rt="1753.193800207980075" mz="130.134825000000006" it="17088.658203"/>
+				<element map="5" id="29" rt="1753.193800207980075" mz="129.131471000000005" it="1.499375e04"/>
+				<element map="6" id="29" rt="1753.193800207980075" mz="129.137789999999995" it="4.468066e04"/>
+				<element map="7" id="29" rt="1753.193800207980075" mz="130.134825000000006" it="1.708866e04"/>
 				<element map="8" id="29" rt="1753.193800207980075" mz="130.141144999999995" it="4451.830566"/>
-				<element map="9" id="29" rt="1753.193800207980075" mz="131.138180000000006" it="44208.242188"/>
+				<element map="9" id="29" rt="1753.193800207980075" mz="131.138180000000006" it="4.420824e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3311"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3308"/>
 			<UserParam type="float" name="precursor_intensity" value="2044.9808349609375"/>
 		</consensusElement>
-		<consensusElement id="e_11115414975438642789" quality="0.0" charge="1">
+		<consensusElement id="e_11115414975438642789" quality="0.0" charge="4">
 			<centroid rt="1752.8614221119999" mz="434.980926513671989" it="1.180662e05"/>
 			<groupedElementList>
-				<element map="0" id="30" rt="1753.394436943980054" mz="126.127725999999996" it="18814.109375"/>
-				<element map="1" id="30" rt="1753.394436943980054" mz="127.124761000000007" it="17812.380859"/>
+				<element map="0" id="30" rt="1753.394436943980054" mz="126.127725999999996" it="1.881411e04"/>
+				<element map="1" id="30" rt="1753.394436943980054" mz="127.124761000000007" it="1.781238e04"/>
 				<element map="2" id="30" rt="1753.394436943980054" mz="127.131080999999995" it="8159.510742"/>
 				<element map="3" id="30" rt="1753.394436943980054" mz="128.128116000000006" it="7637.690918"/>
-				<element map="4" id="30" rt="1753.394436943980054" mz="128.134435999999994" it="13866.325195"/>
+				<element map="4" id="30" rt="1753.394436943980054" mz="128.134435999999994" it="1.386633e04"/>
 				<element map="5" id="30" rt="1753.394436943980054" mz="129.131471000000005" it="7700.683106"/>
-				<element map="6" id="30" rt="1753.394436943980054" mz="129.137789999999995" it="16585.558594"/>
+				<element map="6" id="30" rt="1753.394436943980054" mz="129.137789999999995" it="1.658556e04"/>
 				<element map="7" id="30" rt="1753.394436943980054" mz="130.134825000000006" it="3705.148193"/>
 				<element map="8" id="30" rt="1753.394436943980054" mz="130.141144999999995" it="1612.155151"/>
-				<element map="9" id="30" rt="1753.394436943980054" mz="131.138180000000006" it="22172.673828"/>
+				<element map="9" id="30" rt="1753.394436943980054" mz="131.138180000000006" it="2.217267e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3312"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3310"/>
 			<UserParam type="float" name="precursor_intensity" value="3010.94482421875"/>
 		</consensusElement>
-		<consensusElement id="e_14509930621887606273" quality="0.0" charge="1">
-			<centroid rt="1751.023697728019897" mz="551.596008300781023" it="44013.0"/>
+		<consensusElement id="e_14509930621887606273" quality="0.0" charge="3">
+			<centroid rt="1751.023697728019897" mz="551.596008300781023" it="4.4013e04"/>
 			<groupedElementList>
 				<element map="0" id="31" rt="1753.595705087999932" mz="126.127725999999996" it="5307.833984"/>
 				<element map="1" id="31" rt="1753.595705087999932" mz="127.124761000000007" it="4569.155762"/>
@@ -619,46 +648,49 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3313"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3298"/>
 			<UserParam type="float" name="precursor_intensity" value="3482.52197265625"/>
 		</consensusElement>
-		<consensusElement id="e_13424404046998308790" quality="0.0" charge="1">
+		<consensusElement id="e_13424404046998308790" quality="0.0" charge="2">
 			<centroid rt="1753.892155903979983" mz="423.747833251953011" it="2.017573e05"/>
 			<groupedElementList>
-				<element map="0" id="32" rt="1754.244702784020092" mz="126.127725999999996" it="13377.294922"/>
-				<element map="1" id="32" rt="1754.244702784020092" mz="127.124761000000007" it="21333.148438"/>
+				<element map="0" id="32" rt="1754.244702784020092" mz="126.127725999999996" it="1.337729e04"/>
+				<element map="1" id="32" rt="1754.244702784020092" mz="127.124761000000007" it="2.133315e04"/>
 				<element map="2" id="32" rt="1754.244702784020092" mz="127.131080999999995" it="9026.990234"/>
 				<element map="3" id="32" rt="1754.244702784020092" mz="128.128116000000006" it="8160.505859"/>
-				<element map="4" id="32" rt="1754.244702784020092" mz="128.134435999999994" it="83980.921875"/>
-				<element map="5" id="32" rt="1754.244702784020092" mz="129.131471000000005" it="22010.119141"/>
-				<element map="6" id="32" rt="1754.244702784020092" mz="129.137789999999995" it="21038.814453"/>
+				<element map="4" id="32" rt="1754.244702784020092" mz="128.134435999999994" it="8.398092e04"/>
+				<element map="5" id="32" rt="1754.244702784020092" mz="129.131471000000005" it="2.201012e04"/>
+				<element map="6" id="32" rt="1754.244702784020092" mz="129.137789999999995" it="2.103881e04"/>
 				<element map="7" id="32" rt="1754.244702784020092" mz="130.134825000000006" it="7399.573731"/>
 				<element map="8" id="32" rt="1754.244702784020092" mz="130.141144999999995" it="7500.189453"/>
 				<element map="9" id="32" rt="1754.244702784020092" mz="131.138180000000006" it="7929.740723"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3318"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3316"/>
 			<UserParam type="float" name="precursor_intensity" value="844.985107421875"/>
 		</consensusElement>
-		<consensusElement id="e_12665713047548007769" quality="0.0" charge="1">
+		<consensusElement id="e_12665713047548007769" quality="0.0" charge="3">
 			<centroid rt="1753.96765759997993" mz="440.578918457031023" it="1.373799e05"/>
 			<groupedElementList>
-				<element map="0" id="33" rt="1754.619654287999993" mz="126.127725999999996" it="13041.374023"/>
-				<element map="1" id="33" rt="1754.619654287999993" mz="127.124761000000007" it="13989.364258"/>
+				<element map="0" id="33" rt="1754.619654287999993" mz="126.127725999999996" it="1.304137e04"/>
+				<element map="1" id="33" rt="1754.619654287999993" mz="127.124761000000007" it="1.398936e04"/>
 				<element map="2" id="33" rt="1754.619654287999993" mz="127.131080999999995" it="4552.57959"/>
 				<element map="3" id="33" rt="1754.619654287999993" mz="128.128116000000006" it="7079.413086"/>
-				<element map="4" id="33" rt="1754.619654287999993" mz="128.134435999999994" it="54679.363281"/>
-				<element map="5" id="33" rt="1754.619654287999993" mz="129.131471000000005" it="12273.022461"/>
-				<element map="6" id="33" rt="1754.619654287999993" mz="129.137789999999995" it="11472.786133"/>
+				<element map="4" id="33" rt="1754.619654287999993" mz="128.134435999999994" it="5.467937e04"/>
+				<element map="5" id="33" rt="1754.619654287999993" mz="129.131471000000005" it="1.227302e04"/>
+				<element map="6" id="33" rt="1754.619654287999993" mz="129.137789999999995" it="1.147279e04"/>
 				<element map="7" id="33" rt="1754.619654287999993" mz="130.134825000000006" it="3901.907471"/>
-				<element map="8" id="33" rt="1754.619654287999993" mz="130.141144999999995" it="12722.166016"/>
+				<element map="8" id="33" rt="1754.619654287999993" mz="130.141144999999995" it="1.272217e04"/>
 				<element map="9" id="33" rt="1754.619654287999993" mz="131.138180000000006" it="3667.935791"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3320"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3317"/>
 			<UserParam type="float" name="precursor_intensity" value="2647.34423828125"/>
 		</consensusElement>
-		<consensusElement id="e_17092894204355333314" quality="0.0" charge="1">
-			<centroid rt="1754.262798815999986" mz="534.607971191406023" it="21328.345703"/>
+		<consensusElement id="e_17092894204355333314" quality="0.0" charge="3">
+			<centroid rt="1754.262798815999986" mz="534.607971191406023" it="2.132835e04"/>
 			<groupedElementList>
 				<element map="0" id="34" rt="1754.969150224020041" mz="126.127725999999996" it="3268.281738"/>
 				<element map="1" id="34" rt="1754.969150224020041" mz="127.124761000000007" it="2949.137695"/>
@@ -673,10 +705,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3322"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3319"/>
 			<UserParam type="float" name="precursor_intensity" value="2705.44287109375"/>
 		</consensusElement>
-		<consensusElement id="e_3491056946625602141" quality="0.0" charge="2">
-			<centroid rt="1754.637529504019994" mz="496.006774902343977" it="28498.941406"/>
+		<consensusElement id="e_3491056946625602141" quality="0.0" charge="4">
+			<centroid rt="1754.637529504019994" mz="496.006774902343977" it="2.849894e04"/>
 			<groupedElementList>
 				<element map="0" id="35" rt="1755.319759375980084" mz="126.127725999999996" it="4122.524902"/>
 				<element map="1" id="35" rt="1755.319759375980084" mz="127.124761000000007" it="2599.384277"/>
@@ -691,9 +724,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3324"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3321"/>
 			<UserParam type="float" name="precursor_intensity" value="541.87567138671875"/>
 		</consensusElement>
-		<consensusElement id="e_10627069796380146481" quality="0.0">
+		<consensusElement id="e_10627069796380146481" quality="0.0" charge="3">
 			<centroid rt="1754.987130479999905" mz="652.2978515625" it="2781.868652"/>
 			<groupedElementList>
 				<element map="0" id="36" rt="1755.668389711979899" mz="126.127725999999996" it="7.335577e-14"/>
@@ -709,6 +743,7 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3326"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3323"/>
 			<UserParam type="float" name="precursor_intensity" value="229.676727294921875"/>
 		</consensusElement>
 		<consensusElement id="e_10052793688680741109" quality="0.0" charge="2">
@@ -727,9 +762,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3328"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3325"/>
 			<UserParam type="float" name="precursor_intensity" value="535.63494873046875"/>
 		</consensusElement>
-		<consensusElement id="e_15166508592180818156" quality="0.0" charge="1">
+		<consensusElement id="e_15166508592180818156" quality="0.0" charge="2">
 			<centroid rt="1755.68624412797999" mz="704.873901367187955" it="5313.110352"/>
 			<groupedElementList>
 				<element map="0" id="38" rt="1756.220416288020033" mz="126.127725999999996" it="0.0"/>
@@ -745,10 +781,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3329"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3327"/>
 			<UserParam type="float" name="precursor_intensity" value="525.657470703125"/>
 		</consensusElement>
-		<consensusElement id="e_14768204679546465715" quality="0.0">
-			<centroid rt="1753.850273119980102" mz="585.689514160156023" it="19945.564453"/>
+		<consensusElement id="e_14768204679546465715" quality="0.0" charge="5">
+			<centroid rt="1753.850273119980102" mz="585.689514160156023" it="1.994556e04"/>
 			<groupedElementList>
 				<element map="0" id="39" rt="1756.42192950402" mz="126.127725999999996" it="2886.356934"/>
 				<element map="1" id="39" rt="1756.42192950402" mz="127.124761000000007" it="1784.428833"/>
@@ -763,64 +800,68 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3330"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3315"/>
 			<UserParam type="float" name="precursor_intensity" value="2828.73046875"/>
 		</consensusElement>
-		<consensusElement id="e_12156709473159629610" quality="0.0" charge="1">
-			<centroid rt="1756.693004320020009" mz="667.372741699218977" it="95438.679688"/>
+		<consensusElement id="e_12156709473159629610" quality="0.0" charge="2">
+			<centroid rt="1756.693004320020009" mz="667.372741699218977" it="9.543868e04"/>
 			<groupedElementList>
 				<element map="0" id="40" rt="1757.038833600000089" mz="126.127725999999996" it="5943.47998"/>
-				<element map="1" id="40" rt="1757.038833600000089" mz="127.124761000000007" it="12017.095703"/>
+				<element map="1" id="40" rt="1757.038833600000089" mz="127.124761000000007" it="1.20171e04"/>
 				<element map="2" id="40" rt="1757.038833600000089" mz="127.131080999999995" it="4615.228516"/>
 				<element map="3" id="40" rt="1757.038833600000089" mz="128.128116000000006" it="9907.946289"/>
 				<element map="4" id="40" rt="1757.038833600000089" mz="128.134435999999994" it="2836.488037"/>
-				<element map="5" id="40" rt="1757.038833600000089" mz="129.131471000000005" it="27634.142578"/>
+				<element map="5" id="40" rt="1757.038833600000089" mz="129.131471000000005" it="2.763414e04"/>
 				<element map="6" id="40" rt="1757.038833600000089" mz="129.137789999999995" it="8461.939453"/>
 				<element map="7" id="40" rt="1757.038833600000089" mz="130.134825000000006" it="6134.84082"/>
 				<element map="8" id="40" rt="1757.038833600000089" mz="130.141144999999995" it="1367.459229"/>
-				<element map="9" id="40" rt="1757.038833600000089" mz="131.138180000000006" it="16520.052734"/>
+				<element map="9" id="40" rt="1757.038833600000089" mz="131.138180000000006" it="1.652005e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3335"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3333"/>
 			<UserParam type="float" name="precursor_intensity" value="2144.359130859375"/>
 		</consensusElement>
 		<consensusElement id="e_15885522598119108466" quality="0.0" charge="2">
 			<centroid rt="1756.759874368020064" mz="638.332885742187955" it="1.157177e05"/>
 			<groupedElementList>
-				<element map="0" id="41" rt="1757.41565033597999" mz="126.127725999999996" it="12913.958984"/>
-				<element map="1" id="41" rt="1757.41565033597999" mz="127.124761000000007" it="12997.97168"/>
-				<element map="2" id="41" rt="1757.41565033597999" mz="127.131080999999995" it="10504.379883"/>
-				<element map="3" id="41" rt="1757.41565033597999" mz="128.128116000000006" it="11097.28418"/>
-				<element map="4" id="41" rt="1757.41565033597999" mz="128.134435999999994" it="17894.888672"/>
-				<element map="5" id="41" rt="1757.41565033597999" mz="129.131471000000005" it="15693.464844"/>
+				<element map="0" id="41" rt="1757.41565033597999" mz="126.127725999999996" it="1.291396e04"/>
+				<element map="1" id="41" rt="1757.41565033597999" mz="127.124761000000007" it="1.299797e04"/>
+				<element map="2" id="41" rt="1757.41565033597999" mz="127.131080999999995" it="1.050438e04"/>
+				<element map="3" id="41" rt="1757.41565033597999" mz="128.128116000000006" it="1.109728e04"/>
+				<element map="4" id="41" rt="1757.41565033597999" mz="128.134435999999994" it="1.789489e04"/>
+				<element map="5" id="41" rt="1757.41565033597999" mz="129.131471000000005" it="1.569346e04"/>
 				<element map="6" id="41" rt="1757.41565033597999" mz="129.137789999999995" it="9899.732422"/>
 				<element map="7" id="41" rt="1757.41565033597999" mz="130.134825000000006" it="7987.866699"/>
 				<element map="8" id="41" rt="1757.41565033597999" mz="130.141144999999995" it="6078.931152"/>
-				<element map="9" id="41" rt="1757.41565033597999" mz="131.138180000000006" it="10649.228516"/>
+				<element map="9" id="41" rt="1757.41565033597999" mz="131.138180000000006" it="1.064923e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3337"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3334"/>
 			<UserParam type="float" name="precursor_intensity" value="1432.886962890625"/>
 		</consensusElement>
-		<consensusElement id="e_3823858840059792698" quality="0.0" charge="1">
+		<consensusElement id="e_3823858840059792698" quality="0.0" charge="2">
 			<centroid rt="1757.057131744019898" mz="645.851989746093977" it="1.042214e05"/>
 			<groupedElementList>
 				<element map="0" id="42" rt="1757.765108335979903" mz="126.127725999999996" it="9520.046875"/>
-				<element map="1" id="42" rt="1757.765108335979903" mz="127.124761000000007" it="12599.767578"/>
+				<element map="1" id="42" rt="1757.765108335979903" mz="127.124761000000007" it="1.259977e04"/>
 				<element map="2" id="42" rt="1757.765108335979903" mz="127.131080999999995" it="9898.829102"/>
 				<element map="3" id="42" rt="1757.765108335979903" mz="128.128116000000006" it="8800.260742"/>
-				<element map="4" id="42" rt="1757.765108335979903" mz="128.134435999999994" it="10098.280273"/>
-				<element map="5" id="42" rt="1757.765108335979903" mz="129.131471000000005" it="11048.366211"/>
+				<element map="4" id="42" rt="1757.765108335979903" mz="128.134435999999994" it="1.009828e04"/>
+				<element map="5" id="42" rt="1757.765108335979903" mz="129.131471000000005" it="1.104837e04"/>
 				<element map="6" id="42" rt="1757.765108335979903" mz="129.137789999999995" it="9649.866211"/>
 				<element map="7" id="42" rt="1757.765108335979903" mz="130.134825000000006" it="8991.439453"/>
 				<element map="8" id="42" rt="1757.765108335979903" mz="130.141144999999995" it="2581.921875"/>
-				<element map="9" id="42" rt="1757.765108335979903" mz="131.138180000000006" it="21032.625"/>
+				<element map="9" id="42" rt="1757.765108335979903" mz="131.138180000000006" it="2.103262e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3339"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3336"/>
 			<UserParam type="float" name="precursor_intensity" value="825.64471435546875"/>
 		</consensusElement>
 		<consensusElement id="e_893904610286969204" quality="0.0" charge="2">
-			<centroid rt="1757.433635183999968" mz="792.39794921875" it="20852.740234"/>
+			<centroid rt="1757.433635183999968" mz="792.39794921875" it="2.085274e04"/>
 			<groupedElementList>
 				<element map="0" id="43" rt="1758.116362591980078" mz="126.127725999999996" it="1587.078003"/>
 				<element map="1" id="43" rt="1758.116362591980078" mz="127.124761000000007" it="2735.931641"/>
@@ -835,10 +876,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3341"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3338"/>
 			<UserParam type="float" name="precursor_intensity" value="2299.224365234375"/>
 		</consensusElement>
-		<consensusElement id="e_14851350658635457156" quality="0.0" charge="1">
-			<centroid rt="1757.782974832020045" mz="737.894409179687955" it="17039.453125"/>
+		<consensusElement id="e_14851350658635457156" quality="0.0" charge="2">
+			<centroid rt="1757.782974832020045" mz="737.894409179687955" it="1.703945e04"/>
 			<groupedElementList>
 				<element map="0" id="44" rt="1758.464981935979949" mz="126.127725999999996" it="1225.450562"/>
 				<element map="1" id="44" rt="1758.464981935979949" mz="127.124761000000007" it="1551.316895"/>
@@ -853,17 +895,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3343"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3340"/>
 			<UserParam type="float" name="precursor_intensity" value="466.862701416015625"/>
 		</consensusElement>
-		<consensusElement id="e_17447818880105247092" quality="0.0" charge="2">
-			<centroid rt="1758.134212591980031" mz="501.281951904296989" it="38258.21875"/>
+		<consensusElement id="e_17447818880105247092" quality="0.0" charge="3">
+			<centroid rt="1758.134212591980031" mz="501.281951904296989" it="3.825822e04"/>
 			<groupedElementList>
 				<element map="0" id="45" rt="1758.813486064020026" mz="126.127725999999996" it="2070.043701"/>
 				<element map="1" id="45" rt="1758.813486064020026" mz="127.124761000000007" it="4671.550293"/>
 				<element map="2" id="45" rt="1758.813486064020026" mz="127.131080999999995" it="1932.115234"/>
 				<element map="3" id="45" rt="1758.813486064020026" mz="128.128116000000006" it="2944.770264"/>
 				<element map="4" id="45" rt="1758.813486064020026" mz="128.134435999999994" it="3610.967773"/>
-				<element map="5" id="45" rt="1758.813486064020026" mz="129.131471000000005" it="10926.160156"/>
+				<element map="5" id="45" rt="1758.813486064020026" mz="129.131471000000005" it="1.092616e04"/>
 				<element map="6" id="45" rt="1758.813486064020026" mz="129.137789999999995" it="4195.041504"/>
 				<element map="7" id="45" rt="1758.813486064020026" mz="130.134825000000006" it="2779.587647"/>
 				<element map="8" id="45" rt="1758.813486064020026" mz="130.141144999999995" it="1156.190063"/>
@@ -871,10 +914,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3345"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3342"/>
 			<UserParam type="float" name="precursor_intensity" value="765.46368408203125"/>
 		</consensusElement>
-		<consensusElement id="e_1003624456647096845" quality="0.0" charge="1">
-			<centroid rt="1758.483212399999957" mz="606.31005859375" it="41304.449219"/>
+		<consensusElement id="e_1003624456647096845" quality="0.0" charge="2">
+			<centroid rt="1758.483212399999957" mz="606.31005859375" it="4.130445e04"/>
 			<groupedElementList>
 				<element map="0" id="46" rt="1759.014470287979975" mz="126.127725999999996" it="9979.176758"/>
 				<element map="1" id="46" rt="1759.014470287979975" mz="127.124761000000007" it="4890.295898"/>
@@ -889,28 +933,30 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3346"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3344"/>
 			<UserParam type="float" name="precursor_intensity" value="427.599334716796875"/>
 		</consensusElement>
-		<consensusElement id="e_15120290131060441429" quality="0.0" charge="1">
+		<consensusElement id="e_15120290131060441429" quality="0.0" charge="3">
 			<centroid rt="1756.651112832000081" mz="458.255340576171989" it="9.097309e05"/>
 			<groupedElementList>
-				<element map="0" id="47" rt="1759.211998063979991" mz="126.127725999999996" it="94823.765625"/>
-				<element map="1" id="47" rt="1759.211998063979991" mz="127.124761000000007" it="95018.242188"/>
+				<element map="0" id="47" rt="1759.211998063979991" mz="126.127725999999996" it="9.482376e04"/>
+				<element map="1" id="47" rt="1759.211998063979991" mz="127.124761000000007" it="9.501824e04"/>
 				<element map="2" id="47" rt="1759.211998063979991" mz="127.131080999999995" it="1.094225e05"/>
-				<element map="3" id="47" rt="1759.211998063979991" mz="128.128116000000006" it="71533.460938"/>
-				<element map="4" id="47" rt="1759.211998063979991" mz="128.134435999999994" it="64835.144531"/>
-				<element map="5" id="47" rt="1759.211998063979991" mz="129.131471000000005" it="60156.316406"/>
-				<element map="6" id="47" rt="1759.211998063979991" mz="129.137789999999995" it="93143.539063"/>
-				<element map="7" id="47" rt="1759.211998063979991" mz="130.134825000000006" it="88462.90625"/>
-				<element map="8" id="47" rt="1759.211998063979991" mz="130.141144999999995" it="52463.621094"/>
+				<element map="3" id="47" rt="1759.211998063979991" mz="128.128116000000006" it="7.153346e04"/>
+				<element map="4" id="47" rt="1759.211998063979991" mz="128.134435999999994" it="6.483514e04"/>
+				<element map="5" id="47" rt="1759.211998063979991" mz="129.131471000000005" it="6.015632e04"/>
+				<element map="6" id="47" rt="1759.211998063979991" mz="129.137789999999995" it="9.314354e04"/>
+				<element map="7" id="47" rt="1759.211998063979991" mz="130.134825000000006" it="8.846291e04"/>
+				<element map="8" id="47" rt="1759.211998063979991" mz="130.141144999999995" it="5.246362e04"/>
 				<element map="9" id="47" rt="1759.211998063979991" mz="131.138180000000006" it="1.798714e05"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3347"/>
-			<UserParam type="float" name="precursor_intensity" value="17091.021484375"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3332"/>
+			<UserParam type="float" name="precursor_intensity" value="1.7091021484375e04"/>
 		</consensusElement>
-		<consensusElement id="e_11275867043381640475" quality="0.0" charge="1">
-			<centroid rt="1759.509191472000111" mz="843.368835449218977" it="10815.949219"/>
+		<consensusElement id="e_11275867043381640475" quality="0.0" charge="2">
+			<centroid rt="1759.509191472000111" mz="843.368835449218977" it="1.081595e04"/>
 			<groupedElementList>
 				<element map="0" id="48" rt="1759.860744352019992" mz="126.127725999999996" it="3535.437012"/>
 				<element map="1" id="48" rt="1759.860744352019992" mz="127.124761000000007" it="0.0"/>
@@ -925,10 +971,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3352"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3350"/>
 			<UserParam type="float" name="precursor_intensity" value="1998.5228271484375"/>
 		</consensusElement>
-		<consensusElement id="e_3713543811689521337" quality="0.0" charge="2">
-			<centroid rt="1759.578568447979933" mz="480.598358154296989" it="30392.697266"/>
+		<consensusElement id="e_3713543811689521337" quality="0.0" charge="3">
+			<centroid rt="1759.578568447979933" mz="480.598358154296989" it="3.03927e04"/>
 			<groupedElementList>
 				<element map="0" id="49" rt="1760.23372068797994" mz="126.127725999999996" it="7813.65625"/>
 				<element map="1" id="49" rt="1760.23372068797994" mz="127.124761000000007" it="3034.55127"/>
@@ -943,13 +990,14 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3354"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3351"/>
 			<UserParam type="float" name="precursor_intensity" value="938.8157958984375"/>
 		</consensusElement>
-		<consensusElement id="e_3246735940528705071" quality="0.0" charge="1">
-			<centroid rt="1760.251684031999957" mz="434.752563476563012" it="61440.535156"/>
+		<consensusElement id="e_3246735940528705071" quality="0.0" charge="2">
+			<centroid rt="1760.251684031999957" mz="434.752563476563012" it="6.144053e04"/>
 			<groupedElementList>
 				<element map="0" id="51" rt="1760.931346207979914" mz="126.127725999999996" it="7774.894043"/>
-				<element map="1" id="51" rt="1760.931346207979914" mz="127.124761000000007" it="11146.583008"/>
+				<element map="1" id="51" rt="1760.931346207979914" mz="127.124761000000007" it="1.114658e04"/>
 				<element map="2" id="51" rt="1760.931346207979914" mz="127.131080999999995" it="4621.140137"/>
 				<element map="3" id="51" rt="1760.931346207979914" mz="128.128116000000006" it="3615.354736"/>
 				<element map="4" id="51" rt="1760.931346207979914" mz="128.134435999999994" it="9139.098633"/>
@@ -957,13 +1005,14 @@
 				<element map="6" id="51" rt="1760.931346207979914" mz="129.137789999999995" it="7817.182617"/>
 				<element map="7" id="51" rt="1760.931346207979914" mz="130.134825000000006" it="2029.260254"/>
 				<element map="8" id="51" rt="1760.931346207979914" mz="130.141144999999995" it="886.457642"/>
-				<element map="9" id="51" rt="1760.931346207979914" mz="131.138180000000006" it="11885.692383"/>
+				<element map="9" id="51" rt="1760.931346207979914" mz="131.138180000000006" it="1.188569e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3358"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3355"/>
 			<UserParam type="float" name="precursor_intensity" value="602.0220947265625"/>
 		</consensusElement>
-		<consensusElement id="e_4584897071539917580" quality="0.0" charge="2">
+		<consensusElement id="e_4584897071539917580" quality="0.0" charge="3">
 			<centroid rt="1760.600682928019978" mz="619.639343261718977" it="735.263428"/>
 			<groupedElementList>
 				<element map="0" id="52" rt="1761.280311136019918" mz="126.127725999999996" it="0.0"/>
@@ -979,10 +1028,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3360"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3357"/>
 			<UserParam type="float" name="precursor_intensity" value="1817.78564453125"/>
 		</consensusElement>
-		<consensusElement id="e_260132145239717571" quality="0.0" charge="2">
-			<centroid rt="1760.949302368019971" mz="592.919860839843977" it="19896.15625"/>
+		<consensusElement id="e_260132145239717571" quality="0.0" charge="3">
+			<centroid rt="1760.949302368019971" mz="592.919860839843977" it="1.989616e04"/>
 			<groupedElementList>
 				<element map="0" id="53" rt="1761.628942528019934" mz="126.127725999999996" it="2136.395264"/>
 				<element map="1" id="53" rt="1761.628942528019934" mz="127.124761000000007" it="1826.623291"/>
@@ -997,9 +1047,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3362"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3359"/>
 			<UserParam type="float" name="precursor_intensity" value="1191.42138671875"/>
 		</consensusElement>
-		<consensusElement id="e_14317784148091680644" quality="0.0" charge="1">
+		<consensusElement id="e_14317784148091680644" quality="0.0" charge="2">
 			<centroid rt="1759.461962159999985" mz="813.869384765625" it="4934.327148"/>
 			<groupedElementList>
 				<element map="0" id="55" rt="1762.031577391979908" mz="126.127725999999996" it="1162.051758"/>
@@ -1015,10 +1066,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3364"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3349"/>
 			<UserParam type="float" name="precursor_intensity" value="2113.271484375"/>
 		</consensusElement>
-		<consensusElement id="e_17671779025680303814" quality="0.0" charge="2">
-			<centroid rt="1762.310155103999932" mz="513.578857421875" it="50250.253906"/>
+		<consensusElement id="e_17671779025680303814" quality="0.0" charge="3">
+			<centroid rt="1762.310155103999932" mz="513.578857421875" it="5.025025e04"/>
 			<groupedElementList>
 				<element map="0" id="56" rt="1762.660693135979955" mz="126.127725999999996" it="5183.700684"/>
 				<element map="1" id="56" rt="1762.660693135979955" mz="127.124761000000007" it="3895.319824"/>
@@ -1033,9 +1085,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3369"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3367"/>
 			<UserParam type="float" name="precursor_intensity" value="1986.4034423828125"/>
 		</consensusElement>
-		<consensusElement id="e_1196373166564353753" quality="0.0" charge="1">
+		<consensusElement id="e_1196373166564353753" quality="0.0" charge="2">
 			<centroid rt="1762.380147136020014" mz="726.818542480468977" it="7821.968262"/>
 			<groupedElementList>
 				<element map="0" id="57" rt="1763.028534192000052" mz="126.127725999999996" it="1367.076538"/>
@@ -1051,10 +1104,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3371"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3368"/>
 			<UserParam type="float" name="precursor_intensity" value="993.15277099609375"/>
 		</consensusElement>
-		<consensusElement id="e_7539502987715517688" quality="0.0" charge="1">
-			<centroid rt="1762.67879916798006" mz="421.252563476563012" it="48356.921875"/>
+		<consensusElement id="e_7539502987715517688" quality="0.0" charge="2">
+			<centroid rt="1762.67879916798006" mz="421.252563476563012" it="4.835692e04"/>
 			<groupedElementList>
 				<element map="0" id="58" rt="1763.376291904020036" mz="126.127725999999996" it="521.303467"/>
 				<element map="1" id="58" rt="1763.376291904020036" mz="127.124761000000007" it="6547.294922"/>
@@ -1063,12 +1117,13 @@
 				<element map="4" id="58" rt="1763.376291904020036" mz="128.134435999999994" it="8190.822266"/>
 				<element map="5" id="58" rt="1763.376291904020036" mz="129.131471000000005" it="7027.633301"/>
 				<element map="6" id="58" rt="1763.376291904020036" mz="129.137789999999995" it="5084.951172"/>
-				<element map="7" id="58" rt="1763.376291904020036" mz="130.134825000000006" it="15286.814453"/>
+				<element map="7" id="58" rt="1763.376291904020036" mz="130.134825000000006" it="1.528681e04"/>
 				<element map="8" id="58" rt="1763.376291904020036" mz="130.141144999999995" it="0.0"/>
 				<element map="9" id="58" rt="1763.376291904020036" mz="131.138180000000006" it="938.153625"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3373"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3370"/>
 			<UserParam type="float" name="precursor_intensity" value="2810.0908203125"/>
 		</consensusElement>
 		<consensusElement id="e_9126387050458671424" quality="0.0" charge="2">
@@ -1087,6 +1142,7 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3375"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3372"/>
 			<UserParam type="float" name="precursor_intensity" value="467.714813232421875"/>
 		</consensusElement>
 		<consensusElement id="e_13113514917555180171" quality="0.0" charge="3">
@@ -1105,10 +1161,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3377"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3374"/>
 			<UserParam type="float" name="precursor_intensity" value="1231.610107421875"/>
 		</consensusElement>
-		<consensusElement id="e_7316644956366259183" quality="0.0" charge="2">
-			<centroid rt="1763.743516399980081" mz="734.031555175781023" it="17542.078125"/>
+		<consensusElement id="e_7316644956366259183" quality="0.0" charge="3">
+			<centroid rt="1763.743516399980081" mz="734.031555175781023" it="1.754208e04"/>
 			<groupedElementList>
 				<element map="0" id="61" rt="1764.42616483200004" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="61" rt="1764.42616483200004" mz="127.124761000000007" it="1850.415161"/>
@@ -1123,10 +1180,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3379"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3376"/>
 			<UserParam type="float" name="precursor_intensity" value="2080.5673828125"/>
 		</consensusElement>
-		<consensusElement id="e_14891455924036538147" quality="0.0">
-			<centroid rt="1762.262922175980066" mz="542.915405273437955" it="23899.792969"/>
+		<consensusElement id="e_14891455924036538147" quality="0.0" charge="3">
+			<centroid rt="1762.262922175980066" mz="542.915405273437955" it="2.389979e04"/>
 			<groupedElementList>
 				<element map="0" id="63" rt="1764.828929344020025" mz="126.127725999999996" it="2636.234619"/>
 				<element map="1" id="63" rt="1764.828929344020025" mz="127.124761000000007" it="2559.470947"/>
@@ -1141,9 +1199,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3381"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3366"/>
 			<UserParam type="float" name="precursor_intensity" value="1968.0782470703125"/>
 		</consensusElement>
-		<consensusElement id="e_5860084234476467938" quality="0.0" charge="1">
+		<consensusElement id="e_5860084234476467938" quality="0.0" charge="2">
 			<centroid rt="1765.11049367999999" mz="876.447143554687955" it="8366.400391"/>
 			<groupedElementList>
 				<element map="0" id="64" rt="1765.465679615999989" mz="126.127725999999996" it="1355.212158"/>
@@ -1159,9 +1218,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3386"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3384"/>
 			<UserParam type="float" name="precursor_intensity" value="2332.575439453125"/>
 		</consensusElement>
-		<consensusElement id="e_12758854762884412659" quality="0.0" charge="2">
+		<consensusElement id="e_12758854762884412659" quality="0.0" charge="4">
 			<centroid rt="1765.182495376019915" mz="923.364440917968977" it="887.032593"/>
 			<groupedElementList>
 				<element map="0" id="65" rt="1765.83764694401998" mz="126.127725999999996" it="0.0"/>
@@ -1177,10 +1237,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3388"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3385"/>
 			<UserParam type="float" name="precursor_intensity" value="2819.861328125"/>
 		</consensusElement>
-		<consensusElement id="e_17287849381738438716" quality="0.0">
-			<centroid rt="1765.483749792000026" mz="688.874633789062955" it="30965.113281"/>
+		<consensusElement id="e_17287849381738438716" quality="0.0" charge="2">
+			<centroid rt="1765.483749792000026" mz="688.874633789062955" it="3.096511e04"/>
 			<groupedElementList>
 				<element map="0" id="66" rt="1766.189503519980008" mz="126.127725999999996" it="3803.475342"/>
 				<element map="1" id="66" rt="1766.189503519980008" mz="127.124761000000007" it="3557.443359"/>
@@ -1195,10 +1256,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3390"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3387"/>
 			<UserParam type="float" name="precursor_intensity" value="1632.830322265625"/>
 		</consensusElement>
-		<consensusElement id="e_2660422259164526995" quality="0.0" charge="2">
-			<centroid rt="1765.855610448000107" mz="492.264770507813012" it="15832.352539"/>
+		<consensusElement id="e_2660422259164526995" quality="0.0" charge="3">
+			<centroid rt="1765.855610448000107" mz="492.264770507813012" it="1.583235e04"/>
 			<groupedElementList>
 				<element map="0" id="67" rt="1766.538117216000046" mz="126.127725999999996" it="1001.604126"/>
 				<element map="1" id="67" rt="1766.538117216000046" mz="127.124761000000007" it="2258.259766"/>
@@ -1213,16 +1275,17 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3392"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3389"/>
 			<UserParam type="float" name="precursor_intensity" value="1142.7840576171875"/>
 		</consensusElement>
-		<consensusElement id="e_5495827884756377090" quality="0.0" charge="2">
-			<centroid rt="1766.207480224019946" mz="439.575469970703011" it="59482.5"/>
+		<consensusElement id="e_5495827884756377090" quality="0.0" charge="3">
+			<centroid rt="1766.207480224019946" mz="439.575469970703011" it="5.94825e04"/>
 			<groupedElementList>
 				<element map="0" id="68" rt="1766.886745519979968" mz="126.127725999999996" it="9952.365234"/>
 				<element map="1" id="68" rt="1766.886745519979968" mz="127.124761000000007" it="6373.406738"/>
 				<element map="2" id="68" rt="1766.886745519979968" mz="127.131080999999995" it="4576.574707"/>
 				<element map="3" id="68" rt="1766.886745519979968" mz="128.128116000000006" it="7332.687012"/>
-				<element map="4" id="68" rt="1766.886745519979968" mz="128.134435999999994" it="11511.881836"/>
+				<element map="4" id="68" rt="1766.886745519979968" mz="128.134435999999994" it="1.151188e04"/>
 				<element map="5" id="68" rt="1766.886745519979968" mz="129.131471000000005" it="6386.205566"/>
 				<element map="6" id="68" rt="1766.886745519979968" mz="129.137789999999995" it="5419.277832"/>
 				<element map="7" id="68" rt="1766.886745519979968" mz="130.134825000000006" it="4201.243164"/>
@@ -1231,17 +1294,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3394"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3391"/>
 			<UserParam type="float" name="precursor_intensity" value="4380.9599609375"/>
 		</consensusElement>
-		<consensusElement id="e_4143272592559840046" quality="0.0" charge="1">
-			<centroid rt="1766.555971759979911" mz="466.000732421875" it="76794.398438"/>
+		<consensusElement id="e_4143272592559840046" quality="0.0" charge="4">
+			<centroid rt="1766.555971759979911" mz="466.000732421875" it="7.67944e04"/>
 			<groupedElementList>
 				<element map="0" id="69" rt="1767.237360767999917" mz="126.127725999999996" it="5562.601563"/>
 				<element map="1" id="69" rt="1767.237360767999917" mz="127.124761000000007" it="8760.47168"/>
 				<element map="2" id="69" rt="1767.237360767999917" mz="127.131080999999995" it="2714.440918"/>
 				<element map="3" id="69" rt="1767.237360767999917" mz="128.128116000000006" it="4113.51709"/>
-				<element map="4" id="69" rt="1767.237360767999917" mz="128.134435999999994" it="18519.634766"/>
-				<element map="5" id="69" rt="1767.237360767999917" mz="129.131471000000005" it="19819.666016"/>
+				<element map="4" id="69" rt="1767.237360767999917" mz="128.134435999999994" it="1.851964e04"/>
+				<element map="5" id="69" rt="1767.237360767999917" mz="129.131471000000005" it="1.981967e04"/>
 				<element map="6" id="69" rt="1767.237360767999917" mz="129.137789999999995" it="5914.408203"/>
 				<element map="7" id="69" rt="1767.237360767999917" mz="130.134825000000006" it="4988.361816"/>
 				<element map="8" id="69" rt="1767.237360767999917" mz="130.141144999999995" it="1656.197021"/>
@@ -1249,9 +1313,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3396"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3393"/>
 			<UserParam type="float" name="precursor_intensity" value="3671.0810546875"/>
 		</consensusElement>
-		<consensusElement id="e_7870901012988979006" quality="0.0" charge="1">
+		<consensusElement id="e_7870901012988979006" quality="0.0" charge="2">
 			<centroid rt="1766.904724607999924" mz="775.86572265625" it="8888.197266"/>
 			<groupedElementList>
 				<element map="0" id="70" rt="1767.437770320000027" mz="126.127725999999996" it="804.009277"/>
@@ -1267,17 +1332,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3397"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3395"/>
 			<UserParam type="float" name="precursor_intensity" value="679.1156005859375"/>
 		</consensusElement>
-		<consensusElement id="e_5342974036930030800" quality="0.0" charge="1">
-			<centroid rt="1765.063267264019942" mz="584.634216308593977" it="75245.898438"/>
+		<consensusElement id="e_5342974036930030800" quality="0.0" charge="3">
+			<centroid rt="1765.063267264019942" mz="584.634216308593977" it="7.52459e04"/>
 			<groupedElementList>
-				<element map="0" id="71" rt="1767.638909008019937" mz="126.127725999999996" it="13316.930664"/>
-				<element map="1" id="71" rt="1767.638909008019937" mz="127.124761000000007" it="10146.917969"/>
+				<element map="0" id="71" rt="1767.638909008019937" mz="126.127725999999996" it="1.331693e04"/>
+				<element map="1" id="71" rt="1767.638909008019937" mz="127.124761000000007" it="1.014692e04"/>
 				<element map="2" id="71" rt="1767.638909008019937" mz="127.131080999999995" it="3589.736328"/>
 				<element map="3" id="71" rt="1767.638909008019937" mz="128.128116000000006" it="2983.548096"/>
 				<element map="4" id="71" rt="1767.638909008019937" mz="128.134435999999994" it="8122.117676"/>
-				<element map="5" id="71" rt="1767.638909008019937" mz="129.131471000000005" it="11191.129883"/>
+				<element map="5" id="71" rt="1767.638909008019937" mz="129.131471000000005" it="1.119113e04"/>
 				<element map="6" id="71" rt="1767.638909008019937" mz="129.137789999999995" it="8642.938477"/>
 				<element map="7" id="71" rt="1767.638909008019937" mz="130.134825000000006" it="5706.139648"/>
 				<element map="8" id="71" rt="1767.638909008019937" mz="130.141144999999995" it="4321.055664"/>
@@ -1285,6 +1351,7 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3398"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3383"/>
 			<UserParam type="float" name="precursor_intensity" value="2808.90576171875"/>
 		</consensusElement>
 		<consensusElement id="e_11399299100673837381" quality="0.0" charge="2">
@@ -1303,10 +1370,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3403"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3401"/>
 			<UserParam type="float" name="precursor_intensity" value="386.500274658203125"/>
 		</consensusElement>
-		<consensusElement id="e_16164338904207598736" quality="0.0" charge="2">
-			<centroid rt="1768.016099328000109" mz="556.943420410156023" it="40093.070313"/>
+		<consensusElement id="e_16164338904207598736" quality="0.0" charge="3">
+			<centroid rt="1768.016099328000109" mz="556.943420410156023" it="4.009307e04"/>
 			<groupedElementList>
 				<element map="0" id="73" rt="1768.691597519999959" mz="126.127725999999996" it="2038.583618"/>
 				<element map="1" id="73" rt="1768.691597519999959" mz="127.124761000000007" it="5813.644531"/>
@@ -1321,10 +1389,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3405"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3402"/>
 			<UserParam type="float" name="precursor_intensity" value="1936.651123046875"/>
 		</consensusElement>
-		<consensusElement id="e_8795943655088158336" quality="0.0" charge="2">
-			<centroid rt="1769.058940943999914" mz="591.268310546875" it="28037.755859"/>
+		<consensusElement id="e_8795943655088158336" quality="0.0" charge="3">
+			<centroid rt="1769.058940943999914" mz="591.268310546875" it="2.803776e04"/>
 			<groupedElementList>
 				<element map="0" id="76" rt="1769.739936431999922" mz="126.127725999999996" it="6335.075684"/>
 				<element map="1" id="76" rt="1769.739936431999922" mz="127.124761000000007" it="3405.183105"/>
@@ -1339,9 +1408,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3411"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3408"/>
 			<UserParam type="float" name="precursor_intensity" value="1307.8193359375"/>
 		</consensusElement>
-		<consensusElement id="e_6878260161865568505" quality="0.0" charge="2">
+		<consensusElement id="e_6878260161865568505" quality="0.0" charge="3">
 			<centroid rt="1769.408182255979909" mz="652.641235351562955" it="6092.80957"/>
 			<groupedElementList>
 				<element map="0" id="77" rt="1770.091691472000093" mz="126.127725999999996" it="0.0"/>
@@ -1357,17 +1427,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3413"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3410"/>
 			<UserParam type="float" name="precursor_intensity" value="425.754119873046875"/>
 		</consensusElement>
-		<consensusElement id="e_3386388678910226661" quality="0.0">
-			<centroid rt="1767.894827023980042" mz="630.968994140625" it="57328.035156"/>
+		<consensusElement id="e_3386388678910226661" quality="0.0" charge="3">
+			<centroid rt="1767.894827023980042" mz="630.968994140625" it="5.732803e04"/>
 			<groupedElementList>
 				<element map="0" id="79" rt="1770.4933287199799" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="79" rt="1770.4933287199799" mz="127.124761000000007" it="4522.266113"/>
 				<element map="2" id="79" rt="1770.4933287199799" mz="127.131080999999995" it="0.0"/>
 				<element map="3" id="79" rt="1770.4933287199799" mz="128.128116000000006" it="423.853394"/>
-				<element map="4" id="79" rt="1770.4933287199799" mz="128.134435999999994" it="16043.282227"/>
-				<element map="5" id="79" rt="1770.4933287199799" mz="129.131471000000005" it="29907.988281"/>
+				<element map="4" id="79" rt="1770.4933287199799" mz="128.134435999999994" it="1.604328e04"/>
+				<element map="5" id="79" rt="1770.4933287199799" mz="129.131471000000005" it="2.990799e04"/>
 				<element map="6" id="79" rt="1770.4933287199799" mz="129.137789999999995" it="5201.101074"/>
 				<element map="7" id="79" rt="1770.4933287199799" mz="130.134825000000006" it="1229.543457"/>
 				<element map="8" id="79" rt="1770.4933287199799" mz="130.141144999999995" it="0.0"/>
@@ -1375,7 +1446,8 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3415"/>
-			<UserParam type="float" name="precursor_intensity" value="27271.2890625"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3400"/>
+			<UserParam type="float" name="precursor_intensity" value="2.72712890625e04"/>
 		</consensusElement>
 		<consensusElement id="e_3689406389503231823" quality="0.0" charge="2">
 			<centroid rt="1770.860825087999956" mz="945.948974609375" it="6849.575684"/>
@@ -1393,10 +1465,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3422"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3419"/>
 			<UserParam type="float" name="precursor_intensity" value="161.010345458984375"/>
 		</consensusElement>
-		<consensusElement id="e_11106716189850669289" quality="0.0" charge="1">
-			<centroid rt="1771.162054255979911" mz="598.250732421875" it="26007.033203"/>
+		<consensusElement id="e_11106716189850669289" quality="0.0" charge="3">
+			<centroid rt="1771.162054255979911" mz="598.250732421875" it="2.600703e04"/>
 			<groupedElementList>
 				<element map="0" id="82" rt="1771.873667615999921" mz="126.127725999999996" it="2749.696533"/>
 				<element map="1" id="82" rt="1771.873667615999921" mz="127.124761000000007" it="2957.337647"/>
@@ -1411,10 +1484,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3424"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3421"/>
 			<UserParam type="float" name="precursor_intensity" value="724.20562744140625"/>
 		</consensusElement>
 		<consensusElement id="e_11221884879889731173" quality="0.0" charge="2">
-			<centroid rt="1771.541779903979887" mz="885.416198730468977" it="38433.894531"/>
+			<centroid rt="1771.541779903979887" mz="885.416198730468977" it="3.84339e04"/>
 			<groupedElementList>
 				<element map="0" id="83" rt="1772.224923871980081" mz="126.127725999999996" it="7.20662e-12"/>
 				<element map="1" id="83" rt="1772.224923871980081" mz="127.124761000000007" it="1184.327148"/>
@@ -1424,15 +1498,16 @@
 				<element map="5" id="83" rt="1772.224923871980081" mz="129.131471000000005" it="0.0"/>
 				<element map="6" id="83" rt="1772.224923871980081" mz="129.137789999999995" it="1768.323486"/>
 				<element map="7" id="83" rt="1772.224923871980081" mz="130.134825000000006" it="0.0"/>
-				<element map="8" id="83" rt="1772.224923871980081" mz="130.141144999999995" it="35481.242188"/>
+				<element map="8" id="83" rt="1772.224923871980081" mz="130.141144999999995" it="3.548124e04"/>
 				<element map="9" id="83" rt="1772.224923871980081" mz="131.138180000000006" it="0.0"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3426"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3423"/>
 			<UserParam type="float" name="precursor_intensity" value="1324.65869140625"/>
 		</consensusElement>
-		<consensusElement id="e_575144564576995072" quality="0.0" charge="2">
-			<centroid rt="1771.891652767980077" mz="411.213745117188012" it="49873.933594"/>
+		<consensusElement id="e_575144564576995072" quality="0.0" charge="3">
+			<centroid rt="1771.891652767980077" mz="411.213745117188012" it="4.987393e04"/>
 			<groupedElementList>
 				<element map="0" id="84" rt="1772.573774447999995" mz="126.127725999999996" it="4425.513184"/>
 				<element map="1" id="84" rt="1772.573774447999995" mz="127.124761000000007" it="5023.828613"/>
@@ -1447,16 +1522,17 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3428"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3425"/>
 			<UserParam type="float" name="precursor_intensity" value="1534.86376953125"/>
 		</consensusElement>
 		<consensusElement id="e_5805590394902791448" quality="0.0" charge="2">
-			<centroid rt="1772.242768000020078" mz="687.814880371093977" it="53216.246094"/>
+			<centroid rt="1772.242768000020078" mz="687.814880371093977" it="5.321625e04"/>
 			<groupedElementList>
 				<element map="0" id="85" rt="1772.921410111980094" mz="126.127725999999996" it="8337.726563"/>
 				<element map="1" id="85" rt="1772.921410111980094" mz="127.124761000000007" it="7612.724609"/>
 				<element map="2" id="85" rt="1772.921410111980094" mz="127.131080999999995" it="4739.893066"/>
 				<element map="3" id="85" rt="1772.921410111980094" mz="128.128116000000006" it="3503.966309"/>
-				<element map="4" id="85" rt="1772.921410111980094" mz="128.134435999999994" it="10839.491211"/>
+				<element map="4" id="85" rt="1772.921410111980094" mz="128.134435999999994" it="1.083949e04"/>
 				<element map="5" id="85" rt="1772.921410111980094" mz="129.131471000000005" it="703.236633"/>
 				<element map="6" id="85" rt="1772.921410111980094" mz="129.137789999999995" it="9153.328125"/>
 				<element map="7" id="85" rt="1772.921410111980094" mz="130.134825000000006" it="3615.169434"/>
@@ -1465,14 +1541,15 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3430"/>
-			<UserParam type="float" name="precursor_intensity" value="10813.203125"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3427"/>
+			<UserParam type="float" name="precursor_intensity" value="1.0813203125e04"/>
 		</consensusElement>
-		<consensusElement id="e_7061025990090747374" quality="0.0" charge="1">
+		<consensusElement id="e_7061025990090747374" quality="0.0" charge="2">
 			<centroid rt="1770.75380710398008" mz="559.306274414062955" it="1.876938e06"/>
 			<groupedElementList>
-				<element map="0" id="87" rt="1773.319349056019973" mz="126.127725999999996" it="13264.15918"/>
-				<element map="1" id="87" rt="1773.319349056019973" mz="127.124761000000007" it="76695.15625"/>
-				<element map="2" id="87" rt="1773.319349056019973" mz="127.131080999999995" it="58074.203125"/>
+				<element map="0" id="87" rt="1773.319349056019973" mz="126.127725999999996" it="1.326416e04"/>
+				<element map="1" id="87" rt="1773.319349056019973" mz="127.124761000000007" it="7.669516e04"/>
+				<element map="2" id="87" rt="1773.319349056019973" mz="127.131080999999995" it="5.80742e04"/>
 				<element map="3" id="87" rt="1773.319349056019973" mz="128.128116000000006" it="2.549604e05"/>
 				<element map="4" id="87" rt="1773.319349056019973" mz="128.134435999999994" it="1.673295e05"/>
 				<element map="5" id="87" rt="1773.319349056019973" mz="129.131471000000005" it="1.184734e05"/>
@@ -1483,15 +1560,16 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3432"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3417"/>
 			<UserParam type="float" name="precursor_intensity" value="4093.343505859375"/>
 		</consensusElement>
-		<consensusElement id="e_8195437834883133454" quality="0.0" charge="2">
-			<centroid rt="1773.63475771200001" mz="554.303039550781023" it="68606.648438"/>
+		<consensusElement id="e_8195437834883133454" quality="0.0" charge="3">
+			<centroid rt="1773.63475771200001" mz="554.303039550781023" it="6.860665e04"/>
 			<groupedElementList>
 				<element map="0" id="88" rt="1773.979792303980048" mz="126.127725999999996" it="9753.745117"/>
 				<element map="1" id="88" rt="1773.979792303980048" mz="127.124761000000007" it="7132.407227"/>
 				<element map="2" id="88" rt="1773.979792303980048" mz="127.131080999999995" it="3643.623535"/>
-				<element map="3" id="88" rt="1773.979792303980048" mz="128.128116000000006" it="14047.134766"/>
+				<element map="3" id="88" rt="1773.979792303980048" mz="128.128116000000006" it="1.404714e04"/>
 				<element map="4" id="88" rt="1773.979792303980048" mz="128.134435999999994" it="7890.01123"/>
 				<element map="5" id="88" rt="1773.979792303980048" mz="129.131471000000005" it="7210.461426"/>
 				<element map="6" id="88" rt="1773.979792303980048" mz="129.137789999999995" it="6583.800781"/>
@@ -1501,15 +1579,16 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3437"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3435"/>
 			<UserParam type="float" name="precursor_intensity" value="808.18023681640625"/>
 		</consensusElement>
-		<consensusElement id="e_3395379003172100421" quality="0.0" charge="2">
-			<centroid rt="1773.701130928019893" mz="656.003723144531023" it="23617.119141"/>
+		<consensusElement id="e_3395379003172100421" quality="0.0" charge="3">
+			<centroid rt="1773.701130928019893" mz="656.003723144531023" it="2.361712e04"/>
 			<groupedElementList>
 				<element map="0" id="89" rt="1774.363405135979974" mz="126.127725999999996" it="2381.654785"/>
 				<element map="1" id="89" rt="1774.363405135979974" mz="127.124761000000007" it="1849.057861"/>
 				<element map="2" id="89" rt="1774.363405135979974" mz="127.131080999999995" it="693.375183"/>
-				<element map="3" id="89" rt="1774.363405135979974" mz="128.128116000000006" it="11383.648438"/>
+				<element map="3" id="89" rt="1774.363405135979974" mz="128.128116000000006" it="1.138365e04"/>
 				<element map="4" id="89" rt="1774.363405135979974" mz="128.134435999999994" it="0.0"/>
 				<element map="5" id="89" rt="1774.363405135979974" mz="129.131471000000005" it="657.37793"/>
 				<element map="6" id="89" rt="1774.363405135979974" mz="129.137789999999995" it="2372.745361"/>
@@ -1519,10 +1598,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3439"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3436"/>
 			<UserParam type="float" name="precursor_intensity" value="4959.62109375"/>
 		</consensusElement>
-		<consensusElement id="e_11630589982317102322" quality="0.0" charge="1">
-			<centroid rt="1773.997887823979909" mz="856.377258300781023" it="18942.330078"/>
+		<consensusElement id="e_11630589982317102322" quality="0.0" charge="2">
+			<centroid rt="1773.997887823979909" mz="856.377258300781023" it="1.894233e04"/>
 			<groupedElementList>
 				<element map="0" id="90" rt="1774.713635056019939" mz="126.127725999999996" it="2691.444336"/>
 				<element map="1" id="90" rt="1774.713635056019939" mz="127.124761000000007" it="3499.838867"/>
@@ -1537,10 +1617,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3441"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3438"/>
 			<UserParam type="float" name="precursor_intensity" value="993.91802978515625"/>
 		</consensusElement>
-		<consensusElement id="e_1339341489815824759" quality="0.0" charge="2">
-			<centroid rt="1774.38123232001999" mz="590.613891601562955" it="30385.755859"/>
+		<consensusElement id="e_1339341489815824759" quality="0.0" charge="3">
+			<centroid rt="1774.38123232001999" mz="590.613891601562955" it="3.038576e04"/>
 			<groupedElementList>
 				<element map="0" id="91" rt="1775.063012752020086" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="91" rt="1775.063012752020086" mz="127.124761000000007" it="1797.038452"/>
@@ -1550,15 +1631,16 @@
 				<element map="5" id="91" rt="1775.063012752020086" mz="129.131471000000005" it="0.0"/>
 				<element map="6" id="91" rt="1775.063012752020086" mz="129.137789999999995" it="1582.233887"/>
 				<element map="7" id="91" rt="1775.063012752020086" mz="130.134825000000006" it="0.0"/>
-				<element map="8" id="91" rt="1775.063012752020086" mz="130.141144999999995" it="26536.054688"/>
+				<element map="8" id="91" rt="1775.063012752020086" mz="130.141144999999995" it="2.653605e04"/>
 				<element map="9" id="91" rt="1775.063012752020086" mz="131.138180000000006" it="0.0"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3443"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3440"/>
 			<UserParam type="float" name="precursor_intensity" value="1587.71826171875"/>
 		</consensusElement>
-		<consensusElement id="e_17325731682080510033" quality="0.0">
-			<centroid rt="1774.731486688019913" mz="408.728790283203011" it="26932.597656"/>
+		<consensusElement id="e_17325731682080510033" quality="0.0" charge="4">
+			<centroid rt="1774.731486688019913" mz="408.728790283203011" it="2.69326e04"/>
 			<groupedElementList>
 				<element map="0" id="92" rt="1775.411505775980004" mz="126.127725999999996" it="5983.803711"/>
 				<element map="1" id="92" rt="1775.411505775980004" mz="127.124761000000007" it="2559.066406"/>
@@ -1573,9 +1655,10 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3445"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3442"/>
 			<UserParam type="float" name="precursor_intensity" value="1536.871826171875"/>
 		</consensusElement>
-		<consensusElement id="e_13641829453453140763" quality="0.0" charge="1">
+		<consensusElement id="e_13641829453453140763" quality="0.0" charge="2">
 			<centroid rt="1775.080981471980067" mz="455.745788574218977" it="5509.59082"/>
 			<groupedElementList>
 				<element map="0" id="93" rt="1775.758728960000099" mz="126.127725999999996" it="0.0"/>
@@ -1591,10 +1674,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3447"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3444"/>
 			<UserParam type="float" name="precursor_intensity" value="227.353057861328125"/>
 		</consensusElement>
 		<consensusElement id="e_12388384985798314387" quality="0.0" charge="3">
-			<centroid rt="1775.429364271979921" mz="892.067199707031023" it="17830.175781"/>
+			<centroid rt="1775.429364271979921" mz="892.067199707031023" it="1.783018e04"/>
 			<groupedElementList>
 				<element map="0" id="94" rt="1775.960187919979944" mz="126.127725999999996" it="0.0"/>
 				<element map="1" id="94" rt="1775.960187919979944" mz="127.124761000000007" it="1281.776367"/>
@@ -1609,10 +1693,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3448"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3446"/>
 			<UserParam type="float" name="precursor_intensity" value="1012.636474609375"/>
 		</consensusElement>
-		<consensusElement id="e_4041634828915281168" quality="0.0" charge="1">
-			<centroid rt="1773.587500879980098" mz="579.322692871093977" it="33021.464844"/>
+		<consensusElement id="e_4041634828915281168" quality="0.0" charge="2">
+			<centroid rt="1773.587500879980098" mz="579.322692871093977" it="3.302146e04"/>
 			<groupedElementList>
 				<element map="0" id="95" rt="1776.162656848020106" mz="126.127725999999996" it="3220.684082"/>
 				<element map="1" id="95" rt="1776.162656848020106" mz="127.124761000000007" it="3376.615723"/>
@@ -1627,28 +1712,30 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3449"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3434"/>
 			<UserParam type="float" name="precursor_intensity" value="775.54150390625"/>
 		</consensusElement>
 		<consensusElement id="e_17078574238716611972" quality="0.0" charge="3">
 			<centroid rt="1776.429207055979987" mz="574.970703125" it="1.254714e05"/>
 			<groupedElementList>
-				<element map="0" id="96" rt="1776.779259167999953" mz="126.127725999999996" it="10771.620117"/>
-				<element map="1" id="96" rt="1776.779259167999953" mz="127.124761000000007" it="13161.013672"/>
-				<element map="2" id="96" rt="1776.779259167999953" mz="127.131080999999995" it="11055.419922"/>
-				<element map="3" id="96" rt="1776.779259167999953" mz="128.128116000000006" it="16730.048828"/>
-				<element map="4" id="96" rt="1776.779259167999953" mz="128.134435999999994" it="14156.136719"/>
-				<element map="5" id="96" rt="1776.779259167999953" mz="129.131471000000005" it="13559.518555"/>
-				<element map="6" id="96" rt="1776.779259167999953" mz="129.137789999999995" it="13994.505859"/>
-				<element map="7" id="96" rt="1776.779259167999953" mz="130.134825000000006" it="12480.294922"/>
+				<element map="0" id="96" rt="1776.779259167999953" mz="126.127725999999996" it="1.077162e04"/>
+				<element map="1" id="96" rt="1776.779259167999953" mz="127.124761000000007" it="1.316101e04"/>
+				<element map="2" id="96" rt="1776.779259167999953" mz="127.131080999999995" it="1.105542e04"/>
+				<element map="3" id="96" rt="1776.779259167999953" mz="128.128116000000006" it="1.673005e04"/>
+				<element map="4" id="96" rt="1776.779259167999953" mz="128.134435999999994" it="1.415614e04"/>
+				<element map="5" id="96" rt="1776.779259167999953" mz="129.131471000000005" it="1.355952e04"/>
+				<element map="6" id="96" rt="1776.779259167999953" mz="129.137789999999995" it="1.399451e04"/>
+				<element map="7" id="96" rt="1776.779259167999953" mz="130.134825000000006" it="1.248029e04"/>
 				<element map="8" id="96" rt="1776.779259167999953" mz="130.141144999999995" it="3315.724121"/>
-				<element map="9" id="96" rt="1776.779259167999953" mz="131.138180000000006" it="16247.075195"/>
+				<element map="9" id="96" rt="1776.779259167999953" mz="131.138180000000006" it="1.624707e04"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3454"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3452"/>
 			<UserParam type="float" name="precursor_intensity" value="3388.57080078125"/>
 		</consensusElement>
-		<consensusElement id="e_5106727040801878879" quality="0.0" charge="2">
-			<centroid rt="1776.496096303980039" mz="491.937377929688012" it="40836.667969"/>
+		<consensusElement id="e_5106727040801878879" quality="0.0" charge="3">
+			<centroid rt="1776.496096303980039" mz="491.937377929688012" it="4.083667e04"/>
 			<groupedElementList>
 				<element map="0" id="97" rt="1777.150975087979987" mz="126.127725999999996" it="3835.074707"/>
 				<element map="1" id="97" rt="1777.150975087979987" mz="127.124761000000007" it="4270.61084"/>
@@ -1663,10 +1750,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3456"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3453"/>
 			<UserParam type="float" name="precursor_intensity" value="6904.43017578125"/>
 		</consensusElement>
-		<consensusElement id="e_18390135059454481268" quality="0.0" charge="1">
-			<centroid rt="1776.797359744020014" mz="806.39453125" it="13528.373047"/>
+		<consensusElement id="e_18390135059454481268" quality="0.0" charge="2">
+			<centroid rt="1776.797359744020014" mz="806.39453125" it="1.352837e04"/>
 			<groupedElementList>
 				<element map="0" id="98" rt="1777.499844223980062" mz="126.127725999999996" it="856.660156"/>
 				<element map="1" id="98" rt="1777.499844223980062" mz="127.124761000000007" it="1173.228394"/>
@@ -1681,10 +1769,11 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3458"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3455"/>
 			<UserParam type="float" name="precursor_intensity" value="1177.83984375"/>
 		</consensusElement>
-		<consensusElement id="e_15721057298497490036" quality="0.0" charge="2">
-			<centroid rt="1777.168822096019994" mz="569.272583007812955" it="42586.925781"/>
+		<consensusElement id="e_15721057298497490036" quality="0.0" charge="3">
+			<centroid rt="1777.168822096019994" mz="569.272583007812955" it="4.258693e04"/>
 			<groupedElementList>
 				<element map="0" id="99" rt="1777.849350623999953" mz="126.127725999999996" it="5.50215e-12"/>
 				<element map="1" id="99" rt="1777.849350623999953" mz="127.124761000000007" it="2888.630127"/>
@@ -1694,15 +1783,16 @@
 				<element map="5" id="99" rt="1777.849350623999953" mz="129.131471000000005" it="0.0"/>
 				<element map="6" id="99" rt="1777.849350623999953" mz="129.137789999999995" it="3582.760986"/>
 				<element map="7" id="99" rt="1777.849350623999953" mz="130.134825000000006" it="0.0"/>
-				<element map="8" id="99" rt="1777.849350623999953" mz="130.141144999999995" it="36115.535156"/>
+				<element map="8" id="99" rt="1777.849350623999953" mz="130.141144999999995" it="3.611553e04"/>
 				<element map="9" id="99" rt="1777.849350623999953" mz="131.138180000000006" it="0.0"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3460"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3457"/>
 			<UserParam type="float" name="precursor_intensity" value="2825.875732421875"/>
 		</consensusElement>
-		<consensusElement id="e_2608380305220684729" quality="0.0" charge="1">
-			<centroid rt="1777.517575840020072" mz="835.371398925781023" it="15128.660156"/>
+		<consensusElement id="e_2608380305220684729" quality="0.0" charge="2">
+			<centroid rt="1777.517575840020072" mz="835.371398925781023" it="1.512866e04"/>
 			<groupedElementList>
 				<element map="0" id="100" rt="1778.200469231999932" mz="126.127725999999996" it="2693.829834"/>
 				<element map="1" id="100" rt="1778.200469231999932" mz="127.124761000000007" it="1769.713501"/>
@@ -1717,17 +1807,18 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3462"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3459"/>
 			<UserParam type="float" name="precursor_intensity" value="726.5743408203125"/>
 		</consensusElement>
-		<consensusElement id="e_11422463686885200558" quality="0.0" charge="1">
-			<centroid rt="1777.867215520019954" mz="537.932067871093977" it="62939.398438"/>
+		<consensusElement id="e_11422463686885200558" quality="0.0" charge="3">
+			<centroid rt="1777.867215520019954" mz="537.932067871093977" it="6.29394e04"/>
 			<groupedElementList>
 				<element map="0" id="101" rt="1778.549196544020106" mz="126.127725999999996" it="3648.078125"/>
 				<element map="1" id="101" rt="1778.549196544020106" mz="127.124761000000007" it="7566.002441"/>
 				<element map="2" id="101" rt="1778.549196544020106" mz="127.131080999999995" it="5632.598145"/>
 				<element map="3" id="101" rt="1778.549196544020106" mz="128.128116000000006" it="1008.455139"/>
 				<element map="4" id="101" rt="1778.549196544020106" mz="128.134435999999994" it="6415.965332"/>
-				<element map="5" id="101" rt="1778.549196544020106" mz="129.131471000000005" it="18418.25"/>
+				<element map="5" id="101" rt="1778.549196544020106" mz="129.131471000000005" it="1.841825e04"/>
 				<element map="6" id="101" rt="1778.549196544020106" mz="129.137789999999995" it="6053.339844"/>
 				<element map="7" id="101" rt="1778.549196544020106" mz="130.134825000000006" it="5028.047363"/>
 				<element map="8" id="101" rt="1778.549196544020106" mz="130.141144999999995" it="899.349365"/>
@@ -1735,28 +1826,30 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3464"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3461"/>
 			<UserParam type="float" name="precursor_intensity" value="2146.493408203125"/>
 		</consensusElement>
-		<consensusElement id="e_7283948392886265699" quality="0.0" charge="1">
+		<consensusElement id="e_7283948392886265699" quality="0.0" charge="2">
 			<centroid rt="1776.381964656000037" mz="624.853393554687955" it="2.283526e05"/>
 			<groupedElementList>
-				<element map="0" id="103" rt="1778.950610512019921" mz="126.127725999999996" it="11225.126953"/>
-				<element map="1" id="103" rt="1778.950610512019921" mz="127.124761000000007" it="18275.433594"/>
+				<element map="0" id="103" rt="1778.950610512019921" mz="126.127725999999996" it="1.122513e04"/>
+				<element map="1" id="103" rt="1778.950610512019921" mz="127.124761000000007" it="1.827543e04"/>
 				<element map="2" id="103" rt="1778.950610512019921" mz="127.131080999999995" it="6005.809082"/>
 				<element map="3" id="103" rt="1778.950610512019921" mz="128.128116000000006" it="3151.940674"/>
 				<element map="4" id="103" rt="1778.950610512019921" mz="128.134435999999994" it="1.569233e05"/>
 				<element map="5" id="103" rt="1778.950610512019921" mz="129.131471000000005" it="4104.621582"/>
-				<element map="6" id="103" rt="1778.950610512019921" mz="129.137789999999995" it="20489.816406"/>
+				<element map="6" id="103" rt="1778.950610512019921" mz="129.137789999999995" it="2.048982e04"/>
 				<element map="7" id="103" rt="1778.950610512019921" mz="130.134825000000006" it="3333.681152"/>
 				<element map="8" id="103" rt="1778.950610512019921" mz="130.141144999999995" it="511.813599"/>
 				<element map="9" id="103" rt="1778.950610512019921" mz="131.138180000000006" it="4331.0625"/>
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3466"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3451"/>
 			<UserParam type="float" name="precursor_intensity" value="9265.9423828125"/>
 		</consensusElement>
-		<consensusElement id="e_2130311522918743509" quality="0.0" charge="2">
-			<centroid rt="1779.215557840019983" mz="571.253356933593977" it="34158.390625"/>
+		<consensusElement id="e_2130311522918743509" quality="0.0" charge="3">
+			<centroid rt="1779.215557840019983" mz="571.253356933593977" it="3.415839e04"/>
 			<groupedElementList>
 				<element map="0" id="104" rt="1779.565720351979962" mz="126.127725999999996" it="6853.221191"/>
 				<element map="1" id="104" rt="1779.565720351979962" mz="127.124761000000007" it="4206.413086"/>
@@ -1771,16 +1864,17 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3471"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3469"/>
 			<UserParam type="float" name="precursor_intensity" value="1451.0751953125"/>
 		</consensusElement>
-		<consensusElement id="e_9140546320740515641" quality="0.0" charge="1">
-			<centroid rt="1779.282809743979897" mz="463.582458496093977" it="68299.953125"/>
+		<consensusElement id="e_9140546320740515641" quality="0.0" charge="3">
+			<centroid rt="1779.282809743979897" mz="463.582458496093977" it="6.829995e04"/>
 			<groupedElementList>
-				<element map="0" id="105" rt="1779.939807568019887" mz="126.127725999999996" it="14363.433594"/>
+				<element map="0" id="105" rt="1779.939807568019887" mz="126.127725999999996" it="1.436343e04"/>
 				<element map="1" id="105" rt="1779.939807568019887" mz="127.124761000000007" it="6833.780273"/>
 				<element map="2" id="105" rt="1779.939807568019887" mz="127.131080999999995" it="8568.675781"/>
 				<element map="3" id="105" rt="1779.939807568019887" mz="128.128116000000006" it="9446.639648"/>
-				<element map="4" id="105" rt="1779.939807568019887" mz="128.134435999999994" it="11084.536133"/>
+				<element map="4" id="105" rt="1779.939807568019887" mz="128.134435999999994" it="1.108454e04"/>
 				<element map="5" id="105" rt="1779.939807568019887" mz="129.131471000000005" it="5253.562012"/>
 				<element map="6" id="105" rt="1779.939807568019887" mz="129.137789999999995" it="4603.939941"/>
 				<element map="7" id="105" rt="1779.939807568019887" mz="130.134825000000006" it="3513.236084"/>
@@ -1789,6 +1883,7 @@
 			</groupedElementList>
 			<UserParam type="float" name="precursor_purity" value="1.0"/>
 			<UserParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=3473"/>
+			<UserParam type="string" name="id_scan_id" value="controllerType=0 controllerNumber=1 scan=3470"/>
 			<UserParam type="float" name="precursor_intensity" value="1256.671142578125"/>
 		</consensusElement>
 	</consensusElementList>


### PR DESCRIPTION
# Description

Before, the IsobaricAnalyzer was annotating the charge of the first fragment ion. Now it uses the MS1 precursor ion.
Also, since the exact settings, "precursor" and "correct ppm" are hard to guess during IDMapping, annotate and compare the scan_ids
used for ID instead.
