### PR TITLE
make spectrum and areaiterator const only

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/AreaIterator.h
+++ b/src/openms/include/OpenMS/KERNEL/AreaIterator.h
@@ -37,6 +37,7 @@
 // OpenMS includes
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/PeakIndex.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 // STL includes
 #include <iterator>
@@ -229,8 +230,8 @@ private:
             is_end_ = true;
             return;
           }
-          current_peak_ = current_scan_->MZBegin(low_mz_);
-          end_peak_ = current_scan_->MZEnd(high_mz_);
+          current_peak_ = static_cast<const MSSpectrum>(*current_scan_).MZBegin(low_mz_);
+          end_peak_ = static_cast<const MSSpectrum>(*current_scan_).MZEnd(high_mz_);
           if (current_peak_ != end_peak_)
           {
             return;

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -330,10 +330,10 @@ public:
     ///@name Iterating ranges and areas
     //@{
     /// Returns an area iterator for @p area
-    AreaIterator areaBegin(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz);
+//    AreaIterator areaBegin(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz);
 
     /// Returns an invalid area iterator marking the end of an area
-    AreaIterator areaEnd();
+//    AreaIterator areaEnd();
 
     /// Returns a non-mutable area iterator for @p area
     ConstAreaIterator areaBeginConst(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz) const;

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -418,34 +418,6 @@ public:
 
       @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
     */
-    Iterator MZBegin(CoordinateType mz);
-
-    /**
-      @brief Binary search for peak range begin
-
-      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
-    */
-    Iterator MZBegin(Iterator begin, CoordinateType mz, Iterator end);
-
-    /**
-      @brief Binary search for peak range end (returns the past-the-end iterator)
-
-      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
-    */
-    Iterator MZEnd(CoordinateType mz);
-
-    /**
-      @brief Binary search for peak range end (returns the past-the-end iterator)
-
-      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
-    */
-    Iterator MZEnd(Iterator begin, CoordinateType mz, Iterator end);
-
-    /**
-      @brief Binary search for peak range begin
-
-      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
-    */
     ConstIterator MZBegin(CoordinateType mz) const;
 
     /**
@@ -476,24 +448,6 @@ public:
 
       @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
     */
-    Iterator PosBegin(CoordinateType mz);
-
-    /**
-      @brief Binary search for peak range begin
-
-      Alias for MZBegin()
-
-      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
-    */
-    Iterator PosBegin(Iterator begin, CoordinateType mz, Iterator end);
-
-    /**
-      @brief Binary search for peak range begin
-
-      Alias for MZBegin()
-
-      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
-    */
     ConstIterator PosBegin(CoordinateType mz) const;
 
     /**
@@ -504,24 +458,6 @@ public:
       @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
     */
     ConstIterator PosBegin(ConstIterator begin, CoordinateType mz, ConstIterator end) const;
-
-    /**
-      @brief Binary search for peak range end (returns the past-the-end iterator)
-
-      Alias for MZEnd()
-
-      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
-    */
-    Iterator PosEnd(CoordinateType mz);
-
-    /**
-      @brief Binary search for peak range end (returns the past-the-end iterator)
-
-      Alias for MZEnd()
-
-      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
-    */
-    Iterator PosEnd(Iterator begin, CoordinateType mz, Iterator end);
 
     /**
       @brief Binary search for peak range end (returns the past-the-end iterator)

--- a/src/openms/include/OpenMS/KERNEL/SpectrumHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/SpectrumHelper.h
@@ -81,12 +81,12 @@ namespace OpenMS
     const bool ignore_data_arrays = false
   )
   {
-    typename PeakContainerT::iterator it_start = p.PosBegin(pos_start);
-    typename PeakContainerT::iterator it_end = p.PosEnd(pos_end);
+    typename PeakContainerT::const_iterator it_start = p.PosBegin(pos_start);
+    typename PeakContainerT::const_iterator it_end = p.PosEnd(pos_end);
     if (!ignore_data_arrays)
     {
-      Size hops_left = std::distance(p.begin(), it_start);
-      Size n_elems = std::distance(it_start, it_end);
+      Size hops_left = std::distance<typename PeakContainerT::const_iterator>(p.begin(), it_start);
+      Size n_elems = std::distance<typename PeakContainerT::const_iterator>(it_start, it_end);
 
       typename PeakContainerT::StringDataArrays& SDAs = p.getStringDataArrays();
       for (DataArrays::StringDataArray& sda : SDAs)

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -118,25 +118,6 @@ namespace OpenMS
     return !(operator==(rhs));
   }
 
-
-  ///@name Iterating ranges and areas
-  //@{
-  /// Returns an area iterator for @p area
-  MSExperiment::AreaIterator MSExperiment::areaBegin(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz)
-  {
-    OPENMS_PRECONDITION(min_rt <= max_rt, "Swapped RT range boundaries!")
-    OPENMS_PRECONDITION(min_mz <= max_mz, "Swapped MZ range boundaries!")
-    OPENMS_PRECONDITION(this->isSorted(true), "Experiment is not sorted by RT and m/z! Using AreaIterator will give invalid results!")
-    //std::cout << "areaBegin: " << min_rt << " " << max_rt << " " << min_mz << " " << max_mz << std::endl;
-    return AreaIterator(spectra_.begin(), RTBegin(min_rt), RTEnd(max_rt), min_mz, max_mz);
-  }
-
-  /// Returns an invalid area iterator marking the end of an area
-  MSExperiment::AreaIterator MSExperiment::areaEnd()
-  {
-    return AreaIterator();
-  }
-
   /// Returns a non-mutable area iterator for @p area
   MSExperiment::ConstAreaIterator MSExperiment::areaBeginConst(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz) const
   {

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -653,7 +653,7 @@ namespace OpenMS
   {
     integer_data_arrays_ = ida;
   }
-
+/*
   MSSpectrum::Iterator MSSpectrum::MZBegin(MSSpectrum::CoordinateType mz)
   {
     PeakType p;
@@ -683,7 +683,7 @@ namespace OpenMS
     p.setPosition(mz);
     return upper_bound(begin, end, p, PeakType::PositionLess());
   }
-
+*/
   MSSpectrum::ConstIterator MSSpectrum::MZBegin(MSSpectrum::CoordinateType mz) const
   {
     PeakType p;
@@ -691,6 +691,7 @@ namespace OpenMS
     return lower_bound(ContainerType::begin(), ContainerType::end(), p, PeakType::PositionLess());
   }
 
+/*
   MSSpectrum::Iterator MSSpectrum::PosBegin(MSSpectrum::CoordinateType mz)
   {
     return MZBegin(mz);
@@ -712,7 +713,7 @@ namespace OpenMS
   {
     return MZEnd(begin, mz, end);
   }
-
+*/
   MSSpectrum::ConstIterator MSSpectrum::PosBegin(MSSpectrum::CoordinateType mz) const
   {
     return MZBegin(mz);

--- a/src/tests/class_tests/openms/source/AreaIterator_test.cpp
+++ b/src/tests/class_tests/openms/source/AreaIterator_test.cpp
@@ -50,8 +50,8 @@ START_TEST(AreaIterator, "$Id$")
 /////////////////////////////////////////////////////////////
 
 typedef PeakMap Map;
-typedef Internal::AreaIterator<Map::PeakType, Map::PeakType&, Map::PeakType*, Map::Iterator, Map::SpectrumType::Iterator> AI;
-//typedef Internal::AreaIterator<Map::PeakType, const Map::PeakType&, const Map::PeakType*, Map::ConstIterator, Map::SpectrumType::ConstIterator> CAI;
+//typedef Internal::AreaIterator<Map::PeakType, Map::PeakType&, Map::PeakType*, Map::Iterator, Map::SpectrumType::Iterator> AI;
+typedef Internal::AreaIterator<const Map::PeakType, const Map::PeakType&, const Map::PeakType*, Map::ConstIterator, Map::SpectrumType::ConstIterator> AI;
 
 AI* ptr1 = nullptr, *ptr2 = nullptr;
 AI* nullPointer = nullptr;
@@ -164,11 +164,11 @@ END_SECTION
 
 START_SECTION((AreaIterator& operator++()))
 	AI it = AI(exp.begin(),exp.RTBegin(0), exp.RTEnd(7), 505, 520);
-	Map::PeakType* peak = &(*(it++));
+	const Map::PeakType * peak = &(*(it++));
 	TEST_REAL_SIMILAR(peak->getMZ(),510.0);
 	peak = &(*(it++));
 	TEST_REAL_SIMILAR(peak->getMZ(),506.0);
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 END_SECTION
 
 START_SECTION((AreaIterator operator++(int)))
@@ -177,7 +177,7 @@ START_SECTION((AreaIterator operator++(int)))
 	++it;
 	TEST_REAL_SIMILAR(it->getMZ(),506.0);
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 END_SECTION
 
 START_SECTION((CoordinateType getRT() const))
@@ -194,7 +194,7 @@ START_SECTION((CoordinateType getRT() const))
 	TEST_REAL_SIMILAR(it->getMZ(),506.1);
 	TEST_REAL_SIMILAR(it.getRT(),8.0);
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 END_SECTION
 
 START_SECTION([EXTRA] Overall test)
@@ -224,7 +224,7 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),510.1);
 	TEST_REAL_SIMILAR(it.getRT(),10.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 	
 	//center peaks
 	it = AI(exp.begin(),exp.RTBegin(3), exp.RTEnd(9), 503, 509);
@@ -240,7 +240,7 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),506.1);
 	TEST_REAL_SIMILAR(it.getRT(),8.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 	
 	//upper left area
 	it = AI(exp.begin(),exp.RTBegin(0), exp.RTEnd(7), 505, 520);
@@ -250,7 +250,7 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),506.0);
 	TEST_REAL_SIMILAR(it.getRT(),4.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 	
 	//upper right area
 	it = AI(exp.begin(),exp.RTBegin(5), exp.RTEnd(11), 505, 520);
@@ -260,7 +260,7 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),510.1);
 	TEST_REAL_SIMILAR(it.getRT(),10.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 	
 	//lower right
 	it = AI(exp.begin(),exp.RTBegin(5), exp.RTEnd(11), 500, 505);
@@ -270,7 +270,7 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),502.1);
 	TEST_REAL_SIMILAR(it.getRT(),10.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 
 	//lower left
 	it = AI(exp.begin(),exp.RTBegin(0), exp.RTEnd(7), 500, 505);
@@ -280,19 +280,19 @@ START_SECTION([EXTRA] Overall test)
 	TEST_REAL_SIMILAR(it->getMZ(),504.0);
 	TEST_REAL_SIMILAR(it.getRT(),4.0);	
 	++it;
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 
 	//Test with empty RT range
 	it = AI(exp.begin(),exp.RTBegin(5), exp.RTEnd(5.5), 500, 520);
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 
 	//Test with empty MZ range
 	it = AI(exp.begin(),exp.RTBegin(0), exp.RTEnd(15), 505, 505.5);
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 
 	//Test with empty RT + MZ range
 	it = AI(exp.begin(),exp.RTBegin(5), exp.RTEnd(5.5), 505, 505.5);
-	TEST_EQUAL(it==exp.areaEnd(),true);
+	TEST_EQUAL(it==exp.areaEndConst(),true);
 
 	//Test with empty (no MS level 1) experiment
 	PeakMap exp2(exp);
@@ -302,7 +302,7 @@ START_SECTION([EXTRA] Overall test)
 	exp2[3].setMSLevel(2);
 	exp2[4].setMSLevel(2);
 	it = AI(exp2.begin(),exp2.RTBegin(0), exp2.RTEnd(15), 500, 520);
-	TEST_EQUAL(it==exp2.areaEnd(),true);
+	TEST_EQUAL(it==exp2.areaEndConst(),true);
 END_SECTION
 
 START_SECTION((PeakIndex getPeakIndex() const))

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -741,53 +741,6 @@ START_SECTION((ConstAreaIterator areaBeginConst(CoordinateType min_rt, Coordinat
 }
 END_SECTION
 
-START_SECTION((AreaIterator areaEnd()))
-{
-  NOT_TESTABLE
-}
-END_SECTION
-
-START_SECTION((AreaIterator areaBegin(CoordinateType min_rt, CoordinateType max_rt, CoordinateType min_mz, CoordinateType max_mz)))
-{
-  std::vector< Peak2D> plist;
-
-  Peak2D p1;
-  p1.getPosition()[0] = 1.0;
-  p1.getPosition()[1] = 2.0;
-  plist.push_back(p1);
-  p1.getPosition()[0] = 1.0;
-  p1.getPosition()[1] = 3.0;
-  plist.push_back(p1);
-  p1.getPosition()[0] = 2.0;
-  p1.getPosition()[1] = 10.0;
-  plist.push_back(p1);
-  p1.getPosition()[0] = 2.0;
-  p1.getPosition()[1] = 11.0;
-  plist.push_back(p1);
-
-  PeakMap exp;
-  exp.set2DData(plist);
-
-  PeakMap::AreaIterator it = exp.areaBegin(0,15,0,15);
-
-  TEST_EQUAL(it->getPosition()[0],2.0);
-  it->getPosition()[0] = 4711.0;
-  TEST_EQUAL(it->getPosition()[0],4711.0);
-  it++;
-  TEST_EQUAL(it->getPosition()[0],3.0);
-  it++;
-  TEST_EQUAL(it->getPosition()[0],10.0);
-  it++;
-  TEST_EQUAL(it->getPosition()[0],11.0);
-  it++;
-  TEST_EQUAL(it==exp.areaEnd(),true);
-
-  TEST_PRECONDITION_VIOLATED(exp.areaBegin(15,0,0,15));
-  TEST_PRECONDITION_VIOLATED(exp.areaBegin(0,15,15,0));
-  TEST_PRECONDITION_VIOLATED(exp.areaBegin(15,0,15,0));
-
-}
-END_SECTION
 
 START_SECTION((Iterator RTBegin(CoordinateType rt)))
 {

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -973,50 +973,9 @@ const MSSpectrum spec_find = []() {
   return spec;
 }();
 
-START_SECTION((Iterator MZEnd(CoordinateType mz)))
-{
-  MSSpectrum::Iterator it;
-  auto tmp = spec_find;
-  it = tmp.MZEnd(4.5);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZEnd(5.0);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-  it = tmp.MZEnd(5.5);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-}
-END_SECTION
-
-START_SECTION((Iterator MZBegin(CoordinateType mz)))
-{
-  MSSpectrum::Iterator it;
-  auto tmp = spec_find;
-
-  it = tmp.MZBegin(4.5);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-    it = tmp.MZBegin(5.0);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-    it = tmp.MZBegin(5.5);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-}
-END_SECTION
-
-START_SECTION((Iterator MZBegin(Iterator begin, CoordinateType mz, Iterator end)))
-{
-  MSSpectrum::Iterator it;
-  auto tmp = spec_find;
-
-  it = tmp.MZBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],5.0)
-    it = tmp.MZBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],5.0)
-    it = tmp.MZBegin(tmp.begin(), 4.5, tmp.begin());
-  TEST_EQUAL(it->getPosition()[0],tmp.begin()->getPosition()[0])
-}
-END_SECTION
-
 START_SECTION((ConstIterator MZBegin(ConstIterator begin, CoordinateType mz, ConstIterator end) const))
 {
-  MSSpectrum::Iterator it;
+  MSSpectrum::ConstIterator it;
   auto tmp = spec_find;
 
   it = tmp.MZBegin(tmp.begin(), 4.5, tmp.end());
@@ -1024,20 +983,6 @@ START_SECTION((ConstIterator MZBegin(ConstIterator begin, CoordinateType mz, Con
     it = tmp.MZBegin(tmp.begin(), 4.5, tmp.end());
   TEST_EQUAL(it->getPosition()[0],5.0)
     it = tmp.MZBegin(tmp.begin(), 4.5, tmp.begin());
-  TEST_EQUAL(it->getPosition()[0],tmp.begin()->getPosition()[0])
-}
-END_SECTION
-
-START_SECTION((Iterator MZEnd(Iterator begin, CoordinateType mz, Iterator end)))
-{
-  MSSpectrum::Iterator it;
-  auto tmp = spec_find;
-
-  it = tmp.MZEnd(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],5.0)
-    it = tmp.MZEnd(tmp.begin(), 5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],6.0)
-    it = tmp.MZEnd(tmp.begin(), 4.5, tmp.begin());
   TEST_EQUAL(it->getPosition()[0],tmp.begin()->getPosition()[0])
 }
 END_SECTION
@@ -1083,32 +1028,6 @@ END_SECTION
 
 auto tmp = spec_find;
 
-START_SECTION((Iterator PosBegin(CoordinateType mz)))
-{
-  MSSpectrum::Iterator it;
-  it = tmp.PosBegin(4.5);
-  TEST_EQUAL(it->getPos(), 5.0)
-  it = tmp.PosBegin(5.0);
-  TEST_EQUAL(it->getPos(), 5.0)
-  it = tmp.PosBegin(5.5);
-  TEST_EQUAL(it->getPos(), 6.0)
-}
-END_SECTION
-
-START_SECTION((Iterator PosBegin(Iterator begin, CoordinateType mz, Iterator end)))
-{
-  MSSpectrum::Iterator it;
-  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPos(), 5.0)
-  it = tmp.PosBegin(tmp.begin(), 5.5, tmp.end());
-  TEST_EQUAL(it->getPos(), 6.0)
-  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
-  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
-  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
-  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
-}
-END_SECTION
-
 START_SECTION((ConstIterator PosBegin(CoordinateType mz) const ))
 {
   MSSpectrum::ConstIterator it;
@@ -1121,35 +1040,11 @@ START_SECTION((ConstIterator PosBegin(CoordinateType mz) const ))
 }
 END_SECTION
 
