### PR TITLE
 add intensity-weighted average peak picker 

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
@@ -64,6 +64,14 @@ namespace OpenMS
     appropriate preprocessing steps (e.g. noise reduction and baseline
     subtraction), it might be also applied to low resolution data.
 
+    This implementation performs peak picking in a single dimension (m/z);
+    two-dimensional data such as ion mobility separated data needs additional
+    pre-processing. The current implementation treats these data as
+    one-dimensional data, performs peak picking in the m/z dimension and
+    reports the intensity weighted ion mobility of the picked peaks (which will
+    produce correct results if the data has been binned previously but
+    incorrect results if fully 2D data is provided as input).
+
     @htmlinclude OpenMS_PeakPickerHiRes.parameters
 
     @note The peaks must be sorted according to ascending m/z!

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
@@ -169,7 +169,7 @@ public:
 protected:
 
     template <typename ContainerType>
-    void pick_(const ContainerType& input, ContainerType& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = true) const;
+    void pick_(const ContainerType& input, ContainerType& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = true, int im_index = -1) const;
 
     // signal-to-noise parameter
     double signal_to_noise_;

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Author: Erhan Kenar $
-// $Maintainer: Timo Sachsenberg$
+// $Maintainer: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 //
 
@@ -102,7 +102,15 @@ namespace OpenMS
     copySpectrumMeta(input, output);
     output.setType(SpectrumSettings::CENTROID);
 
-    pick_(input, output, boundaries, check_spacings);
+    int im_data_index = -1;
+    if (input.containsIMData())
+    {
+      // will throw if IM float data array is missing
+      const auto [tmp_index, im_unit] = input.getIMData();
+      im_data_index = tmp_index;
+    }
+
+    pick_(input, output, boundaries, check_spacings, im_data_index);
   }
 
   void PeakPickerHiRes::pick(const MSChromatogram& input, MSChromatogram& output, std::vector<PeakBoundary>& boundaries, bool check_spacings) const
@@ -117,13 +125,30 @@ namespace OpenMS
   }
 
   template <typename ContainerType>
-  void PeakPickerHiRes::pick_(const ContainerType& input, ContainerType& output, std::vector<PeakBoundary>& boundaries, bool check_spacings) const
+  void PeakPickerHiRes::pick_(const ContainerType& input,
+                              ContainerType& output,
+                              std::vector<PeakBoundary>& boundaries,
+                              bool check_spacings,
+                              int im_data_index) const
   {
+    OPENMS_PRECONDITION( im_data_index < 0 || input.getFloatDataArrays()[im_data_index].size() == input.size(),
+        "Ion Mobility array needs to have the same length as the m/z and intensity array.")
 
+    bool has_im = (im_data_index >= 0);
+    Size out_im_index = 0;
+    if (has_im)
+    {
+      out_im_index = output.getFloatDataArrays().size();
+      output.getFloatDataArrays().resize(output.getFloatDataArrays().size() + 1);
+      output.getFloatDataArrays()[out_im_index].setName( input.getFloatDataArrays()[im_data_index].getName() );
+    }
+
+    Size out_fwhm_index = 0;
     if (report_FWHM_)
     {
-      output.getFloatDataArrays().resize(1);
-      output.getFloatDataArrays()[0].setName( report_FWHM_as_ppm_ ? "FWHM_ppm" : "FWHM");
+      out_fwhm_index = output.getFloatDataArrays().size();
+      output.getFloatDataArrays().resize(output.getFloatDataArrays().size() + 1);
+      output.getFloatDataArrays()[out_fwhm_index].setName( report_FWHM_as_ppm_ ? "FWHM_ppm" : "FWHM");
     }
 
     // don't pick a spectrum with less than 5 data points
@@ -218,10 +243,18 @@ namespace OpenMS
         }
 
         std::map<double, double> peak_raw_data;
+        double weighted_im = 0;
 
         peak_raw_data[central_peak_mz] = central_peak_int;
         peak_raw_data[left_neighbor_mz] = left_neighbor_int;
         peak_raw_data[right_neighbor_mz] = right_neighbor_int;
