### PR TITLE
[Feature] Sirius user account login

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
@@ -168,6 +168,14 @@ namespace OpenMS
                                    const MSExperiment& spectra) const;
 
       /**
+      @brief Log in to Sirius with personal user account (required in Sirius >= 5).
+
+      @param email User account E-Mail.
+      @param password User account password.
+      */
+      void logInSiriusAccount(String& executable, const String& email, const String& password) const;
+
+      /**
       @brief Call SIRIUS with QProcess
 
       @param tmp_ms_file path to temporary .ms file

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -538,6 +538,40 @@ namespace OpenMS
     // Algorithm
     // ################
 
+    void SiriusAdapterAlgorithm::logInSiriusAccount(String& executable, const String& email, const String& password) const
+    {
+      if (!email.empty() && !password.empty())
+      {
+        // sirius login --email=email --password=password
+        QString executable_qstring = SiriusAdapterAlgorithm::determineSiriusExecutable(executable).toQString();
+        QStringList command_line{"login", String("--email="+email).toQString(), String("--password="+password).toQString()};
+        
+        // start QProcess with sirius login command
+        QProcess qp;
+        qp.start(executable_qstring, command_line);
+
+        // print executed command as info
+        std::stringstream ss;
+        ss << "Executing command: " << executable_qstring.toStdString();
+        for (const QString& it : command_line)
+        {
+          ss << " " << it.toStdString();
+        }
+        OPENMS_LOG_INFO << ss.str() << std::endl;
+
+        // wait until process finished
+        qp.waitForFinished(-1);
+
+        // always print process stdout (info) and stderror (warning)
+        const QString sirius_stdout(qp.readAllStandardOutput());
+        const QString sirius_stderr(qp.readAllStandardError());
+        OPENMS_LOG_INFO << String(sirius_stdout) << std::endl;
+        OPENMS_LOG_WARN << String(sirius_stderr) << std::endl;
+        
+        qp.close();
+      }
+    }
+
     // tmp_msfile (store), all parameters, out_dir (tmpstructure)
     const std::vector<String> SiriusAdapterAlgorithm::callSiriusQProcess(const String& tmp_ms_file,
                                                                          const String& tmp_out_dir,

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -540,36 +540,33 @@ namespace OpenMS
 
     void SiriusAdapterAlgorithm::logInSiriusAccount(String& executable, const String& email, const String& password) const
     {
-      if (!email.empty() && !password.empty())
+      // sirius login --email=email --password=password
+      QString executable_qstring = SiriusAdapterAlgorithm::determineSiriusExecutable(executable).toQString();
+      QStringList command_line{"login", String("--email="+email).toQString(), String("--password="+password).toQString()};
+      
+      // start QProcess with sirius login command
+      QProcess qp;
+      qp.start(executable_qstring, command_line);
+
+      // print executed command as info
+      std::stringstream ss;
+      ss << "Executing command: " << executable_qstring.toStdString();
+      for (const QString& it : command_line)
       {
-        // sirius login --email=email --password=password
-        QString executable_qstring = SiriusAdapterAlgorithm::determineSiriusExecutable(executable).toQString();
-        QStringList command_line{"login", String("--email="+email).toQString(), String("--password="+password).toQString()};
-        
-        // start QProcess with sirius login command
-        QProcess qp;
-        qp.start(executable_qstring, command_line);
-
-        // print executed command as info
-        std::stringstream ss;
-        ss << "Executing command: " << executable_qstring.toStdString();
-        for (const QString& it : command_line)
-        {
-          ss << " " << it.toStdString();
-        }
-        OPENMS_LOG_INFO << ss.str() << std::endl;
-
-        // wait until process finished
-        qp.waitForFinished(-1);
-
-        // always print process stdout (info) and stderror (warning)
-        const QString sirius_stdout(qp.readAllStandardOutput());
-        const QString sirius_stderr(qp.readAllStandardError());
-        OPENMS_LOG_INFO << String(sirius_stdout) << std::endl;
-        OPENMS_LOG_WARN << String(sirius_stderr) << std::endl;
-        
-        qp.close();
+        ss << " " << it.toStdString();
       }
+      OPENMS_LOG_INFO << ss.str() << std::endl;
+
+      // wait until process finished
+      qp.waitForFinished(-1);
+
+      // always print process stdout (info) and stderror (warning)
+      const QString sirius_stdout(qp.readAllStandardOutput());
+      const QString sirius_stderr(qp.readAllStandardError());
+      OPENMS_LOG_INFO << String(sirius_stdout) << std::endl;
+      OPENMS_LOG_WARN << String(sirius_stderr) << std::endl;
+      
+      qp.close();
     }
 
     // tmp_msfile (store), all parameters, out_dir (tmpstructure)

--- a/src/pyOpenMS/pxds/SiriusAdapterAlgorithm.pxd
+++ b/src/pyOpenMS/pxds/SiriusAdapterAlgorithm.pxd
@@ -62,6 +62,16 @@ cdef extern from "<OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h>" namespace "Open
                 #   :param feature_mapping: FeatureToMs2Indices with feature mapping
                 #   :param spectra: Input of MSExperiment with spectra information
 
+        void logInSiriusAccount(String& executable,
+                                const String& email,
+                                const String& password) nogil except +
+        # wrap-doc:
+                #   Log in to SIRIUS using your personal account
+                #   -----
+                #   :param executable: Path to executable.
+                #   :param email: User account E-Mail.
+                #   :param password: User account password.
+     
         libcpp_vector[String] callSiriusQProcess(const String& tmp_ms_file,
                                                  const String& tmp_out_dir,
                                                  String& executable,

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -149,6 +149,10 @@ protected:
 
     registerStringOption_("out_project_space", "<directory>", "", "Output directory for SIRIUS project space", false);
 
+    registerStringOption_("sirius_user_email", "<string>", "", "E-mail for your SIRIUS account.", false);
+    
+    registerStringOption_("sirius_user_password", "<string>", "", "Password for your SIRIUS account.", false);
+
     registerFlag_("converter_mode", "Use this flag in combination with the out_ms file to convert the input mzML and featureXML to a .ms file. Without further SIRIUS processing.", true);
 
     addEmptyLine_();
@@ -172,6 +176,8 @@ protected:
     String out_ms = getStringOption_("out_ms");
     String out_ann_spectra = getStringOption_("out_annotated_spectra");
     String sirius_workspace_directory = getStringOption_("out_project_space");
+    String sirius_user_email = getStringOption_("sirius_user_email");
+    String sirius_user_password = getStringOption_("sirius_user_password");
     bool converter_mode = getFlag_("converter_mode");
 
     auto params = getParam_();
@@ -226,6 +232,9 @@ protected:
       
       return EXECUTION_OK;
     }
+
+    // log in to Sirius account if email and password are specified
+    algorithm.logInSiriusAccount(sirius_executable, sirius_user_email, sirius_user_password);
 
     // calls Sirius and returns vector of paths to sirius folder structure
     std::vector<String> subdirs = algorithm.callSiriusQProcess(sirius_tmp.getTmpMsFile(),

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -234,7 +234,11 @@ protected:
     }
 
     // log in to Sirius account if email and password are specified
-    algorithm.logInSiriusAccount(sirius_executable, sirius_user_email, sirius_user_password);
+    if (!sirius_user_email.empty() && !sirius_user_password.empty())
+    {
+      algorithm.logInSiriusAccount(sirius_executable, sirius_user_email, sirius_user_password);
+    }
+    else OPENMS_LOG_WARN << "No Sirius user account login information specified!" << std::endl;
 
     // calls Sirius and returns vector of paths to sirius folder structure
     std::vector<String> subdirs = algorithm.callSiriusQProcess(sirius_tmp.getTmpMsFile(),


### PR DESCRIPTION
## Description

Since Sirius 5 a login with a personal user account is required. Here, the SiriusAdapter gets new options for the user account email and password. If they are provided, the login command will be executed. The tests and pyopenms run locally with the new login options.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
