### PR TITLE
[pyOpenMS] simple helper to update scores from a previously exported dataframe

### DIFF
--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -521,7 +521,7 @@ def peptide_identifications_to_df(peps: List[_PeptideIdentification], decode_ont
     return _pd.DataFrame(_np.fromiter((extract(pep) for pep in peps), dtype=dt, count=count))
 
 
-def update_scores_from_df(peps: List[PeptideIdentification], df : _pd.DataFrame, main_score_name : str):
+def update_scores_from_df(peps: List[_PeptideIdentification], df : _pd.DataFrame, main_score_name : str):
     """Updates the scores in PeptideIdentification objects using a pandas dataframe.
     Parameters:
     peps (List[PeptideIdentification]): list of PeptideIdentification objects
@@ -534,9 +534,11 @@ def update_scores_from_df(peps: List[PeptideIdentification], df : _pd.DataFrame,
 
     for index, row in df.iterrows():
         pid_index = int(row["P_ID"])
-        pi = PeptideIdentification(peps[pid_index])
-        pi.setScore(float(row[main_score_name]))
+        pi = _PeptideIdentification(peps[pid_index])
         pi.setScoreType(main_score_name)
+        hits = pi.getHits()
+        hits[0] = hits[0].setScore(float(row[main_score_name]))
+        pi.setHits(hits)
         rets[pid_index] = pi
 
     return rets

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -523,12 +523,12 @@ def peptide_identifications_to_df(peps: List[_PeptideIdentification], decode_ont
 
 
 def update_scores_from_df(peps: List[_PeptideIdentification], df : _pd.DataFrame, main_score_name : str):
-    """Updates the scores in PeptideIdentification objects using a pandas dataframe.
-    Parameters:
-    peps (List[PeptideIdentification]): list of PeptideIdentification objects
-    df dataframe obtained by converting peps to a dataframe. Minimum required: P_ID column and column with name main_score_name
-    Returns:
-    List[PeptideIdentification]: peptide identifications
+    """
+    Updates the scores in PeptideIdentification objects using a pandas dataframe.
+                
+    :param peps: list of PeptideIdentification objects
+    :param df: pandas dataframe obtained by converting peps to a dataframe. Minimum required: P_ID column and column with name passed by main_score_name
+    :return: the updated list of peptide identifications
     """
 
     rets = peps

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2304,7 +2304,7 @@ def test_peptide_identifications_to_df():
 
     # update from dataframe
     df = pyopenms.peptide_identifications_to_df(peps)
-    df["ScoreType"][0] = 10.0;
+    df["ScoreType"][0] = 10.0
     peps = pyopenms.update_scores_from_df(peps, df, "ScoreType")
     assert peps[0].getHits()[0].getScore() == 10.0
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2260,6 +2260,7 @@ def testIdXMLFile():
 
 @report
 def test_peptide_identifications_to_df():
+    # convert to dataframe
     peps = []
 
     p = pyopenms.PeptideIdentification()
@@ -2300,6 +2301,12 @@ def test_peptide_identifications_to_df():
     assert pyopenms.peptide_identifications_to_df(peps, decode_ontology=False).shape == (2,10)
     assert pyopenms.peptide_identifications_to_df(peps)['protein_accession'][0] == 'sp|Accession1,sp|Accession2'
     assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,10)
+
+    # update from dataframe
+    df = pyopenms.peptide_identifications_to_df(peps)
+    df["ScoreType"][0] = 10.0;
+    peps = pyopenms.update_scores_from_df(peps, df, "ScoreType")
+    assert peps[0].getHits()[0].getScore() == 10.0
 
 @report
 def testPepXMLFile():

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2137,13 +2137,13 @@ def testFeatureXMLFile():
     assert fm.get_df(meta_values='all', export_peptide_identifications=False).shape == (2, 12)
 
     assert pd.merge(fm.get_df(), pyopenms.peptide_identifications_to_df(fm.get_assigned_peptide_identifications()),
-                on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (2,22)
+                on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (2,24)
 
     fm = pyopenms.FeatureMap()
     pyopenms.FeatureXMLFile().load(os.path.join(os.environ['OPENMS_DATA_PATH'], 'examples/FRACTIONS/BSA1_F1_idmapped.featureXML'), fm)
 
     assert pd.merge(fm.get_df(), pyopenms.peptide_identifications_to_df(fm.get_assigned_peptide_identifications()),
-                    on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (15,24)
+                    on = ['feature_id', 'ID_native_id', 'ID_filename']).shape == (15,26)
 
     fh = pyopenms.FeatureXMLFile()
     fh.store("test.featureXML", fm)
@@ -2297,10 +2297,10 @@ def test_peptide_identifications_to_df():
 
     peps.append(p1)
 
-    assert pyopenms.peptide_identifications_to_df(peps).shape == (2,10)
-    assert pyopenms.peptide_identifications_to_df(peps, decode_ontology=False).shape == (2,10)
+    assert pyopenms.peptide_identifications_to_df(peps).shape == (2,12)
+    assert pyopenms.peptide_identifications_to_df(peps, decode_ontology=False).shape == (2,12)
     assert pyopenms.peptide_identifications_to_df(peps)['protein_accession'][0] == 'sp|Accession1,sp|Accession2'
-    assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,10)
+    assert pyopenms.peptide_identifications_to_df(peps, export_unidentified=False).shape == (1,12)
 
     # update from dataframe
     df = pyopenms.peptide_identifications_to_df(peps)


### PR DESCRIPTION
## Description

Use case is e.g., rescoring with ML methods.
e.g., user could write a simple script to export id date from idXML to df, run a DL method to calculate an updated score, feed it back into the OpenMS datastructures, write idXML out.
This could be plugged into e.g., larger workflows

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
