### PR TITLE
[Fix] packaging

### DIFF
--- a/cmake/Windows/NSIS.template.in
+++ b/cmake/Windows/NSIS.template.in
@@ -284,7 +284,8 @@ Section "Documentation" SEC_Doc
       SetOutPath $INSTDIR\share\doc\html
       File /r "${OPENMSDOCDIR}\html\*.*"
       SetOutPath $INSTDIR\share\doc
-      File "${OPENMSDOCDIR}\OpenMS_tutorial.pdf"
+      File /nonfatal
+      "${OPENMSDOCDIR}\OpenMS_tutorial.pdf"
     !endif
 
     !insertmacro UNINSTALL.LOG_CLOSE_INSTALL

--- a/cmake/Windows/ToolchainCommon.cmake
+++ b/cmake/Windows/ToolchainCommon.cmake
@@ -1,0 +1,115 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
+
+#[[====================================================================================================================
+    toolchain_update_file
+    ---------------------
+    Updates the file at the given path to have the given contents. If the contents already match, then the file is not
+    touched.
+
+        toolchain_update_file(
+            PATH <file path>
+            CONTENT <content>
+        )
+====================================================================================================================]]#
+function(toolchain_update_file)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS CONTENT PATH)
+    set(MULTI_VALUE_KEYWORDS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 UPDATE_FILE "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    if(NOT (EXISTS ${UPDATE_FILE_PATH}))
+        message(VERBOSE "update_file: Creating ${UPDATE_FILE_PATH}")
+        file(WRITE ${UPDATE_FILE_PATH} ${UPDATE_FILE_CONTENT})
+    else()
+        file(READ ${UPDATE_FILE_PATH} CURRENT_CONTENT)
+        if(NOT (CURRENT_CONTENT STREQUAL UPDATE_FILE_CONTENT))
+            message(VERBOSE "update_file: Updating ${UPDATE_FILE_PATH}")
+            file(WRITE ${UPDATE_FILE_PATH} ${UPDATE_FILE_CONTENT})
+        endif()
+    endif()
+endfunction()
+
+#[[====================================================================================================================
+    toolchain_find_powershell
+    -------------------------
+    Searches for PowerShell.
+
+        toolchain_find_powershell(
+            <VARIABLE_NAME>
+        )
+
+    If the POWERSHELL_PATH value is set, that will be preferred. The VARIABLE_NAME will be set in the parent scope
+    with the result.
+====================================================================================================================]]#
+function(toolchain_find_powershell VARIABLE_NAME)
+    if(NOT EXISTS ${POWERSHELL_PATH})
+        find_program(
+                POWERSHELL_PATH
+                NAMES pwsh.exe powershell.exe
+                DOC "The path to PowerShell"
+                REQUIRED
+        )
+    endif()
+    message(VERBOSE "toolchain_find_powershell: Using PowerShell from: ${POWERSHELL_PATH}")
+    set(${VARIABLE_NAME} ${POWERSHELL_PATH} PARENT_SCOPE)
+endfunction()
+
+#[[====================================================================================================================
+    toolchain_download_file
+    -----------------------
+    Downloads a file to the given path.
+
+        toolchain_download_file(
+            URL <url>
+            PATH <file path>
+            EXPECTED_HASH <algorithm>=<hash>
+        )
+
+    The URL and EXPECTED_HASH values will be written to "<file path>.key" forcing a re-download if the values change.
+====================================================================================================================]]#
+function(toolchain_download_file)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS URL PATH EXPECTED_HASH)
+    set(MULTI_VALUE_KEYWORDS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 DOWNLOAD_FILE "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    toolchain_update_file(
+            PATH "${DOWNLOAD_FILE_PATH}.key"
+            CONTENT "URL ${DOWNLOAD_FILE_URL}:EXPECTED_HASH ${DOWNLOAD_FILE_EXPECTED_HASH}"
+    )
+
+    if("${DOWNLOAD_FILE_PATH}.key" IS_NEWER_THAN ${DOWNLOAD_FILE_PATH})
+        message(VERBOSE "download_file: ${DOWNLOAD_FILE_URL} --> ${DOWNLOAD_FILE_PATH}")
+        file(REMOVE ${DOWNLOAD_FILE_PATH})
+        file(DOWNLOAD
+                ${DOWNLOAD_FILE_URL}
+                ${DOWNLOAD_FILE_PATH}
+                EXPECTED_HASH ${DOWNLOAD_FILE_EXPECTED_HASH}
+                )
+    endif()
+endfunction()

