### PR TITLE
Fix 5911

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -72,6 +72,7 @@ the authors tag in the respective file header.
  - Matthew The
  - Matthias Bernt
  - Michał Startek
+ - Moritz Berger
  - Nico Pfeifer
  - Ole Schulz-Trieglaff
  - Oliver Alka

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -119,7 +119,6 @@ namespace OpenMS
     OpenMS::UInt64 run_id_;
     bool doWrite_;
     bool use_ms1_traces_;
-    bool sonar_;
     bool enable_uis_scoring_;
 
   public:

--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
@@ -157,7 +157,6 @@ class OPENMS_DLLAPI SplineInterpolatedPeaks
         /**
         * @brief m/z (or RT) limits of the spectrum (or chromatogram)
         */
-        double pos_min_;
         double pos_max_;
         
         /**

--- a/src/openms/include/OpenMS/KERNEL/RangeUtils.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeUtils.h
@@ -184,7 +184,7 @@ public:
     {
       Int tmp = s.getMSLevel();
       // XOR(^): same as 'if (rev_) return !(test) else return test;' where (test) is the condition;   Speed: XOR is about 25% faster in VS10
-      return reverse_ ^ std::find(levels_.begin(), levels_.end(), tmp) != levels_.end();
+      return reverse_ ^ (std::find(levels_.begin(), levels_.end(), tmp) != levels_.end());
     }
 
 protected:

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -58,17 +58,6 @@ namespace OpenMS
   {
   }
 
-  static int callback(void * /* NotUsed */, int argc, char **argv, char **azColName)
-  {
-    int i;
-    for (i = 0; i < argc; i++)
-    {
-      printf("%s = %s\n", azColName[i], argv[i] ? argv[i] : "NULL");
-    }
-    printf("\n");
-    return 0;
-  }
-
   void TransitionPQPFile::readPQPInput_(const char* filename, std::vector<TSVTransition>& transition_list, bool legacy_traml_id)
   {
     sqlite3 *db;


### PR DESCRIPTION
Took  three warnings from https://cdash.openms.de/build/20646 ( pr-5911-macOS_10.14.6_x64-appleclang-11.0.0-Release-x64) and solved (tot he best of my knowledge). 
1. Added myselft to Authors.
2. removed pos_min from: src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h reason: warning: private field 'pos_min_' is not used [-Wunused-private-field]
3. removed sonar_ from src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h reason:  warning: private field 'sonar_' is not used [-Wunused-private-field]
4. removed function callback from: src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp reason:  warning: unused function 'callback' [-Wunused-function]






# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
