### PR TITLE
Peak annotations fix (not working)

### DIFF
--- a/src/openms_gui/source/VISUAL/Painter2DBase.cpp
+++ b/src/openms_gui/source/VISUAL/Painter2DBase.cpp
@@ -498,7 +498,7 @@ namespace OpenMS
     p.setColor(Qt::black);
     painter.setPen(p);
 
-    auto it_prec = peak_map.end();
+    auto it_prec = peak_map.end(); // MS1 spectrum of parent ion
     auto it_end = peak_map.RTEnd(canvas->visible_area_.getAreaUnit().getMaxRT());
     for (auto it = peak_map.RTBegin(canvas->visible_area_.getAreaUnit().getMinRT()); it != it_end; ++it)
     {
@@ -508,16 +508,21 @@ namespace OpenMS
         it_prec = it;
       }
       else if (it->getMSLevel() == 2 && !it->getPrecursors().empty())
-      {                                                                              // this is an MS/MS scan
-        QPoint pos_ms2 = canvas->dataToWidget_(it->getPrecursors()[0].getMZ(), it->getRT()); // position of precursor in MS2
-        const int x2 = pos_ms2.x();
-        const int y2 = pos_ms2.y();
+      { // this is an MS/MS scan
+        
+        // position of precursor in MS2
+        const auto data_xy_ms2 = canvas->unit_mapper_.map(Peak2D({it->getRT(), it->getPrecursors()[0].getMZ()}, {}));
+        const QPoint pos_px_ms2 = canvas->dataToWidget_(data_xy_ms2); 
+        const int x2 = pos_px_ms2.x();
+        const int y2 = pos_px_ms2.y();
 
         if (it_prec != peak_map.end())
         {
-          QPoint pos_ms1 = canvas->dataToWidget_(it->getPrecursors()[0].getMZ(), it_prec->getRT()); // position of precursor in MS1
-          const int x = pos_ms1.x();
-          const int y = pos_ms1.y();
+          // position of precursor in MS1
+          const auto data_xy_ms1 = canvas->unit_mapper_.map(Peak2D({it_prec->getRT(), it->getPrecursors()[0].getMZ()}, {}));
+          const QPoint pos_px_ms1 = canvas->dataToWidget_(data_xy_ms1);
+          const int x = pos_px_ms1.x();
+          const int y = pos_px_ms1.y();
           // diamond shape in MS1
           painter.drawLine(x, y + 3, x + 3, y);
           painter.drawLine(x + 3, y, x, y - 3);

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -606,6 +606,14 @@ namespace OpenMS
     QStringList lines;
     lines << unit_mapper_.getDim(DIM::X).formattedValue(xy_point.getX()).toQString();
     lines << unit_mapper_.getDim(DIM::Y).formattedValue(xy_point.getY()).toQString();
+    if (unit_mapper_.getDim(DIM::X).getUnit() != DIM_UNIT::INT && unit_mapper_.getDim(DIM::X).getUnit() != DIM_UNIT::INT)
+    { // if intensity is not mapped to X or Y, add it
+      // Note: it may be cleaner to hoist this function into the derived classes of Painter2D, 
+      //       if the logic here depends on the actual Layer type (currently, 'INT' should work fine for all).
+      DimMapper<2> int_mapper({DIM_UNIT::INT, DIM_UNIT::INT});
+      const auto int_point = getCurrentLayer().peakIndexToXY(peak, int_mapper);
+      lines << int_mapper.getDim(DIM::X).formattedValue(int_point.getX()).toQString();
+    }
     drawText_(painter, lines);
   }
 


### PR DESCRIPTION
## Description

@cbielow dug out the code for better peak annotation drawing that might have been lost

https://github.com/OpenMS/OpenMS/blob/973674372b1e97e542acdb6d59295f492b3c051c/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DPeakItem.cpp


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
