### PR TITLE
Fix/linear transform

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
       symmetric_ = params_.getValue("symmetric_regression") == "true";
       // weight the data (if weighting is specified)
       TransformationModel::DataPoints data_weighted = data;
-      if ((params.exists("x_weight") && params.getValue("x_weight") != "x") 
+      if ((params.exists("x_weight") && params.getValue("x_weight") != "x")
        || (params.exists("y_weight") && params.getValue("y_weight") != "y"))
       {
         weightData(data_weighted);
@@ -74,7 +74,7 @@ namespace OpenMS
                                          "no data points for 'linear' model");
       }
       else if (size == 1) // degenerate case, but we can still do something
-      {               
+      {
         slope_ = 1.0;
         intercept_ = data_weighted[0].second - data_weighted[0].first;
       }
@@ -84,9 +84,22 @@ namespace OpenMS
         {
           points.push_back(Wm5::Vector2d(data_weighted[i].first, data_weighted[i].second));
         }
-        if (!Wm5::HeightLineFit2<double>(static_cast<int>(size), &points.front(), slope_, intercept_))
+        if (size == 2)
         {
-          throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "TransformationModelLinear", "Unable to fit linear transformation to data points.");
+          if (!Wm5::HeightLineFit2<double>(static_cast<int>(size), &points.front(), slope_, intercept_))
+          {
+            // if the two points are too close, Wm5::HeightLineFit2 can't fit a line
+            // but in the special case of two points, there is an exact solution and we don't need a least-sqaures fit
+            slope_ = (data_weighted[1].second - data_weighted[0].second) / (data_weighted[1].first - data_weighted[0].first);
+            intercept_ = data_weighted[0].second - (slope_ * data_weighted[0].first);
+          }
+        }
+        else
+        {
+          if (!Wm5::HeightLineFit2<double>(static_cast<int>(size), &points.front(), slope_, intercept_))
+          {
+            throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "TransformationModelLinear", "Unable to fit linear transformation to data points.");
+          }
         }
       }
       // update params
@@ -97,7 +110,7 @@ namespace OpenMS
 
   double TransformationModelLinear::evaluate(double value) const
   {
-    if (!weighting_) 
+    if (!weighting_)
     {
       return slope_ * value + intercept_;
     }
@@ -117,7 +130,7 @@ namespace OpenMS
     }
     intercept_ = -intercept_ / slope_;
     slope_ = 1.0 / slope_;
-    
+
     // invert the weights:
     std::swap(x_datum_min_,y_datum_min_);
     std::swap(x_datum_max_,y_datum_max_);

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Hendrik Weisser $
+// $Authors: Hendrik Weisser, Eugen Netz $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
@@ -86,12 +86,14 @@ namespace OpenMS
         }
         if (size == 2)
         {
-          if (!Wm5::HeightLineFit2<double>(static_cast<int>(size), &points.front(), slope_, intercept_))
+          // if the two points are too close, Wm5::HeightLineFit2 can't fit a line
+          // but in the special case of two points, there is an exact solution and we don't need a least-sqaures fit
+          slope_ = (data_weighted[1].second - data_weighted[0].second) / (data_weighted[1].first - data_weighted[0].first);
+          intercept_ = data_weighted[0].second - (slope_ * data_weighted[0].first);
+
+          if (std::isinf(slope_) || std::isnan(slope_) || std::isinf(intercept_) || std::isnan(intercept_))
           {
-            // if the two points are too close, Wm5::HeightLineFit2 can't fit a line
-            // but in the special case of two points, there is an exact solution and we don't need a least-sqaures fit
-            slope_ = (data_weighted[1].second - data_weighted[0].second) / (data_weighted[1].first - data_weighted[0].first);
-            intercept_ = data_weighted[0].second - (slope_ * data_weighted[0].first);
+            throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "TransformationModelLinear", "Unable to fit linear transformation to the two data points.");
           }
         }
         else


### PR DESCRIPTION
# Description

Least-squares fitting with `Wm5::HeightLineFit2` can fail with two points that are too close to each other.
Added code to handle this specific case manually, since there is an exact solution with two points.

Fixes #5978

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
