### PR TITLE
Fix XSD value parsing in XML files

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
@@ -257,9 +257,9 @@ public:
     T convert(const String& s);
   
     template<>
-    inline Int convert(const String& s)
+    inline Int32 convert(const String& s)
     {
-      return s.toInt();
+      return s.toInt32();
     }
     template<>
     inline double convert(const String& s)

--- a/src/openms/include/OpenMS/DATASTRUCTURES/String.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/String.h
@@ -312,15 +312,36 @@ public:
     */
     //@{
 
+    
     /**
-        @brief Conversion to int
+        @brief Conversion to Int
 
         This method extracts only the integral part of the string.
         If you want the result rounded, use toFloat() and round the result.
 
-        @exception Exception::ConversionError is thrown if the string could not be converted to int
+        @exception Exception::ConversionError is thrown if the string could not be converted to Int
     */
     OPENMS_DLLAPI Int toInt() const;
+
+    /**
+        @brief Conversion to Int32
+
+        This method extracts only the integral part of the string.
+        If you want the result rounded, use toFloat() and round the result.
+
+        @exception Exception::ConversionError is thrown if the string could not be converted to Int32
+    */
+    OPENMS_DLLAPI Int32 toInt32() const;
+
+    /**
+    @brief Conversion to Int64
+
+    This method extracts only the integral part of the string.
+    If you want the result rounded, use toFloat() and round the result.
+
+    @exception Exception::ConversionError is thrown if the string could not be converted to Int64
+    */
+    OPENMS_DLLAPI Int32 toInt64() const;
 
     /**
       @brief Conversion to float

--- a/src/openms/include/OpenMS/DATASTRUCTURES/String.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/String.h
@@ -341,7 +341,7 @@ public:
 
     @exception Exception::ConversionError is thrown if the string could not be converted to Int64
     */
