### PR TITLE
[Feature] direct singularity images on ghcr.io

### DIFF
--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -114,6 +114,9 @@ jobs:
         shell: bash
         run: |
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
+            sed -i "s/(^From:.*:)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/executables/Singularity.def
+            sed -i "s/(^OPENMS_BRANCH=)(.*)/\1${{ steps.extract_branch.outputs.branch }}/" dockerfiles/executables/Singularity.def
+            sed -i "s/(^OPENMS_TAG=)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/executables/Singularity.def
             cat dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             
@@ -121,7 +124,6 @@ jobs:
         shell: bash
         run: |
             spython recipe dockerfiles/executables/Dockerfile &> dockerfiles/executables/Singularity.def
-            cat dockerfiles/executables/Singularity.def
             sed -i "s%^From:.*%From: $(pwd)/library.sif%" dockerfiles/executables/Singularity.def
             sed -i "s/^Bootstrap:.*/Bootstrap: localimage/" dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -104,6 +104,7 @@ jobs:
             fi
       - name: Build Singularity library image
         run: |
+            sudo apk add --no-cache py3-pip
             python3 -m pip install spython
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -2,8 +2,9 @@ name: deploy-container-images
 on:
   workflow_dispatch:
   push:
-    branches:        
+    branches:
       - nightly
+      - feat/singularity
       - 'release/**'
 
 jobs:
@@ -19,15 +20,11 @@ jobs:
         run: |
             BRANCH=${{ steps.extract_branch.outputs.branch }}
             ## use latest to follow docker conventions
-            if [[ "$BRANCH" == "develop" ]]
+            if [[ "$BRANCH" == "develop" || "$BRANCH" == "nightly" || "$BRANCH" == "feat/singularity"]]
             then 
               BRANCH="latest"
             fi
-            if [[ "$BRANCH" == "nightly" ]]
-            then 
-              BRANCH="latest"
-            fi
-            ## Remove release/ from release branch name
+            ## Remove release/ from release branch name (or keep the non-release name)
             echo "##[set-output name=tag;]$(echo ${BRANCH#release/})"
         id: tag_name
       - name: Downcase REPO

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -104,6 +104,7 @@ jobs:
             fi
       - name: Build Singularity library image
         run: |
+            pip3 install spython
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -109,4 +109,4 @@ jobs:
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
-            singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}
+            singularity push library.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -109,4 +109,4 @@ jobs:
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
-            singularity push container.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}
+            singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "{branch}={${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Define tag name
         shell: bash
@@ -25,10 +25,10 @@ jobs:
               BRANCH="latest"
             fi
             ## Remove release/ from release branch name (or keep the non-release name)
-            echo "##[set-output name=tag;]$(echo ${BRANCH#release/})"
+            echo "{tag}={${BRANCH#release/}}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: echo "##[set-output name=repo;]$(echo ${GITHUB_REPOSITORY,,})"
+        run: echo "{repo}={${GITHUB_REPOSITORY,,}}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
         shell: bash # uses git bash on windows
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "{branch}={${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Define tag name
         shell: bash
@@ -87,10 +87,10 @@ jobs:
               BRANCH="latest"
             fi
             ## Remove release/ from release branch name
-            echo "##[set-output name=tag;]$(echo ${BRANCH#release/})"
+            echo "{tag}={${BRANCH#release/}}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: echo "##[set-output name=repo;]$(echo ${GITHUB_REPOSITORY,,})"
+        run: echo "{repo}={${GITHUB_REPOSITORY,,}}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
         shell: bash # uses git bash on windows
@@ -109,4 +109,4 @@ jobs:
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
-            singularity push library.sif oras://ghcr.io/${GITHUB_REPOSITORY}:${{ steps.tag_name.outputs.tag }}
+            singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -90,13 +90,11 @@ jobs:
             echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: |
-            echo "???????????????????????????????"
-            echo "${GITHUB_REPOSITORY}"
-            echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
-        shell: bash # uses git bash on windows
+        shell: bash
         run: |
             git clone https://github.com/OpenMS/dockerfiles
             cd dockerfiles
@@ -106,6 +104,7 @@ jobs:
               git checkout ${{ steps.extract_branch.outputs.branch }} || git checkout master
             fi
       - name: Build Singularity library image
+        shell: bash
         run: |
             sudo apk add --no-cache py3-pip
             python3 -m pip install spython

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -122,11 +122,14 @@ jobs:
         run: |
             spython recipe dockerfiles/executables/Dockerfile &> dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def
