### PR TITLE
[BUILD] Use Cmake exports from boost

### DIFF
--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.workspace }}/OpenMS/contrib
-        key: ${{ runner.os }}-contrib2
+        key: ${{ runner.os }}-contrib3
 
     - name: Load contrib build
       if: steps.cache-contrib-win.outputs.cache-hit != 'true'
@@ -150,7 +150,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.workspace }}/OpenMS/contrib
-        key: ${{ runner.os }}-contrib2
+        key: ${{ runner.os }}-contrib3
 
     - name: Load contrib build
       if: steps.cache-contrib-os.outputs.cache-hit != 'true'
@@ -245,7 +245,7 @@ jobs:
           ADDRESS_SANITIZER: "Off"
           BUILD_TYPE: "Release"
           OPENMP: "On"
-          USE_STATIC_BOOST: "Off"
+          USE_STATIC_BOOST: "On"
           BUILD_FLAGS: "-j3"
 
   build-lnx:
@@ -352,5 +352,5 @@ jobs:
           ADDRESS_SANITIZER: "Off"
           BUILD_TYPE: "Release"
           OPENMP: "On"
-          USE_STATIC_BOOST: "Off"
+          USE_STATIC_BOOST: "On"
           BUILD_FLAGS: "-j2"

--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -47,18 +47,12 @@ macro(find_boost)
   set(Boost_USE_STATIC_RUNTIME OFF)
   add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
   set(Boost_COMPILER "")
-  ## since boost 1.70 they provide CMake config files which only define imported targets and do not fill
-  ## Boost_LIBRARIES anymore
-  ## Try to avoid that until we changed our build system to use imported targets
-  if(NOT Boost_NO_BOOST_CMAKE)
-    set(Boost_NO_BOOST_CMAKE ON)
-  endif()  
+  
   ## since boost 1.66 they add an architecture tag if you build with layout=versioned and since 1.69 even when you
   ## build with layout=tagged (which we do in the contrib)
   if(NOT Boost_ARCHITECTURE)
     set(Boost_ARCHITECTURE "-x64")
   endif()
-
 
   # help boost finding it's packages
   set(Boost_ADDITIONAL_VERSIONS

--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -88,7 +88,7 @@ macro(find_boost)
     "1.49.1" "1.49.0" "1.49"
     "1.48.1" "1.48.0" "1.48")
 
-  find_package(Boost 1.48.0 COMPONENTS ${ARGN})
+  find_package(Boost 1.48.0 COMPONENTS ${ARGN} REQUIRED)
 
 endmacro(find_boost)
 

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -48,7 +48,7 @@ find_package(XercesC REQUIRED)
 
 #------------------------------------------------------------------------------
 # BOOST
-set(OpenMS_BOOST_COMPONENTS date_time math_c99 regex CACHE INTERNAL "Boost components for core lib")
+set(OpenMS_BOOST_COMPONENTS date_time regex CACHE INTERNAL "Boost components for core lib")
 find_boost(iostreams ${OpenMS_BOOST_COMPONENTS})
 
 if(Boost_FOUND)

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -104,7 +104,7 @@ include (${PROJECT_SOURCE_DIR}/includes.cmake)
 
 set(OPENMS_DEP_LIBRARIES Evergreen LibSVM::LibSVM XercesC::XercesC Qt5::Core Qt5::Network Qt5::Sql)
 
-set(OPENMS_DEP_PRIVATE_LIBRARIES WM5::WM5 CoinOR::CoinOR Eigen3::Eigen GLPK::GLPK HDF5::HDF5 Boost::iostreams Boost::date_time Boost::math_c99 Boost::regex
+set(OPENMS_DEP_PRIVATE_LIBRARIES WM5::WM5 CoinOR::CoinOR Eigen3::Eigen GLPK::GLPK HDF5::HDF5 Boost::iostreams Boost::date_time Boost::boost Boost::regex
   BZip2::BZip2 ZLIB::ZLIB SQLite::SQLite3)
 
 # xerces requires linking against CoreFoundation&CoreServices on macOS

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -42,14 +42,6 @@ set (CONFIGURED_TEST_CONFIG_H "${PROJECT_BINARY_DIR}/include/OpenMS/test_config.
 configure_file(${PROJECT_SOURCE_DIR}/include/OpenMS/test_config.h.in ${CONFIGURED_TEST_CONFIG_H})
 
 #------------------------------------------------------------------------------
-# Some tests have a link dependency to boost so we find our own boost here
-find_boost(math_c99)
-
-if(NOT Boost_FOUND)
-  message(FATAL_ERROR "Boost was not found!")
-endif()
-
-#------------------------------------------------------------------------------
 # get the test executables
 include(executables.cmake)
 
@@ -66,14 +58,6 @@ include_directories(SYSTEM ${OPENMS_CLASS_TESTS_EXTERNAL_INCLUDE_DIRECTORIES})
 if (CMAKE_COMPILER_IS_INTELCXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
   set(_TMP_CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
   set(CMAKE_CXX_FLAGS_RELEASE "-O0")
-endif()
-
-#------------------------------------------------------------------------------
-# QT dependencies
-find_package(Qt5 COMPONENTS Core Network Sql REQUIRED)
-if (NOT Qt5Network_FOUND)
-  message(STATUS "QtNetwork module not found!")
-  message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -D QT_QMAKE_EXECUTABLE='<path_to_qmake(.exe)' <src-dir>")
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Try to use the official exports from Boost Cmake instead of the find module.