### PR TITLE
GUI: improvements, mostly better File-save dialogs

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FileTypes.h
+++ b/src/openms/include/OpenMS/FORMAT/FileTypes.h
@@ -119,62 +119,6 @@ namespace OpenMS
       SIZE_OF_TYPE        ///< No file type. Simply stores the number of types
     };
 
-
-    enum class Filter
-    {
-      COMPACT,    ///< make a single item, e.g. 'all readable files (*.mzML *.mzXML);;'
-      ONE_BY_ONE, ///< list all types individually, e.g. 'mzML files (*.mzML);;mzXML files (*.mzXML);;'
-      BOTH        ///< combine COMPACT and ONE_BY_ONE
-    };
-    /**
-      @brief holds a vector of known file types, e.g. as a way to specify supported input formats
-
-      The vector can be exported in Qt's file dialog format.
-    */
-    class OPENMS_DLLAPI FileTypeList
-    {
-    public:
-      FileTypeList(const std::vector<Type>& types);
-
-      /// check if @p type is contained in this array
-      bool contains(const Type& type) const;
-
-      /// converts the array into a Qt-compatible filter for selecting files in a user dialog.
-      /// e.g. "all readable files (*.mzML *.mzXML);;". See Filter enum.
-      /// @param style Create a combined filter, or single filters, or both
-      /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
-      String toFileDialogFilter(const Filter style, bool add_all_filter) const;
-
-      /**
-        @brief Convert a Qt filter back to a Type if possible.
-        
-        E.g. from a full filter such as '"mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;all files (*)"',
-        as created by toFileDialogFilter(), the selected @p filter could be "mzML files (*.mzML)", in which case the type is Type::MZML .
-        However, for the filter "all files (*)", Type::UNKNOWN will be returned.
-
-        If the type is UNKNOWN, then the fallback is returned (by default also UNKNOWN). This is useful if you want a default type to fall back to.
-
-        @param filter The filter returned by 'QFileDialog::getSaveFileName' and others, i.e. an item from the result of 'toFileDialogFilter'.
-        @param fallback If the filter is ambiguous, return this type instead
-        @return The type associated to the filter or the fallback
-        @throw Exception::ElementNotFound if the given @p filter is not a filter produced by toFileDialogFilter()
-      **/
-      Type fromFileDialogFilter(const String& filter, const Type fallback = Type::UNKNOWN) const;
-
-    private:
-      struct FilterElements_
-      {
-        std::vector<String> items;
-        std::vector<Type> types;
-      };
-      /// creates Qt filters and the corresponding elements from type_list_
-      /// @param style Create a combined filter, or single filters, or both
-      /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
-      FilterElements_ asFilterElements_(const Filter style, bool add_all_filter) const;
-
-      std::vector<Type> type_list_;
-    };
-
     /// Returns the name/extension of the type.
     static String typeToName(Type type);
     
@@ -191,5 +135,61 @@ namespace OpenMS
     static String typeToMZML(Type type);
   };
 
-} //namespace OpenMS
+ enum class FilterLayout
+  {
+    COMPACT,    ///< make a single item, e.g. 'all readable files (*.mzML *.mzXML);;'
+    ONE_BY_ONE, ///< list all types individually, e.g. 'mzML files (*.mzML);;mzXML files (*.mzXML);;'
+    BOTH        ///< combine COMPACT and ONE_BY_ONE
+  };
+  /**
+    @brief holds a vector of known file types, e.g. as a way to specify supported input formats
+
+    The vector can be exported in Qt's file dialog format.
+  */
+  class OPENMS_DLLAPI FileTypeList
+  {
+  public:
+    FileTypeList(const std::vector<FileTypes::Type>& types);
+
+    /// check if @p type is contained in this array
+    bool contains(const FileTypes::Type& type) const;
+
+    /// converts the array into a Qt-compatible filter for selecting files in a user dialog.
+    /// e.g. "all readable files (*.mzML *.mzXML);;". See Filter enum.
+    /// @param style Create a combined filter, or single filters, or both
+    /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
+    String toFileDialogFilter(const FilterLayout style, bool add_all_filter) const;
+
+    /**
+      @brief Convert a Qt filter back to a Type if possible.
+
+      E.g. from a full filter such as '"mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;all files (*)"',
+      as created by toFileDialogFilter(), the selected @p filter could be "mzML files (*.mzML)", in which case the type is Type::MZML .
+      However, for the filter "all files (*)", Type::UNKNOWN will be returned.
+
+      If the type is UNKNOWN, then the fallback is returned (by default also UNKNOWN). This is useful if you want a default type to fall back to.
+
+      @param filter The filter returned by 'QFileDialog::getSaveFileName' and others, i.e. an item from the result of 'toFileDialogFilter'.
+      @param fallback If the filter is ambiguous, return this type instead
+      @return The type associated to the filter or the fallback
+      @throw Exception::ElementNotFound if the given @p filter is not a filter produced by toFileDialogFilter()
+    **/
+    FileTypes::Type fromFileDialogFilter(const String& filter, const FileTypes::Type fallback = FileTypes::Type::UNKNOWN) const;
+
+  private:
+    /// hold filter items (for Qt dialogs) along with their OpenMS type
+    struct FilterElements_
+    {
+      std::vector<String> items;
+      std::vector<FileTypes::Type> types;
+    };
+    /// creates Qt filters and the corresponding elements from type_list_
+    /// @param style Create a combined filter, or single filters, or both
+    /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
+    FilterElements_ asFilterElements_(const FilterLayout style, bool add_all_filter) const;
+
+    std::vector<FileTypes::Type> type_list_;
+  };
+
+} // namespace OpenMS
 