--- a/cmake/Windows/VSWhere.cmake
+++ b/cmake/Windows/VSWhere.cmake
@@ -1,0 +1,144 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
+
+include("${CMAKE_CURRENT_LIST_DIR}/ToolchainCommon.cmake")
+
+#[[====================================================================================================================
+    toolchain_ensure_vswhere
+    ------------------------
+
+    Ensures that 'vswhere' is available and the VSWHERE_PATH variables is set in the cache. The following steps will be
+    taken:
+
+        1. If `VSWHERE_PATH` is set, then that value will be used.
+        2. If 'vswhere' is found through `find_program`, that path will be used.
+        3. 'vswhere' will be downloaded - specified by `VSWHERE_VERSION` and `VSWHERE_HASH` - into the
+           `TOOLCHAIN_TOOLS_PATH` and `VSWHERE_PATH` will be set to the download location. If `TOOLCHAIN_TOOLS_PATH` is
+           not set, then it will default to `${CMAKE_BINARY_DIR}/__tools`.
+
+    Note: Since `CMAKE_BINARY_DIR` is platform specific, the default download location will change by platform,
+    resulting in the tool being downloaded once for each platform that is built. Setting
+    `TOOLCHAIN_TOOLS_PATH` to a platform-independent path (e.g. relative to the root of the repository) will
+    allow 'vswhere' to be downloaded once for all platforms.
+====================================================================================================================]]#
+function(toolchain_ensure_vswhere)
+    find_program(VSWHERE_PATH
+            NAMES vswhere vswhere.exe
+            HINTS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer"
+            )
+
+    # If vswhere isn't found, download it.
+    #
+    # vswhere.exe will be downloaded to `TOOLCHAIN_TOOLS_PATH`. If `TOOLCHAIN_TOOLS_PATH` is not set then it will be downloaded to '${CMAKE_BINARY_DIR}/__tools'.
+    if(VSWHERE_PATH STREQUAL "VSWHERE_PATH-NOTFOUND")
+        if(NOT VSWHERE_VERSION)
+            set(VSWHERE_VERSION "2.8.4")
+            set(VSWHERE_HASH "SHA256=E50A14767C27477F634A4C19709D35C27A72F541FB2BA5C3A446C80998A86419")
+        else()
+            if(NOT VSWHERE_HASH)
+                message(FATAL_ERROR "VSWHERE_VERSION is set to ${VSWHERE_VERSION}. VSWHERE_HASH must be set if VSWHERE_VERSION is set.")
+            endif()
+        endif()
+
+        if(NOT TOOLCHAIN_TOOLS_PATH)
+            set(TOOLCHAIN_TOOLS_PATH "${CMAKE_BINARY_DIR}/__tools")
+        endif()
+
+        set(VSWHERE_PATH "${TOOLCHAIN_TOOLS_PATH}/vswhere.exe" CACHE FILEPATH "The location of 'vswhere.exe'" FORCE)
+
+        toolchain_download_file(
+                URL "https://github.com/microsoft/vswhere/releases/download/${VSWHERE_VERSION}/vswhere.exe"
+                PATH ${VSWHERE_PATH}
+                EXPECTED_HASH ${VSWHERE_HASH}
+        )
+    endif()
+endfunction()
+
+#[[====================================================================================================================
+    findVisualStudio
+    ----------------
+
+    Finds a Visual Studio instance, and sets CMake variables based on properties of the found instance.
+
+        findVisualStudio(
+            [VERSION <version range>]
+            [PRERELEASE <ON|OFF>]
+            [PRODUCTS <products>]
+            [REQUIRES <vs component>...]
+            PROPERTIES
+                <<vswhere property> <cmake variable>>
+            )
+====================================================================================================================]]#
+function(findVisualStudio)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS VERSION PRERELEASE PRODUCTS)
+    set(MULTI_VALUE_KEYWORDS REQUIRES PROPERTIES)
+
+    cmake_parse_arguments(PARSE_ARGV 0 FIND_VS "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    toolchain_ensure_vswhere()
+
+    set(VSWHERE_COMMAND ${VSWHERE_PATH} -latest)
+
+    if(FIND_VS_PRERELEASE)
+        list(APPEND VSWHERE_COMMAND -prerelease)
+    endif()
+
+    if(FIND_VS_PRODUCTS)
+        list(APPEND VSWHERE_COMMAND -products ${FIND_VS_PRODUCTS})
+    endif()
+
+    if(FIND_VS_REQUIRES)
+        list(APPEND VSWHERE_COMMAND -requires ${FIND_VS_REQUIRES})
+    endif()
+
+    if(FIND_VS_VERSION)
+        list(APPEND VSWHERE_COMMAND -version "${FIND_VS_VERSION}")
+    endif()
+
+    message(VERBOSE "findVisualStudio: VSWHERE_COMMAND = ${VSWHERE_COMMAND}")
+
+    execute_process(
+            COMMAND ${VSWHERE_COMMAND}
+            OUTPUT_VARIABLE VSWHERE_OUTPUT
+    )
+
+    message(VERBOSE "findVisualStudio: VSWHERE_OUTPUT = ${VSWHERE_OUTPUT}")
+
+    # Matches `VSWHERE_PROPERTY` in the `VSWHERE_OUTPUT` text in the format written by vswhere.
+    # The matched value is assigned to the variable `VARIABLE_NAME` in the parent scope.
+    function(getVSWhereProperty VSWHERE_OUTPUT VSWHERE_PROPERTY VARIABLE_NAME)
+        string(REGEX MATCH "${VSWHERE_PROPERTY}: [^\r\n]*" VSWHERE_VALUE "${VSWHERE_OUTPUT}")
+        string(REPLACE "${VSWHERE_PROPERTY}: " "" VSWHERE_VALUE "${VSWHERE_VALUE}")
+        set(${VARIABLE_NAME} "${VSWHERE_VALUE}" PARENT_SCOPE)
+    endfunction()
+
+    while(FIND_VS_PROPERTIES)
+        list(POP_FRONT FIND_VS_PROPERTIES VSWHERE_PROPERTY)
+        list(POP_FRONT FIND_VS_PROPERTIES VSWHERE_CMAKE_VARIABLE)
+        getVSWhereProperty("${VSWHERE_OUTPUT}" ${VSWHERE_PROPERTY} VSWHERE_VALUE)
+        set(${VSWHERE_CMAKE_VARIABLE} ${VSWHERE_VALUE} PARENT_SCOPE)
+    endwhile()
+endfunction()

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -301,19 +301,23 @@ function(openms_add_library)
     endforeach()
 
     if(Qt5WebEngineWidgets_FOUND)
-      get_target_property(fsfa Qt5::QuickWidgets IMPORTED_LOCATION_DEBUG)
-      message("tgtprop ${fsfa}")
       set (genex "IMPORTED_LOCATION_$<UPPER_CASE:$<CONFIG>>")
       add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
               COMMAND ${CMAKE_COMMAND} -E copy_if_different
               $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>
               $<TARGET_FILE_DIR:${openms_add_library_TARGET_NAME}>
               )
