### PR TITLE
Fix PeptideIndexer to handle no cleavage with full specificity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ the authors tag in the respective file header.
  - Anton Kriese
  - Anton Pervukhin
  - Bastian Blank
+ - Chenghao Zhu
  - Chris Bauer
  - Chris Bielow
  - Christian Ehrlich

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ UTIL - An executable, just like a TOPP tool, but usually experimental or of less
 - Resolve compatibility issues between IDRipper and IDMerger (#4957)
 - Basic MzTabM support for AccurateMassSearch
 - Changed default parameter keep_unidentified_masses to "true" (AccurateMassSearch/AccurateMassSearchEngine)
+- Added parameter allow_nterm_protein_cleavage to PeptideIndexer to support no cleavage.
 
 ------------------------------------------------------------------------------------------
 ----                                OpenMS 2.7     (released 9/2021)                  ----

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -217,6 +217,7 @@ public:
     bool keep_unreferenced_proteins_{ false };
     Unmatched unmatched_action_ = Unmatched::IS_ERROR;
     bool IL_equivalent_{ false };
+    bool allow_nterm_protein_cleavage_{ true };
 
     Int aaa_max_{0};
     Int mm_max_{0};

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -124,9 +124,9 @@ using namespace std;
       other.filter_rejected = 0;
     }
 
-    bool validate(const String& seq_prot, const Int position, const Int len_pep)
+    bool validate(const String& seq_prot, const Int position, const Int len_pep, const bool allow_nterm_protein_cleavage)
     {
-      return enzyme.isValidProduct(seq_prot, position, len_pep, true, true, xtandem_);
+      return enzyme.isValidProduct(seq_prot, position, len_pep, true, true, xtandem_, allow_nterm_protein_cleavage);
     }
 
     void addHit(
@@ -163,7 +163,7 @@ using namespace std;
 
   // free function (not exported) used to add hits
   void search(ACTrie& trie, ACTrieState& state, const String& prot, const String& full_prot, size_t prot_offset, Hit::T idx_prot, 
-              FoundProteinFunctor& func_threads)
+              FoundProteinFunctor& func_threads, const bool allow_nterm_protein_cleavage)
   {
     state.setQuery(prot);
     trie.getAllHits(state);
@@ -181,7 +181,7 @@ using namespace std;
       Hit::T pos = Hit::T(hit.query_pos + prot_offset);
       if (!(hit.needle_length == old.needle_length && hit.query_pos == old.query_pos))
       { // new stretch in protein. Validate if cutting site
-        last_valid = func_threads.validate(full_prot, pos, hit.needle_length);
+        last_valid = func_threads.validate(full_prot, pos, hit.needle_length, allow_nterm_protein_cleavage);
       }
       func_threads.addHit(last_valid, hit.needle_index, idx_prot, hit.needle_length, full_prot, pos);
       old = hit;
@@ -242,6 +242,9 @@ using namespace std;
     defaults_.setValue("IL_equivalent", "false", "Treat the isobaric amino acids isoleucine ('I') and leucine ('L') as equivalent (indistinguishable). Also occurrences of 'J' will be treated as 'I' thus avoiding ambiguous matching.");
     defaults_.setValidStrings("IL_equivalent", { "true", "false" });
 
+    defaults_.setValue("allow_nterm_protein_cleavage", "true", "Allow the protein N-terminus amino acid to clip.");
+    defaults_.setValidStrings("allow_nterm_protein_cleavage", { "true", "false" });
+
     defaultsToParam_();
   }
 
@@ -263,6 +266,7 @@ using namespace std;
     IL_equivalent_ = param_.getValue("IL_equivalent").toBool();
     aaa_max_ = static_cast<Int>(param_.getValue("aaa_max"));
     mm_max_ = static_cast<Int>(param_.getValue("mismatches_max"));
+    allow_nterm_protein_cleavage_ = params_.getValue("allow_nterm_protein_cleavage").toBool();
   }
 
 PeptideIndexing::ExitCodes PeptideIndexing::run(std::vector<FASTAFile::FASTAEntry>& proteins, std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids)
