### PR TITLE
SoA-Data-Layout-Abstraction

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/LinearResampler.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/LinearResampler.h
@@ -64,7 +64,7 @@ namespace OpenMS
   {
 
 public:
-
+    typedef MSSpectrum::Container Container;
     /// Constructor
     LinearResampler() :
       DefaultParamHandler("LinearResampler")
@@ -94,11 +94,11 @@ public:
       int number_raw_points = static_cast<int>(spectrum.size());
       int number_resampled_points = static_cast<int>(ceil((end_pos - start_pos) / spacing_ + 1));
 
-      std::vector<Peak1D> resampled_peak_container;
+      Container resampled_peak_container;
       resampled_peak_container.resize(number_resampled_points);
 
       // generate the resampled peaks at positions origin+i*spacing_
-      std::vector<Peak1D>::iterator it = resampled_peak_container.begin();
+      Container::iterator it = resampled_peak_container.begin();
       for (int i = 0; i < number_resampled_points; ++i)
       {
         it->setMZ(start_pos + i * spacing_);
@@ -136,8 +136,8 @@ public:
         intensity += static_cast<double>((first + i)->getIntensity()) * distance_left;
         (it + right_index)->setIntensity(intensity);
       }
-
-      spectrum.swap(resampled_peak_container);
+      swap(spectrum, resampled_peak_container);
+      //spectrum.swap(resampled_peak_container);
     }
 
     /**

--- a/src/openms/include/OpenMS/KERNEL/AreaIterator.h
+++ b/src/openms/include/OpenMS/KERNEL/AreaIterator.h
@@ -53,11 +53,19 @@ namespace OpenMS
 
         @note This iterator iterates over spectra with MS level 1 only!
     */
-    template <class ValueT, class ReferenceT, class PointerT, class SpectrumIteratorT, class PeakIteratorT>
+    template <typename SpectrumContainerT>
     class AreaIterator :
-      public std::iterator<std::forward_iterator_tag, ValueT>
+      public std::iterator<std::forward_iterator_tag, typename SpectrumContainerT::value_type::value_type>
     {
 public:
+      
+      using ValueT = typename SpectrumContainerT::value_type::value_type;
+      using ReferenceT = typename SpectrumContainerT::value_type::reference;
+      using PointerT = typename SpectrumContainerT::value_type::Iterator::pointer;
+      using SpectrumIteratorT = typename SpectrumContainerT::iterator;
+      using PeakIteratorT = typename SpectrumContainerT::value_type::Iterator;
+
+
       typedef double CoordinateType;
       typedef ValueT PeakType;
       typedef SpectrumIteratorT SpectrumIteratorType;
@@ -140,6 +148,8 @@ public:
       /// Test for equality
       bool operator==(const AreaIterator & rhs) const
       {
+        if (&(*(current_scan_)) != &(*(rhs.current_scan_))) return false; 
+
         //Both end iterators => equal
         if (is_end_ && rhs.is_end_) return true;
 
@@ -149,7 +159,7 @@ public:
         if (is_end_ && !rhs.is_end_) return false;
 
         //Equality of pointed to peak addresses
-        return &(*current_peak_) == &(*(rhs.current_peak_));
+        return current_peak_ == rhs.current_peak_;
       }
 
       /// Test for inequality
@@ -189,7 +199,13 @@ public:
       }
 
       /// Dereferencing of this pointer yields the underlying peak
-      pointer operator->() const
+      pointer operator->() 
+      {
+        return current_peak_.operator->();
+      }
+
+      /// Dereferencing of this const pointer yields the underlying peak
+      const pointer operator->() const
       {
         return current_peak_.operator->();
       }

--- a/src/openms/include/OpenMS/KERNEL/AreaIterator.h
+++ b/src/openms/include/OpenMS/KERNEL/AreaIterator.h
@@ -35,6 +35,7 @@
 #pragma once
 
 // OpenMS includes
+#include <type_traits>
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/PeakIndex.h>
 
@@ -53,7 +54,7 @@ namespace OpenMS
 
         @note This iterator iterates over spectra with MS level 1 only!
     */
-    template <typename SpectrumContainerT>
+    template <typename SpectrumContainerT, bool Constness>
     class AreaIterator :
       public std::iterator<std::forward_iterator_tag, typename SpectrumContainerT::value_type::value_type>
     {
@@ -62,8 +63,10 @@ public:
       using ValueT = typename SpectrumContainerT::value_type::value_type;
       using ReferenceT = typename SpectrumContainerT::value_type::reference;
       using PointerT = typename SpectrumContainerT::value_type::Iterator::pointer;
-      using SpectrumIteratorT = typename SpectrumContainerT::iterator;
-      using PeakIteratorT = typename SpectrumContainerT::value_type::Iterator;
+      typedef typename std::conditional< Constness, typename SpectrumContainerT::iterator, typename SpectrumContainerT::const_iterator>::type SpectrumIteratorT;
+      typedef typename std::conditional< Constness, typename SpectrumContainerT::value_type::Iterator, typename SpectrumContainerT::value_type::ConstIterator>::type PeakIteratorT;
+      // using SpectrumIteratorT = typename SpectrumContainerT::iterator;
+      // using PeakIteratorT = typename SpectrumContainerT::value_type::Iterator;
 
 
       typedef double CoordinateType;

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -106,9 +106,9 @@ public:
     /// Non-mutable iterator
     typedef std::vector<SpectrumType>::const_iterator ConstIterator;
     /// Mutable area iterator type (for traversal of a rectangular subset of the peaks)
-    typedef Internal::AreaIterator<Base> AreaIterator;
+    typedef Internal::AreaIterator<Base, false> AreaIterator;
     /// Immutable area iterator type (for traversal of a rectangular subset of the peaks)
-    typedef Internal::AreaIterator<const Base> ConstAreaIterator;
+    typedef Internal::AreaIterator<const Base, true> ConstAreaIterator;
     //@}
 
     /// @name Delegations of calls to the vector of MSSpectra

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -74,6 +74,7 @@ namespace OpenMS
 
 public:
     typedef Peak1D PeakT;
+    typedef MSSpectrum::Peak1DTuple Peak1DTuple;
     typedef ChromatogramPeak ChromatogramPeakT;
 
     /// @name Base type definitions
@@ -105,9 +106,9 @@ public:
     /// Non-mutable iterator
     typedef std::vector<SpectrumType>::const_iterator ConstIterator;
     /// Mutable area iterator type (for traversal of a rectangular subset of the peaks)
-    typedef Internal::AreaIterator<PeakT, PeakT&, PeakT*, Iterator, SpectrumType::Iterator> AreaIterator;
+    typedef Internal::AreaIterator<Base> AreaIterator;
     /// Immutable area iterator type (for traversal of a rectangular subset of the peaks)
-    typedef Internal::AreaIterator<const PeakT, const PeakT&, const PeakT*, ConstIterator, SpectrumType::ConstIterator> ConstAreaIterator;
+    typedef Internal::AreaIterator<const Base> ConstAreaIterator;
     //@}
 
     /// @name Delegations of calls to the vector of MSSpectra
@@ -214,7 +215,7 @@ public:
           continue;
         }
         typename Container::value_type s; // explicit object here, since instantiation within push_back() fails on VS<12
