### PR TITLE
[FEATURE] package type stubs with pyopenms

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -357,6 +357,7 @@ file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS/extra_includes)
 
 _copy_assets("${PROJECT_SOURCE_DIR}/pyopenms/" "*.py" ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms/)
 _copy_assets("${PROJECT_SOURCE_DIR}/pyopenms/" "*.sh" ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms/)
+_copy_assets("${PROJECT_SOURCE_DIR}/pyopenms/" "py.typed" ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms/)
 _copy_assets("${PROJECT_SOURCE_DIR}/pyTOPP/" "*.py" ${CMAKE_BINARY_DIR}/pyOpenMS/pyTOPP/)
 _copy_assets("${PROJECT_SOURCE_DIR}/tests/unittests/" "*" ${CMAKE_BINARY_DIR}/pyOpenMS/tests/unittests)
 _copy_assets("${PROJECT_SOURCE_DIR}/tests/" "*.mzXML" ${CMAKE_BINARY_DIR}/pyOpenMS/tests)

--- a/src/pyOpenMS/MANIFEST.in
+++ b/src/pyOpenMS/MANIFEST.in
@@ -4,6 +4,7 @@ include pyopenms/*.dll
 include pyopenms/*.dylib
 include pyopenms/*.so
 include pyopenms/*.pyd
+include pyopenms/*.pyi
 include pyopenms/*.txt
 graft pyopenms/*.framework
 include pyopenms/Qt*

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -253,6 +253,9 @@ setup(
     name=package_name,
     packages=["pyopenms"],
     ext_package="pyopenms",
+    package_data= {
+        'pyopenms': ['py.typed']
+    },
 	install_requires=[
           'numpy',
           'pandas'


### PR DESCRIPTION
# Description

Fixes #5821

I am just having some problems with internal imports. I think in theory we somehow need to import each submodule in each submodule, such that the type engine finds all types from sibling modules. Maybe we need a __init__.pyi?
I tried that on PyCharm but it did not completely solve it. Trying mypy would be another TODO.
