### PR TITLE
[FIX] sync spectrumtype in pxd

### DIFF
--- a/src/pyOpenMS/pxds/SpectrumSettings.pxd
+++ b/src/pyOpenMS/pxds/SpectrumSettings.pxd
@@ -53,4 +53,4 @@ cdef extern from "<OpenMS/METADATA/SpectrumSettings.h>" namespace "OpenMS::Spect
     cdef enum SpectrumType:
         # wrap-attach:
         #     SpectrumSettings
-        UNKNOWN,  PEAKS, RAWDATA, SIZE_OF_SPECTRUMTYPE
+        UNKNOWN, CENTROID, PROFILE, SIZE_OF_SPECTRUMTYPE

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4654,8 +4654,8 @@ def testSpectrumSetting(s=pyopenms.SpectrumSettings()):
     """
 
     assert s.getType() in [ pyopenms.SpectrumSettings.SpectrumType.UNKNOWN,
-                               pyopenms.SpectrumSettings.SpectrumType.PEAKS,
-                               pyopenms.SpectrumSettings.SpectrumType.RAWDATA]
+                               pyopenms.SpectrumSettings.SpectrumType.CENTROID,
+                               pyopenms.SpectrumSettings.SpectrumType.PROFILE]
 
     assert isinstance(s.getAcquisitionInfo(), pyopenms.AcquisitionInfo)
     assert isinstance(s.getInstrumentSettings(), pyopenms.InstrumentSettings)


### PR DESCRIPTION
see https://github.com/OpenMS/pyopenms-docs/issues/294#issuecomment-1222537883

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