+
+      # For now, we add Qt to the path when calling the documenters.
+      # Since the documenters depend on OpenMS_GUI
+      # they need Qt platform plugins etc. which very hard to set up correctly.
+      # And I think the documenters are not called very often outside of CMake.
       #add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
       #        COMMAND ${CMAKE_COMMAND} -E copy_if_different
       #        $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>
       #        ${DLL_DOC_TARGET_PATH}
       #        )
+
       add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
               COMMAND ${CMAKE_COMMAND} -E copy_if_different
               $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -290,7 +290,7 @@ function(openms_add_library)
             ${DLL_DOC_TARGET_PATH}
             )
 
-    foreach(command IN ITEMS "${copy_dlls_to_output_folder}" "${copy_dlls_to_test_folder}" "${copy_dlls_to_doc_folder}")
+    foreach(command IN ITEMS "${copy_dlls_to_output_folder}" "${copy_dlls_to_test_folder}")# "${copy_dlls_to_doc_folder}")
       set(if_runtime_dlls_copy
               $<IF:${has_dll_dep},${command},${none_command}>
               )
@@ -299,6 +299,27 @@ function(openms_add_library)
               COMMAND_EXPAND_LISTS
               )
     endforeach()
+
+    if(Qt5WebEngineWidgets_FOUND)
+      get_target_property(fsfa Qt5::QuickWidgets IMPORTED_LOCATION_DEBUG)
+      message("tgtprop ${fsfa}")
+      set (genex "IMPORTED_LOCATION_$<UPPER_CASE:$<CONFIG>>")
+      add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
+              COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>
+              $<TARGET_FILE_DIR:${openms_add_library_TARGET_NAME}>
+              )
+      #add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
+      #        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      #        $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>
+      #        ${DLL_DOC_TARGET_PATH}
+      #        )
+      add_custom_command(TARGET ${openms_add_library_TARGET_NAME} POST_BUILD
+              COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_PROPERTY:Qt5::QuickWidgets,${genex}>
+              ${DLL_TEST_TARGET_PATH}
+              )
+    endif()
   endif()
   #------------------------------------------------------------------------------
   # Status message for configure output

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -148,7 +148,7 @@ set(OpenMS_QT_COMPONENTS Core Network Sql CACHE INTERNAL "QT components for core
 find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS ${OpenMS_QT_COMPONENTS} REQUIRED)
 
 IF (NOT Qt5Core_FOUND)
-  message(STATUS "QT5Core not found!")
+  message(STATUS "Qt5Core not found!")
   message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt5Libs>' <src-dir>")
 ELSE()
   message(STATUS "Found Qt ${Qt5Core_VERSION}")
@@ -190,12 +190,18 @@ if (WITH_GUI)
     message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt5Libs>' <src-dir>")
   ENDIF()
 
-  find_package(Qt5 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT})
+  ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
+  find_package(Qt5 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
 
   # TODO only works if WebEngineWidgets is the only optional component
   set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)
   if(Qt5WebEngineWidgets_FOUND)
     list(APPEND OpenMS_GUI_QT_FOUND_COMPONENTS_OPT "WebEngineWidgets")
+    # we assume that it is available for now. They should have dependencies when installing Qt.
+    install(IMPORTED_RUNTIME_ARTIFACTS "Qt5::QuickWidgets"
+            DESTINATION "${INSTALL_BIN_DIR}"
+            RUNTIME_DEPENDENCY_SET OPENMS_GUI_DEPS
+            COMPONENT Dependencies)
   else()
     message(WARNING "Qt5WebEngineWidgets not found or disabled, disabling JS Views in TOPPView!")
   endif()

