### PR TITLE
use contrib_manylinux container from github registry

### DIFF
--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -125,7 +125,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    continue-on-error: true
+    continue-on-error: true    
     steps:
     - uses: actions/checkout@v2
       with:
@@ -140,6 +140,7 @@ jobs:
         install-deps: 'true'
         modules: 'qtsvg'
         cached: 'false'
+        setup-python: 'false' # fixes an error with newer qt versions
 
     - name: Install build tools
       run: brew install autoconf automake libtool

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -250,7 +250,7 @@ jobs:
   build-lnx:
     runs-on: ubuntu-latest
     continue-on-error: true
-    container: openms/manylinux:latest
+    container: ghcr.io/openms/contrib_manylinux2014:latest
 
     steps:
     # Cancels older builds if still running

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -140,7 +140,7 @@ jobs:
         install-deps: 'true'
         modules: 'qtsvg'
         cached: 'false'
-        setup-python: 'false' # fixes an error with newer qt versions
+        setup-python: 'false' # see https://github.com/jurplel/install-qt-action/issues/130
 
     - name: Install build tools
       run: brew install autoconf automake libtool

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -269,7 +269,6 @@ jobs:
       if: github.event_name == 'push'
       shell: bash
       run: |
-        yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum -y install jq
         ref=`jq --raw-output .ref "$GITHUB_EVENT_PATH"`
         ref=${ref#"refs/heads/"}
@@ -282,7 +281,6 @@ jobs:
       if: github.event_name == 'pull_request'
       shell: bash
       run: |
-        yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
         yum -y install jq
         echo "RUN_NAME=pr$(jq --raw-output .pull_request.number $GITHUB_EVENT_PATH)" >> $GITHUB_ENV
       id: extract_pr

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -125,7 +125,7 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    continue-on-error: true    
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -287,7 +287,7 @@ jobs:
 
   build-lnx:
     runs-on: ubuntu-latest
-    container: openms/manylinux:latest
+    container: ghcr.io/openms/contrib_manylinux2014:latest
 
     steps:
     # Cancels older builds if still running

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -154,6 +154,7 @@ jobs:
         install-deps: 'true'
         modules: 'qtsvg'
         cached: 'false'
+        setup-python: 'false' # fixes an error with newer qt versions
 
     - name: Install Miniconda
       shell: bash

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -154,7 +154,7 @@ jobs:
         install-deps: 'true'
         modules: 'qtsvg'
         cached: 'false'
-        setup-python: 'false' # fixes an error with newer qt versions
+        setup-python: 'false' # https://github.com/jurplel/install-qt-action/issues/130
 
     - name: Install Miniconda
       shell: bash


### PR DESCRIPTION
# Description

We use github package registry now to host our container used in CI. Previously those were on dockerhub

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
