### PR TITLE
[FIX] Suppress -Wunused-private-field warnings 

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -119,7 +119,7 @@ namespace OpenMS
     OpenMS::UInt64 run_id_;
     bool doWrite_;
     bool use_ms1_traces_;
-    [[maybe_unused]] bool sonar_;
+    bool sonar_;
     bool enable_uis_scoring_;
 
   public:

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -119,7 +119,7 @@ namespace OpenMS
     OpenMS::UInt64 run_id_;
     bool doWrite_;
     bool use_ms1_traces_;
-    bool sonar_;
+    [[maybe_unused]] bool sonar_;
     bool enable_uis_scoring_;
 
   public:

--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
@@ -115,7 +115,7 @@ class OPENMS_DLLAPI SplineInterpolatedPeaks
         * @param scaling    The step width can be scaled by this factor. Often it is advantageous to iterate
         * in slightly smaller steps over the spectrum (or chromatogram).
         */
-        Navigator(const std::vector<SplinePackage> * packages, double posMin, double posMax, double scaling);
+        Navigator(const std::vector<SplinePackage> * packages, double posMax, double scaling);
 
         /**
         * @brief constructor (for pyOpenMS)

--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h
@@ -157,7 +157,6 @@ class OPENMS_DLLAPI SplineInterpolatedPeaks
         /**
         * @brief m/z (or RT) limits of the spectrum (or chromatogram)
         */
-        double pos_min_;
         double pos_max_;
         
         /**

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -288,9 +288,9 @@ namespace OpenMS
         "VAR_MI_SCORE, VAR_MI_WEIGHTED_SCORE, VAR_MI_RATIO_SCORE, VAR_NORM_RT_SCORE, "\
         "VAR_XCORR_COELUTION,VAR_XCORR_COELUTION_WEIGHTED, VAR_XCORR_SHAPE, "\
         "VAR_XCORR_SHAPE_WEIGHTED, VAR_YSERIES_SCORE, VAR_ELUTION_MODEL_FIT_SCORE, "\
-        "VAR_IM_XCORR_SHAPE, VAR_IM_XCORR_COELUTION, VAR_IM_DELTA_SCORE, " \
-        "VAR_SONAR_LAG, VAR_SONAR_SHAPE, VAR_SONAR_LOG_SN, VAR_SONAR_LOG_DIFF, VAR_SONAR_LOG_TREND, VAR_SONAR_RSQ "\
-        ") VALUES ("
+        "VAR_IM_XCORR_SHAPE, VAR_IM_XCORR_COELUTION, VAR_IM_DELTA_SCORE"
+        << (sonar_ ? ", VAR_SONAR_LAG, VAR_SONAR_SHAPE, VAR_SONAR_LOG_SN, VAR_SONAR_LOG_DIFF, VAR_SONAR_LOG_TREND, VAR_SONAR_RSQ " : "")
+        << ") VALUES ("
                       << feature_id << ", "
                       << feature_it.getIntensity() << ", "
                       << getScore(feature_it, "total_xic") << ", "
@@ -323,13 +323,16 @@ namespace OpenMS
                       << getScore(feature_it, "var_elution_model_fit_score") << ", "
                       << getScore(feature_it, "var_im_xcorr_shape") << ", "
                       << getScore(feature_it, "var_im_xcorr_coelution") << ", "
-                      << getScore(feature_it, "var_im_delta_score") << ", "
-                      << getScore(feature_it, "var_sonar_lag") << ", "
-                      << getScore(feature_it, "var_sonar_shape") << ", "
-                      << getScore(feature_it, "var_sonar_log_sn") << ", "
-                      << getScore(feature_it, "var_sonar_log_diff") << ", "
-                      << getScore(feature_it, "var_sonar_log_trend") << ", "
-                      << getScore(feature_it, "var_sonar_rsq") << "); ";
+                      << getScore(feature_it, "var_im_delta_score");
+      if (sonar_) {
+        sql_feature_ms2 << ", " << getScore(feature_it, "var_sonar_lag")
+                        << ", " << getScore(feature_it, "var_sonar_shape")
+                        << ", " << getScore(feature_it, "var_sonar_log_sn")
+                        << ", " << getScore(feature_it, "var_sonar_log_diff")
+                        << ", " << getScore(feature_it, "var_sonar_log_trend")
+                        << ", " << getScore(feature_it, "var_sonar_rsq");
+      }
+      sql_feature_ms2 << "); ";
 
       if (use_ms1_traces_)
       {

--- a/src/openms/source/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.cpp
@@ -207,7 +207,6 @@ namespace OpenMS
   SplineInterpolatedPeaks::Navigator::Navigator(const std::vector<SplinePackage>* packages, double pos_min, double pos_max, double scaling) :
     packages_(packages),
     last_package_(0),
-    pos_min_(pos_min),
     pos_max_(pos_max),
     pos_step_width_scaling_(scaling)
   {

--- a/src/openms/source/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.cpp
@@ -201,10 +201,10 @@ namespace OpenMS
     {
       throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 0);
     }
-    return Navigator(&packages_, pos_min_, pos_max_, scaling);
+    return Navigator(&packages_, pos_max_, scaling);
   }
 
-  SplineInterpolatedPeaks::Navigator::Navigator(const std::vector<SplinePackage>* packages, double pos_min, double pos_max, double scaling) :
+  SplineInterpolatedPeaks::Navigator::Navigator(const std::vector<SplinePackage>* packages, double pos_max, double scaling) :
     packages_(packages),
     last_package_(0),
     pos_max_(pos_max),

--- a/src/pyOpenMS/pxds/SplineInterpolatedPeaks.pxd
+++ b/src/pyOpenMS/pxds/SplineInterpolatedPeaks.pxd
@@ -35,7 +35,7 @@ cdef extern from "<OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h>" na
             SplineSpectrum_Navigator() nogil except +
             SplineSpectrum_Navigator(SplineSpectrum_Navigator) nogil except + # compiler
             
-            SplineSpectrum_Navigator(libcpp_vector[SplinePackage]* packages, double posMin, double posMax, double scaling)  nogil except +
+            SplineSpectrum_Navigator(libcpp_vector[SplinePackage]* packages, double posMax, double scaling)  nogil except +
 
             double eval(double pos) nogil except +
 


### PR DESCRIPTION
# Description

This PR (partly) fixes `-Wunused-private-field` warnings when compiling with `clang` on macOS.

There are two unused private fields:
1. `snoar_` in `OpenSwathOSWWriter.h`
2. `pos_min_` of `SplineInterpolatedPeaks::Navigator` in `SplineInterpolatedPeaks.h`

Both unused fields can be removed since they were not used anywhere in the code.

However, I feel that the first unused field should not be trivially removed since in `OpenSwathTSVWriter`, we utilized `sonar_` to determine whether we should write `var_sonar_<options>`  in the output or not:

```c++
if (sonar_)
{
  ofs << "\tvar_sonar_lag\tvar_sonar_shape\tvar_sonar_log_sn\tvar_sonar_log_diff\tvar_sonar_log_trend\tvar_sonar_rsq";
}
```
But in OSW writer, we append `VAR_SONAR<options>` to `sql_feature_ms2` regardless of `sonar_` provided or not. I'm curious whether we should add an `if` statement checking the value of `sonar_` like in TSV writer. (Hence `sonar_` is suppressed only using `[[maybe_unused]]`)


# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