+
+        if (has_im)
+        {
+          weighted_im += input.getFloatDataArrays()[im_data_index][i] * input[i].getIntensity();
+          weighted_im += input.getFloatDataArrays()[im_data_index][i-1] * input[i-1].getIntensity();
+          weighted_im += input.getFloatDataArrays()[im_data_index][i+1] * input[i+1].getIntensity();
+        }
 
         // peak core found, now extend it
         // to the left
@@ -251,6 +284,7 @@ namespace OpenMS
             (peak_raw_data.begin()->first - input[i - k].getMZ() < spacing_difference_ * min_spacing)))
           {
             peak_raw_data[input[i - k].getMZ()] = input[i - k].getIntensity();
+            if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i - k] * input[i - k].getIntensity();
           }
           else
           {
@@ -258,6 +292,7 @@ namespace OpenMS
             if (missing_left <= missing_)
             {
               peak_raw_data[input[i - k].getMZ()] = input[i - k].getIntensity();
+              if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i - k] * input[i - k].getIntensity();
             }
           }
 
@@ -292,6 +327,7 @@ namespace OpenMS
             (input[i + k].getMZ() - peak_raw_data.rbegin()->first < spacing_difference_ * min_spacing)))
           {
             peak_raw_data[input[i + k].getMZ()] = input[i + k].getIntensity();
+            if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i + k] * input[i + k].getIntensity();
           }
           else
           {
@@ -299,6 +335,7 @@ namespace OpenMS
             if (missing_right <= missing_)
             {
               peak_raw_data[input[i + k].getMZ()] = input[i + k].getIntensity();
+              if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i + k] * input[i + k].getIntensity();
             }
           }
 
@@ -380,8 +417,16 @@ namespace OpenMS
           }
           const double fwhm_right_mz = mz_mid;
           const double fwhm_absolute = fwhm_right_mz - fwhm_left_mz;
-          output.getFloatDataArrays()[0].push_back( report_FWHM_as_ppm_ ? fwhm_absolute / max_peak_mz  * 1e6 : fwhm_absolute);
+          output.getFloatDataArrays()[out_fwhm_index].push_back( report_FWHM_as_ppm_ ? fwhm_absolute / max_peak_mz  * 1e6 : fwhm_absolute);
         } // FWHM
+
+        // compute the intensity-weighted mean ion mobility
+        if (has_im)
+        {
+          double total_intensity(0);
+          for (const auto& t : peak_raw_data) {total_intensity += t.second;}
+          output.getFloatDataArrays()[out_im_index].push_back(weighted_im / total_intensity);
+        }
 
         // save picked peak into output spectrum
         typename ContainerType::PeakType peak;

--- a/src/tests/class_tests/openms/source/PeakPickerHiRes_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerHiRes_test.cpp
@@ -93,6 +93,7 @@ param.setValue("signal_to_noise", 1.0);
 pp_hires.setParameters(param);
 
 START_SECTION((template <typename PeakType> void pick(const MSSpectrum& input, MSSpectrum& output) const))
+{
   MSSpectrum tmp_spec;
   pp_hires.pick(input[0], tmp_spec);
 #ifdef WRITE_REF_FILES
@@ -110,9 +111,11 @@ START_SECTION((template <typename PeakType> void pick(const MSSpectrum& input, M
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getMZ(), output[0][peak_idx].getMZ())
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getIntensity(), output[0][peak_idx].getIntensity())
   }
+}
 END_SECTION
 
 START_SECTION((template <typename PeakType> void pick(const MSSpectrum& input, MSSpectrum& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = true) const))
+{
   MSSpectrum tmp_spec;
   std::vector<PeakPickerHiRes::PeakBoundary> tmp_boundaries;
   pp_hires.pick(input[0], tmp_spec, tmp_boundaries);
@@ -136,7 +139,7 @@ START_SECTION((template <typename PeakType> void pick(const MSSpectrum& input, M
   TEST_REAL_SIMILAR(tmp_boundaries[25].mz_max, 359.736419677734)
   TEST_REAL_SIMILAR(tmp_boundaries[26].mz_min, 360.155609130859)
   TEST_REAL_SIMILAR(tmp_boundaries[26].mz_max, 360.173675537109)
-
+}
 END_SECTION
 
 START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSExperiment<PeakType>& input, MSExperiment<PeakType>& output)))
