### PR TITLE
[FIX] deprecated QTreeWidgetItem::setTextColor

### DIFF
--- a/src/openms_gui/source/VISUAL/ParamEditor.cpp
+++ b/src/openms_gui/source/VISUAL/ParamEditor.cpp
@@ -520,7 +520,7 @@ namespace OpenMS
           item = new QTreeWidgetItem(parent);
           //name
           item->setText(0, String(par.name).toQString());
-          item->setTextColor(0, Qt::darkGray);  // color of nodes with children
+          item->setForeground(0, Qt::darkGray);  // color of nodes with children
 
           //description
           item->setData(1, Qt::UserRole, String(par.description).toQString());
@@ -554,15 +554,15 @@ namespace OpenMS
       bool is_required = it->tags.find("required") != it->tags.end();
       if (is_required)  // special color for required parameters
       {
-        item->setTextColor(0, QColor(255, 140, 0, 255)); // orange
-        item->setTextColor(2, QColor(255, 140, 0, 255));
-        item->setTextColor(3, QColor(255, 140, 0, 255));
+        item->setForeground(0, QColor(255, 140, 0, 255)); // orange
+        item->setForeground(2, QColor(255, 140, 0, 255));
+        item->setForeground(3, QColor(255, 140, 0, 255));
       }
       else
       {
-        item->setTextColor(0, Qt::darkGray);
-        item->setTextColor(2, Qt::darkGray);
-        item->setTextColor(3, Qt::darkGray);
+        item->setForeground(0, Qt::darkGray);
+        item->setForeground(2, Qt::darkGray);
+        item->setForeground(3, Qt::darkGray);
       }
 
       // advanced parameter


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Fixes #5945

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