--- a/cmake/knime_package_support.cmake
+++ b/cmake/knime_package_support.cmake
@@ -216,15 +216,13 @@ add_custom_target(
 #    COMMAND ${CMAKE_COMMAND} -E make_directory ${PAYLOAD_LIB_PATH}/plugins/
 #    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Qt5::QSQLiteDriverPlugin> ${PAYLOAD_LIB_PATH}/plugins/
 #)
-
-
 # create qt.conf file that specifies plugin dir location
-add_custom_command(
-    TARGET prepare_knime_payload_libs POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E echo "[Paths]" > ${PAYLOAD_LIB_PATH}/qt.conf
-    COMMAND ${CMAKE_COMMAND} -E echo "Plugins = plugins" >> ${PAYLOAD_LIB_PATH}/qt.conf
-    COMMAND ${CMAKE_COMMAND} -E echo "" >> ${PAYLOAD_LIB_PATH}/qt.conf
-)
+#add_custom_command(
+#    TARGET prepare_knime_payload_libs POST_BUILD
+#    COMMAND ${CMAKE_COMMAND} -E echo "[Paths]" > ${PAYLOAD_BIN_PATH}/qt.conf
+#    COMMAND ${CMAKE_COMMAND} -E echo "Plugins = ../${PAYLOAD_LIB_PATH}/plugins" >> ${PAYLOAD_BIN_PATH}/qt.conf
+#    COMMAND ${CMAKE_COMMAND} -E echo "" >> ${PAYLOAD_BIN_PATH}/qt.conf
+#)
 
 ## Assemble common required libraries for win and lnx
 ## Note that we do not need QtGui libraries since we do not include GUI tools here.
@@ -240,8 +238,8 @@ endforeach()
 if (APPLE) ## On APPLE use our script because the executables need to be relinked and some rpath lookups done
   add_custom_command(
     TARGET prepare_knime_payload_libs POST_BUILD
-    COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -l ${PAYLOAD_LIB_PATH} -b ${PAYLOAD_BIN_PATH} -p ${PAYLOAD_LIB_PATH}/plugins -f
-  )
+    COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -l ${PAYLOAD_LIB_PATH} -b ${PAYLOAD_BIN_PATH} -f
+  ) # -p ${PAYLOAD_LIB_PATH}/plugins not applicable for now
   add_custom_command(
           TARGET prepare_knime_payload_libs POST_BUILD
           COMMAND find ${PAYLOAD_BIN_PATH} -depth 1 -type f -exec ${CMAKE_STRIP} -S {} "\;"

--- a/cmake/package_dragndrop_dmg.cmake
+++ b/cmake/package_dragndrop_dmg.cmake
@@ -52,9 +52,9 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${OPENMS_PACKAGE_VERSION_FULL
 ## Fix OpenMS dependencies for all executables in the install directory under bin.
 ## That affects everything but the bundles (which have their own structure and are fixed up in add_mac_bundle.cmake)
 ########################################################### Fix Dependencies
-install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -b \${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}/ -l \${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/ -p \${CMAKE_INSTALL_PREFIX}/${INSTALL_PLUGIN_DIR})"
+install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/fix_dependencies.rb -b \${CMAKE_INSTALL_PREFIX}/${INSTALL_BIN_DIR}/ -l \${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/"
   COMPONENT zzz-fixing-dependencies
-)
+) # not applicable as long as we dont use Qt plugins in the TOPP tools: -p \${CMAKE_INSTALL_PREFIX}/${INSTALL_PLUGIN_DIR}) 
 
 if(DEFINED CPACK_BUNDLE_APPLE_CERT_APP)
   install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/sign_bins_and_libs.rb -d \${CMAKE_INSTALL_PREFIX}/ -s ${CPACK_BUNDLE_APPLE_CERT_APP})"

--- a/cmake/package_dragndrop_dmg.cmake
+++ b/cmake/package_dragndrop_dmg.cmake
@@ -56,7 +56,6 @@ install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/fix_dep
   COMPONENT zzz-fixing-dependencies
 )
 
-## Apple no longer supports signing for DMGs in a useful way.
 if(DEFINED CPACK_BUNDLE_APPLE_CERT_APP)
   install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/MacOSX/sign_bins_and_libs.rb -d \${CMAKE_INSTALL_PREFIX}/ -s ${CPACK_BUNDLE_APPLE_CERT_APP})"
     COMPONENT zzz-sign-bins-and-libs
@@ -90,7 +89,7 @@ install(FILES       ${PROJECT_SOURCE_DIR}/cmake/MacOSX/README.md
         COMPONENT   TOPPShell)
 
 ## ----------
-## No need to for this at the moment: no Qt plugins required anymore. Left here for reference.
+## No need to for this at the moment: no Qt plugins for the general CLI tools required anymore. Left here for reference.
 ## ----------
 ## Install the qt.conf file so we can find the libraries
 ## add qt.conf to the bin directory for DMGs
@@ -118,8 +117,19 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "3.5")
   #Next line could overcome a script but since we do not have a fixed name of the OpenMS-$VERSION folder, it probably won't work
   #set(CPACK_DMG_DS_STORE ${PROJECT_SOURCE_DIR}/cmake/MacOSX/DS_store_new)
   set(CPACK_DMG_BACKGROUND_IMAGE ${PROJECT_SOURCE_DIR}/cmake/MacOSX/background.png)
-  set(CPACK_DMG_FORMAT UDBZ) ## Try bzip2 to get slighlty smaller images
-
+  set(CPACK_DMG_FORMAT UDBZ) ## Try bzip2 to get slightly smaller images
+  
+  ## Sign the image. CPACK_BUNDLE_APPLE_CERT_APP needs to be unique and found in one of the
+  ## keychains in the search list (which needs to be unlocked).
+  if (DEFINED CPACK_BUNDLE_APPLE_CERT_APP)
+    add_custom_target(signed_dist
+                      COMMAND codesign --deep --force --sign ${CPACK_BUNDLE_APPLE_CERT_APP} ${CPACK_PACKAGE_FILE_NAME}.dmg
+                      COMMAND ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/notarize_app.sh ${CPACK_PACKAGE_FILE_NAME}.dmg de.openms ${SIGNING_EMAIL} CODESIGNPW ${OPENMS_HOST_BINARY_DIRECTORY}
+                      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+                      COMMENT "Signing and notarizing ${CPACK_PACKAGE_FILE_NAME}.dmg as ${CPACK_BUNDLE_APPLE_CERT_APP}"
+                      DEPENDS dist)
+  endif()
+  
 else()
   ## The old scripts need the background image in the target folder.
   ########################################################### Background Image