@@ -150,6 +153,7 @@ START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSE
 END_SECTION
 
 START_SECTION((template <typename PeakType, typename ChromatogramPeakT> void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output) const))
+{
   PeakMap tmp_exp;
   pp_hires.pickExperiment(input,tmp_exp);
 
@@ -161,6 +165,7 @@ START_SECTION((template <typename PeakType, typename ChromatogramPeakT> void pic
       TEST_REAL_SIMILAR(tmp_exp[scan_idx][peak_idx].getIntensity(), output[scan_idx][peak_idx].getIntensity())
     }
   }
+}
 END_SECTION
 
 output.clear(true);
@@ -183,6 +188,7 @@ param.setValue("signal_to_noise", 4.0);
 pp_hires.setParameters(param);
 
 START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& input, MSSpectrum& output)))
+{
   MSSpectrum tmp_spec;
   pp_hires.pick(input[0],tmp_spec);
 #ifdef WRITE_REF_FILES
@@ -200,9 +206,11 @@ START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& i
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getMZ(), output[0][peak_idx].getMZ())
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getIntensity(), output[0][peak_idx].getIntensity())
   }
+}
 END_SECTION
 
 START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSExperiment<PeakType>& input, MSExperiment<PeakType>& output)))
+{
   PeakMap tmp_exp;
   pp_hires.pickExperiment(input,tmp_exp);
 
@@ -214,6 +222,7 @@ START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSE
       TEST_REAL_SIMILAR(tmp_exp[scan_idx][peak_idx].getIntensity(), output[scan_idx][peak_idx].getIntensity())
     }
   }
+}
 END_SECTION
 
 output.clear(true);
@@ -247,6 +256,7 @@ param.setValue("signal_to_noise", 1.0);
 pp_hires.setParameters(param);
 
 START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& input, MSSpectrum& output)))
+{
   MSSpectrum tmp_spec;
   pp_hires.pick(input[0],tmp_spec);
 #ifdef WRITE_REF_FILES
@@ -263,6 +273,7 @@ START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& i
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getMZ(), output[0][peak_idx].getMZ())
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getIntensity(), output[0][peak_idx].getIntensity())
   }
+}
 END_SECTION
 
 output.clear(true);
@@ -285,6 +296,7 @@ param.setValue("signal_to_noise", 4.0);
 pp_hires.setParameters(param);
 
 START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& input, MSSpectrum& output)))
+{
   MSSpectrum tmp_spec;
   pp_hires.pick(input[0],tmp_spec);
 #ifdef WRITE_REF_FILES
@@ -302,9 +314,11 @@ START_SECTION([EXTRA](template <typename PeakType> void pick(const MSSpectrum& i
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getMZ(), output[0][peak_idx].getMZ())
     TEST_REAL_SIMILAR(tmp_spec[peak_idx].getIntensity(), output[0][peak_idx].getIntensity())
   }
+}
 END_SECTION
 
 START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSExperiment<PeakType>& input, MSExperiment<PeakType>& output)))
