### PR TITLE
use automoc only on openms libs, fix asan flag propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,14 +227,6 @@ if(STL_DEBUG)
 endif()
 
 #------------------------------------------------------------------------------
-# Enable AddressSanitizer
-#------------------------------------------------------------------------------
-option(ADDRESS_SANITIZER "[Clang/GCC only] Enable AddressSanitizer mode (quite slow)." OFF)
-if(ADDRESS_SANITIZER)
-  include(cmake/AddressSanitizer.cmake)
-endif()
-
-#------------------------------------------------------------------------------
 # Add options for link time optimizations (LTO) aka interprocedural optimization
 #------------------------------------------------------------------------------
 option(ENABLE_IPO

--- a/cmake/AddressSanitizer.cmake
+++ b/cmake/AddressSanitizer.cmake
@@ -47,9 +47,9 @@ if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     add_compile_options( -fsanitize=address
                          -fno-omit-frame-pointer)
     # add AddressSanitizer also for linker
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
-    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -fsanitize=address")
+    set(CXX_EXE_LINKER_FLAGS "${CMAKE_CXX_EXE_LINKER_FLAGS} -fsanitize=address")
+    set(CXX_SHARED_LINKER_FLAGS "${CMAKE_CXX_SHARED_LINKER_FLAGS} -fsanitize=address")
+    set(CXX_STATIC_LINKER_FLAGS "${CMAKE_CXX_STATIC_LINKER_FLAGS} -fsanitize=address")
     message(STATUS "AddressSanitizer is on.")
   endif()
 else()

--- a/cmake/AddressSanitizer.cmake
+++ b/cmake/AddressSanitizer.cmake
@@ -29,7 +29,7 @@
 #
 # --------------------------------------------------------------------------
 # $Maintainer: Hannes Roest $
-# $Authors: Hannes Roest $
+# $Authors: Hannes Roest, Timo Sachsenberg $
 # --------------------------------------------------------------------------
 
 #------------------------------------------------------------------------------
@@ -37,23 +37,24 @@
 # see http://clang.llvm.org/docs/AddressSanitizer.html 
 #     http://en.wikipedia.org/wiki/AddressSanitizer
 
-if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  # add compiler flag
-  # -> requires clang > 3.1 or gcc > 4.8
-  if (MSVC)
-    message(WARNING "AddressSanitizer can only be enabled for GCC and Clang.")
-  else()
-    # add AddressSanitizer also for compiler
-    add_compile_options( -fsanitize=address
-                         -fno-omit-frame-pointer)
-    # add AddressSanitizer also for linker
-    set(CXX_EXE_LINKER_FLAGS "${CMAKE_CXX_EXE_LINKER_FLAGS} -fsanitize=address")
-    set(CXX_SHARED_LINKER_FLAGS "${CMAKE_CXX_SHARED_LINKER_FLAGS} -fsanitize=address")
-    set(CXX_STATIC_LINKER_FLAGS "${CMAKE_CXX_STATIC_LINKER_FLAGS} -fsanitize=address")
-    message(STATUS "AddressSanitizer is on.")
+function(add_asan_to_target TARGET_NAME_ARG)
+  if(ADDRESS_SANITIZER)
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+      # add compiler flag
+      if (MSVC)
+        message(WARNING "AddressSanitizer can only be enabled for GCC and Clang.")
+      else()
+        # add AddressSanitizer for compiler and linker
+        target_compile_options("${TARGET_NAME_ARG}" 
+          PRIVATE 
+            -fsanitize=address
+            -fno-omit-frame-pointer)
+        target_link_options(${TARGET_NAME_ARG} PRIVATE -fsanitize=address)           
+        message(STATUS "AddressSanitizer is on.")
+      endif()
+    else()
+      message(WARNING "AddressSanitizer is supported for OpenMS debug mode only.")
+      message(WARNING "Build type is ${CMAKE_BUILD_TYPE}")
+    endif()
   endif()
-else()
-  message(WARNING "AddressSanitizer is supported for OpenMS debug mode only.")
-  message(WARNING "Build type is ${CMAKE_BUILD_TYPE}")
-endif()
-
+endfunction()

--- a/cmake/AddressSanitizer.cmake
+++ b/cmake/AddressSanitizer.cmake
@@ -46,10 +46,10 @@ function(add_asan_to_target TARGET_NAME_ARG)
       else()
         # add AddressSanitizer for compiler and linker
         target_compile_options("${TARGET_NAME_ARG}" 
-          PRIVATE 
+          PUBLIC 
             -fsanitize=address
             -fno-omit-frame-pointer)
-        target_link_options(${TARGET_NAME_ARG} PRIVATE -fsanitize=address)           
+        target_link_options("${TARGET_NAME_ARG}" PUBLIC -fsanitize=address)           
         message(STATUS "AddressSanitizer is on.")
       endif()
     else()

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -37,6 +37,13 @@ include(CMakeParseArguments)
 include(GenerateExportHeader)
 include(CheckLibArchitecture)
 
+
+#------------------------------------------------------------------------------
+# Enable AddressSanitizer and include some helper function to add compiler and linker flags
+#------------------------------------------------------------------------------  
+option(ADDRESS_SANITIZER "[Clang/GCC only] Enable AddressSanitizer mode (quite slow)." OFF)
+include(${PROJECT_SOURCE_DIR}/cmake/AddressSanitizer.cmake)
+
 #------------------------------------------------------------------------------
 ## export a single option indicating if libraries should be build as unity
 ## build
@@ -193,6 +200,11 @@ function(openms_add_library)
     -Wno-variadic-macros)
   endif()
 
