### PR TITLE
Feature/isotopes

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -50,7 +50,10 @@ namespace OpenMS
 {
   /** @ingroup Chemistry
 
-          @brief Representation of an element
+      @brief Representation of an element
+
+      This contains information on an element and its isotopes, including a
+      common name, atomic symbol and mass/abundance of its isotopes.
   */
   class OPENMS_DLLAPI Element
   {
@@ -158,7 +161,7 @@ protected:
     /// mono isotopic weight of the most frequent isotope
     double mono_weight_;
 
-    /// distribution of the isotopes
+    /// distribution of the isotopes (mass and natural frequency)
     IsotopeDistribution isotopes_;
   };
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -39,6 +39,7 @@
 #include <OpenMS/DATASTRUCTURES/Map.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 #include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CONCEPT/Exception.h>
 
 #include <map>
 #include <string>
@@ -48,7 +49,7 @@ namespace OpenMS
 
   /** @ingroup Chemistry
 
-          @brief Singleton that stores elements.
+      @brief Singleton that stores elements and isotopes.
 
       The elements weights (in the default file) are taken from
       "Isotopic Compositions of the Elements 1997", Pure Appl. Chem., 70(1), 217-235, 1998.
@@ -59,11 +60,11 @@ namespace OpenMS
           Pure Appl. Chem., 2003, Vol. 75, No. 6, pp. 683-799
           doi:10.1351/pac200375060683
 
-          Specific isotopes of elements can be accessed by writing the atomic number of the isotope
-          in brackets followed by the element name, e.g. "(2)H" for deuterium.
+      Specific isotopes of elements can be accessed by writing the atomic number of the isotope
+      in brackets followed by the element name, e.g. "(2)H" for deuterium.
 
-    @improvement include exact mass values for the isotopes (done) and update IsotopeDistribution (Andreas)
-          @improvement add exact isotope distribution based on exact isotope values (Andreas)
+      @improvement include exact mass values for the isotopes (done) and update IsotopeDistribution (Andreas)
+      @improvement add exact isotope distribution based on exact isotope values (Andreas)
 */
 
   class OPENMS_DLLAPI ElementDB
@@ -75,7 +76,7 @@ public:
     //@{
     /// returns a pointer to the singleton instance of the element db
     /// This is thread safe upon first and subsequent calls.
-    static const ElementDB* getInstance();
+    static ElementDB* getInstance();
 
     /// returns a hashmap that contains names mapped to pointers to the elements
     const std::map<std::string, const Element*>& getNames() const;
@@ -95,6 +96,30 @@ public:
     /// returns a pointer to the element of atomic number; if no element is found 0 is returned
     const Element* getElement(unsigned int atomic_number) const;
 
+    /** Adds or replaces a new element to the database
+     *
+     * Adds a new element (or replaces an existing one if @em replace_existing is true). 
+     *
+     * @param name Common name of the element
+     * @param symbol Element symbol (one or two letter)
+     * @param an Atomic number (number of protons)
+     * @param abundance List of abundances for each isotope (e.g. {{12u, 0.9893}, {13u, 0.0107}} for Carbon)
+     * @param abundance List of masses for each isotope (e.g. {{12u, 12.0}, {13u, 13.003355}} for Carbon)
+    */
+    void addElement(const std::string& name,
+                    const std::string& symbol,
+                    const unsigned int an,
+                    const std::map<unsigned int, double>& abundance,
+                    const std::map<unsigned int, double>& mass,
+                    bool replace_existing)
+    {
+      if (hasElement(an) && !replace_existing)
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Element with atomic number ") + an + " already exists");
+      }
+      buildElement_(name, symbol, an, abundance, mass);
+    }
+
     //@}
 
     /** @name Predicates
@@ -109,34 +134,34 @@ public:
 
 protected:
 
-    /*_ parses a Histogram given as a OpenMS String and return the distribution
+    /** parses a Histogram given as a OpenMS String and return the distribution
 
             @throw throws exception ParseError
-     */
+    **/
     IsotopeDistribution parseIsotopeDistribution_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
-    /*_ calculates the average weight based on isotope abundance and mass
-     */
+    /** calculates the average weight based on isotope abundance and mass
+     **/
     double calculateAvgWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
-    /*_ calculates the mono weight based on the smallest isotope mass
-     */
+    /**_ calculates the mono weight based on the smallest isotope mass
+     **/
     double calculateMonoWeight_(const std::map<unsigned int, double>& Z_to_mass);
 
-	// constructs element objects
+	  /// constructs element objects
     void storeElements_();
 
-  // build element objects from given abundances, masses, name, symbol, and atomic number
+    /// build element objects from given abundances, masses, name, symbol, and atomic number
     void buildElement_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
-  // add element objects to documentation maps
+    /// add element objects to documentation maps
     void addElementToMaps_(const std::string& name, const std::string& symbol, const unsigned int an, const Element* e);
 
-  // constructs isotope objects
+    /// constructs isotope objects
     void storeIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& Z_to_mass, const IsotopeDistribution& isotopes);
 
-    /*_ resets all containers
-     */
+    /**_ resets all containers
+    **/
     void clear_();
 
     std::map<std::string, const Element*> names_;

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -29,19 +29,15 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Andreas Bertsch, Timo Sachsenberg, Chris Bielow, Jang Jang Jin‚$
+// $Authors: Andreas Bertsch, Timo Sachsenberg, Chris Bielow, Jang Jang Jin$
 // --------------------------------------------------------------------------
 //
