### PR TITLE
Fix/log thread issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,8 @@ UTIL - An executable, just like a TOPP tool, but usually experimental or of less
 - OpenSwath: Add support for diaPASEF data with overlapping m/z and IM windows
 - TOPPView: TheoreticalSpectrumGenerationDialog now supports generation of isotope patterns for metabolites
 - pyopenms: pyopenms-extra is renamed to pyopenms-docs.
+- Fixed race condition when logging messages.
+
 ------------------------------------------------------------------------------------------
 ----                                OpenMS 2.8     (released 2/2022)                  ----
 ------------------------------------------------------------------------------------------

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -1242,7 +1242,7 @@ namespace OpenMS
         {
           if (this->getValue(it.getName()) != it->value)
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << "Warning: for ':version' entry, augmented and Default Ini-File differ in value. Default value will not be altered!\n";
           }
           continue;
@@ -1258,7 +1258,7 @@ OPENMS_THREAD_CRITICAL(oms_log)
           {
             if (this->getValue(it.getName()) != it->value) 
             {
-                OPENMS_THREAD_CRITICAL(oms_log)
+                OPENMS_THREAD_CRITICAL(LOGSTREAM)
                 stream << "Warning: for ':type' entry, augmented and Default Ini-File differ in value. Default value will not be altered!\n";
             }
             continue;
@@ -1284,7 +1284,7 @@ OPENMS_THREAD_CRITICAL(oms_log)
           // make sure the same leaf name does not exist at any other position
           if (this->findNext(l1_entry.name, it_match) == this->end())
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << "Found '" << it.getName() << "' as '" << it_match.getName() << "' in new param." << std::endl;
             new_entry = this->getEntry(it_match.getName());
             target_name = it_match.getName();
@@ -1295,13 +1295,13 @@ OPENMS_THREAD_CRITICAL(oms_log)
         {
           if (fail_on_unknown_parameters)
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file!" << std::endl;
             is_update_success = false;
           }
           else if (add_unknown)
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Adding to current set." << std::endl;
             Param::ParamEntry local_entry = p_outdated.getEntry(it.getName());
             std::string prefix = "";
@@ -1313,7 +1313,7 @@ OPENMS_THREAD_CRITICAL(oms_log)
           }
           else if (verbose)
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Ignoring parameter. " << std::endl;
           }
           continue;
@@ -1334,24 +1334,24 @@ OPENMS_THREAD_CRITICAL(oms_log)
             // overwrite default value
             if (verbose) 
             {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
                 stream << "Default-Parameter '" << target_name << "' overridden: '" << default_value << "' --> '" << it->value << "'!" << std::endl;
             }
             this->setValue(target_name, it->value, new_entry.description, this->getTags(target_name));
           }
           else
           {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
             stream << validation_result;
             if (fail_on_invalid_values)
             {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
               stream << " Updating failed!" << std::endl;
               is_update_success = false;
             }
             else
             {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
               stream << " Ignoring invalid value (using new default '" << default_value << "')!" << std::endl;
               new_entry.value = default_value;
             }
@@ -1364,17 +1364,17 @@ OPENMS_THREAD_CRITICAL(oms_log)
       }
       else
       {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
         stream << "Parameter '" << it.getName() << "' has changed value type!\n";
         if (fail_on_invalid_values)
         {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
           stream << " Updating failed!" << std::endl;
           is_update_success = false;
         } 
         else
         {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
           stream << " Ignoring invalid value (using new default)!" << std::endl;
         }
       }

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -649,7 +649,7 @@ namespace OpenMS
     {
       if (stream != nullptr)
       {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
         *stream << "Map descriptions (file name + label) in ConsensusMap are not unique:\n" << all_maps << std::endl;
       }
       return false;
@@ -674,14 +674,14 @@ OPENMS_THREAD_CRITICAL(oms_log)
     {
       if (stream != nullptr)
       {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
         *stream << "ConsensusMap contains " << stats_wrongMID << " invalid references to maps:\n";
         for (std::map<Size, Size>::const_iterator it = wrong_ID_count.begin(); it != wrong_ID_count.end(); ++it)
         {
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
           *stream << "  wrong id=" << it->first << " (occurred " << it->second << "x)\n";
         }
-OPENMS_THREAD_CRITICAL(oms_log)
+OPENMS_THREAD_CRITICAL(LOGSTREAM)
         *stream << std::endl;
       }
       return false;


### PR DESCRIPTION
## Description

Using OpenMS in our software, we had some crashes, some time randomly, when using pickSpectrum.

we had the chance to get a call stack that shows memory corruption while logging at 2 different threads at the same time.

![image](https://user-images.githubusercontent.com/1705849/168766484-ae9585d8-989b-4387-a04e-793a82053711.png)

![image](https://user-images.githubusercontent.com/1705849/168766508-1c063700-1468-4ede-bdfb-9c570a9b9ec3.png)

Logging is however protected with omp critical section.

Unfortunately, the standard messages produced by OPENMS_LOG_WARN use "LOGSTREAM" as the critical section name while param.cpp or ConsensusMap uses "oms_log" which to my understanding causes an issue. 

Using "LOGSTREAM" everywhere seems to fix our issue (it's however difficult to be sure 100% as this crash does not occurs always - but it passed several tests).