+  if(ADDRESS_SANITIZER)
+    add_asan_to_target(${openms_add_library_TARGET_NAME})
+  endif()
+  
+  
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
 

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -157,6 +157,8 @@ function(openms_add_library)
 
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
+  set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES AUTOMOC ON)
+
   #------------------------------------------------------------------------------
   # Include directories
   # since internal includes all start with include/OpenMS and install_headers takes care of merging them in the install tree,
@@ -177,6 +179,19 @@ function(openms_add_library)
   # If we want full support, we need our own try_compiles (e.g. for structured bindings first available in GCC7)
   # or specify a min version of each compiler.
   target_compile_features(${openms_add_library_TARGET_NAME} PUBLIC cxx_std_17)
+
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(${openms_add_library_TARGET_NAME} PRIVATE 
+    -Wall
+    -Wextra
+    #-fvisibility=hidden # This is now added as a target property for each library.     
+    -Wno-non-virtual-dtor
+    -Wno-unknown-pragmas
+    -Wno-long-long 
+    -Wno-unknown-pragmas
+    -Wno-unused-function
+    -Wno-variadic-macros)
+  endif()
 
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
   set_target_properties(${openms_add_library_TARGET_NAME} PROPERTIES VISIBILITY_INLINES_HIDDEN 1)

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -51,8 +51,7 @@ endif()
 if (CMAKE_COMPILER_IS_GNUCXX)
 
   add_compile_options(-Wall -Wextra
-    #-fvisibility=hidden # This is now added as a target property for each library.
-    -Wno-non-virtual-dtor 
+    #-fvisibility=hidden # This is now added as a target property for each library.     
     -Wno-unknown-pragmas
     -Wno-long-long 
     -Wno-unknown-pragmas

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -35,7 +35,6 @@
 project("OpenMS")
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
-set(CMAKE_AUTOMOC ON) # some OpenMS classes make use of Signal/Slot, e.g. SYSTEM/FileWatcher.cpp
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 #------------------------------------------------------------------------------

--- a/src/openms/thirdparty/SQLiteCpp/CMakeLists.txt
+++ b/src/openms/thirdparty/SQLiteCpp/CMakeLists.txt
@@ -4,21 +4,9 @@
 #
 # Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
 # or copy at http://opensource.org/licenses/MIT)
-cmake_minimum_required(VERSION 3.1) # for "CMAKE_CXX_STANDARD" version
+cmake_minimum_required(VERSION 3.6) # for "CMAKE_CXX_STANDARD" version
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake") # custom CMake modules like FindSQLiteCpp
 project(SQLiteCpp VERSION 3.2.0)
-
-# SQLiteC++ 3.x requires C++11 features
-if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-elseif (CMAKE_CXX_STANDARD LESS 11)
-    message(WARNING "CMAKE_CXX_STANDARD has been set to '${CMAKE_CXX_STANDARD}' which is lower than the minimum required standard (c++11).")
-endif ()
-message(STATUS "Using c++ standard c++${CMAKE_CXX_STANDARD}")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-message (STATUS "CMake version: ${CMAKE_VERSION}")
-message (STATUS "Project version: ${PROJECT_VERSION}")
 
 option(SQLITECPP_BUILD_TESTS "Build and run tests." OFF)
 
@@ -72,28 +60,6 @@ endif (MSVC)
 # and then common variables
 set(CPPLINT_ARG_VERBOSE "--verbose=3")
 set(CPPLINT_ARG_LINELENGTH "--linelength=120")
-
-# Print CXX compiler information
-message (STATUS "CMAKE_CXX_COMPILER '${CMAKE_CXX_COMPILER}' '${CMAKE_CXX_COMPILER_ID}' '${CMAKE_CXX_COMPILER_VERSION}'")
-
-# Print CXX FLAGS
-message (STATUS "CMAKE_CXX_FLAGS                '${CMAKE_CXX_FLAGS}'")
-if (MSVC)
-    message (STATUS "CMAKE_CXX_FLAGS_DEBUG          '${CMAKE_CXX_FLAGS_DEBUG}'")
-    message (STATUS "CMAKE_CXX_FLAGS_RELEASE        '${CMAKE_CXX_FLAGS_RELEASE}'")
-    message (STATUS "CMAKE_CXX_FLAGS_RELWITHDEBINFO '${CMAKE_CXX_FLAGS_RELWITHDEBINFO}'")
-    message (STATUS "CMAKE_CXX_FLAGS_MINSIZEREL     '${CMAKE_CXX_FLAGS_MINSIZEREL}'")
-else (NOT MSVC)
-    if     (CMAKE_BUILD_TYPE STREQUAL Debug)
-        message (STATUS "CMAKE_CXX_FLAGS_DEBUG          '${CMAKE_CXX_FLAGS_DEBUG}'")
-    elseif (CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
-        message (STATUS "CMAKE_CXX_FLAGS_RELWITHDEBINFO '${CMAKE_CXX_FLAGS_RELWITHDEBINFO}'")
-    elseif (CMAKE_BUILD_TYPE STREQUAL MinSizeRel)
-        message (STATUS "CMAKE_CXX_FLAGS_MINSIZEREL     '${CMAKE_CXX_FLAGS_MINSIZEREL}'")
-    else ()
-        message (STATUS "CMAKE_CXX_FLAGS_RELEASE        '${CMAKE_CXX_FLAGS_RELEASE}'")
-    endif ()
-endif ()
 
 ## Build the C++ Wrapper ##
 
@@ -157,7 +123,7 @@ set(SQLITECPP_DOC
 )
 source_group(doc FILES ${SQLITECPP_DOC})
 
-option(SQLITECPP_INCLUDE_SCRIPT "Include config & script files." ON)
+option(SQLITECPP_INCLUDE_SCRIPT "Include config & script files." OFF)
 if (SQLITECPP_INCLUDE_SCRIPT)
     # list of config & script files of the library
     set(SQLITECPP_SCRIPT
@@ -181,6 +147,7 @@ endif()
 
 # add sources of the wrapper as a "SQLiteCpp" static library
 add_library(SQLiteCpp STATIC ${SQLITECPP_SRC} ${SQLITECPP_INC} ${SQLITECPP_DOC} ${SQLITECPP_SCRIPT})
+target_compile_features(SQLiteCpp PUBLIC cxx_std_11)
 
 # Options relative to SQLite and SQLiteC++ functions
 
@@ -336,21 +303,22 @@ install(FILES
 
 # Optional additional targets:
 
-option(SQLITECPP_RUN_CPPLINT "Run cpplint.py tool for Google C++ StyleGuide." ON)
-if (SQLITECPP_RUN_CPPLINT)
-    find_package(PythonInterp)
-    if (PYTHONINTERP_FOUND)
-        # add a cpplint target to the "all" target
-        add_custom_target(SQLiteCpp_cpplint
-         ALL
-         COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/cpplint.py ${CPPLINT_ARG_OUTPUT} ${CPPLINT_ARG_VERBOSE} ${CPPLINT_ARG_LINELENGTH} ${SQLITECPP_SRC} ${SQLITECPP_INC}
-        )
-    endif (PYTHONINTERP_FOUND)
-else (SQLITECPP_RUN_CPPLINT)
-    message(STATUS "SQLITECPP_RUN_CPPLINT OFF")
-endif (SQLITECPP_RUN_CPPLINT)
+# Uses ancient python find module!! DO NOT USE!
+#option(SQLITECPP_RUN_CPPLINT "Run cpplint.py tool for Google C++ StyleGuide." OFF)
+#if (SQLITECPP_RUN_CPPLINT)
+#    find_package(PythonInterp)
+#    if (PYTHONINTERP_FOUND)
+#        # add a cpplint target to the "all" target
+#        add_custom_target(SQLiteCpp_cpplint
+#         ALL
+#         COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/cpplint.py ${CPPLINT_ARG_OUTPUT} ${CPPLINT_ARG_VERBOSE} ${CPPLINT_ARG_LINELENGTH} ${SQLITECPP_SRC} ${SQLITECPP_INC}
+#        )
+#    endif (PYTHONINTERP_FOUND)
+#else (SQLITECPP_RUN_CPPLINT)
+#    message(STATUS "SQLITECPP_RUN_CPPLINT OFF")
+#endif (SQLITECPP_RUN_CPPLINT)
 
-option(SQLITECPP_RUN_CPPCHECK "Run cppcheck C++ static analysis tool." ON)
+option(SQLITECPP_RUN_CPPCHECK "Run cppcheck C++ static analysis tool." OFF)
 if (SQLITECPP_RUN_CPPCHECK)
     find_program(CPPCHECK_EXECUTABLE NAMES cppcheck)
     if (CPPCHECK_EXECUTABLE)


### PR DESCRIPTION
## Description

fixes #6508 
fixes #6504 
fixes #6503 

TODO:  currently C++ compiler flags seem to be forwarded to C (but ignored). This should probably be fixed

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