+{
   PeakMap tmp_exp;
   pp_hires.pickExperiment(input,tmp_exp);
 
@@ -316,6 +330,7 @@ START_SECTION([EXTRA](template <typename PeakType> void pickExperiment(const MSE
       TEST_REAL_SIMILAR(tmp_exp[scan_idx][peak_idx].getIntensity(), output[scan_idx][peak_idx].getIntensity())
     }
   }
+}
 END_SECTION
 
 output.clear(true);
@@ -324,7 +339,7 @@ output.clear(true);
 /////////////////////////////////////////////////////////////
 
 START_SECTION([EXTRA] test spectrum level selection)
-
+{
   PeakMap inSpecSelection;
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("PeakPickerHiRes_spectrum_selection.mzML"), inSpecSelection);
 
@@ -339,17 +354,17 @@ START_SECTION([EXTRA] test spectrum level selection)
   pp_spec_select.pickExperiment(inSpecSelection, outMs2Only);
 
   ABORT_IF(inSpecSelection.size() != outMs2Only.size())
-  for(Size i = 0; i < outMs2Only.size(); ++i)
-  {
-    if (outMs2Only[i].getMSLevel() == 2)
+    for(Size i = 0; i < outMs2Only.size(); ++i)
     {
-      TEST_NOT_EQUAL(inSpecSelection[i], outMs2Only[i])
+      if (outMs2Only[i].getMSLevel() == 2)
+      {
+        TEST_NOT_EQUAL(inSpecSelection[i], outMs2Only[i])
+      }
+      else
+      {
+        TEST_EQUAL(inSpecSelection[i], outMs2Only[i])
+      }
     }
-    else
-    {
-      TEST_EQUAL(inSpecSelection[i], outMs2Only[i])
-    }
-  }
 
   // pick only ms1
   PeakMap outMs1Only;
@@ -359,17 +374,17 @@ START_SECTION([EXTRA] test spectrum level selection)
   pp_spec_select.pickExperiment(inSpecSelection, outMs1Only);
 
   ABORT_IF(inSpecSelection.size() != outMs1Only.size())
-  for(Size i = 0; i < outMs2Only.size(); ++i)
-  {
-    if (outMs2Only[i].getMSLevel() == 1)
+    for(Size i = 0; i < outMs2Only.size(); ++i)
     {
-      TEST_NOT_EQUAL(inSpecSelection[i], outMs1Only[i])
+      if (outMs2Only[i].getMSLevel() == 1)
+      {
+        TEST_NOT_EQUAL(inSpecSelection[i], outMs1Only[i])
+      }
+      else
+      {
+        TEST_EQUAL(inSpecSelection[i], outMs1Only[i])
+      }
     }
-    else
-    {
-      TEST_EQUAL(inSpecSelection[i], outMs1Only[i])
-    }
-  }
 
   // pick ms1 and ms2
   PeakMap outMs1And2;
@@ -379,13 +394,14 @@ START_SECTION([EXTRA] test spectrum level selection)
   pp_spec_select.pickExperiment(inSpecSelection, outMs1And2);
 
   ABORT_IF(inSpecSelection.size() != outMs2Only.size())
-  for(Size i = 0; i < outMs2Only.size(); ++i)
-  {
-    if (outMs1And2[i].getMSLevel() == 2 || outMs1And2[i].getMSLevel() == 1)
+    for(Size i = 0; i < outMs2Only.size(); ++i)
     {
-      TEST_NOT_EQUAL(inSpecSelection[i], outMs1And2[i])
+      if (outMs1And2[i].getMSLevel() == 2 || outMs1And2[i].getMSLevel() == 1)
+      {
+        TEST_NOT_EQUAL(inSpecSelection[i], outMs1And2[i])
+      }
     }
-  }
+}
 END_SECTION
 
 //////////////////////////////////////////////
@@ -402,40 +418,41 @@ param.setValue("spacing_difference_gap", 4.0);
 pp_hires.setParameters(param);
 
 START_SECTION(void pick(const MSSpectrum& input, MSSpectrum& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = true) const)
