### PR TITLE
[FIX] deprecated QDirModel and update with QFileSystemModel

### DIFF
--- a/src/openms_gui/source/VISUAL/InputFile.cpp
+++ b/src/openms_gui/source/VISUAL/InputFile.cpp
@@ -41,7 +41,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QCompleter>
-#include <QtWidgets/QDirModel>
+#include <QFileSystemModel>
 #include <QDragEnterEvent>
 #include <QMimeData>
 
@@ -54,7 +54,7 @@ namespace OpenMS
   {
     ui_->setupUi(this);
     QCompleter* completer = new QCompleter(this);
-    completer->setModel(new QDirModel(completer));
+    completer->setModel(new QFileSystemModel(completer));
     ui_->line_edit->setCompleter(completer);
     connect(ui_->browse_button, SIGNAL(clicked()), this, SLOT(showFileDialog()));
   }

--- a/src/openms_gui/source/VISUAL/OutputDirectory.cpp
+++ b/src/openms_gui/source/VISUAL/OutputDirectory.cpp
@@ -42,7 +42,7 @@
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QCompleter>
-#include <QtWidgets/QDirModel>
+#include <QFileSystemModel>
 
 
 namespace OpenMS
@@ -53,7 +53,7 @@ namespace OpenMS
   {
     ui_->setupUi(this);
     QCompleter* completer = new QCompleter(this);
-    QDirModel* dir_model = new QDirModel(completer);
+    QFileSystemModel* dir_model = new QFileSystemModel(completer);
     dir_model->setFilter(QDir::AllDirs);
     completer->setModel(dir_model);
     ui_->line_edit->setCompleter(completer);


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Fixes #5939 
# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
