### PR TITLE
fix segfault when assigning to a moved-from DateTime

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
@@ -217,9 +217,8 @@ public:
       */
       void set(const String& date);
 
-private:
     private:
-      std::unique_ptr<QDateTime> dt_; // use PImpl, to avoid constly #include
+      std::unique_ptr<QDateTime> dt_; // use PImpl, to avoid costly #include
   };
 
 } // namespace OPENMS

--- a/src/openms/source/DATASTRUCTURES/DateTime.cpp
+++ b/src/openms/source/DATASTRUCTURES/DateTime.cpp
@@ -66,7 +66,14 @@ namespace OpenMS
       return *this;
     }
 
-    *dt_ = *source.dt_;
+    if (dt_ == nullptr)
+    { // *this is in a 'moved-from' state; we need to create a dt_ object first
+      dt_ = make_unique<QDateTime>(*source.dt_);
+    }
+    else
+    {
+      *dt_ = *source.dt_;
+    }
 
     return *this;
   }


### PR DESCRIPTION
## Description

amends #6207 and fixes a segfault when doing this:
```
DateTime a;
DateTime b(std::move(a));
a = b; // segfaults
```

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
