### PR TITLE
Fix/gui

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DataSelectionTabs.h
@@ -89,6 +89,9 @@ namespace OpenMS
     /// Default constructor
     DataSelectionTabs(QWidget* parent, TOPPViewBase* tv);
 
+    /// Destructor
+    ~DataSelectionTabs();
+
     /// Update items in the tabs according to the currently selected layer.
     /// Tabs which have data to show are automatically enabled. Others are disabled.
     /// If the currently visible tab would have to data to show, we pick the highest (rightmost) tab

--- a/src/openms_gui/include/OpenMS/VISUAL/Painter1DBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Painter1DBase.h
@@ -50,6 +50,8 @@ namespace OpenMS
   class OPENMS_GUI_DLLAPI Painter1DBase
   {
   public:
+    virtual ~Painter1DBase() = default;
+
     /**
        @brief Paints items using the given painter onto the canvas.
  

--- a/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
+++ b/src/openms_gui/source/VISUAL/DataSelectionTabs.cpp
@@ -112,6 +112,13 @@ namespace OpenMS
     connect(this, &QTabWidget::tabBarDoubleClicked, this, &DataSelectionTabs::tabBarDoubleClicked);
   }
 
+  DataSelectionTabs::~DataSelectionTabs()
+  {
+    delete spectraview_controller_;
+    delete idview_controller_;
+    delete diatab_controller_;
+  }
+
   LayerDataBase* getCurrentLayerData(TOPPViewBase* tv)
   {
     PlotCanvas* cc = tv->getActiveCanvas();

--- a/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVSpectraViewController.cpp
@@ -199,15 +199,16 @@ namespace OpenMS
       // only need to grab the one with the desired index
       ExperimentSharedPtrType exp_sptr = layer.getChromatogramData();
       auto ondisc_sptr = layer.getOnDiscPeakData();
+      auto annotation = layer.getChromatogramAnnotation();
+      String fname = layer.filename;
 
       widget_1d->canvas()->removeLayers();
 
       // fix legend and set layer name
-      String fname = layer.filename;
       String caption = fname + "[" + index + "]";
 
       // add chromatogram data as peak spectrum and update other controls
-      widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, fname, caption, false);
+      widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, annotation, index, fname, caption, false);
 
       tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)
     }
@@ -236,13 +237,14 @@ namespace OpenMS
       // first get raw data (the full experiment with all chromatograms), we
       // only need to grab the ones with the desired indices
       ExperimentSharedPtrType exp_sptr = layer.getChromatogramData();
-      auto ondisc_sptr = layer.getOnDiscPeakData();
 
-      widget_1d->canvas()->removeLayers();
+      String fname = layer.filename;
+      auto annotation = layer.getChromatogramAnnotation();
+      auto ondisc_sptr = layer.getOnDiscPeakData();
+      widget_1d->canvas()->removeLayers(); // this actually deletes layer, make sure its not used any more
 
       widget_1d->canvas()->blockSignals(true);
       RAIICleanup clean([&]() {widget_1d->canvas()->blockSignals(false); });
-      String fname = layer.filename;
       for (const auto& index : indices)
       {
         // get caption (either chromatogram idx or peptide sequence, if available)
@@ -253,7 +255,7 @@ namespace OpenMS
         }
         ((caption += "[") += index) += "]";
         // add chromatogram data as peak spectrum
-        widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, layer.getChromatogramAnnotation(), index, fname, caption, true);
+        widget_1d->canvas()->addChromLayer(exp_sptr, ondisc_sptr, annotation, index, fname, caption, true);
       }
 
       tv_->updateBarsAndMenus(); // needed since we blocked update above (to avoid repeated layer updates for many layers!)


### PR DESCRIPTION
# Description

Several fixes that cause segfaults / memory leaks in TOPPView

- major bugfix for chromatogram view: use-after-free fixed for `layer` which caused random segfaults when viewing chromatograms.
- `Painter1DBase` needs a virtual destructor since its a base class, now the correct destructor is called (for derived, not base class)