### PR TITLE
A Painter1D class for Peaks

### DIFF
--- a/doc/code_examples/Tutorial_GUI_Plot1D.cpp
+++ b/doc/code_examples/Tutorial_GUI_Plot1D.cpp
@@ -28,32 +28,36 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <QApplication>
-#include <OpenMS/VISUAL/Plot1DWidget.h>
 #include <OpenMS/FORMAT/DTAFile.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/OnDiscMSExperiment.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/VISUAL/LayerDataBase.h>
+#include <OpenMS/VISUAL/Plot1DWidget.h>
+#include <OpenMS/VISUAL/Plot2DWidget.h>
+#include <OpenMS/openms_data_path.h>
+#include <QApplication>
 
 using namespace OpenMS;
 using namespace std;
 
-Int main(int argc, const char ** argv)
+Int main(int argc, const char** argv)
 {
-  if (argc < 2) return 1;
-  // the path to the data should be given on the command line
-  String tutorial_data_path(argv[1]);
-  
-  QApplication app(argc, const_cast<char **>(argv));
+  String tutorial_data_path(OPENMS_DOC_PATH + String("/code_examples/data/Tutorial_Spectrum1D.dta"));
+  if (argc >= 2)
+  { // the path to the data can be given on the command line
+    tutorial_data_path = argv[1];
+  }
+
+  QApplication app(argc, const_cast<char**>(argv));
 
   PeakMap exp;
   exp.resize(1);
-  DTAFile().load(tutorial_data_path + "/data/Tutorial_Spectrum1D.dta", exp[0]);
+  DTAFile().load(tutorial_data_path, exp[0]);
   LayerDataBase::ExperimentSharedPtrType exp_sptr(new PeakMap(exp));
   LayerDataBase::ODExperimentSharedPtrType on_disc_exp_sptr(new OnDiscMSExperiment());
-  Plot1DWidget * widget = new Plot1DWidget(Param(), nullptr);
+  auto* widget = new Plot1DWidget(Param(), nullptr);
   widget->canvas()->addLayer(exp_sptr, on_disc_exp_sptr);
   widget->show();
 
   return app.exec();
-} //end of main
+} // end of main

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -40,21 +40,20 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/METADATA/MetaInfoInterface.h>
 
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/sax2/DefaultHandler.hpp>
-#include <xercesc/sax/Locator.hpp>
 #include <xercesc/sax2/Attributes.hpp>
 
 #include <iosfwd>
 #include <string>
 #include <memory>
 
