### PR TITLE
[DOC] Require and document the actually required min Qt version

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -151,7 +151,7 @@ endif()
 #------------------------------------------------------------------------------
 # QT
 #------------------------------------------------------------------------------
-SET(QT_MIN_VERSION "5.5.0")
+SET(QT_MIN_VERSION "5.6.0")
 
 # find qt
 set(OpenMS_QT_COMPONENTS Core Network Sql CACHE INTERNAL "QT components for core lib")

--- a/doc/doxygen/install/install-linux.doxygen
+++ b/doc/doxygen/install/install-linux.doxygen
@@ -50,7 +50,7 @@
   <ul>
     <li>
       Essential are \b gcc/g++ (>= 7.0) or similar ANSI C++ compiler with full C++17 support,
-      \b CMake (>= 3.1; with >= 3.9 suggested), \b Qt5, \b patch, \b autoconf (> 2.60), \b automake (> 1.9), \b libtool (libtoolize/glibtoolize).
+      \b CMake (>= 3.1; with >= 3.9 suggested), \b Qt5 (>= 5.6), \b patch, \b autoconf (> 2.60), \b automake (> 1.9), \b libtool (libtoolize/glibtoolize).
     </li>
     <li>
       For the complete feature set to be enabled, %OpenMS needs recent versions of


### PR DESCRIPTION
fixes #5604

for the most part. As discussed, I think this is reasonable.