### PR TITLE
Allow missing score types in IDDData conversion

### DIFF
--- a/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
@@ -67,7 +67,7 @@ namespace OpenMS
       ID::ProcessingSoftware software(prot.getSearchEngine(),
                                           prot.getSearchEngineVersion());
 
-      bool missing_protein_score_type = prot.getScoreType().empty();
+      const bool missing_protein_score_type = prot.getScoreType().empty();
       ID::ScoreType score_type;
       ID::ScoreTypeRef prot_score_ref;
       if (!missing_protein_score_type)

--- a/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
@@ -63,7 +63,10 @@ namespace OpenMS
     {
       proteins_counter++;
       progresslogger.setProgress(proteins_counter);
-      
+
+      ID::ProcessingSoftware software(prot.getSearchEngine(),
+                                          prot.getSearchEngineVersion());
+
       bool missing_protein_score_type = prot.getScoreType().empty();
       ID::ScoreType score_type;
       ID::ScoreTypeRef prot_score_ref;
@@ -71,15 +74,13 @@ namespace OpenMS
       {
         score_type = ID::ScoreType(prot.getScoreType(), prot.isHigherScoreBetter());
         prot_score_ref = id_data.registerScoreType(score_type);
+        software.assigned_scores.push_back(prot_score_ref);
       }
       else
       {
         OPENMS_LOG_WARN << "Missing protein score type. All protein scores without score type will be removed during conversion." << std::endl;
       }
 
-      ID::ProcessingSoftware software(prot.getSearchEngine(),
-                                          prot.getSearchEngineVersion());
-      software.assigned_scores.push_back(prot_score_ref);
       ID::ProcessingSoftwareRef software_ref =
         id_data.registerProcessingSoftware(software);
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes. (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out 
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. If you click in the column that lists the failed tests you will get detailed error messages.
- Or click on the action: e.g., for clang-format linting

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
