### PR TITLE
Mutual info test

### DIFF
--- a/src/tests/class_tests/openswathalgo/Scoring_test.cpp
+++ b/src/tests/class_tests/openswathalgo/Scoring_test.cpp
@@ -445,10 +445,18 @@ m1 = mi(x_ranking,y_ranking)
 
   TEST_REAL_SIMILAR (result, 3.2776);
 
+  rank_vec1 = {0};
+  rank_vec2 = {0};
+  result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
+  TEST_REAL_SIMILAR (result, 0);
+
   rank_vec1 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2};
   result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
   TEST_REAL_SIMILAR (result, 0);
+
+  double result_symmetric = Scoring::rankedMutualInformation(rank_vec2, rank_vec1);
+  TEST_REAL_SIMILAR (result, result_symmetric);
 
   rank_vec1 = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
   rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2, 6, 7, 7, 6, 5, 3};
@@ -460,7 +468,7 @@ m1 = mi(x_ranking,y_ranking)
   result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
   TEST_REAL_SIMILAR (result, 2.52193);
 
-  double result_symmetric = Scoring::rankedMutualInformation(rank_vec2, rank_vec1);
+  result_symmetric = Scoring::rankedMutualInformation(rank_vec2, rank_vec1);
   TEST_REAL_SIMILAR (result, result_symmetric);
 }
 END_SECTION

--- a/src/tests/class_tests/openswathalgo/Scoring_test.cpp
+++ b/src/tests/class_tests/openswathalgo/Scoring_test.cpp
@@ -444,6 +444,24 @@ m1 = mi(x_ranking,y_ranking)
   double result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
 
   TEST_REAL_SIMILAR (result, 3.2776);
+
+  rank_vec1 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2};
+  result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
+  TEST_EQUAL (result, 0);
+
+  rank_vec1 = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
+  rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2, 6, 7, 7, 6, 5, 3};
+  result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
+  TEST_EQUAL (result, 2);
+
+  rank_vec1 = {0, 1, 2, 3, 4, 4, 5, 6, 5, 1};
+  rank_vec2 = {6, 7, 8, 4, 5, 1, 2, 0, 3, 0};
+  result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
+  TEST_REAL_SIMILAR (result, 2.52193);
+
+  double result_symmetric = Scoring::rankedMutualInformation(rank_vec2, rank_vec1);
+  TEST_REAL_SIMILAR (result, result_symmetric);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openswathalgo/Scoring_test.cpp
+++ b/src/tests/class_tests/openswathalgo/Scoring_test.cpp
@@ -448,12 +448,12 @@ m1 = mi(x_ranking,y_ranking)
   rank_vec1 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2};
   result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
-  TEST_EQUAL (result, 0);
+  TEST_REAL_SIMILAR (result, 0);
 
   rank_vec1 = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
   rank_vec2 = {0, 1, 5, 4, 4, 2, 3, 1, 0, 2, 6, 7, 7, 6, 5, 3};
   result = Scoring::rankedMutualInformation(rank_vec1, rank_vec2);
-  TEST_EQUAL (result, 2);
+  TEST_REAL_SIMILAR (result, 2);
 
   rank_vec1 = {0, 1, 2, 3, 4, 4, 5, 6, 5, 1};
   rank_vec2 = {6, 7, 8, 4, 5, 1, 2, 0, 3, 0};


### PR DESCRIPTION
# Description
Added some tests for MIToolbox on calculating mutual information between 2 vectors of ranks. This is used to make sure the new implementation in PR #5795 is correct.

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- /rebase will try to rebase the PR on the current develop branch.
- /reformat (experimental) applies the clang-format style changes as additional commit
- setting the label NoJenkins will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