+
 #include <OpenMS/CHEMISTRY/ElementDB.h>
+
 #include <OpenMS/CHEMISTRY/Element.h>
-
-#include <OpenMS/DATASTRUCTURES/Param.h>
-
-#include <OpenMS/FORMAT/ParamXMLFile.h>
-
-#include <OpenMS/SYSTEM/File.h>
-
 #include <iostream>
+#include <cmath>
 
 using namespace std;
 
@@ -57,7 +53,7 @@ namespace OpenMS
     clear_();
   }
 
-  const ElementDB* ElementDB::getInstance()
+  ElementDB* ElementDB::getInstance()
   {
     static ElementDB* db_ = new ElementDB;
     return db_;
@@ -580,7 +576,7 @@ namespace OpenMS
     for (const auto& isotope : isotopes)
     {
       double atomic_mass = isotope.getMZ();
-      unsigned int mass_number = round(atomic_mass);
+      unsigned int mass_number = std::round(atomic_mass);
       string iso_name = "(" + std::to_string(mass_number) + ")" + name;
       string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -566,6 +566,11 @@ namespace OpenMS
 
   void ElementDB::addElementToMaps_(const string& name, const string& symbol, const unsigned int an, const Element* e)
   {
+    // delete existing element before adding a new one
+    if (atomic_numbers_.find(an) != atomic_numbers_.end())
+    {
+      delete atomic_numbers_[an];
+    }
     names_[name] = e;
     symbols_[symbol] = e;
     atomic_numbers_[an] = e;

--- a/src/pyOpenMS/addons/ElementDB.pyx
+++ b/src/pyOpenMS/addons/ElementDB.pyx
@@ -1,10 +1,10 @@
 
 
     # NOTE: using shared_ptr for a singleton will lead to segfaults, use raw ptr instead
-    # cdef AutowrapConstPtrHolder[_ElementDB] inst
+    # cdef AutowrapPtrHolder[_ElementDB] inst
 
     def __init__(self):
-      self.inst = AutowrapConstPtrHolder[_ElementDB](_getInstance_ElementDB())
+      self.inst = AutowrapPtrHolder[_ElementDB](_getInstance_ElementDB())
 
     def __dealloc__(self):
       # Careful here, the wrapped ptr is a single instance and we should not

--- a/src/pyOpenMS/pxds/ElementDB.pxd
+++ b/src/pyOpenMS/pxds/ElementDB.pxd
@@ -9,7 +9,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ElementDB.h>" namespace "OpenMS":
     
     cdef cppclass ElementDB "OpenMS::ElementDB":
         # wrap-manual-memory:
-        #    cdef AutowrapConstPtrHolder[_ElementDB] inst
+        #    cdef AutowrapPtrHolder[_ElementDB] inst
 
         # private
         ElementDB() nogil except + # wrap-ignore
@@ -22,11 +22,16 @@ cdef extern from "<OpenMS/CHEMISTRY/ElementDB.h>" namespace "OpenMS":
         # const Map[unsigned int, Element * ] getAtomicNumbers() nogil except +
         const Element * getElement(const String & name) nogil except +
         const Element * getElement(UInt atomic_number) nogil except +
+        void addElement(libcpp_string name, libcpp_string symbol,
+                        unsigned int an,
+                        libcpp_map[unsigned int, double] abundance,
+                        libcpp_map[unsigned int, double] mass,
+                        bool replace_existing) nogil except +
         bool hasElement(const String & name) nogil except + # wrap-doc:Returns true if the db contains an element with the given name, else false
         bool hasElement(UInt atomic_number) nogil except + # wrap-doc:Returns true if the db contains an element with the given atomic_number, else false
 
 ## wrap static methods
 cdef extern from "<OpenMS/CHEMISTRY/ElementDB.h>" namespace "OpenMS::ElementDB":
     
-    const ElementDB* getInstance() nogil except + # wrap-ignore
+    ElementDB* getInstance() nogil except + # wrap-ignore
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5251,6 +5251,19 @@ def testElementDB():
     assert e2.getSymbol() == "O"
     assert e2.getIsotopeDistribution()
 
+    # assume we discovered a new element
+    e2 = edb.addElement("NewElement", "NE", 300, {400 : 1.0}, {400 : 400.1}, False)
+    e2 = edb.getElement(pyopenms.String("NE"))
+    assert e2.getName() == "NewElement"
+
+    # replace oxygen
+    e2 = edb.addElement("Oxygen", "O", 8, {16 : 0.7, 19 : 0.3}, {16 : 16.01, 19 : 19.01}, True)
+    e2 = edb.getElement(pyopenms.String("O"))
+    assert e2.getName() == "Oxygen"
+    assert e2.getIsotopeDistribution()
+    assert len(e2.getIsotopeDistribution()) == 2
+    assert abs(e2.getIsotopeDistribution()[1].getIntensity() - 0.3) < 1e-5
+
     # assert e == e2
 
     #  not yet implemented


### PR DESCRIPTION
# Description

Fixes  #5851 -- allows modification of ElementDB and drops the `const`

also adds the pyOpenMS bindings

However, there are some conceptual problems that remain with our approach, it seems what we call `Element` is actually used to represent *both* an element as well as an individual isotope. We may want to think about representing half lives for individual isotopes and separate the concepts of isotopes and elements (maybe with an extra class for isotopes?)