### PR TITLE
added WizardHelper class to be shared with other Wizards

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/SwathTabWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/SwathTabWidget.h
@@ -65,28 +65,13 @@ namespace OpenMS
   {
     class SwathTabWidget;
 
-    /**
-      @brief RAII class to switch to certain TabWidget, disable the GUI and go back to the orignal Tab when this class is destroyed
-    */
-    class SwathGUILock
-    {
-      public:
-        SwathGUILock(SwathTabWidget* stw);
-
-      ~SwathGUILock();
-      private:
-        SwathTabWidget* stw_;
-        QWidget* old_;
-        GUIHelpers::GUILock glock_;
-    };
-
     /// A multi-tabbed widget for the SwathWizard offering setting of parameters, input-file specification and running Swath and more
     class OPENMS_GUI_DLLAPI SwathTabWidget : public QTabWidget
     {
       Q_OBJECT
 
     public:
-      friend class SwathGUILock;
+      template <typename> friend class WizardGUILock;
 
       explicit SwathTabWidget(QWidget *parent = nullptr);
       ~SwathTabWidget();

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/WizardHelper.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/WizardHelper.h
@@ -1,0 +1,135 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Jihyung Kim $
+// $Authors: Jihyung Kim, Chris Bielow $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+namespace OpenMS
+{
+  class InputFile;
+  class OutputDirectory;
+  class ParamEditor;
+
+  namespace Internal
+  {
+    /**
+      @brief RAII class to switch to certain TabWidget, disable the GUI and go back to the orignal Tab when this class is destroyed
+    */
+    template<class TWidgetClass>
+    class WizardGUILock
+    {
+    public:
+        WizardGUILock(TWidgetClass* stw):
+            stw_(stw),
+            old_(stw->currentWidget()),
+            glock_(stw)
+        {
+          stw->setCurrentWidget(stw->ui->tab_log);
+        }
+
+        ~WizardGUILock()
+        {
+          stw_->setCurrentWidget(old_);
+        }
+
+      private:
+        TWidgetClass* stw_;
+        QWidget* old_;
+        GUIHelpers::GUILock glock_;
+    };
+
+    /// custom arguments to allow for looping calls
+    struct Args
+    {
+      QStringList loop_arg; ///< list of arguments to insert; one for every loop
+      size_t insert_pos;       ///< where to insert in the target argument list (index is 0-based)
+    };
+
+    typedef std::vector<Args> ArgLoop;
+
+    /// Allows running an executable with arguments
+    /// Multiple execution in a loop is supported by the ArgLoop argument
+    /// e.g. running 'ls -la .' and 'ls -la ..'
+    /// uses Command("ls", QStringList() << "-la" << "%1", ArgLoop{ Args {QStringList() << "." << "..", 1 } })
+    /// All lists in loop[i].loop_arg should have the same size (i.e. same number of loops)
+    struct Command
+    {
+      String exe;
+      QStringList args;
+      ArgLoop loop;
+
+      Command(const String& e, const QStringList& a, const ArgLoop& l) :
+          exe(e),
+          args(a),
+          loop(l) {}
+
+      /// how many loops can we make according to the ArgLoop provided?
+      /// if ArgLoop is empty, we just do a single invokation
+      size_t getLoopCount() const
+      {
+        if (loop.empty()) return 1;
+        size_t common_size = loop[0].loop_arg.size();
+        for (const auto& l : loop)
+        {
+          if (l.loop_arg.size() != (int)common_size) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. Not all loop arguments support the same number of loops!");
+          if ((int)l.insert_pos >= args.size()) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. Loop argument wants to insert after end of template arguments!");
+        }
+        return common_size;
+      }
+      /// for a given loop, return the substituted arguments
+      /// @p loop_number of 0 is always valid, i.e. no loop args, just use the unmodified args provided
+      QStringList getArgs(const int loop_number) const
+      {
+        if (loop_number >= (int)getLoopCount())
+        {
+          throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. The loop number you requested is too high!");
+        }
+        if (loop.empty()) return args; // no looping available
+
+        QStringList arg_l = args;
+        for (const auto& largs : loop) // replace all args for the current round
+        {
+          arg_l[largs.insert_pos] = args[largs.insert_pos].arg(largs.loop_arg[loop_number]);
+        }
+        return arg_l;
+      }
+    };
+
+  }
+} // ns OpenMS
+
+// this is required to allow Ui_[tool_name]TabWidget (auto UIC'd from .ui) to have a InputFile member
+using InputFile = OpenMS::InputFile;
+using OutputDirectory = OpenMS::OutputDirectory;
+using ParamEditor = OpenMS::ParamEditor;
+using TableView = OpenMS::TableView;

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/sources.cmake
@@ -28,7 +28,7 @@ TOPPViewOpenDialog.h
 TOPPViewPrefDialog.h
 TheoreticalSpectrumGenerationDialog.h
 ToolsDialog.h
-		WizardHelper.h
+WizardHelper.h
 )
 
 ### add path to the filenames

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/sources.cmake
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/sources.cmake
@@ -28,6 +28,7 @@ TOPPViewOpenDialog.h
 TOPPViewPrefDialog.h
 TheoreticalSpectrumGenerationDialog.h
 ToolsDialog.h
+		WizardHelper.h
 )
 
 ### add path to the filenames

