### PR TITLE
[FIX] suppress buttongroup(int) is deprecated

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -231,7 +231,13 @@ namespace OpenMS
     intensity_button_group_->addButton(b, PlotCanvas::IM_LOG);
     tool_bar_->addWidget(b);
 
+    /*
+     * Suppressed warning QButtonGroup buttonClicked(int) till Qt 5.15
+     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     connect(intensity_button_group_, CONNECTCAST(QButtonGroup,buttonClicked,(int)), this, &TOPPViewBase::setIntensityMode);
+#pragma GCC diagnostic pop
     tool_bar_->addSeparator();
 
     //common buttons
@@ -266,7 +272,14 @@ namespace OpenMS
     draw_group_1d_->addButton(b, Plot1DCanvas::DM_CONNECTEDLINES);
     tool_bar_1d_->addWidget(b);
 
+    /*
+     * Suppressed warning QButtonGroup buttonClicked(int) till Qt 5.15
+     */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     connect(draw_group_1d_, CONNECTCAST(QButtonGroup, buttonClicked, (int)), this, &TOPPViewBase::setDrawMode1D);
+#pragma GCC diagnostic pop
+
     tool_bar_->addSeparator();
 
     //--2D peak toolbar--


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
Fixes #5932 

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
