### PR TITLE
Support for enzyme term specificity (DB search params.) in OMS (SQLite) files

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
@@ -143,6 +143,8 @@ namespace OpenMS
       // store name, not database connection itself (see https://stackoverflow.com/a/55200682):
       QString db_name_;
 
+      int version_number_; ///< schema version number
+
       // mappings between database keys and loaded data:
       std::unordered_map<Key, IdentificationData::ScoreTypeRef> score_type_refs_;
       std::unordered_map<Key, IdentificationData::InputFileRef> input_file_refs_;

--- a/src/openms/include/OpenMS/METADATA/ID/DBSearchParam.h
+++ b/src/openms/include/OpenMS/METADATA/ID/DBSearchParam.h
@@ -84,21 +84,19 @@ namespace OpenMS
 
       bool operator<(const DBSearchParam& other) const
       {
-        return (std::tie(molecule_type, mass_type, database,
-                         database_version, taxonomy, charges, fixed_mods,
-                         variable_mods, fragment_mass_tolerance,
-                         precursor_mass_tolerance, fragment_tolerance_ppm,
-                         precursor_tolerance_ppm, digestion_enzyme,
-                         enzyme_term_specificity, missed_cleavages, min_length, max_length) <
+        return (std::tie(molecule_type, mass_type,
+                         database, database_version, taxonomy,
+                         charges, fixed_mods, variable_mods,
+                         precursor_mass_tolerance, fragment_mass_tolerance,
+                         precursor_tolerance_ppm, fragment_tolerance_ppm,
+                         digestion_enzyme, enzyme_term_specificity, missed_cleavages,
+                         min_length, max_length) <
                 std::tie(other.molecule_type, other.mass_type,
                          other.database, other.database_version, other.taxonomy,
                          other.charges, other.fixed_mods, other.variable_mods,
-                         other.fragment_mass_tolerance,
-                         other.precursor_mass_tolerance,
-                         other.fragment_tolerance_ppm,
-                         other.precursor_tolerance_ppm,
-                         other.digestion_enzyme,
-                         other.enzyme_term_specificity, other.missed_cleavages,
+                         other.precursor_mass_tolerance, other.fragment_mass_tolerance,
+                         other.precursor_tolerance_ppm, other.fragment_tolerance_ppm,
+                         other.digestion_enzyme, other.enzyme_term_specificity, other.missed_cleavages,
                          other.min_length, other.max_length));
       }
 

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -66,6 +66,14 @@ namespace OpenMS::Internal
       // if d'tor doesn't get called, DB connection (db_name_) doesn't get
       // removed, but that shouldn't be a big problem
     }
+    // read version number:
+    QSqlQuery query(db);
+    if (!query.exec("SELECT OMSFile FROM version"))
+    {
+      raiseDBError_(db.lastError(), __LINE__, OPENMS_PRETTY_FUNCTION,
+                    "error reading file format version number");
+    }
+    version_number_ = query.value(0).toInt();
   }
 
 
@@ -356,6 +364,11 @@ namespace OpenMS::Internal
         {
           param.digestion_enzyme = RNaseDB::getInstance()->getEnzyme(enzyme);
         }
+      }
+      if (version_number_ > 1)
+      {
+        String spec = query.value("enzyme_term_specificity").toString();
+        param.enzyme_term_specificity = EnzymaticDigestion::getSpecificityByName(spec);
       }
       param.missed_cleavages = query.value("missed_cleavages").toUInt();
       param.min_length = query.value("min_length").toUInt();

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -68,7 +68,7 @@ namespace OpenMS::Internal
     }
     // read version number:
     QSqlQuery query(db);