--- a/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/SwathTabWidget.cpp
@@ -34,14 +34,13 @@
 
 #include <OpenMS/VISUAL/DIALOGS/SwathTabWidget.h>
 #include <ui_SwathTabWidget.h>
+#include <OpenMS/VISUAL/DIALOGS/WizardHelper.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/DIALOGS/PythonModuleRequirement.h>
-#include <OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h>
-#include <OpenMS/VISUAL/MISC/GUIHelpers.h>
 
 #include <QtCore/QDateTime>
 #include <QtCore/QDir>
@@ -58,20 +57,7 @@ namespace OpenMS
 {
   namespace Internal
   {
-
-    SwathGUILock::SwathGUILock(SwathTabWidget* stw)
-      : 
-      stw_(stw),
-      old_(stw->currentWidget()),
-      glock_(stw)
-    {
-      stw->setCurrentWidget(stw->ui->tab_log);
-    }
-
-    SwathGUILock::~SwathGUILock()
-    {
-      stw_->setCurrentWidget(old_);
-    }
+    template class WizardGUILock<SwathTabWidget>;
 
     String getOSWExe()
     {
@@ -179,8 +165,8 @@ namespace OpenMS
     void SwathTabWidget::on_run_swath_clicked()
     {
       if (!checkOSWInputReady_()) return;
-      
-      SwathGUILock lock(this); // forbid user interaction
+
+      WizardGUILock lock(this); // forbid user interaction
 
       updateSwathParamFromWidgets_();
       Param tmp_param;
@@ -385,63 +371,6 @@ namespace OpenMS
       ui->input_swath_windows->setCWD(new_cwd);
     }
 
-    /// custom arguments to allow for looping calls
-    struct Args
-    {
-      QStringList loop_arg; ///< list of arguments to insert; one for every loop
-      size_t insert_pos;       ///< where to insert in the target argument list (index is 0-based)
-    };
-    
-    typedef std::vector<Args> ArgLoop;
-
-    /// Allows running an executable with arguments
-    /// Multiple execution in a loop is supported by the ArgLoop argument
-    /// e.g. running 'ls -la .' and 'ls -la ..'
-    /// uses Command("ls", QStringList() << "-la" << "%1", ArgLoop{ Args {QStringList() << "." << "..", 1 } })
-    /// All lists in loop[i].loop_arg should have the same size (i.e. same number of loops)
-    struct Command
-    {
-      String exe;
-      QStringList args;
-      ArgLoop loop;
-
-      Command(const String& e, const QStringList& a, const ArgLoop& l) :
-        exe(e),
-        args(a),
-        loop(l) {}
-
-      /// how many loops can we make according to the ArgLoop provided?
-      /// if ArgLoop is empty, we just do a single invokation
-      size_t getLoopCount() const
-      {
-        if (loop.empty()) return 1;
-        size_t common_size = loop[0].loop_arg.size();
-        for (const auto& l : loop)
-        {
-          if (l.loop_arg.size() != (int)common_size) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. Not all loop arguments support the same number of loops!");
-          if ((int)l.insert_pos >= args.size()) throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. Loop argument wants to insert after end of template arguments!");
-        }
-        return common_size;
-      }
-      /// for a given loop, return the substituted arguments
-      /// @p loop_number of 0 is always valid, i.e. no loop args, just use the unmodified args provided
-      QStringList getArgs(const int loop_number) const
-      {
-        if (loop_number >= (int)getLoopCount())
-        {
-          throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal error. The loop number you requested is too high!");
-        }
-        if (loop.empty()) return args; // no looping available
-
-        QStringList arg_l = args;
-        for (const auto& largs : loop) // replace all args for the current round
-        {
-          arg_l[largs.insert_pos] = args[largs.insert_pos].arg(largs.loop_arg[loop_number]);
-        }
-        return arg_l;
-      }
-    };
-
     bool SwathTabWidget::findPythonScript_(const String& path_to_python_exe, String& script_name)
     {
       String path = File::path(path_to_python_exe);
@@ -476,7 +405,7 @@ namespace OpenMS
         QMessageBox::warning(this, "Error", "Could not find all requirements for 'pyprophet & tric' (see 'Config' tab). Install modules via 'pip install <modulename>' and make sure it's available in $PATH");
         return;
       }
-      SwathGUILock lock(this); // forbid user interaction
+      WizardGUILock lock(this); // forbid user interaction
 
       auto inputs = getPyProphetInputFiles();
       if (inputs.empty())


### PR DESCRIPTION
# Description

As suggested in the PR here: #5690, WizardHelper class is added to be shared between both SwathWizard and FLASHDeconvWizard

# Checklist:
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
