### PR TITLE
MzMLSplitter and OpenSwathFileSplitter: use output-prefix

### DIFF
--- a/src/utils/MzMLSplitter.cpp
+++ b/src/utils/MzMLSplitter.cpp
@@ -85,7 +85,7 @@ protected:
   {
     registerInputFile_("in", "<file>", "", "Input file");
     setValidFormats_("in", ListUtils::create<String>("mzML"));
-    registerStringOption_("out", "<file>", "", "Prefix for output files ('_part1of2.mzML' etc. will be appended; default: same as 'in' without the file extension)", false);
+    registerOutputPrefix_("out", "<prefix>", "", "Prefix for output files ('_part1of2.mzML' etc. will be appended; default: same as 'in' without the file extension)", false);
     registerIntOption_("parts", "<num>", 1, "Number of parts to split into (takes precedence over 'size' if set)", false);
     setMinInt_("parts", 1);
     registerIntOption_("size", "<num>", 0, "Approximate upper limit for resulting file sizes (in 'unit')", false);

--- a/src/utils/MzMLSplitter.cpp
+++ b/src/utils/MzMLSplitter.cpp
@@ -33,11 +33,10 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-
 #include <QFile>
 #include <iomanip>
 #include <sstream>
@@ -54,9 +53,13 @@ using namespace std;
 
     @brief Splits an mzML file into multiple parts
 
-    This utility will split an input mzML file into @e N parts, with an approximately equal number of spectra and chromatograms in each part. @e N is set by the parameter @p parts; optionally only spectra (parameter @p no_chrom) or only chromatograms (parameter @p no_spec) can be transferred to the output.
+    This utility will split an input mzML file into @e N parts, with an approximately equal number of spectra and chromatograms in each part.
+    @e N is set by the parameter @p parts; optionally only spectra (parameter @p no_chrom) or only chromatograms (parameter @p no_spec) can be transferred to the output.
 
-    Alternatively to setting the number of parts directly, a target maximum file size for the parts can be specified (parameters @p size and @p unit). The number of parts is then calculated by dividing the original file size by the target and rounding up. Note that the resulting parts may actually be bigger than the target size (due to meta data that is included in every part) or that more parts than necessary may be produced (if spectra or chromatograms are removed via @p no_spec/@p no_chrom).
+    Alternatively to setting the number of parts directly, a target maximum file size for the parts can be specified (parameters @p size and @p unit).
+    The number of parts is then calculated by dividing the original file size by the target and rounding up.
+    Note that the resulting parts may actually be bigger than the target size (due to meta data that is included in every part) or
+    that more parts than necessary may be produced (if spectra or chromatograms are removed via @p no_spec/@p no_chrom).
 
     This tool cannot be used as part of a TOPPAS workflow, because the number of output files is variable.
 
@@ -69,18 +72,14 @@ using namespace std;
 // We do not want this class to show up in the docu:
 /// @cond TOPPCLASSES
 
-class TOPPMzMLSplitter :
-  public TOPPBase
+class TOPPMzMLSplitter : public TOPPBase
 {
 public:
-
-  TOPPMzMLSplitter() :
-    TOPPBase("MzMLSplitter", "Splits an mzML file into multiple parts", false)
+  TOPPMzMLSplitter() : TOPPBase("MzMLSplitter", "Splits an mzML file into multiple parts", false)
   {
   }
 
 protected:
-
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input file");
@@ -98,11 +97,12 @@ protected:
     registerFlag_("no_spec", "Remove spectra, keep only chromatograms.");
   }
 
-  ExitCodes main_(int, const char **) override
+  ExitCodes main_(int, const char**) override
   {
     String in = getStringOption_("in"), out = getStringOption_("out");
 
-    if (out.empty()) out = FileHandler::stripExtension(in);
+    if (out.empty())
+      out = FileHandler::stripExtension(in);
 
     bool no_chrom = getFlag_("no_chrom"), no_spec = getFlag_("no_spec");
     if (no_chrom && no_spec)
@@ -124,9 +124,12 @@ protected:
       // use float here to avoid too many decimals in output below:
       float total_size = mzml_file.size();
       String unit = getStringOption_("unit");
-      if (unit == "KB") total_size /= 1024;
-      else if (unit == "MB") total_size /= (1024 * 1024);
-      else total_size /= (1024 * 1024 * 1024); // "GB"
+      if (unit == "KB")
+        total_size /= 1024;
+      else if (unit == "MB")
+        total_size /= (1024 * 1024);
+      else
+        total_size /= (1024 * 1024 * 1024); // "GB"
 
       writeLog_("File size: " + String(total_size) + " " + unit);
       parts = ceil(total_size / size);
@@ -136,8 +139,8 @@ protected:
     PeakMap experiment;
     MzMLFile().load(in, experiment);
 
-    vector<MSSpectrum > spectra;
-    vector<MSChromatogram > chromatograms;
+    vector<MSSpectrum> spectra;
+    vector<MSChromatogram> chromatograms;
 
     if (no_spec)
     {
@@ -165,8 +168,7 @@ protected:
     for (Size counter = 1; counter <= parts; ++counter)
     {
       ostringstream out_name;
-      out_name << out << "_part" << setw(width) << setfill('0') << counter
-               << "of" << parts << ".mzML";
+      out_name << out << "_part" << setw(width) << setfill('0') << counter << "of" << parts << ".mzML";
       PeakMap part = experiment;
       addDataProcessing_(part, getProcessingInfo_(DataProcessing::FILTERING));
 
@@ -182,8 +184,7 @@ protected:
       }
       spec_start += n_spec;
 
-      Size n_chrom = ceil((chromatograms.size() - chrom_start) /
-                          double(remaining));
+      Size n_chrom = ceil((chromatograms.size() - chrom_start) / double(remaining));
       if (n_chrom > 0)
       {
         part.reserveSpaceChromatograms(n_chrom);
@@ -194,14 +195,12 @@ protected:
       }
       chrom_start += n_chrom;
 
-      writeLog_("Part " + String(counter) + ": " + String(n_spec) + 
-                " spectra, " + String(n_chrom) + " chromatograms");
+      writeLog_("Part " + String(counter) + ": " + String(n_spec) + " spectra, " + String(n_chrom) + " chromatograms");
       MzMLFile().store(out_name.str(), part);
     }
 
     return EXECUTION_OK;
   }
-
 };
 
 

