### PR TITLE
[FIX] -pasef flag with TraML file

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -144,7 +144,7 @@ namespace OpenMS
       transition_exp.compounds.push_back(p);
     }
 
-    //copy compounds and store as compounds 
+    //copy compounds and store as compounds
     for (Size i = 0; i < transition_exp_.getCompounds().size(); i++)
     {
       OpenSwath::LightCompound c;
@@ -161,11 +161,19 @@ namespace OpenMS
       t.precursor_mz = transition.getPrecursorMZ();
       t.library_intensity = transition.getLibraryIntensity();
       t.peptide_ref = transition.getPeptideRef();
+
+      // If compound is a peptide, get the ion mobility information from the compound
+      if (!t.peptide_ref.empty())
+      {
+        OpenSwath::LightCompound p = transition_exp.getPeptideByRef(t.peptide_ref);
+        t.precursor_im = p.getDriftTime();
+      }
       // try compound ref
-      if (t.peptide_ref.empty())
+      else  // (t.peptide_ref.empty())
       {
         t.peptide_ref = transition.getCompoundRef();
       }
+
       if (transition.isProductChargeStateSet())
       {
         t.fragment_charge = transition.getProductChargeState();


### PR DESCRIPTION
Very minor changes
Previously bug with -pasef flag using TraML file as ion mobility data was not able to be accessed through the light transition object. Fix this here.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [X] Make sure that you are listed in the AUTHORS file
- [X] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
