### PR TITLE
[FIX] BasicStatistics: reasonable results with vectors of zeroes

### DIFF
--- a/src/openms/include/OpenMS/MATH/STATISTICS/BasicStatistics.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/BasicStatistics.h
@@ -132,6 +132,12 @@ public:
           variance_ += *iter * diff;
         }
         variance_ /= sum_;
+
+        if (sum_ == 0 && (std::isnan(mean_) || std::isinf(mean_)) )
+        {
+          mean_ = 0;
+          variance_ = 0;
+        }
       }
 
       /// This does the actual calculation.
@@ -310,4 +316,3 @@ private:
   }   // namespace Math
 
 } // namespace OpenMS
-

--- a/src/tests/class_tests/openms/source/BasicStatistics_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicStatistics_test.cpp
@@ -1,32 +1,32 @@
 // --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
+//                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
 // ETH Zurich, and Freie Universitaet Berlin 2002-2021.
-// 
+//
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
 //    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
+// For a full list of authors, refer to the file AUTHORS.
 // --------------------------------------------------------------------------
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
 // $Authors: $
@@ -90,7 +90,13 @@ namespace OpenMS
 		29.84631, 47.59564, 118.73823, 77.77458, 72.75859, 18.41622
 	};
 
+	double dvector_zero_data[] =
+	{
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	};
+
 	size_t num_numbers = sizeof (dvector_data) / sizeof (*dvector_data);
+	size_t num_zeros = 12;
 
 } // namespace OpenMS
 
@@ -196,6 +202,11 @@ START_SECTION((template <typename ProbabilityIterator> void update(ProbabilityIt
 	TEST_REAL_SIMILAR( stats.sum(), 15228.2 );
 	TEST_REAL_SIMILAR( stats.mean(), 96.4639 );
 	TEST_REAL_SIMILAR( stats.variance(), 3276.51 );
+
+	stats.update( &*dvector_zero_data, dvector_zero_data + num_zeros );
+	TEST_REAL_SIMILAR( stats.sum(), 0 );
+	TEST_REAL_SIMILAR( stats.mean(), 0 );
+	TEST_REAL_SIMILAR( stats.variance(), 0 );
 }
 END_SECTION
 //-----------------------------------------------------------


### PR DESCRIPTION
`BasicStatistics` `mean_` and `variance_` returned `-nan` when given a vector of only zeroes, due to dividing by the sum.

This should fix #5981 and possibly a few other unexpected `nan` issues.

This is one possible solution, but more input would be appreciated.
Problems here are:
`sum_` and `mean_` would be zero for a vector like this as well: [-5, -3, 0, 3, 5], but the variance would not be zero.
Still we use `variance_ /= sum_` as a step in the calculation, which would cause a `nan`.

# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