-START_SECTION((ConstIterator PosBegin(ConstIterator begin, CoordinateType mz, ConstIterator end) const ))
-{
-  MSSpectrum::ConstIterator it;
-  it = tmp.PosBegin(tmp.begin(), 3.5, tmp.end());
-  TEST_EQUAL(it->getPos(), 4.0)
-  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPos(), 5.0)
-  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
-  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
-  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
-  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
-}
-END_SECTION
 
-START_SECTION((Iterator PosEnd(CoordinateType mz)))
-{
-  MSSpectrum::Iterator it;
-  it = tmp.PosEnd(4.5);
-  TEST_EQUAL(it->getPos(), 5.0)
-  it = tmp.PosEnd(5.0);
-  TEST_EQUAL(it->getPos(), 6.0)
-  it = tmp.PosEnd(5.5);
-  TEST_EQUAL(it->getPos(), 6.0)
-}
-END_SECTION
 
 START_SECTION((Iterator PosEnd(Iterator begin, CoordinateType mz, Iterator end)))
 {
-  MSSpectrum::Iterator it;
+  MSSpectrum::ConstIterator it;
   it = tmp.PosEnd(tmp.begin(), 3.5, tmp.end());
   TEST_EQUAL(it->getPos(), 4.0)
   it = tmp.PosEnd(tmp.begin(), 4.0, tmp.end());

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -451,8 +451,8 @@ public:
           PeakMap::Iterator itm = exp.RTBegin(max_peak.getRT());
           SignedSize low = std::min<SignedSize>(std::distance(exp.begin(), itm), rt_collect);
           SignedSize high = std::min<SignedSize>(std::distance(itm, exp.end()) - 1, rt_collect);
-          PeakMap::AreaIterator itt = exp.areaBegin((itm - low)->getRT() - 0.01, (itm + high)->getRT() + 0.01, cm[i].getMZ() - mz_da, cm[i].getMZ() + mz_da);
-          for (; itt != exp.areaEnd(); ++itt)
+          PeakMap::ConstAreaIterator itt = exp.areaBeginConst((itm - low)->getRT() - 0.01, (itm + high)->getRT() + 0.01, cm[i].getMZ() - mz_da, cm[i].getMZ() + mz_da);
+          for (; itt != exp.areaEndConst(); ++itt)
           {
             mz.push_back(itt->getMZ());
             //std::cerr << "ppm: " << itt.getRT() << " " <<  itt->getMZ() << " " << itt->getIntensity() << std::endl;


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

PeakIterators in MSSpectrum harbor a lot of possibilities for messing up e.g., the relation with the data arrays.  Changeing the data layout from AoS to SoA is also not easily possible, with many iterators returning non-const references to Peak1D.
This change removes some of the non-const iterators for said reasons and to evaluate the impact on the OpenMS code base.

In addition, makes AreaIterator a const view that doesn't allow changing the underlying peaks.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