-    if (!query.exec("SELECT OMSFile FROM version"))
+    if (!(query.exec("SELECT OMSFile FROM version") && query.first()))
     {
       raiseDBError_(db.lastError(), __LINE__, OPENMS_PRETTY_FUNCTION,
                     "error reading file format version number");

--- a/src/openms/source/FORMAT/OMSFileStore.cpp
+++ b/src/openms/source/FORMAT/OMSFileStore.cpp
@@ -48,7 +48,7 @@ using ID = OpenMS::IdentificationData;
 
 namespace OpenMS::Internal
 {
-  int version_number = 1;
+  int version_number = 2; // increase this whenever the DB schema changes!
 
   void raiseDBError_(const QSqlError& error, int line,
                      const char* function, const String& context)
@@ -577,6 +577,7 @@ namespace OpenMS::Internal
       "precursor_tolerance_ppm NUMERIC NOT NULL CHECK (precursor_tolerance_ppm in (0, 1)) DEFAULT 0, " \
       "fragment_tolerance_ppm NUMERIC NOT NULL CHECK (fragment_tolerance_ppm in (0, 1)) DEFAULT 0, " \
       "digestion_enzyme TEXT, "                                         \
+      "enzyme_term_specificity TEXT, " \ // new in version 2!
       "missed_cleavages NUMERIC, "                                      \
       "min_length NUMERIC, "                                            \
       "max_length NUMERIC, "                                            \
@@ -598,6 +599,7 @@ namespace OpenMS::Internal
                   ":precursor_tolerance_ppm, "            \
                   ":fragment_tolerance_ppm, "             \
                   ":digestion_enzyme, "                   \
+                  ":enzyme_term_specificity, "            \
                   ":missed_cleavages, "                   \
                   ":min_length, "                         \
                   ":max_length)");
@@ -632,6 +634,8 @@ namespace OpenMS::Internal
       {
         query.bindValue(":digestion_enzyme", QVariant(QVariant::String));
       }
+      query.bindValue(":enzyme_term_specificity",
+                      QString::fromStdString(EnzymaticDigestion::NamesOfSpecificity[param.enzyme_term_specificity]));
       query.bindValue(":missed_cleavages", uint(param.missed_cleavages));
       query.bindValue(":min_length", uint(param.min_length));
       query.bindValue(":max_length", uint(param.max_length));

--- a/src/openms/source/FORMAT/OMSFileStore.cpp
+++ b/src/openms/source/FORMAT/OMSFileStore.cpp
@@ -577,7 +577,7 @@ namespace OpenMS::Internal
       "precursor_tolerance_ppm NUMERIC NOT NULL CHECK (precursor_tolerance_ppm in (0, 1)) DEFAULT 0, " \
       "fragment_tolerance_ppm NUMERIC NOT NULL CHECK (fragment_tolerance_ppm in (0, 1)) DEFAULT 0, " \
       "digestion_enzyme TEXT, "                                         \
-      "enzyme_term_specificity TEXT, " \ // new in version 2!
+      "enzyme_term_specificity TEXT, " // new in version 2!
       "missed_cleavages NUMERIC, "                                      \
       "min_length NUMERIC, "                                            \
       "max_length NUMERIC, "                                            \

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -287,7 +287,7 @@ namespace OpenMS
 
   // stream output operator for a ProteinHit
   SVOutStream& operator<<(SVOutStream& out, const ProteinHit& hit)
-  {    
+  {
     out << String(hit.getScore()) << hit.getRank() << hit.getAccession() << hit.getDescription()
         << String(hit.getCoverage()) << hit.getSequence();
     return out;
@@ -643,7 +643,7 @@ protected:
       {
         sep = ",";
       }
-      else 
+      else
       {
         sep = "\t";
       }
@@ -724,7 +724,7 @@ protected:
                 }
         }
 
-        if (add_feature_metavalues >= 0) 
+        if (add_feature_metavalues >= 0)
         {
           meta_keys = MetaInfoInterfaceUtils::findCommonMetaKeys<FeatureMap, StringList>(feature_map.begin(), feature_map.end(), add_feature_metavalues);
         }
@@ -1316,10 +1316,10 @@ protected:
         StringList peptide_hit_meta_keys;
         StringList protein_hit_meta_keys;
 
-        if (add_id_metavalues >= 0) 
+        if (add_id_metavalues >= 0)
         {
           peptide_id_meta_keys = MetaInfoInterfaceUtils::findCommonMetaKeys<vector<PeptideIdentification>, StringList>(pep_ids.begin(), pep_ids.end(), add_id_metavalues);
-          // currently there is some hardcoded logic to create extra columns for these meta values so remove them to prevent duplication 
+          // currently there is some hardcoded logic to create extra columns for these meta values so remove them to prevent duplication
           peptide_id_meta_keys.erase(std::remove(peptide_id_meta_keys.begin(), peptide_id_meta_keys.end(), "predicted_RT"), peptide_id_meta_keys.end());
           peptide_id_meta_keys.erase(std::remove(peptide_id_meta_keys.begin(), peptide_id_meta_keys.end(), "predicted_RT_first_dim"), peptide_id_meta_keys.end());
           peptide_id_meta_keys.erase(std::remove(peptide_id_meta_keys.begin(), peptide_id_meta_keys.end(), "first_dim_rt"), peptide_id_meta_keys.end());
@@ -1332,7 +1332,7 @@ protected:
           for (Size i = 0; i != pep_ids.size(); ++i)
           {
             const vector<PeptideHit>& hits = pep_ids[i].getHits();
-            temp_hits.insert(temp_hits.end(), hits.begin(), hits.end());  
+            temp_hits.insert(temp_hits.end(), hits.begin(), hits.end());
           }
           peptide_hit_meta_keys = MetaInfoInterfaceUtils::findCommonMetaKeys<vector<PeptideHit>, StringList>(temp_hits.begin(), temp_hits.end(), add_hit_metavalues);
         }

--- a/src/utils/FeatureFinderMetaboIdent.cpp
+++ b/src/utils/FeatureFinderMetaboIdent.cpp
@@ -53,6 +53,7 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/FORMAT/OMSFileLoad.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -137,7 +138,7 @@ class TOPPFeatureFinderMetaboIdent :
 {
 public:
   TOPPFeatureFinderMetaboIdent() :
-    TOPPBase("FeatureFinderMetaboIdent", "Detects features in MS1 data based on metabolite identifications.", false)    
+    TOPPBase("FeatureFinderMetaboIdent", "Detects features in MS1 data based on metabolite identifications.", false)
   {
   }
 
@@ -261,7 +262,7 @@ protected:
 
     FeatureMap features;
     ff_mident.run(table, features, in);
-    
+
     // annotate "spectra_data" metavalue
     if (getFlag_("test"))
     {
@@ -271,7 +272,7 @@ protected:
     else
     {
       features.setPrimaryMSRunPath({in}, ff_mident.getMSData());
-    }    
+    }
 
     addDataProcessing_(features, getProcessingInfo_(DataProcessing::QUANTITATION));
 
@@ -298,7 +299,7 @@ protected:
     }
 
     // write expected vs. observed retention times
-    if (!trafo_out.empty()) 
+    if (!trafo_out.empty())
     {
       const TransformationDescription& trafo = ff_mident.getTransformations();
       TransformationXMLFile().store(trafo_out, trafo);


### PR DESCRIPTION
Term specificity information for digestion enzymes was missing from the comparison operator in `DBSearchParam` and from input/output in OMS (SQLite) files. I've now added it.
Since there may be existing OMS files without the corresponding column in the database schema, I've increased the OMS file version number and added a version check to the file loading code. This makes it possible to still load files with the old schema (version 1).