--- a/src/openms/include/OpenMS/FORMAT/FileTypes.h
+++ b/src/openms/include/OpenMS/FORMAT/FileTypes.h
@@ -144,7 +144,34 @@ namespace OpenMS
       /// @param style Create a combined filter, or single filters, or both
       /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
       String toFileDialogFilter(const Filter style, bool add_all_filter) const;
+
+      /**
+        @brief Convert a Qt filter back to a Type if possible.
+        
+        E.g. from a full filter such as '"mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;all files (*)"',
+        as created by toFileDialogFilter(), the selected @p filter could be "mzML files (*.mzML)", in which case the type is Type::MZML .
+        However, for the filter "all files (*)", Type::UNKNOWN will be returned.
+
+        If the type is UNKNOWN, then the fallback is returned (by default also UNKNOWN). This is useful if you want a default type to fall back to.
+
+        @param filter The filter returned by 'QFileDialog::getSaveFileName' and others, i.e. an item from the result of 'toFileDialogFilter'.
+        @param fallback If the filter is ambiguous, return this type instead
+        @return The type associated to the filter or the fallback
+        @throw Exception::ElementNotFound if the given @p filter is not a filter produced by toFileDialogFilter()
+      **/
+      Type fromFileDialogFilter(const String& filter, const Type fallback = Type::UNKNOWN) const;
+
     private:
+      struct FilterElements_
+      {
+        std::vector<String> items;
+        std::vector<Type> types;
+      };
+      /// creates Qt filters and the corresponding elements from type_list_
+      /// @param style Create a combined filter, or single filters, or both
+      /// @param add_all_filter Add 'all files (*)' as a single filter at the end?
+      FilterElements_ asFilterElements_(const Filter style, bool add_all_filter) const;
+
       std::vector<Type> type_list_;
     };
 

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -41,8 +41,6 @@
 
 namespace OpenMS
 {
-
-  static FileTypes::FileTypeList test_type_list({ FileTypes::MZML });
   /// connect the type to some other information
   /// We could also use paired arrays, but this way, its less likely to have mismatches if a new type is added
   struct TypeNameBinding
@@ -122,12 +120,12 @@ namespace OpenMS
     TypeNameBinding(FileTypes::XML, "xml", "any XML file")  // make sure this comes last, since the name is a suffix of other formats and should only be matched last
   };
 
-  FileTypes::FileTypeList::FileTypeList(const std::vector<Type>& types)
+  FileTypeList::FileTypeList(const std::vector<FileTypes::Type>& types)
     : type_list_(types)
   {
   }
 
-  bool FileTypes::FileTypeList::contains(const Type& type) const
+  bool FileTypeList::contains(const FileTypes::Type& type) const
   {
     for (const auto& t : type_list_)
     {
@@ -139,30 +137,30 @@ namespace OpenMS
     return false;
   }
 
-  String FileTypes::FileTypeList::toFileDialogFilter(const Filter style, bool add_all_filter) const
+  String FileTypeList::toFileDialogFilter(const FilterLayout style, bool add_all_filter) const
   {
     return ListUtils::concatenate(asFilterElements_(style, add_all_filter).items, ";;");
   }
 
-  FileTypes::Type FileTypes::FileTypeList::fromFileDialogFilter(const String& filter, const Type fallback) const
+  FileTypes::Type FileTypeList::fromFileDialogFilter(const String& filter, const FileTypes::Type fallback) const
   {
-    auto candidates = asFilterElements_(Filter::BOTH, true); // may add more filters than needed, but that's fine
+    auto candidates = asFilterElements_(FilterLayout::BOTH, true); // may add more filters than needed, but that's fine
 
     auto where = std::find(candidates.items.begin(), candidates.items.end(), filter);
     if (where == candidates.items.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filter);
     }
-    const Type r = candidates.types[where - candidates.items.begin()];
-    return r == Type::UNKNOWN ? fallback : r;
+    const FileTypes::Type r = candidates.types[where - candidates.items.begin()];
+    return r == FileTypes::Type::UNKNOWN ? fallback : r;
   }
 
   
-  FileTypes::FileTypeList::FilterElements_ FileTypes::FileTypeList::asFilterElements_(const Filter style, bool add_all_filter) const
+  FileTypeList::FilterElements_ FileTypeList::asFilterElements_(const FilterLayout style, bool add_all_filter) const
   {
     FilterElements_ result;
 
-    if (style == Filter::COMPACT || style == Filter::BOTH)
+    if (style == FilterLayout::COMPACT || style == FilterLayout::BOTH)
     {
       StringList items;
       for (const auto& t : type_list_)
@@ -170,9 +168,9 @@ namespace OpenMS
         items.push_back("*." + FileTypes::typeToName(t));
       }
       result.items.push_back("all readable files (" + ListUtils::concatenate(items, " ") + ")");
-      result.types.push_back(Type::UNKNOWN); // cannot associate a single type to a collection
+      result.types.push_back(FileTypes::Type::UNKNOWN); // cannot associate a single type to a collection
     }                                     
