### PR TITLE
[Feature] set OpenMP number of threads in pyOpenMS

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -161,7 +161,7 @@ namespace OpenMS
         #endif
       }
       /// @brief Set the number of threads that OpenMP will use (including hyperthreads)
-      /// Note: This could also be limited by the OMP_NUM_THREADS environment variable
+      /// Note: Can be initialized by the OMP_NUM_THREADS environment variable. This function can overwrite this at runtime.
       static void setOpenMPNumThreads(Int num_threads)
       {
         #ifdef _OPENMP

--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -162,7 +162,6 @@ namespace OpenMS
       }
       /// @brief Set the number of threads that OpenMP will use (including hyperthreads)
       /// Note: This could also be limited by the OMP_NUM_THREADS environment variable
-      /// Returns 1 if OpenMP was disabled.
       static void setOpenMPNumThreads(Int num_threads)
       {
         #ifdef _OPENMP

--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -160,6 +160,15 @@ namespace OpenMS
         return 1;
         #endif
       }
+      /// @brief Set the number of threads that OpenMP will use (including hyperthreads)
+      /// Note: This could also be limited by the OMP_NUM_THREADS environment variable
+      /// Returns 1 if OpenMP was disabled.
+      static void setOpenMPNumThreads(Int num_threads)
+      {
+        #ifdef _OPENMP
+        omp_set_num_threads(num_threads);
+        #endif
+      }
     };
 
   } // NS Internal

--- a/src/pyOpenMS/pxds/BuildInfo.pxd
+++ b/src/pyOpenMS/pxds/BuildInfo.pxd
@@ -32,3 +32,5 @@ cdef extern from "<OpenMS/SYSTEM/BuildInfo.h>" namespace "OpenMS::Internal::Open
     String getBuildType() nogil except + # wrap-attach:OpenMSBuildInfo
 
     Size getOpenMPMaxNumThreads() nogil except + # wrap-attach:OpenMSBuildInfo
+
+    void setOpenMPNumThreads(Int num_threads) nogil except + # wrap-attach:OpenMSBuildInfo


### PR DESCRIPTION
# Description

fixes #5794 
To set the number of threads in pyOpenMS, added and wrapped a Method to BuildInfo. That way the threads can be managed also in pyOpenMS directly.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
