### PR TITLE
[FIX] do not clear data arrays when setting peaks

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -558,6 +558,12 @@ public:
     /**
       @brief Clears all data and meta data
 
+      Will delete (clear) all peaks contained in the spectrum as well as any
+      associated data arrays (FloatDataArrays, IntegerDataArrays,
+      StringDataArrays) by default. If @em clear_meta_data is @em true, then
+      also all meta data (such as RT, drift time, ms level etc) will be
+      deleted.
+
       @param clear_meta_data If @em true, all meta data is cleared in addition to the data.
     */
     void clear(bool clear_meta_data);

--- a/src/pyOpenMS/addons/MSChromatogram.pyx
+++ b/src/pyOpenMS/addons/MSChromatogram.pyx
@@ -52,7 +52,7 @@ import numpy as np
 
         cdef _MSChromatogram * chrom_ = self.inst.get()
 
-        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.resize(0) # empty vector, keep meta data and data arrays
         chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
         cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt
@@ -74,7 +74,7 @@ import numpy as np
 
         cdef _MSChromatogram * chrom_ = self.inst.get()
 
-        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.resize(0) # empty vector, keep meta data and data arrays
         chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
         cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt
@@ -97,7 +97,7 @@ import numpy as np
 
         cdef _MSChromatogram * chrom_ = self.inst.get()
 
-        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.resize(0) # empty vector, keep meta data and data arrays
         chrom_.reserve(<int>len(rts)) # allocate space for incoming data
         cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -61,7 +61,7 @@ import numpy as np
 
         cdef _MSSpectrum * spec_ = self.inst.get()
 
-        spec_.clear(0) # empty vector , keep meta data
+        spec_.resize(0) # empty vector, keep meta data and data arrays
         spec_.reserve(<int>len(data_mz)) # allocate space for incoming data
         cdef _Peak1D p = _Peak1D()
         cdef double mz
@@ -83,7 +83,7 @@ import numpy as np
 
         cdef _MSSpectrum * spec_ = self.inst.get()
 
-        spec_.clear(0) # empty vector , keep meta data
+        spec_.resize(0) # empty vector, keep meta data and data arrays
         spec_.reserve(<int>len(data_mz)) # allocate space for incoming data
         cdef _Peak1D p = _Peak1D()
         cdef double mz
@@ -106,7 +106,7 @@ import numpy as np
 
         cdef _MSSpectrum * spec_ = self.inst.get()
 
-        spec_.clear(0) # empty vector , keep meta data
+        spec_.resize(0) # empty vector, keep meta data and data arrays
         spec_.reserve(<int>len(mzs)) # allocate space for incoming data
         cdef _Peak1D p = _Peak1D()
         cdef double mz

--- a/src/pyOpenMS/pxds/MSChromatogram.pxd
+++ b/src/pyOpenMS/pxds/MSChromatogram.pxd
@@ -38,6 +38,7 @@ cdef extern from "<OpenMS/KERNEL/MSChromatogram.h>" namespace "OpenMS":
 
         Size size() nogil except +
         void reserve(size_t n) nogil except + 
+        void resize(size_t n) nogil except + # wrap-doc:Resize the peak array 
 
         ChromatogramPeak & operator[](size_t) nogil except +
 

--- a/src/pyOpenMS/pxds/MSSpectrum.pxd
+++ b/src/pyOpenMS/pxds/MSSpectrum.pxd
@@ -90,6 +90,7 @@ cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
 
         Size size() nogil except + # wrap-doc:Returns the number of peaks in the spectrum
         void reserve(size_t n) nogil except + 
+        void resize(size_t n) nogil except + # wrap-doc:Resize the peak array 
 
         Peak1D& operator[](size_t) nogil except + # wrap-upper-limit:size()
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3260,6 +3260,25 @@ def testMSSpectrum():
     assert spec.containsIMData()
     assert spec.getIMData()[0] == 1
 
+    # Ensure that "set_peaks()" doesnt clear the float data arrays
+    spec = pyopenms.MSSpectrum()
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float32)
+    f_da = [ pyopenms.FloatDataArray() ]
+    f_da[0].set_data(data)
+    f_da[0].setName("Ion Mobility")
+    spec.setFloatDataArrays( f_da )
+    spec.set_peaks( [data_mz,data_i] )
+    assert spec.containsIMData()
+    assert spec.getIMData()[0] == 0
+    assert len(spec.getFloatDataArrays()) == 1
+
+    f = spec.getFloatDataArrays()[0]
+    assert len(f.get_data()) == 3
+    assert f.get_data()[0] == 5
+    assert spec.size() == len(data_mz)
+    assert spec.size() == len(data_i)
+
 @report
 def testStringDataArray():
     """
@@ -3458,6 +3477,31 @@ def testMSChromatogram():
     assert mz[1] == 8.0
     assert ii[0] == 50.0
     assert ii[1] == 80.0
+
+    # test float data
+    chrom = pyopenms.MSChromatogram()
+    data = np.array( [5, 8, 42] ).astype(np.float32)
+    f_da = [ pyopenms.FloatDataArray() ]
+    f_da[0].set_data(data)
+    f_da[0].setName("Test Data")
+    chrom.setFloatDataArrays( f_da )
+    assert len(chrom.getFloatDataArrays()) == 1
+    f = chrom.getFloatDataArrays()[0]
+    assert f.get_data()[0] == 5
+    assert f.getName() == "Test Data"
+
+    # Ensure that "set_peaks()" doesnt clear the float data arrays
+    chrom = pyopenms.MSChromatogram()
+    chrom.setFloatDataArrays( f_da )
+    chrom.set_peaks( [data_mz,data_i] )
+    assert len(chrom.getFloatDataArrays()) == 1
+
+    f = chrom.getFloatDataArrays()[0]
+    assert len(f.get_data()) == 3
+    assert f.get_data()[0] == 5
+    assert chrom.size() == len(data_mz)
+    assert chrom.size() == len(data_i)
+
 
 @report
 def testMRMFeature():


### PR DESCRIPTION
- fixes bug #5876
- set_peaks() no longer clears data arrays, only clears the peak data

# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
