### PR TITLE
[DOC] fix documentation for isotopes

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -68,9 +68,12 @@ namespace OpenMS
     but a natural distribution or different isotopes. This distribution can be accessed via the
     member getIsotopeDistribution().
 
-    If one wants only use a specific isotope, it can be specified using "(",")" brackets. For example,
-    to specify 14C a heavy isotope of carbon it is expressed as "(14)C". The isotope distribution
-    of that instance contains only one isotope, 14C itself with a frequency of 100%.
+    If one wants only use a specific isotope, it can be specified using "(",")"
+    brackets. For example, to specify 13C a heavy isotope of carbon it is
+    expressed as "(13)C". The isotope distribution of that instance contains
+    only one isotope, 13C itself with a frequency of 100%. It is possible to
+    mix isotopes, for example "(13)C1CH6O" specifies an ethanol molecule with
+    one 12C and one 13C isotope.
 
     Instances EmpiricalFormula support a (limited) set of mathematical operations. Additions and subtractions
     are supported in different flavors. However, one must be careful, because this can lead to negative

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -77,6 +77,7 @@ START_SECTION(EmpiricalFormula(const String& rhs))
   // all spaces, tabs and newlines from the provided formula
   e_ptr = new EmpiricalFormula("C4 ");
   TEST_NOT_EQUAL(e_ptr, e_nullPointer)
+  // test isotopes (Carbon 13)
   EmpiricalFormula e0("C5(13)C4H2 ");
   EmpiricalFormula e1("C5(13)C4\n\n ");
   EmpiricalFormula e2("(12)C5(13)C4\t\n ");


### PR DESCRIPTION
# Description

After reading #5843 I realized that our documentation is actually incorrect and we currently dont support "(14)C" since we do not have a representation for 14C (only 13C and 12C). This fixes the documentation

Note that currently any attempt to try

```
EmpiricalFormula("(14)C")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyopenms/pyopenms_4.pyx", line 6385, in pyopenms.pyopenms_4.EmpiricalFormula.__init__
  File "pyopenms/pyopenms_4.pyx", line 6353, in pyopenms.pyopenms_4.EmpiricalFormula._init_2
RuntimeError: '(14)C' found. in: Unknown element '(14)C'
```

will not work as 14C is not known and unfortunately there is currently no way in ElementDB to even add an element, see #5851