--- a/cmake/package_general.cmake
+++ b/cmake/package_general.cmake
@@ -60,7 +60,19 @@ set(OPENMS_LOGOSMALL ${PROJECT_SOURCE_DIR}/cmake/MacOSX/${OPENMS_LOGOSMALL_NAME}
 ## This currently works because our libs and TOPP tools include all dependencies. For macOS,
 ##  the app bundles need to have a different RUNTIME_DEPENDENCY_SET (TOPPView_DEPS, ...) due
 ##  to CMake assuming you want standalone bundles. But we want to share libs between them.
-install(RUNTIME_DEPENDENCY_SET OPENMS_DEPS DESTINATION ${INSTALL_LIB_DIR} COMPONENT Dependencies)
+
+# This would be to look in the Contrib and other cmake_prefix_paths for dependencies.
+#list(TRANSFORM CMAKE_PREFIX_PATH APPEND "/bin" OUTPUT_VARIABLE DEP_BIN_DIRS)
+#list(TRANSFORM CMAKE_PREFIX_PATH APPEND "/lib" OUTPUT_VARIABLE DEP_LIB_DIRS)
+# But since we copy them in the build stage to our runtime directory (bin), we can add this one.
+
+# On Windows we need to tell CMake where to look for.
+# We also do not need API sets. So exclude them.
+install(RUNTIME_DEPENDENCY_SET OPENMS_DEPS
+        DESTINATION ${INSTALL_LIB_DIR}
+        COMPONENT Dependencies
+        PRE_EXCLUDE_REGEXES "api-ms" "ext-ms" "hvsi" "pdmutilities"
+        DIRECTORIES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 #install(RUNTIME_DEPENDENCY_SET TOPPView_DEPS) # I think without giving DESTINATION and COMPONENT it will be inferred
 #install(RUNTIME_DEPENDENCY_SET TOPPAS_DEPS)
 #...

--- a/cmake/package_mac_productbuild.cmake
+++ b/cmake/package_mac_productbuild.cmake
@@ -81,16 +81,17 @@ install(FILES       ${PROJECT_SOURCE_DIR}/cmake/MacOSX/README.md
                     WORLD_READ
         COMPONENT   TOPPShell)
 
+## Not needed unless we need Qt plugins for TOPP again
 ## Install the qt.conf file so we can find the libraries
 ## add qt.conf to the bin directory for DMGs/pkgs
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
-"[Paths]\nPlugins = ../${INSTALL_PLUGIN_DIR}\n")
-install(FILES       ${CMAKE_CURRENT_BINARY_DIR}/qt.conf
-        DESTINATION ./${INSTALL_BIN_DIR}
-        PERMISSIONS OWNER_WRITE OWNER_READ
-                    GROUP_READ
-                    WORLD_READ
-        COMPONENT   Applications)
+#file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
+#"[Paths]\nPlugins = ../${INSTALL_PLUGIN_DIR}\n")
+#install(FILES       ${CMAKE_CURRENT_BINARY_DIR}/qt.conf
+#        DESTINATION ./${INSTALL_BIN_DIR}
+#        PERMISSIONS OWNER_WRITE OWNER_READ
+#                    GROUP_READ
+#                    WORLD_READ
+#        COMPONENT   Applications)
 
 ## Fix OpenMS dependencies for all executables in the install directory under bin.
 ## That affects everything but the bundles (whose Framework folders are symlinked to lib anyway).
@@ -105,13 +106,13 @@ install(CODE "execute_process(COMMAND ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/fix_
 # If the install CODE is not in the same component though, we need to navigate from the component specific install
 # prefix to the other prefix. This is unfortunately very unrobust.
 # TODO find better order or rewrite fix_dependencies script to be called separately
-install(CODE "execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/../../../Applications${CPACK_PACKAGING_INSTALL_PREFIX}/${INSTALL_BIN_DIR}/ -type f -exec codesign --force --options runtime --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\;)"
+install(CODE "execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/../../../Applications${CPACK_PACKAGING_INSTALL_PREFIX}/${INSTALL_BIN_DIR}/ -type f -exec codesign --force --options runtime -i de.openms.TOPP.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\;)"
         COMPONENT Dependencies
         )
 install(CODE "execute_process(COMMAND ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/fix_dependencies.rb -l \${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/ -e @rpath/ -n -c)"
         COMPONENT library
         )
-install(CODE "execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/ -type f -exec codesign --force --options runtime --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\;)"
+install(CODE "execute_process(COMMAND find \${CMAKE_INSTALL_PREFIX}/${INSTALL_LIB_DIR}/ -type f -exec codesign --force --options runtime -i de.openms.TOPP.libs.{} --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" {} \\;)"
         COMPONENT library
         )
 

--- a/cmake/package_nsis.cmake
+++ b/cmake/package_nsis.cmake
@@ -44,47 +44,88 @@ else()
   set(PLATFORM "64")
   set(ARCH "x64")
 endif()
+
 if (NOT VC_REDIST_EXE)
-  set(VC_REDIST_EXE "vcredist_${ARCH}.exe")
+	set(VC_REDIST_EXE "vcredist_${ARCH}.exe")
 endif()
 
-## Find redistributable to be installed by NSIS
+# Find redistributable to be installed by NSIS
 if (NOT VC_REDIST_PATH)
-  string(REGEX REPLACE ".*Visual Studio ([1-9][1-9]).*" "\\1" OPENMS_MSVC_VERSION_STRING "${CMAKE_GENERATOR}")
-  if("${OPENMS_MSVC_VERSION_STRING}" GREATER "15")
-    if (DEFINED ENV{VCINSTALLDIR})
-      ## according to https://docs.microsoft.com/de-de/cpp/windows/redistributing-visual-cpp-files?view=msvc-160
-      get_filename_component(VC_ROOT_PATH "$ENV{VCINSTALLDIR}Redist/MSVC/v142" ABSOLUTE)
-      file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/${VC_REDIST_EXE}")
-      message(STATUS "VS Redist locations (1st try): ${VC_REDIST_ABS_PATH}")
-    endif()
-    if (NOT VC_REDIST_ABS_PATH AND DEFINED ENV{VCToolsRedistDir}) ## if still not found, try to use older methods
-      ## An alternative solution to find redists
-      #execute_process(COMMAND "$ENV{PROGRAMFILES}/Microsoft Visual Studio/Installer/vswhere" -latest -version "${OPENMS_MSVC_VERSION_STRING}" -property installationPath
-      #                OUTPUT_VARIABLE VC_ROOT_PATH
-      #				  ERROR_VARIABLE VSWHERE_ERROR
-      #				  RESULT_VARIABLE VSWHERE_RESULT)
-      #if ("${VSWHERE_RESULT}" NOTEQUAL "0")
-      #  message(FATAL_ERROR "Executing vswhere to find vsredist executable for win packaging failed. Either specify VC_REDIST_PATH or make sure vswhere works.")
-      #endif()
+	if (MSVC_TOOLSET_VERSION EQUAL 141)
+		set(VS_VERSION 15)
+	elseif(MSVC_TOOLSET_VERSION EQUAL 142)
+		set(VS_VERSION 16)
+	elseif(MSVC_TOOLSET_VERSION EQUAL 143)
+		set(VS_VERSION 17)
+	endif()
 
-      ## We have to glob recurse in the parent folder because there is a version number in the end.
-      ## Unfortunately in my case the default version (latest) does not include the redist?!
-      ## TODO Not sure if this environment variable always exists. In the VS command line it should! Fallback vswhere or VCINSTALLDIR/Redist/MSVC?
-      get_filename_component(VC_ROOT_PATH "$ENV{VCToolsRedistDir}.." ABSOLUTE)
-      file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/${VC_REDIST_EXE}")
-      message(STATUS "VS Redist locations (2nd try): ${VC_REDIST_ABS_PATH}")
-    endif()
-    if (VC_REDIST_ABS_PATH)
-      ## arbitrarily pick first of the found redists
-      list(GET VC_REDIST_ABS_PATH 0 VC_REDIST_ABS_PATH)
-      get_filename_component(VC_REDIST_PATH "${VC_REDIST_ABS_PATH}" DIRECTORY)
-      message(STATUS "   ... picked first directory: ${VC_REDIST_PATH}")
-    endif()
-  endif()
-  if (NOT VC_REDIST_PATH) ## if still not found
-    message(FATAL_ERROR "Variable VC_REDIST_PATH missing. Are you on a proper VS 2019+ command line?")
-  endif()
+	if (DEFINED ENV{VCINSTALLDIR})
+		## according to https://docs.microsoft.com/de-de/cpp/windows/redistributing-visual-cpp-files?view=msvc-160
+		get_filename_component(VC_ROOT_PATH "$ENV{VCINSTALLDIR}Redist/MSVC/v${MSVC_TOOLSET_VERSION}" ABSOLUTE)
+		file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
+		if (NOT VC_REDIST_ABS_PATH)
+			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
+		endif()
+		if (NOT VC_REDIST_ABS_PATH)
+			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
+		endif()
+
+		message(STATUS "VS Redist locations (1st try): ${VC_REDIST_ABS_PATH}")
+	endif()
+
+	if (NOT VC_REDIST_ABS_PATH AND DEFINED ENV{VCToolsRedistDir}) ## if still not found, try to use older methods
+		## We have to glob recurse in the parent folder because there is a version number in the end.
+		## Unfortunately in my case the default version (latest) does not include the redist?!
+		## TODO Not sure if this environment variable always exists. In the VS command line it should! Fallback vswhere or VCINSTALLDIR/Redist/MSVC?
+		get_filename_component(VC_ROOT_PATH "$ENV{VCToolsRedistDir}.." ABSOLUTE)
+		file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
+		if (NOT VC_REDIST_ABS_PATH)
+			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
+		endif()
+		if (NOT VC_REDIST_ABS_PATH)
+			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
+		endif()
+
+		message(STATUS "VS Redist locations (2nd try): ${VC_REDIST_ABS_PATH}")
+	endif()
+
+	if (NOT VC_REDIST_ABS_PATH) ## if still not found try vswhere
+
+		include(${OPENMS_HOST_DIRECTORY}/cmake/Windows/VSWhere.cmake)
+
+		toolchain_ensure_vswhere()
+
+		execute_process(COMMAND ${VSWHERE_PATH} -products * -latest -version "${VS_VERSION}" -property installationPath
+		OUTPUT_VARIABLE VC_ROOT_PATH
+		ERROR_VARIABLE VSWHERE_ERROR
+		RESULT_VARIABLE VSWHERE_RESULT
+		#COMMAND_ECHO STDOUT
+		)
+
+		if (VSWHERE_RESULT EQUAL 0)
+			message(${VC_ROOT_PATH})
+			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
+			if (NOT VC_REDIST_ABS_PATH)
+				file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
+			endif()
+			if (NOT VC_REDIST_ABS_PATH)
+				file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
+			endif()
+			message(STATUS "VS Redist locations (3rd try): ${VC_REDIST_ABS_PATH}")
+		endif()
+	endif()
+
+	if (VC_REDIST_ABS_PATH)
+		## arbitrarily pick first of the found redists
+		list(GET VC_REDIST_ABS_PATH 0 VC_REDIST_ABS_PATH)
+		get_filename_component(VC_REDIST_PATH "${VC_REDIST_ABS_PATH}" DIRECTORY)
+		get_filename_component(VC_REDIST_EXE "${VC_REDIST_ABS_PATH}" NAME)
+		message(STATUS "   ... picked first directory: ${VC_REDIST_PATH}")
+	endif()
+endif()
+
+if (NOT VC_REDIST_PATH) ## if still not found: error
+	message(FATAL_ERROR "Variable VC_REDIST_PATH missing. Are you on a proper VS 2019+ command line?")
 endif()
 
 if(EXISTS ${SEARCH_ENGINES_DIRECTORY})
@@ -97,7 +138,9 @@ if(EXISTS ${SEARCH_ENGINES_DIRECTORY})
 		)
 endif()
 
-##TODO try following instead once CMake generates NSIS commands for us. Installs dll instead of redist though. Thirdparties?
+#TODO try following instead once CMake generates NSIS commands for us. Installs dll instead of redist though.
+# This means we would need to change the NSIS script to just copy them over.
+
 # ########################################################### System runtime libraries
 # set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
 # include(InstallRequiredSystemLibraries)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -161,6 +161,16 @@ if(ENABLE_DOCS)
     file(TO_NATIVE_PATH "${_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}" DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE)
     file(TO_NATIVE_PATH "${_BINARY_PATH}" BINARY_PATH)
 
+    if(WIN32)
+      set(pathsep ";")
+    else()
+      set(pathsep ":")
+    endif()
+    list(TRANSFORM CMAKE_PREFIX_PATH APPEND "/bin" OUTPUT_VARIABLE DEP_BIN_DIRS)
+    string(REPLACE ";" "${pathsep}" DEP_BIN_DIRS "${DEP_BIN_DIRS}")
+    list(TRANSFORM CMAKE_PREFIX_PATH APPEND "/lib" OUTPUT_VARIABLE DEP_LIB_DIRS)
+    string(REPLACE ";" "${pathsep}" DEP_LIB_DIRS "${DEP_LIB_DIRS}")
+
     #------------------------------------------------------------------------------
     # doc_param_internal targets
     add_custom_target(doc_param_internal
@@ -177,11 +187,11 @@ if(ENABLE_DOCS)
                       COMMAND ${CMAKE_COMMAND} -E echo "Building OpenMS parameter docu:"
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
                       COMMAND ${CMAKE_COMMAND} -E make_directory doxygen/parameters/output/
-                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}
+                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${CMAKE_COMMAND} -E env "PATH=${DEP_BIN_DIRS}${pathsep}${DEP_LIB_DIRS}${pathsep}$ENV{PATH}" ${DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "Building TOPP/UTILS docu:"
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~"
-                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${TOPPDOCUMENTER_EXECUTABLE} ${BINARY_PATH}
+                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${CMAKE_COMMAND} -E env "PATH=${DEP_BIN_DIRS}${pathsep}${DEP_LIB_DIRS}${pathsep}$ENV{PATH}" ${TOPPDOCUMENTER_EXECUTABLE} ${BINARY_PATH}
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMENT "Build the parameters documentation"
                       VERBATIM)

--- a/src/openms/thirdparty/SQLiteCpp/CMakeLists.txt
+++ b/src/openms/thirdparty/SQLiteCpp/CMakeLists.txt
@@ -275,32 +275,6 @@ target_include_directories(SQLiteCpp
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/>)
 
-# Allow the library to be installed via "make install" and found with "find_package"
-
-include(GNUInstallDirs)
-install(TARGETS SQLiteCpp
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libraries)
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers FILES_MATCHING REGEX ".*\\.(hpp|h)$")
-install(EXPORT ${PROJECT_NAME}Targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-install(FILES ${PROJECT_SOURCE_DIR}/package.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    cmake/${PROJECT_NAME}ConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion)
-configure_package_config_file(
-    cmake/${PROJECT_NAME}Config.cmake.in
-    cmake/${PROJECT_NAME}Config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-
 # Optional additional targets:
 
 # Uses ancient python find module!! DO NOT USE!

--- a/src/openms/thirdparty/SQLiteCpp/sqlite3/CMakeLists.txt
+++ b/src/openms/thirdparty/SQLiteCpp/sqlite3/CMakeLists.txt
@@ -53,13 +53,3 @@ if (UNIX AND CMAKE_COMPILER_IS_GNUCXX)
         target_compile_options(sqlite3 PRIVATE "-Wno-cast-function-type")
     endif()
 endif()
-
-# Allow the library to be installed via "make install" and found with "find_package"
-
-include(GNUInstallDirs)
-install(TARGETS sqlite3
-    EXPORT ${PROJECT_NAME}Targets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    COMPONENT libraries)
-install(FILES sqlite3.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)

--- a/src/openms_gui/add_mac_bundle.cmake
+++ b/src/openms_gui/add_mac_bundle.cmake
@@ -112,15 +112,14 @@ macro(add_mac_app_bundle _name)
 						DESTINATION .
 						COMPONENT Applications)
 		
-		## Write a qt.conf file with a ref to the plugin dir in app bundles = PlugIns
-		file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
-				 "[Paths]\nPlugins = PlugIns\n")
-		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
-						DESTINATION "${_name}.app/Contents/Resources/"
-						RENAME "qt.conf"
-						COMPONENT Applications)
-		
 		if("${PACKAGE_TYPE}" STREQUAL "pkg")
