### PR TITLE
pyopenms test - don't modify existing element (leads to side effects …

### DIFF
--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -368,9 +368,9 @@ def testFineIsotopePatternGenerator():
     water = pyopenms.EmpiricalFormula("H2O")
     mw = methanol + water
     iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-20, False, False))
-    assert len(iso_dist.getContainer()) == 56 # now 33 ?
+    assert len(iso_dist.getContainer()) == 56
     iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200, False, False))
-    assert len(iso_dist.getContainer()) == 88 # now 42
+    assert len(iso_dist.getContainer()) == 84
 
     c100 = pyopenms.EmpiricalFormula("C100")
     iso_dist = c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200, False, False))

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5270,7 +5270,7 @@ def testElementDB():
     assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()
     assert len(e2.getIsotopeDistribution().getContainer()) == 1
-    assert abs(e2.getIsotopeDistribution().getContainer()[0].getIntensity() - 0.1) < 1e-5
+    assert abs(e2.getIsotopeDistribution().getContainer()[0].getIntensity() - 1.0) < 1e-5
     # assert e == e2
 
     #  not yet implemented

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5258,14 +5258,14 @@ def testElementDB():
 
     # changing existing elements in tests might have side effects so we define a new element
     # add first new element
-    e2 = edb.addElement(b"Kryptonite", b"@", 500, {999 : 0.7, 1000 : 0.3}, {999 : 999.99, 1000 : 1000.01}, False)
+    e2 = edb.addElement(b"Kryptonite", b"@", 500, {999 : 0.7, 1000 : 0.3}, {999 : 999.01, 1000 : 1000.01}, False)
     e2 = edb.getElement(pyopenms.String("@"))
     assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()
     assert len(e2.getIsotopeDistribution().getContainer()) == 2
     assert abs(e2.getIsotopeDistribution().getContainer()[1].getIntensity() - 0.3) < 1e-5
     # replace element
-    e2 = edb.addElement(b"Kryptonite", b"@", 500, {9999 : 0.9}, {9999 : 9999.9}, True)
+    e2 = edb.addElement(b"Kryptonite", b"@", 500, {9999 : 1.0}, {9999 : 9999.1}, True)
     e2 = edb.getElement(pyopenms.String("@"))
     assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5256,14 +5256,21 @@ def testElementDB():
     e2 = edb.getElement(pyopenms.String("NE"))
     assert e2.getName() == "NewElement"
 
-    # replace oxygen
-    e2 = edb.addElement(b"Oxygen", b"O", 8, {16 : 0.7, 19 : 0.3}, {16 : 16.01, 19 : 19.01}, True)
-    e2 = edb.getElement(pyopenms.String("O"))
-    assert e2.getName() == "Oxygen"
+    # changing existing elements in tests might have side effects so we define a new element
+    # add first new element
+    e2 = edb.addElement(b"Cryptonite", b"@", 500, {999 : 0.7, 1000 : 0.3}, {999 : 999.99, 1000 : 1000.01}, False)
+    e2 = edb.getElement(pyopenms.String("@"))
+    assert e2.getName() == "Cryptonite"
     assert e2.getIsotopeDistribution()
     assert len(e2.getIsotopeDistribution().getContainer()) == 2
     assert abs(e2.getIsotopeDistribution().getContainer()[1].getIntensity() - 0.3) < 1e-5
-
+    # replace element
+    e2 = edb.addElement(b"Cryptonite", b"@", 500, {9999 : 0.9, 1000 : 0.1}, True)
+    e2 = edb.getElement(pyopenms.String("@"))
+    assert e2.getName() == "Cryptonite"
+    assert e2.getIsotopeDistribution()
+    assert len(e2.getIsotopeDistribution().getContainer()) == 1
+    assert abs(e2.getIsotopeDistribution().getContainer()[0].getIntensity() - 0.1) < 1e-5
     # assert e == e2
 
     #  not yet implemented

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5265,7 +5265,7 @@ def testElementDB():
     assert len(e2.getIsotopeDistribution().getContainer()) == 2
     assert abs(e2.getIsotopeDistribution().getContainer()[1].getIntensity() - 0.3) < 1e-5
     # replace element
-    e2 = edb.addElement(b"Kryptonite", b"@", 500, {9999 : 0.9, 1000 : 0.1}, True)
+    e2 = edb.addElement(b"Kryptonite", b"@", 500, {9999 : 0.9}, {9999 : 9999.9}, True)
     e2 = edb.getElement(pyopenms.String("@"))
     assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5258,16 +5258,16 @@ def testElementDB():
 
     # changing existing elements in tests might have side effects so we define a new element
     # add first new element
-    e2 = edb.addElement(b"Cryptonite", b"@", 500, {999 : 0.7, 1000 : 0.3}, {999 : 999.99, 1000 : 1000.01}, False)
+    e2 = edb.addElement(b"Kryptonite", b"@", 500, {999 : 0.7, 1000 : 0.3}, {999 : 999.99, 1000 : 1000.01}, False)
     e2 = edb.getElement(pyopenms.String("@"))
-    assert e2.getName() == "Cryptonite"
+    assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()
     assert len(e2.getIsotopeDistribution().getContainer()) == 2
     assert abs(e2.getIsotopeDistribution().getContainer()[1].getIntensity() - 0.3) < 1e-5
     # replace element
-    e2 = edb.addElement(b"Cryptonite", b"@", 500, {9999 : 0.9, 1000 : 0.1}, True)
+    e2 = edb.addElement(b"Kryptonite", b"@", 500, {9999 : 0.9, 1000 : 0.1}, True)
     e2 = edb.getElement(pyopenms.String("@"))
-    assert e2.getName() == "Cryptonite"
+    assert e2.getName() == "Kryptonite"
     assert e2.getIsotopeDistribution()
     assert len(e2.getIsotopeDistribution().getContainer()) == 1
     assert abs(e2.getIsotopeDistribution().getContainer()[0].getIntensity() - 0.1) < 1e-5


### PR DESCRIPTION
…in combination with parallel execution)

fixes #6081
replaces https://github.com/OpenMS/OpenMS/pull/6223

Best explanation:
nose tests are run in parallel. Sometimes the ElementsDB test that modified Oxygen get's called before the IsotopeDistribution test -> sometimes we get the right and sometimes the wrong result.


## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
