### PR TITLE
[FIX] massql df export empty spectrum

### DIFF
--- a/src/pyOpenMS/pyopenms/dataframes.py
+++ b/src/pyOpenMS/pyopenms/dataframes.py
@@ -369,7 +369,7 @@ class MSExperimentDF(MSExperiment):
                 if spec.getMSLevel() == mslevel:
                     mz, inty = spec.get_peaks()
                     # data for both DataFrames: i, i_norm, i_tic_norm, mz, scan, rt, polarity
-                    data = (inty, inty/np.amax(inty), inty/np.sum(inty), mz, scan_num + 1, spec.getRT()/60, _get_polarity(spec))
+                    data = (inty, inty/np.amax(inty, initial=0), inty/np.sum(inty), mz, scan_num + 1, spec.getRT()/60, _get_polarity(spec))
                     cols = 7
                     if mslevel == 2:
                         cols = 10


### PR DESCRIPTION
# Description

MSExperiment.get_massql_df failed on empty spectra. Setting initial value for np.amax solved the issue.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
