### PR TITLE
fix error in mac dependency script when plugin dir is not given

### DIFF
--- a/cmake/MacOSX/fix_dependencies.rb
+++ b/cmake/MacOSX/fix_dependencies.rb
@@ -431,7 +431,8 @@ debug "HANDLING LIB DIR"
 Dir.chdir($lib_dir.to_s) do
   lib_files = Dir.glob(["*","*/*"])
   for content in lib_files
-    if not ($lib_dir+content).to_s.start_with?($plugin_dir.to_s) and fixable(content, $lib_dir)
+    # in case plugin dir is a subdir of lib dir
+    if not ($plugin_dir.nil? and ($lib_dir+content).to_s.start_with?($plugin_dir.to_s)) and fixable(content, $lib_dir)
       if isFramework(content)
         handleFramework($lib_dir + content, $lib_dir, [])
       elsif (content.end_with?(".dylib") or content.end_with?(".so"))


### PR DESCRIPTION
## Description

fixes #6444  hopefully

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
