### PR TITLE
Fix/openswathworkflow duplicated transition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ the authors tag in the respective file header.
  - Julia Thueringer
  - Juliane Schmachtenberg
  - Julianus Pfeuffer
+ - Justin Sing
  - Katharina Albers
  - Khue Nguyen
  - Knut Reinert
@@ -107,5 +108,4 @@ the authors tag in the respective file header.
  - Volker Mosthaf
  - Witold Wolski
  - Xiao Liang
- - Justin Sing
  - Radu Suciu

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ UTIL - An executable, just like a TOPP tool, but usually experimental or of less
 
 - full release
 - OpenSwath: Add support for diaPASEF data with overlapping m/z and IM windows
+- OpenSwath: Fix duplicated transition error when multiple genes map to a single peptide (#5653)
 - TOPPView: TheoreticalSpectrumGenerationDialog now supports generation of isotope patterns for metabolites
 - pyopenms: pyopenms-extra is renamed to pyopenms-docs.
 - Add extractSpectra to TargetedSpectraExtractor with support of MS1 features

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -97,10 +97,15 @@ namespace OpenMS
     bool gene_exists = SqliteConnector::tableExists(db, "GENE");
     if (gene_exists)
     {
-      select_gene = ", GENE.GENE_NAME AS gene_name ";
+      select_gene = ", GENE_AGGREGATED.GENE_NAME AS gene_name ";
       select_gene_null = ", 'NA' AS gene_name ";
       join_gene = "INNER JOIN PEPTIDE_GENE_MAPPING ON PEPTIDE.ID = PEPTIDE_GENE_MAPPING.PEPTIDE_ID " \
-                  "INNER JOIN GENE ON PEPTIDE_GENE_MAPPING.GENE_ID = GENE.ID ";
+                  "INNER JOIN " \
+                    "(SELECT PEPTIDE_ID, GROUP_CONCAT(GENE_NAME,';') AS GENE_NAME " \
+                    "FROM GENE " \
+                    "INNER JOIN PEPTIDE_GENE_MAPPING ON PROTEIN.ID = PEPTIDE_GENE_MAPPING.PROTEIN_ID "\
+                    "GROUP BY PEPTIDE_ID) " \
+                    "AS GENE_AGGREGATED ON PEPTIDE.ID = GENE_AGGREGATED.PEPTIDE_ID ";
     }
 
     String select_annotation = "'' AS Annotation, ";

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -103,7 +103,7 @@ namespace OpenMS
                   "INNER JOIN " \
                     "(SELECT PEPTIDE_ID, GROUP_CONCAT(GENE_NAME,';') AS GENE_NAME " \
                     "FROM GENE " \
-                    "INNER JOIN PEPTIDE_GENE_MAPPING ON PROTEIN.ID = PEPTIDE_GENE_MAPPING.PROTEIN_ID "\
+                    "INNER JOIN PEPTIDE_GENE_MAPPING ON GENE.ID = PEPTIDE_GENE_MAPPING.GENE_ID "\
                     "GROUP BY PEPTIDE_ID) " \
                     "AS GENE_AGGREGATED ON PEPTIDE.ID = GENE_AGGREGATED.PEPTIDE_ID ";
     }


### PR DESCRIPTION
## Description

Fix duplicated transition error thrown by OpenSwathWorkflow (see issue [#5653](https://github.com/OpenMS/OpenMS/issues/5653)), due to 1:n peptide to gene mapping. The error occurs due to the intial [TransitionPQPFile::readPQPInput_](https://github.com/singjc/OpenMS/blob/ffc1c10476e268d93ccc6da6e517a52be9b29aaf/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp#L100-L103) query that does not aggregate multiple genes mapping to a single peptide. This is done for proteins, so the [query](https://github.com/singjc/OpenMS/blob/3acc6fddcc44197bd29639149d79257d740a6b07/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp#L100-L108) is modified to apply the same aggregation for genes.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
