### PR TITLE
fixes-array-subscript-for-char-values

### DIFF
--- a/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
+++ b/src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp
@@ -428,7 +428,7 @@ START_SECTION(constexpr AA())
   // make sure ctor is constexpr
   static_assert(AA('?').isValid() == false);
 
-  static_assert(AA('?')() == CharToAA['?']);
+  static_assert(AA('?')() == CharToAA[(unsigned char)'?']);
 
   static_assert(AA('G') <= AA('B'));
   


### PR DESCRIPTION
# Description
This PR fixes Arrau Subscript Warning for char values by casting them to `(unsigned char)` since the indices can only take non-negative values. 
Warning - `src/tests/class_tests/openms/source/AhoCorasickAmbiguous_test.cpp:431:30: warning: array subscript is of type 'char' [-Wchar-subscripts] and 431:38: warning: array subscript is of type 'char' [-Wchar-subscripts]`

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

Fixes #5940 12th Point
