### PR TITLE
[FIX] Error in FeatureMap.get_df when PeptideIdentification has no PeptideHits

### DIFF
--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -224,6 +224,8 @@ class FeatureMapDF(FeatureMap):
                     if len(hits) > 0:
                         besthit = hits[0]
                         pep_values = (besthit.getSequence().toString(), besthit.getScore(), ID_filename, f.getMetaValue('spectrum_native_id'))
+                    else:
+                        pep_values = (None, None, None, None)
                 else:
                     pep_values = (None, None, None, None)
             else:


### PR DESCRIPTION
# Description

Fix small bug in FeatureMap.get_df during export of peptide identifications. In rare cases the PeptideHits are empty, e.g. IDMapper annotations of features that have fragmented, which was not considered before.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