-    OPENMS_DLLAPI Int32 toInt64() const;
+    OPENMS_DLLAPI Int64 toInt64() const;
 
     /**
       @brief Conversion to float

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -62,7 +62,7 @@ public:
     //
     /// Functions
     //
-    static Int toInt32(const String & this_s)
+    static Int toInt32(const String& this_s)
     {
       Int ret;
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -62,7 +62,7 @@ public:
     //
     /// Functions
     //
-    static Int toInt(const String & this_s)
+    static Int toInt32(const String & this_s)
     {
       Int ret;
 
@@ -76,7 +76,28 @@ public:
       // was the string parsed (white spaces are skipped automatically!) completely? If not, we have a problem because a previous split might have used the wrong split char
       if (it != this_s.end())
       {
-        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Prefix of string '") + this_s + "' successfully converted to an integer value. Additional characters found at position " + (int)(distance(this_s.begin(), it) + 1));
+        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Prefix of string '") + this_s + "' successfully converted to an int32 value. Additional characters found at position " + (int)(distance(this_s.begin(), it) + 1));
+      }
+      return ret;
+    }
+
+    static Int64 toInt64(const String& this_s)
+    {
+      Int64 ret;
+
+      // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
+      // so don't change this unless you have benchmarks for all platforms!
+      String::ConstIterator it = this_s.begin();
+      if (!boost::spirit::qi::phrase_parse(it, this_s.end(), boost::spirit::qi::long_long, boost::spirit::ascii::space, ret))
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Could not convert string '") + this_s + "' to an int64 value");
+      }
+      // was the string parsed (white spaces are skipped automatically!) completely? If not, we have a problem because a previous split might have used the wrong split char
+      if (it != this_s.end())
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         String("Prefix of string '") + this_s + "' successfully converted to an integer value. Additional characters found at position " +
+                                           (int)(distance(this_s.begin(), it) + 1));
       }
       return ret;
     }
@@ -203,9 +224,14 @@ public:
       return QString(this_s.c_str());
     }
 
-    [[maybe_unused]] static Int toInt(const String & this_s)
+    [[maybe_unused]] static Int32 toInt32(const String & this_s)
     {
-      return StringUtilsHelper::toInt(this_s);
+      return StringUtilsHelper::toInt32(this_s);
+    }
+
+    [[maybe_unused]] static Int64 toInt64(const String& this_s)
+    {
+      return StringUtilsHelper::toInt64(this_s);
     }
 
     [[maybe_unused]] static float toFloat(const String & this_s)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -39,6 +39,7 @@
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 #include <xercesc/util/XMLString.hpp>
@@ -416,6 +417,51 @@ public:
         if (_copy.has('\'')) _copy.substitute("'","&apos;");
 
         return _copy;
+      }
+
+      /**
+      *  @brief Convert an XSD type (e.g. 'xsd:double') to a DataValue.
+      * 
+      *  Not all conversions are supported yet, due to DataValue using an Int64 as the largest possible integer.
+      *  Thus, if the @p value contains a large UInt64, conversion will fail.
+      *  Value ranges are currently also not checked, only for XSD types which happen to match the internal representation.
+      * 
+      *  @param type An XSD type. If the type is not supported, the returned type will be a string
+      *  @param value The value in sting format, e.g. "123.34"
+      *  @return The Datavalue with the respective type (double, int or string)
+      *  @throws Exception::ConversionError if the value does not fit into the internal representation or (for few types) exceeds the XSD specs.
+      * 
+      */
+      static DataValue fromXSDString(const String& type, const String& value)
+      {
+        DataValue data_value;
+        // float type
+        if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
+        {
+          data_value = DataValue(value.toDouble());
+        }
+        // <=32 bit integer types
+        else if (type == "xsd:byte" ||          // 8bit signed
+                 type == "xsd:int" ||           // 32bit signed
+                 type == "xsd:unsignedShort" || // 16bit unsigned
+                 type == "xsd:short" ||         // 16bit signed
+                 type == "xsd:unsignedByte" || type == "xsd:unsignedInt")
+        {
+          data_value = DataValue(value.toInt32());
+        }
+        // 64 bit integer types
+        else if (type == "xsd:long" || type == "xsd:unsignedLong" ||       // 64bit signed or unsigned respectively
+                 type == "xsd:integer" || type == "xsd:negativeInteger" || // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
+                 type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger")
+        {
+          data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
+        }
+        // everything else is treated as a string
+        else
+        {
+          data_value = DataValue(value);
+        }
+        return data_value;
       }
 
       /// throws a ParseError if protIDs are not unique, i.e. PeptideIDs will be randomly assigned (bad!)

--- a/src/openms/source/DATASTRUCTURES/String.cpp
+++ b/src/openms/source/DATASTRUCTURES/String.cpp
@@ -301,7 +301,21 @@ namespace OpenMS
 
   Int String::toInt() const
   {
-    return StringUtils::toInt(*this);
+    if constexpr (is_same<Int, Int32>::value)
+    {
+      return StringUtils::toInt32(*this);
+    }
+    return StringUtils::toInt64(*this);
+  }
+
+  Int String::toInt32() const
+  {
+    return StringUtils::toInt32(*this);
+  }
+
+  Int String::toInt64() const
+  {
+    return StringUtils::toInt64(*this);
   }
 
   float String::toFloat() const

--- a/src/openms/source/DATASTRUCTURES/String.cpp
+++ b/src/openms/source/DATASTRUCTURES/String.cpp
@@ -305,15 +305,18 @@ namespace OpenMS
     {
       return StringUtils::toInt32(*this);
     }
-    return StringUtils::toInt64(*this);
+    else
+    {
+      return StringUtils::toInt64(*this);
+    }
   }
 
-  Int String::toInt32() const
+  Int32 String::toInt32() const
   {
     return StringUtils::toInt32(*this);
   }
 
-  Int String::toInt64() const
+  Int64 String::toInt64() const
   {
     return StringUtils::toInt64(*this);
   }

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3631,14 +3631,14 @@ namespace OpenMS::Internal
       }
 
       // write out all the cvParams and userParams in correct order
-      for (std::vector<String>::iterator term = cvParams.begin(); term != cvParams.end(); ++term)
+      for (const auto& p : cvParams)
       {
-        os << String(indent, '\t') << *term;
+        os << String(indent, '\t') << p;
       }
 
