### PR TITLE
Suppress -Wunused-variable mac warnings

### DIFF
--- a/src/openms/source/FILTERING/CALIBRATION/TOFCalibration.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/TOFCalibration.cpp
@@ -194,8 +194,6 @@ namespace OpenMS
 
   void TOFCalibration::getMonoisotopicPeaks_(PeakMap & calib_peaks, std::vector<std::vector<unsigned int> > & monoiso_peaks)
   {
-
-    [[maybe_unused]] PeakMap::iterator spec_iter;
     PeakMap::SpectrumType::iterator peak_iter, help_iter;
 
 #ifdef DEBUG_CALIBRATION

--- a/src/openms/source/FILTERING/CALIBRATION/TOFCalibration.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/TOFCalibration.cpp
@@ -195,7 +195,7 @@ namespace OpenMS
   void TOFCalibration::getMonoisotopicPeaks_(PeakMap & calib_peaks, std::vector<std::vector<unsigned int> > & monoiso_peaks)
   {
 
-    PeakMap::iterator spec_iter;
+    [[maybe_unused]] PeakMap::iterator spec_iter;
     PeakMap::SpectrumType::iterator peak_iter, help_iter;
 
 #ifdef DEBUG_CALIBRATION

--- a/src/tests/class_tests/openms/source/LibSVMEncoder_test.cpp
+++ b/src/tests/class_tests/openms/source/LibSVMEncoder_test.cpp
@@ -540,7 +540,7 @@ START_SECTION((void libSVMVectorToString(svm_node* vector, String& output)))
 	String allowed_characters = "ACNGT";
 	vector< pair<Int, double> > encoded_sequence;
 	svm_node* nodes;
-	vector<svm_node*>::iterator it;
+	[[maybe_unused]] vector<svm_node*>::iterator it;
 	String output;	
 	String correct_output = "(1, 0.1) (2, 0.2) (4, 0.3) (5, 0.4) ";
 	

--- a/src/tests/class_tests/openms/source/LibSVMEncoder_test.cpp
+++ b/src/tests/class_tests/openms/source/LibSVMEncoder_test.cpp
@@ -540,7 +540,6 @@ START_SECTION((void libSVMVectorToString(svm_node* vector, String& output)))
 	String allowed_characters = "ACNGT";
 	vector< pair<Int, double> > encoded_sequence;
 	svm_node* nodes;
-	[[maybe_unused]] vector<svm_node*>::iterator it;
 	String output;	
 	String correct_output = "(1, 0.1) (2, 0.2) (4, 0.3) (5, 0.4) ";
 	


### PR DESCRIPTION
# Description

Suppresses mac warnings for ```-Wunused-variable```. 

Fixed ``` src/openms/source/FILTERING/CALIBRATION/TOFCalibration.cpp:198:23: warning: unused variable 'spec_iter' [-Wunused-variable]```

Fixed ```src/tests/class_tests/openms/source/LibSVMEncoder_test.cpp:543:30: warning: unused variable 'it' [-Wunused-variable]```

Fixed 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

Fixes #5940 7th and 13th points
