### PR TITLE
Fix failing IM tests (issue #4339)

### DIFF
--- a/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
@@ -127,7 +127,8 @@ namespace OpenSwath::Scoring
 
     void standardize_data(std::vector<double>& data)
     {
-      if (data.size() == 0){
+      if (data.empty())
+      {
 	      return;
       }
 

--- a/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
@@ -127,7 +127,9 @@ namespace OpenSwath::Scoring
 
     void standardize_data(std::vector<double>& data)
     {
-      OPENSWATH_PRECONDITION(data.size() > 0, "Need non-empty array.");
+      if (data.size() == 0){
+	      return;
+      }
 
       // subtract the mean and divide by the standard deviation
       double mean = std::accumulate(data.begin(), data.end(), 0.0) / (double) data.size();
@@ -178,7 +180,7 @@ namespace OpenSwath::Scoring
     XCorrArrayType calculateCrossCorrelation(const std::vector<double>& data1,
                                              const std::vector<double>& data2, const int maxdelay, const int lag)
     {
-      OPENSWATH_PRECONDITION(data1.size() != 0 && data1.size() == data2.size(), "Both data vectors need to have the same length");
+      OPENSWATH_PRECONDITION(data1.size() == data2.size(), "Both data vectors need to have the same length");
 
       XCorrArrayType result;
       result.data.reserve( (size_t)std::ceil((2*maxdelay + 1) / lag));

--- a/src/tests/class_tests/openms/source/IonMobilityScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/IonMobilityScoring_test.cpp
@@ -444,7 +444,7 @@ START_SECTION(([EXTRA]
   TEST_EQUAL(drift_spectrum->getMZArray()->data.size(), 24)
   TEST_EQUAL(drift_spectrum->getMZArray()->data.size(), drift_spectrum->getIntensityArray()->data.size())
   TEST_EQUAL(drift_spectrum->getMZArray()->data.size(), drift_spectrum->getDriftTimeArray()->data.size())
-  /*
+  
   IonMobilityScoring::driftScoringMS1Contrast(drift_spectrum, drift_spectrum_ms1, transitions, scores,
                                    drift_lower, drift_upper,
                                    dia_extract_window_, dia_extraction_ppm_,
@@ -507,11 +507,9 @@ START_SECTION(([EXTRA]
   TEST_EQUAL(std::isnan(scores.im_ms1_contrast_shape), true)
   TEST_REAL_SIMILAR(scores.im_ms1_sum_contrast_coelution, 0)
   TEST_EQUAL(std::isnan(scores.im_ms1_sum_contrast_shape), true)
-  */
 }
 END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-


### PR DESCRIPTION
# Description

Fix  https://github.com/OpenMS/OpenMS/issues/4339
IM tests that failed was the one that had 0 MS1 and 0 MS2 transitions
extracted.

To fix failing IM test allow standardize_data and
calculateCrossCorrelation to accept empty vectors (in Scoring.cpp)

Please include a summary of the change and which issue is fixed.

# Checklist:
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/rebase` will try to rebase the PR on the current develop branch.
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
