### PR TITLE
[FIX] some fixes for reduced pyopenms API

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -209,7 +209,7 @@ if( _PYTEST_MISSING EQUAL 0)
     set(PYTEST_MISSING FALSE)
 endif()
 if(PYTEST_MISSING)
-	message(FATAL_ERROR "Looking for pytest testing framework - not found")
+	message(WARNING "Looking for pytest testing framework - not found. Testing pyopenms will not work.")
 else()
 	message(STATUS "Looking for pytest testing framework - found")
 endif()
@@ -290,7 +290,7 @@ endif()
 #------------------------------------------------------------------------------
 # Handle missing libraries (this should never be reached, as the individual
 #  parts should fire FATAL_ERRORs if something is missing)
-if(NUMPY_MISSING OR CYTHON_MODULE_NOTFOUND OR NOT CYTHON_MODULE_VERSION_CHECK_OK OR NOT AUTOWRAP_VERSION_OK OR PYTEST_MISSING
+if(NUMPY_MISSING OR CYTHON_MODULE_NOTFOUND OR NOT CYTHON_MODULE_VERSION_CHECK_OK OR NOT AUTOWRAP_VERSION_OK
    OR SETUPTOOLS_MISSING OR WHEEL_MISSING)
   message(FATAL_ERROR "Required Python modules not found or out of date")
 endif()
@@ -716,31 +716,6 @@ ELSE()
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
     ENDIF()
 ENDIF()
-
-# IF(LINUX AND PY_NO_OUTPUT)
-#   add_custom_command(
-#             OUTPUT ${PYSOFILES}
-#             COMMAND ${Python_EXECUTABLE} setup.py build_ext -j ${PY_NUM_THREADS} ${PY_EXTRA_ARGS} 2> /dev/null
-#             COMMENT "Compiling and linking pyopenms C++ extension with the chosen C++ compiler"
-#             DEPENDS compile_pxds prepare_pyopenms_libs
-#             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
-# ELSEIF(APPLE) # We need to still copy libs with our script
-#   add_custom_command(
-#             OUTPUT ${PYSOFILES}
-#             COMMAND ${Python_EXECUTABLE} setup.py build_ext -j ${PY_NUM_THREADS} ${PY_EXTRA_ARGS}
-#             COMMAND ${CMAKE_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -l ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms -e "@rpath/" -f -v
-#             COMMENT "Compiling and linking pyopenms C++ extension with the chosen C++ compiler"
-#             DEPENDS compile_pxds prepare_pyopenms_libs
-#             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
-# ELSE()
-#   add_custom_command(
-#             OUTPUT ${PYSOFILES}
-#             COMMAND ${Python_EXECUTABLE} setup.py build_ext -j ${PY_NUM_THREADS} ${PY_EXTRA_ARGS}
-#             COMMENT "Compiling and linking pyopenms C++ extension with the chosen C++ compiler"
-#             DEPENDS compile_pxds prepare_pyopenms_libs
-#             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
-# ENDIF()
-
 
 ###########################################################################
 #####                      Testing pyOpenMS                           #####

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -218,7 +218,7 @@ if not iswin:
         extra_compile_args.append("-O0")
         extra_link_args.append("-O0")
 
-mnames = ["pyopenms_%s" % (k+1) for k in range(int(PY_NUM_MODULES))]
+mnames = ["_pyopenms_%s" % (k+1) for k in range(int(PY_NUM_MODULES))]
 ext = []
 
 ##WARNING debug


### PR DESCRIPTION
## Description

nightlies failed because of this

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
