### PR TITLE
[FIX] suppress [-Wdeprecated-declaration] warnings until Qt5.14

### DIFF
--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DCaret.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DCaret.cpp
@@ -158,7 +158,15 @@ namespace OpenMS
       bool found_intersection = false;
 
       // intersection with top
+      /*
+       * These pragmas can be removed when we are on Qt 5.14 or later
+       * QLineF::IntersectType QLineF::intersect() is deprecated at Qt 5.14
+       */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(top, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(caret_position_widget, *ip).length() < QLineF(caret_position_widget, *closest_ip).length())
       {
@@ -166,7 +174,11 @@ namespace OpenMS
         *closest_ip = *ip;
       }
       // intersection with left
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(left, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(caret_position_widget, *ip).length() < QLineF(caret_position_widget, *closest_ip).length())
       {
@@ -175,7 +187,11 @@ namespace OpenMS
       }
 
       // intersection with right
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(right, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(caret_position_widget, *ip).length() < QLineF(caret_position_widget, *closest_ip).length())
       {
@@ -184,7 +200,11 @@ namespace OpenMS
       }
 
       // intersection with bottom
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(bottom, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(caret_position_widget, *ip).length() < QLineF(caret_position_widget, *closest_ip).length())
       {

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DPeakItem.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DPeakItem.cpp
@@ -158,7 +158,15 @@ namespace OpenMS
       bool found_intersection = false;
 
       // intersection with top
+      /*
+       * These pragmas can be removed when we are on Qt 5.14 or later
+       * QLineF::IntersectType QLineF::intersect() is deprecated at Qt 5.14
+       */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(top, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(peak_position_widget, *ip).length() < QLineF(peak_position_widget, *closest_ip).length())
       {
@@ -166,7 +174,11 @@ namespace OpenMS
         *closest_ip = *ip;
       }
       // intersection with left
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(left, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(peak_position_widget, *ip).length() < QLineF(peak_position_widget, *closest_ip).length())
       {
@@ -175,7 +187,11 @@ namespace OpenMS
       }
 
       // intersection with right
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(right, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(peak_position_widget, *ip).length() < QLineF(peak_position_widget, *closest_ip).length())
       {
@@ -184,7 +200,11 @@ namespace OpenMS
       }
 
       // intersection with bottom
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       itype = line.intersect(bottom, ip);
+#pragma GCC diagnostic pop
+
       if (itype == QLineF::BoundedIntersection &&
           QLineF(peak_position_widget, *ip).length() < QLineF(peak_position_widget, *closest_ip).length())
       {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Fixes #5930 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
