### PR TITLE
attempt to fix linux pyopenms-wheel action

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -321,6 +321,7 @@ jobs:
             for i in 0{1..3}
             do
               PYBIN="${py_paths[${#py_paths[@]}-i]}"
+              "$PYBIN/bin/pip" install -U pip
               "$PYBIN/bin/pip" install -U Cython
               "$PYBIN/bin/pip" install -U setuptools
               "$PYBIN/bin/pip" install -U wheel==0.31.1
@@ -345,7 +346,7 @@ jobs:
               PYBIN="${py_paths[${#py_paths[@]}-i]}"
 
               # configure
-              cmake -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DCMAKE_PREFIX_PATH="/contrib-build/" -DPYOPENMS=On -DPYTHON_EXECUTABLE:FILEPATH=$PYBIN/bin/python $GITHUB_WORKSPACE/OpenMS
+              cmake -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DCMAKE_PREFIX_PATH="/contrib-build/" -DPYOPENMS=On -DPYTHON_EXECUTABLE:FILEPATH=$PYBIN/bin/python3 $GITHUB_WORKSPACE/OpenMS
               make -j4 pyopenms
 
               pushd pyOpenMS


### PR DESCRIPTION
# Description

Currently it is looking for python at: /opt/python/cp39-cp39/bin/python
but maybe /opt/python/cp39-cp39/bin/python3 works.

If that is not the case, the python executables are probables named /opt/python/cp39-cp39/bin/python3.9 etc.
Which would make things a bit more complex as we run the script for the last 3 python versions.


# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