@@ -544,7 +548,8 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
             while ((offset = prot.find(jumpX, offset + 1)) != std::string::npos)
             {
               //std::cout << "found X..X at " << offset << " in protein " << proteins[i].identifier << "\n";
-              search(ac_trie, ac_state, prot.substr(start, offset + jumpX.size() - start), prot, start, prot_idx, func_threads);
+              search(ac_trie, ac_state, prot.substr(start, offset + jumpX.size() - start), prot, start, prot_idx, func_threads,
+                     allow_nterm_protein_cleavage_);
               // skip ahead while we encounter more X...
               while (offset + jumpX.size() < prot.size() && prot[offset + jumpX.size()] == 'X') ++offset;
               start = offset;
@@ -553,12 +558,12 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
             // last chunk
             if (start < prot.size())
             {
-              search(ac_trie, ac_state, prot.substr(start), prot, start, prot_idx, func_threads);
+              search(ac_trie, ac_state, prot.substr(start), prot, start, prot_idx, func_threads, allow_nterm_protein_cleavage_);
             }
           }
           else // search the whole protein at once
           {
-            search(ac_trie, ac_state, prot, prot, 0, prot_idx, func_threads);
+            search(ac_trie, ac_state, prot, prot, 0, prot_idx, func_threads, allow_nterm_protein_cleavage_);
           }
           // was protein found?
           if (hits_total < func_threads.filter_passed + func_threads.filter_rejected)

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -126,7 +126,8 @@ using namespace std;
 
     bool validate(const String& seq_prot, const Int position, const Int len_pep, const bool allow_nterm_protein_cleavage)
     {
-      return enzyme.isValidProduct(seq_prot, position, len_pep, true, true, xtandem_, allow_nterm_protein_cleavage);
+      const bool ignore_missed_cleavages = true;
+      return enzyme.isValidProduct(seq_prot, position, len_pep, ignore_missed_cleavages, allow_nterm_protein_cleavage, xtandem_);
     }
 
     void addHit(
@@ -354,6 +355,11 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
     if (search_engine == "MS-GF+" || search_engine == "MSGFPLUS" || prot_id.getSearchParameters().metaValueExists("SE:MS-GF+")) { msgfplus_fix_parameters = true; }
   }
 
+  if (xtandem_fix_parameters)
+  {
+    OPENMS_LOG_WARN << "X!Tandem detected. Allowing random Asp/Pro cleavage." << std::endl;
+  }
+
   // including MSGFPlus -> Trypsin/P as enzyme
   if (msgfplus_fix_parameters && enzyme.getEnzymeName() == "Trypsin")
   {
@@ -535,7 +541,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
             }
           }
 
-          const Hit::T prot_idx = i + proteins.getChunkOffset();
+          const Hit::T prot_idx = Hit::T(i + proteins.getChunkOffset());
           
           // grab #hits before searching protein; we know its a hit if this number changes
           const Size hits_total = func_threads.filter_passed + func_threads.filter_rejected;

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -266,7 +266,7 @@ using namespace std;
     IL_equivalent_ = param_.getValue("IL_equivalent").toBool();
     aaa_max_ = static_cast<Int>(param_.getValue("aaa_max"));
     mm_max_ = static_cast<Int>(param_.getValue("mismatches_max"));
-    allow_nterm_protein_cleavage_ = params_.getValue("allow_nterm_protein_cleavage").toBool();
+    allow_nterm_protein_cleavage_ = param_.getValue("allow_nterm_protein_cleavage").toBool();
   }
 
 PeptideIndexing::ExitCodes PeptideIndexing::run(std::vector<FASTAFile::FASTAEntry>& proteins, std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids)

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -181,6 +181,11 @@ namespace OpenMS
       return (cleavage_positions.size() - 1) <= missed_cleavages_;
     }
     
+    if (specificity_ == SPEC_FULL && enzyme_->getName() == NoCleavage)
+    { // we want them to be exactly match
+      return pos == 0 && sequence.size() == end;
+    }
+
     // either SPEC_SEMI or SPEC_FULL
     bool spec_c = false, spec_n = false;
     // tokenize_ is really slow, so reduce work by working on substring with +-2 chars margin:

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -180,11 +180,6 @@ namespace OpenMS
       const std::vector<int> cleavage_positions = tokenize_(sequence, pos, end); // has 'pos' as first site
       return (cleavage_positions.size() - 1) <= missed_cleavages_;
     }