-        for (typename SpectrumType::const_iterator it = spec->begin(); it != spec->end(); ++it)
+        for (typename MSSpectrum::ConstIterator it = spec->cbegin(); it != spec->cend(); ++it)
         {
           cont.push_back(s);
           cont.back().setRT(spec->getRT());
@@ -614,9 +615,9 @@ private:
       static void addData_(SpectrumType* spectrum, const ContainerValueType* item)
       {
         // create temporary peak and insert it into spectrum
-        spectrum->insert(spectrum->end(), PeakType());
+        spectrum->insert(spectrum->end(), Peak1DTuple());
         spectrum->back().setIntensity(item->getIntensity());
-        spectrum->back().setPosition(item->getMZ());
+        spectrum->back().setMZ(item->getMZ());
       }
       /// general method for adding data points, including metadata arrays (populated from metainfointerface)
       static void addData_(SpectrumType* spectrum, const ContainerValueType* item, const StringList& store_metadata_names)

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -104,7 +104,7 @@ public:
     ///@name Base type definitions
     //@{
     /// Peak type
-    typedef OpenMS::Peak1D PeakType;
+    typedef Peak1DT<double, double> PeakType;
     /// Peak1D Tuple
     typedef Peak1DT<double, double> Peak1DTuple;
     /// Container for Peak1DT
@@ -144,6 +144,10 @@ public:
     //@}
 
     using Container::back;
+    using Container::begin;
+    using Container::cbegin;
+    using Container::end;
+    using Container::cend;
     using Container::emplace_back;
     using Container::empty;
     using Container::erase;
@@ -152,13 +156,17 @@ public:
     using Container::operator[];
     using Container::push_back;
     using Container::operator=;
+    using Container::pointer;
     using Container::pop_back;
     using Container::reserve;
-    using Container::value_type;
     using Container::resize;
     using Container::reference;
-    using Container::pointer;
+    using Container::size;
+    using Container::value_type;
     using Container::const_value_type;
+
+    using typename Container::iterator;
+    using typename Container::const_iterator;
 
     ///@name Export methods from std::vector<Peak1D>
     //@{
@@ -288,14 +296,6 @@ public:
     TConstIterator TCbegin() const;
 
     TConstIterator TCend() const;
-
-    TIterator begin();
-
-    TIterator end();
-
-    TConstIterator cbegin() const;
-
-    TConstIterator cend() const;
 
     void insert(TIterator it, Peak1DTuple peak);
 

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -65,7 +65,7 @@ namespace OpenMS
     @ingroup Kernel
   */
   class OPENMS_DLLAPI MSSpectrum final :
-    private BaseContainer<VectorTemplate, Peak1DT<double,double>>,
+    public BaseContainer<VectorTemplate, Peak1DT<double,double>>,
     public RangeManagerContainer<RangeMZ, RangeIntensity>,
     public SpectrumSettings
   {

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -39,7 +39,7 @@
 #include <OpenMS/KERNEL/RangeManager.h>
 #include <OpenMS/METADATA/DataArrays.h>
 #include <OpenMS/METADATA/MetaInfoDescription.h>
-#include <OpenMS/KERNEL/Peak1DT.h>
+#include <OpenMS/KERNEL/MSSpectrumSoAWrapper.h>
 
 #include <numeric>
 
@@ -108,7 +108,7 @@ public:
     /// Peak1D Tuple
     typedef Peak1DT<double, double> Peak1DTuple;
     /// Container for Peak1DT
-    typedef BaseContainer<MyVector, Peak1DTuple> Container;
+    typedef BaseContainer<VectorTemplate, Peak1DTuple> Container;
     /// Coordinate (m/z) type
     typedef typename PeakType::CoordinateType CoordinateType;
     /// Spectrum base type
@@ -129,6 +129,10 @@ public:
 
     ///@name Peak container iterator type definitions
     //@{
+    /// Mutable Iterator for Tuple
+    typedef typename Container::iterator TIterator;
+    /// Non-Mutable Iterator for Tuple
+    typedef typename Container::const_iterator TConstIterator;
     /// Mutable iterator
     typedef typename ContainerType::iterator Iterator;
     /// Non-mutable iterator
@@ -160,7 +164,7 @@ public:
     using ContainerType::insert;
     using ContainerType::erase;
     using ContainerType::swap;
-
+    
     using typename ContainerType::iterator;
     using typename ContainerType::const_iterator;
     using typename ContainerType::size_type;
@@ -259,6 +263,16 @@ public:
     void setName(const String& name);
 
     //@}
+
+    TIterator TBegin();
+
+    TIterator TEnd();
+
+    TConstIterator TCbegin() const;
+
+    TConstIterator TCend() const;
+
+
 
     /**
       @name Peak data array methods
@@ -600,11 +614,11 @@ public:
 
     /// return the peak with the highest intensity. If the peak is not unique, the first peak in the container is returned.
     /// The function works correctly, even if the spectrum is unsorted.
-    ConstIterator getBasePeak() const;
+    TConstIterator getBasePeak() const;
 
     /// return the peak with the highest intensity. If the peak is not unique, the first peak in the container is returned.
     /// The function works correctly, even if the spectrum is unsorted.
-    Iterator getBasePeak();
+    TIterator getBasePeak();
 
     /// compute the total ion count (sum of all peak intensities)
     PeakType::IntensityType calculateTIC() const;
@@ -612,7 +626,7 @@ public:
 protected:
 
     /// Peak1d Tuple
-    Container spectra();
+    Container peaks;
 
     /// Retention time
     double retention_time_;

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -39,6 +39,7 @@
 #include <OpenMS/KERNEL/RangeManager.h>
 #include <OpenMS/METADATA/DataArrays.h>
 #include <OpenMS/METADATA/MetaInfoDescription.h>
+#include <OpenMS/KERNEL/Peak1DT.h>
 
 #include <numeric>
 
@@ -104,6 +105,10 @@ public:
     //@{
     /// Peak type
     typedef OpenMS::Peak1D PeakType;
+    /// Peak1D Tuple
+    typedef Peak1DT<double, double> Peak1DTuple;
+    /// Container for Peak1DT
+    typedef BaseContainer<MyVector, Peak1DTuple> Container;
     /// Coordinate (m/z) type
     typedef typename PeakType::CoordinateType CoordinateType;
     /// Spectrum base type
@@ -605,6 +610,10 @@ public:
     PeakType::IntensityType calculateTIC() const;
 
 protected:
+
+    /// Peak1d Tuple
+    Container spectra();
+
     /// Retention time
     double retention_time_;
 

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -65,7 +65,7 @@ namespace OpenMS
     @ingroup Kernel
   */
   class OPENMS_DLLAPI MSSpectrum final :
-    private std::vector<Peak1D>,
+    private BaseContainer<VectorTemplate, Peak1DT<double,double>>,
     public RangeManagerContainer<RangeMZ, RangeIntensity>,
     public SpectrumSettings
   {
@@ -134,45 +134,62 @@ public:
     /// Non-Mutable Iterator for Tuple
     typedef typename Container::const_iterator TConstIterator;
     /// Mutable iterator
-    typedef typename ContainerType::iterator Iterator;
+    typedef typename Container::iterator Iterator;
     /// Non-mutable iterator
-    typedef typename ContainerType::const_iterator ConstIterator;
+    typedef typename Container::const_iterator ConstIterator;
     /// Mutable reverse iterator
     typedef typename ContainerType::reverse_iterator ReverseIterator;
     /// Non-mutable reverse iterator
     typedef typename ContainerType::const_reverse_iterator ConstReverseIterator;
     //@}
 
+    using Container::back;
+    using Container::emplace_back;
+    using Container::empty;
+    using Container::erase;
+    using Container::front;
+    using Container::insertionSort;
+    using Container::operator[];
+    using Container::push_back;
+    using Container::operator=;
+    using Container::pop_back;
+    using Container::reserve;
+    using Container::value_type;
+    using Container::resize;
+    using Container::reference;
+    using Container::pointer;
+    using Container::const_value_type;
+
     ///@name Export methods from std::vector<Peak1D>
     //@{
-    using ContainerType::operator[];
-    using ContainerType::begin;
-    using ContainerType::rbegin;
-    using ContainerType::end;
-    using ContainerType::rend;
-    using ContainerType::cbegin;
-    using ContainerType::cend;
-    using ContainerType::resize;
-    using ContainerType::size;
-    using ContainerType::push_back;
-    using ContainerType::emplace_back;
-    using ContainerType::pop_back;
-    using ContainerType::empty;
-    using ContainerType::front;
-    using ContainerType::back;
-    using ContainerType::reserve;
-    using ContainerType::insert;
-    using ContainerType::erase;
-    using ContainerType::swap;
+    // using ContainerType::operator[];
+    // using ContainerType::begin;
+    // using ContainerType::rbegin;
+    // using ContainerType::end;
+    // using ContainerType::rend;
+    // using ContainerType::cbegin;
+    // using ContainerType::cend;
+    // using ContainerType::resize;
+    // using ContainerType::size;
+    // using ContainerType::push_back;
+    // using ContainerType::emplace_back;
+    // using ContainerType::pop_back;
+    // using ContainerType::empty;
+    // using ContainerType::front;
+    // using ContainerType::back;
+    // using ContainerType::reserve;
+    // using ContainerType::insert;
+    // using ContainerType::erase;
+    // using ContainerType::swap;
     
-    using typename ContainerType::iterator;
-    using typename ContainerType::const_iterator;
-    using typename ContainerType::size_type;
-    using typename ContainerType::value_type;
-    using typename ContainerType::reference;
-    using typename ContainerType::const_reference;
-    using typename ContainerType::pointer;
-    using typename ContainerType::difference_type;
+    // using typename ContainerType::iterator;
+    // using typename ContainerType::const_iterator;
+    // using typename ContainerType::size_type;
+    // using typename ContainerType::value_type;
+    // using typename ContainerType::reference;
+    // using typename ContainerType::const_reference;
+    // using typename ContainerType::pointer;
+    // using typename ContainerType::difference_type;
 
     //@}
 
@@ -272,6 +289,16 @@ public:
 
     TConstIterator TCend() const;
 
+    TIterator begin();
+
+    TIterator end();
+
+    TConstIterator cbegin() const;
+
+    TConstIterator cend() const;
+
+    void insert(TIterator it, Peak1DTuple peak);
+
 
 
     /**
@@ -339,28 +366,6 @@ public:
       @param chunks a Chunk is an object that contains the start and end of a sublist of peaks in the spectrum, that is or isn't sorted yet (is_sorted member)
     */
     void sortByPositionPresorted(const std::vector<Chunk>& chunks);
-
-    /// Checks if all peaks are sorted with respect to ascending m/z
-    bool isSorted() const;
-
-    /// Checks if container is sorted by a certain user-defined property.
-    /// You can pass any lambda function with <tt>[](Size index_1, Size index_2) --> bool</tt>
-    /// which given two indices into MSSpectrum (either for peaks or data arrays) returns a weak-ordering.
-    /// (you need to capture the MSSpectrum in the lambda and operate on it, based on the indices)
-    template<class Predicate>
-    bool isSorted(const Predicate& lambda) const
-    {
-      auto value_2_index_wrapper = [this, &lambda](const value_type& value1, const value_type& value2) {
-        // translate values into indices (this relies on no copies being made!)
-        const Size index1 = (&value1) - (&this->front());
-        const Size index2 = (&value2) - (&this->front());
-        // just make sure the pointers above are actually pointing to a Peak inside our container
-        assert(index1 < this->size()); 
-        assert(index2 < this->size());
-        return lambda(index1, index2);
-      }; 
-      return std::is_sorted(this->begin(), this->end(), value_2_index_wrapper);
-    }
 
     /// Sort by a user-defined property
     /// You can pass any @p lambda function with <tt>[](Size index_1, Size index_2) --> bool</tt>
@@ -661,7 +666,7 @@ protected:
     os << static_cast<const SpectrumSettings&>(spec);
 
     // peaklist
-    for (MSSpectrum::ConstIterator it = spec.begin(); it != spec.end(); ++it)
+    for (MSSpectrum::ConstIterator it = spec.cbegin(); it != spec.cend(); ++it)
     {
       os << *it << std::endl;
     }

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
@@ -493,6 +493,10 @@ template<typename ... T>
 struct Peak1DT : public std::tuple<T ...>{
     using std::tuple<T...>::tuple;
     using std::tuple<T...>::operator=;
+    /// Intensity type
+    using IntensityType = float;
+    /// Coordinate type
+    using CoordinateType = double;
     Peak1DT(const Peak1DT& other) = default;
     Peak1DT(Peak1DT&& other) = default;
     Peak1DT& operator=(Peak1DT&& other_) = default;

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
@@ -191,10 +191,7 @@ struct BaseContainer
 
     bool empty()
     {
-        if(this->size()==0)
-            return true;
-        
-        return false;
+        return !this->size();
     }
 
     void pop_back()
@@ -223,6 +220,9 @@ struct BaseContainer
     {
         std::size_t position_ = it.getPosition();
         std::size_t newPos_ = policy_t::erase( mValues, position_ );
+        if(newPos_ >= this->size()){
+            return this->end();
+        }
         return (this->begin() + newPos_);
     }
 
@@ -338,7 +338,7 @@ public:
     Iterator operator-( T sub ){ return Iterator(this->mContainer, this->mIterPosition - sub); }
 
 
-    friend bool operator!=( Iterator const& lhs, Iterator const& rhs ){ return lhs.mIterPosition != rhs.mIterPosition;}
+    friend bool operator!=( Iterator const& lhs, Iterator const& rhs ){ return lhs.mContainer != rhs.mContainer || lhs.mIterPosition != rhs.mIterPosition;}
     friend bool operator==( Iterator const& lhs, Iterator const& rhs ){ return !operator!=(lhs, rhs);}
 
     operator bool(void) const { return mIterPosition != std::numeric_limits<std::size_t>::infinity(); }

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
@@ -280,6 +280,10 @@ struct BaseContainer
         policy_t::resize( mValues, size_ );
     }
 
+    void friend swap(BaseContainer& one, BaseContainer& other){
+           swap(one.mValues, other.mValues);
+    }
+
     // Function performs insertion sort
     void insertionSort()
     {

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
@@ -1,0 +1,395 @@
+// SOA and AOS tests on god bolt
+
+#include <tuple>
+#include <vector>
+#include <functional>
+#include <string>
+#include <limits>
+#include <iostream>
+
+template <typename T>
+class proxy_holder {
+  T t;
+public:
+  proxy_holder(T&& t) : t(t) {}
+  T* operator ->() { return &t; }
+};
+
+template <typename T>
+struct ref_wrap : public std::reference_wrapper<T>{
+    using type = T;
+    void friend swap(ref_wrap& a, ref_wrap& b) {
+        T tmp = a.get();
+        a.get() = b.get();
+        b.get() = tmp;
+     };
+    void friend swap(ref_wrap&& a, ref_wrap&& b) {
+        T tmp = a.get();
+        a.get() = b.get();
+        b.get() = tmp;
+     };
+    operator T&() const noexcept {return this->get(); }
+    //ref_wrap(const ref_wrap& other_) : std::reference_wrapper<T>(other_.get()){}
+    ref_wrap(const ref_wrap& other_) = default;
+    
+    //ref_wrap(ref_wrap&& other_) : std::reference_wrapper<T>(other_.get()){}
+    ref_wrap(T& other_) : std::reference_wrapper<T>(other_){}
+    ref_wrap(T&& other_) : std::reference_wrapper<T>(other_){}
+    //void operator =(T && other_) {this->get()=other_;}
+    using std::reference_wrapper<T>::operator=;
+    //ref_wrap& operator=(const ref_wrap & other_) {this->get()=other_.get(); return *this;}
+    //ref_wrap& operator=(ref_wrap && other_) {this->get()=other_.get(); return *this;}
+    ref_wrap& operator=(T & other_) {this->get()=other_; return *this;}
+    ref_wrap& operator=(T && other_) {this->get()=other_; return *this;}
+};
+
+template <typename TContainer>
+class Iterator;
+template <typename TContainer>
+class ConstIterator;
+
+template <template <typename...> class Container, typename TItem>
+struct SOAPolicy;
+
+template <template <typename...> class Container, template<typename...> class TItem, typename... Types>
+struct SOAPolicy<Container, TItem<Types...>> {
+    using type = std::tuple<Container<Types>...>;
+    using const_type = std::tuple<const Container<Types>...>;
+    using value_type = TItem<Types...>;
+    using const_value_type = TItem<const ref_wrap<Types>...>;
+    using value_ref_type = TItem<ref_wrap<Types>...>;
+    using const_value_ref_type = TItem<const ref_wrap<Types>...>;
+    using reference_type = TItem<ref_wrap<Types>...>&;
+
+    constexpr static value_type get( type& c_, std::size_t position_ )
+    {
+        return doGet( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static value_ref_type getRef( type& c_, std::size_t position_ )
+    {
+        return doGetRef( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static const_value_ref_type getConstRef(type& c_, std::size_t position_ )
+    {
+        return doGetConstRef( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static void resize( type& c_, std::size_t size_ ) {
+        doResize( c_, size_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    template <typename TValue>
+    constexpr static void push_back( type& c_, TValue&& val_ ){
+        doPushBack( c_, std::forward<TValue>(val_), std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    static constexpr std::size_t size(const type& c_){ return std::get<0>( c_ ).size(); }
+
+    private:
+
+    template <unsigned... Ids>
+    constexpr static auto doGet( type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return value_type{ std::get<Ids>( c_ )[ position_ ]... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static auto doGetRef( type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return value_ref_type{ ref_wrap( std::get<Ids>( c_ )[ position_ ] )... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static auto doGetConstRef(type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return const_value_ref_type{ ref_wrap( std::get<Ids>( c_ )[ position_ ] )... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static void doResize( type& c_, unsigned size_, std::integer_sequence<unsigned, Ids...> )
+    {
+        ( std::get<Ids>( c_ ).resize( size_ ), ... ); //fold expressions
+    }
+
+    template <typename TValue, unsigned... Ids>
+    constexpr static void doPushBack( type& c_, TValue&& val_, std::integer_sequence<unsigned, Ids...> )
+    {
+        ( std::get<Ids>( c_ ).push_back( std::get<Ids>( std::forward<TValue>( val_ ) ) ), ... ); // fold expressions
+    }
+};
+
+
+template <template <typename ValueType> class TContainer, typename TItem, typename ... ItemTs>
+struct BaseContainer
+{
+    using policy_t        = SOAPolicy<TContainer, TItem, ItemTs ...>;
+    using iterator        = Iterator<BaseContainer<TContainer, TItem>>;
+    using const_iterator  = ConstIterator<BaseContainer<TContainer, TItem>>;
+    using difference_type = std::ptrdiff_t;
+    using value_type      = typename policy_t::value_ref_type;
+    using const_value_type= typename policy_t::const_value_ref_type;
+    using reference       = typename policy_t::reference_type;
+    using size_type       = std::size_t;
+
+    BaseContainer( size_t size_=0 ){
+        resize(size_);
+    }
+
+    template <typename Fwd>
+    void push_back( Fwd&& val )
+    {
+        policy_t::push_back( mValues, std::forward<Fwd>(val) );
+    }
+
+    std::size_t size() const {
+        return policy_t::size( mValues );
+    }
+
+    value_type operator[]( std::size_t position_ )
+    {
+        return policy_t::getRef( mValues, position_ );
+    }
+
+    const_value_type operator[]( std::size_t position_ ) const
+    {
+        return policy_t::getConstRef( mValues, position_ );
+    }
+
+    BaseContainer operator=(TContainer<TItem> otherAOS)
+    {
+        resize(0);
+        for (const auto& item : otherAOS)
+        {
+            push_back(item);
+        }
+        return *this;
+    }
+
+    void resize( size_t size_ ) {
+        policy_t::resize( mValues, size_ );
+    }
+
+    // Function performs insertion sort
+    void insertionSort()
+    {
+        int N = size();
+        int i, j, key;
+        auto& V = *this;
+
+        for (i = 1; i < N; i++) {
+            j = i;
+
+            // Insert V[i] into list 0..i-1
+            while (j > 0 and V[j] < V[j - 1]) {
+
+                // Swap V[j] and V[j-1]
+                swap(V[j], V[j - 1]);
+
+                // Decrement j by 1
+                j -= 1;
+            }
+        }
+    }
+
+    iterator       begin() { return iterator( this, 0 ); }
+    iterator       end() { return iterator( this, size() ); }
+
+    // casting away const is safe here, because ConstIterator only returns const ref_wrappers
+    const_iterator cbegin() const { return const_iterator( const_cast<BaseContainer*>(this), 0 ); }
+    const_iterator cend() const { return const_iterator( const_cast<BaseContainer*>(this), size() ); }
+    private:
+
+    typename policy_t::type mValues;
+
+};
+
+template <typename TContainer>
+class Iterator
+{
+
+private:
+    using container_t = TContainer;
+public:
+    using policy_t          = typename container_t::policy_t;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = typename policy_t::value_ref_type;
+    using reference         = typename policy_t::reference_type;
+    using pointer           = value_type*;
+    using iterator_category = std::random_access_iterator_tag;
+
+    template<typename TTContainer>
+    Iterator( TTContainer* container_, std::size_t position_ = 0 ):
+        mContainer( container_ ),
+        mIterPosition( position_ )
+    {
+    }
+
+    Iterator& operator=( Iterator const& other_ ){
+        mIterPosition = other_.mIterPosition;
+        return *this;
+        // mContainer = other_.mContainer;
+    }
+
+    difference_type operator+( Iterator const& other_ ){ std::cout << "foo+" << std::endl; return mIterPosition + other_.mIterPosition; }
+    difference_type operator-( Iterator const& other_ ){ std::cout << "foo-" << std::endl; return mIterPosition - other_.mIterPosition; }
+    template <typename T>
+    Iterator operator+( T add ){std::cout << "foo+int" << std::endl; return Iterator(this->mContainer, this->mIterPosition + add); }
+    template <typename T>
+    Iterator operator-( T sub ){ return Iterator(this->mContainer, this->mIterPosition - sub); }
+
+
+    friend bool operator!=( Iterator const& lhs, Iterator const& rhs ){ return lhs.mIterPosition != rhs.mIterPosition;}
+    friend bool operator==( Iterator const& lhs, Iterator const& rhs ){ return !operator!=(lhs, rhs);}
+
+    operator bool(void) const { return mIterPosition != std::numeric_limits<std::size_t>::infinity(); }
+
+    Iterator& operator=( std::nullptr_t const& ){ mIterPosition = std::numeric_limits<std::size_t>::infinity();}
+
+    template <typename T>
+    Iterator& operator+=( T size_ ){ mIterPosition += size_; return *this;}
+
+    template <typename T>
+    Iterator& operator-=( T size_ ){ mIterPosition -= size_; return *this;}
+
+    Iterator& operator++(){ return operator +=(1); }
+    Iterator& operator--(){ return operator -=(1); }
+
+    Iterator operator++(int){
+        Iterator tmp(*this);
+        operator++(); // prefix-increment this instance
+        return tmp;   // return value before increment operator +=(1);
+    }
+    Iterator operator--(int){
+        Iterator tmp(*this);
+        operator--(); // prefix-decrement this instance
+        return tmp;   // return value before decrement operator -=(1);
+    }
+
+    value_type operator*() {
+        //std::cout << "Pos:" << mIterPosition << std::endl;
+        return (*mContainer)[ mIterPosition ];
+    }
+
+    proxy_holder<value_type> operator ->() {
+        return proxy_holder<value_type>(**this);
+    }
+
+    private:
+    container_t*        mContainer = nullptr;
+    std::size_t         mIterPosition = std::numeric_limits<std::size_t>::infinity();
+
+};
+
+template <typename TContainer>
+class ConstIterator
+{
+
+private:
+    using container_t = TContainer;
+public:
+    using policy_t          = typename container_t::policy_t;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = typename policy_t::const_value_ref_type;
+    using reference         = typename policy_t::reference_type;
+    using pointer           = value_type*;
+    using iterator_category = std::random_access_iterator_tag;
+
+    template<typename TTContainer>
+    ConstIterator( TTContainer* container_, std::size_t position_ = 0 ):
+        mContainer( container_ ),
+        mIterPosition( position_ )
+    {
+    }
+
+    ConstIterator& operator=( ConstIterator const& other_ ){
+        mIterPosition = other_.mIterPosition;
+        return *this;
+        // mContainer = other_.mContainer;
+    }
+
+    difference_type operator+( ConstIterator const& other_ ){ std::cout << "foo+" << std::endl; return mIterPosition + other_.mIterPosition; }
+    difference_type operator-( ConstIterator const& other_ ){ std::cout << "foo-" << std::endl; return mIterPosition - other_.mIterPosition; }
+    template <typename T>
+    ConstIterator operator+( T add ){std::cout << "foo+int" << std::endl; return ConstIterator(this->mContainer, this->mIterPosition + add); }
+    template <typename T>
+    ConstIterator operator-( T sub ){ return ConstIterator(this->mContainer, this->mIterPosition - sub); }
+
+
+    friend bool operator!=( ConstIterator const& lhs, ConstIterator const& rhs ){ return lhs.mIterPosition != rhs.mIterPosition;}
+    friend bool operator==( ConstIterator const& lhs, ConstIterator const& rhs ){ return !operator!=(lhs, rhs);}
+
+    operator bool(void) const { return mIterPosition != std::numeric_limits<std::size_t>::infinity(); }
+
+    ConstIterator& operator=( std::nullptr_t const& ){ mIterPosition = std::numeric_limits<std::size_t>::infinity();}
+
+    template <typename T>
+    ConstIterator& operator+=( T size_ ){ mIterPosition += size_; return *this;}
+
+    template <typename T>
+    ConstIterator& operator-=( T size_ ){ mIterPosition -= size_; return *this;}
+
+    ConstIterator& operator++(){ return operator +=(1); }
+    ConstIterator& operator--(){ return operator -=(1); }
+
+    ConstIterator operator++(int){
+        Iterator tmp(*this);
+        operator++(); // prefix-increment this instance
+        return tmp;   // return value before increment operator +=(1);
+    }
+    ConstIterator operator--(int){
+        Iterator tmp(*this);
+        operator--(); // prefix-decrement this instance
+        return tmp;   // return value before decrement operator -=(1);
+    }
+
+    value_type operator*() const {
+        //std::cout << "Pos:" << mIterPosition << std::endl;
+        return (*mContainer)[ mIterPosition ];
+    }
+
+    proxy_holder<value_type> operator ->() const {
+        return proxy_holder<value_type>(**this);
+    }
+
+    private:
+    container_t*        mContainer = nullptr;
+    std::size_t         mIterPosition = std::numeric_limits<std::size_t>::infinity();
+
+};
+
+template<typename T>
+using VectorTemplate = std::vector<T, std::allocator<T>>;
+
+enum Component : int {
+    eMz,
+    eIty
+};
+
+template<typename ... T>
+struct Peak1DT : public std::tuple<T ...>{
+    using std::tuple<T...>::tuple;
+    using std::tuple<T...>::operator=;
+    Peak1DT(const Peak1DT& other) = default;
+    Peak1DT(Peak1DT&& other) = default;
+    Peak1DT& operator=(Peak1DT&& other_) = default;
+
+    void friend swap(Peak1DT& a, Peak1DT& b)
+    {
+        a.swap(b);
+    }
+    void friend swap(Peak1DT&& a, Peak1DT&& b)
+    {
+        a.swap(b);
+    }
+
+    auto & getMZ() {return std::get<eMz>(*this);}
+    auto & getMZ() const {return std::get<eMz>(*this);}
+    void setMZ(double mz) {std::get<eMz>(*this) = mz;}
+    auto & getIntensity() {return std::get<eIty>(*this);}
+    auto & getIntensity() const {return std::get<eIty>(*this);}
+    void setIntensity(double ity) {std::get<eIty>(*this) = ity;}
+};
+
+ 

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrumSoAWrapper.h
@@ -183,6 +183,7 @@ struct BaseContainer
     using value_type      = typename policy_t::value_ref_type;
     using const_value_type= typename policy_t::const_value_ref_type;
     using reference       = typename policy_t::reference_type;
+    using pointer         = value_type*;
     using size_type       = std::size_t;
 
     BaseContainer( size_t size_=0 ){
@@ -227,11 +228,21 @@ struct BaseContainer
     }
 
     value_type front(){
-        return policy_t::front( mValues);
+        return operator[](0);
+    }
+
+    const_value_type front() const 
+    {
+        return operator[](0);
     }
 
     value_type back(){
-        return policy_t::back( mValues);
+       return operator[](this->size()-1);
+    }
+
+    const_value_type back() const 
+    {
+        return operator[](this->size()-1);
     }
 
     template <typename Fwd>
@@ -314,7 +325,7 @@ public:
     using difference_type   = std::ptrdiff_t;
     using value_type        = typename policy_t::value_ref_type;
     using reference         = typename policy_t::reference_type;
-    using pointer           = value_type*;
+    using pointer           = proxy_holder<value_type>;
     using iterator_category = std::random_access_iterator_tag;
 
     template<typename TTContainer>
@@ -370,11 +381,20 @@ public:
         return (*mContainer)[ mIterPosition ];
     }
 
+    const value_type operator*() const {
+        //std::cout << "Pos:" << mIterPosition << std::endl;
+        return (*mContainer)[ mIterPosition ];
+    }
+
     std::size_t getPosition () {
         return this->mIterPosition;
     }
 
     proxy_holder<value_type> operator ->() {
+        return proxy_holder<value_type>(**this);
+    }
+
+    proxy_holder<value_type> operator ->() const {
         return proxy_holder<value_type>(**this);
     }
 

--- a/src/openms/include/OpenMS/KERNEL/Peak1DT.h
+++ b/src/openms/include/OpenMS/KERNEL/Peak1DT.h
@@ -1,0 +1,396 @@
+// SOA and AOS tests on god bolt
+
+#include <tuple>
+#include <vector>
+#include <functional>
+#include <string>
+#include <limits>
+#include <iostream>
+
+template <typename T>
+class proxy_holder {
+  T t;
+public:
+  proxy_holder(T&& t) : t(t) {}
+  T* operator ->() { return &t; }
+};
+
+template <typename T>
+struct ref_wrap : public std::reference_wrapper<T>{
+    using type = T;
+    void friend swap(ref_wrap& a, ref_wrap& b) {
+        T tmp = a.get();
+        a.get() = b.get();
+        b.get() = tmp;
+     };
+    void friend swap(ref_wrap&& a, ref_wrap&& b) {
+        T tmp = a.get();
+        a.get() = b.get();
+        b.get() = tmp;
+     };
+    operator T&() const noexcept {return this->get(); }
+    //ref_wrap(const ref_wrap& other_) : std::reference_wrapper<T>(other_.get()){}
+    ref_wrap(const ref_wrap& other_) = default;
+    
+    //ref_wrap(ref_wrap&& other_) : std::reference_wrapper<T>(other_.get()){}
+    ref_wrap(T& other_) : std::reference_wrapper<T>(other_){}
+    ref_wrap(T&& other_) : std::reference_wrapper<T>(other_){}
+    //void operator =(T && other_) {this->get()=other_;}
+    using std::reference_wrapper<T>::operator=;
+    //ref_wrap& operator=(const ref_wrap & other_) {this->get()=other_.get(); return *this;}
+    //ref_wrap& operator=(ref_wrap && other_) {this->get()=other_.get(); return *this;}
+    ref_wrap& operator=(T & other_) {this->get()=other_; return *this;}
+    ref_wrap& operator=(T && other_) {this->get()=other_; return *this;}
+};
+
+template <typename TContainer>
+class Iterator;
+template <typename TContainer>
+class ConstIterator;
+
+template <template <typename...> class Container, typename TItem>
+struct SOAPolicy;
+
+template <template <typename...> class Container, template<typename...> class TItem, typename... Types>
+struct SOAPolicy<Container, TItem<Types...>> {
+    using type = std::tuple<Container<Types>...>;
+    using const_type = std::tuple<const Container<Types>...>;
+    using value_type = TItem<Types...>;
+    using const_value_type = TItem<const ref_wrap<Types>...>;
+    using value_ref_type = TItem<ref_wrap<Types>...>;
+    using const_value_ref_type = TItem<const ref_wrap<Types>...>;
+    using reference_type = TItem<ref_wrap<Types>...>&;
+
+    constexpr static value_type get( type& c_, std::size_t position_ )
+    {
+        return doGet( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static value_ref_type getRef( type& c_, std::size_t position_ )
+    {
+        return doGetRef( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static const_value_ref_type getConstRef(type& c_, std::size_t position_ )
+    {
+        return doGetConstRef( c_, position_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    constexpr static void resize( type& c_, std::size_t size_ ) {
+        doResize( c_, size_, std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    template <typename TValue>
+    constexpr static void push_back( type& c_, TValue&& val_ ){
+        doPushBack( c_, std::forward<TValue>(val_), std::make_integer_sequence<unsigned, sizeof...( Types )>() ); // unrolling parameter pack
+    }
+
+    static constexpr std::size_t size(type& c_){ return std::get<0>( c_ ).size(); }
+
+    private:
+
+    template <unsigned... Ids>
+    constexpr static auto doGet( type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return value_type{ std::get<Ids>( c_ )[ position_ ]... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static auto doGetRef( type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return value_ref_type{ ref_wrap( std::get<Ids>( c_ )[ position_ ] )... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static auto doGetConstRef(type& c_, std::size_t position_, std::integer_sequence<unsigned, Ids...> )
+    {
+        return const_value_ref_type{ ref_wrap( std::get<Ids>( c_ )[ position_ ] )... }; // guaranteed copy elision
+    }
+
+    template <unsigned... Ids>
+    constexpr static void doResize( type& c_, unsigned size_, std::integer_sequence<unsigned, Ids...> )
+    {
+        ( std::get<Ids>( c_ ).resize( size_ ), ... ); //fold expressions
+    }
+
+    template <typename TValue, unsigned... Ids>
+    constexpr static void doPushBack( type& c_, TValue&& val_, std::integer_sequence<unsigned, Ids...> )
+    {
+        ( std::get<Ids>( c_ ).push_back( std::get<Ids>( std::forward<TValue>( val_ ) ) ), ... ); // fold expressions
+    }
+};
+
+
+template <template <typename ValueType> class TContainer, typename TItem, typename ... ItemTs>
+struct BaseContainer
+{
+    using policy_t        = SOAPolicy<TContainer, TItem, ItemTs ...>;
+    using iterator        = Iterator<BaseContainer<TContainer, TItem>>;
+    using const_iterator  = ConstIterator<BaseContainer<TContainer, TItem>>;
+    using difference_type = std::ptrdiff_t;
+    using value_type      = typename policy_t::value_ref_type;
+    using const_value_type= typename policy_t::const_value_ref_type;
+    using reference       = typename policy_t::reference_type;
+    using size_type       = std::size_t;
+
+    BaseContainer( size_t size_ ){
+        resize(size_);
+    }
+
+    template <typename Fwd>
+    void push_back( Fwd&& val )
+    {
+        policy_t::push_back( mValues, std::forward<Fwd>(val) );
+    }
+
+    std::size_t size(){
+        return policy_t::size( mValues );
+    }
+
+    value_type operator[]( std::size_t position_ )
+    {
+        return policy_t::getRef( mValues, position_ );
+    }
+
+    const_value_type operator[]( std::size_t position_ ) const
+    {
+        return policy_t::getConstRef( mValues, position_ );
+    }
+
+    BaseContainer operator=(TContainer<TItem> otherAOS)
+    {
+        resize(0);
+        for (const auto& item : otherAOS)
+        {
+            push_back(item);
+        }
+        return *this;
+    }
+
+    void resize( size_t size_ ) {
+        policy_t::resize( mValues, size_ );
+    }
+
+    // Function performs insertion sort
+    void insertionSort()
+    {
+        int N = size();
+        int i, j, key;
+        auto& V = *this;
+
+        for (i = 1; i < N; i++) {
+            j = i;
+
+            // Insert V[i] into list 0..i-1
+            while (j > 0 and V[j] < V[j - 1]) {
+
+                // Swap V[j] and V[j-1]
+                swap(V[j], V[j - 1]);
+
+                // Decrement j by 1
+                j -= 1;
+            }
+        }
+    }
+
+    iterator       begin() { return iterator( this, 0 ); }
+    iterator       end() { return iterator( this, size() ); }
+
+    // casting away const is safe here, because ConstIterator only returns const ref_wrappers
+    const_iterator cbegin() const { return const_iterator( const_cast<BaseContainer*>(this), 0 ); }
+    const_iterator cend() const { return const_iterator( const_cast<BaseContainer*>(this), size() ); }
+
+    private:
+
+    typename policy_t::type mValues;
+
+};
+
+template <typename TContainer>
+class Iterator
+{
+
+private:
+    using container_t = TContainer;
+public:
+    using policy_t          = typename container_t::policy_t;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = typename policy_t::value_ref_type;
+    using reference         = typename policy_t::reference_type;
+    using pointer           = value_type*;
+    using iterator_category = std::random_access_iterator_tag;
+
+    template<typename TTContainer>
+    Iterator( TTContainer* container_, std::size_t position_ = 0 ):
+        mContainer( container_ ),
+        mIterPosition( position_ )
+    {
+    }
+
+    Iterator& operator=( Iterator const& other_ ){
+        mIterPosition = other_.mIterPosition;
+        return *this;
+        // mContainer = other_.mContainer;
+    }
+
+    difference_type operator+( Iterator const& other_ ){ std::cout << "foo+" << std::endl; return mIterPosition + other_.mIterPosition; }
+    difference_type operator-( Iterator const& other_ ){ std::cout << "foo-" << std::endl; return mIterPosition - other_.mIterPosition; }
+    template <typename T>
+    Iterator operator+( T add ){std::cout << "foo+int" << std::endl; return Iterator(this->mContainer, this->mIterPosition + add); }
+    template <typename T>
+    Iterator operator-( T sub ){ return Iterator(this->mContainer, this->mIterPosition - sub); }
+
+
+    friend bool operator!=( Iterator const& lhs, Iterator const& rhs ){ return lhs.mIterPosition != rhs.mIterPosition;}
+    friend bool operator==( Iterator const& lhs, Iterator const& rhs ){ return !operator!=(lhs, rhs);}
+
+    operator bool(void) const { return mIterPosition != std::numeric_limits<std::size_t>::infinity(); }
+
+    Iterator& operator=( std::nullptr_t const& ){ mIterPosition = std::numeric_limits<std::size_t>::infinity();}
+
+    template <typename T>
+    Iterator& operator+=( T size_ ){ mIterPosition += size_; return *this;}
+
+    template <typename T>
+    Iterator& operator-=( T size_ ){ mIterPosition -= size_; return *this;}
+
+    Iterator& operator++(){ return operator +=(1); }
+    Iterator& operator--(){ return operator -=(1); }
+
+    Iterator operator++(int){
+        Iterator tmp(*this);
+        operator++(); // prefix-increment this instance
+        return tmp;   // return value before increment operator +=(1);
+    }
+    Iterator operator--(int){
+        Iterator tmp(*this);
+        operator--(); // prefix-decrement this instance
+        return tmp;   // return value before decrement operator -=(1);
+    }
+
+    value_type operator*() {
+        //std::cout << "Pos:" << mIterPosition << std::endl;
+        return (*mContainer)[ mIterPosition ];
+    }
+
+    proxy_holder<value_type> operator ->() {
+        return proxy_holder<value_type>(**this);
+    }
+
+    private:
+    container_t*        mContainer = nullptr;
+    std::size_t         mIterPosition = std::numeric_limits<std::size_t>::infinity();
+
+};
+
+template <typename TContainer>
+class ConstIterator
+{
+
+private:
+    using container_t = TContainer;
+public:
+    using policy_t          = typename container_t::policy_t;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = typename policy_t::const_value_ref_type;
+    using reference         = typename policy_t::reference_type;
+    using pointer           = value_type*;
+    using iterator_category = std::random_access_iterator_tag;
+
+    template<typename TTContainer>
+    ConstIterator( TTContainer* container_, std::size_t position_ = 0 ):
+        mContainer( container_ ),
+        mIterPosition( position_ )
+    {
+    }
+
+    ConstIterator& operator=( ConstIterator const& other_ ){
+        mIterPosition = other_.mIterPosition;
+        return *this;
+        // mContainer = other_.mContainer;
+    }
+
+    difference_type operator+( ConstIterator const& other_ ){ std::cout << "foo+" << std::endl; return mIterPosition + other_.mIterPosition; }
+    difference_type operator-( ConstIterator const& other_ ){ std::cout << "foo-" << std::endl; return mIterPosition - other_.mIterPosition; }
+    template <typename T>
+    ConstIterator operator+( T add ){std::cout << "foo+int" << std::endl; return ConstIterator(this->mContainer, this->mIterPosition + add); }
+    template <typename T>
+    ConstIterator operator-( T sub ){ return ConstIterator(this->mContainer, this->mIterPosition - sub); }
+
+
+    friend bool operator!=( ConstIterator const& lhs, ConstIterator const& rhs ){ return lhs.mIterPosition != rhs.mIterPosition;}
+    friend bool operator==( ConstIterator const& lhs, ConstIterator const& rhs ){ return !operator!=(lhs, rhs);}
+
+    operator bool(void) const { return mIterPosition != std::numeric_limits<std::size_t>::infinity(); }
+
+    ConstIterator& operator=( std::nullptr_t const& ){ mIterPosition = std::numeric_limits<std::size_t>::infinity();}
+
+    template <typename T>
+    ConstIterator& operator+=( T size_ ){ mIterPosition += size_; return *this;}
+
+    template <typename T>
+    ConstIterator& operator-=( T size_ ){ mIterPosition -= size_; return *this;}
+
+    ConstIterator& operator++(){ return operator +=(1); }
+    ConstIterator& operator--(){ return operator -=(1); }
+
+    ConstIterator operator++(int){
+        Iterator tmp(*this);
+        operator++(); // prefix-increment this instance
+        return tmp;   // return value before increment operator +=(1);
+    }
+    ConstIterator operator--(int){
+        Iterator tmp(*this);
+        operator--(); // prefix-decrement this instance
+        return tmp;   // return value before decrement operator -=(1);
+    }
+
+    value_type operator*() const {
+        //std::cout << "Pos:" << mIterPosition << std::endl;
+        return (*mContainer)[ mIterPosition ];
+    }
+
+    proxy_holder<value_type> operator ->() const {
+        return proxy_holder<value_type>(**this);
+    }
+
+    private:
+    container_t*        mContainer = nullptr;
+    std::size_t         mIterPosition = std::numeric_limits<std::size_t>::infinity();
+
+};
+
+template<typename T>
+using MyVector = std::vector<T, std::allocator<T>>;
+
+enum Component : int {
+    eMz,
+    eIty
+};
+
+template<typename ... T>
+struct Peak1DT : public std::tuple<T ...>{
+    using std::tuple<T...>::tuple;
+    using std::tuple<T...>::operator=;
+    Peak1DT(const Peak1DT& other) = default;
+    Peak1DT(Peak1DT&& other) = default;
+    Peak1DT& operator=(Peak1DT&& other_) = default;
+
+    void friend swap(Peak1DT& a, Peak1DT& b)
+    {
+        a.swap(b);
+    }
+    void friend swap(Peak1DT&& a, Peak1DT&& b)
+    {
+        a.swap(b);
+    }
+
+    auto & getMZ() {return std::get<eMz>(*this);}
+    auto & getMZ() const {return std::get<eMz>(*this);}
+    void setMZ(double mz) {std::get<eMz>(*this) = mz;}
+    auto & getIntensity() {return std::get<eIty>(*this);}
+    auto & getIntensity() const {return std::get<eIty>(*this);}
+    void setIntensity(double ity) {std::get<eIty>(*this) = ity;}
+};
+
+ 

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -995,15 +995,15 @@ namespace OpenMS::Internal
         
         if (!writeAttributeIfExists_(os, spec, "base peak m/z", "basePeakMz"))
         { // base peak mz (used by some programs like MAVEN), according to xsd: "m/z of the base peak (most intense peak)"
-          auto it = spec.getBasePeak();
-          writeKeyValue(os, "basePeakMz", (it != spec.end() ? it->getMZ() : 0.0));
+          auto&& it = spec.getBasePeak();
+          writeKeyValue(os, "basePeakMz", (it != spec.TCend() ? double(it->getMZ()) : 0.0));
         }
 
         if (!writeAttributeIfExists_(os, spec, "base peak intensity", "basePeakIntensity") &&
             options_.getForceMQCompatability())
         {
           auto it = spec.getBasePeak();
-          writeKeyValue(os, "basePeakIntensity", (it != spec.end() ? it->getIntensity() : 0.0));
+          writeKeyValue(os, "basePeakIntensity", (it != spec.TCend() ? double(it->getIntensity()) : 0.0));
         }
         if (!writeAttributeIfExists_(os, spec, "total ion current", "totIonCurrent") &&
             options_.getForceMQCompatability())

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -149,16 +149,17 @@ namespace OpenMS
     return SpectrumSettings::UNKNOWN;
   }
 
-  MSSpectrum::ConstIterator MSSpectrum::getBasePeak() const
+  MSSpectrum::TConstIterator MSSpectrum::getBasePeak() const
   {
-    ConstIterator largest = cbegin();
-    if (empty())
+    const Container& const_peaks = peaks;
+    TConstIterator largest = const_peaks.cbegin();
+    if (peaks.size()==0)
     {
       return largest;
     }
-    ConstIterator current = cbegin();
+    TConstIterator current = const_peaks.cbegin();
     ++current;
-    for (; current != cend(); ++current)
+    for (; current != const_peaks.cend(); ++current)
     {
       if (largest->getIntensity() < current->getIntensity())
       {
@@ -168,10 +169,11 @@ namespace OpenMS
     return largest;
   }
 
-  MSSpectrum::Iterator MSSpectrum::getBasePeak()
+  MSSpectrum::TIterator MSSpectrum::getBasePeak()
   {
-    ConstIterator largest = const_cast<const MSSpectrum&>(*this).getBasePeak();
-    return begin() + std::distance(cbegin(), largest);
+    const Container& const_peaks = peaks;
+    TConstIterator largest = const_cast<const MSSpectrum&>(*this).getBasePeak();
+    return peaks.begin() + std::distance(const_peaks.cbegin(), largest);
   }
 
   MSSpectrum::PeakType::IntensityType MSSpectrum::calculateTIC() const
@@ -503,7 +505,7 @@ namespace OpenMS
     RangeManagerType::operator=(source);
     SpectrumSettings::operator=(source);
 
-    spectra = source.spectra;
+    peaks = source.peaks;
     retention_time_ = source.retention_time_;
     drift_time_ = source.drift_time_;
     drift_time_unit_ = source.drift_time_unit_;
@@ -520,7 +522,7 @@ namespace OpenMS
     ContainerType(),
     RangeManagerContainerType(),
     SpectrumSettings(),
-    spectra(),
+    peaks(0),
     retention_time_(-1),
     drift_time_(-1),
     drift_time_unit_(DriftTimeUnit::NONE),
@@ -535,7 +537,7 @@ namespace OpenMS
     ContainerType(source),
     RangeManagerContainerType(source),
     SpectrumSettings(source),
-    spectra(source.spectra.size()),
+    peaks(source.peaks.size()),
     retention_time_(source.retention_time_),
     drift_time_(source.drift_time_),
     drift_time_unit_(source.drift_time_unit_),
@@ -656,6 +658,29 @@ namespace OpenMS
   {
     integer_data_arrays_ = ida;
   }
+
+  MSSpectrum::TIterator MSSpectrum::TBegin()
+  {
+    return peaks.begin();
+  }
+
+  MSSpectrum::TIterator MSSpectrum::TEnd()
+  {
+    return peaks.end();
+  }
+
+  MSSpectrum::TConstIterator MSSpectrum::TCbegin() const
+  {
+    const Container& const_peaks = peaks;
+    return const_peaks.cbegin();
+  }
+
+  MSSpectrum::TConstIterator MSSpectrum::TCend() const
+  {
+    const Container& const_peaks = peaks;
+    return const_peaks.cend();
+  }
+
 
   MSSpectrum::Iterator MSSpectrum::MZBegin(MSSpectrum::CoordinateType mz)
   {

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -503,6 +503,7 @@ namespace OpenMS
     RangeManagerType::operator=(source);
     SpectrumSettings::operator=(source);
 
+    spectra = source.spectra;
     retention_time_ = source.retention_time_;
     drift_time_ = source.drift_time_;
     drift_time_unit_ = source.drift_time_unit_;
@@ -519,6 +520,7 @@ namespace OpenMS
     ContainerType(),
     RangeManagerContainerType(),
     SpectrumSettings(),
+    spectra(),
     retention_time_(-1),
     drift_time_(-1),
     drift_time_unit_(DriftTimeUnit::NONE),
@@ -533,6 +535,7 @@ namespace OpenMS
     ContainerType(source),
     RangeManagerContainerType(source),
     SpectrumSettings(source),
+    spectra(source.spectra.size()),
     retention_time_(source.retention_time_),
     drift_time_(source.drift_time_),
     drift_time_unit_(source.drift_time_unit_),

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -680,29 +680,7 @@ namespace OpenMS
     const Container& const_peaks = peaks;
     return const_peaks.cend();
   }
-
-  MSSpectrum::TIterator MSSpectrum::begin()
-  {
-    return peaks.begin();
-  }
-
-  MSSpectrum::TIterator MSSpectrum::end()
-  {
-    return peaks.end();
-  }
-
-  MSSpectrum::TConstIterator MSSpectrum::cbegin() const
-  {
-    const Container& const_peaks = peaks;
-    return const_peaks.cbegin();
-  }
-
-  MSSpectrum::TConstIterator MSSpectrum::cend() const
-  {
-    const Container& const_peaks = peaks;
-    return const_peaks.cend();
-  }
-
+  
   void MSSpectrum::insert(MSSpectrum::TIterator it, MSSpectrum::Peak1DTuple peak)
   {
     peaks.insert(it, peak);

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -681,6 +681,34 @@ namespace OpenMS
     return const_peaks.cend();
   }
 
+  MSSpectrum::TIterator MSSpectrum::begin()
+  {
+    return peaks.begin();
+  }
+
+  MSSpectrum::TIterator MSSpectrum::end()
+  {
+    return peaks.end();
+  }
+
+  MSSpectrum::TConstIterator MSSpectrum::cbegin() const
+  {
+    const Container& const_peaks = peaks;
+    return const_peaks.cbegin();
+  }
+
+  MSSpectrum::TConstIterator MSSpectrum::cend() const
+  {
+    const Container& const_peaks = peaks;
+    return const_peaks.cend();
+  }
+
+  void MSSpectrum::insert(MSSpectrum::TIterator it, MSSpectrum::Peak1DTuple peak)
+  {
+    peaks.insert(it, peak);
+    return;
+  }
+
 
   MSSpectrum::Iterator MSSpectrum::MZBegin(MSSpectrum::CoordinateType mz)
   {

--- a/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
+++ b/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
@@ -760,12 +760,12 @@ namespace OpenMS
   ) const
   {
     // Extract points
-    typename PeakContainerT::const_iterator start_it = left_pos ? input_peak.PosBegin(left_pos) : input_peak.begin();
-    typename PeakContainerT::const_iterator end_it = right_pos ? input_peak.PosEnd(right_pos) : input_peak.end();
+    typename PeakContainerT::const_iterator start_it = left_pos ? input_peak.PosBegin(left_pos) : input_peak.cbegin();
+    typename PeakContainerT::const_iterator end_it = right_pos ? input_peak.PosEnd(right_pos) : input_peak.cend();
     std::vector<double> xs, ys;
     for (typename PeakContainerT::const_iterator it = start_it; it != end_it; ++it)
     {
-      xs.push_back(it->getPos());
+      xs.push_back(it->getMZ());
       ys.push_back(it->getIntensity());
     }
 

--- a/src/openms/source/QC/Ms2SpectrumStats.cpp
+++ b/src/openms/source/QC/Ms2SpectrumStats.cpp
@@ -150,8 +150,8 @@ namespace OpenMS
   MSSpectrum::PeakType::IntensityType Ms2SpectrumStats::getBPI_(const MSSpectrum& spec)
   {
     PeakSpectrum::PeakType::IntensityType bpi{ 0 };
-    auto it = spec.getBasePeak();
-    if (it != spec.end())
+    auto&& it = spec.getBasePeak();
+    if (it != spec.TCend())
     {
       bpi = it->getIntensity();
     }

--- a/src/tests/class_tests/openms/source/AreaIterator_test.cpp
+++ b/src/tests/class_tests/openms/source/AreaIterator_test.cpp
@@ -50,7 +50,7 @@ START_TEST(AreaIterator, "$Id$")
 /////////////////////////////////////////////////////////////
 
 typedef PeakMap Map;
-typedef Internal::AreaIterator<vector<Map::MSSpectrum>> AI;
+typedef Internal::AreaIterator<vector<Map::MSSpectrum>, false> AI;
 //typedef Internal::AreaIterator<Map::PeakType, const Map::PeakType&, const Map::PeakType*, Map::ConstIterator, Map::SpectrumType::ConstIterator> CAI;
 
 AI* ptr1 = nullptr, *ptr2 = nullptr;

--- a/src/tests/class_tests/openms/source/AreaIterator_test.cpp
+++ b/src/tests/class_tests/openms/source/AreaIterator_test.cpp
@@ -50,7 +50,7 @@ START_TEST(AreaIterator, "$Id$")
 /////////////////////////////////////////////////////////////
 
 typedef PeakMap Map;
-typedef Internal::AreaIterator<Map::PeakType, Map::PeakType&, Map::PeakType*, Map::Iterator, Map::SpectrumType::Iterator> AI;
+typedef Internal::AreaIterator<vector<Map::MSSpectrum>> AI;
 //typedef Internal::AreaIterator<Map::PeakType, const Map::PeakType&, const Map::PeakType*, Map::ConstIterator, Map::SpectrumType::ConstIterator> CAI;
 
 AI* ptr1 = nullptr, *ptr2 = nullptr;

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -1362,11 +1362,12 @@ END_SECTION
 
 START_SECTION(ConstIterator getBasePeak() const)
 {
-  const auto it = spec_test.getBasePeak();
+  const MSSpectrum& const_spec_test = spec_test;
+  const auto&& it = const_spec_test.getBasePeak();
   TEST_REAL_SIMILAR(it->getIntensity(), 201.0)
-  TEST_EQUAL(std::distance(spec_test.begin(), it), 8);
+  TEST_EQUAL(std::distance(spec_test.TCbegin(), it), 8);
   MSSpectrum empty;
-  TEST_EQUAL(empty.getBasePeak() == empty.end(), true);
+  TEST_EQUAL(empty.getBasePeak() == empty.TEnd(), true);
 }
 END_SECTION
 
@@ -1374,10 +1375,10 @@ END_SECTION
 START_SECTION(Iterator getBasePeak())
 {
   MSSpectrum test = spec_test;
-  auto it = test.getBasePeak();
+  auto&& it = test.getBasePeak();
   it->setIntensity(it->getIntensity() + 0.0);
   TEST_REAL_SIMILAR(it->getIntensity(), 201.0)
-  TEST_EQUAL(std::distance(test.begin(), it), 8);
+  TEST_EQUAL(std::distance(test.TBegin(), it), 8);
 }
 END_SECTION
 


### PR DESCRIPTION
## Description
GSoC'22 Project
Attempts to create a Structure of Arrays (SoA) Data layout for MSSpectrum class using Zero-Cost Abstraction.

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
