### PR TITLE
[CI] Update cmake version in gitpod file

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,6 +4,16 @@ FROM ghcr.io/openms/contrib:latest
 # Avoid user input
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CLANGDVER=12.0.1
+ARG CMAKE_VERSION=3.22.2
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+      -q -O /tmp/cmake-install.sh \
+      && chmod u+x /tmp/cmake-install.sh \
+      && mkdir /usr/bin/cmake \
+      && /tmp/cmake-install.sh --skip-license --prefix=/usr/bin/cmake \
+      && rm /tmp/cmake-install.sh
+
+ENV PATH="/usr/bin/cmake/bin:${PATH}"
 
 # Install tools for VSCode, Intellisense, JRE for Thirdparties, etc. using apt-get
 RUN apt-get -q update && apt-get install -yq gdb unzip wget php openjdk-11-jre python3-pip && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
FYI @KyowonJeong

# Description

Update gitpod docker file to make it work again with current OpenMS version

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
