### PR TITLE
reduce compile time

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
@@ -40,6 +40,7 @@
 
 #include <unordered_map>
 #include <QString>
+#include <QStringList>
 
 using namespace std;
 

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
@@ -41,6 +41,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ExperimentalDesign.h>
 
+
 namespace OpenMS
 {
   /**
@@ -249,46 +250,7 @@ private:
      */ 
     bool getBest_(
       const std::map<Int, std::map<Int, SampleAbundances>> & peptide_abundances, 
-      std::pair<size_t, size_t> & best)
-    {
-      size_t best_n_quant(0);
-      double best_abundance(0);
-      best = std::make_pair(0,0);
-
-      for (auto & fa : peptide_abundances)  // for all fractions 
-      {
-        for (auto & ca : fa.second) // for all charge states
-        {
-          const Int & fraction = fa.first;
-          const Int & charge = ca.first;
-
-          double current_abundance = std::accumulate(
-              std::begin(ca.second),
-              std::end(ca.second),
-              0.0,
-              [] (int value, const SampleAbundances::value_type& p)
-              { return value + p.second; }
-          ); // loop over abundances
-
-          if (current_abundance <= 0) { continue; }
-
-          const size_t current_n_quant = ca.second.size();
-          if (current_n_quant > best_n_quant)
-          {           
-            best_abundance = current_abundance;
-            best_n_quant = current_n_quant;
-            best = std::make_pair(fraction, charge);
-          }
-          else if (current_n_quant == best_n_quant 
-            && current_abundance > best_abundance)  // resolve tie by abundance
-          {
-            best_abundance = current_abundance;
-            best = std::make_pair(fraction, charge);
-          }
-        }
-      }
-      return best_abundance > 0.;
-    }
+      std::pair<size_t, size_t> & best);
 
     /**
          @brief Order keys (charges/peptides for peptide/protein quantification) according to how many samples they allow to quantify, breaking ties by total abundance.

--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -48,6 +48,8 @@
 
 #include <fstream>
 
+#include <QString>
+
 class QStringList;
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -92,6 +92,9 @@ public:
     /// Copy constructor
     EnzymaticDigestion(const EnzymaticDigestion& rhs);
 
+    /// Assignment operator
+    EnzymaticDigestion& operator=(const EnzymaticDigestion& rhs);
+
     /// Destructor
     virtual ~EnzymaticDigestion();
 

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -37,11 +37,12 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CHEMISTRY/DigestionEnzyme.h>
 
-#include <boost/regex.hpp>
 #include <string>
 #include <vector>
 
 #include <functional> // for std::function
+
+#include <boost/regex_fwd.hpp> // forward declaration of boost::regex
 
 namespace OpenMS
 {
@@ -220,7 +221,7 @@ protected:
     /// Used enzyme
     const DigestionEnzyme* enzyme_;
     /// Regex for tokenizing (huge speedup by making this a member instead of stack object in tokenize_())
-    boost::regex re_;
+    boost::regex* re_;
 
     /// specificity of enzyme
     Specificity specificity_;

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
@@ -38,7 +38,6 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 
-#include <string>
 #include <vector>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/CONCEPT/UniqueIdInterface.h
+++ b/src/openms/include/OpenMS/CONCEPT/UniqueIdInterface.h
@@ -34,7 +34,6 @@
 
 #pragma once
 
-#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 
 namespace OpenMS
@@ -143,24 +142,11 @@ public:
 
     /// Assigns a new, valid unique id.  Always returns 1.
     Size
-    setUniqueId()
-    {
-      unique_id_ = UniqueIdGenerator::getUniqueId();
-      return 1;
-    }
+    setUniqueId();
 
     /// Assigns a valid unique id, but only if the present one is invalid.  Returns 1 if the unique id was changed, 0 otherwise.
     Size
-    ensureUniqueId()
-    {
-      if (!hasValidUniqueId())
-      {
-        unique_id_ = UniqueIdGenerator::getUniqueId();
-        return 1;
-      }
-      else
-        return 0;
-    }
+    ensureUniqueId();
 
     /// Assigns the given unique id.
     void

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
@@ -214,7 +214,7 @@ public:
     void set(const String& date);
 
 private:
-    QDateTime* dt_;
+    QDateTime* dt_; // access through PImpl to avoid heavy include penalty
   };
 
 } // namespace OPENMS

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
@@ -37,7 +37,10 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/OpenMSConfig.h>
 
-#include <QtCore/QDate>
+#include <string>
+
+// foward declarations
+class QDateTime; 
 
 namespace OpenMS
 {
@@ -211,7 +214,7 @@ public:
     void set(const String& date);
 
 private:
-    QDateTime dt_;
+    QDateTime* dt_;
   };
 
 } // namespace OPENMS

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
@@ -60,8 +60,9 @@
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/util/XMLUni.hpp>
-#include <xercesc//framework/psvi/XSValue.hpp>
+#include <xercesc/framework/psvi/XSValue.hpp>
 
+#include <list>
 #include <string>
 #include <stdexcept>
 #include <vector>

--- a/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
@@ -38,6 +38,7 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/ID/IdentificationData.h>
 
+#include <QString>
 class QSqlQuery;
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -35,15 +35,15 @@
 #pragma once
 
 #include <OpenMS/KERNEL/Peak1D.h>
-#include <OpenMS/KERNEL/StandardDeclarations.h>
 #include <OpenMS/METADATA/SpectrumSettings.h>
 #include <OpenMS/KERNEL/RangeManager.h>
 #include <OpenMS/METADATA/DataArrays.h>
 #include <OpenMS/METADATA/MetaInfoDescription.h>
 
+#include <numeric>
+
 namespace OpenMS
 {
-  class Peak1D;
   enum class DriftTimeUnit;
   /**
     @brief The representation of a 1D spectrum.

--- a/src/openms/include/OpenMS/QC/DBSuitability.h
+++ b/src/openms/include/OpenMS/QC/DBSuitability.h
@@ -40,8 +40,9 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 
 #include <cfloat>
-#include <map>
 #include <vector>
+
+#include <boost/regex.hpp>
 
 namespace OpenMS
 {

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -32,6 +32,9 @@
 // $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
+#include <boost/foreach.hpp> // must be first, otherwise Q_FOREACH macro will wreak havoc
+#include <boost/regex.hpp>
+
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreGetterSetter.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -40,7 +43,6 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 
 #include <algorithm>
-#include <numeric>
 
 // #define FALSE_DISCOVERY_RATE_DEBUG
 // #undef  FALSE_DISCOVERY_RATE_DEBUG

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -32,6 +32,8 @@
 // $Authors: Oliver Alka, Lukas Zimmermann $
 // --------------------------------------------------------------------------
 
+#include <boost/foreach.hpp> // must be first, otherwise Q_FOREACH macro will wreak havoc
+
 #include <OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h>
 
 #include <OpenMS/CONCEPT/Constants.h>
@@ -47,7 +49,7 @@
 #include <QDirIterator>
 #include <QString>
 #include <QtCore/QProcess>
-#include <fstream>
+#include <sstream>
 
 namespace OpenMS
 {

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -144,6 +144,47 @@ namespace OpenMS
       feature.getIntensity(); // new map element is initialized with 0
   }
 
+  bool PeptideAndProteinQuant::getBest_(const std::map<Int, std::map<Int, SampleAbundances>>& peptide_abundances, std::pair<size_t, size_t>& best)
+  {
+    size_t best_n_quant(0);
+    double best_abundance(0);
+    best = std::make_pair(0,0);
+
+    for (auto & fa : peptide_abundances) // for all fractions 
+    {
+      for (auto & ca : fa.second) // for all charge states
+      {
+        const Int & fraction = fa.first;
+        const Int & charge = ca.first;
+
+        double current_abundance = std::accumulate(
+          std::begin(ca.second),
+          std::end(ca.second),
+          0.0,
+          [] (int value, const SampleAbundances::value_type& p)
+          { return value + p.second; }
+          ); // loop over abundances
+
+        if (current_abundance <= 0) { continue; }
+
+        const size_t current_n_quant = ca.second.size();
+        if (current_n_quant > best_n_quant)
+        {           
+          best_abundance = current_abundance;
+          best_n_quant = current_n_quant;
+          best = std::make_pair(fraction, charge);
+        }
+        else if (current_n_quant == best_n_quant 
+                 && current_abundance > best_abundance) // resolve tie by abundance
+        {
+          best_abundance = current_abundance;
+          best = std::make_pair(fraction, charge);
+        }
+      }
+    }
+    return best_abundance > 0.;
+  }
+
 
   void PeptideAndProteinQuant::quantifyPeptides(
     const vector<PeptideIdentification>& peptides)

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/APPLICATIONS/ToolHandler.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 
 #include <OpenMS/DATASTRUCTURES/Date.h>
@@ -51,6 +52,7 @@
 #include <OpenMS/FORMAT/ParamCTDFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>
+            
 
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
@@ -63,14 +65,10 @@
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 
 #include <QDir>
-#include <QFile>
 #include <QStringList>
 
 #include <boost/math/special_functions/fpclassify.hpp>
 
-#include <ctime>
-#include <cstdio>
-#include <cstdlib>
 #include <iostream>
 
 // OpenMP support

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -65,6 +65,15 @@ namespace OpenMS
   {
   }
 
+  EnzymaticDigestion& EnzymaticDigestion::operator=(const EnzymaticDigestion& rhs)
+  {
+    missed_cleavages_ = rhs.missed_cleavages_;
+    enzyme_ = rhs.enzyme_;
+    re_.reset(new boost::regex(*rhs.re_));
+    specificity_ = rhs.specificity_;
+    return *this;
+  }
+
   EnzymaticDigestion::~EnzymaticDigestion()
   {
   }

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
+#include <boost/regex.hpp>
+
 using namespace std;
 
 namespace OpenMS
@@ -50,13 +52,14 @@ namespace OpenMS
   EnzymaticDigestion::EnzymaticDigestion() :
     missed_cleavages_(0),
     enzyme_(ProteaseDB::getInstance()->getEnzyme("Trypsin")), // @TODO: keep trypsin as default?
-    re_(enzyme_->getRegEx()),
+    re_(new boost::regex(enzyme_->getRegEx())),
     specificity_(SPEC_FULL)
   {
   }
 
   EnzymaticDigestion::~EnzymaticDigestion()
   {
+    delete re_;
   }
 
   Size EnzymaticDigestion::getMissedCleavages() const
@@ -72,7 +75,8 @@ namespace OpenMS
   void EnzymaticDigestion::setEnzyme(const DigestionEnzyme* enzyme)
   {
     enzyme_ = enzyme;
-    re_ = boost::regex(enzyme_->getRegEx());
+    delete re_;
+    re_ = new boost::regex(enzyme_->getRegEx());
   }
 
   String EnzymaticDigestion::getEnzymeName() const
@@ -108,7 +112,7 @@ namespace OpenMS
 
     if (enzyme_->getRegEx() != "()") // if it's not "no cleavage"
     {
-      boost::sregex_token_iterator i(sequence.begin() + start, sequence.begin() + end, re_, -1);
+      boost::sregex_token_iterator i(sequence.begin() + start, sequence.begin() + end, *re_, -1);
       boost::sregex_token_iterator j;
       while (i != j)
       {

--- a/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
@@ -401,11 +401,10 @@ namespace OpenMS
 
     MSSpectrum uncharged_spectrum = getUnchargedSpectrum_(oligo);
 
-    for (uint z = (uint)abs(min_charge); z <= (uint)abs(max_charge) && z < (uint)oligo.size(); ++z)
+    for (UInt z = (UInt)abs(min_charge); z <= (UInt)abs(max_charge) && z < (UInt)oligo.size(); ++z)
     {
       bool add_precursor =
-        ((add_precursor_peaks_ && add_all_precursor_charges_) ||
-         (add_precursor_peaks_ && (z == (uint)abs(max_charge))));
+        ((add_precursor_peaks_ && add_all_precursor_charges_) || (add_precursor_peaks_ && (z == (UInt)abs(max_charge))));
       addChargedSpectrum_(spectrum, uncharged_spectrum, z * sign,
                           add_precursor);
     }

--- a/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
@@ -35,10 +35,8 @@
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <boost/regex.hpp>
 
-#include <iostream>
 #include <limits>
 
 using namespace std;
@@ -48,7 +46,8 @@ namespace OpenMS
   void ProteaseDigestion::setEnzyme(const String& enzyme_name)
   {
     enzyme_ = ProteaseDB::getInstance()->getEnzyme(enzyme_name);
-    re_ = boost::regex(enzyme_->getRegEx());
+    delete re_;
+    re_ = new boost::regex(enzyme_->getRegEx());
   }
 
   bool ProteaseDigestion::isValidProduct(const String& protein,

--- a/src/openms/source/CONCEPT/Exception.cpp
+++ b/src/openms/source/CONCEPT/Exception.cpp
@@ -63,7 +63,7 @@ namespace OpenMS
       function_("?"),
       name_("Exception")
     {
-      GlobalExceptionHandler::getInstance().set(file_, line_, function_, std::string(name_), std::string(what()));
+      GlobalExceptionHandler::getInstance().set(file_, line_, function_, name_, what());
     }
 
     BaseException::BaseException(const char* file, int line, const char* function, const std::string& name, const std::string& message) noexcept :
@@ -73,7 +73,7 @@ namespace OpenMS
       function_(function),
       name_(name)
     {
-      GlobalExceptionHandler::getInstance().set(file_, line_, function_, name_, this->what());
+      GlobalExceptionHandler::getInstance().set(file_, line_, function_, name_, what());
     }
 
     BaseException::BaseException(const char* file, int line, const char* function) noexcept :

--- a/src/openms/source/CONCEPT/UniqueIdInterface.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdInterface.cpp
@@ -34,8 +34,27 @@
 
 #include <OpenMS/CONCEPT/UniqueIdInterface.h>
 
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
+
+
 namespace OpenMS
 {
+  Size UniqueIdInterface::setUniqueId()
+  {
+    unique_id_ = UniqueIdGenerator::getUniqueId();
+    return 1;
+  }
+
+  Size UniqueIdInterface::ensureUniqueId()
+  {
+    if (!hasValidUniqueId())
+    {
+      unique_id_ = UniqueIdGenerator::getUniqueId();
+      return 1;
+    }
+    else
+      return 0;
+  }
 
   void UniqueIdInterface::setUniqueId(const String & rhs)
   {

--- a/src/openms/source/DATASTRUCTURES/DateTime.cpp
+++ b/src/openms/source/DATASTRUCTURES/DateTime.cpp
@@ -37,11 +37,15 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
+
+#include <QtCore/QDate> // very expensive to include!
+
 using namespace std;
 
 namespace OpenMS
 {
-  DateTime::DateTime()
+  DateTime::DateTime() :
+    dt_(new QDateTime)
   {
   }
 
@@ -53,7 +57,7 @@ namespace OpenMS
       return *this;
     }
 
-    dt_ = source.dt_;
+    *dt_ = *source.dt_;
 
     return *this;
   }
@@ -65,34 +69,34 @@ namespace OpenMS
       return *this;
     }
 
-    dt_ = std::move(source.dt_); // use Qt implementation if available
+    std::swap(dt_, source.dt_);
 
     return *this;
   }
 
   bool DateTime::operator==(const DateTime& rhs) const
   {
-    return (dt_ == rhs.dt_);
+    return (*dt_ == *rhs.dt_);
   }
 
   bool DateTime::operator!=(const DateTime& rhs) const
   {
-    return !(dt_ == rhs.dt_);
+    return !(*this == rhs);
   }
 
   bool DateTime::operator<(const DateTime& rhs) const
   {
-    return (dt_ < rhs.dt_);
+    return (*dt_ < *rhs.dt_);
   }
 
   bool DateTime::isValid() const
   {
-    return dt_.isValid();
+    return dt_->isValid();
   }
 
   String DateTime::toString(std::string format) const
   {
-    return dt_.toString(QString::fromStdString(format)).toStdString();
+    return dt_->toString(QString::fromStdString(format)).toStdString();
   }
 
   void DateTime::set(const String& date)
@@ -101,11 +105,11 @@ namespace OpenMS
 
     if (date.has('.') && !date.has('T'))
     {
-      dt_ = (QDateTime::fromString(date.c_str(), "dd.MM.yyyy hh:mm:ss"));
+      *dt_ = (QDateTime::fromString(date.c_str(), "dd.MM.yyyy hh:mm:ss"));
     }
     else if (date.has('/'))
     {
-      dt_ = (QDateTime::fromString(date.c_str(), "MM/dd/yyyy hh:mm:ss"));
+      *dt_ = (QDateTime::fromString(date.c_str(), "MM/dd/yyyy hh:mm:ss"));
     }
     else if (date.has('-'))
     {
@@ -116,38 +120,38 @@ namespace OpenMS
           // remove timezone part, since Qt cannot handle this, check if we also have a millisecond part
           if (date.has('.'))
           {
-            dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss.zzz"));
+            *dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss.zzz"));
           }
           else
           {
-            dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss"));
+            *dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss"));
           }
         }
         else
         {
-          dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddThh:mm:ss"));
+          *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddThh:mm:ss"));
         }
       }
       else if (date.has('Z'))
       {
-        dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddZ"));
+        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddZ"));
       }
       else if (date.has('+'))
       {
-        dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd+hh:mm"));
+        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd+hh:mm"));
       }
       else
       {
-        dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd hh:mm:ss"));
+        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd hh:mm:ss"));
       }
     }
 
-    if (!dt_.isValid())
+    if (!dt_->isValid())
     {
-      dt_ = QDateTime::fromString(date.c_str());  // ddd MMM d YYYY format as found in (old?) protXML files
+      *dt_ = QDateTime::fromString(date.c_str());  // ddd MMM d YYYY format as found in (old?) protXML files
     }
 
-    if (!dt_.isValid())
+    if (!dt_->isValid())
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Invalid date time string");
     }
@@ -155,10 +159,10 @@ namespace OpenMS
 
   void DateTime::set(UInt month, UInt day, UInt year, UInt hour, UInt minute, UInt second)
   {
-    dt_.setDate(QDate(year, month, day));
-    dt_.setTime(QTime(hour, minute, second));
+    dt_->setDate(QDate(year, month, day));
+    dt_->setTime(QTime(hour, minute, second));
 
-    if (!dt_.isValid())
+    if (!dt_->isValid())
     {
       String date_time = String(year) + "-" + String(month) + "-" + String(day)
                          + " " + String(hour) + ":" + String(minute) + ":" + String(second);
@@ -169,15 +173,15 @@ namespace OpenMS
   DateTime DateTime::now()
   {
     DateTime d;
-    d.dt_ = QDateTime::currentDateTime();
+    *d.dt_ = QDateTime::currentDateTime();
     return d;
   }
 
   String DateTime::get() const
   {
-    if (dt_.isValid())
+    if (dt_->isValid())
     {
-      return dt_.toString("yyyy-MM-dd hh:mm:ss");
+      return dt_->toString("yyyy-MM-dd hh:mm:ss");
     }
     return "0000-00-00 00:00:00";
   }
@@ -185,8 +189,8 @@ namespace OpenMS
   void DateTime::get(UInt& month, UInt& day, UInt& year,
                      UInt& hour, UInt& minute, UInt& second) const
   {
-    const QDate& temp_date = dt_.date();
-    const QTime& temp_time = dt_.time();
+    const QDate& temp_date = dt_->date();
+    const QTime& temp_time = dt_->time();
 
     year = temp_date.year();
     month = temp_date.month();
@@ -198,7 +202,7 @@ namespace OpenMS
 
   void DateTime::clear()
   {
-    dt_ = QDateTime();
+    *dt_ = QDateTime();
   }
 
   void DateTime::setDate(const String& date)
@@ -226,7 +230,7 @@ namespace OpenMS
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Could not set date");
     }
 
-    dt_.setDate(temp_date);
+    dt_->setDate(temp_date);
   }
 
   void DateTime::setTime(const String& time)
@@ -239,7 +243,7 @@ namespace OpenMS
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, time, "Could not set time");
     }
 
-    dt_.setTime(temp_time);
+    dt_->setTime(temp_time);
   }
 
   void DateTime::setDate(UInt month, UInt day, UInt year)
@@ -251,7 +255,7 @@ namespace OpenMS
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(year) + "-" + String(month) + "-" + String(day), "Could not set date");
     }
 
-    dt_.setDate(temp_date);
+    dt_->setDate(temp_date);
   }
 
   void DateTime::setTime(UInt hour, UInt minute, UInt second)
@@ -262,12 +266,12 @@ namespace OpenMS
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(hour) + ":" + String(minute) + ":" + String(second), "Could not set time");
     }
-    dt_.setTime(temp_time);
+    dt_->setTime(temp_time);
   }
 
   void DateTime::getDate(UInt& month, UInt& day, UInt& year) const
   {
-    const QDate& temp_date = dt_.date();
+    const QDate& temp_date = dt_->date();
 
     month = temp_date.month();
     day = temp_date.day();
@@ -276,16 +280,16 @@ namespace OpenMS
 
   String DateTime::getDate() const
   {
-    if (dt_.isValid())
+    if (dt_->isValid())
     {
-      return dt_.date().toString("yyyy-MM-dd");
+      return dt_->date().toString("yyyy-MM-dd");
     }
     return "0000-00-00";
   }
 
   void DateTime::getTime(UInt& hour, UInt& minute, UInt& second) const
   {
-    const QTime& temp_time =dt_.time();
+    const QTime& temp_time =dt_->time();
 
     hour = temp_time.hour();
     minute = temp_time.minute();
@@ -294,29 +298,29 @@ namespace OpenMS
 
   String DateTime::getTime() const
   {
-    if (dt_.isValid())
+    if (dt_->isValid())
     {
-      return dt_.time().toString("hh:mm:ss");
+      return dt_->time().toString("hh:mm:ss");
     }
     return "00:00:00";
   }
   
   DateTime& DateTime::addSecs(int s)
   {
-    dt_ = dt_.addSecs(s);
+    *dt_ = dt_->addSecs(s);
     return *this;
   }
 
   bool DateTime::isNull() const
   {
-    return dt_.isNull();
+    return dt_->isNull();
   }
 
   // static
   DateTime DateTime::fromString(const std::string& date, std::string format)
   {
     DateTime d;
-    d.dt_ = QDateTime::fromString(QString::fromStdString(date), QString::fromStdString(format));
+    *d.dt_ = QDateTime::fromString(QString::fromStdString(date), QString::fromStdString(format));
     return d;
   }
 

--- a/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
@@ -33,20 +33,19 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FILTERING/DATAREDUCTION/FeatureFindingMetabo.h>
+
+#include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
 
 #include <fstream>
 
 #include <boost/dynamic_bitset.hpp>
 
 #include "svm.h"
-
-#ifdef _OPENMP
-#endif
 
 // #define FFM_DEBUG
 

--- a/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/ConsensusXMLHandler.cpp
@@ -32,15 +32,17 @@
 // $Authors: Clemens Groepl, Marc Sturm, Mathias Walzer $
 // --------------------------------------------------------------------------
 
+
 #include <OpenMS/FORMAT/HANDLERS/ConsensusXMLHandler.h>
 
-#include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
-#include <fstream>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
+#include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/METADATA/DataProcessing.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <map>
+#include <fstream>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -34,11 +34,12 @@
 
 #include <OpenMS/FORMAT/HANDLERS/FeatureXMLHandler.h>
 
-#include <OpenMS/KERNEL/FeatureMap.h>
-#include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/METADATA/DataProcessing.h>
 
 #include <fstream>
 #include <map>

--- a/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
@@ -32,9 +32,13 @@
 // $Authors: Mathias Walzer$
 // --------------------------------------------------------------------------
 
+
 #include <OpenMS/FORMAT/HANDLERS/MzQuantMLHandler.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <map>
+
 #include <map>
 
 using namespace std;

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -41,6 +41,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <algorithm>
+#include <QString>
 
 #include <boost/regex.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/CHEMISTRY/RNaseDB.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 
+#include <QString>
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlQuery>

--- a/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
+++ b/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
@@ -35,6 +35,8 @@
 #include <OpenMS/MATH/MISC/EmgGradientDescent.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 
+#include <numeric>
+
 namespace OpenMS
 {
   EmgGradientDescent::EmgGradientDescent() :

--- a/src/openms/source/METADATA/MSQuantifications.cpp
+++ b/src/openms/source/METADATA/MSQuantifications.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/METADATA/MSQuantifications.h>
 
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
+
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/QC/DBSuitability.cpp
+++ b/src/openms/source/QC/DBSuitability.cpp
@@ -32,11 +32,13 @@
 // $Authors: Tom Waschischeck $
 // --------------------------------------------------------------------------
 
+
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 #include <OpenMS/FILTERING/ID/IDFilter.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-// OpenMS_GUI config
+#include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
 #include <OpenMS/DATASTRUCTURES/String.h>
@@ -63,7 +63,6 @@ class QWidget;
 namespace OpenMS
 {
   class LayerStatistics;
-  class OnDiscMSExperiment;
   class OSWData;
   class Painter1DBase;
 

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -72,6 +72,20 @@ START_SECTION(([EXTRA] ProteaseDigestion(const ProteaseDigestion& rhs)))
     TEST_EQUAL(pd.getSpecificity(), pd2.getSpecificity());
 END_SECTION
 
+START_SECTION(([EXTRA] ProteaseDigestion& operator=(const ProteaseDigestion& rhs)))
+    ProteaseDigestion pd;
+    pd.setMissedCleavages(1234);
+    pd.setEnzyme("no cleavage");
+    pd.setSpecificity(EnzymaticDigestion::SPEC_SEMI);
+
+    ProteaseDigestion pd2;
+    pd2 = pd;
+
+    TEST_EQUAL(pd.getMissedCleavages(), pd2.getMissedCleavages());
+    TEST_EQUAL(pd.getEnzymeName(), pd2.getEnzymeName());
+    TEST_EQUAL(pd.getSpecificity(), pd2.getSpecificity());
+END_SECTION
+
 START_SECTION((void setEnzyme(const String& enzyme_name)))
     ProteaseDigestion pd;
     pd.setEnzyme("Trypsin");

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -49,6 +49,8 @@
 
 #include <fstream>
 
+#include <QStringList>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -58,6 +58,9 @@
 #include <OpenMS/KERNEL/ChromatogramTools.h>
 #include <OpenMS/KERNEL/ConversionHelper.h>
 
+#include <QStringList>
+
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -50,6 +50,8 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <fstream>
+#include <QStringList>
+
 
 using namespace OpenMS;
 using namespace std;


### PR DESCRIPTION
## Description

Using some results from #5077, this PR removes the QDateTime dependency from OpenMS' DateTime (which has a huge include-time overhead) using PIMPL, and similarly reduces boost/regex.h dependencies.

**Results:**
Compile time for Clang 11 on Linux reduces by 10%
before: 11600 sec
after: 10500 sec 


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
