### PR TITLE
TV make sure that accessions are still exported

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/TableView.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TableView.h
@@ -63,6 +63,8 @@ namespace OpenMS
       All cells will be queried for their Qt::UserRole, then for Qt::DisplayRole and last for Qt::CheckStateRole.
       The first item to return data will be used!
       Thus, to export data which differs from the visible (==DisplayRole), use QTableWidgetItem::setData(Qt::UserRole, ...).
+      
+      Note: to force export of hidden columns use @p setMandatoryExportColumns()
     */
     virtual void exportEntries();
 
@@ -101,7 +103,7 @@ namespace OpenMS
        @return List of header names 
     */
     QStringList getHeaderNames(const WidgetHeader which, bool use_export_name = false);
-    
+
     /**
       @brief Set the export-name of a column, which will be returned in getHeaderNames() when @p use_export_name it true
 
@@ -134,14 +136,18 @@ namespace OpenMS
     /// @throws Exception::ElementNotFound if header at index @p header_column is not valid
     QString getHeaderName(const int header_column);
 
+    /// Set the mandatory export columns @p cols which get exported even if the user decided to hide them.
+    void setMandatoryExportColumns(QStringList& cols);    
   signals:
     /// emitted when the widget is resized
     void resized();
 
   protected:
-    // emits the resized signal
+    /// emits the resized signal
     void resizeEvent(QResizeEvent* event) override;
 
+    /// columns that are exported to tsv files even if they are hidden in the GUI
+    QStringList mandatory_export_columns_;
   protected slots:
     /// Display header context menu; allows to show/hide columns
     void headerContextMenu_(const QPoint&);

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -35,7 +35,6 @@
 #include <OpenMS/VISUAL/SpectraIDViewTab.h>
 #include <OpenMS/VISUAL/SequenceVisualizer.h>
 
-
 #include <OpenMS/VISUAL/TableView.h>
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
@@ -127,6 +126,10 @@ namespace OpenMS
 
     QHBoxLayout* tables = new QHBoxLayout(tables_splitter_);
     table_widget_ = new TableView(tables_splitter_);
+
+    // exported protein accessions and PSM rank even if hidden
+    table_widget_->setMandatoryExportColumns(QStringList() << "accessions" << "rank");
+    
     table_widget_->setWhatsThis("Spectrum selection bar<BR><BR>Here all spectra of the current experiment are shown. Left-click on a spectrum to open it.");
     tables_splitter_->addWidget(table_widget_);
 

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -118,7 +118,7 @@ namespace OpenMS
     QStringList str_list;
     
     QStringList cols_to_export = (getHeaderNames(WidgetHeader::VISIBLE_ONLY, true) + mandatory_export_columns_);    
-    cols_to_export.remove_duplicates();
+    cols_to_export.removeDuplicates();
 
     QStringList all_header_names = getHeaderNames(WidgetHeader::WITH_INVISIBLE, true);
 

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -116,16 +116,18 @@ namespace OpenMS
     }
     QTextStream ts(&f);
     QStringList str_list;
+    
+    QStringList cols_to_export = (getHeaderNames(WidgetHeader::VISIBLE_ONLY, true) + mandatory_export_columns_);    
+    cols_to_export.remove_duplicates();
 
-    // write header
     QStringList all_header_names = getHeaderNames(WidgetHeader::WITH_INVISIBLE, true);
 
+    // write header
     bool first{true};
     for (int c = 0; c < columnCount(); ++c)
     {
-      // print visible or mandatory exported column
-      if (!isColumnHidden(c)
-        || mandatory_export_columns_.indexOf(all_header_names[c]) != -1)
+      // columns marked for export
+      if (cols_to_export.indexOf(all_header_names[c]) != -1)
       {
         if (!first) 
         { 
@@ -145,9 +147,8 @@ namespace OpenMS
     {
       for (int c = 0; c < columnCount(); ++c)
       {
-        // skip hidden columns (if not marked as mandatory export column)
-        if (isColumnHidden(c)
-           && mandatory_export_columns_.indexOf(all_header_names[c]) == -1)
+        // only export columns we marked for export
+        if (cols_to_export.indexOf(all_header_names[c]) == -1)
         {
           continue;
         }

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -100,6 +100,11 @@ namespace OpenMS
     context_menu.exec(mapToGlobal(pos));
   }
 
+  void TableView::setMandatoryExportColumns(QStringList& cols)
+  {
+    mandatory_export_columns_ = cols;
+  }
+
   void TableView::exportEntries()
   {
     QString filename = QFileDialog::getSaveFileName(this, "Save File", "", "tsv file (*.tsv)");
@@ -113,15 +118,36 @@ namespace OpenMS
     QStringList str_list;
 
     // write header
-    ts << getHeaderNames(WidgetHeader::VISIBLE_ONLY, true).join("\t") + "\n";
+    QStringList all_header_names = getHeaderNames(WidgetHeader::WITH_INVISIBLE, true);
+
+    bool first{true};
+    for (int c = 0; c < columnCount(); ++c)
+    {
+      // print visible or mandatory exported column
+      if (!isColumnHidden(c)
+        || mandatory_export_columns_.indexOf(all_header_names[c]) != -1)
+      {
+        if (!first) 
+        { 
+          ts << "\t"; 
+        }
+        else 
+        {
+          first = false;
+        }
+        ts << a;        
+      }
+      ts << "\n";      
+    }
 
     // write entries
     for (int r = 0; r < rowCount(); ++r)
     {
       for (int c = 0; c < columnCount(); ++c)
       {
-        // do not export hidden columns
-        if (isColumnHidden(c))
+        // skip hidden columns (if not marked as mandatory export column)
+        if (isColumnHidden(c)
+           && mandatory_export_columns_.indexOf(all_header_names[c]) == -1)
         {
           continue;
         }

--- a/src/openms_gui/source/VISUAL/TableView.cpp
+++ b/src/openms_gui/source/VISUAL/TableView.cpp
@@ -135,7 +135,7 @@ namespace OpenMS
         {
           first = false;
         }
-        ts << a;        
+        ts << all_header_names[c];        
       }
       ts << "\n";      
     }


### PR DESCRIPTION
# Description

After adding the protein table, protein accessions were not exported anymore because they are hidden by default.
This PR allows TableViews to define columns that are always exported irrespective of being visible or hidden.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