+
 namespace OpenMS
 {
   class ProteinIdentification;
-
+  class MetaInfoInterface;
 
   namespace Internal
   {

--- a/src/openms/source/FORMAT/CVMappingFile.cpp
+++ b/src/openms/source/FORMAT/CVMappingFile.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/DATASTRUCTURES/CVReference.h>
 #include <OpenMS/DATASTRUCTURES/CVMappingTerm.h>
+#include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/SYSTEM/File.h>
 
 using namespace xercesc;

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -34,8 +34,9 @@
 
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 
-#include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <iostream>
 #include <fstream>

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
@@ -49,6 +49,7 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h>
+//#include <OpenMS/VISUAL/Painter1DBase.h>
 #include <OpenMS/VISUAL/LogWindow.h>
 #include <OpenMS/VISUAL/MultiGradient.h>
 
@@ -64,6 +65,7 @@ namespace OpenMS
   class LayerStatistics;
   class OnDiscMSExperiment;
   class OSWData;
+  class Painter1DBase;
 
   /**
   @brief Class that stores the data for one layer
@@ -183,6 +185,8 @@ namespace OpenMS
     LayerDataBase& operator=(LayerDataBase&& ld) = default;
     /// D'tor
     virtual ~LayerDataBase() = default;
+
+    virtual std::unique_ptr<Painter1DBase> getPainter1D() const = 0;
 
 
     /// Returns a const reference to the current feature data

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
@@ -171,17 +171,17 @@ namespace OpenMS
 
     /// Default constructor
     LayerDataBase() = delete;
-    /// Ctor for child classes
+    /// C'tor for child classes
     LayerDataBase(const DataType type) : type(type) {};
     /// no Copy-ctor (should not be needed)
     LayerDataBase(const LayerDataBase& ld) = delete;
     /// no assignment operator (should not be needed)
     LayerDataBase& operator=(const LayerDataBase& ld) = delete;
-    /// move Ctor
+    /// move C'tor
     LayerDataBase(LayerDataBase&& ld) = default;
     /// move assignment
     LayerDataBase& operator=(LayerDataBase&& ld) = default;
-    /// Dtor
+    /// D'tor
     virtual ~LayerDataBase() = default;
 
 
@@ -267,11 +267,11 @@ namespace OpenMS
       return chromatogram_map_;
     }
 
-    /// get annotation (e.g. to build a hierachical ID View)
+    /// get annotation (e.g. to build a hierarchical ID View)
     /// Not const, because we might have incomplete data, which needs to be loaded from sql source
     OSWDataSharedPtrType& getChromatogramAnnotation();
 
-    /// get annotation (e.g. to build a hierachical ID View)
+    /// get annotation (e.g. to build a hierarchical ID View)
     /// Not actually const (only the pointer, not the data), because we might have incomplete data, which needs to be loaded from sql source
     const OSWDataSharedPtrType& getChromatogramAnnotation() const;
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataChrom.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataChrom.h
@@ -54,10 +54,12 @@ public:
     LayerDataChrom(const LayerDataChrom& ld) = delete;
     /// no assignment operator (should not be needed)
     LayerDataChrom& operator=(const LayerDataChrom& ld) = delete;
-    /// move Ctor
+    /// move C'tor
     LayerDataChrom(LayerDataChrom&& ld) = default;
     /// move assignment
     LayerDataChrom& operator=(LayerDataChrom&& ld) = default;
+
+    std::unique_ptr<Painter1DBase> getPainter1D() const override;
 
     void updateRanges() override
     {

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataConsensus.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataConsensus.h
@@ -58,6 +58,8 @@ namespace OpenMS
     /// move assignment
     LayerDataConsensus& operator=(LayerDataConsensus&& ld) = default;
 
+    std::unique_ptr<Painter1DBase> getPainter1D() const override;
+
     void updateRanges() override
     {
       consensus_map_->updateRanges();

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataFeature.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataFeature.h
@@ -54,7 +54,7 @@ namespace OpenMS
     LayerDataFeature(const LayerDataFeature& ld) = delete;
     /// no assignment operator (should not be needed)
     LayerDataFeature& operator=(const LayerDataFeature& ld) = delete;
-    /// move Ctor
+    /// move C'tor
     LayerDataFeature(LayerDataFeature&& ld) = default;
     /// move assignment
     LayerDataFeature& operator=(LayerDataFeature&& ld) = default;

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataIdent.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataIdent.h
@@ -60,6 +60,8 @@ namespace OpenMS
     /// move assignment
     LayerDataIdent& operator=(LayerDataIdent&& ld) = default;
 
+    std::unique_ptr<Painter1DBase> getPainter1D() const override;
+
     void updateRanges() override
     {
       // nothing to do...

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataPeak.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataPeak.h
@@ -58,6 +58,8 @@ namespace OpenMS
     /// move assignment
     LayerDataPeak& operator=(LayerDataPeak&& ld) = default;
     
+    std::unique_ptr<Painter1DBase> getPainter1D() const override;
+
     void updateRanges() override
     {
       peak_map_->updateRanges();

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
@@ -39,7 +39,9 @@
 
 // OpenMS
 #include <OpenMS/VISUAL/PlotCanvas.h>
+#include <OpenMS/VISUAL/Painter1DBase.h>
 
+// QT
 #include <QTextDocument>
 
 // STL
@@ -51,6 +53,7 @@ class QAction;
 
 namespace OpenMS
 {
+
   /**
       @brief Canvas for visualization of one or several spectra.
 
@@ -157,19 +160,12 @@ public:
     /// Add an annotation item for the given peak
     Annotation1DItem* addPeakAnnotation(const PeakIndex& peak_index, const QString& text, const QColor& color);
 
-    /// Draws all annotation items of @p layer_index on @p painter
-    void drawAnnotations(Size layer_index, QPainter& painter);
-
     /// ----- Alignment
-
     /// Performs an alignment of the layers with @p layer_index_1 and @p layer_index_2
     void performAlignment(Size layer_index_1, Size layer_index_2, const Param& param);
 
     /// Resets alignment_
     void resetAlignment();
-
-    /// Draws the alignment on @p painter
-    void drawAlignment(QPainter& painter);
 
     /// Returns the number of aligned pairs of peaks
     Size getAlignmentSize();
@@ -248,9 +244,9 @@ protected:
     void drawCoordinates_(QPainter& painter, const PeakIndex& peak);
     /// Draws the coordinates (or coordinate deltas) to the widget's upper left corner
     void drawDeltas_(QPainter& painter, const PeakIndex& start, const PeakIndex& end);
-
-    /// annotate interesting peaks in visible area with m/z
-    void drawMZAtInterestingPeaks_(Size layer_index, QPainter& painter);
+    
+    /// Draws the alignment on @p painter
+    void drawAlignment_(QPainter& painter);
 
     /**
         @brief Changes visible area interval
@@ -261,9 +257,6 @@ protected:
 
     /// Draws a highlighted peak; if draw_elongation is true, the elongation line is drawn (for measuring)
     void drawHighlightedPeak_(Size layer_index, const PeakIndex& peak, QPainter& painter, bool draw_elongation = false);
-
-    /// Draws a dashed line using the highlighted peak color parameter
-    void drawDashedLine_(const QPoint& from, const QPoint& to, QPainter& painter);
 
     /// Recalculates the current scale factor based on the specified layer (= 1.0 if intensity mode != IM_PERCENTAGE)
     void updatePercentageFactor_(Size layer_index);
@@ -353,6 +346,9 @@ protected:
     void translateRight_(Qt::KeyboardModifiers m) override;
     //docu in base class
     void paintGridLines_(QPainter& painter) override;
+
+    friend class Painter1DPeak;
+
   };
 } // namespace OpenMS
 

--- a/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/sources.cmake
@@ -30,6 +30,7 @@ MetaDataBrowser.h
 MultiGradient.h
 MultiGradientSelector.h
 OutputDirectory.h
+Painter1DBase.h
 ParamEditor.h
 Plot1DCanvas.h
 Plot1DWidget.h

--- a/src/openms_gui/source/VISUAL/LayerDataBase.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataBase.cpp
@@ -97,13 +97,6 @@ namespace OpenMS
     }
   }
 
-
-  /// add annotation from an OSW sqlite file.
-
-
-  /// get annotation (e.g. to build a hierachical ID View)
-  /// Not const, because we might have incomplete data, which needs to be loaded from sql source
-
   LayerDataBase::OSWDataSharedPtrType& LayerDataBase::getChromatogramAnnotation()
   {
     return chrom_annotation_;
@@ -153,7 +146,6 @@ namespace OpenMS
     return cached_spectrum_;
   }
 
-  /// Returns a const-copy of the required spectrum which is guaranteed to be populated with raw data
 
   const LayerDataBase::ExperimentType::SpectrumType LayerDataBase::getSpectrum(Size spectrum_idx) const
   {

--- a/src/openms_gui/source/VISUAL/LayerDataChrom.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataChrom.cpp
@@ -39,8 +39,13 @@ using namespace std;
 
 namespace OpenMS
 {
+  std::unique_ptr<Painter1DBase> LayerDataChrom::getPainter1D() const
+  {
+    throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+  }
+
   std::unique_ptr<LayerStatistics> LayerDataChrom::getStats() const
   {
     return make_unique<LayerStatisticsPeakMap>(*peak_map_);
   }
-}// namespace OpenMS
+} // namespace OpenMS

--- a/src/openms_gui/source/VISUAL/LayerDataConsensus.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataConsensus.cpp
@@ -45,6 +45,11 @@ namespace OpenMS
     consensus_map_ = map;
   }
   
+  std::unique_ptr<Painter1DBase> LayerDataConsensus::getPainter1D() const
+  {
+    throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+  }
+  
   std::unique_ptr<LayerStatistics> LayerDataConsensus::getStats() const
   {
     return make_unique<LayerStatisticsConsensusMap>(*consensus_map_);

--- a/src/openms_gui/source/VISUAL/LayerDataFeature.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataFeature.cpp
@@ -44,6 +44,11 @@ namespace OpenMS
   {
     flags.set(LayerDataBase::F_HULL);
   }
+  
+  std::unique_ptr<Painter1DBase> LayerDataFeature::getPainter1D() const
+  {
+    throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+  }
 
   std::unique_ptr<LayerStatistics> LayerDataFeature::getStats() const
   {

--- a/src/openms_gui/source/VISUAL/LayerDataIdent.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataIdent.cpp
@@ -39,6 +39,11 @@ using namespace std;
 
 namespace OpenMS
 {
+  std::unique_ptr<Painter1DBase> LayerDataIdent::getPainter1D() const
+  {
+    throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+  }
+
   std::unique_ptr<LayerStatistics> LayerDataIdent::getStats() const
   {
     return make_unique<LayerStatisticsIdent>(peptides_);

--- a/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
@@ -35,12 +35,12 @@
 #include <OpenMS/VISUAL/LayerDataPeak.h>
 #include <OpenMS/VISUAL/VISITORS/LayerStatistics.h>
 
+#include <OpenMS/VISUAL/Painter1DBase.h>
+
 using namespace std;
 
 namespace OpenMS
 {
-  /// Default constructor
-
   LayerDataPeak::LayerDataPeak() : LayerDataBase(LayerDataBase::DT_PEAK)
   {
     flags.set(LayerDataBase::P_PRECURSORS);
@@ -49,6 +49,11 @@ namespace OpenMS
   std::unique_ptr<LayerStatistics> LayerDataPeak::getStats() const
   {
     return make_unique<LayerStatisticsPeakMap>(*peak_map_);
+  }
+
+  std::unique_ptr<Painter1DBase> LayerDataPeak::getPainter1D() const
+  {
+    return make_unique<Painter1DPeak>(this);
   }
 
 }// namespace OpenMS

--- a/src/openms_gui/source/VISUAL/Painter1DBase.cpp
+++ b/src/openms_gui/source/VISUAL/Painter1DBase.cpp
@@ -1,0 +1,307 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/VISUAL/LayerDataPeak.h>
+#include <OpenMS/VISUAL/Painter1DBase.h>
+
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DTextItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h>
+#include <OpenMS/VISUAL/Plot1DCanvas.h>
+
+// preprocessing and filtering for automated m/z annotations
+#include <OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h>
+#include <OpenMS/FILTERING/TRANSFORMERS/ThresholdMower.h>
+#include <OpenMS/FILTERING/TRANSFORMERS/NLargest.h>
+#include <OpenMS/FILTERING/TRANSFORMERS/WindowMower.h>
+
+
+#include <QPainter>
+#include <QPen>
+
+using namespace std;
+
+namespace OpenMS
+{
+  void Painter1DBase::drawDashedLine(const QPoint& from, const QPoint& to, QPainter* painter, QColor color)
+  {
+    QPen pen;
+    QVector<qreal> dashes;
+    dashes << 5 << 5 << 1 << 5;
+    pen.setDashPattern(dashes);
+    pen.setColor(color);
+    painter->save();
+    painter->setPen(pen);
+    painter->drawLine(from, to);
+    painter->restore();
+  }
+
+  Painter1DPeak::Painter1DPeak(const LayerDataPeak* parent) : layer_(parent)
+  {
+  }
+
+  void Painter1DPeak::paint(QPainter* painter, Plot1DCanvas* canvas, int layer_index)
+  {
+    if (!layer_->visible)
+    {
+      return;
+    }                              
+    
+    const auto& spectrum = layer_->getCurrentSpectrum();
+
+    // get default icon and peak color
+    //QPen icon_pen = QPen(QColor(String(layer_->param.getValue("icon_color").toString()).toQString()), 1);
+    QPen pen(QColor(String(layer_->param.getValue("peak_color").toString()).toQString()), 1);
+    Qt::PenStyle pen_style = canvas->peak_penstyle_[layer_index];
+    pen.setStyle(pen_style);
+
+    painter->setPen(pen);
+    // draw dashed elongations for pairs of peaks annotated with a distance
+    QColor color = String(canvas->param_.getValue("highlighted_peak_color").toString()).toQString();
+    for (auto& it : layer_->getCurrentAnnotations())
+    {
+      Annotation1DDistanceItem* distance_item = dynamic_cast<Annotation1DDistanceItem*>(it);
+      if (distance_item)
+      {
+        QPoint from, to;
+        canvas->dataToWidget(distance_item->getStartPoint().getX(), 0, from, layer_->flipped);
+
+        canvas->dataToWidget(distance_item->getStartPoint().getX(), canvas->visible_area_.maxY(), to, layer_->flipped);
+        drawDashedLine(from, to, painter, color);
+
+        canvas->dataToWidget(distance_item->getEndPoint().getX(), 0, from, layer_->flipped);
+
+        canvas->dataToWidget(distance_item->getEndPoint().getX(), canvas->visible_area_.maxY(), to, layer_->flipped);
+        drawDashedLine(from, to, painter, color);
+      }
+    }
+   
+    auto vbegin = spectrum.MZBegin(canvas->visible_area_.minX());
+    auto vend = spectrum.MZEnd(canvas->visible_area_.maxX());
+    QPoint begin, end;
+    Plot1DCanvas::DrawModes line_mode = canvas->draw_modes_[layer_index];
+    switch (line_mode)
+    {
+      case Plot1DCanvas::DrawModes::DM_PEAKS:
+      {
+        //---------------------DRAWING PEAKS---------------------
+
+        for (auto it = vbegin; it != vend; ++it)
+        {
+          if (!layer_->filters.passes(spectrum, it - spectrum.begin())) continue;
+          
+          // use peak colors stored in the layer, if available
+          if (layer_->peak_colors_1d.size() == spectrum.size())
+          {
+            // find correct peak index
+            Size peak_index = std::distance(spectrum.begin(), it);
+            pen.setColor(layer_->peak_colors_1d[peak_index]);
+            painter->setPen(pen);
+          }
+
+          // Warn if non-empty peak color array present but size doesn't match number of peaks
+          // This indicates a bug but we gracefully just issue a warning
+          if (!layer_->peak_colors_1d.empty() && layer_->peak_colors_1d.size() < spectrum.size())
+          {
+            OPENMS_LOG_ERROR << "Peak color array size (" << layer_->peak_colors_1d.size() << ") doesn't match number of peaks (" << spectrum.size() << ") in spectrum." << endl;
+          }
+          canvas->dataToWidget(*it, end, layer_->flipped);
+          canvas->dataToWidget(it->getMZ(), 0.0f, begin, layer_->flipped);
+          // draw peak
+          painter->drawLine(begin, end);
+        }
+        break;
+      }
+      case Plot1DCanvas::DrawModes::DM_CONNECTEDLINES:
+      {
+        //---------------------DRAWING CONNECTED LINES---------------------
+
+        QPainterPath path;
+
+        // connect peaks in visible area; (no clipping needed)
+        bool first_point = true;
+        for (auto it = vbegin; it != vend; it++)
+        {
+          canvas->dataToWidget(*it, begin, layer_->flipped);
+
+          // connect lines
+          if (first_point)
+          {
+            path.moveTo(begin);
+            first_point = false;
+          }
+          else
+          {
+            path.lineTo(begin);
+          }
+        }
+        painter->drawPath(path);
+
+        // clipping on left side
+        if (vbegin != spectrum.begin() && vbegin != spectrum.end())
+        {
+          canvas->dataToWidget(*(vbegin - 1), begin, layer_->flipped);
+          canvas->dataToWidget(*(vbegin), end, layer_->flipped);
+          painter->drawLine(begin, end);
+        }
+
+        // clipping on right side
+        if (vend != spectrum.end() && vend != spectrum.begin())
+        {
+          canvas->dataToWidget(*(vend - 1), begin, layer_->flipped);
+          canvas->dataToWidget(*(vend), end, layer_->flipped);
+          painter->drawLine(begin, end);
+        }
+
+        break;
+      }
+
+      default:
+        throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+    }
+
+    // annotate interesting m/z's
+    if (canvas->draw_interesting_MZs_)
+    {
+      drawMZAtInterestingPeaks_(*painter, canvas, vbegin, vend);
+    }
+
+    // draw all annotation items
+    drawAnnotations_(*painter, canvas);
+
+    // draw a legend
+    if (canvas->param_.getValue("show_legend").toBool())
+    {
+      double xpos = canvas->getVisibleArea().maxX() - (canvas->getVisibleArea().maxX() - canvas->getVisibleArea().minX()) * 0.1;
+      auto tmp = max_element(spectrum.MZBegin(canvas->visible_area_.minX()), spectrum.MZEnd(xpos), Plot1DCanvas::PeakType::IntensityLess());
+      if (tmp != spectrum.end())
+      {
+        Plot1DCanvas::PointType position(xpos, std::max<double>(tmp->getIntensity() - 100, tmp->getIntensity() * 0.8));
+        Annotation1DPeakItem item = Annotation1DPeakItem(position, layer_->getName().toQString(), QColor(String(layer_->param.getValue("peak_color").toString()).toQString()));
+        item.draw(canvas, *painter);
+      }
+    }
+  }
+  
+
+
+  void Painter1DPeak::drawAnnotations_(QPainter& painter, Plot1DCanvas* canvas)
+  {
+    QColor col {QColor(String(layer_->param.getValue("annotation_color").toString()).toQString())};
+    // 0: default pen; 1: selected pen
+    QPen pen[2] = {col, col.lighter()};
+
+    for (const auto& c : layer_->getCurrentAnnotations())
+    {
+      painter.setPen(pen[c->isSelected()]);
+      c->draw(canvas, painter, layer_->flipped);
+    }
+  }
+
+  void Painter1DPeak::drawMZAtInterestingPeaks_(QPainter& painter, Plot1DCanvas* canvas, MSSpectrum::ConstIterator vbegin, MSSpectrum::ConstIterator vend)
+  {
+    if (vbegin == vend)
+    {
+      return;
+    }
+    // find interesting peaks
+
+    // copy visible peaks into spec
+    MSSpectrum spec;
+    for (auto it(vbegin); it != vend; ++it)
+    {
+      spec.push_back(*it);
+    }
+
+    // calculate distance between first and last peak
+    --vend;
+    double visible_range = vend->getMZ() - vbegin->getMZ();
+
+    // remove 0 intensities
+    ThresholdMower threshold_mower_filter;
+    threshold_mower_filter.filterPeakSpectrum(spec);
+
+    // deisotope so we don't consider higher isotopic peaks
+    Deisotoper::deisotopeAndSingleCharge(spec,
+                                         100,   // tolerance
+                                         true,  // ppm
+                                         1, 6,  // min / max charge
+                                         false, // keep only deisotoped
+                                         3, 10, // min / max isopeaks
+                                         false, // don't convert fragment m/z to mono-charge
+                                         true); // annotate charge in integer data array
+
+    // filter for local high-intensity peaks
+    WindowMower window_mower_filter;
+    Param filter_param = window_mower_filter.getParameters();
+    double window_size = visible_range / 10.0;
+    filter_param.setValue("windowsize", window_size, "The size of the sliding window along the m/z axis.");
+    filter_param.setValue("peakcount", 2, "The number of peaks that should be kept.");
+    filter_param.setValue("movetype", "slide", "Whether sliding window (one peak steps) or jumping window (window size steps) should be used.");
+    window_mower_filter.setParameters(filter_param);
+    window_mower_filter.filterPeakSpectrum(spec);
+
+    NLargest nlargest_filter(10); // maximum number of annotated m/z's in visible area
+    nlargest_filter.filterPeakSpectrum(spec);
+    spec.sortByPosition(); // nlargest changes order
+
+    for (size_t i = 0; i < spec.size(); ++i)
+    {
+      auto mz(spec[i].getMZ());
+      auto intensity(spec[i].getIntensity());
+
+      QString label = String::number(mz, 4).toQString();
+
+      if (!spec.getIntegerDataArrays().empty() && spec.getIntegerDataArrays()[0].size() == spec.size())
+      {
+        int charge = spec.getIntegerDataArrays()[0][i];
+        // TODO: handle negative mode
+
+        // here we explicitly also annotate singly charged ions to distinguish them from unknown charge (0)
+        if (charge != 0)
+        {
+          label += charge == 1 ? "<sup>+</sup>" : "<sup>" + QString::number(charge) + "+</sup>";
+        }
+      }
+
+      Annotation1DPeakItem item({mz, intensity}, label, Qt::darkGray);
+      item.setSelected(false);
+      item.draw(canvas, painter, layer_->flipped);
+    }
+  }
+
+} // namespace OpenMS

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -32,17 +32,7 @@
 // $Authors: Marc Sturm, Timo Sachsenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 
-// Qt
-#include <QMouseEvent>
-#include <QtWidgets/QMessageBox>
-#include <QPainterPath>
-#include <QPainter>
-#include <QtCore/QTime>
-#include <QtWidgets/QMenu>
-#include <QtWidgets/QComboBox>
-#include <QtWidgets/QFileDialog>
-#include <QtWidgets/QInputDialog>
-#include <QtSvg/QSvgGenerator>
+#include <OpenMS/VISUAL/Plot1DCanvas.h>
 
 // OpenMS
 #include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h>
@@ -50,31 +40,27 @@
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
-#include <OpenMS/MATH/MISC/MathFunctions.h>
-#include <OpenMS/SYSTEM/FileWatcher.h>
-#include <OpenMS/VISUAL/Plot1DCanvas.h>
 #include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/ColorSelector.h>
 #include <OpenMS/VISUAL/PlotWidget.h>
 #include <OpenMS/VISUAL/Plot1DWidget.h>
-#include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DTextItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
-#include <OpenMS/VISUAL/ANNOTATION/Annotation1DVerticalLineItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h>
 #include <OpenMS/VISUAL/DIALOGS/Plot1DPrefDialog.h>
 
-// preprocessing and filtering for automated m/z annotations
-#include <OpenMS/FILTERING/DATAREDUCTION/Deisotoper.h>
-#include <OpenMS/FILTERING/TRANSFORMERS/ThresholdMower.h>
-#include <OpenMS/FILTERING/TRANSFORMERS/NLargest.h>
-#include <OpenMS/FILTERING/TRANSFORMERS/WindowMower.h>
 
-#include <iostream>
-#include <boost/math/special_functions/fpclassify.hpp>
+// Qt
+#include <QMouseEvent>
+#include <QPainter>
+#include <QtCore/QTime>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QMenu>
+#include <QtWidgets/QMessageBox>
+
 
 using namespace std;
 
@@ -381,14 +367,8 @@ namespace OpenMS
         {
           measurement_start_ = selected_peak_;
           const ExperimentType::PeakType & peak = getCurrentLayer().getCurrentSpectrum()[measurement_start_.peak];
-          if (intensity_mode_ == IM_PERCENTAGE)
-          {
-            updatePercentageFactor_(getCurrentLayerIndex());
-          }
-          else
-          {
-            percentage_factor_ = 1.0;
-          }
+          updatePercentageFactor_(getCurrentLayerIndex());
+
           dataToWidget(peak, measurement_start_point_, getCurrentLayer().flipped);
           if (isMzToXAxis())
           {
@@ -490,7 +470,7 @@ namespace OpenMS
     }
     else if (!e->buttons())     //no buttons pressed
     {
-      selected_peak_ = findPeakAtPosition_(p);
+      selected_peak_ = near_peak;
       update_(OPENMS_PRETTY_FUNCTION);
     }
 
@@ -580,7 +560,7 @@ namespace OpenMS
       getCurrentLayer().getCurrentAnnotations().removeSelectedItems();
       update_(OPENMS_PRETTY_FUNCTION);
     }
-    // 'a' pressed && in zoom mode (ctrl pressed) => select all annotation items
+    // 'a' pressed && in zoom mode (Ctrl pressed) => select all annotation items
     else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_A))
     {
       e->accept();
@@ -609,7 +589,7 @@ namespace OpenMS
     const SpectrumType& spectrum = getCurrentLayer().getCurrentSpectrum();
     Size spectrum_index = getCurrentLayer().getCurrentSpectrumIndex();
 
-    // get the interval (in diagramm metric) that will be projected on screen coordinate p.x() or p.y() (depending on orientation)
+    // get the interval (in diagram metric) that will be projected on screen coordinate p.x() or p.y() (depending on orientation)
     PointType lt = widgetToData(p - QPoint(2, 2), true);
     PointType rb = widgetToData(p + QPoint(2, 2), true);
 
@@ -753,150 +733,17 @@ namespace OpenMS
     emit recalculateAxes();
     paintGridLines_(*painter);
 
+    // paint each layer
     for (Size i = 0; i < getLayerCount(); ++i)
     {
-      const LayerDataBase& layer = getLayer(i);
-
-      // skip non peak data layer or invisible
-      if (layer.type != LayerDataBase::DT_PEAK || !layer.visible) { continue; }
-
-      const ExperimentType::SpectrumType& spectrum = layer.getCurrentSpectrum();
-
-      // get default icon and peak color
-      QPen icon_pen = QPen(QColor(String(layer.param.getValue("icon_color").toString()).toQString()), 1);
-      QPen pen(QColor(String(layer.param.getValue("peak_color").toString()).toQString()), 1);
-      pen.setStyle(peak_penstyle_[i]);
-
-      // TODO option for variable pen width
-      // pen.setWidthF(1.5);
-      painter->setPen(pen);
       updatePercentageFactor_(i);
-      SpectrumConstIteratorType vbegin = getLayer(i).getCurrentSpectrum().MZBegin(visible_area_.minX());
-      SpectrumConstIteratorType vend = getLayer(i).getCurrentSpectrum().MZEnd(visible_area_.maxX());
+      auto paint_1d = getLayer(i).getPainter1D();
+      paint_1d->paint(painter, this, i);      
+    }
 
-      // draw dashed elongations for pairs of peaks annotated with a distance
-      for (auto& it : layer.getCurrentAnnotations())
-      {
-        Annotation1DDistanceItem* distance_item = dynamic_cast<Annotation1DDistanceItem*>(it);
-        if (distance_item)
-        {
-          QPoint from, to;
-          dataToWidget(distance_item->getStartPoint().getX(), 0, from, layer.flipped);
-
-          dataToWidget(distance_item->getStartPoint().getX(), getVisibleArea().maxY(), to, layer.flipped);
-          drawDashedLine_(from, to, *painter);
-
-          dataToWidget(distance_item->getEndPoint().getX(), 0, from, layer.flipped);
-
-          dataToWidget(distance_item->getEndPoint().getX(), getVisibleArea().maxY(), to, layer.flipped);
-          drawDashedLine_(from, to, *painter);
-        }
-      }
-      QPoint begin, end; 
-      switch (draw_modes_[i])
-      {
-      case DM_PEAKS:
-        //---------------------DRAWING PEAKS---------------------
-
-        for (SpectrumConstIteratorType it = vbegin; it != vend; ++it)
-        {
-          if (layer.filters.passes(spectrum, it - spectrum.begin()))
-          {
-            // use peak colors stored in the layer, if available
-            if (layer.peak_colors_1d.size() == spectrum.size())
-            {
-              // find correct peak index
-              Size peak_index = std::distance(spectrum.begin(), it);
-              pen.setColor(layer.peak_colors_1d[peak_index]);
-              painter->setPen(pen);
-            }
-
-            // Warn if non-empty peak color array present but size doesn't match number of peaks
-            // This indicates a bug but we gracefully just issue a warning
-            if (!layer.peak_colors_1d.empty() &&
-                layer.peak_colors_1d.size() < spectrum.size())
-            {
-              OPENMS_LOG_ERROR << "Peak color array size ("
-                               << layer.peak_colors_1d.size()
-                               << ") doesn't match number of peaks ("
-                               << spectrum.size()
-                               << ") in spectrum."
-                               << endl;
-            }
-            dataToWidget(*it, end, layer.flipped);
-            dataToWidget(it->getMZ(), 0.0f, begin, layer.flipped);
-            // draw peak
-            painter->drawLine(begin, end);
-          }
-        }
-        break;
-
-      case DM_CONNECTEDLINES:
-      {
-        //---------------------DRAWING CONNECTED LINES---------------------
-
-        QPainterPath path;
-
-        // connect peaks in visible area; (no clipping needed)
-        bool first_point = true;
-        for (SpectrumConstIteratorType it = vbegin; it != vend; it++)
-        {
-          dataToWidget(*it, begin, layer.flipped);
-
-          // connect lines
-          if (first_point)
-          {
-            path.moveTo(begin);
-            first_point = false;
-          }
-          else
-          {
-            path.lineTo(begin);
-          }
-        }
-        painter->drawPath(path);
-
-        // clipping on left side
-        if (vbegin != spectrum.begin() && vbegin != spectrum.end())
-        {
-          dataToWidget(*(vbegin - 1), begin, layer.flipped);
-          dataToWidget(*(vbegin), end, layer.flipped);
-          painter->drawLine(begin, end);
-        }
-
-        // clipping on right side
-        if (vend != spectrum.end() && vend != spectrum.begin())
-        {
-          dataToWidget(*(vend - 1), begin, layer.flipped);
-          dataToWidget(*(vend), end, layer.flipped);
-          painter->drawLine(begin, end);
-        }
-      }
-      break;
-
-      default:
-        throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
-      }
-
-      // annotate interesting m/z's
-      if (draw_interesting_MZs_) { drawMZAtInterestingPeaks_(i, *painter); }
-
-      // draw all annotation items
-      drawAnnotations(i, *painter);
-
-      // draw a legend
-      if (param_.getValue("show_legend").toBool())
-      {
-        const SpectrumType & spectrum = getLayer(i).getCurrentSpectrum();
-        double xpos = getVisibleArea().maxX() - (getVisibleArea().maxX() - getVisibleArea().minX()) * 0.1;
-        SpectrumConstIteratorType tmp  = max_element(spectrum.MZBegin(visible_area_.minX()), spectrum.MZEnd(xpos), PeakType::IntensityLess());
-        if (tmp != spectrum.end())
-        {
-          PointType position(xpos, std::max<double>(tmp->getIntensity() - 100, tmp->getIntensity() * 0.8));
-          Annotation1DPeakItem item = Annotation1DPeakItem(position, layer.getName().toQString(), QColor(String(layer.param.getValue("peak_color").toString()).toQString()));
-          item.draw(this, *painter);
-        }
-      }
+    if (show_alignment_)
+    {
+      drawAlignment_(*painter);
     }
 
     if (mirror_mode_)
@@ -911,7 +758,6 @@ namespace OpenMS
       }
       else
       {
-        drawAlignment(*painter);
         // two x-axes:
         painter->setPen(Qt::black);
         painter->drawLine(0, height() / 2 + 5, width(), height() / 2 + 5);
@@ -919,13 +765,7 @@ namespace OpenMS
       }
       painter->restore();
     }
-    else   // !mirror_mode_
-    {
-      if (show_alignment_)
-      {
-        drawAlignment(*painter);
-      }
-    }
+
 
     // draw measuring line when in measure mode and valid measurement start peak selected
     if (action_mode_ == AM_MEASURE && measurement_start_.isValid())
@@ -978,176 +818,62 @@ namespace OpenMS
 
   void Plot1DCanvas::drawHighlightedPeak_(Size layer_index, const PeakIndex& peak, QPainter& painter, bool draw_elongation)
   {
-    if (peak.isValid())
+    if (!peak.isValid()) return;
+    QPoint begin;
+    const auto& spec = getLayer(layer_index).getCurrentSpectrum();
+    if (peak.peak >= spec.size())
     {
-      QPoint begin;
-      const auto& spec = getLayer(layer_index).getCurrentSpectrum();
-      if (peak.peak >= spec.size())
+      // somehow the peak is invalid. This happens from time to time and should be tracked down elsewhere
+      // but it's hard to reproduce (changing spectra in 1D view using arrow keys while hovering over the spectrum with the mouse?).
+      return;
+    }
+    const ExperimentType::PeakType& sel = spec[peak.peak];
+
+    painter.setPen(QPen(QColor(String(param_.getValue("highlighted_peak_color").toString()).toQString()), 2));
+
+    updatePercentageFactor_(layer_index);
+
+    dataToWidget(sel, begin, getLayer(layer_index).flipped);
+    QPoint top_end(begin);
+
+    bool layer_flipped = getLayer(layer_index).flipped;
+    if (isMzToXAxis())
+    {
+      if (layer_flipped)
       {
-        // somehow the peak is invalid. This happens from time to time and should be tracked down elsewhere
-        // but it's hard to reproduce (changing spectra in 1D view using arrow keys while hovering over the spectrum with the mouse?).
-        return;
-      }
-      const ExperimentType::PeakType& sel = spec[peak.peak];
-
-      painter.setPen(QPen(QColor(String(param_.getValue("highlighted_peak_color").toString()).toQString()), 2));
-
-      updatePercentageFactor_(layer_index);
-
-      dataToWidget(sel, begin, getLayer(layer_index).flipped);
-      QPoint top_end(begin);
-
-      bool layer_flipped = getLayer(layer_index).flipped;
-      if (isMzToXAxis())
-      {
-        if (layer_flipped)
-        {
-          top_end.setY(height());
-        }
-        else
-        {
-          top_end.setY(0);
-        }
+        top_end.setY(height());
       }
       else
       {
-        if (!layer_flipped)
-        {
-          top_end.setX(width());
-        }
-        else // should not happen
-        {
-          top_end.setX(0);
-        }
-      }
-
-      // paint the crosshair only for currently selected peaks of the current layer
-      if (layer_index == getCurrentLayerIndex() && (peak == measurement_start_ || peak == selected_peak_))
-      {
-        painter.drawLine(begin.x(), begin.y() - 4, begin.x(), begin.y() + 4);
-        painter.drawLine(begin.x() - 4, begin.y(), begin.x() + 4, begin.y());
-      }
-      // draw elongation as dashed line (while in measure mode and for all existing distance annotations)
-      if (draw_elongation)
-      {
-        drawDashedLine_(begin, top_end, painter);
+        top_end.setY(0);
       }
     }
-  }
-
-  void Plot1DCanvas::drawDashedLine_(const QPoint& from, const QPoint& to, QPainter& painter)
-  {
-    QPen pen;
-    QVector<qreal> dashes;
-    dashes << 5 << 5 << 1 << 5;
-    pen.setDashPattern(dashes);
-    pen.setColor(QColor(String(param_.getValue("highlighted_peak_color").toString()).toQString()));
-    painter.save();
-    painter.setPen(pen);
-    painter.drawLine(from, to);
-    painter.restore();
-  }
-
-  void Plot1DCanvas::drawAnnotations(Size layer_index, QPainter& painter)
-  {
-    LayerDataBase& layer = getLayer(layer_index);
-    updatePercentageFactor_(layer_index);
-    QColor col{ QColor(String(layer.param.getValue("annotation_color").toString()).toQString()) };
-    // 0: default pen; 1: selected pen
-    QPen pen[2] = { col, col.lighter() };
-
-    for (const auto& c : layer.getCurrentAnnotations())
+    else
     {
-      painter.setPen(pen[c->isSelected()]);
-      c->draw(this, painter, layer.flipped);
-    }
-  }
-
-  void Plot1DCanvas::drawMZAtInterestingPeaks_(Size layer_index, QPainter& painter)
-  {
-    LayerDataBase& layer = getLayer(layer_index);
-    const MSSpectrum& current_spectrum = layer.getCurrentSpectrum();
-
-    bool flipped = layer.flipped;
-    updatePercentageFactor_(layer_index);
-
-    // get visible peaks
-    auto vbegin = current_spectrum.MZBegin(visible_area_.minX());
-    auto vend = current_spectrum.MZEnd(visible_area_.maxX());
-
-    if (vbegin == vend)
-    { 
-      return;
-    }
-
-    // find interesting peaks
-
-    // copy visible peaks into spec
-    MSSpectrum spec;
-    for (auto it(vbegin); it != vend; ++it)
-    { 
-      spec.push_back(*it);
-    }
-
-    // calculate distance between first and last peak
-    --vend;
-    double visible_range = vend->getMZ() - vbegin->getMZ();
-
-    // remove 0 intensities
-    ThresholdMower threshold_mower_filter;
-    threshold_mower_filter.filterPeakSpectrum(spec);
-
-    // deisotope so we don't consider higher isotopic peaks
-    Deisotoper::deisotopeAndSingleCharge(spec,
-      100,     // tolerance
-      true,   // ppm
-      1, 6,   // min / max charge
-      false,  // keep only deisotoped
-      3, 10,  // min / max isopeaks
-      false,  // don't convert fragment m/z to mono-charge
-      true);  // annotate charge in integer data array
-
-    // filter for local high-intensity peaks
-    WindowMower window_mower_filter;
-    Param filter_param = window_mower_filter.getParameters();
-    double window_size = visible_range / 10.0;
-    filter_param.setValue("windowsize", window_size, "The size of the sliding window along the m/z axis.");
-    filter_param.setValue("peakcount", 2, "The number of peaks that should be kept.");
-    filter_param.setValue("movetype", "slide", "Whether sliding window (one peak steps) or jumping window (window size steps) should be used.");
-    window_mower_filter.setParameters(filter_param);
-    window_mower_filter.filterPeakSpectrum(spec);
-
-    NLargest nlargest_filter(10);  // maximum number of annotated m/z's in visible area
-    nlargest_filter.filterPeakSpectrum(spec);
-    spec.sortByPosition(); // nlargest changes order
-
-    for (Size i = 0; i != spec.size(); ++i)
-    {
-      Size current_peak_index = current_spectrum.findNearest(spec[i].getMZ());
-      double mz(current_spectrum[current_peak_index].getMZ());
-      double intensity(current_spectrum[current_peak_index].getIntensity());
-
-      QString label = String::number(mz, 4).toQString();
-
-      if (!spec.getIntegerDataArrays().empty()
-          && spec.getIntegerDataArrays()[0].size() == spec.size())
+      if (!layer_flipped)
       {
-        int charge = spec.getIntegerDataArrays()[0][i];
-        // TODO: handle negative mode
-
-        // here we explicitly also annotate singly charged ions to distinguish them from unknown charge (0)
-        if (charge != 0)
-        {
-          label += charge == 1 ? "<sup>+</sup>" : "<sup>" + QString::number(charge) + "+</sup>";
-        }
+        top_end.setX(width());
       }
+      else // should not happen
+      {
+        top_end.setX(0);
+      }
+    }
 
-      Annotation1DPeakItem item({mz, intensity}, label, Qt::darkGray);
-      item.setSelected(false);
-      item.draw(this, painter, flipped);
+    // paint the cross-hair only for currently selected peaks of the current layer
+    if (layer_index == getCurrentLayerIndex() && (peak == measurement_start_ || peak == selected_peak_))
+    {
+      painter.drawLine(begin.x(), begin.y() - 4, begin.x(), begin.y() + 4);
+      painter.drawLine(begin.x() - 4, begin.y(), begin.x() + 4, begin.y());
+    }
+    // draw elongation as dashed line (while in measure mode and for all existing distance annotations)
+    if (draw_elongation)
+    {
+      Painter1DBase::drawDashedLine(begin, top_end, &painter, String(param_.getValue("highlighted_peak_color").toString()).toQString());
     }
   }
 
+  
   void Plot1DCanvas::changeVisibleArea_(const AreaType& new_area, bool repaint, bool add_to_stack)
   {
     // set new visible area (if changed)
@@ -1656,50 +1382,52 @@ namespace OpenMS
       proposed_name = layer.filename;
     }
 
-    QString selected_filter = "";
+    QString selected_filter;
     QString file_name = QFileDialog::getSaveFileName(this, "Save file", proposed_name.toQString(), "mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;All files (*)", &selected_filter);
-    if (!file_name.isEmpty())
+    if (file_name.isEmpty())
     {
-      // check whether a file type suffix has been given
-      // first check mzData and mzXML then mzML
-      // if the setting is at "All files"
-      // mzML will be used
-      String upper_filename = file_name;
-      upper_filename.toUpper();
-      if (selected_filter == "mzData files (*.mzData)")
-      {
-        if (!upper_filename.hasSuffix(".MZDATA"))
-        {
-          file_name += ".mzData";
-        }
-      }
-      else if (selected_filter == "mzXML files (*.mzXML)")
-      {
-        if (!upper_filename.hasSuffix(".MZXML"))
-        {
-          file_name += ".mzXML";
-        }
-      }
-      else
-      {
-        if (!upper_filename.hasSuffix(".MZML"))
-        {
-          file_name += ".mzML";
-        }
-      }
+      return;
+    }
 
-      if (visible)
+    // check whether a file type suffix has been given
+    // first check mzData and mzXML then mzML
+    // if the setting is at "All files"
+    // mzML will be used
+    String upper_filename = file_name;
+    upper_filename.toUpper();
+    if (selected_filter == "mzData files (*.mzData)")
+    {
+      if (!upper_filename.hasSuffix(".MZDATA"))
       {
-        ExperimentType out;
-        getVisiblePeakData(out);
-        addDataProcessing_(out, DataProcessing::FILTERING);
-        FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
+        file_name += ".mzData";
       }
-      else
+    }
+    else if (selected_filter == "mzXML files (*.mzXML)")
+    {
+      if (!upper_filename.hasSuffix(".MZXML"))
       {
-        // TODO: this will not work if the data is cached on disk
-        FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
+        file_name += ".mzXML";
       }
+    }
+    else
+    {
+      if (!upper_filename.hasSuffix(".MZML"))
+      {
+        file_name += ".mzML";
+      }
+    }
+
+    if (visible)
+    {
+      ExperimentType out;
+      getVisiblePeakData(out);
+      addDataProcessing_(out, DataProcessing::FILTERING);
+      FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
+    }
+    else
+    {
+      // TODO: this will not work if the data is cached on disk
+      FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
     }
   }
 
@@ -2004,7 +1732,7 @@ namespace OpenMS
     update_(OPENMS_PRETTY_FUNCTION);
   }
 
-  void Plot1DCanvas::drawAlignment(QPainter& painter)
+  void Plot1DCanvas::drawAlignment_(QPainter& painter)
   {
     painter.save();
 

--- a/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DWidget.cpp
@@ -341,7 +341,7 @@ namespace OpenMS
         //display feature with a margin
         if (canvas()->getCurrentLayer().type == LayerDataBase::DT_FEATURE)
         {
-          const FeatureMapType& map = *canvas()->getCurrentLayer().getFeatureMap();
+          const FeatureMap& map = *canvas()->getCurrentLayer().getFeatureMap();
           DBoundingBox<2> bb = map[feature_index].getConvexHull().getBoundingBox();
           double rt_margin = (bb.maxPosition()[0] - bb.minPosition()[0]) * 0.5;
           double mz_margin = (bb.maxPosition()[1] - bb.minPosition()[1]) * 2;

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -503,7 +503,7 @@ namespace OpenMS
   }
 
   double PlotCanvas::getSnapFactor()
-  {
+  { // FIXME: probably a bug. There should be one entry per layer?
     return snap_factors_[0];
   }
 

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -34,39 +34,35 @@
 
 // OpenMS
 #include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/VISUAL/PlotCanvas.h>
-#include <OpenMS/VISUAL/PlotWidget.h>
-#include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/SYSTEM/FileWatcher.h>
-#include <OpenMS/VISUAL/MetaDataBrowser.h>
-#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+#include <OpenMS/VISUAL/AxisWidget.h>
 #include <OpenMS/VISUAL/LayerDataChrom.h>
-#include <OpenMS/VISUAL/LayerDataPeak.h>
 #include <OpenMS/VISUAL/LayerDataConsensus.h>
 #include <OpenMS/VISUAL/LayerDataFeature.h>
 #include <OpenMS/VISUAL/LayerDataIdent.h>
+#include <OpenMS/VISUAL/LayerDataPeak.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+#include <OpenMS/VISUAL/MetaDataBrowser.h>
+#include <OpenMS/VISUAL/PlotCanvas.h>
+#include <OpenMS/VISUAL/PlotWidget.h>
 
 // QT
-#include <QPainter>
-#include <QPaintEvent>
 #include <QBitmap>
+#include <QFontMetrics>
+#include <QPaintEvent>
+#include <QPainter>
 #include <QWheelEvent>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPushButton>
-#include <QFontMetrics>
-
 #include <iostream>
 
 using namespace std;
 
 namespace OpenMS
 {
-  PlotCanvas::PlotCanvas(const Param & /*preferences*/, QWidget * parent) :
-    QWidget(parent),
-    DefaultParamHandler("PlotCanvas"),
-    rubber_band_(QRubberBand::Rectangle, this)
+  PlotCanvas::PlotCanvas(const Param& /*preferences*/, QWidget* parent) : QWidget(parent), DefaultParamHandler("PlotCanvas"), rubber_band_(QRubberBand::Rectangle, this)
   {
-    //Prevent filling background
+    // Prevent filling background
     setAttribute(Qt::WA_OpaquePaintEvent);
     // get mouse coordinates while mouse moves over diagramm and for focus handling
     setMouseTracking(true);
@@ -75,18 +71,18 @@ namespace OpenMS
     setMinimumSize(200, 200);
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
-    //set common defaults for all canvases
+    // set common defaults for all canvases
     defaults_.setValue("default_path", ".", "Default path for loading/storing data.");
 
-    //Set focus policy in order to get keyboard events
+    // Set focus policy in order to get keyboard events
 
-    //Set 'whats this' text
-    setWhatsThis("Translate: Translate mode is activated by default. Hold down the left mouse key and move the mouse to translate. Arrow keys can be used for translation independent of the current mode.\n\n"
-                 "Zoom: Zoom mode is activated with the CTRL key. CTRL+/CTRL- are used to traverse the zoom stack (or mouse wheel). Pressing Backspace resets the zoom.\n\n"
-                 "Measure: Measure mode is activated with the SHIFT key. To measure the distace between data points, press the left mouse button on a point and drag the mouse to another point.\n\n"
-                 );
+    // Set 'whats this' text
+    setWhatsThis(
+      "Translate: Translate mode is activated by default. Hold down the left mouse key and move the mouse to translate. Arrow keys can be used for translation independent of the current mode.\n\n"
+      "Zoom: Zoom mode is activated with the CTRL key. CTRL+/CTRL- are used to traverse the zoom stack (or mouse wheel). Pressing Backspace resets the zoom.\n\n"
+      "Measure: Measure mode is activated with the SHIFT key. To measure the distace between data points, press the left mouse button on a point and drag the mouse to another point.\n\n");
 
-    //set move cursor and connect signal that updates the cursor automatically
+    // set move cursor and connect signal that updates the cursor automatically
     updateCursor_();
     connect(this, SIGNAL(actionModeChange()), this, SLOT(updateCursor_()));
   }
@@ -95,7 +91,7 @@ namespace OpenMS
   {
   }
 
-  void PlotCanvas::resizeEvent(QResizeEvent * /* e */)
+  void PlotCanvas::resizeEvent(QResizeEvent* /* e */)
   {
 #ifdef DEBUG_TOPPVIEW
     cout << "BEGIN " << OPENMS_PRETTY_FUNCTION << endl;
@@ -111,9 +107,9 @@ namespace OpenMS
 
   void PlotCanvas::setFilters(const DataFilters& filters)
   {
-    //set filters
+    // set filters
     layers_.getCurrentLayer().filters = filters;
-    //update the content
+    // update the content
     update_buffer_ = true;
     update_(OPENMS_PRETTY_FUNCTION);
   }
@@ -136,7 +132,7 @@ namespace OpenMS
   {
     mz_to_x_axis_ = mz_to_x_axis;
 
-    //swap axes if necessary
+    // swap axes if necessary
     if (spectrum_widget_)
     {
       spectrum_widget_->updateAxes();
@@ -147,14 +143,13 @@ namespace OpenMS
     update_(OPENMS_PRETTY_FUNCTION);
   }
 
-  void PlotCanvas::changeVisibleArea_(const AreaType & new_area, bool repaint, bool add_to_stack)
+  void PlotCanvas::changeVisibleArea_(const AreaType& new_area, bool repaint, bool add_to_stack)
   {
-    //store old zoom state
+    // store old zoom state
     if (add_to_stack)
     {
       // if we scrolled in between zooming we want to store the last position before zooming as well
-      if ((zoom_stack_.size() > 0)
-         && (zoom_stack_.back() != visible_area_))
+      if ((zoom_stack_.size() > 0) && (zoom_stack_.back() != visible_area_))
       {
         zoomAdd_(visible_area_);
       }
@@ -179,10 +174,9 @@ namespace OpenMS
 
   void PlotCanvas::updateScrollbars_()
   {
-
   }
 
-  void PlotCanvas::wheelEvent(QWheelEvent * e)
+  void PlotCanvas::wheelEvent(QWheelEvent* e)
   {
     zoom_(e->x(), e->y(), e->delta() > 0);
     e->accept();
@@ -212,22 +206,22 @@ namespace OpenMS
 
   void PlotCanvas::zoomBack_()
   {
-    //cout << "Zoom out" << endl;
-    //cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
-    //cout << " - size before:" << zoom_stack_.size() << endl;
+    // cout << "Zoom out" << endl;
+    // cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - size before:" << zoom_stack_.size() << endl;
     if (zoom_pos_ != zoom_stack_.begin())
     {
       --zoom_pos_;
       changeVisibleArea_(*zoom_pos_);
     }
-    //cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
   }
 
   void PlotCanvas::zoomForward_()
   {
-    //cout << "Zoom in" << endl;
-    //cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
-    //cout << " - size before:" << zoom_stack_.size() <<endl;
+    // cout << "Zoom in" << endl;
+    // cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - size before:" << zoom_stack_.size() <<endl;
 
     // if at end of zoom level then simply add a new zoom
     if (zoom_pos_ == zoom_stack_.end() || (zoom_pos_ + 1) == zoom_stack_.end())
@@ -249,24 +243,24 @@ namespace OpenMS
     }
     changeVisibleArea_(*zoom_pos_);
 
-    //cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
   }
 
-  void PlotCanvas::zoomAdd_(const AreaType & area)
+  void PlotCanvas::zoomAdd_(const AreaType& area)
   {
-    //cout << "Adding to stack" << endl;
-    //cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
-    //cout << " - size before:" << zoom_stack_.size() <<endl;
+    // cout << "Adding to stack" << endl;
+    // cout << " - pos before:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - size before:" << zoom_stack_.size() <<endl;
     if (zoom_pos_ != zoom_stack_.end() && (zoom_pos_ + 1) != zoom_stack_.end())
     {
-      //cout << " - removing from:" << ((zoom_pos_+1)-zoom_stack_.begin()) << endl;
+      // cout << " - removing from:" << ((zoom_pos_+1)-zoom_stack_.begin()) << endl;
       zoom_stack_.erase(zoom_pos_ + 1, zoom_stack_.end());
     }
     zoom_stack_.push_back(area);
     zoom_pos_ = zoom_stack_.end();
     --zoom_pos_;
-    //cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
-    //cout << " - size after:" << zoom_stack_.size() <<endl;
+    // cout << " - pos after:" << (zoom_pos_-zoom_stack_.begin()) << endl;
+    // cout << " - size after:" << zoom_stack_.size() <<endl;
   }
 
   void PlotCanvas::zoomClear_()
@@ -285,11 +279,11 @@ namespace OpenMS
 
   void PlotCanvas::setVisibleArea(const AreaType& area)
   {
-    //cout << OPENMS_PRETTY_FUNCTION << endl;
+    // cout << OPENMS_PRETTY_FUNCTION << endl;
     changeVisibleArea_(area);
   }
 
-  void PlotCanvas::paintGridLines_(QPainter & painter)
+  void PlotCanvas::paintGridLines_(QPainter& painter)
   {
     if (!show_grid_ || !spectrum_widget_)
     {
@@ -303,7 +297,7 @@ namespace OpenMS
 
     painter.save();
 
-    unsigned int xl, xh, yl, yh;     //width/height of the diagram area, x, y coordinates of lo/hi x,y values
+    unsigned int xl, xh, yl, yh; // width/height of the diagram area, x, y coordinates of lo/hi x,y values
 
     xl = 0;
     xh = width();
@@ -317,18 +311,18 @@ namespace OpenMS
       // style definitions
       switch (j)
       {
-      case 0:           // style settings for big intervals
-        painter.setPen(p1);
-        break;
+        case 0: // style settings for big intervals
+          painter.setPen(p1);
+          break;
 
-      case 1:           // style settings for small intervals
-        painter.setPen(p2);
-        break;
+        case 1: // style settings for small intervals
+          painter.setPen(p2);
+          break;
 
-      default:
-        std::cout << "empty vertical grid line vector error!" << std::endl;
-        painter.setPen(QPen(QColor(0, 0, 0)));
-        break;
+        default:
+          std::cout << "empty vertical grid line vector error!" << std::endl;
+          painter.setPen(QPen(QColor(0, 0, 0)));
+          break;
       }
 
       for (std::vector<double>::const_iterator it = spectrum_widget_->xAxis()->gridLines()[j].begin(); it != spectrum_widget_->xAxis()->gridLines()[j].end(); ++it)
@@ -340,22 +334,21 @@ namespace OpenMS
 
     for (Size j = 0; j != spectrum_widget_->yAxis()->gridLines().size(); j++)
     {
-
       // style definitions
       switch (j)
       {
-      case 0:           // style settings for big intervals
-        painter.setPen(p1);
-        break;
+        case 0: // style settings for big intervals
+          painter.setPen(p1);
+          break;
 
-      case 1:           // style settings for small intervals
-        painter.setPen(p2);
-        break;
+        case 1: // style settings for small intervals
+          painter.setPen(p2);
+          break;
 
-      default:
-        std::cout << "empty vertical grid line vector error!" << std::endl;
-        painter.setPen(QPen(QColor(0, 0, 0)));
-        break;
+        default:
+          std::cout << "empty vertical grid line vector error!" << std::endl;
+          painter.setPen(QPen(QColor(0, 0, 0)));
+          break;
       }
 
       for (std::vector<double>::const_iterator it = spectrum_widget_->yAxis()->gridLines()[j].begin(); it != spectrum_widget_->yAxis()->gridLines()[j].end(); ++it)
@@ -377,11 +370,10 @@ namespace OpenMS
     new_layer->setName(QFileInfo(filename.toQString()).completeBaseName());
   }
 
-  bool PlotCanvas::addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String & filename)
+  bool PlotCanvas::addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String& filename)
   {
     // both empty
-    if (!map->getChromatograms().empty() 
-     && !map->empty())
+    if (!map->getChromatograms().empty() && !map->empty())
     {
       // TODO : handle this case better
       OPENMS_LOG_WARN << "Your input data contains chromatograms and spectra, falling back to display spectra only." << std::endl;
@@ -389,8 +381,7 @@ namespace OpenMS
 
     LayerDataBaseUPtr new_layer;
     // check which one is empty
-    if (!map->getChromatograms().empty() 
-      && map->empty())
+    if (!map->getChromatograms().empty() && map->empty())
     {
       new_layer.reset(new LayerDataChrom);
     }
@@ -400,13 +391,13 @@ namespace OpenMS
     }
     new_layer->setPeakData(map);
     new_layer->setOnDiscPeakData(od_map);
-    
+
     setBaseLayerParameters(new_layer.get(), param_, filename);
     layers_.addLayer(std::move(new_layer));
     return finishAdding_();
   }
 
-  bool PlotCanvas::addLayer(FeatureMapSharedPtrType map, const String & filename)
+  bool PlotCanvas::addLayer(FeatureMapSharedPtrType map, const String& filename)
   {
     LayerDataBaseUPtr new_layer(new LayerDataFeature);
     new_layer->getFeatureMap() = map;
@@ -416,7 +407,7 @@ namespace OpenMS
     return finishAdding_();
   }
 
-  bool PlotCanvas::addLayer(ConsensusMapSharedPtrType map, const String & filename)
+  bool PlotCanvas::addLayer(ConsensusMapSharedPtrType map, const String& filename)
   {
     LayerDataBaseUPtr new_layer(new LayerDataConsensus(map));
 
@@ -431,19 +422,20 @@ namespace OpenMS
     new_layer->setPeptideIds(std::move(peptides));
     setBaseLayerParameters(new_layer, param_, filename);
     layers_.addLayer(LayerDataBaseUPtr(new_layer));
-    return finishAdding_(); 
+    return finishAdding_();
   }
 
   void PlotCanvas::popIncompleteLayer_(const QString& error_message)
   {
     layers_.removeCurrentLayer();
-    if (!error_message.isEmpty()) QMessageBox::critical(this, "Error", error_message);
+    if (!error_message.isEmpty())
+      QMessageBox::critical(this, "Error", error_message);
   }
 
-  void PlotCanvas::setLayerName(Size i, const String & name)
+  void PlotCanvas::setLayerName(Size i, const String& name)
   {
     getLayer(i).setName(name);
-    if (i == 0 && spectrum_widget_) 
+    if (i == 0 && spectrum_widget_)
     {
       spectrum_widget_->setWindowTitle(name.toQString());
     }
@@ -484,11 +476,11 @@ namespace OpenMS
   void PlotCanvas::recalculateRanges_(UInt mz_dim, UInt rt_dim, UInt it_dim)
   {
     RangeType layer_range; // temporary, until we switch overall_data_range_ to a RangeType
-    //overall_data_range_.clearRanges();
+    // overall_data_range_.clearRanges();
 
     for (Size layer_index = 0; layer_index < getLayerCount(); ++layer_index)
     {
-      layer_range.extend(getLayer(layer_index).getRange());  
+      layer_range.extend(getLayer(layer_index).getRange());
     }
 
     // add 4% margin (2% left, 2% right) to RT, m/z and intensity
@@ -522,26 +514,23 @@ namespace OpenMS
 
   void PlotCanvas::recalculateSnapFactor_()
   {
-
   }
 
   void PlotCanvas::horizontalScrollBarChange(int /*value*/)
   {
-
   }
 
   void PlotCanvas::verticalScrollBarChange(int /*value*/)
   {
-
   }
 
-  void PlotCanvas::update_(const char *)
+  void PlotCanvas::update_(const char*)
   {
     update();
   }
 
-  //this does not work anymore, probably due to Qt::StrongFocus :( -- todo: delete!
-  void PlotCanvas::focusOutEvent(QFocusEvent * /*e*/)
+  // this does not work anymore, probably due to Qt::StrongFocus :( -- todo: delete!
+  void PlotCanvas::focusOutEvent(QFocusEvent* /*e*/)
   {
     // Alt/Shift pressed and focus lost => change back action mode
     if (action_mode_ != AM_TRANSLATE)
@@ -550,27 +539,27 @@ namespace OpenMS
       emit actionModeChange();
     }
 
-    //reset peaks
+    // reset peaks
     selected_peak_.clear();
     measurement_start_.clear();
 
-    //update
+    // update
     update_(OPENMS_PRETTY_FUNCTION);
   }
 
-  void PlotCanvas::leaveEvent(QEvent * /*e*/)
+  void PlotCanvas::leaveEvent(QEvent* /*e*/)
   {
-    //release keyboard, when the mouse pointer leaves
+    // release keyboard, when the mouse pointer leaves
     releaseKeyboard();
   }
 
-  void PlotCanvas::enterEvent(QEvent * /*e*/)
+  void PlotCanvas::enterEvent(QEvent* /*e*/)
   {
-    //grab keyboard, as we need to handle key presses
+    // grab keyboard, as we need to handle key presses
     grabKeyboard();
   }
 
-  void PlotCanvas::keyReleaseEvent(QKeyEvent * e)
+  void PlotCanvas::keyReleaseEvent(QKeyEvent* e)
   {
     // Alt/Shift released => change back action mode
     if (e->key() == Qt::Key_Control || e->key() == Qt::Key_Shift)
@@ -583,7 +572,7 @@ namespace OpenMS
     e->ignore();
   }
 
-  void PlotCanvas::keyPressEvent(QKeyEvent * e)
+  void PlotCanvas::keyPressEvent(QKeyEvent* e)
   {
     if (e->key() == Qt::Key_Control)
     { // Ctrl pressed => change action mode
@@ -595,8 +584,9 @@ namespace OpenMS
       action_mode_ = AM_MEASURE;
       emit actionModeChange();
     }
-    else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_Plus)) // do not use (e->modifiers() == Qt::ControlModifier) to target Ctrl exclusively, since +/- might(!) also trigger the Qt::KeypadModifier
-    { // CTRL+Plus => Zoom stack
+    else if ((e->modifiers() & Qt::ControlModifier) &&
+             (e->key() == Qt::Key_Plus)) // do not use (e->modifiers() == Qt::ControlModifier) to target Ctrl exclusively, since +/- might(!) also trigger the Qt::KeypadModifier
+    {                                    // CTRL+Plus => Zoom stack
       zoomForward_();
     }
     else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_Minus))
@@ -657,14 +647,14 @@ namespace OpenMS
 
   void PlotCanvas::getVisiblePeakData(ExperimentType& map) const
   {
-    //clear output experiment
+    // clear output experiment
     map.clear(true);
 
     const LayerDataBase& layer = getCurrentLayer();
     if (layer.type == LayerDataBase::DT_PEAK)
     {
-      const AreaType & area = getVisibleArea();
-      const ExperimentType & peaks = *layer.getPeakData();
+      const AreaType& area = getVisibleArea();
+      const ExperimentType& peaks = *layer.getPeakData();
       // copy experimental settings
       map.ExperimentalSettings::operator=(peaks);
       // get begin / end of the range
@@ -697,7 +687,7 @@ namespace OpenMS
         // copy peak information
         if (!is_1d && spectrum_ref.getMSLevel() > 1 && !spectrum_ref.getPrecursors().empty())
         {
-          //MS^n (n>1) spectra are copied if their precursor is in the m/z range
+          // MS^n (n>1) spectra are copied if their precursor is in the m/z range
           if (spectrum_ref.getPrecursors()[0].getMZ() >= area.minPosition()[0] && spectrum_ref.getPrecursors()[0].getMZ() <= area.maxPosition()[0])
           {
             spectrum.insert(spectrum.begin(), spectrum_ref.begin(), spectrum_ref.end());
@@ -721,34 +711,30 @@ namespace OpenMS
     }
     else if (layer.type == LayerDataBase::DT_CHROMATOGRAM)
     {
-      //TODO CHROM
+      // TODO CHROM
     }
   }
 
-  void PlotCanvas::getVisibleFeatureData(FeatureMapType & map) const
+  void PlotCanvas::getVisibleFeatureData(FeatureMapType& map) const
   {
-    //clear output experiment
+    // clear output experiment
     map.clear(true);
 
     const LayerDataBase& layer = getCurrentLayer();
     if (layer.type == LayerDataBase::DT_FEATURE)
     {
-      //copy meta data
+      // copy meta data
       map.setIdentifier(layer.getFeatureMap()->getIdentifier());
       map.setProteinIdentifications(layer.getFeatureMap()->getProteinIdentifications());
-      //Visible area
+      // Visible area
       double min_rt = getVisibleArea().minPosition()[1];
       double max_rt = getVisibleArea().maxPosition()[1];
       double min_mz = getVisibleArea().minPosition()[0];
       double max_mz = getVisibleArea().maxPosition()[0];
-      //copy features
+      // copy features
       for (FeatureMapType::ConstIterator it = layer.getFeatureMap()->begin(); it != layer.getFeatureMap()->end(); ++it)
       {
-        if (layer.filters.passes(*it)
-           && it->getRT() >= min_rt
-           && it->getRT() <= max_rt
-           && it->getMZ() >= min_mz
-           && it->getMZ() <= max_mz)
+        if (layer.filters.passes(*it) && it->getRT() >= min_rt && it->getRT() <= max_rt && it->getMZ() >= min_mz && it->getMZ() <= max_mz)
         {
           map.push_back(*it);
         }
@@ -756,29 +742,25 @@ namespace OpenMS
     }
   }
 
-  void PlotCanvas::getVisibleConsensusData(ConsensusMapType & map) const
+  void PlotCanvas::getVisibleConsensusData(ConsensusMapType& map) const
   {
-    //clear output experiment
+    // clear output experiment
     map.clear(true);
 
     const LayerDataBase& layer = getCurrentLayer();
     if (layer.type == LayerDataBase::DT_CONSENSUS)
     {
-      //copy file descriptions
+      // copy file descriptions
       map.getColumnHeaders() = layer.getConsensusMap()->getColumnHeaders();
-      //Visible area
+      // Visible area
       double min_rt = getVisibleArea().minPosition()[1];
       double max_rt = getVisibleArea().maxPosition()[1];
       double min_mz = getVisibleArea().minPosition()[0];
       double max_mz = getVisibleArea().maxPosition()[0];
-      //copy features
+      // copy features
       for (ConsensusMapType::ConstIterator it = layer.getConsensusMap()->begin(); it != layer.getConsensusMap()->end(); ++it)
       {
-        if (layer.filters.passes(*it)
-           && it->getRT() >= min_rt
-           && it->getRT() <= max_rt
-           && it->getMZ() >= min_mz
-           && it->getMZ() <= max_mz)
+        if (layer.filters.passes(*it) && it->getRT() >= min_rt && it->getRT() <= max_rt && it->getMZ() >= min_mz && it->getMZ() <= max_mz)
         {
           map.push_back(*it);
         }
@@ -791,7 +773,8 @@ namespace OpenMS
     peptides.clear();
 
     auto p = dynamic_cast<const IPeptideIds*>(&getCurrentLayer());
-    if (p == nullptr) return;
+    if (p == nullptr)
+      return;
 
     // copy peptides, if visible
     for (const auto& p : p->getPeptideIds())
@@ -832,14 +815,14 @@ namespace OpenMS
       }
       else if (layer.type == LayerDataBase::DT_CHROMATOGRAM)
       {
-        //TODO CHROM
+        // TODO CHROM
       }
       else if (layer.type == LayerDataBase::DT_IDENT)
       {
         // TODO IDENT
       }
     }
-    else     //show element meta data
+    else // show element meta data
     {
       if (layer.type == LayerDataBase::DT_PEAK)
       {
@@ -855,7 +838,7 @@ namespace OpenMS
       }
       else if (layer.type == LayerDataBase::DT_CHROMATOGRAM)
       {
-        //TODO CHROM
+        // TODO CHROM
       }
       else if (layer.type == LayerDataBase::DT_IDENT)
       {
@@ -863,7 +846,7 @@ namespace OpenMS
       }
     }
 
-    //if the meta data was modified, set the flag
+    // if the meta data was modified, set the flag
     if (modifiable && dlg.exec())
     {
       modificationStatus_(getCurrentLayerIndex(), true);
@@ -874,17 +857,17 @@ namespace OpenMS
   {
     switch (action_mode_)
     {
-    case AM_TRANSLATE:
-      setCursor(QCursor(QPixmap(":/cursor_move.png"), 0, 0));
-      break;
+      case AM_TRANSLATE:
+        setCursor(QCursor(QPixmap(":/cursor_move.png"), 0, 0));
+        break;
 
-    case AM_ZOOM:
-      setCursor(QCursor(QPixmap(":/cursor_zoom.png"), 0, 0));
-      break;
+      case AM_ZOOM:
+        setCursor(QCursor(QPixmap(":/cursor_zoom.png"), 0, 0));
+        break;
 
-    case AM_MEASURE:
-      setCursor(QCursor(QPixmap(":/cursor_measure.png"), 0, 0));
-      break;
+      case AM_MEASURE:
+        setCursor(QCursor(QPixmap(":/cursor_measure.png"), 0, 0));
+        break;
     }
   }
 
@@ -903,18 +886,16 @@ namespace OpenMS
     }
   }
 
-  void PlotCanvas::drawText_(QPainter & painter, QStringList text)
+  void PlotCanvas::drawText_(QPainter& painter, QStringList text)
   {
     GUIHelpers::drawText(painter, text, {2, 3}, Qt::black, QColor(255, 255, 255, 200));
   }
 
-  double PlotCanvas::getIdentificationMZ_(const Size layer_index,
-                                                  const PeptideIdentification &
-                                                  peptide) const
+  double PlotCanvas::getIdentificationMZ_(const Size layer_index, const PeptideIdentification& peptide) const
   {
     if (getLayerFlag(layer_index, LayerDataBase::I_PEPTIDEMZ))
     {
-      const PeptideHit & hit = peptide.getHits().front();
+      const PeptideHit& hit = peptide.getHits().front();
       Int charge = hit.getCharge();
       return hit.getSequence().getMZ(charge);
     }
@@ -926,11 +907,10 @@ namespace OpenMS
 
   void LayerStack::addLayer(LayerDataBaseUPtr new_layer)
   {
-    // insert after last layer of same type, 
-    // if there is no such layer after last layer of previous types, 
+    // insert after last layer of same type,
+    // if there is no such layer after last layer of previous types,
     // if there are no layers at all put at front
-    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [&new_layer](const LayerDataBaseUPtr& l)
-    { return l->type <= new_layer->type; });
+    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [&new_layer](const LayerDataBaseUPtr& l) { return l->type <= new_layer->type; });
 
     auto where = layers_.insert(it.base(), std::move(new_layer));
     // update to index we just inserted into
@@ -1017,4 +997,4 @@ namespace OpenMS
     removeLayer(current_layer_);
   }
 
-} //namespace
+} // namespace OpenMS

--- a/src/openms_gui/source/VISUAL/sources.cmake
+++ b/src/openms_gui/source/VISUAL/sources.cmake
@@ -34,6 +34,7 @@ MultiGradient.cpp
 MultiGradientSelector.cpp
 OutputDirectory.cpp
 OutputDirectory.ui
+Painter1DBase.cpp
 ParamEditor.cpp
 ParamEditor.ui
 Plot1DCanvas.cpp


### PR DESCRIPTION
# Description

This PR is a first attempt to separate the plotting of layer data in Canvas1D from the layer type.
Painting is delegated to a separate class for the essential parts.
This will allow to add painters for chromatograms, mobilograms etc in the future (some more refatoring is needed).


Going in small pieces here, so this is the first PR or some more to come.
The Painter class is not fully fledged out yet. Expect some future changes there.



# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