-      for (std::vector<String>::iterator term = userParams.begin(); term != userParams.end(); ++term)
+      for (const auto& p : userParams)
       {
-        os << String(indent, '\t') << *term;
+        os << String(indent, '\t') << p;
       }
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3295,29 +3295,31 @@ namespace OpenMS::Internal
                                        const String& value,
                                        const String& unit_accession)
     {
-      //create a DataValue that contains the data in the right type
+      // create a DataValue that contains the data in the right type
       DataValue data_value;
 
       // float type
-      if (type == "xsd:double" || type == "xsd:float")
+      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
       {
         data_value = DataValue(value.toDouble());
       }
-      // integer type
-      else if (type == "xsd:byte" || type == "xsd:decimal" ||
-               type == "xsd:int" || type == "xsd:integer" ||
-               type == "xsd:negativeInteger" || type == "xsd:unsignedShort" ||
-               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" ||
-               type == "xsd:positiveInteger" || type == "xsd:short" ||
+      // <=32 bit integer types
+      else if (type == "xsd:byte" || // 8bit signed
+               type == "xsd:int" ||  // 32bit signed 
+               type == "xsd:unsignedShort" || // 16bit unsigned
+               type == "xsd:short" ||         // 16bit signed
                type == "xsd:unsignedByte" || type == "xsd:unsignedInt"
                )
       {
         data_value = DataValue(value.toInt32());
       }
-      // integer type
-      else if (type == "xsd:long" || type == "xsd:unsignedLong")
+      // 64 bit integer types
+      else if (type == "xsd:long" || type == "xsd:unsignedLong" || // 64bit signed or unsigned respectively
+               type == "xsd:integer"  || type == "xsd:negativeInteger" ||  // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
+               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" ||
+               type == "xsd:positiveInteger")
       {
-        data_value = DataValue(value.toInt64());
+        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
       }
       // everything else is treated as a string
       else

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3296,36 +3296,7 @@ namespace OpenMS::Internal
                                        const String& unit_accession)
     {
       // create a DataValue that contains the data in the right type
-      DataValue data_value;
-
-      // float type
-      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
-      {
-        data_value = DataValue(value.toDouble());
-      }
-      // <=32 bit integer types
-      else if (type == "xsd:byte" || // 8bit signed
-               type == "xsd:int" ||  // 32bit signed 
-               type == "xsd:unsignedShort" || // 16bit unsigned
-               type == "xsd:short" ||         // 16bit signed
-               type == "xsd:unsignedByte" || type == "xsd:unsignedInt"
-               )
-      {
-        data_value = DataValue(value.toInt32());
-      }
-      // 64 bit integer types
-      else if (type == "xsd:long" || type == "xsd:unsignedLong" || // 64bit signed or unsigned respectively
-               type == "xsd:integer"  || type == "xsd:negativeInteger" ||  // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
-               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" ||
-               type == "xsd:positiveInteger")
-      {
-        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
-      }
-      // everything else is treated as a string
-      else
-      {
-        data_value = DataValue(value);
-      }
+      DataValue data_value = fromXSDString(type, value);
 
       if (!unit_accession.empty())
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3306,13 +3306,18 @@ namespace OpenMS::Internal
       // integer type
       else if (type == "xsd:byte" || type == "xsd:decimal" ||
                type == "xsd:int" || type == "xsd:integer" ||
-               type == "xsd:long" || type == "xsd:negativeInteger" ||
+               type == "xsd:negativeInteger" || type == "xsd:unsignedShort" ||
                type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" ||
                type == "xsd:positiveInteger" || type == "xsd:short" ||
                type == "xsd:unsignedByte" || type == "xsd:unsignedInt"
-               || type == "xsd:unsignedLong" || type == "xsd:unsignedShort")
+               )
       {
-        data_value = DataValue(value.toInt());
+        data_value = DataValue(value.toInt32());
+      }
+      // integer type
+      else if (type == "xsd:long" || type == "xsd:unsignedLong")
+      {
+        data_value = DataValue(value.toInt64());
       }
       // everything else is treated as a string
       else

--- a/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
@@ -653,34 +653,8 @@ namespace OpenMS::Internal
 
     void MzQuantMLHandler::handleUserParam_(const String& parent_parent_tag, const String& parent_tag, const String& name, const String& type, const String& value)
     {
-      //create a DataValue that contains the data in the right type
-      DataValue data_value;
-      // float type
-      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
-      {
-        data_value = DataValue(value.toDouble());
-      }
-      // <=32 bit integer types
-      else if (type == "xsd:byte" ||          // 8bit signed
-               type == "xsd:int" ||           // 32bit signed
-               type == "xsd:unsignedShort" || // 16bit unsigned
-               type == "xsd:short" ||         // 16bit signed
-               type == "xsd:unsignedByte" || type == "xsd:unsignedInt")
-      {
-        data_value = DataValue(value.toInt32());
-      }
-      // 64 bit integer types
-      else if (type == "xsd:long" || type == "xsd:unsignedLong" ||       // 64bit signed or unsigned respectively
-               type == "xsd:integer" || type == "xsd:negativeInteger" || // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
-               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger")
-      {
-        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
-      }
-      //everything else is treated as a string
-      else
-      {
-        data_value = DataValue(value);
-      }
+      // create a DataValue that contains the data in the right type
+      DataValue data_value = fromXSDString(type, value);
 
       if (parent_parent_tag.empty())
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzQuantMLHandler.cpp
@@ -655,15 +655,26 @@ namespace OpenMS::Internal
     {
       //create a DataValue that contains the data in the right type
       DataValue data_value;
-      //float type
-      if (type == "xsd:double" || type == "xsd:float")
+      // float type
+      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
       {
         data_value = DataValue(value.toDouble());
       }
-      //integer type
-      else if (type == "xsd:byte" || type == "xsd:decimal" || type == "xsd:int" || type == "xsd:integer" || type == "xsd:long" || type == "xsd:negativeInteger" || type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger" || type == "xsd:short" || type == "xsd:unsignedByte" || type == "xsd:unsignedInt" || type == "xsd:unsignedLong" || type == "xsd:unsignedShort")
+      // <=32 bit integer types
+      else if (type == "xsd:byte" ||          // 8bit signed
+               type == "xsd:int" ||           // 32bit signed
+               type == "xsd:unsignedShort" || // 16bit unsigned
+               type == "xsd:short" ||         // 16bit signed
+               type == "xsd:unsignedByte" || type == "xsd:unsignedInt")
       {
-        data_value = DataValue(value.toInt());
+        data_value = DataValue(value.toInt32());
+      }
+      // 64 bit integer types
+      else if (type == "xsd:long" || type == "xsd:unsignedLong" ||       // 64bit signed or unsigned respectively
+               type == "xsd:integer" || type == "xsd:negativeInteger" || // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
+               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger")
+      {
+        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
       }
       //everything else is treated as a string
       else

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -1593,15 +1593,26 @@ namespace OpenMS::Internal
     {
       //create a DataValue that contains the data in the right type
       DataValue data_value;
-      //float type
-      if (type == "xsd:double" || type == "xsd:float")
+      // float type
+      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
       {
         data_value = DataValue(value.toDouble());
       }
-      //integer type
-      else if (type == "xsd:byte" || type == "xsd:decimal" || type == "xsd:int" || type == "xsd:integer" || type == "xsd:long" || type == "xsd:negativeInteger" || type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger" || type == "xsd:short" || type == "xsd:unsignedByte" || type == "xsd:unsignedInt" || type == "xsd:unsignedLong" || type == "xsd:unsignedShort")
+      // <=32 bit integer types
+      else if (type == "xsd:byte" ||          // 8bit signed
+               type == "xsd:int" ||           // 32bit signed
+               type == "xsd:unsignedShort" || // 16bit unsigned
+               type == "xsd:short" ||         // 16bit signed
+               type == "xsd:unsignedByte" || type == "xsd:unsignedInt")
       {
-        data_value = DataValue(value.toInt());
+        data_value = DataValue(value.toInt32());
+      }
+      // 64 bit integer types
+      else if (type == "xsd:long" || type == "xsd:unsignedLong" ||       // 64bit signed or unsigned respectively
+               type == "xsd:integer" || type == "xsd:negativeInteger" || // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
+               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger")
+      {
+        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
       }
       //everything else is treated as a string
       else

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -1591,36 +1591,10 @@ namespace OpenMS::Internal
 
     void TraMLHandler::handleUserParam_(const String& parent_parent_tag, const String& parent_tag, const String& name, const String& type, const String& value)
     {
-      //create a DataValue that contains the data in the right type
-      DataValue data_value;
-      // float type
-      if (type == "xsd:double" || type == "xsd:float" || type == "xsd:decimal")
-      {
-        data_value = DataValue(value.toDouble());
-      }
-      // <=32 bit integer types
-      else if (type == "xsd:byte" ||          // 8bit signed
-               type == "xsd:int" ||           // 32bit signed
-               type == "xsd:unsignedShort" || // 16bit unsigned
-               type == "xsd:short" ||         // 16bit signed
-               type == "xsd:unsignedByte" || type == "xsd:unsignedInt")
-      {
-        data_value = DataValue(value.toInt32());
-      }
-      // 64 bit integer types
-      else if (type == "xsd:long" || type == "xsd:unsignedLong" ||       // 64bit signed or unsigned respectively
-               type == "xsd:integer" || type == "xsd:negativeInteger" || // any 'integer' has arbitrary size... but we have to cope with 64bit for now.
-               type == "xsd:nonNegativeInteger" || type == "xsd:nonPositiveInteger" || type == "xsd:positiveInteger")
-      {
-        data_value = DataValue(value.toInt64()); // internally a signed 64-bit integer. So if someone uses 2^64-1 as value, toInt64() will raise an exception...
-      }
-      //everything else is treated as a string
-      else
-      {
-        data_value = DataValue(value);
-      }
+      // create a DataValue that contains the data in the right type
+      DataValue data_value = fromXSDString(type, value);
 
-      //find the right MetaInfoInterface
+      // find the right MetaInfoInterface
       if (parent_tag == "Software")
       {
         actual_software_.setMetaValue(name, data_value);

--- a/src/tests/class_tests/openms/data/MzMLFile_xsd-ranges.mzML
+++ b/src/tests/class_tests/openms/data/MzMLFile_xsd-ranges.mzML
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" version="1.1.0">
+	<cvList count="1">
+    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" version="2.0.2" URI="http://psidev.sourceforge.net/ms/xml/mzdata/psi-ms.2.0.2.obo"/>
+	</cvList>
+	
+	<fileDescription>
+		<fileContent/>
+    <sourceFileList count="1">
+      <sourceFile id="sf1" name="tiny1.RAW" location="file:///F:/data/Exp01">
+        <cvParam cvRef="MS" accession="MS:1000563" name="Thermo RAW format"/>
+        <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="71be39fb2700ab2f3c8b2234b91274968b6899b1"/>
+      	<cvParam cvRef="MS" accession="MS:1000774" name="multiple peak list nativeID format"/>
+				<userParam name="a large integer 2^63 - 1" type="xsd:integer" value="9223372036854775807"/>
+				<userParam name="a large negative integer -2^63" type="xsd:integer" value="-9223372036854775808"/>
+				<userParam name="a large long 2^63 - 1" type="xsd:long" value="9223372036854775807"/>
+				<userParam name="a large negative long -2^63" type="xsd:long" value="-9223372036854775808"/>
+				<userParam name="a large unsignedLong 2^63 - 1" type="xsd:unsignedLong" value="9223372036854775807"/>
+				<userParam name="a large negativeInteger -2^63" type="xsd:negativeInteger" value="-9223372036854775808"/>
+
+				<userParam name="a normal integer 2^31 - 1" type="xsd:int" value="2147483647"/>
+				<userParam name="a normal negative integer -2^31" type="xsd:int" value="-2147483648"/>
+
+				<userParam name="a decimal number" type="xsd:decimal" value="123.56"/>
+
+      </sourceFile>
+    </sourceFileList>
+	</fileDescription>
+	
+	<softwareList count="1">
+		<software id="ID_2" version="3.3.1 sp1">
+      <cvParam cvRef="MS" accession="MS:1000533" name="Bioworks"/>
+		</software>
+	</softwareList>
+
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ID_1">
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+
+	<dataProcessingList count="1">
+		<dataProcessing id="ID_3">
+			<processingMethod order="1" softwareRef="ID_2"/>
+		</dataProcessing>
+	</dataProcessingList>
+	
+	<run id="ID_9" defaultInstrumentConfigurationRef="ID_1">
+	</run>
+</mzML>

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -983,42 +983,13 @@ START_SECTION([EXTRA] load intensity range)
 }
 END_SECTION
 
-class MzMLHandlerTest : public Internal::MzMLHandler
-{
-public:
-  // expose Ctors
-  using MzMLHandler::MzMLHandler;
-  // expose protected function so we can test it
-  void handleUserParam(const String& type, const String& value, const String& unit_accession = "")
-  {
-    MzMLHandler::handleUserParam_("", "run", "meta", type, value, unit_accession);
-  }
-};
-
 START_SECTION([EXTRA] load xsd:integer types)
 {
   MzMLFile file;
   PeakMap exp;
   // just load without crashing...
   file.load(OPENMS_GET_TEST_DATA_PATH("MzMLFile_xsd-ranges.mzML"), exp);
-
-
-  MzMLHandlerTest mt(exp, "", "v1.1", ProgressLogger());
-  mt.handleUserParam("xsd:int", "2147483647");  TEST_EQUAL((Int64)exp.getMetaValue("meta"), 2147483647)
-  mt.handleUserParam("xsd:long", "9223372036854775807");  TEST_EQUAL((Int64)exp.getMetaValue("meta"), 9223372036854775807)
-  mt.handleUserParam("xsd:decimal", "123.45");  TEST_EQUAL((double)exp.getMetaValue("meta"), 123.45)
-  mt.handleUserParam("xsd:unsignedLong", "9223372036854775807");  TEST_EQUAL((Int64)exp.getMetaValue("meta"), 9223372036854775807)
-
-  // input exceeds valid range
-  TEST_EXCEPTION(Exception::ConversionError, mt.handleUserParam("xsd:int", "2147483648")) // +1 larger than 2^31-1
-  TEST_EXCEPTION(Exception::ConversionError, mt.handleUserParam("xsd:long", "9223372036854775808")) // +1 larger than 2^63-1
-
-  // things we SHOULD support, but don't, due to using a signed 64bit type in DataValue
-  TEST_EXCEPTION(Exception::ConversionError, mt.handleUserParam("xsd:unsignedLong", "9223372036854775808")) // +1 larger than 2^63-1; 'xsd:unsignedLong' up to 2^64-1
-
-  // things which are really hard to support (arbitrarily large numbers)
-  TEST_EXCEPTION(Exception::ConversionError, mt.handleUserParam("xsd:integer",      "9223372036854775808")) // +1 larger than 2^63-1; 'xsd:integer' can be any number... hard to support :)
-  TEST_EXCEPTION(Exception::ConversionError, mt.handleUserParam("xsd:negativeInteger", "-9223372036854775809"))      // -1 smaller than 2^63; 'xsd:negativeInteger' can be any negative number... hard to support :)
+  NOT_TESTABLE
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/StringUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/StringUtils_test.cpp
@@ -217,20 +217,48 @@ START_SECTION((static QString toQString(const String &this_s)))
 }
 END_SECTION
 
-START_SECTION((static Int toInt(const String &this_s)))
+
+START_SECTION((static Int32 toInt32(const String &this_s)))
 {
   // easy case
-  TEST_EQUAL(StringUtils::toInt("1234"), 1234)
+  TEST_EQUAL(StringUtils::toInt32("2147483647"), 2147483647)
   // with spaces (allowed)
-  TEST_EQUAL(StringUtils::toInt("  1234"), 1234)
-  TEST_EQUAL(StringUtils::toInt("1234 "), 1234)
-  TEST_EQUAL(StringUtils::toInt("   1234  "), 1234)
+  TEST_EQUAL(StringUtils::toInt32("  2147483647"), 2147483647)
+  TEST_EQUAL(StringUtils::toInt32("2147483647 "), 2147483647)
+  TEST_EQUAL(StringUtils::toInt32("   2147483647  "), 2147483647)
+  //
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32("2147483648")) // +1 too large
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32("-2147483649")) // -1 too small
+
   // with trailing chars (unexplained) --> error (because it means the input was not split correctly beforehand)!!!
-  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt("1234  moreText"))  // 'moreText' is not explained...
-  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" 1234 911.0"))     // '911.0' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32("1234  moreText")) // 'moreText' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32(" 1234 911.0"))    // '911.0' is not explained...
   // incorrect type
-  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" abc "))
-  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" 123.45 "))
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32(" abc "))
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt32(" 123.45 "))
+}
+END_SECTION
+
+
+
+START_SECTION((static Int64 toInt64(const String &this_s)))
+{
+  // easy case
+  TEST_EQUAL(StringUtils::toInt64("9223372036854775807"), 9223372036854775807)
+  // with spaces (allowed)
+  TEST_EQUAL(StringUtils::toInt64("  9223372036854775807"), 9223372036854775807)
+  TEST_EQUAL(StringUtils::toInt64("9223372036854775807 "), 9223372036854775807)
+  TEST_EQUAL(StringUtils::toInt64("   9223372036854775807  "), 9223372036854775807)
+  //
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64("9223372036854775808")) // +1 too large
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64("-9223372036854775809")) // -1 too small
+
+  // with trailing chars (unexplained) --> error (because it means the input was not split correctly beforehand)!!!
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64("1234  moreText"))  // 'moreText' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64(" 1234 911.0"))     // '911.0' is not explained...
+  // incorrect type
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64(" abc "))
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt64(" 123.45 "))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/XMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/XMLFile_test.cpp
@@ -88,7 +88,26 @@ START_SECTION(([EXTRA] String writeXMLEscape(const String& to_escape)))
   TEST_STRING_EQUAL(XMLHandler::writeXMLEscape(s3), "This string also contains characters which is not allowed, and must be escaped; the characters are &apos;&gt;&apos; and &quot;&lt;&quot;");
 END_SECTION
 
