### PR TITLE
[Fix] GNPSMetaValueFile get mzML file names from ConsensusMap

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/GNPSMetaValueFile.h
+++ b/src/openms/include/OpenMS/FORMAT/GNPSMetaValueFile.h
@@ -31,7 +31,7 @@
 // $Maintainer: Axel Walter $
 // $Authors: Axel Walter $
 
-#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 
 #pragma once
 
@@ -40,7 +40,7 @@ namespace OpenMS
   class OPENMS_DLLAPI GNPSMetaValueFile
   {
     public:
-      /// Generate a meta value table (tsv file) for GNPS FBMN with information on the input mzML files.
-      static void store(const StringList& mzml_file_paths, const String& output_file);
+      /// Generate a meta value table (tsv file) for GNPS FBMN with information on the input mzML files extracted from ConsensusMap.
+      static void store(const ConsensusMap& consensus_map, const String& output_file);
   };
 }

--- a/src/openms/source/FORMAT/GNPSMetaValueFile.cpp
+++ b/src/openms/source/FORMAT/GNPSMetaValueFile.cpp
@@ -43,16 +43,21 @@
 namespace OpenMS
 {   
     /**
-    @brief Generates a meta value required for GNPS FBMN, as defined here: https://ccms-ucsd.github.io/GNPSDocumentation/metadata/
+    @brief Generates a meta value table required for GNPS FBMN, as defined here: https://ccms-ucsd.github.io/GNPSDocumentation/metadata/
     */
-    void GNPSMetaValueFile::store(const StringList& mzml_file_paths, const String& output_file)
-    {
+    void GNPSMetaValueFile::store(const ConsensusMap& consensus_map, const String& output_file)
+    {   
+        StringList mzML_file_paths;
+        for (const auto& header: consensus_map.getColumnHeaders())
+        {
+            mzML_file_paths.push_back(header.second.filename);
+        }
         std::ofstream outstr(output_file.c_str());
         SVOutStream out(outstr, "\t", "_", String::NONE);
 
         out << "filename" << "ATTRIBUTE_MAPID" << std::endl;
         Size i = 0;
-        for (const auto& path: mzml_file_paths)
+        for (const auto& path: mzML_file_paths)
         {
             out << path.substr(path.find_last_of("/\\")+1) << "MAP"+String(i) << std::endl;
             i++;

--- a/src/openms/source/FORMAT/GNPSMetaValueFile.cpp
+++ b/src/openms/source/FORMAT/GNPSMetaValueFile.cpp
@@ -41,17 +41,14 @@
 #include <unordered_map>
 
 namespace OpenMS
-{   
+{
     /**
     @brief Generates a meta value table required for GNPS FBMN, as defined here: https://ccms-ucsd.github.io/GNPSDocumentation/metadata/
     */
     void GNPSMetaValueFile::store(const ConsensusMap& consensus_map, const String& output_file)
     {   
         StringList mzML_file_paths;
-        for (const auto& header: consensus_map.getColumnHeaders())
-        {
-            mzML_file_paths.push_back(header.second.filename);
-        }
+        consensus_map.getPrimaryMSRunPath(mzML_file_paths);
         std::ofstream outstr(output_file.c_str());
         SVOutStream out(outstr, "\t", "_", String::NONE);
 

--- a/src/pyOpenMS/pxds/GNPSMetaValueFile.pxd
+++ b/src/pyOpenMS/pxds/GNPSMetaValueFile.pxd
@@ -1,6 +1,6 @@
 from Types cimport *
 from String cimport *
-from StringList cimport *
+from ConsensusMap cimport *
 
 cdef extern from "<OpenMS/FORMAT/GNPSMetaValueFile.h>" namespace "OpenMS":
 
@@ -9,7 +9,7 @@ cdef extern from "<OpenMS/FORMAT/GNPSMetaValueFile.h>" namespace "OpenMS":
         GNPSMetaValueFile() nogil except +
         GNPSMetaValueFile(GNPSMetaValueFile &) nogil except +
 
-        void store(StringList & mzml_file_paths, String & output_file) nogil except +
+        void store(ConsensusMap& consensus_map, String & output_file) nogil except +
         # wrap-doc:
         #  Write meta value table (tsv file) from a list of mzML files. Required for GNPS FBMN.
         #  
@@ -17,8 +17,8 @@ cdef extern from "<OpenMS/FORMAT/GNPSMetaValueFile.h>" namespace "OpenMS":
         #  
         #  Parameters
         #  ----------
-        #  mzml_file_paths: list of str
-        #    Path list as string to the input mzML files.
+        #  consensus_map: ConsensusMap
+        #    Input ConsensusMap from which the input mzML files will be determined.
         #  
         #  output_file : str
         #    Output file path for the meta value table.  

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5647,3 +5647,11 @@ CONSENSUS	62.0	294.100000000000023	0.0	1	0.0	2.0	4	[M+H]+		2
 """
     os.remove("FeatureQuantificationTable.txt")
 
+    pyopenms.GNPSMetaValueFile.store(cm, "MetaValueTable.tsv")
+    with open("MetaValueTable.tsv", "r") as f:
+        assert f.read() == """filename	ATTRIBUTE_MAPID
+1.mzML	MAP0
+2.mzML	MAP1
+"""
+    os.remove("MetaValueTable.tsv")
+

--- a/src/tests/topp/GNPSExport_4_out_meta_values.tsv
+++ b/src/tests/topp/GNPSExport_4_out_meta_values.tsv
@@ -1,3 +1,3 @@
 filename	ATTRIBUTE_MAPID
-GNPSExport_mzml1.mzML	MAP0
-GNPSExport_mzml2.mzML	MAP1
+1.mzML	MAP0
+2.mzML	MAP1

--- a/src/topp/GNPSExport.cpp
+++ b/src/topp/GNPSExport.cpp
@@ -179,7 +179,7 @@ protected:
 
     if (!out_pairs.empty()) IonIdentityMolecularNetworking::writeSupplementaryPairTable(cm, out_pairs);
     if (!out_quantification.empty()) GNPSQuantificationFile::store(cm, out_quantification);
-    if (!out_meta.empty()) GNPSMetaValueFile::store(mzml_file_paths, out_meta);
+    if (!out_meta.empty()) GNPSMetaValueFile::store(cm, out_meta);
     
     return EXECUTION_OK;
   }


### PR DESCRIPTION
## Description

Small fix for GNPSMetaValueFile. Instead of passing a list of mzML file names, pass a ConsensusMap from which the mzML file names will be used to generate the meta value table.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
