### PR TITLE
move unused vars to OpenMS target only to prevent pyOpenMS build failing

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -81,12 +81,6 @@ elseif (MSVC)
 	## disable dll-interface warning
 	set(CF_OPENMS_ADDCXX_FLAGS "${CF_OPENMS_ADDCXX_FLAGS} /wd4251 /wd4275")
 
-	## treat warning of unused function parameter as error
-	set(CF_OPENMS_ADDCXX_FLAGS "${CF_OPENMS_ADDCXX_FLAGS} /we4100")
-
-	## treat warning of unused local variable as error
-	set(CF_OPENMS_ADDCXX_FLAGS "${CF_OPENMS_ADDCXX_FLAGS} /we4189")
-
 	## disable deprecated functions warning (e.g. for POSIX functions)
 	set(CF_OPENMS_ADDCXX_FLAGS "${CF_OPENMS_ADDCXX_FLAGS} /wd4996")
 

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -131,6 +131,14 @@ openms_add_library(TARGET_NAME  OpenMS
                    PRIVATE_LINK_LIBRARIES ${OPENMS_DEP_PRIVATE_LIBRARIES}
                    DLL_EXPORT_PATH "OpenMS/")
 
+if (MSVC)
+  ## treat warning of unused function parameter as error
+  target_compile_options(OpenMS PRIVATE "/we4100")
+
+  ## treat warning of unused local variable as error
+  target_compile_options(OpenMS PRIVATE "/we4189")
+endif()
+
 #------------------------------------------------------------------------------
 # since the share basically belongs to OpenMS core we control its installation
 # here


### PR DESCRIPTION
## Description

fixes #6417 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