--- a/src/utils/MzMLSplitter.cpp
+++ b/src/utils/MzMLSplitter.cpp
@@ -102,7 +102,9 @@ protected:
     String in = getStringOption_("in"), out = getStringOption_("out");
 
     if (out.empty())
+    {
       out = FileHandler::stripExtension(in);
+    }
 
     bool no_chrom = getFlag_("no_chrom"), no_spec = getFlag_("no_spec");
     if (no_chrom && no_spec)

--- a/src/utils/OpenSwathFileSplitter.cpp
+++ b/src/utils/OpenSwathFileSplitter.cpp
@@ -93,8 +93,7 @@ protected:
   {
     registerInputFile_("in", "<files>", "", "Input file (SWATH/DIA file)");
     setValidFormats_("in", ListUtils::create<String>("mzML,mzXML"));
-
-    registerStringOption_("outputDirectory", "<output>", "./", "Output path to store the split files", false, true);
+    registerOutputPrefix_("outputDirectory", "<output>", "./", "Output file prefix", false, true);
     
     // additional QC data
     registerOutputFile_("out_qc", "<file>", "", "Optional QC meta data (charge distribution in MS1). Only works with mzML input files.", false, true);

--- a/src/utils/OpenSwathFileSplitter.cpp
+++ b/src/utils/OpenSwathFileSplitter.cpp
@@ -35,17 +35,12 @@
 // Files
 #include <OpenMS/ANALYSIS/OPENSWATH/SwathQC.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h>
-
+#include <OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h>
+#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/SwathFile.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h>
-
 #include <OpenMS/METADATA/ExperimentalSettings.h>
-
 #include <OpenMS/SYSTEM/File.h>
-
-
 #include <QDir>
 
 using namespace OpenMS;
@@ -55,7 +50,7 @@ using namespace OpenMS;
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 
 //-------------------------------------------------------------
-//Doxygen docu
+// Doxygen docu
 //-------------------------------------------------------------
 
 /**
@@ -77,34 +72,25 @@ using namespace OpenMS;
 // We do not want this class to show up in the docu:
 /// @cond TOPPCLASSES
 
-class TOPPOpenSwathFileSplitter
-  : public TOPPBase
+class TOPPOpenSwathFileSplitter : public TOPPBase
 {
 public:
-
-  TOPPOpenSwathFileSplitter()
-    : TOPPBase("OpenSwathFileSplitter", "Splits SWATH files into n files, each containing one window.", false)
+  TOPPOpenSwathFileSplitter() : TOPPBase("OpenSwathFileSplitter", "Splits SWATH files into n files, each containing one window.", false)
   {
   }
 
 protected:
-
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<files>", "", "Input file (SWATH/DIA file)");
     setValidFormats_("in", ListUtils::create<String>("mzML,mzXML"));
     registerOutputPrefix_("outputDirectory", "<output>", "./", "Output file prefix", false, true);
-    
     // additional QC data
     registerOutputFile_("out_qc", "<file>", "", "Optional QC meta data (charge distribution in MS1). Only works with mzML input files.", false, true);
     setValidFormats_("out_qc", ListUtils::create<String>("json"));
   }
 
-  void loadSwathFiles(const String& file_in,
-                      const String& tmp,
-                      const String& readoptions,
-                      boost::shared_ptr<ExperimentalSettings >& exp_meta,
-                      std::vector< OpenSwath::SwathMap >& swath_maps,
+  void loadSwathFiles(const String& file_in, const String& tmp, const String& readoptions, boost::shared_ptr<ExperimentalSettings>& exp_meta, std::vector<OpenSwath::SwathMap>& swath_maps,
                       Interfaces::IMSDataConsumer* plugin_consumer = nullptr)
   {
     SwathFile swath_file;
@@ -121,24 +107,23 @@ protected:
     }
     else
     {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Input file needs to have ending .mzML(.gz) or .mzXML(.gz)");
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Input file needs to have ending .mzML(.gz) or .mzXML(.gz)");
     }
   }
 
-  ExitCodes main_(int, const char **) override
+  ExitCodes main_(int, const char**) override
   {
     ///////////////////////////////////
     // Prepare Parameters
     ///////////////////////////////////
     String file_in = getStringOption_("in");
 
-	  // make sure tmp is a directory with proper separator at the end (downstream methods simply do path + filename)
-	  // (do not use QDir::separator(), since its platform specific (/ or \) while absolutePath() will always use '/')
-	  String tmp_dir = String(QDir(getStringOption_("outputDirectory").c_str()).absolutePath()).ensureLastChar('/');
+    // make sure tmp is a directory with proper separator at the end (downstream methods simply do path + filename)
+    // (do not use QDir::separator(), since its platform specific (/ or \) while absolutePath() will always use '/')
+    String tmp_dir = String(QDir(getStringOption_("outputDirectory").c_str()).absolutePath()).ensureLastChar('/');
 
-	  QFileInfo fi(file_in.toQString());
-	  String tmp = tmp_dir + String(fi.baseName());
+    QFileInfo fi(file_in.toQString());
+    String tmp = tmp_dir + String(fi.baseName());
 
     String out_qc = getStringOption_("out_qc");
 
@@ -146,7 +131,7 @@ protected:
     // Load the SWATH files
     ///////////////////////////////////
     boost::shared_ptr<ExperimentalSettings> exp_meta(new ExperimentalSettings);
-    std::vector< OpenSwath::SwathMap > swath_maps;
+    std::vector<OpenSwath::SwathMap> swath_maps;
 
     // collect some QC data
     if (out_qc.empty())
@@ -165,10 +150,9 @@ protected:
 
     return EXECUTION_OK;
   }
-
 };
 
-int main(int argc, const char ** argv)
+int main(int argc, const char** argv)
 {
   TOPPOpenSwathFileSplitter tool;
   return tool.main(argc, argv);


### PR DESCRIPTION
# Description

seems to be covered by tests:

https://github.com/OpenMS/OpenMS/blob/f3910ff6988b4910ced0787a964a8e48ced9262b/src/tests/topp/CMakeLists.txt#L2837
https://github.com/OpenMS/OpenMS/blob/f3910ff6988b4910ced0787a964a8e48ced9262b/src/tests/topp/CMakeLists.txt#L1762

ref https://github.com/OpenMS/OpenMS/issues/4404

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