-            #sudo -E singularity build executables.sif dockerfiles/executables/Singularity.def
+            sed -i "s/^From:.*/From: $(pwd)\/library.sif/" dockerfiles/executables/Singularity.def
+            sed -i "s/Bootstrap:.*/Bootstrap: localimage/" dockerfiles/executables/Singularity.def
+            cat dockerfiles/executables/Singularity.def
+            sudo -E singularity build executables.sif dockerfiles/executables/Singularity.def
             
       - name: Upload images to ghcr.io
         shell: bash
         run: |
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
             singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}
-            #singularity push executables.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables-sif:${{ steps.tag_name.outputs.tag }}
+            singularity push executables.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables-sif:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
             spython recipe dockerfiles/executables/Dockerfile &> dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def
-            sed -i "s/^From:.*/From: $(pwd)\/library.sif/" dockerfiles/executables/Singularity.def
+            sed -i "s§^From:.*§From: $(pwd)/library.sif§" dockerfiles/executables/Singularity.def
             sed -i "s/Bootstrap:.*/Bootstrap: localimage/" dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def
             sudo -E singularity build executables.sif dockerfiles/executables/Singularity.def

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "{branch}={${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Define tag name
         shell: bash
@@ -25,10 +25,10 @@ jobs:
               BRANCH="latest"
             fi
             ## Remove release/ from release branch name (or keep the non-release name)
-            echo "{tag}={${BRANCH#release/}}" >> $GITHUB_OUTPUT
+            echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: echo "{repo}={${GITHUB_REPOSITORY,,}}" >> $GITHUB_OUTPUT
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
         shell: bash # uses git bash on windows
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "{branch}={${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: extract_branch
       - name: Define tag name
         shell: bash
@@ -87,10 +87,10 @@ jobs:
               BRANCH="latest"
             fi
             ## Remove release/ from release branch name
-            echo "{tag}={${BRANCH#release/}}" >> $GITHUB_OUTPUT
+            echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: echo "{repo}={${GITHUB_REPOSITORY,,}}" >> $GITHUB_OUTPUT
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
         shell: bash # uses git bash on windows

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -132,4 +132,5 @@ jobs:
         run: |
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
             singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}
+            echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
             singularity push executables.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables-sif:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -104,7 +104,7 @@ jobs:
             fi
       - name: Build Singularity library image
         run: |
-            pip3 install spython
+            python3 -m pip install spython
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -114,9 +114,9 @@ jobs:
         shell: bash
         run: |
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
-            sed -i "s/(^From:.*:)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/executables/Singularity.def
-            sed -i "s/(^OPENMS_BRANCH=)(.*)/\1${{ steps.extract_branch.outputs.branch }}/" dockerfiles/executables/Singularity.def
-            sed -i "s/(^OPENMS_TAG=)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/executables/Singularity.def
+            sed -i "s/(^From:.*:)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/library/Singularity.def
+            sed -i "s/(^OPENMS_BRANCH=)(.*)/\1${{ steps.extract_branch.outputs.branch }}/" dockerfiles/library/Singularity.def
+            sed -i "s/(^OPENMS_TAG=)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/library/Singularity.def
             cat dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
             

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -122,8 +122,8 @@ jobs:
         run: |
             spython recipe dockerfiles/executables/Dockerfile &> dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def
-            sed -i "s§^From:.*§From: $(pwd)/library.sif§" dockerfiles/executables/Singularity.def
-            sed -i "s/Bootstrap:.*/Bootstrap: localimage/" dockerfiles/executables/Singularity.def
+            sed -i "s%^From:.*%From: $(pwd)/library.sif%" dockerfiles/executables/Singularity.def
+            sed -i "s/^Bootstrap:.*/Bootstrap: localimage/" dockerfiles/executables/Singularity.def
             cat dockerfiles/executables/Singularity.def
             sudo -E singularity build executables.sif dockerfiles/executables/Singularity.def
             

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -90,7 +90,10 @@ jobs:
             echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
         id: tag_name
       - name: Downcase REPO
-        run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        run: |
+            echo "???????????????????????????????"
+            echo "${GITHUB_REPOSITORY}"
+            echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
       - name: Checkout Dockerfiles
         shell: bash # uses git bash on windows

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -1,4 +1,4 @@
-name: deploy-docker-images
+name: deploy-container-images
 on:
   workflow_dispatch:
   push:
@@ -7,7 +7,7 @@ on:
       - 'release/**'
 
 jobs:
-  Deploy:
+  DeployDocker:
     runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
