### PR TITLE
Try collecting GH job status to display overall status

### DIFF
--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -485,5 +485,5 @@ jobs:
     if: ${{ always() }}
     steps:
     - name: Check on failures
-      if: ${{ needs.build-win.outputs.job-status != "Success" || needs.build-lnx.outputs.job.status == "Success" || needs.build-macos.outputs.job.status == "Success" }} 
+      if: ${{ needs.build-win.outputs.job-status != 'Success' || needs.build-lnx.outputs.job-status != 'Success' || needs.build-macos.outputs.job-status != 'Success' }} 
       run: exit 1

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -12,6 +12,8 @@ jobs:
   build-win:
     runs-on: windows-2022
     continue-on-error: true
+    outputs:
+      job-status: ${{ job.status }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -125,6 +127,8 @@ jobs:
   build-macos:
     runs-on: macos-latest
     continue-on-error: true
+    outputs:
+      job-status: ${{ job.status }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -250,6 +254,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container: ghcr.io/openms/contrib_manylinux2014:latest
+    outputs:
+      job-status: ${{ job.status }}
 
     steps:
     # Cancels older builds if still running
@@ -356,7 +362,8 @@ jobs:
   build-lnx-clang:
     runs-on: ubuntu-20.04
     continue-on-error: true
-
+    outputs:
+      job-status: ${{ job.status }}
     steps:
     # Cancels older builds if still running
     - uses: rokroskar/workflow-run-cleanup-action@master
@@ -471,3 +478,12 @@ jobs:
           OPENMP: "On"
           USE_STATIC_BOOST: "Off"
           BUILD_FLAGS: "-j2"
+        
+  overall-status:
+    runs-on: ubuntu-latest
+    needs: [build-win, build-lnx, build-macos]
+    if: ${{ always() }}
+    steps:
+    - name: Check on failures
+      if: needs.build-win.outputs.job-status != "Success" || needs.build-lnx.outputs.job.status == "Success" || needs.build-macos.outputs.job.status == "Success" 
+      run: exit 1

--- a/.github/workflows/openms-ci.yml
+++ b/.github/workflows/openms-ci.yml
@@ -485,5 +485,5 @@ jobs:
     if: ${{ always() }}
     steps:
     - name: Check on failures
-      if: needs.build-win.outputs.job-status != "Success" || needs.build-lnx.outputs.job.status == "Success" || needs.build-macos.outputs.job.status == "Success" 
+      if: ${{ needs.build-win.outputs.job-status != "Success" || needs.build-lnx.outputs.job.status == "Success" || needs.build-macos.outputs.job.status == "Success" }} 
       run: exit 1


### PR DESCRIPTION
Alternative: Use different workflows.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