+			## Write a qt.conf file with a ref to the plugin dir outside of the bundle (to share)
+			file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
+					 "[Paths]\nPlugins = ../../../${INSTALL_PLUGIN_DIR}\n")
+			install(FILES "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
+							DESTINATION "${_name}.app/Contents/Resources/"
+							RENAME "qt.conf"
+							COMPONENT Applications)
       install(IMPORTED_RUNTIME_ARTIFACTS "Qt5::QCocoaIntegrationPlugin"
               DESTINATION "${INSTALL_PLUGIN_DIR}/platforms"
               RUNTIME_DEPENDENCY_SET OPENMS_DEPS
@@ -129,31 +128,41 @@ macro(add_mac_app_bundle _name)
 							DESTINATION "${INSTALL_PLUGIN_DIR}/styles"
 							RUNTIME_DEPENDENCY_SET OPENMS_DEPS
 							COMPONENT Dependencies)
-      install(CODE "execute_process(COMMAND ln -fs ../../${INSTALL_LIB_DIR} \${CMAKE_INSTALL_PREFIX}/${_name}.app/Contents/Frameworks)"
-							COMPONENT Applications)
-      install(CODE "execute_process(COMMAND ln -fs ../../${INSTALL_PLUGIN_DIR} \${CMAKE_INSTALL_PREFIX}/${_name}.app/Contents/PlugIns)"
-							COMPONENT Applications)
+			# Instead of softlinking, it is recommended by Apple to use RPATHs
+      #install(CODE "execute_process(COMMAND ln -fs ../../${INSTALL_LIB_DIR} \${CMAKE_INSTALL_PREFIX}/${_name}.app/Contents/Frameworks)"
+			#				COMPONENT Applications)
+      #install(CODE "execute_process(COMMAND ln -fs ../../${INSTALL_PLUGIN_DIR} \${CMAKE_INSTALL_PREFIX}/${_name}.app/Contents/PlugIns)"
+		  # 			COMPONENT Applications)
 			install(CODE "execute_process(COMMAND ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/fix_dependencies.rb -b \${CMAKE_INSTALL_PREFIX}/${_name}.app/Contents/MacOS/ -e @rpath/ -n -c)"
 							COMPONENT Applications)