-    if (style == Filter::ONE_BY_ONE || style == Filter::BOTH)
+    if (style == FilterLayout::ONE_BY_ONE || style == FilterLayout::BOTH)
     {
       StringList items;
       for (const auto& t : type_list_)
@@ -184,7 +182,7 @@ namespace OpenMS
     if (add_all_filter)
     {
       result.items.push_back("all files (*)");
-      result.types.push_back(Type::UNKNOWN); // cannot associate a single type to a collection
+      result.types.push_back(FileTypes::Type::UNKNOWN); // cannot associate a single type to a collection
     }
     return result;
   }

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
@@ -539,25 +539,25 @@ namespace OpenMS
         @param file_dialog_text The header text of the file dialog shown to the user
         @param gui_lock Optional GUI element which will be locked (disabled) during call to 'annotateWorker_'; can be null_ptr
       **/
-    LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock);
+    LayerAnnotatorBase(const FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock);
 
     /// Annotates a @p layer, writing messages to @p log and showing QMessageBoxes on errors.
     /// The input file is selected via a file-dialog which is opened with @p current_path as initial path.
-    /// The filetype is checked to be one of the supported_types_ before the annotateWorker_ function is called
+    /// The file type is checked to be one of the supported_types_ before the annotateWorker_ function is called
     /// as implemented by the derived classes
     bool annotateWithFileDialog(LayerDataBase& layer, LogWindow& log, const String& current_path) const;
 
     /// Annotates a @p layer, given a filename from which to load the data.
-    /// The filetype is checked to be one of the supported_types_ before the annotateWorker_ function is called
+    /// The file type is checked to be one of the supported_types_ before the annotateWorker_ function is called
     /// as implemented by the derived classes
     bool annotateWithFilename(LayerDataBase& layer, LogWindow& log, const String& filename) const;
 
-    /// get a derived annotator class, which supports annotation of the given filetype.
+    /// get a derived annotator class, which supports annotation of the given file type.
     /// If multiple class support this type (currently not the case) an Exception::IllegalSelfOperation will be thrown
     /// If NO class supports this type, the unique_ptr points to nothing (.get() == nullptr).
     static std::unique_ptr<LayerAnnotatorBase> getAnnotatorWhichSupports(const FileTypes::Type& type);
 
-    /// see getAnnotatorWhichSupports(const FileTypes::Type& type). Filetype is queried from filename
+    /// see getAnnotatorWhichSupports(const FileTypes::Type& type). File type is queried from filename
     static std::unique_ptr<LayerAnnotatorBase> getAnnotatorWhichSupports(const String& filename);
 
   protected:
@@ -565,7 +565,7 @@ namespace OpenMS
     /// returns true on success
     virtual bool annotateWorker_(LayerDataBase& layer, const String& filename, LogWindow& log) const = 0;
 
-    const FileTypes::FileTypeList supported_types_;
+    const FileTypeList supported_types_;
     const String file_dialog_text_;
     QWidget* gui_lock_ = nullptr;///< optional widget which will be locked when calling annotateWorker_() in child-classes
   };

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -34,24 +34,28 @@
 
 #pragma once
 
-// OpenMS_GUI config
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+
 
 // declare Qt classes OUTSIDE of namespace OpenMS!
-class QString; 
-class QStringList;
 class QPainter;
 class QPoint;
+class QString; 
+class QStringList;
+class QWidget;
 
 #include <QColor>
-#include <QCursor>
 #include <QFont>
 
 #include <array>
 
 namespace OpenMS
 {
+
+  class FileTypeList;
+
   /**
     Namespace which holds static GUI-related helper functions.
   */
@@ -61,6 +65,16 @@ namespace OpenMS
     /// Open a folder in file explorer
     /// Will show a message box on failure
     OPENMS_GUI_DLLAPI void openFolder(const QString& folder);
+
+    /// Open a dialog to select a filename to save data to.
+
+    OPENMS_GUI_DLLAPI QString getSaveFilename(QWidget* parent,
+                                              const QString& caption,
+                                              const QString& dir,
+                                              FileTypeList supported_file_types, 
+                                              bool add_all_filter,
+                                              const FileTypes::Type fallback_extension);
+
 
     /// Open TOPPView (e.g. from within TOPPAS)
     OPENMS_GUI_DLLAPI void startTOPPView(const QStringList& args);

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -60,14 +60,14 @@ namespace OpenMS
     
     /// Open a folder in file explorer
     /// Will show a message box on failure
-    void openFolder(const QString& folder);
+    OPENMS_GUI_DLLAPI void openFolder(const QString& folder);
 
     /// Open TOPPView (e.g. from within TOPPAS)
-    void startTOPPView(const QStringList& args);
+    OPENMS_GUI_DLLAPI void startTOPPView(const QStringList& args);
 
     /// Open a certain URL (in a browser)
     /// Will show a message box on failure
-    void openURL(const QString& target);
+    OPENMS_GUI_DLLAPI void openURL(const QString& target);
 
     /**
        @brief draw a multi-line text at coordinates XY using a specific font and color
@@ -81,28 +81,32 @@ namespace OpenMS
        @param col_bg Optional background color of bounding rectangle; if invalid (=default) no background will be painted
        @param font Font to use; will use Courier by default
     */
-    void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"), const QFont& font = QFont("Courier"));
+    OPENMS_GUI_DLLAPI void drawText(QPainter& painter, const QStringList& text, const QPoint& where, const QColor col_fg = QColor("invalid"), const QColor col_bg = QColor("invalid"),
+                                   const QFont& font = QFont("Courier"));
 
 
     /**
       @brief Obtains the bounding rectangle of a text (useful to determine overlaps etc)
     
     */
-    QRectF getTextDimension(const QStringList& text, const QFont& font, int& line_spacing);
+    OPENMS_GUI_DLLAPI QRectF getTextDimension(const QStringList& text, const QFont& font, int& line_spacing);
 
 
     /**
-      @brief Given a set of levels (rows), try to add items at to topmost row which does not overlap an already placed item in this row (according to its x-coordinate)
+      @brief A heuristic: Given a set of levels (rows), try to add items at to topmost row which does not overlap an already placed item in this row (according to its x-coordinate)
 
       If a collision occurs, try the row below.
       If no row is collision-free, pick the one with the smallest overlap.
 
-      X coordinates should always be positive.
+      Only positions beyond the largest x-coordinate observed so far are considered (i.e. gaps are not filled).
+
+      X-coordinates should always be positive (a warning is issued otherwise).
     */
-    class OverlapDetector
+    class OPENMS_GUI_DLLAPI OverlapDetector
     {
     public:
       /// C'tor: number of @p levels must be >=1
+      /// @throw Exception::InvalidSize if levels <= 0
       explicit OverlapDetector(int levels);
 
       /// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
@@ -110,13 +114,13 @@ namespace OpenMS
       size_t placeItem(double x_start, double x_end);
 
     private:
-      std::vector<double> rows_;
+      std::vector<double> rows_; ///< store the largest x_end for each row
     };
 
     /**
-      @brief RAII class to disable the GUI and set a busy cursor and go back to the orignal state when this class is destroyed
+      @brief RAII class to disable the GUI and set a busy cursor and go back to the original state when this class is destroyed
     */
-    class GUILock
+    class OPENMS_GUI_DLLAPI GUILock
     {
     public:
       /// C'tor receives the widget to lock
@@ -194,8 +198,8 @@ namespace OpenMS
       }
     }; // ColorBrewer
 