@@ -69,3 +69,49 @@ jobs:
             OPENMS_BRANCH=${{ steps.extract_branch.outputs.branch }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables:${{ steps.tag_name.outputs.tag }}
+
+  DeploySingularity:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/singularity/singularity:v3.10.4
+      options: --privileged
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Define tag name
+        shell: bash
+        run: |
+            BRANCH=${{ steps.extract_branch.outputs.branch }}
+            ## use latest to follow docker conventions
+            if [[ "$BRANCH" == "develop" ]]
+            then 
+              BRANCH="latest"
+            fi
+            if [[ "$BRANCH" == "nightly" ]]
+            then 
+              BRANCH="latest"
+            fi
+            ## Remove release/ from release branch name
+            echo "##[set-output name=tag;]$(echo ${BRANCH#release/})"
+        id: tag_name
+      - name: Downcase REPO
+        run: echo "##[set-output name=repo;]$(echo ${GITHUB_REPOSITORY,,})"
+        id: downcase_repo
+      - name: Checkout Dockerfiles
+        shell: bash # uses git bash on windows
+        run: |
+            git clone https://github.com/OpenMS/dockerfiles
+            cd dockerfiles
+            ## for release, try to checkout the specific release branch in the dockerfiles repo first
+            if [[ "${{ steps.extract_branch.outputs.branch }}" == "release/"* ]]
+            then
+              git checkout ${{ steps.extract_branch.outputs.branch }} || git checkout master
+            fi
+      - name: Build Singularity library image
+        run: |
+            spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
+            sudo -E singularity build library.sif dockerfiles/library/Singularity.def
+            echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
+            singularity push container.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
             sed -i "s/(^From:.*:)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/library/Singularity.def
-            sed -i "s/(^OPENMS_BRANCH=)(.*)/\1${{ steps.extract_branch.outputs.branch }}/" dockerfiles/library/Singularity.def
+            sed -i "s%(^OPENMS_BRANCH=)(.*)%\1${{ steps.extract_branch.outputs.branch }}%" dockerfiles/library/Singularity.def
             sed -i "s/(^OPENMS_TAG=)(.*)/\1${{ steps.tag_name.outputs.tag }}/" dockerfiles/library/Singularity.def
             cat dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
             BRANCH=${{ steps.extract_branch.outputs.branch }}
             ## use latest to follow docker conventions
-            if [[ "$BRANCH" == "develop" || "$BRANCH" == "nightly" || "$BRANCH" == "feat/singularity"]]
+            if [[ "$BRANCH" == "develop" || "$BRANCH" == "nightly" || "$BRANCH" == "feat/singularity" ]]
             then 
               BRANCH="latest"
             fi
@@ -82,11 +82,7 @@ jobs:
         run: |
             BRANCH=${{ steps.extract_branch.outputs.branch }}
             ## use latest to follow docker conventions
-            if [[ "$BRANCH" == "develop" ]]
-            then 
-              BRANCH="latest"
-            fi
-            if [[ "$BRANCH" == "nightly" ]]
+            if [[ "$BRANCH" == "develop" || "$BRANCH" == "nightly" || "$BRANCH" == "feat/singularity" ]]
             then 
               BRANCH="latest"
             fi

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -103,12 +103,30 @@ jobs:
             then
               git checkout ${{ steps.extract_branch.outputs.branch }} || git checkout master
             fi
-      - name: Build Singularity library image
+            
+      - name: Install spython for conversion
         shell: bash
         run: |
             sudo apk add --no-cache py3-pip
             python3 -m pip install spython
+            
+      - name: Build Singularity library image
+        shell: bash
+        run: |
             spython recipe dockerfiles/library/Dockerfile &> dockerfiles/library/Singularity.def
+            cat dockerfiles/library/Singularity.def
             sudo -E singularity build library.sif dockerfiles/library/Singularity.def
+            
+      - name: Build Singularity tools image
+        shell: bash
+        run: |
+            spython recipe dockerfiles/executables/Dockerfile &> dockerfiles/executables/Singularity.def
+            cat dockerfiles/executables/Singularity.def
+            #sudo -E singularity build executables.sif dockerfiles/executables/Singularity.def
+            
+      - name: Upload images to ghcr.io
+        shell: bash
+        run: |
             echo ${{ secrets.GITHUB_TOKEN }} | singularity remote login -u jpfeuffer --password-stdin oras://ghcr.io
             singularity push library.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library-sif:${{ steps.tag_name.outputs.tag }}
+            #singularity push executables.sif oras://ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables-sif:${{ steps.tag_name.outputs.tag }}


### PR DESCRIPTION
## Description

so you do not have to convert while pulling. e.g. for nextflow

TODO:
- make spython conversion respect the build arguments we use for docker (sed the resulting file) or mount the checked-out repo instead of pulling it in the container. does not work for the base container though.
- ~~fix 404 error when pushing. Wrong URL? Do we have to avoid sub URLs?~~

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
