### PR TITLE
Update PULL_REQUEST_TEMPLATE.md with information on reformat

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,32 @@
 # Description
 
-Please include a summary of the change and which issue is fixed.
+<!-- Please include a summary of the change and which issue is fixed here. -->
 
-# Checklist:
+# Checklist
 - [ ] Make sure that you are listed in the AUTHORS file
 - [ ] Add relevant changes and new features to the CHANGELOG file
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)
 
-# How can I get additional information on failed tests during CI:
+## How can I get additional information on failed tests during CI
+<details>
+  <summary>Click to expand</summary>
 If your PR is failing you can check out 
 - http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
 - Or click on the action: e.g., for clang-format linting
 
-# Note:
-- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
+</details>
 
-# Advanced commands (admins / reviewer only):
+## Advanced commands (admins / reviewer only)
+<details>
+  <summary>Click to expand</summary>
+  
 - `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
 - setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
 - commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
+  
+</details>
+
+---
+:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@ If your PR is failing you can check out
 - Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
 
 # Advanced commands (admins / reviewer only):
-- `/reformat` (experimental) applies the clang-format style changes as additional commit
+- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
 - setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
 - commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.

# Checklist:
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

# How can I get additional information on failed tests during CI:
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

# Note:
- Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

# Advanced commands (admins / reviewer only):
- `/reformat` (experimental) applies the clang-format style changes as additional commit
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