-    StringList convert(const QStringList& in);
-    QStringList convert(const StringList& in);
+    OPENMS_GUI_DLLAPI StringList convert(const QStringList& in);
+    OPENMS_GUI_DLLAPI QStringList convert(const StringList& in);
 
   }; // GUIHelpers
 }

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -110,10 +110,10 @@ namespace OpenMS
   const std::string user_section = "preferences:user:";
 
   /// supported types which can be opened with File-->Open
-  const FileTypes::FileTypeList supported_types({ FileTypes::MZML, FileTypes::MZXML, FileTypes::MZDATA, FileTypes::SQMASS,
-                                                  FileTypes::FEATUREXML, FileTypes::CONSENSUSXML, FileTypes::IDXML,
-                                                  FileTypes::DTA, FileTypes::DTA2D, FileTypes::MGF, FileTypes::MS2,
-                                                  FileTypes::MSP, FileTypes::BZ2, FileTypes::GZ });
+  const FileTypeList supported_types({ FileTypes::MZML, FileTypes::MZXML, FileTypes::MZDATA, FileTypes::SQMASS,
+                                       FileTypes::FEATUREXML, FileTypes::CONSENSUSXML, FileTypes::IDXML,
+                                       FileTypes::DTA, FileTypes::DTA2D, FileTypes::MGF, FileTypes::MS2,
+                                       FileTypes::MSP, FileTypes::BZ2, FileTypes::GZ });
 
   TOPPViewBase::TOPPViewBase(TOOL_SCAN scan_mode, QWidget* parent) :
     QMainWindow(parent),
@@ -1646,7 +1646,7 @@ namespace OpenMS
     // we use the QT file dialog instead of using QFileDialog::Names(...)
     // On Windows and Mac OS X, this static function will use the native file dialog and not a QFileDialog,
     // which prevents us from doing GUI testing on it.
-    QFileDialog dialog(this, "Open file(s)", open_path, supported_types.toFileDialogFilter(FileTypes::Filter::BOTH, true).toQString());
+    QFileDialog dialog(this, "Open file(s)", open_path, supported_types.toFileDialogFilter(FilterLayout::BOTH, true).toQString());
     dialog.setFileMode(QFileDialog::ExistingFiles);
     if (dialog.exec())
     {

--- a/src/openms_gui/source/VISUAL/LayerDataBase.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataBase.cpp
@@ -445,7 +445,7 @@ namespace OpenMS
     }
   }
 
-  LayerAnnotatorBase::LayerAnnotatorBase(const FileTypes::FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock) :
+  LayerAnnotatorBase::LayerAnnotatorBase(const FileTypeList& supported_types, const String& file_dialog_text, QWidget* gui_lock) :
       supported_types_(supported_types),
       file_dialog_text_(file_dialog_text),
       gui_lock_(gui_lock)
@@ -465,7 +465,7 @@ namespace OpenMS
     QString fname = QFileDialog::getOpenFileName(nullptr,
                                                  file_dialog_text_.toQString(),
                                                  current_path.toQString(),
-                                                 supported_types_.toFileDialogFilter(FileTypes::Filter::BOTH, true).toQString());
+                                                 supported_types_.toFileDialogFilter(FilterLayout::BOTH, true).toQString());
 
     bool success = annotateWithFilename(layer, log, fname);
 

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -244,7 +244,7 @@ namespace OpenMS
       OPENMS_LOG_WARN << "Warning: x-end is larger than x-start!\n";
 
     size_t best_index = 0;
-    double best_distance = -std::numeric_limits<double>::max();
+    double best_distance = std::numeric_limits<double>::max();
     for (size_t i = 0; i < rows_.size(); ++i)
     {
       if (rows_[i] < x_start)
@@ -260,6 +260,7 @@ namespace OpenMS
       }
     }
 
+    rows_[best_index] = x_end; // update space for next call
     return best_index;
   }
 

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -36,7 +36,6 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
-
 #include <QDesktopServices>
 #include <QDir>
 #include <QGuiApplication>
