### PR TITLE
Optimize PeptideIndexer

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -423,6 +423,9 @@ namespace OpenMS
     **/
     bool addHits_(Index i, const size_t text_pos, std::vector<Hit>& hits) const;
 
+    /// same as addHits_, but only follows the suffix chain until the spawn looses its prefix
+    bool addHitsSpawn_(Index i, const ACSpawn& spawn, const size_t text_pos, std::vector<Hit>& hits, const int current_spawn_depths) const;
+
     /// Starting at node @p i, find the child with label @p edge
     /// If no child exists, follow the suffix link and try again (until root is reached)
     /// Note: This operates on the BFS trie (after compressTrie()), not the naive one.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -423,7 +423,7 @@ namespace OpenMS
     **/
     bool addHits_(Index i, const size_t text_pos, std::vector<Hit>& hits) const;
 
-    /// same as addHits_, but only follows the suffix chain until the spawn looses its prefix
+    /// same as addHits_, but only follows the suffix chain until the spawn loses its prefix
     bool addHitsSpawn_(Index i, const ACSpawn& spawn, const size_t text_pos, std::vector<Hit>& hits, const int current_spawn_depths) const;
 
     /// Starting at node @p i, find the child with label @p edge

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzyme.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzyme.h
@@ -97,7 +97,7 @@ namespace OpenMS
     void setName(const String& name);
 
     /// returns the name of the enzyme
-    String getName() const;
+    const String& getName() const;
 
     /// sets the synonyms
     void setSynonyms(const std::set<String>& synonyms);
@@ -112,13 +112,13 @@ namespace OpenMS
     void setRegEx(const String& cleavage_regex);
 
     /// returns the cleavage regex
-    String getRegEx() const;
+    const String& getRegEx() const;
 
     /// sets the regex description
     void setRegExDescription(const String& value);
 
     /// returns the regex description
