### PR TITLE
Uncomment wrapping of other operators in Empirical Formula

### DIFF
--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -62,11 +62,11 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         bool operator!=(EmpiricalFormula) nogil except + # wrap-doc:Returns true if the formulas differ in elements composition
 
         EmpiricalFormula operator+(EmpiricalFormula) nogil except +
-        # EmpiricalFormula operator-(EmpiricalFormula) nogil except +
-        # EmpiricalFormula operator*(EmpiricalFormula) nogil except +
+        EmpiricalFormula operator-(EmpiricalFormula) nogil except +
+        EmpiricalFormula operator*(EmpiricalFormula) nogil except +
 
         EmpiricalFormula iadd(EmpiricalFormula)   nogil except + # wrap-as:operator+=
-        # EmpiricalFormula iminus(EmpiricalFormula)   nogil except + # wrap-as:operator-=
+        EmpiricalFormula iminus(EmpiricalFormula)   nogil except + # wrap-as:operator-=
 
         double calculateTheoreticalIsotopesNumber() nogil except +
         

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -67,7 +67,9 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
 
         EmpiricalFormula iadd(EmpiricalFormula)   nogil except + # wrap-as:operator+=
         EmpiricalFormula isub(EmpiricalFormula)   nogil except + # wrap-as:operator-=
-        EmpiricalFormula imul(EmpiricalFormula)   nogil except + # wrap-as:operator*=
+
+        # autowrap does not support overloaded operators. Only same type
+        #EmpiricalFormula imul(unsigned int)   nogil except + # wrap-as:operator*=
 
         double calculateTheoreticalIsotopesNumber() nogil except +
         

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -66,7 +66,8 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         EmpiricalFormula operator*(EmpiricalFormula) nogil except +
 
         EmpiricalFormula iadd(EmpiricalFormula)   nogil except + # wrap-as:operator+=
-        EmpiricalFormula iminus(EmpiricalFormula)   nogil except + # wrap-as:operator-=
+        EmpiricalFormula isub(EmpiricalFormula)   nogil except + # wrap-as:operator-=
+        EmpiricalFormula imul(EmpiricalFormula)   nogil except + # wrap-as:operator*=
 
         double calculateTheoreticalIsotopesNumber() nogil except +
         

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -63,7 +63,7 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
 
         EmpiricalFormula operator+(EmpiricalFormula) nogil except +
         EmpiricalFormula operator-(EmpiricalFormula) nogil except +
-        EmpiricalFormula operator*(EmpiricalFormula) nogil except +
+        #EmpiricalFormula operator*(EmpiricalFormula) nogil except +
 
         EmpiricalFormula iadd(EmpiricalFormula)   nogil except + # wrap-as:operator+=
         EmpiricalFormula isub(EmpiricalFormula)   nogil except + # wrap-as:operator-=


### PR DESCRIPTION
Fixes #5914 if it runs through. I have no idea why it was uncommented.

# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