+START_SECTION(static DataValue fromXSDString(const String& type, const String& value))
+{
+  TEST_EQUAL((Int64)XMLHandler::fromXSDString("xsd:int", "2147483647"), 2147483647)
+  TEST_EQUAL((Int64)XMLHandler::fromXSDString("xsd:long", "9223372036854775807"), 9223372036854775807)
+  TEST_EQUAL((double)XMLHandler::fromXSDString("xsd:decimal", "123.45"), 123.45)
+  TEST_EQUAL((Int64)XMLHandler::fromXSDString("xsd:unsignedLong", "9223372036854775807"), 9223372036854775807)
 
+  // input exceeds valid range
+  TEST_EXCEPTION(Exception::ConversionError, XMLHandler::fromXSDString("xsd:int", "2147483648"))           // +1 larger than 2^31-1
+  TEST_EXCEPTION(Exception::ConversionError, XMLHandler::fromXSDString("xsd:long", "9223372036854775808")) // +1 larger than 2^63-1
+
+  // things we SHOULD support, but don't, due to using a signed 64bit type in DataValue
+  TEST_EXCEPTION(Exception::ConversionError, XMLHandler::fromXSDString("xsd:unsignedLong", "9223372036854775808")) // +1 larger than 2^63-1; 'xsd:unsignedLong' up to 2^64-1
+
+  // things which are really hard to support (arbitrarily large numbers)
+  TEST_EXCEPTION(Exception::ConversionError, XMLHandler::fromXSDString("xsd:integer", "9223372036854775808")) // +1 larger than 2^63-1; 'xsd:integer' can be any number... hard to support :)
+  TEST_EXCEPTION(Exception::ConversionError,
+                 XMLHandler::fromXSDString("xsd:negativeInteger", "-9223372036854775809")) // -1 smaller than 2^63; 'xsd:negativeInteger' can be any negative number... hard to support :)
+}
+END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
## Description

I stumbled upon this when loading a exotic mzML, which had something like
```
<userParam name="someInt" type="xsd:integer" value="9223372036854775807"/>
```

It turns out, our implementation only supported ranges covered by signed 32bit integers.
Any larger numbers would throw an Exception::ConversionError.

Also, anyone passing a "xsd:decimal" would also get an error, since we treated it as an integer, not a decimal number (float, double). Luckily, no one ever tried!

This PR fixes most of these things in **mzML**, **mzQuantML** and **traML**, but our internal representation of integers is an Int64, i.e. if an mzML file contains a large 64 bit unsigned int
```
<userParam name="aLargeUnsigned64bit" type="xsd:unsignedLong" value="9223372036854775809"/>
```
that's still an error. Fixing this would mean fixing `DataValue`... good luck.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