-    String getRegExDescription() const;
+    const String& getRegExDescription() const;
     //@}
 
     /** @name Predicates

--- a/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
+++ b/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
@@ -325,6 +325,7 @@ namespace OpenMS
     }
     return hits_before != hits.size();
   }
+  
   Index ACTrie::follow_(const Index i, const AA aa) const
   {
     Index ch = findChildBFS_(i, aa);

--- a/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
+++ b/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
@@ -295,6 +295,36 @@ namespace OpenMS
     return hits_before != hits.size();
   }
 
+  bool ACTrie::addHitsSpawn_(Index i, const ACSpawn& spawn, const size_t text_pos, std::vector<Hit>& hits, const int current_spawn_depths) const
+  {
+    size_t hits_before = hits.size();
+    // hits from current node; return true if going upstream has more hits..
+    auto collect = [&]() {
+      if (trie_[i()].depth_and_hits.has_hit)
+      {
+        const auto needle_length = trie_[i()].depth_and_hits.depth;
+        const auto text_start = text_pos - needle_length;
+        // we want the first AAA of the spawn to be part of the hit; otherwise that hit will be reported by shorter sub-spawns or the master
+        if (current_spawn_depths - needle_length >= spawn.max_prefix_loss_leftover) 
+        {
+          return false;
+        }
+        for (const auto needle_idx : umap_index2needles_.at(i()))
+        {
+          hits.emplace_back(needle_idx, needle_length, Hit::T(text_start));
+        }
+        return true;
+      }
+      return false;
+    };
+
+    // follow chain of suffix nodes until a node does not have hits anymore
+    while (collect())
+    {
+      i = trie_[i()].suffix;
+    }
+    return hits_before != hits.size();
+  }
   Index ACTrie::follow_(const Index i, const AA aa) const
   {
     Index ch = findChildBFS_(i, aa);
@@ -320,8 +350,9 @@ namespace OpenMS
   {
     // let spawn follow the original edge
     Index j = follow_(spawn.tree_pos, edge);
-    // did we loose a prefix?        old-depth                  new depth
-    int up_count = int(trie_[spawn.tree_pos()].depth_and_hits.depth) - int(trie_[j()].depth_and_hits.depth) + 1;
+    const int new_depth = int(trie_[j()].depth_and_hits.depth);
+    // did we loose a prefix?              old-depth                         new depth
+    const int up_count = int(trie_[spawn.tree_pos()].depth_and_hits.depth) - new_depth + 1;
     if (up_count >= spawn.max_prefix_loss_leftover)
     { // spawn is dead because it lost its AAA/MM
       return false;
@@ -329,7 +360,7 @@ namespace OpenMS
     // update the prefix length
     spawn.max_prefix_loss_leftover -= up_count;
     spawn.tree_pos = j;
-    addHits_(j, spawn.textPos(state), state.hits);
+    addHitsSpawn_(j, spawn, spawn.textPos(state), state.hits, new_depth);
     return true;
   }
 

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -587,9 +587,24 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
     std::cout << "Merge took: " << s.toString() << "\n";
     mu.after();
     std::cout << mu.delta("Aho-Corasick") << "\n\n";
+    
+    {
+      // count number of peptides found
+      // the vector 'pep_to_prot' is sorted by peptide_index, and then by protein_index 
+      size_t found_peptide_count{0};
+      Hit::T last_peptide_idx = -1;
+      for (const auto& hit : func.pep_to_prot)
+      {
+        if (hit.peptide_index != last_peptide_idx)
+        {
+          last_peptide_idx = hit.peptide_index;
+          ++found_peptide_count;
+        }
+      }
 
-    OPENMS_LOG_INFO << "\nAho-Corasick done:\n  found " << func.filter_passed << " hits for " << func.pep_to_prot.size() << " of " << ac_trie.getNeedleCount() << " peptides.\n";
-
+      OPENMS_LOG_INFO << "\nAho-Corasick done:\n  found " << func.filter_passed << " hits for " << found_peptide_count << " of " << ac_trie.getNeedleCount() << " peptides.\n";
+    }
+    
     // write some stats
     OPENMS_LOG_INFO << "Peptide hits passing enzyme filter: " << func.filter_passed << "\n"
                     << "     ... rejected by enzyme filter: " << func.filter_rejected << std::endl;

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -60,8 +60,8 @@ using namespace std;
   struct PeptideProteinMatchInformation
   {
     Hit::T peptide_index; ///< index of the peptide
-    Hit::T protein_index; //< index of the protein the peptide is contained in
-    Hit::T position;      //< the position of the peptide in the protein
+    Hit::T protein_index; ///< index of the protein the peptide is contained in
+    Hit::T position;      ///< the position of the peptide in the protein
     char AABefore; //< the amino acid after the peptide in the protein
     char AAAfter; //< the amino acid before the peptide in the protein
 
@@ -90,9 +90,9 @@ using namespace std;
   {
   public:
     using MapType = std::vector< PeptideProteinMatchInformation >;
-    MapType pep_to_prot; //< peptide index --> protein indices as flat vector
-    Size filter_passed{}; //< number of accepted hits (passing addHit() constraints)
-    Size filter_rejected{}; //< number of rejected hits (not passing addHit())
+    MapType pep_to_prot; ///< peptide index --> protein indices as flat vector
+    Size filter_passed{}; ///< number of accepted hits (passing addHit() constraints)
+    Size filter_rejected{}; ///< number of rejected hits (not passing addHit())
 
     ProteaseDigestion enzyme;
 

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -626,6 +626,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
 
   Size pep_idx(0);
   Size func_hits_idx(0); ///< current position in func.pep_to_prot[] which has a stretch of matches for current pep_idx
+  const Size func_hits_size = func.pep_to_prot.size(); 
   for (std::vector<PeptideIdentification>::iterator it1 = pep_ids.begin(); it1 != pep_ids.end(); ++it1)
   {
     // which ProteinIdentification does the peptide belong to?
@@ -648,7 +649,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
       Hit::T last_prot_index = -1;
       // add new protein references
       // the vector 'pep_to_prot' is sorted by peptide_index, and then by protein_index 
-      while (func.pep_to_prot[func_hits_idx].peptide_index == pep_idx)
+      while ((func_hits_idx < func_hits_size) && (func.pep_to_prot[func_hits_idx].peptide_index == pep_idx))
       {
         const auto& pe = func.pep_to_prot[func_hits_idx];
 

--- a/src/openms/source/CHEMISTRY/DigestionEnzyme.cpp
+++ b/src/openms/source/CHEMISTRY/DigestionEnzyme.cpp
@@ -122,7 +122,7 @@ namespace OpenMS
     name_ = name;
   }
 
-  String DigestionEnzyme::getName() const
+  const String& DigestionEnzyme::getName() const
   {
     return name_;
   }
@@ -147,7 +147,7 @@ namespace OpenMS
     cleavage_regex_ = cleavage_regex;
   }
 
-  String DigestionEnzyme::getRegEx() const
+  const String& DigestionEnzyme::getRegEx() const
   {
     return cleavage_regex_;
   }
@@ -157,7 +157,7 @@ namespace OpenMS
     regex_description_ = value;
   }
 
-  String DigestionEnzyme::getRegExDescription() const
+  const String& DigestionEnzyme::getRegExDescription() const
   {
     return regex_description_;
   }

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -143,7 +143,7 @@ namespace OpenMS
                                            bool ignore_missed_cleavages,
                                            bool allow_nterm_protein_cleavage,
                                            bool allow_random_asp_pro_cleavage) const
-    {
+  {
     // for XTandem specific rules (see https://github.com/OpenMS/OpenMS/issues/2497)
     // M or MX at the N-terminus might have been cleaved off 
     if (allow_nterm_protein_cleavage && (pos <= 2) && (sequence[0] == 'M'))

--- a/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
+++ b/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
@@ -340,16 +340,26 @@ START_SECTION(bool nextHits(ACTrieState& state) const)
   
   ///
   /// TEST if offsets into proteins are correct in the presence of non-AA characters like '*'
-  /// 
+  ///        NOTE: offsets will be incorrect if a hit overlaps with a '*', since the trie only knows the length of a hit and the end position
+  ///              in the protein, thus computing the start will be off by the amount of '*'s
   t = ACTrie(0, 0);
   needles = {"MLTEAEK"};
   t.addNeedlesAndCompress(needles);
-  testCase(t, "*MLT*EAXK", "", needles, __LINE__);
+  testCase(t, "*MLTEAXK*", "", needles, __LINE__);
 
   t = ACTrie(1, 0);
   needles = {"MLTEAEK"};
   t.addNeedlesAndCompress(needles);
   testCase(t, "*MLTEAXK*", "MLTEAEK@1", needles, __LINE__);
+
+  ///
+  /// test if spawn does not report hits which do not cover its first AAA
+  /// 
+  t = ACTrie(4, 0);
+  needles = {"MDDDEADC", "MDD", "DD", "DEADC"};
+  t.addNeedlesAndCompress(needles);
+  testCase(t, "MBBDEABCRAFG", "MDDDEADC@0, MDD@0, DD@1, DD@2, DEADC@3", needles, __LINE__);
+             //MDDDEADC
 }
 END_SECTION
 


### PR DESCRIPTION
# Description

This PR removes the costly storage of all peptide hits in a std::map and uses std::vector instead.
Also each hit takes up less space now.

For an (extreme) dataset with 1e9 hits (!), the runtime reduces from 1h to 15min, while the peak memory usage reduces from 134 GB to 91 GB. The resulting idXML is 34 GB in size.

There is further potential (since there is another map) but that is for another PR.

This change also surfaced a small bug in the new AC implementation (#5776), which may report hits twice (which was not discovered since the results were stored in a map). This is also fixed now.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
