### PR TITLE
[FEATURE] prepare for ion mobility support in FFCentroid

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPickedHelperStructs.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPickedHelperStructs.h
@@ -38,7 +38,6 @@
 #include <OpenMS/CONCEPT/Exception.h>
 
 #include <OpenMS/DATASTRUCTURES/ConvexHull2D.h>
-#include <OpenMS/KERNEL/Peak1D.h>
 
 #include <vector>
 #include <list>
@@ -46,6 +45,9 @@
 
 namespace OpenMS
 {
+
+  class MSSpectrum;
+  class Peak1D;
 
   /**
    * @brief Wrapper struct for all the classes needed by the FeatureFinderAlgorithmPicked and the associated classes
@@ -86,8 +88,9 @@ namespace OpenMS
       ///Theoretical intensity value (scaled to [0,1])
       double theoretical_int;
 
-      ///Contained peaks (pair of RT and pointer to peak)
-      std::vector<std::pair<double, const Peak1D*> > peaks;
+      ///Contained peaks (pair of pointer to spectrum and pointer to peak)
+      ///RT and ion mobility is extracted from spectrum, m/z and intensity from peak
+      std::vector<std::pair<const MSSpectrum*, const Peak1D*> > peaks;
 
       ///determines the convex hull of the trace
       ConvexHull2D getConvexhull() const;
@@ -97,6 +100,9 @@ namespace OpenMS
 
       ///Returns the average m/z of all peaks in this trace (weighted by intensity)
       double getAvgMZ() const;
+
+      ///Returns the average ion mobility of all peaks in this trace (weighted by intensity)
+      double getAvgIM(Size im_array_location) const;
 
       ///Checks if this Trace is valid (has more than 2 points)
       bool isValid() const;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EGHTraceFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EGHTraceFitter.cpp
@@ -38,6 +38,7 @@
 #include <Eigen/Core>
 
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <numeric> // for "accumulate"
 
@@ -78,7 +79,7 @@ namespace OpenMS
       double weight = m_data->weighted ? trace.theoretical_int : 1.0;
       for (Size i = 0; i < trace.peaks.size(); ++i)
       {
-        double rt = trace.peaks[i].first;
+        double rt = trace.peaks[i].first->getRT();
 
         t_diff = rt - tR;
         t_diff2 = t_diff * t_diff; // -> (t - t_R)^2
@@ -118,7 +119,7 @@ namespace OpenMS
       double weight = m_data->weighted ? trace.theoretical_int : 1.0;
       for (Size i = 0; i < trace.peaks.size(); ++i)
       {
-        double rt = trace.peaks[i].first;
+        double rt = trace.peaks[i].first->getRT();
 
         t_diff = rt - tR;
         t_diff2 = t_diff * t_diff; // -> (t - t_R)^2

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -1296,7 +1296,6 @@ namespace OpenMS
     Size start_index = pattern.spectrum[max_trace_index];
     const PeakType* start_peak = &(map_[pattern.spectrum[max_trace_index]][pattern.peak[max_trace_index]]);
     double start_mz = start_peak->getMZ();
-    double start_rt = map_[start_index].getRT();
     if (debug_)
     {
       log_ << " - Trace " << max_trace_index << " (maximum intensity)" << std::endl;
@@ -1307,12 +1306,12 @@ namespace OpenMS
     }
     //initialize the trace and extend
     MassTrace max_trace;
-    max_trace.peaks.emplace_back(start_rt, start_peak);
+    max_trace.peaks.emplace_back(&map_[start_index], start_peak);
     extendMassTrace_(max_trace, start_index, start_mz, false, meta_index_overall);
     extendMassTrace_(max_trace, start_index, start_mz, true, meta_index_overall);
 
-    double rt_max = max_trace.peaks.back().first;
-    double rt_min = max_trace.peaks.begin()->first;
+    double rt_max = max_trace.peaks.back().first->getRT();
+    double rt_min = max_trace.peaks.begin()->first->getRT();
     if (debug_)
     {
       log_ << "   - rt bounds: " << rt_min << "-" << rt_max << std::endl;
@@ -1400,7 +1399,7 @@ namespace OpenMS
       MassTrace trace;
       const PeakType* seed = &(map_[starting_peak.spectrum][starting_peak.peak]);
       //initialize trace with seed data and extend
-      trace.peaks.emplace_back(map_[starting_peak.spectrum].getRT(), seed);
+      trace.peaks.emplace_back(&map_[starting_peak.spectrum], seed);
       extendMassTrace_(trace, starting_peak.spectrum, seed->getMZ(), false, meta_index_overall, rt_min, rt_max);
       extendMassTrace_(trace, starting_peak.spectrum, seed->getMZ(), true, meta_index_overall, rt_min, rt_max);
 
@@ -1497,7 +1496,7 @@ namespace OpenMS
         missing_peaks = 0;
 
         //add found peak to trace
-        trace.peaks.emplace_back(map_[spectrum_index].getRT(), &(map_[spectrum_index][peak_index]));
+        trace.peaks.emplace_back(&map_[spectrum_index], &(map_[spectrum_index][peak_index]));
 
         //update deltas and intensities
         deltas.push_back((map_[spectrum_index][peak_index].getIntensity() - last_observed_intensity) / last_observed_intensity);
@@ -1924,7 +1923,7 @@ namespace OpenMS
       for (Size k = 0; k < trace.peaks.size(); ++k)
       {
         //consider peaks when inside RT bounds only
-        if (trace.peaks[k].first >= low_bound && trace.peaks[k].first <= high_bound)
+        if (trace.peaks[k].first->getRT() >= low_bound && trace.peaks[k].first->getRT() <= high_bound)
         {
           new_trace.peaks.push_back(trace.peaks[k]);
 
@@ -2093,7 +2092,7 @@ namespace OpenMS
       {
         for (Size j = 0; j < traces[k].peaks.size(); ++j)
         {
-          tf.addLine(String(pseudo_rt_shift * k + traces[k].peaks[j].first) + "\t" + traces[k].peaks[j].second->getIntensity());
+          tf.addLine(String(pseudo_rt_shift * k + traces[k].peaks[j].first->getRT()) + "\t" + traces[k].peaks[j].second->getIntensity());
         }
       }
       tf.store(path + plot_nr + ".dta");
@@ -2108,7 +2107,7 @@ namespace OpenMS
         {
           for (Size j = 0; j < new_traces[k].peaks.size(); ++j)
           {
-            tf_new_trace.addLine(String(pseudo_rt_shift * k + new_traces[k].peaks[j].first) + "\t" + new_traces[k].peaks[j].second->getIntensity());
+            tf_new_trace.addLine(String(pseudo_rt_shift * k + new_traces[k].peaks[j].first->getRT()) + "\t" + new_traces[k].peaks[j].second->getIntensity());
           }
         }
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussTraceFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussTraceFitter.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/GaussTraceFitter.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <Eigen/Core>
 
@@ -182,7 +184,7 @@ namespace OpenMS
       for (Size i = 0; i < trace.peaks.size(); ++i)
       {
         fvec(count) = (m_data->traces_ptr->baseline + trace.theoretical_int * height
-                       * exp(c_fac * pow(trace.peaks[i].first - x0, 2)) - trace.peaks[i].second->getIntensity()) * weight;
+                       * exp(c_fac * pow(trace.peaks[i].first->getRT() - x0, 2)) - trace.peaks[i].second->getIntensity()) * weight;
         ++count;
       }
     }
@@ -207,7 +209,7 @@ namespace OpenMS
       double weight = m_data->weighted ? trace.theoretical_int : 1.0;
       for (Size i = 0; i < trace.peaks.size(); ++i)
       {
-        double rt = trace.peaks[i].first;
+        double rt = trace.peaks[i].first->getRT();
         double e = exp(c_fac * pow(rt - x0, 2));
         J(count, 0) = trace.theoretical_int * e * weight;
         J(count, 1) = trace.theoretical_int * height * e * (rt - x0) / sig_sq * weight;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/TraceFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/TraceFitter.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/TraceFitter.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+
 #include <unsupported/Eigen/NonLinearOptimization>
 #include <Eigen/Core>
 
@@ -88,7 +90,7 @@ namespace OpenMS
 
   double TraceFitter::computeTheoretical(const FeatureFinderAlgorithmPickedHelperStructs::MassTrace& trace, Size k) const
   {
-    double rt = trace.peaks[k].first;
+    double rt = trace.peaks[k].first->getRT();
 
     return trace.theoretical_int * getValue(rt);
   }

--- a/src/tests/class_tests/openms/source/EGHTraceFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/EGHTraceFitter_test.cpp
@@ -40,6 +40,7 @@
 ///////////////////////////
 
 #include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <cmath>
 
@@ -64,174 +65,34 @@ mt2.theoretical_int = 0.2;
 /////////////////////////////////////////////////////////////
 // set up mass traces to fit
 
-Peak1D p1_1;
-p1_1.setIntensity(1.08268226589f);
-p1_1.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.1, &p1_1));
-Peak1D p2_1;
-p2_1.setIntensity(0.270670566473f);
-p2_1.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.1, &p2_1));
-Peak1D p1_2;
-p1_2.setIntensity(1.58318959267f);
-p1_2.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.4, &p1_2));
-Peak1D p2_2;
-p2_2.setIntensity(0.395797398167f);
-p2_2.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.4, &p2_2));
-Peak1D p1_3;
-p1_3.setIntensity(2.22429840363f);
-p1_3.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.7, &p1_3));
-Peak1D p2_3;
-p2_3.setIntensity(0.556074600906f);
-p2_3.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.7, &p2_3));
-Peak1D p1_4;
-p1_4.setIntensity(3.00248879081f);
-p1_4.setMZ(1000);
-mt1.peaks.push_back(make_pair(678, &p1_4));
-Peak1D p2_4;
-p2_4.setIntensity(0.750622197703f);
-p2_4.setMZ(1001);
-mt2.peaks.push_back(make_pair(678, &p2_4));
-Peak1D p1_5;
-p1_5.setIntensity(3.89401804768f);
-p1_5.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.3, &p1_5));
-Peak1D p2_5;
-p2_5.setIntensity(0.97350451192f);
-p2_5.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.3, &p2_5));
-Peak1D p1_6;
-p1_6.setIntensity(4.8522452777f);
-p1_6.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.6, &p1_6));
-Peak1D p2_6;
-p2_6.setIntensity(1.21306131943f);
-p2_6.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.6, &p2_6));
-Peak1D p1_7;
-p1_7.setIntensity(5.80919229659f);
-p1_7.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.9, &p1_7));
-Peak1D p2_7;
-p2_7.setIntensity(1.45229807415f);
-p2_7.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.9, &p2_7));
-Peak1D p1_8;
-p1_8.setIntensity(6.68216169129f);
-p1_8.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.2, &p1_8));
-Peak1D p2_8;
-p2_8.setIntensity(1.67054042282f);
-p2_8.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.2, &p2_8));
-Peak1D p1_9;
-p1_9.setIntensity(7.38493077109f);
-p1_9.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.5, &p1_9));
-Peak1D p2_9;
-p2_9.setIntensity(1.84623269277f);
-p2_9.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.5, &p2_9));
-Peak1D p1_10;
-p1_10.setIntensity(7.84158938645f);
-p1_10.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.8, &p1_10));
-Peak1D p2_10;
-p2_10.setIntensity(1.96039734661f);
-p2_10.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.8, &p2_10));
-Peak1D p1_11;
-p1_11.setIntensity(8.0f);
-p1_11.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.1, &p1_11));
-Peak1D p2_11;
-p2_11.setIntensity(2.0f);
-p2_11.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.1, &p2_11));
-Peak1D p1_12;
-p1_12.setIntensity(7.84158938645f);
-p1_12.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.4, &p1_12));
-Peak1D p2_12;
-p2_12.setIntensity(1.96039734661f);
-p2_12.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.4, &p2_12));
-Peak1D p1_13;
-p1_13.setIntensity(7.38493077109f);
-p1_13.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.7, &p1_13));
-Peak1D p2_13;
-p2_13.setIntensity(1.84623269277f);
-p2_13.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.7, &p2_13));
-Peak1D p1_14;
-p1_14.setIntensity(6.68216169129f);
-p1_14.setMZ(1000);
-mt1.peaks.push_back(make_pair(681, &p1_14));
-Peak1D p2_14;
-p2_14.setIntensity(1.67054042282f);
-p2_14.setMZ(1001);
-mt2.peaks.push_back(make_pair(681, &p2_14));
-Peak1D p1_15;
-p1_15.setIntensity(5.80919229659f);
-p1_15.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.3, &p1_15));
-Peak1D p2_15;
-p2_15.setIntensity(1.45229807415f);
-p2_15.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.3, &p2_15));
-Peak1D p1_16;
-p1_16.setIntensity(4.8522452777f);
-p1_16.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.6, &p1_16));
-Peak1D p2_16;
-p2_16.setIntensity(1.21306131943f);
-p2_16.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.6, &p2_16));
-Peak1D p1_17;
-p1_17.setIntensity(3.89401804768f);
-p1_17.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.9, &p1_17));
-Peak1D p2_17;
-p2_17.setIntensity(0.97350451192f);
-p2_17.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.9, &p2_17));
-Peak1D p1_18;
-p1_18.setIntensity(3.00248879081f);
-p1_18.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.2, &p1_18));
-Peak1D p2_18;
-p2_18.setIntensity(0.750622197703f);
-p2_18.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.2, &p2_18));
-Peak1D p1_19;
-p1_19.setIntensity(2.22429840363f);
-p1_19.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.5, &p1_19));
-Peak1D p2_19;
-p2_19.setIntensity(0.556074600906f);
-p2_19.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.5, &p2_19));
-Peak1D p1_20;
-p1_20.setIntensity(1.58318959267f);
-p1_20.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.8, &p1_20));
-Peak1D p2_20;
-p2_20.setIntensity(0.395797398167f);
-p2_20.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.8, &p2_20));
-Peak1D p1_21;
-p1_21.setIntensity(1.08268226589f);
-p1_21.setMZ(1000);
-mt1.peaks.push_back(make_pair(683.1, &p1_21));
-Peak1D p2_21;
-p2_21.setIntensity(0.270670566473f);
-p2_21.setMZ(1001);
-mt2.peaks.push_back(make_pair(683.1, &p2_21));
+
+double intensities[] = { 1.08268226589f, 0.270670566473f, 1.58318959267f, 0.395797398167f, 2.22429840363f, 0.556074600906f, 3.00248879081f, 0.750622197703f, 3.89401804768f, 0.97350451192f, 4.8522452777f, 1.21306131943f, 5.80919229659f, 1.45229807415f, 6.68216169129f, 1.67054042282f, 7.38493077109f, 1.84623269277f, 7.84158938645f, 1.96039734661f, 8.0f, 2.0f, 7.84158938645f, 1.96039734661f, 7.38493077109f, 1.84623269277f, 6.68216169129f, 1.67054042282f, 5.80919229659f, 1.45229807415f, 4.8522452777f, 1.21306131943f, 3.89401804768f, 0.97350451192f, 3.00248879081f, 0.750622197703f, 2.22429840363f, 0.556074600906f, 1.58318959267f, 0.395797398167f, 1.08268226589f, 0.270670566473f};
+double rts[] = { 677.1, 677.1, 677.4, 677.4, 677.7, 677.7, 678, 678, 678.3, 678.3, 678.6, 678.6, 678.9, 678.9, 679.2, 679.2, 679.5, 679.5, 679.8, 679.8, 680.1, 680.1, 680.4, 680.4, 680.7, 680.7, 681, 681, 681.3, 681.3, 681.6, 681.6, 681.9, 681.9, 682.2, 682.2, 682.5, 682.5, 682.8, 682.8, 683.1, 683.1};
+
+std::vector<Peak1D> all_peaks;
+std::vector<MSSpectrum> all_spectra;
+all_spectra.reserve(42);
+all_peaks.reserve(42);
+
+for (int k = 0; k < 42; k++)
+{
+  Peak1D p1; MSSpectrum s1;
+  p1.setIntensity( intensities[k] );
+  p1.setMZ(1000);
+  s1.setRT( rts[k] );
+  all_peaks.push_back(p1); all_spectra.push_back(s1);
+  mt1.peaks.push_back(make_pair(&all_spectra.back(), &all_peaks.back()));
+  // std::cout << "1_" << k /2 +1 << " :: " << mt1.peaks.back().first->getRT() << " : " << mt1.peaks.back().second->getIntensity() << std::endl;
+
+  k++;
+  Peak1D p2; MSSpectrum s2;
+  p2.setIntensity(intensities[k]);
+  p2.setMZ(1001);
+  s2.setRT(rts[k]);
+  all_peaks.push_back(p2); all_spectra.push_back(s2);
+  mt2.peaks.push_back(make_pair(&all_spectra.back(), &all_peaks.back()));
+  // std::cout << "2_" << k /2 +1 << " :: " << mt2.peaks.back().first->getRT() << " : " << mt2.peaks.back().second->getIntensity() << std::endl;
+}
 
 mt1.updateMaximum();
 mts.push_back(mt1);
@@ -372,7 +233,10 @@ START_SECTION((double computeTheoretical(const FeatureFinderAlgorithmPickedHelpe
   Peak1D peak;
   peak.setIntensity(8.0);
 
-  mt.peaks.push_back(make_pair(expected_x0, &peak));
+  MSSpectrum spec;
+  spec.setRT(expected_x0);
+
+  mt.peaks.push_back(make_pair(&spec, &peak));
 
   // theoretical should be expected_H * theoretical_int at position expected_x0
   TEST_REAL_SIMILAR(egh_trace_fitter.computeTheoretical(mt, 0), mt.theoretical_int * expected_H)
@@ -384,7 +248,7 @@ START_SECTION((bool checkMaximalRTSpan(const double max_rt_span)))
   // Maximum RT span in relation to extended area that the model is allowed to have
   // 5.0 * sigma_ > max_rt_span * region_rt_span_
 
-  double region_rt_span = mt1.peaks[mt1.peaks.size() - 1].first - mt1.peaks[0].first;
+  double region_rt_span = mt1.peaks[mt1.peaks.size() - 1].first->getRT() - mt1.peaks[0].first->getRT();
   double max_rt_span = 5.0 * expected_sigma/ region_rt_span;
 
   TEST_EQUAL(egh_trace_fitter.checkMaximalRTSpan(max_rt_span), false);

--- a/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPickedHelperStructs_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPickedHelperStructs_test.cpp
@@ -40,6 +40,7 @@
 ///////////////////////////
 
 #include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -67,46 +68,27 @@ FeatureFinderAlgorithmPickedHelperStructs::MassTrace mt1;
 mt1.theoretical_int = 0.8;
 
 /////////////////////////////////////////////////////////////
-Peak1D p1_1;
-p1_1.setIntensity(1.08268226589f);
-p1_1.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(677.1 , &p1_1));
-Peak1D p1_2;
-p1_2.setIntensity(1.58318959267f);
-p1_2.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(677.4 , &p1_2));
-Peak1D p1_3;
-p1_3.setIntensity(2.22429840363f);
-p1_3.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(677.7 , &p1_3));
-Peak1D p1_4;
-p1_4.setIntensity(3.00248879081f);
-p1_4.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(678 , &p1_4));
-Peak1D p1_5;
-p1_5.setIntensity(3.89401804768f);
-p1_5.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(678.3 , &p1_5));
-Peak1D p1_6;
-p1_6.setIntensity(4.8522452777f);
-p1_6.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(678.6 , &p1_6));
-Peak1D p1_7;
-p1_7.setIntensity(5.80919229659f);
-p1_7.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(678.9 , &p1_7));
-Peak1D p1_8;
-p1_8.setIntensity(6.68216169129f);
-p1_8.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(679.2 , &p1_8));
-Peak1D p1_9;
-p1_9.setIntensity(7.38493077109f);
-p1_9.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(679.5 , &p1_9));
-Peak1D p1_10;
-p1_10.setIntensity(7.84158938645f);
-p1_10.setMZ(1000);
-mt1.peaks.push_back(std::make_pair(679.8 , &p1_10));
+double intensities[] = { 1.08268226589f, 0.270670566473f, 1.58318959267f, 0.395797398167f, 2.22429840363f, 0.556074600906f, 3.00248879081f, 0.750622197703f, 3.89401804768f, 0.97350451192f, 4.8522452777f, 1.21306131943f, 5.80919229659f, 1.45229807415f, 6.68216169129f, 1.67054042282f, 7.38493077109f, 1.84623269277f, 7.84158938645f, 1.96039734661f, 8.0f, 2.0f, 7.84158938645f, 1.96039734661f, 7.38493077109f, 1.84623269277f, 6.68216169129f, 1.67054042282f, 5.80919229659f, 1.45229807415f, 4.8522452777f, 1.21306131943f, 3.89401804768f, 0.97350451192f, 3.00248879081f, 0.750622197703f, 2.22429840363f, 0.556074600906f, 1.58318959267f, 0.395797398167f, 1.08268226589f, 0.270670566473f};
+double rts[] = { 677.1, 677.1, 677.4, 677.4, 677.7, 677.7, 678, 678, 678.3, 678.3, 678.6, 678.6, 678.9, 678.9, 679.2, 679.2, 679.5, 679.5, 679.8, 679.8, 680.1, 680.1, 680.4, 680.4, 680.7, 680.7, 681, 681, 681.3, 681.3, 681.6, 681.6, 681.9, 681.9, 682.2, 682.2, 682.5, 682.5, 682.8, 682.8, 683.1, 683.1};
+
+std::vector<Peak1D> all_peaks;
+std::vector<MSSpectrum> all_spectra;
+all_spectra.reserve(10);
+all_peaks.reserve(10);
+
+// Generate 10 peaks for mt1 (skip all mt2 peaks for now)
+for (int k = 0; k < 20; k++)
+{
+  Peak1D p1; MSSpectrum s1;
+  p1.setIntensity( intensities[k] );
+  p1.setMZ(1000);
+  s1.setRT( rts[k] );
+  all_peaks.push_back(p1); all_spectra.push_back(s1);
+  mt1.peaks.push_back(make_pair(&all_spectra.back(), &all_peaks.back()));
+  std::cout << "1_" << k /2 +1 << " :: " << mt1.peaks.back().first->getRT() << " : " << mt1.peaks.back().second->getIntensity() << std::endl;
+
+  k++;
+}
 
 START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTrace] ConvexHull2D getConvexhull() const ))
 {
@@ -114,14 +96,14 @@ START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTrace] ConvexHull
 
   DPosition<2> point;
   point[0] = 679.8;
-  point[1] = p1_10.getMZ();
+  point[1] = all_peaks[10-1].getMZ();
 
   TEST_EQUAL(ch.encloses(point),true);
 
-  point[1] = p1_10.getMZ() + 1.0;
+  point[1] = all_peaks[10-1].getMZ() + 1.0;
   TEST_EQUAL(ch.encloses(point),false);
 
-  point[1] = p1_10.getMZ();
+  point[1] = all_peaks[10-1].getMZ();
   point[0] = 679.9;
   TEST_EQUAL(ch.encloses(point),false);
 }
@@ -130,7 +112,7 @@ END_SECTION
 START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTrace] void updateMaximum()))
 {
   mt1.updateMaximum();
-  TEST_EQUAL(mt1.max_peak, &p1_10)
+  TEST_EQUAL(mt1.max_peak, &all_peaks[9])
   TEST_EQUAL(mt1.max_rt, 679.8)
 }
 END_SECTION
@@ -145,17 +127,23 @@ START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTrace] double get
   Peak1D pAvg1;
   pAvg1.setMZ(10.5);
   pAvg1.setIntensity(1000);
-  mt_avg.peaks.push_back(std::make_pair(100.0, &pAvg1));
+  MSSpectrum sAvg1;
+  sAvg1.setRT(100.0);
+  mt_avg.peaks.push_back(std::make_pair(&sAvg1, &pAvg1));
 
   Peak1D pAvg2;
   pAvg2.setMZ(10.0);
   pAvg2.setIntensity(100);
-  mt_avg.peaks.push_back(std::make_pair(100.0, &pAvg2));
+  MSSpectrum sAvg2;
+  sAvg2.setRT(100.0);
+  mt_avg.peaks.push_back(std::make_pair(&sAvg2, &pAvg2));
 
   Peak1D pAvg3;
   pAvg3.setMZ(9.5);
   pAvg3.setIntensity(10);
-  mt_avg.peaks.push_back(std::make_pair(100.0, &pAvg3));
+  MSSpectrum sAvg3;
+  sAvg3.setRT(100.0);
+  mt_avg.peaks.push_back(std::make_pair(&sAvg3, &pAvg3));
 
   TEST_REAL_SIMILAR(mt_avg.getAvgMZ(), 10.4459)
 }
@@ -166,13 +154,17 @@ START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTrace] bool isVal
   TEST_EQUAL(mt1.isValid(), true)
   FeatureFinderAlgorithmPickedHelperStructs::MassTrace mt_non_valid;
 
-  mt_non_valid.peaks.push_back(std::make_pair(679.8 , &p1_10));
+  MSSpectrum s;
+  s.setRT(679.8);
+  mt_non_valid.peaks.push_back(std::make_pair(&s, &all_peaks[9]));
   TEST_EQUAL(mt_non_valid.isValid(), false)
 
-  mt_non_valid.peaks.push_back(std::make_pair(679.5 , &p1_9));
+  s.setRT(679.5);
+  mt_non_valid.peaks.push_back(std::make_pair(&s, &all_peaks[8]));
   TEST_EQUAL(mt_non_valid.isValid(), false)
 
-  mt_non_valid.peaks.push_back(std::make_pair(679.2 , &p1_8));
+  s.setRT(679.2);
+  mt_non_valid.peaks.push_back(std::make_pair(&s, &all_peaks[7]));
   TEST_EQUAL(mt_non_valid.isValid(), true)
 }
 END_SECTION
@@ -203,15 +195,21 @@ mt2.theoretical_int = 0.2;
 Peak1D p2_4;
 p2_4.setIntensity(0.750622197703f);
 p2_4.setMZ(1001);
-mt2.peaks.push_back(std::make_pair(678, &p2_4));
+MSSpectrum s2_4;
+s2_4.setRT(678);
+mt2.peaks.push_back(std::make_pair(&s2_4, &p2_4));
 Peak1D p2_5;
 p2_5.setIntensity(0.97350451192f);
 p2_5.setMZ(1001);
-mt2.peaks.push_back(std::make_pair(678.3, &p2_5));
+MSSpectrum s2_5;
+s2_5.setRT(678.3);
+mt2.peaks.push_back(std::make_pair(&s2_5, &p2_5));
 Peak1D p2_6;
 p2_6.setIntensity(1.21306131943f);
 p2_6.setMZ(1001);
-mt2.peaks.push_back(std::make_pair(678.6, &p2_6));
+MSSpectrum s2_6;
+s2_6.setRT(678.6);
+mt2.peaks.push_back(std::make_pair(&s2_6, &p2_6));
 
 mt.push_back(mt2);
 
@@ -264,19 +262,25 @@ END_SECTION
 Peak1D p2_0;
 p2_0.setIntensity(0.286529652f);
 p2_0.setMZ(1001);
-mt[1].peaks.insert(mt[1].peaks.begin(), std::make_pair(676.8, &p2_0));
+MSSpectrum s2_0;
+s2_0.setRT(676.8);
+mt[1].peaks.insert(mt[1].peaks.begin(), std::make_pair(&s2_0, &p2_0));
 
 // .. add a peak after a gap
 Peak1D p2_7;
 p2_7.setIntensity(0.72952935f);
 p2_7.setMZ(1001);
-mt[1].peaks.push_back(std::make_pair(679.2, &p2_7));
+MSSpectrum s2_7;
+s2_7.setRT(679.2);
+mt[1].peaks.push_back(std::make_pair(&s2_7, &p2_7));
 
 // .. and a trailing peak
 Peak1D p2_8;
 p2_8.setIntensity(0.672624672f);
 p2_8.setMZ(1001);
-mt[1].peaks.push_back(std::make_pair(680.1, &p2_8));
+MSSpectrum s2_8;
+s2_8.setRT(680.1);
+mt[1].peaks.push_back(std::make_pair(&s2_8, &p2_8));
 
 START_SECTION(([FeatureFinderAlgorithmPickedHelperStructs::MassTraces] void computeIntensityProfile(std::list< std::pair<double, double> > intensity_profile) const))
 {

--- a/src/tests/class_tests/openms/source/GaussTraceFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/GaussTraceFitter_test.cpp
@@ -40,6 +40,7 @@
 ///////////////////////////
 
 #include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -61,174 +62,33 @@ mt2.theoretical_int = 0.2;
 /////////////////////////////////////////////////////////////
 // set up mass traces to fit
 
-Peak1D p1_1;
-p1_1.setIntensity(1.08268226589f);
-p1_1.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.1, &p1_1));
-Peak1D p2_1;
-p2_1.setIntensity(0.270670566473f);
-p2_1.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.1, &p2_1));
-Peak1D p1_2;
-p1_2.setIntensity(1.58318959267f);
-p1_2.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.4, &p1_2));
-Peak1D p2_2;
-p2_2.setIntensity(0.395797398167f);
-p2_2.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.4, &p2_2));
-Peak1D p1_3;
-p1_3.setIntensity(2.22429840363f);
-p1_3.setMZ(1000);
-mt1.peaks.push_back(make_pair(677.7, &p1_3));
-Peak1D p2_3;
-p2_3.setIntensity(0.556074600906f);
-p2_3.setMZ(1001);
-mt2.peaks.push_back(make_pair(677.7, &p2_3));
-Peak1D p1_4;
-p1_4.setIntensity(3.00248879081f);
-p1_4.setMZ(1000);
-mt1.peaks.push_back(make_pair(678, &p1_4));
-Peak1D p2_4;
-p2_4.setIntensity(0.750622197703f);
-p2_4.setMZ(1001);
-mt2.peaks.push_back(make_pair(678, &p2_4));
-Peak1D p1_5;
-p1_5.setIntensity(3.89401804768f);
-p1_5.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.3, &p1_5));
-Peak1D p2_5;
-p2_5.setIntensity(0.97350451192f);
-p2_5.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.3, &p2_5));
-Peak1D p1_6;
-p1_6.setIntensity(4.8522452777f);
-p1_6.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.6, &p1_6));
-Peak1D p2_6;
-p2_6.setIntensity(1.21306131943f);
-p2_6.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.6, &p2_6));
-Peak1D p1_7;
-p1_7.setIntensity(5.80919229659f);
-p1_7.setMZ(1000);
-mt1.peaks.push_back(make_pair(678.9, &p1_7));
-Peak1D p2_7;
-p2_7.setIntensity(1.45229807415f);
-p2_7.setMZ(1001);
-mt2.peaks.push_back(make_pair(678.9, &p2_7));
-Peak1D p1_8;
-p1_8.setIntensity(6.68216169129f);
-p1_8.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.2, &p1_8));
-Peak1D p2_8;
-p2_8.setIntensity(1.67054042282f);
-p2_8.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.2, &p2_8));
-Peak1D p1_9;
-p1_9.setIntensity(7.38493077109f);
-p1_9.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.5, &p1_9));
-Peak1D p2_9;
-p2_9.setIntensity(1.84623269277f);
-p2_9.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.5, &p2_9));
-Peak1D p1_10;
-p1_10.setIntensity(7.84158938645f);
-p1_10.setMZ(1000);
-mt1.peaks.push_back(make_pair(679.8, &p1_10));
-Peak1D p2_10;
-p2_10.setIntensity(1.96039734661f);
-p2_10.setMZ(1001);
-mt2.peaks.push_back(make_pair(679.8, &p2_10));
-Peak1D p1_11;
-p1_11.setIntensity(8.0f);
-p1_11.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.1, &p1_11));
-Peak1D p2_11;
-p2_11.setIntensity(2.0f);
-p2_11.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.1, &p2_11));
-Peak1D p1_12;
-p1_12.setIntensity(7.84158938645f);
-p1_12.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.4, &p1_12));
-Peak1D p2_12;
-p2_12.setIntensity(1.96039734661f);
-p2_12.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.4, &p2_12));
-Peak1D p1_13;
-p1_13.setIntensity(7.38493077109f);
-p1_13.setMZ(1000);
-mt1.peaks.push_back(make_pair(680.7, &p1_13));
-Peak1D p2_13;
-p2_13.setIntensity(1.84623269277f);
-p2_13.setMZ(1001);
-mt2.peaks.push_back(make_pair(680.7, &p2_13));
-Peak1D p1_14;
-p1_14.setIntensity(6.68216169129f);
-p1_14.setMZ(1000);
-mt1.peaks.push_back(make_pair(681, &p1_14));
-Peak1D p2_14;
-p2_14.setIntensity(1.67054042282f);
-p2_14.setMZ(1001);
-mt2.peaks.push_back(make_pair(681, &p2_14));
-Peak1D p1_15;
-p1_15.setIntensity(5.80919229659f);
-p1_15.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.3, &p1_15));
-Peak1D p2_15;
-p2_15.setIntensity(1.45229807415f);
-p2_15.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.3, &p2_15));
-Peak1D p1_16;
-p1_16.setIntensity(4.8522452777f);
-p1_16.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.6, &p1_16));
-Peak1D p2_16;
-p2_16.setIntensity(1.21306131943f);
-p2_16.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.6, &p2_16));
-Peak1D p1_17;
-p1_17.setIntensity(3.89401804768f);
-p1_17.setMZ(1000);
-mt1.peaks.push_back(make_pair(681.9, &p1_17));
-Peak1D p2_17;
-p2_17.setIntensity(0.97350451192f);
-p2_17.setMZ(1001);
-mt2.peaks.push_back(make_pair(681.9, &p2_17));
-Peak1D p1_18;
-p1_18.setIntensity(3.00248879081f);
-p1_18.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.2, &p1_18));
-Peak1D p2_18;
-p2_18.setIntensity(0.750622197703f);
-p2_18.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.2, &p2_18));
-Peak1D p1_19;
-p1_19.setIntensity(2.22429840363f);
-p1_19.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.5, &p1_19));
-Peak1D p2_19;
-p2_19.setIntensity(0.556074600906f);
-p2_19.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.5, &p2_19));
-Peak1D p1_20;
-p1_20.setIntensity(1.58318959267f);
-p1_20.setMZ(1000);
-mt1.peaks.push_back(make_pair(682.8, &p1_20));
-Peak1D p2_20;
-p2_20.setIntensity(0.395797398167f);
-p2_20.setMZ(1001);
-mt2.peaks.push_back(make_pair(682.8, &p2_20));
-Peak1D p1_21;
-p1_21.setIntensity(1.08268226589f);
-p1_21.setMZ(1000);
-mt1.peaks.push_back(make_pair(683.1, &p1_21));
-Peak1D p2_21;
-p2_21.setIntensity(0.270670566473f);
-p2_21.setMZ(1001);
-mt2.peaks.push_back(make_pair(683.1, &p2_21));
+double intensities[] = { 1.08268226589f, 0.270670566473f, 1.58318959267f, 0.395797398167f, 2.22429840363f, 0.556074600906f, 3.00248879081f, 0.750622197703f, 3.89401804768f, 0.97350451192f, 4.8522452777f, 1.21306131943f, 5.80919229659f, 1.45229807415f, 6.68216169129f, 1.67054042282f, 7.38493077109f, 1.84623269277f, 7.84158938645f, 1.96039734661f, 8.0f, 2.0f, 7.84158938645f, 1.96039734661f, 7.38493077109f, 1.84623269277f, 6.68216169129f, 1.67054042282f, 5.80919229659f, 1.45229807415f, 4.8522452777f, 1.21306131943f, 3.89401804768f, 0.97350451192f, 3.00248879081f, 0.750622197703f, 2.22429840363f, 0.556074600906f, 1.58318959267f, 0.395797398167f, 1.08268226589f, 0.270670566473f};
+double rts[] = { 677.1, 677.1, 677.4, 677.4, 677.7, 677.7, 678, 678, 678.3, 678.3, 678.6, 678.6, 678.9, 678.9, 679.2, 679.2, 679.5, 679.5, 679.8, 679.8, 680.1, 680.1, 680.4, 680.4, 680.7, 680.7, 681, 681, 681.3, 681.3, 681.6, 681.6, 681.9, 681.9, 682.2, 682.2, 682.5, 682.5, 682.8, 682.8, 683.1, 683.1};
+
+std::vector<Peak1D> all_peaks;
+std::vector<MSSpectrum> all_spectra;
+all_spectra.reserve(42);
+all_peaks.reserve(42);
+
+for (int k = 0; k < 42; k++)
+{
+  Peak1D p1; MSSpectrum s1;
+  p1.setIntensity( intensities[k] );
+  p1.setMZ(1000);
+  s1.setRT( rts[k] );
+  all_peaks.push_back(p1); all_spectra.push_back(s1);
+  mt1.peaks.push_back(make_pair(&all_spectra.back(), &all_peaks.back()));
+  // std::cout << "1_" << k /2 +1 << " :: " << mt1.peaks.back().first->getRT() << " : " << mt1.peaks.back().second->getIntensity() << std::endl;
+
+  k++;
+  Peak1D p2; MSSpectrum s2;
+  p2.setIntensity(intensities[k]);
+  p2.setMZ(1001);
+  s2.setRT(rts[k]);
+  all_peaks.push_back(p2); all_spectra.push_back(s2);
+  mt2.peaks.push_back(make_pair(&all_spectra.back(), &all_peaks.back()));
+  // std::cout << "2_" << k /2 +1 << " :: " << mt2.peaks.back().first->getRT() << " : " << mt2.peaks.back().second->getIntensity() << std::endl;
+}
 
 mt1.updateMaximum();
 mts.push_back(mt1);
@@ -357,7 +217,7 @@ START_SECTION((bool checkMaximalRTSpan(const double max_rt_span)))
   // Maximum RT span in relation to extended area that the model is allowed to have
   // 5.0 * sigma_ > max_rt_span * region_rt_span_
 
-  double region_rt_span = mt1.peaks[mt1.peaks.size() - 1].first - mt1.peaks[0].first;
+  double region_rt_span = mt1.peaks[mt1.peaks.size() - 1].first->getRT() - mt1.peaks[0].first->getRT();
   double max_rt_span = 5.0 * gaussian_trace_fitter.getSigma() / region_rt_span + 0.00000000000001; // we add some small number to overcome precision problems on 32-bit machines
 
   TEST_EQUAL(gaussian_trace_fitter.checkMaximalRTSpan(max_rt_span), false);
@@ -395,7 +255,10 @@ START_SECTION((double computeTheoretical(const FeatureFinderAlgorithmPickedHelpe
   Peak1D peak;
   peak.setIntensity(8.0);
 
-  mt.peaks.push_back(make_pair(expected_x0, &peak));
+  MSSpectrum s;
+  s.setRT(expected_x0);
+
+  mt.peaks.push_back(make_pair(&s, &peak));
 
   // theoretical should be expected_H * theoretical_int at position expected_x0
   TEST_REAL_SIMILAR(gaussian_trace_fitter.computeTheoretical(mt, 0), mt.theoretical_int * expected_H)


### PR DESCRIPTION
- prepare for ion mobility support in FeatureFinderCentroided
- change data structure in mass trace to point to spectrum, allowing
access to RT and ion mobility

@timosachsenberg what do you think about this approach, adding the spectrum to the mass trace will allow us to access the ion mobility and other characteristics of the spectrum from which the peak was derived (including the RT). Maybe we could have a more generalized discussion on how to do feature finding in ion mobility data?