@@ -46,6 +45,7 @@
 #include <QProcess>
 #include <QString>
 #include <QStringList>
+#include <QtWidgets/QFileDialog>
 #include <QUrl>
 
 namespace OpenMS
@@ -70,6 +70,20 @@ namespace OpenMS
       QMessageBox::warning(nullptr, "Open Folder Error", "The folder '" + folder + "' could not be opened!");
     }
 #endif
+  }
+
+  OPENMS_GUI_DLLAPI QString GUIHelpers::getSaveFilename(QWidget* parent, const QString& caption, const QString& dir, FileTypeList supported_file_types, bool add_all_filter,
+                                                        const FileTypes::Type fallback_extension)
+  {
+    QString selected_filter;
+    QString file_name = QFileDialog::getSaveFileName(parent, caption, dir, supported_file_types.toFileDialogFilter(FilterLayout::ONE_BY_ONE, add_all_filter).toQString(), &selected_filter);
+    if (file_name.isEmpty())
+    {
+      return file_name;
+    }
+    // check whether a file type suffix has been given, or fall back to @p fallback_extension (if 'all filter' was used)
+    file_name = FileHandler::swapExtension(file_name, supported_file_types.fromFileDialogFilter(selected_filter, fallback_extension)).toQString();
+    return file_name;
   }
 
   void GUIHelpers::startTOPPView(const QStringList& args)

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -228,41 +228,40 @@ namespace OpenMS
     QGuiApplication::restoreOverrideCursor(); 
     currently_locked_ = false;
   }
+  
+  GUIHelpers::OverlapDetector::OverlapDetector(int levels)
+  {
+    if (levels <= 0)
+      throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, levels);
+    rows_.resize(levels, 0);
+  }
+
+  size_t GUIHelpers::OverlapDetector::placeItem(double x_start, double x_end)
+  {
+    if (x_start < 0)
+      OPENMS_LOG_WARN << "Warning: x coordinates should be positive!\n";
+    if (x_start > x_end)
+      OPENMS_LOG_WARN << "Warning: x-end is larger than x-start!\n";
+
+    size_t best_index = 0;
+    double best_distance = -std::numeric_limits<double>::max();
+    for (size_t i = 0; i < rows_.size(); ++i)
+    {
+      if (rows_[i] < x_start)
+      {                   // easy win; row[i] does not overlap; take it
+        rows_[i] = x_end; // update space for next call
+        return i;
+      }
+      // x_start is smaller than row's end...
+      if ((rows_[i] - x_start) < best_distance)
+      {
+        best_distance = rows_[i] - x_start;
+        best_index = i;
+      }
+    }
+
+    return best_index;
+  }
 
 } //namespace OpenMS
 
-  /// C'tor: number of @p levels must be >=1
-
-OpenMS::GUIHelpers::OverlapDetector::OverlapDetector(int levels)
-{
-  if (levels <= 0) throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, levels);
-  rows_.resize(levels, 0);
-}
-
-/// try to put an item which spans from @p x_start to @p x_end in the topmost row possible
-/// @return the smallest row index (starting at 0) which has none (or the least) overlap
-
-size_t OpenMS::GUIHelpers::OverlapDetector::placeItem(double x_start, double x_end)
-{
-  if (x_start < 0) OPENMS_LOG_WARN << "Warning: x coordinates should be positive!\n";
-  if (x_start > x_end) OPENMS_LOG_WARN << "Warning: x-end is larger than x-start!\n";
-
-  size_t best_index = 0;
-  double best_distance = -std::numeric_limits<double>::max();
-  for (size_t i = 0; i < rows_.size(); ++i)
-  {
-    if (rows_[i] < x_start)
-    { // easy win; row[i] does not overlap; take it
-      rows_[i] = x_end; // update space for next call
-      return i;
-    }
-    // x_start is smaller than row's end...
-    if ((rows_[i] - x_start) < best_distance)
-    {
-      best_distance = rows_[i] - x_start;
-      best_index = i;
-    }
-  }
-
-  return best_index;
-}

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -35,22 +35,23 @@
 #include <OpenMS/VISUAL/Plot1DCanvas.h>
 
 // OpenMS
-#include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h>
-#include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignmentScore.h>
-#include <OpenMS/CONCEPT/RAIICleanup.h>
-#include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/VISUAL/AxisWidget.h>
-#include <OpenMS/VISUAL/ColorSelector.h>
 #include <OpenMS/VISUAL/PlotWidget.h>
 #include <OpenMS/VISUAL/Plot1DWidget.h>
-#include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
-#include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+#include <OpenMS/VISUAL/DIALOGS/Plot1DPrefDialog.h>
+#include <OpenMS/VISUAL/ColorSelector.h>
+#include <OpenMS/VISUAL/AxisWidget.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DTextItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
-#include <OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h>
-#include <OpenMS/VISUAL/DIALOGS/Plot1DPrefDialog.h>
-
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>
+#include <OpenMS/FORMAT/FileTypes.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/CONCEPT/RAIICleanup.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignmentScore.h>
+#include <OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h>
 
 // Qt
 #include <QMouseEvent>
@@ -1382,39 +1383,10 @@ namespace OpenMS
       proposed_name = layer.filename;
     }
 
