### PR TITLE
Fix/GitHub workflow

### DIFF
--- a/.github/workflows/openms_clang_format.yml
+++ b/.github/workflows/openms_clang_format.yml
@@ -29,5 +29,5 @@ jobs:
       if: steps.changed_files.outputs.any_modified == 'true'
       uses: DoozyX/clang-format-lint-action@v0.13
       with:
-        source: ${{ steps.changed_files.outputs.all_modified_files }}
+        source: ${{ steps.changed_files.outputs.all_changed_files }}
         clangFormatVersion: 13

--- a/.github/workflows/openms_clang_format.yml
+++ b/.github/workflows/openms_clang_format.yml
@@ -17,17 +17,17 @@ jobs:
 # Get files changed in the PR
     - name: Get changed files
       id: changed_files
-      uses: tj-actions/changed-files@v12
+      uses: tj-actions/changed-files@v22.2
       with:
           path: .
           files: |
-            \.h$
-            \.cpp$
+            **/*.h
+            **/*.cpp
 
 # Perform linting
     - name: Use clang format linting
       if: steps.changed_files.outputs.any_modified == 'true'
-      uses: DoozyX/clang-format-lint-action@v0.13
+      uses: DoozyX/clang-format-lint-action@v0.14
       with:
         source: ${{ steps.changed_files.outputs.all_changed_files }}
         clangFormatVersion: 13

--- a/.github/workflows/openms_clang_format_add_and_commit.yml
+++ b/.github/workflows/openms_clang_format_add_and_commit.yml
@@ -28,16 +28,16 @@ jobs:
 # Get files changed in the PR
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v10.1
+        uses: tj-actions/changed-files@v22.2
         with:
             path: .
             files: |
-              \.h$
-              \.cpp$
+              **/*.h
+              **/*.cpp
 
 # Perform linting
       - name: Use clang format linting
-        uses: DoozyX/clang-format-lint-action@v0.13
+        uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: ${{ steps.changed-files.outputs.all_modified_files }}
           clangFormatVersion: 13


### PR DESCRIPTION
## Description

This fixes and updates github actions.

- Only changed files are being used for linting (deleted files aren't being linted any more ;-))
- Updated lint and reformat actions to newest tj-action version

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
