### PR TITLE
infra-fix: don't lint deleted files

### DIFF
--- a/.github/workflows/openms_clang_format_add_and_commit.yml
+++ b/.github/workflows/openms_clang_format_add_and_commit.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Use clang format linting
         uses: DoozyX/clang-format-lint-action@v0.14
         with:
-          source: ${{ steps.changed-files.outputs.all_modified_files }}
+          source: ${{ steps.changed-files.outputs.all_changed_files }}
           clangFormatVersion: 13
           inplace: True
       - name: commit


### PR DESCRIPTION
## Description

Follow up for PR https://github.com/OpenMS/OpenMS/pull/6171.
I forgot to adjust to "all_changed_files" not just for "clang_format" but also "clang_format_add_and_commit.

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