-    
-    if (specificity_ == SPEC_FULL && enzyme_->getName() == NoCleavage)
-    { // we want them to be exactly match
-      return pos == 0 && sequence.size() == end;
-    }
 
     // either SPEC_SEMI or SPEC_FULL
     bool spec_c = false, spec_n = false;

--- a/src/tests/class_tests/openms/source/PeptideIndexing_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIndexing_test.cpp
@@ -316,8 +316,55 @@ START_SECTION((ExitCodes run(std::vector<FASTAFile::FASTAEntry>& proteins, std::
     TEST_EQUAL(r.size(), 1); // one hit!
     TEST_EQUAL(*r.begin(), "Protein1"); // one hit!
   }
+  }
 
+  {
+  // test no-cleavage (e.g. matching a peptide FASTA DB exactly)
+  PeptideIndexing pi_8;
+  Param p_8 = pi_8.getParameters();
+  p_8.setValue("aaa_max", 0);
+  p_8.setValue("mm_max", 0);
+  p_8.setValue("enzyme:name", "no cleavage");
+  p_8.setValue("allow_nterm_protein_cleavage", "false");
+  pi_8.setParameters(p_8);
+  std::vector<FASTAFile::FASTAEntry> proteins_8 = toFASTAVec(QStringList() << "MKDPLMMLK"
+                                                                           << "KDPLMMLK",
+                                                             QStringList() << "Protein1" << "otherProtein");
+  pep_ids = toPepVec(QStringList() << "KDPLMMLK" << "MKD"); 
+  pi_8.run(proteins_8, prot_ids_2, pep_ids);
+  TEST_EQUAL(pep_ids[0].getHits().size(), 1)
+  const auto r = pep_ids[0].getHits()[0].extractProteinAccessionsSet();
+  TEST_EQUAL(r.size(), 1); // one hit!
+  TEST_EQUAL(*r.begin(), "otherProtein"); // one hit!
 
+  TEST_EQUAL(pep_ids[1].getHits()[0].extractProteinAccessionsSet().size(), 0) // no hit for "MKD"
+  }
+
+  {
+    // test no-cleavage (e.g. matching a peptide FASTA DB exactly) but with ASP/PRO cleavage enabled
+    PeptideIndexing pi_8;
+    Param p_8 = pi_8.getParameters();
+    p_8.setValue("aaa_max", 0);
+    p_8.setValue("mm_max", 0);
+    p_8.setValue("enzyme:name", "no cleavage");
+    p_8.setValue("allow_nterm_protein_cleavage", "false");
+    pi_8.setParameters(p_8);
+    std::vector<FASTAFile::FASTAEntry> proteins_8 = toFASTAVec(QStringList() << "MKDPLMMLK" // should not hit, due to !allow_nterm_protein_cleavage
+                                                                             << "KDPLMMLK", // target
+                                                               QStringList() << "Protein1"
+                                                                             << "otherProtein");
+    prot_ids_2.resize(1);
+    prot_ids_2[0].setSearchEngine("XTANDEM"); // enable random ASP/PRO cleavage in PeptideIndexing
+    pep_ids = toPepVec(QStringList() << "KDPLMMLK"  // one hit
+                                     << "KD");      // one hit due to D/P cleavage
+    pi_8.run(proteins_8, prot_ids_2, pep_ids);
+    for (auto& pep : pep_ids)
+    {
+      TEST_EQUAL(pep.getHits().size(), 1)
+      const auto r = pep.getHits()[0].extractProteinAccessionsSet();
+      TEST_EQUAL(r.size(), 1);                // one hit!
+      TEST_EQUAL(*r.begin(), "otherProtein"); // one hit!
+    }
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -602,6 +602,64 @@ START_SECTION((bool isValidProduct(const AASequence& protein, int pep_pos, int p
     TEST_EQUAL(pd.isValidProduct(prot, 6, 28, false, true, true), true); // valid C and N-term (but 2 missed)
     TEST_EQUAL(pd.isValidProduct(prot, 6, 28, false, true, false), true); // valid C and N-term (but 2 missed)
 
+    /// no cleavage:
+    pd.setEnzyme("no cleavage");
+    pd.setSpecificity(EnzymaticDigestion::SPEC_FULL); // require both sides
+
+    prot = AASequence::fromString("MADPDE"); // something which start with 'M' to test nterm prot cleavage
+    TEST_EQUAL(pd.isValidProduct(prot, 100, 3), false); // invalid position
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 300), false); // invalid length
+    TEST_EQUAL(pd.isValidProduct(prot, 3, 0), false);   // invalid size
+
+    const bool with_nterm_prot_cleavage = true;
+    const bool no_nterm_prot_cleavage = false;
+    const bool with_rnd_asppro_cleavage = true;
+    const bool no_rnd_asppro_cleavage = false;
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, with_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, no_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, with_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, no_nterm_prot_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, with_nterm_prot_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, no_nterm_prot_cleavage), false);
+
+    // asppro_cleavage should make no difference
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), false);
+    // ... unless we hit one
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 2, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 3, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 3, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), false);
+
+    pd.setSpecificity(EnzymaticDigestion::SPEC_SEMI); // require one side
+
+    prot = AASequence::fromString("MADPDE");            // something which starts with 'M' to test nterm prot cleavage and has a D/P cleavage
+    TEST_EQUAL(pd.isValidProduct(prot, 100, 3), false); // invalid position
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 300), false); // invalid length
+    TEST_EQUAL(pd.isValidProduct(prot, 3, 0), false);   // invalid size
+
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, with_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, no_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, with_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, no_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, with_nterm_prot_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, no_nterm_prot_cleavage), true);
+
+    // asppro_cleavage should make no difference
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 6, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 5, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 5, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), true);
+    // ... unless we hit one
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 2, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), false);
+    TEST_EQUAL(pd.isValidProduct(prot, 1, 2, true, no_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 3, true, with_nterm_prot_cleavage, with_rnd_asppro_cleavage), true);
+    TEST_EQUAL(pd.isValidProduct(prot, 0, 3, true, no_nterm_prot_cleavage, no_rnd_asppro_cleavage), true);
 
 END_SECTION
 

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
@@ -66,6 +66,7 @@
 				<UserParam type="int" name="CometAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="CometAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="CometAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="CometAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="CometAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="CometAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
