### PR TITLE
"auto" changed as "const auto&" as per issue - Convert iterator for loops #6160

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
@@ -1,3 +1,66 @@
+------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2022.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+erlin 2002-2022.
+//
+//// This software is released under a three-clause BSD license:
+/////  * Redistributions of source code must retain the above copyright
+/////    notice, this list of conditions and the erlin 2002-2022.
+/////
+///// This software is released under a three-clause BSD license:
+/////  * Redistributions of source code must retain the above copyright
+/////    notice, this list of conditions and the // --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: $
+// --------------------------------------------------------------------------
+//
+
+#pragma once
+
+#include <OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimator.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <vector>
+#include <algorithm> //for std::max_element
+
+namespace OpenMS
+{
+  /**
+    @brief Estimates the signal/noise (S/N) ratio of each data point in a scan
+           based on an iterative scheme which discards high intensities
+
+    For each datapoint in the given scan, we collect a range of data points around it (param: <i>win_len</i>).
+    The noise for a datapoint is estimated iteratively by discarding peaks which are more than
+    (<i>stdev_mp</i> * StDev) above the mean value. After three iterations, the mean value is
+    considered to be the noise level. If the number of elements in the current window is not sufficient (param: <i>min_required_elements</i>),
+SignalToNoiseEstimatorMeanIterative.h [unix] (19:31 11/09/2022)                                 1,1 Top
+-- INSERT --
 // --------------------------------------------------------------------------
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
@@ -45,7 +108,9 @@ namespace OpenMS
 {
   /**
     @brief Estimates the signal/noise (S/N) ratio of each data point in a scan
-           based on an iterative scheme which discards high intensities
+           based on an iterative scheme which discards high intensi
+	   
+	   ties
 
     For each datapoint in the given scan, we collect a range of data points around it (param: <i>win_len</i>).
     The noise for a datapoint is estimated iteratively by discarding peaks which are more than
@@ -406,9 +471,7 @@ protected:
     double max_intensity_;
     /// parameter for initial automatic estimation of "max_intensity_": a stdev multiplier
     double auto_max_stdev_Factor_;
-    /// parameter for initial automatic estimation of "max_intensity_" percentile or a stdev
-    double auto_max_percentile_;
-    /// determines which method shall be used for estimating "max_intensity_". valid are MANUAL=-1, AUTOMAXBYSTDEV=0 or AUTOMAXBYPERCENT=1
+    /// parameter for initial automatic estimation of "max_intens/// determines which method shall be used for estimating "max_intensity_". valid are MANUAL=-1, AUTOMAXBYSTDEV=0 or AUTOMAXBYPERCENT=1
     int    auto_mode_;
     /// range of data points which belong to a window in Thomson
     double win_len_;

--- a/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp
@@ -127,9 +127,9 @@ END_SECTION
 
 START_SECTION((std::map<unsigned int, std::vector<String> > getFractionToMSFilesMapping() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getFractionToMSFilesMapping();
-  const auto lfst = labelfree_unfractionated_single_table_design.getFractionToMSFilesMapping();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getFractionToMSFilesMapping();
+  const auto& lf = labelfree_unfractionated_design.getFractionToMSFilesMapping();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getFractionToMSFilesMapping();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getFractionToMSFilesMapping();
   // test both two table as well as single table design
   for (const auto& f2ms : { lf, lfst, lfstns})
   { 
@@ -139,8 +139,8 @@ START_SECTION((std::map<unsigned int, std::vector<String> > getFractionToMSFiles
     TEST_EQUAL(f2ms.at(1).size(), 12);
   }
 
-  const auto fplex = fourplex_fractionated_design.getFractionToMSFilesMapping();
-  const auto fplexst = fourplex_fractionated_single_table_design.getFractionToMSFilesMapping();
+  const auto& fplex = fourplex_fractionated_design.getFractionToMSFilesMapping();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getFractionToMSFilesMapping();
   // test both two table as well as single table design
   for (const auto& f2ms : { fplex, fplexst})
   { 
@@ -156,11 +156,11 @@ END_SECTION
 
 START_SECTION((std::map< std::pair< String, unsigned >, unsigned> getPathLabelToSampleMapping(bool) const ))
 {
-  const auto lf = labelfree_unfractionated_design.getPathLabelToSampleMapping(true);
-  const auto lfst = labelfree_unfractionated_single_table_design.getPathLabelToSampleMapping(true);
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToSampleMapping(true);
-  const auto fplex = fourplex_fractionated_design.getPathLabelToSampleMapping(true);
-  const auto fplexst = fourplex_fractionated_single_table_design.getPathLabelToSampleMapping(true);
+  const auto& lf = labelfree_unfractionated_design.getPathLabelToSampleMapping(true);
+  const auto& lfst = labelfree_unfractionated_single_table_design.getPathLabelToSampleMapping(true);
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToSampleMapping(true);
+  const auto& fplex = fourplex_fractionated_design.getPathLabelToSampleMapping(true);
+  const auto& fplexst = fourplex_fractionated_single_table_design.getPathLabelToSampleMapping(true);
 
   // 12 quant. values from label-free, unfractionated files map to 12 samples
   for (const auto& pl2s : { lf, lfst, lfstns })
@@ -179,11 +179,11 @@ END_SECTION
 
 START_SECTION((std::map< std::pair< String, unsigned >, unsigned> getPathLabelToFractionMapping(bool) const ))
 {
-  const auto lf = labelfree_unfractionated_design.getPathLabelToFractionMapping(true);
-  const auto lfst = labelfree_unfractionated_single_table_design.getPathLabelToFractionMapping(true);
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToFractionMapping(true);
-  const auto fplex = fourplex_fractionated_design.getPathLabelToFractionMapping(true);
-  const auto fplexst = fourplex_fractionated_single_table_design.getPathLabelToFractionMapping(true);
+  const auto& lf = labelfree_unfractionated_design.getPathLabelToFractionMapping(true);
+  const auto& lfst = labelfree_unfractionated_single_table_design.getPathLabelToFractionMapping(true);
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToFractionMapping(true);
+  const auto& fplex = fourplex_fractionated_design.getPathLabelToFractionMapping(true);
+  const auto& fplexst = fourplex_fractionated_single_table_design.getPathLabelToFractionMapping(true);
 
   // 12 quant. values from label-free, unfractionated files map to fraction 1 each
   for (const auto& pl2f : { lf, lfst, lfstns })
@@ -203,11 +203,11 @@ END_SECTION
 
 START_SECTION((std::map< std::pair< String, unsigned >, unsigned> getPathLabelToFractionGroupMapping(bool) const ))
 {
-  const auto lf = labelfree_unfractionated_design.getPathLabelToFractionGroupMapping(true);
-  const auto lfst = labelfree_unfractionated_single_table_design.getPathLabelToFractionGroupMapping(true);
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToFractionGroupMapping(true);
-  const auto fplex = fourplex_fractionated_design.getPathLabelToFractionGroupMapping(true);
-  const auto fplexst = fourplex_fractionated_single_table_design.getPathLabelToFractionGroupMapping(true);
+  const auto& lf = labelfree_unfractionated_design.getPathLabelToFractionGroupMapping(true);
+  const auto& lfst = labelfree_unfractionated_single_table_design.getPathLabelToFractionGroupMapping(true);
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getPathLabelToFractionGroupMapping(true);
+  const auto& fplex = fourplex_fractionated_design.getPathLabelToFractionGroupMapping(true);
+  const auto& fplexst = fourplex_fractionated_single_table_design.getPathLabelToFractionGroupMapping(true);
 
   // 12 quant. values from label-free, unfractionated files map to different fraction groups
   for (const auto& pl2fg : { lf, lfst})
@@ -232,11 +232,11 @@ START_SECTION((std::map< std::pair< String, unsigned >, unsigned> getPathLabelTo
 END_SECTION
 
 START_SECTION((std::set< String > ExperimentalDesign::SampleSection::getFactors() const))
-  const auto lfac = labelfree_unfractionated_design.getSampleSection().getFactors();
-  const auto lfacst = labelfree_unfractionated_single_table_design.getSampleSection().getFactors();
-  const auto lfacstns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection().getFactors();
-  const auto facplex = fourplex_fractionated_design.getSampleSection().getFactors();
-  const auto facplexst = fourplex_fractionated_single_table_design.getSampleSection().getFactors();
+  const auto& lfac = labelfree_unfractionated_design.getSampleSection().getFactors();
+  const auto& lfacst = labelfree_unfractionated_single_table_design.getSampleSection().getFactors();
+  const auto& lfacstns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection().getFactors();
+  const auto& facplex = fourplex_fractionated_design.getSampleSection().getFactors();
+  const auto& facplexst = fourplex_fractionated_single_table_design.getSampleSection().getFactors();
 
   TEST_EQUAL(lfac.size(), 3)
   TEST_EQUAL(lfacst.size(), 3)
@@ -246,7 +246,7 @@ START_SECTION((std::set< String > ExperimentalDesign::SampleSection::getFactors(
   TEST_EQUAL(lfac == lfacstns, true)
   TEST_EQUAL(facplex == facplexst, true)
 
-  auto l = lfac.begin();
+  const auto& l = lfac.begin();
   TEST_EQUAL(*l++, "MSstats_BioReplicate")
   TEST_EQUAL(*l++, "MSstats_Condition")
   TEST_EQUAL(*l++, "Sample")
@@ -264,17 +264,17 @@ END_SECTION
 
 START_SECTION((unsigned getNumberOfSamples() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getNumberOfSamples();
-  const auto lfst = labelfree_unfractionated_single_table_design.getNumberOfSamples();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfSamples();
+  const auto& lf = labelfree_unfractionated_design.getNumberOfSamples();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getNumberOfSamples();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfSamples();
 
   for (const auto& ns : { lf, lfst, lfstns })
   {
     TEST_EQUAL(ns, 12);
   }
 
-  const auto fplex = fourplex_fractionated_design.getNumberOfSamples();
-  const auto fplexst = fourplex_fractionated_single_table_design.getNumberOfSamples();
+  const auto& fplex = fourplex_fractionated_design.getNumberOfSamples();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getNumberOfSamples();
   for (const auto& ns : { fplex, fplexst })
   {
     TEST_EQUAL(ns, 8);
@@ -286,11 +286,11 @@ END_SECTION
 START_SECTION((String SampleSection::getFactorValue(const unsigned sample, const String &factor) const))
   // Note: Number of samples are the same (correctness tested in ExperimentalDesign::SampleSection::getNumberOfSamples())
   // Note: Factors are the same (correctness tested in ExperimentalDesign::SampleSection::getFactors())
-  const auto lns = labelfree_unfractionated_design.getNumberOfSamples();
+  const auto& lns = labelfree_unfractionated_design.getNumberOfSamples();
 
-  auto lss_tt = labelfree_unfractionated_design.getSampleSection();
-  auto lss_st = labelfree_unfractionated_single_table_design.getSampleSection();
-  auto lss_stns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection();
+ const auto& lss_tt = labelfree_unfractionated_design.getSampleSection();
+  const auto& lss_st = labelfree_unfractionated_single_table_design.getSampleSection();
+  const auto& lss_stns = labelfree_unfractionated_single_table_no_sample_column.getSampleSection();
 
   // 12 samples (see getNumberOfSamples test)
   for (size_t sample = 1; sample <= lns; ++sample)
@@ -307,9 +307,9 @@ START_SECTION((String SampleSection::getFactorValue(const unsigned sample, const
     }
   }    
 
-  const auto fns = fourplex_fractionated_design.getNumberOfSamples();
-  auto fss_tt = fourplex_fractionated_design.getSampleSection();
-  auto fss_st = fourplex_fractionated_single_table_design.getSampleSection();
+  const auto& fns = fourplex_fractionated_design.getNumberOfSamples();
+ const auto& fss_tt = fourplex_fractionated_design.getSampleSection();
+ const auto& fss_st = fourplex_fractionated_single_table_design.getSampleSection();
   // 8 samples (see getNumberOfSamples test)
   for (size_t sample = 1; sample <= fns; ++sample)
   {
@@ -326,11 +326,11 @@ END_SECTION
 
 START_SECTION((unsigned getNumberOfFractions() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getNumberOfFractions();
-  const auto lfst = labelfree_unfractionated_single_table_design.getNumberOfFractions();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfFractions();
-  const auto fplex = fourplex_fractionated_design.getNumberOfFractions();
-  const auto fplexst = fourplex_fractionated_single_table_design.getNumberOfFractions();
+  const auto& lf = labelfree_unfractionated_design.getNumberOfFractions();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getNumberOfFractions();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfFractions();
+  const auto& fplex = fourplex_fractionated_design.getNumberOfFractions();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getNumberOfFractions();
 
   for (const auto& ns : { lf, lfst, lfstns})
   {
@@ -346,11 +346,11 @@ END_SECTION
 
 START_SECTION((unsigned getNumberOfLabels() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getNumberOfLabels();
-  const auto lfst = labelfree_unfractionated_single_table_design.getNumberOfLabels();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfLabels();
-  const auto fplex = fourplex_fractionated_design.getNumberOfLabels();
-  const auto fplexst = fourplex_fractionated_single_table_design.getNumberOfLabels();
+  const auto& lf = labelfree_unfractionated_design.getNumberOfLabels();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getNumberOfLabels();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfLabels();
+  const auto& fplex = fourplex_fractionated_design.getNumberOfLabels();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getNumberOfLabels();
 
   for (const auto& ns : { lf, lfst, lfstns })
   {
@@ -366,11 +366,11 @@ END_SECTION
 
 START_SECTION((unsigned getNumberOfMSFiles() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getNumberOfMSFiles();
-  const auto lfst = labelfree_unfractionated_single_table_design.getNumberOfMSFiles();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfMSFiles();
-  const auto fplex = fourplex_fractionated_design.getNumberOfMSFiles();
-  const auto fplexst = fourplex_fractionated_single_table_design.getNumberOfMSFiles();
+  const auto& lf = labelfree_unfractionated_design.getNumberOfMSFiles();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getNumberOfMSFiles();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfMSFiles();
+  const auto& fplex = fourplex_fractionated_design.getNumberOfMSFiles();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getNumberOfMSFiles();
 
   for (const auto& ns : { lf, lfst, lfstns} )
   {
@@ -386,11 +386,11 @@ END_SECTION
 
 START_SECTION((unsigned getNumberOfFractionGroups() const ))
 {
-  const auto lf = labelfree_unfractionated_design.getNumberOfFractionGroups();
-  const auto lfst = labelfree_unfractionated_single_table_design.getNumberOfFractionGroups();
-  const auto lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfFractionGroups();
-  const auto fplex = fourplex_fractionated_design.getNumberOfFractionGroups();
-  const auto fplexst = fourplex_fractionated_single_table_design.getNumberOfFractionGroups();
+  const auto& lf = labelfree_unfractionated_design.getNumberOfFractionGroups();
+  const auto& lfst = labelfree_unfractionated_single_table_design.getNumberOfFractionGroups();
+  const auto& lfstns = labelfree_unfractionated_single_table_no_sample_column.getNumberOfFractionGroups();
+  const auto& fplex = fourplex_fractionated_design.getNumberOfFractionGroups();
+  const auto& fplexst = fourplex_fractionated_single_table_design.getNumberOfFractionGroups();
 
   for (const auto& ns : { lf, lfst, lfstns} )
   {
@@ -406,11 +406,11 @@ END_SECTION
 
 START_SECTION((unsigned getSample(unsigned fraction_group, unsigned label=1)))
 {
-  const auto lf11 = labelfree_unfractionated_design.getSample(1, 1);
-  const auto lfst11 = labelfree_unfractionated_single_table_design.getSample(1, 1);
-  const auto lfstns11 = labelfree_unfractionated_single_table_no_sample_column.getSample(1, 1);
-  const auto fplex11 = fourplex_fractionated_design.getSample(1, 1);
-  const auto fplexst11 = fourplex_fractionated_single_table_design.getSample(1, 1);
+  const auto& lf11 = labelfree_unfractionated_design.getSample(1, 1);
+  const auto& lfst11 = labelfree_unfractionated_single_table_design.getSample(1, 1);
+  const auto& lfstns11 = labelfree_unfractionated_single_table_no_sample_column.getSample(1, 1);
+  const auto& fplex11 = fourplex_fractionated_design.getSample(1, 1);
+  const auto& fplexst11 = fourplex_fractionated_single_table_design.getSample(1, 1);
 
   for (const auto& s : { lf11, lfst11, lfstns11})
   {
@@ -421,16 +421,16 @@ START_SECTION((unsigned getSample(unsigned fraction_group, unsigned label=1)))
     TEST_EQUAL(s, 1);
   }
 
-  const auto lf12_1 = labelfree_unfractionated_design.getSample(12, 1);
-  const auto lfst12_1 = labelfree_unfractionated_single_table_design.getSample(12, 1);
-  const auto lfstns11_1 = labelfree_unfractionated_single_table_no_sample_column.getSample(12, 1);
+  const auto& lf12_1 = labelfree_unfractionated_design.getSample(12, 1);
+  const auto& lfst12_1 = labelfree_unfractionated_single_table_design.getSample(12, 1);
+  const auto& lfstns11_1 = labelfree_unfractionated_single_table_no_sample_column.getSample(12, 1);
   for (const auto& s : { lf12_1, lfst12_1, lfstns11_1})
   {
     TEST_EQUAL(s, 12);
   }
 
-  const auto fplex24 = fourplex_fractionated_design.getSample(2, 4);
-  const auto fplexst24 = fourplex_fractionated_single_table_design.getSample(2, 4);
+  const auto& fplex24 = fourplex_fractionated_design.getSample(2, 4);
+  const auto& fplexst24 = fourplex_fractionated_single_table_design.getSample(2, 4);
   for (const auto& s : { fplex24, fplexst24})
   {
     TEST_EQUAL(s, 8);


### PR DESCRIPTION
#6160  "auto" has been changed to "const auto&" based on the issue -  "auto" has been changed to "const auto&" based on the issue - Convert iterator for loops https://github.com/OpenMS/OpenMS/issues/6160

src/tests/class_tests/openms/source/ExperimentalDesign_test.cpp