### PR TITLE
[FIX] test fix after #5891

### DIFF
--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -236,7 +236,7 @@ def testAASequence():
         print("Error: Exception not triggered.")
         assert False
     assert seq.getFormula(pyopenms.Residue.ResidueType.Full, 0) == pyopenms.EmpiricalFormula("C75H122N20O32S2Se1")
-    assert abs(seq.getMonoWeight(pyopenms.Residue.ResidueType.Full, 0) - 1952.7200317517998) < 1e-5
+    assert abs(seq.getMonoWeight(pyopenms.Residue.ResidueType.Full, 0) - 1958.7140766518) < 1e-5
     # assert seq.has(pyopenms.ResidueDB.getResidue("P"))
 
     

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -286,6 +286,21 @@ START_SECTION(AASequence fromString(const String& s, bool permissive = true))
     seq4 = AASequence::fromString("PEPTIDEK(UniMod:313)");
     TEST_STRING_EQUAL(seq4.getCTerminalModification()->getFullId(), "Lys-loss (Protein C-term K)");
   }
+
+  // test with Selenocysteine
+  {
+    AASequence seq = AASequence::fromString("PEPTIDESEKUEM(Oxidation)CER");
+    TEST_EQUAL(seq.toUniModString(), "PEPTIDESEKUEM(UniMod:35)CER")
+    TEST_EQUAL(seq.getFormula(), EmpiricalFormula("C75H122N20O32S2Se1"))
+    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2").getMonoWeight(), 1878.7975553518002)
+
+    // note that the monoisotopic weight of Selenium is 80 and not 74
+    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2Se1").getAverageWeight(), 1958.981404189803)
+    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2Se1").getMonoWeight(), 1958.7140766518)
+    TEST_REAL_SIMILAR(seq.getMonoWeight(), 1958.7140766518)
+    TEST_REAL_SIMILAR(seq.getAverageWeight(), 1958.981404189803)
+  }
+
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -292,11 +292,11 @@ START_SECTION(AASequence fromString(const String& s, bool permissive = true))
     AASequence seq = AASequence::fromString("PEPTIDESEKUEM(Oxidation)CER");
     TEST_EQUAL(seq.toUniModString(), "PEPTIDESEKUEM(UniMod:35)CER")
     TEST_EQUAL(seq.getFormula(), EmpiricalFormula("C75H122N20O32S2Se1"))
-    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2").getMonoWeight(), 1878.7975553518002)
+    TEST_REAL_SIMILAR(EmpiricalFormula("C75H122N20O32S2").getMonoWeight(), 1878.7975553518002)
 
     // note that the monoisotopic weight of Selenium is 80 and not 74
-    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2Se1").getAverageWeight(), 1958.981404189803)
-    TEST_EQUAL(EmpiricalFormula("C75H122N20O32S2Se1").getMonoWeight(), 1958.7140766518)
+    TEST_REAL_SIMILAR(EmpiricalFormula("C75H122N20O32S2Se1").getAverageWeight(), 1958.981404189803)
+    TEST_REAL_SIMILAR(EmpiricalFormula("C75H122N20O32S2Se1").getMonoWeight(), 1958.7140766518)
     TEST_REAL_SIMILAR(seq.getMonoWeight(), 1958.7140766518)
     TEST_REAL_SIMILAR(seq.getAverageWeight(), 1958.981404189803)
   }


### PR DESCRIPTION
- after the change in monoisotopic mass, we have to adjust the test for
monoisotopic mass for selenocysteine from 74 to 80 (most abundant
isotope)
