### PR TITLE
Remove `long` type from convProv

### DIFF
--- a/src/pyOpenMS/converters/special_autowrap_conversionproviders.py
+++ b/src/pyOpenMS/converters/special_autowrap_conversionproviders.py
@@ -136,10 +136,10 @@ class OpenMSDataValue(TypeConverterBase):
         return ""
 
     def matching_python_type_full(self, cpp_type):
-        return "Union[int, long, float, bytes, str, List[int], List[long], List[float], List[bytes]]"
+        return "Union[int, float, bytes, str, List[int], List[float], List[bytes]]"
 
     def type_check_expression(self, cpp_type, argument_var):
-        return "isinstance(%s, (int, long, float, list, bytes, str))" % argument_var
+        return "isinstance(%s, (int, float, list, bytes, str))" % argument_var
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         call_as = "deref(DataValue(%s).inst.get())" % argument_var
@@ -183,10 +183,10 @@ class OpenMSParamValue(TypeConverterBase):
         return ""
       
     def matching_python_type_full(self, cpp_type):
-        return "Union[int, long, float, bytes, str, List[int], List[long], List[float], List[bytes]]"
+        return "Union[int, float, bytes, str, List[int], List[float], List[bytes]]"
 
     def type_check_expression(self, cpp_type, argument_var):
-        return "isinstance(%s, (int, long, float, list, bytes, str))" % argument_var
+        return "isinstance(%s, (int, float, list, bytes, str))" % argument_var
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         call_as = "deref(ParamValue(%s).inst.get())" % argument_var


### PR DESCRIPTION
also removed in py3

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
