### PR TITLE
fixed indentation in developer-faq.doxygen by adding closing ul tag

### DIFF
--- a/doc/doxygen/public/developer-faq.doxygen
+++ b/doc/doxygen/public/developer-faq.doxygen
@@ -178,14 +178,14 @@
 
  Tool tests are using the tool executable that the user would also receive. We use those executables to run the full algorithm on a small test dataset, to ensure that from version to version, the results stay the same.
 
- @subsection how_to_add_a_new_topp_test How to add a new TOPP test?
+ @subsection how_to_add_a_new_topp_test How to add a new TOPP test
 
  Each tool test consists of:
  <ul>
  <li>An executable call on a test dataset (by using either fixed command line parameters or a <code>.ini</code> file).</li>
  <li>A <code>FuzzyDiff</code> call that compares the temporary output file of the last call and a reference test output that you have to provide.</li>
  <li>A line to add a dependency of the <code>FuzzyDiff</code> call on the actual executable call (so they get executed after each other). Use e.g., <code>ctest -V -R IDMapper</code> to only test tests that include the regex <code>IDMapper</code> (<code>-V</code> is just verbose). Make sure to build the <code>IDMapper</code> and <code>IDMapper_test</code> executable after it is edited. <code>ctest</code> does not have any automatic dependency on the timestamps of the executables.</li>
- <ul>
+ </ul>
 
  @subsection how_to_add_a_new_class_test How to add a new class test
 


### PR DESCRIPTION
## Description

List was missing a ul tag, causing the subsection to not be rendered properly. This has been fixed now:
<img width="1099" alt="Screen Shot 2022-06-16 at 4 28 18 pm" src="https://user-images.githubusercontent.com/31978630/174010821-3fbb930d-2d77-4346-94a2-3ee2943b3c58.png">

Ref: #6177 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