-    QString selected_filter;
-    QString file_name = QFileDialog::getSaveFileName(this, "Save file", proposed_name.toQString(), "mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;All files (*)", &selected_filter);
+    QString file_name = GUIHelpers::getSaveFilename(this, "Save file", proposed_name.toQString(), FileTypeList({FileTypes::MZML, FileTypes::MZDATA, FileTypes::MZXML}), true, FileTypes::MZML);
     if (file_name.isEmpty())
     {
       return;
-    }
-
-    // check whether a file type suffix has been given
-    // first check mzData and mzXML then mzML
-    // if the setting is at "All files"
-    // mzML will be used
-    String upper_filename = file_name;
-    upper_filename.toUpper();
-    if (selected_filter == "mzData files (*.mzData)")
-    {
-      if (!upper_filename.hasSuffix(".MZDATA"))
-      {
-        file_name += ".mzData";
-      }
-    }
-    else if (selected_filter == "mzXML files (*.mzXML)")
-    {
-      if (!upper_filename.hasSuffix(".MZXML"))
-      {
-        file_name += ".mzXML";
-      }
-    }
-    else
-    {
-      if (!upper_filename.hasSuffix(".MZML"))
-      {
-        file_name += ".mzML";
-      }
     }
 
     if (visible)

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -33,38 +33,34 @@
 // --------------------------------------------------------------------------
 
 // OpenMS
-#include <OpenMS/VISUAL/Plot2DCanvas.h>
-#include <OpenMS/VISUAL/PlotWidget.h>
+#include <OpenMS/FORMAT/ConsensusXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/FORMAT/FeatureXMLFile.h>
-#include <OpenMS/FORMAT/ConsensusXMLFile.h>
-#include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/VISUAL/DIALOGS/Plot2DPrefDialog.h>
-#include <OpenMS/VISUAL/ColorSelector.h>
-#include <OpenMS/VISUAL/MultiGradientSelector.h>
-#include <OpenMS/VISUAL/DIALOGS/FeatureEditDialog.h>
-#include <OpenMS/VISUAL/INTERFACES/IPeptideIds.h>
-
-#include <OpenMS/SYSTEM/FileWatcher.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
+#include <OpenMS/SYSTEM/FileWatcher.h>
+#include <OpenMS/VISUAL/ColorSelector.h>
+#include <OpenMS/VISUAL/DIALOGS/FeatureEditDialog.h>
+#include <OpenMS/VISUAL/DIALOGS/Plot2DPrefDialog.h>
+#include <OpenMS/VISUAL/INTERFACES/IPeptideIds.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+#include <OpenMS/VISUAL/MultiGradientSelector.h>
+#include <OpenMS/VISUAL/Plot2DCanvas.h>
+#include <OpenMS/VISUAL/PlotWidget.h>
 //STL
 #include <algorithm>
 
 //QT
+#include <QBitmap>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QtWidgets/QMenu>
-#include <QBitmap>
 #include <QPolygon>
 #include <QtCore/QTime>
 #include <QtWidgets/QComboBox>
-#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMenu>
 #include <QtWidgets/QMessageBox>
-
-//boost
-#include <boost/math/special_functions/fpclassify.hpp>
 
 #define PEN_SIZE_MAX_LIMIT 100    // maximum size of a rectangle representing a point for raw peak data
 #define PEN_SIZE_MIN_LIMIT 1      // minimum. This should not be changed without adapting the way dots are plotted
