### PR TITLE
[FIX] scan number extraction

### DIFF
--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -352,7 +352,7 @@ namespace OpenMS
           String value = String(matches[0]);
           if (native_id_type_accession == "MS:1000774")
           {
-            return ++value.toInt(); // if the native ID is index=.., the scan number is usually considered index+1 (especially for pepXML)
+            return ++(value.toInt()); // if the native ID is index=.., the scan number is usually considered index+1 (especially for pepXML)
           }
           else
           {

--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -352,7 +352,7 @@ namespace OpenMS
           String value = String(matches[0]);
           if (native_id_type_accession == "MS:1000774")
           {
-            return ++(value.toInt()); // if the native ID is index=.., the scan number is usually considered index+1 (especially for pepXML)
+            return value.toInt() + 1; // if the native ID is index=.., the scan number is usually considered index+1 (especially for pepXML)
           }
           else
           {

--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -350,7 +350,14 @@ namespace OpenMS
         try
         {
           String value = String(matches[0]);
-          return value.toInt();
+          if (native_id_type_accession == "MS:1000774")
+          {
+            return ++value.toInt(); // if the native ID is index=.., the scan number is usually considered index+1 (especially for pepXML)
+          }
+          else
+          {
+            return value.toInt();
+          }
         }
         catch (Exception::ConversionError&)
         {

--- a/src/tests/class_tests/openms/source/SpectrumLookup_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumLookup_test.cpp
@@ -174,7 +174,7 @@ START_SECTION((static Int extractScanNumber(const String&,
   TEST_EQUAL(SpectrumLookup::extractScanNumber("sample=1 period=1 cycle=42 experiment=1", "MS:1000770"), 42001);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("file=42", "MS:1000773"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("file=42", "MS:1000775"), 42);
-  TEST_EQUAL(SpectrumLookup::extractScanNumber("index=42", "MS:1000774"), 42);
+  TEST_EQUAL(SpectrumLookup::extractScanNumber("index=42", "MS:1000774"), 43);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("scanId=42", "MS:1001508"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("spectrum=42", "MS:1000777"), 42);
   TEST_EQUAL(SpectrumLookup::extractScanNumber("42", "MS:1001530"), 42);


### PR DESCRIPTION
# Description

In the IDFileConverter, when converting to pepXML with SpectrumLookup, we see a weird behaviour when the mzML
contains native IDs in the format "index=n".
Since spectrum metadata returns n as the scan number. Basically you end up with scan_number=n and index=n in the pepXML which is not correct.

Not sure if it is the right place to fix, but it should fix the problem.