-    endif()
+    else() # dmg
+    		## Write a qt.conf file with a ref to the plugin dir in app bundles = PlugIns
+				file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
+						 "[Paths]\nPlugins = PlugIns\n")
+				install(FILES "${CMAKE_CURRENT_BINARY_DIR}/macappqt.conf"
+								DESTINATION "${_name}.app/Contents/Resources/"
+								RENAME "qt.conf"
+								COMPONENT Applications)
+		endif()
 
 		
 		## Notarization is only possible with Xcode/Appleclang 10, otherwise we just skip
-		if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10 AND "${PACKAGE_TYPE}" STREQUAL "dmg")
+		if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10 AND ("${PACKAGE_TYPE}" STREQUAL "dmg" OR "${PACKAGE_TYPE}" STREQUAL "pkg"))
 			## We also need an identity to sign with
 			if(DEFINED CPACK_BUNDLE_APPLE_CERT_APP)
-			## TODO try to find codesign to make sure the right exec is used (currently needs to be in path)
-			## TODO allow choosing keychain
-			## Note: Signing identity has to be unique, and present in any of the keychains in search list
-			## which needs to be unlocked. Play around with keychain argument otherwise.
+				## TODO try to find codesign to make sure the right exec is used (currently needs to be in path)
+				## TODO allow choosing keychain
+				## Note: Signing identity has to be unique, and present in any of the keychains in search list
+				## which needs to be unlocked. Play around with keychain argument otherwise.
 				 install(CODE "
-execute_process(COMMAND codesign --deep --force --options runtime --sign ${CPACK_BUNDLE_APPLE_CERT_APP} -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
+execute_process(COMMAND codesign --deep --force --options runtime --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
 message('\${sign_out}')" COMPONENT Applications)
 
 				 install(CODE "
 execute_process(COMMAND codesign -dv \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_check_out ERROR_VARIABLE sign_check_out)
 message('\${sign_check_out}')" COMPONENT Applications)
 
+				if("${PACKAGE_TYPE}" STREQUAL "dmg")
 				 install(CODE "
 execute_process(COMMAND ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/notarize_app.sh \${CMAKE_INSTALL_PREFIX}/${_name}.app de.openms.${_name} ${SIGNING_EMAIL} CODESIGNPW ${OPENMS_HOST_BINARY_DIRECTORY} OUTPUT_VARIABLE notarize_out ERROR_VARIABLE notarize_out)
 message('\${notarize_out}')" COMPONENT Applications)
@@ -161,7 +170,7 @@ message('\${notarize_out}')" COMPONENT Applications)
 				 install(CODE "
 execute_process(COMMAND spctl -a -v \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE verify_out ERROR_VARIABLE verify_out)
 message('\${verify_out}')" COMPONENT Applications)
-   
+   			endif()
 			endif(DEFINED CPACK_BUNDLE_APPLE_CERT_APP)
 		endif()
 	else()


### PR DESCRIPTION
## Description

fixes #6528 

- Removes Qt plugin leftovers that caused crashes because the plugin folder did not exist anymore.
- Adds contrib and Qt to path for documenters. Allows building without PATH mods on Win. Should be done for tests as well. I am pretty sure there is an issue for it already.
- Fixes layout and signing for pkg. Only notarization is missing, for which we need a new certificate (see Discord discussion). See also https://developer.apple.com/forums/thread/721094
- Makes tutorial optional in NSIS installer (finally allows building without Latex) [We should switch to CMake-driven NSIS packaging!]
- Finds vcredists on non VS command lines (allowing full build from git bash on Win now). [We should switch to just copying the needed DLLs or stubs!]
- Readds signing for dmgs. It is not broken, just no signing identities were registered.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
