### PR TITLE
[FIX] add missing std::array header file

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMergerAlgorithm.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <unordered_map>
+#include <array>
 
 using namespace std;
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -36,6 +36,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <QDir>
+#include <array>
 
 using std::vector;
 using std::string;

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -43,6 +43,7 @@
 
 #include <atomic>
 #include <map>
+#include <array>
 
 #ifdef _OPENMP 
 #include <omp.h>


### PR DESCRIPTION
## Fix the build failure with Visual Studio 2022 on Windows 10

Add missing header files of std::array in order to pass the build.
And boost 1.78.0 is required, if you are going to work with VS2022, .

