### PR TITLE
[FIX] various Qtime methods deprecated

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -60,6 +60,7 @@
 #include <QtWidgets/QActionGroup>
 #include <QtCore/QStringList>
 #include <QtCore/QProcess>
+#include <QElapsedTimer>
 
 class QAction;
 class QComboBox;
@@ -523,7 +524,7 @@ protected:
       UInt window_id;
       Size spectrum_id;
       QProcess* process = nullptr;
-      QTime timer;
+      QElapsedTimer timer;
       bool visible_area_only;
     } topp_;
     //@}

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -56,7 +56,7 @@
 // Qt
 #include <QMouseEvent>
 #include <QPainter>
-#include <QtCore/QTime>
+#include <QElapsedTimer>
 #include <QtWidgets/QFileDialog>
 #include <QtWidgets/QInputDialog>
 #include <QtWidgets/QMenu>
@@ -716,7 +716,7 @@ namespace OpenMS
 
   void Plot1DCanvas::paint(QPainter* painter, QPaintEvent* e)
   {
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     // clear

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -57,7 +57,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPolygon>
-#include <QtCore/QTime>
+#include <QElapsedTimer>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QMessageBox>
@@ -1448,7 +1448,7 @@ namespace OpenMS
 #endif
 
     //timing
-    QTime overall_timer;
+    QElapsedTimer overall_timer;
     if (show_timing_)
     {
       overall_timer.start();
@@ -1472,7 +1472,7 @@ namespace OpenMS
 
       buffer_.fill(QColor(String(param_.getValue("background_color").toString()).toQString()).rgb());
       painter.begin(&buffer_);
-      QTime layer_timer;
+      QElapsedTimer layer_timer;
 
       for (Size i = 0; i < getLayerCount(); i++)
       {

--- a/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
+++ b/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
@@ -35,7 +35,7 @@
 #include <TOPPView_test.h>
 
 #include <QTimer>
-
+#include <QElapsedTimer>
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/EnhancedTabBar.h>
@@ -71,7 +71,7 @@ void TestTOPPView::waitForModalWidget(const int max_wait, const String& line)
   }
 
 
-  QTime t;
+  QElapsedTimer t;
   t.start();
   while (!modal_key_sequence_.isEmpty () && max_wait > t.elapsed())
   {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Fixes #5924 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