@@ -2628,51 +2624,24 @@ namespace OpenMS
 
     if (layer.type == LayerDataBase::DT_PEAK)   //peak data
     {
-      QString selected_filter = "";
-      QString file_name = QFileDialog::getSaveFileName(this, "Save file", proposed_name.toQString(), "mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;All files (*)", &selected_filter);
-      if (!file_name.isEmpty())
+      QString file_name = GUIHelpers::getSaveFilename(this, "Save file", proposed_name.toQString(), FileTypeList({FileTypes::MZML, FileTypes::MZDATA, FileTypes::MZXML}), true, FileTypes::MZML);
+      if (file_name.isEmpty())
       {
-        // check whether a file type suffix has been given
-        // first check mzData and mzXML then mzML
-        // if the setting is at "All files"
-        // mzML will be used
-        String upper_filename = file_name;
-        upper_filename.toUpper();
-        if (selected_filter == "mzData files (*.mzData)")
-        {
-          if (!upper_filename.hasSuffix(".MZDATA"))
-          {
-            file_name += ".mzData";
-          }
-        }
-        else if (selected_filter == "mzXML files (*.mzXML)")
-        {
-          if (!upper_filename.hasSuffix(".MZXML"))
-          {
-            file_name += ".mzXML";
-          }
-        }
-        else
-        {
-          if (!upper_filename.hasSuffix(".MZML"))
-          {
-            file_name += ".mzML";
-          }
-        }
+        return;
+      }      
 
-        if (visible)     //only visible data
-        {
-          ExperimentType out;
-          getVisiblePeakData(out);
-          addDataProcessing_(out, DataProcessing::FILTERING);
-          FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
-        }
-        else         //all data
-        {
-          FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
-        }
-        modificationStatus_(getCurrentLayerIndex(), false);
+      if (visible)     //only visible data
+      {
+        ExperimentType out;
+        getVisiblePeakData(out);
+        addDataProcessing_(out, DataProcessing::FILTERING);
+        FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
       }
+      else         //all data
+      {
+        FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
+      }
+      modificationStatus_(getCurrentLayerIndex(), false);
     }
     else if (layer.type == LayerDataBase::DT_FEATURE) //features
     {

--- a/src/openms_gui/source/VISUAL/Plot3DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot3DCanvas.cpp
@@ -33,14 +33,15 @@
 // --------------------------------------------------------------------------
 
 //OpenMS
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/SYSTEM/FileWatcher.h>
+#include <OpenMS/VISUAL/ColorSelector.h>
+#include <OpenMS/VISUAL/DIALOGS/Plot3DPrefDialog.h>
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+#include <OpenMS/VISUAL/MultiGradientSelector.h>
 #include <OpenMS/VISUAL/Plot3DCanvas.h>
 #include <OpenMS/VISUAL/Plot3DOpenGLCanvas.h>
 #include <OpenMS/VISUAL/PlotWidget.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/VISUAL/DIALOGS/Plot3DPrefDialog.h>
-#include <OpenMS/VISUAL/ColorSelector.h>
-#include <OpenMS/VISUAL/MultiGradientSelector.h>
-#include <OpenMS/SYSTEM/FileWatcher.h>
 
 #include <QResizeEvent>
 #include <QtWidgets/QComboBox>
@@ -314,50 +315,22 @@ namespace OpenMS
     {
       proposed_name = layer.filename;
     }
-
-    QString selected_filter = "";
-    QString file_name = QFileDialog::getSaveFileName(this, "Save file", proposed_name.toQString(), "mzML files (*.mzML);;mzData files (*.mzData);;mzXML files (*.mzXML);;All files (*)", &selected_filter);
-    if (!file_name.isEmpty())
+    QString file_name = GUIHelpers::getSaveFilename(this, "Save file", proposed_name.toQString(), FileTypeList({FileTypes::MZML, FileTypes::MZDATA, FileTypes::MZXML}), true, FileTypes::MZML);
+    if (file_name.isEmpty())
     {
-      // check whether a file type suffix has been given
-      // first check mzData and mzXML then mzML
-      // if the setting is at "All files"
-      // mzML will be used
-      String upper_filename = file_name;
-      upper_filename.toUpper();
-      if (selected_filter == "mzData files (*.mzData)")
-      {
-        if (!upper_filename.hasSuffix(".MZDATA"))
-        {
-          file_name += ".mzData";
-        }
-      }
-      else if (selected_filter == "mzXML files (*.mzXML)")
-      {
-        if (!upper_filename.hasSuffix(".MZXML"))
-        {
-          file_name += ".mzXML";
-        }
-      }
-      else
-      {
-        if (!upper_filename.hasSuffix(".MZML"))
-        {
-          file_name += ".mzML";
-        }
-      }
+      return;
+    }
 
-      if (visible)   //only visible data
-      {
-        ExperimentType out;
-        getVisiblePeakData(out);
-        addDataProcessing_(out, DataProcessing::FILTERING);
-        FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
-      }
-      else       //all data
-      {
-        FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
-      }
+    if (visible)   //only visible data
+    {
+      ExperimentType out;
+      getVisiblePeakData(out);
+      addDataProcessing_(out, DataProcessing::FILTERING);
+      FileHandler().storeExperiment(file_name, out, ProgressLogger::GUI);
+    }
+    else       //all data
+    {
+      FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
     }
   }
 

--- a/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIDViewTab.cpp
@@ -971,8 +971,6 @@ namespace OpenMS
     // synchronize PeptideHits with the annotations in the spectrum
     layer_->synchronizePeakAnnotations();
 
-    QString selectedFilter;
-    QString filename = QFileDialog::getSaveFileName(this, "Save File", "", "idXML file (*.idXML);;mzIdentML file (*.mzid)", &selectedFilter);
     vector<ProteinIdentification> prot_id = (*layer_->getPeakData()).getProteinIdentifications();
     vector<PeptideIdentification> all_pep_ids;
 
@@ -996,22 +994,17 @@ namespace OpenMS
       copy(pep_id.begin(), pep_id.end(), back_inserter(all_pep_ids));
     }
 
-    if (String(filename).hasSuffix(String(".mzid")))
+    QString filename = GUIHelpers::getSaveFilename(this, "Save file", "", FileTypeList({FileTypes::IDXML, FileTypes::MZIDENTML}), true, FileTypes::IDXML);
+    if (filename.isEmpty())
+    {
+      return;
+    }      
+    if (FileHandler::getTypeByFileName(filename) == FileTypes::MZIDENTML)
     {
       MzIdentMLFile().store(filename, prot_id, all_pep_ids);
     }
-    else if (String(filename).hasSuffix(String(".idXML")))
+    else 
     {
-      IdXMLFile().store(filename, prot_id, all_pep_ids);
-    }
-    else if (String(selectedFilter).hasSubstring(String(".mzid")))
-    {
-      filename = filename + ".mzid";
-      MzIdentMLFile().store(filename, prot_id, all_pep_ids);
-    }
-    else
-    {
-      filename = filename + ".idXML";
       IdXMLFile().store(filename, prot_id, all_pep_ids);
     }
   }

--- a/src/tests/class_tests/openms/source/FileTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/FileTypes_test.cpp
@@ -121,15 +121,15 @@ START_SECTION((static Type nameToType(const String& name)))
 END_SECTION
 
 START_SECTION([EXTRA] FileTypes::FileTypeList)
-  FileTypes::FileTypeList list({ FileTypes::MZML, FileTypes::BZ2 });
+  FileTypeList list({ FileTypes::MZML, FileTypes::BZ2 });
   TEST_EQUAL(list.contains(FileTypes::MZML), true);
   TEST_EQUAL(list.contains(FileTypes::BZ2), true);
   TEST_EQUAL(list.contains(FileTypes::MZDATA), false);
 
