### PR TITLE
[Fix] GNPSExport pyopenms tests

### DIFF
--- a/src/pyOpenMS/pxds/GNPSMGFFile.pxd
+++ b/src/pyOpenMS/pxds/GNPSMGFFile.pxd
@@ -14,5 +14,4 @@ cdef extern from "<OpenMS/FORMAT/GNPSMGFFile.h>" namespace "OpenMS":
         GNPSMGFFile() nogil except +
         GNPSMGFFile(GNPSMGFFile &) nogil except +
 
-        void store(String & consensus_file_path, StringList & mzml_file_paths, String & out) nogil except + # wrap-doc:Export consensus file from default workflow to GNPS MGF format
-        
+        void store(const String& consensus_file_path, const StringList& mzml_file_paths, const String& out) nogil except + # wrap-doc:Export consensus file from default workflow to GNPS MGF format

--- a/src/pyOpenMS/pxds/GNPSMetaValueFile.pxd
+++ b/src/pyOpenMS/pxds/GNPSMetaValueFile.pxd
@@ -9,7 +9,7 @@ cdef extern from "<OpenMS/FORMAT/GNPSMetaValueFile.h>" namespace "OpenMS":
         GNPSMetaValueFile() nogil except +
         GNPSMetaValueFile(GNPSMetaValueFile &) nogil except +
 
-        void store(ConsensusMap& consensus_map, String & output_file) nogil except +
+        void store(const ConsensusMap& consensus_map, const String& output_file) nogil except +
         # wrap-doc:
         #  Write meta value table (tsv file) from a list of mzML files. Required for GNPS FBMN.
         #  

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5608,7 +5608,7 @@ def testString():
     assert(r.decode("iso8859_15") == u"bläh")
 
 @report
-def testIIMN():
+def testGNPSExport():
     cm = pyopenms.ConsensusMap()
     
     for mz, rt, ion, linked_groups in [(222.08, 62.0, "[M+H]+", ["1","2","3"]),
@@ -5636,7 +5636,7 @@ def testIIMN():
 """
     os.remove("SupplementaryPairsTable.csv")
 
-    pyopenms.GNPSQuantificationFile.store(cm, "FeatureQuantificationTable.txt")
+    pyopenms.GNPSQuantificationFile().store(cm, "FeatureQuantificationTable.txt")
     with open("FeatureQuantificationTable.txt", "r") as f:
         assert f.read() == """#MAP	id	filename	label	size
 #CONSENSUS	rt_cf	mz_cf	intensity_cf	charge_cf	width_cf	quality_cf	row ID	best ion	partners	annotation network number
@@ -5647,7 +5647,7 @@ CONSENSUS	62.0	294.100000000000023	0.0	1	0.0	2.0	4	[M+H]+		2
 """
     os.remove("FeatureQuantificationTable.txt")
 
-    pyopenms.GNPSMetaValueFile.store(cm, "MetaValueTable.tsv")
+    pyopenms.GNPSMetaValueFile().store(cm, "MetaValueTable.tsv")
     with open("MetaValueTable.tsv", "r") as f:
         assert f.read() == """filename	ATTRIBUTE_MAPID
 1.mzML	MAP0


### PR DESCRIPTION
Small fix for the pyopenms tests for GNPSQuantificationFile and GNPSMetaValueFile. Also changed GNPSMGFFile.store that conversion to String of input and output file paths is not necessary anymore.

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
