### PR TITLE
Fix thread safety of DB classes

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -79,9 +79,6 @@ public:
     /// Returns a pointer to the modifications DB (singleton)
     static ModificationsDB* getInstance();
 
-    /// Initializes the modification DB with non-default modification files (can only be done once)
-    static ModificationsDB* initializeModificationsDB(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo", OpenMS::String xlmod_file = "CHEMISTRY/XLMOD.obo");
-
     /// Check whether ModificationsDB was instantiated before
     static bool isInstantiated();
 

--- a/src/openms/include/OpenMS/CHEMISTRY/RibonucleotideDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/RibonucleotideDB.h
@@ -58,9 +58,6 @@ namespace OpenMS
     /// replacement for constructor (singleton pattern)
     static RibonucleotideDB* getInstance();
 
-    /// destructor
-    virtual ~RibonucleotideDB();
-
     /// copy constructor not available
     RibonucleotideDB(const RibonucleotideDB& other) = delete;
 
@@ -102,8 +99,6 @@ namespace OpenMS
 
 
   protected:
-    /// default constructor
-    RibonucleotideDB();
 
     /// read (modified) nucleotides from input file
     void readFromFile_(const std::string& path);
@@ -121,5 +116,17 @@ namespace OpenMS
     std::map<std::string, std::pair<ConstRibonucleotidePtr, ConstRibonucleotidePtr>> ambiguity_map_;
 
     Size max_code_length_;
+
+  private:
+
+    /// @brief default constructor for RibonucleotideDB
+    /// @param modomics_file 
+    /// @param custom_mods_file 
+    /// @param proprietary_mods_file 
+    explicit RibonucleotideDB(OpenMS::String modomics_file = "CHEMISTRY/Modomics.tsv", OpenMS::String custom_mods_file = "CHEMISTRY/Custom_RNA_modifications.tsv", OpenMS::String proprietary_mods_file = "");
+
+    /// destructor
+    virtual ~RibonucleotideDB();
+
   };
 }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -80,20 +80,8 @@ namespace OpenMS
 
   ModificationsDB* ModificationsDB::getInstance()
   {
-    static ModificationsDB* db_ = ModificationsDB::initializeModificationsDB();
-    return db_;
-  }
-
-  ModificationsDB* ModificationsDB::initializeModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
-  {
-    // Currently its not possible to check for double initialization since getInstance() also calls this function.
-    // if (is_instantiated_)
-    // {
-    //   throw Exception::FailedAPICall(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Cannot initialize ModificationsDB twice");
-    // }
-
-    static ModificationsDB* db_ = new ModificationsDB(unimod_file, psimod_file, xlmod_file);
-    return db_;
+    static ModificationsDB db_;
+    return &db_;
   }
 
   ModificationsDB::ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -52,15 +52,12 @@ namespace OpenMS
 
   ResidueDB* ResidueDB::getInstance()
   {
-    static ResidueDB* db_ = new ResidueDB(); // Meyers' singleton -> thread safe
-    return db_;
+    static ResidueDB db_; // Meyers' singleton -> thread safe
+    return &db_;
   }
 
   ResidueDB::~ResidueDB()
   {
-    // free memory
-    for (auto& r : const_residues_) { delete r; }
-    for (auto& r : const_modified_residues_) { delete r; }
   }
 
   const Residue* ResidueDB::getResidue(const String& name) const

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -43,21 +43,27 @@ using namespace std;
 
 namespace OpenMS
 {
-  RibonucleotideDB::RibonucleotideDB():
+    RibonucleotideDB::RibonucleotideDB(OpenMS::String modomics_file, OpenMS::String custom_mods_file, OpenMS::String proprietary_mods_file):
     max_code_length_(0)
   {
-    readFromFile_("CHEMISTRY/Modomics.tsv");
-    readFromFile_("CHEMISTRY/Custom_RNA_modifications.tsv");
+    if (! modomics_file.empty())
+    {
+      readFromFile_(modomics_file);
+    }
+    if ( !custom_mods_file.empty())
+    {
+      readFromFile_(custom_mods_file);
+    }
+    if (!proprietary_mods_file.empty())
+    {
+      readFromFile_(proprietary_mods_file); // We add this for future use by developers who need to work with proprietary compounds, but don't want them to get added to git
+    }
   }
 
   RibonucleotideDB* RibonucleotideDB::getInstance()
   {
-    static RibonucleotideDB* db_ = nullptr;
-    if (db_ == nullptr)
-    {
-      db_ = new RibonucleotideDB;
-    }
-    return db_;
+    static RibonucleotideDB db;
+    return &db;
   }
 
   RibonucleotideDB::~RibonucleotideDB()


### PR DESCRIPTION
## Description

This makes the singleton construction of the DB classes thread-safe.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