-  TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::BOTH, true), "all readable files (*.mzML *.bz2);;mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2);;all files (*)")
-  TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::COMPACT, true), "all readable files (*.mzML *.bz2);;all files (*)")
-  TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::ONE_BY_ONE, true), "mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2);;all files (*)")
-  TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::BOTH, false), "all readable files (*.mzML *.bz2);;mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2)")
+  TEST_EQUAL(list.toFileDialogFilter(FilterLayout::BOTH, true), "all readable files (*.mzML *.bz2);;mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2);;all files (*)")
+  TEST_EQUAL(list.toFileDialogFilter(FilterLayout::COMPACT, true), "all readable files (*.mzML *.bz2);;all files (*)")
+  TEST_EQUAL(list.toFileDialogFilter(FilterLayout::ONE_BY_ONE, true), "mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2);;all files (*)")
+  TEST_EQUAL(list.toFileDialogFilter(FilterLayout::BOTH, false), "all readable files (*.mzML *.bz2);;mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2)")
 
   // testing Type FileTypeList::fromFileDialogFilter(const String& filter, const Type fallback = Type::UNKNOWN) const
   TEST_EQUAL(list.fromFileDialogFilter("all readable files (*.mzML *.bz2)"), FileTypes::UNKNOWN);

--- a/src/tests/class_tests/openms/source/FileTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/FileTypes_test.cpp
@@ -130,6 +130,20 @@ START_SECTION([EXTRA] FileTypes::FileTypeList)
   TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::COMPACT, true), "all readable files (*.mzML *.bz2);;all files (*)")
   TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::ONE_BY_ONE, true), "mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2);;all files (*)")
   TEST_EQUAL(list.toFileDialogFilter(FileTypes::Filter::BOTH, false), "all readable files (*.mzML *.bz2);;mzML raw data file (*.mzML);;bzip2 compressed file (*.bz2)")
-END_SECTION
+
+  // testing Type FileTypeList::fromFileDialogFilter(const String& filter, const Type fallback = Type::UNKNOWN) const
+  TEST_EQUAL(list.fromFileDialogFilter("all readable files (*.mzML *.bz2)"), FileTypes::UNKNOWN);
+  TEST_EQUAL(list.fromFileDialogFilter("all files (*)"), FileTypes::UNKNOWN);
+  TEST_EQUAL(list.fromFileDialogFilter("mzML raw data file (*.mzML)"), FileTypes::MZML);
+  TEST_EQUAL(list.fromFileDialogFilter("bzip2 compressed file (*.bz2)"), FileTypes::BZ2);
+  TEST_EXCEPTION(Exception::ElementNotFound, list.fromFileDialogFilter("not a valid filter"));
+  // with default
+  TEST_EQUAL(list.fromFileDialogFilter("all readable files (*.mzML *.bz2)", FileTypes::CONSENSUSXML), FileTypes::CONSENSUSXML);
+  TEST_EQUAL(list.fromFileDialogFilter("all files (*)", FileTypes::CONSENSUSXML), FileTypes::CONSENSUSXML);
+  TEST_EQUAL(list.fromFileDialogFilter("mzML raw data file (*.mzML)", FileTypes::CONSENSUSXML), FileTypes::MZML);
+  TEST_EQUAL(list.fromFileDialogFilter("bzip2 compressed file (*.bz2)", FileTypes::CONSENSUSXML), FileTypes::BZ2);
+  TEST_EXCEPTION(Exception::ElementNotFound, list.fromFileDialogFilter("not a valid filter", FileTypes::CONSENSUSXML));
+
+  END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms_gui/CMakeLists.txt
+++ b/src/tests/class_tests/openms_gui/CMakeLists.txt
@@ -37,6 +37,7 @@ project("OpenMS_class_tests_openms_gui")
 
 set(visual_executables_list
   AxisTickCalculator_test
+  GUIHelpers_test
   MultiGradient_test
 )
 

--- a/src/tests/class_tests/openms_gui/source/GUIHelpers_test.cpp
+++ b/src/tests/class_tests/openms_gui/source/GUIHelpers_test.cpp
@@ -1,0 +1,77 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+
+///////////////////////////
+
+#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
+
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(GUIHelpers, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+
+START_SECTION(([EXTRA] size_t OverlapDetector::placeItem(double x_start, double x_end)))
+	GUIHelpers::OverlapDetector od(3);
+	TEST_EQUAL(od.placeItem(1, 3), 0);
+  TEST_EQUAL(od.placeItem(1, 3), 1);
+  TEST_EQUAL(od.placeItem(1, 3), 2);
+  TEST_EQUAL(od.placeItem(1, 3), 0);
+
+  TEST_EQUAL(od.placeItem(4, 8), 0);
+  TEST_EQUAL(od.placeItem(5, 11), 1);
+  TEST_EQUAL(od.placeItem(9, 10), 0);
+
+  TEST_EQUAL(od.placeItem(12, 20), 0);
+  TEST_EQUAL(od.placeItem(12, 18), 1);
+  TEST_EQUAL(od.placeItem(12, 19), 2);
+
+  TEST_EQUAL(od.placeItem(16, 25), 1);
+  TEST_EQUAL(od.placeItem(16, 25), 2);
+  TEST_EQUAL(od.placeItem(16, 25), 0);
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST
+
+
+


### PR DESCRIPTION
# Description

[FEATURE] add getSaveFilename function with predefined OpenMS data types for less boilerplate

[FIX] fix a bug in GUIHelpers::OverlapDetector (and add a regression test)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