-    PeakMap tmp_picked;
-    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_s; // peak boundaries for spectra
-    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_c; // peak boundaries for chromatograms
+{
+  PeakMap tmp_picked;
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_s; // peak boundaries for spectra
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_c; // peak boundaries for chromatograms
 
-    pp_hires.pickExperiment(input, tmp_picked, tmp_boundaries_s, tmp_boundaries_c);
+  pp_hires.pickExperiment(input, tmp_picked, tmp_boundaries_s, tmp_boundaries_c);
 
-    TEST_EQUAL(tmp_picked[0].size(), 167);
-    MSSpectrum::Iterator it_mz = tmp_picked.begin()->begin();
-    vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundary = tmp_boundaries_s.begin()->begin();
-    
-    it_mz += 146;
-    it_mz_boundary += 146;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),1141.57188829383);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1141.51216791402);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1141.63481354941);
-    
-    it_mz += 2;
-    it_mz_boundary += 2;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),1142.57196823237);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1142.50968574851);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1142.6323313839);
-    
-    it_mz += 10;
-    it_mz_boundary += 10;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),1178.08692219102);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1178.02013862689);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1178.14847787348);
-    
-    it_mz += 1;
-    it_mz_boundary += 1;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),1178.58906411531);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1178.5249396635);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1178.6532789101);
-    
+  TEST_EQUAL(tmp_picked[0].size(), 167);
+  MSSpectrum::Iterator it_mz = tmp_picked.begin()->begin();
+  vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundary = tmp_boundaries_s.begin()->begin();
+
+  it_mz += 146;
+  it_mz_boundary += 146;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),1141.57188829383);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1141.51216791402);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1141.63481354941);
+
+  it_mz += 2;
+  it_mz_boundary += 2;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),1142.57196823237);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1142.50968574851);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1142.6323313839);
+
+  it_mz += 10;
+  it_mz_boundary += 10;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),1178.08692219102);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1178.02013862689);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1178.14847787348);
+
+  it_mz += 1;
+  it_mz_boundary += 1;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),1178.58906411531);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,1178.5249396635);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,1178.6532789101);
+}
 END_SECTION
 
 input.clear(true);
@@ -455,40 +472,41 @@ param.setValue("spacing_difference_gap", 4.0);
 pp_hires.setParameters(param);
 
 START_SECTION(void pick(const MSSpectrum& input, MSSpectrum& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = true) const)
-    PeakMap tmp_picked;
-    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_s; // peak boundaries for spectra
-    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_c; // peak boundaries for chromatograms
+{
+  PeakMap tmp_picked;
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_s; // peak boundaries for spectra
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > tmp_boundaries_c; // peak boundaries for chromatograms
 
-    pp_hires.pickExperiment(input, tmp_picked, tmp_boundaries_s, tmp_boundaries_c);
+  pp_hires.pickExperiment(input, tmp_picked, tmp_boundaries_s, tmp_boundaries_c);
 
-    TEST_EQUAL(tmp_picked[0].size(), 82);
-    MSSpectrum::Iterator it_mz = tmp_picked.begin()->begin();
-    vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundary = tmp_boundaries_s.begin()->begin();
-    
-    it_mz += 14;
-    it_mz_boundary += 14;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),355.070081088692);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,355.064544677734);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,355.078430175781);
+  TEST_EQUAL(tmp_picked[0].size(), 82);
+  MSSpectrum::Iterator it_mz = tmp_picked.begin()->begin();
+  vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundary = tmp_boundaries_s.begin()->begin();
 
-    it_mz += 23;
-    it_mz_boundary += 23;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),362.848715607077);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,362.844085693359);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,362.851928710938);
+  it_mz += 14;
+  it_mz_boundary += 14;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),355.070081088692);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,355.064544677734);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,355.078430175781);
 
-    it_mz += 17;
-    it_mz_boundary += 17;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),370.210756298155);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,370.205871582031);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,370.215301513672); // Same as min of next peak.
+  it_mz += 23;
+  it_mz_boundary += 23;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),362.848715607077);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,362.844085693359);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,362.851928710938);
 
-    it_mz += 1;
-    it_mz_boundary += 1;
-    TEST_REAL_SIMILAR(it_mz->getMZ(),370.219596356153);
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,370.215301513672); // Same as max of previous peak.
-    TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,370.223358154297);
-    
+  it_mz += 17;
+  it_mz_boundary += 17;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),370.210756298155);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,370.205871582031);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,370.215301513672); // Same as min of next peak.
+
+  it_mz += 1;
+  it_mz_boundary += 1;
+  TEST_REAL_SIMILAR(it_mz->getMZ(),370.219596356153);
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_min,370.215301513672); // Same as max of previous peak.
+  TEST_REAL_SIMILAR((*it_mz_boundary).mz_max,370.223358154297);
+}
 END_SECTION
 
 END_TEST


### PR DESCRIPTION
# Description

When ion mobility is present, use intensity-weighted average in a peak picker. 

- This works well if the ion mobilities are close to each other, eg if the data is already binned
- This will fail when a full ion mobility frame is provided, for this a more advanced peak picker would be required that takes into account the full 2nd dimension. It is still an improvement compared to dropping the ion mobility completely