@@ -66,6 +66,7 @@
 				<UserParam type="int" name="CometAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="CometAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="CometAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="CometAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="CometAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="CometAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
@@ -72,6 +72,7 @@
 				<UserParam type="int" name="CometAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="CometAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="CometAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="CometAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="CometAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="CometAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
@@ -68,6 +68,7 @@
 				<UserParam type="int" name="CometAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="CometAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="CometAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="CometAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="CometAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="CometAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -63,6 +63,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="MSGFPlusAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_1_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="XTandemAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="XTandemAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="XTandemAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="XTandemAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="XTandemAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="XTandemAdapter:1:specificity" value="auto"/>
 	</SearchParameters>

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_2_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="XTandemAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="XTandemAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="XTandemAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="XTandemAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="XTandemAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="XTandemAdapter:1:specificity" value="auto"/>
 	</SearchParameters>

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_3_out.idXML
@@ -41,6 +41,7 @@
 				<UserParam type="int" name="XTandemAdapter:1:aaa_max" value="3"/>
 				<UserParam type="int" name="XTandemAdapter:1:mismatches_max" value="0"/>
 				<UserParam type="string" name="XTandemAdapter:1:IL_equivalent" value="false"/>
+				<UserParam type="string" name="XTandemAdapter:1:allow_nterm_protein_cleavage" value="true"/>
 				<UserParam type="string" name="XTandemAdapter:1:name" value="auto"/>
 				<UserParam type="string" name="XTandemAdapter:1:specificity" value="auto"/>
 	</SearchParameters>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
