### PR TITLE
Huge test compilation improvement

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/ClassTest.h
+++ b/src/openms/include/OpenMS/CONCEPT/ClassTest.h
@@ -406,6 +406,12 @@ namespace OpenMS
         }
       }
 
+      
+      void OPENMS_DLLAPI printLastException(std::ostream& out);
+      
+      int OPENMS_DLLAPI endTestPostProcess(std::ostream& out);
+
+      void OPENMS_DLLAPI endSectionPostProcess(std::ostream& out, const int line);
     }
   }
 }
@@ -484,82 +490,12 @@ namespace TEST = OpenMS::Internal::ClassTest;
  */
 #define END_TEST                                                                          \
   /* global try block */                                                                  \
-  }                                                                                       \
-  catch (::OpenMS::Exception::BaseException& e)                                           \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
-    {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unexpected OpenMS exception of type '"                  \
-                << e.getName()                                                            \
-                << "'";                                                                   \
-      if ((e.getLine() > 0) && std::strcmp(e.getFile(), ""))                       \
-      {                                                                                   \
-        stdcout << " thrown in line " << e.getLine() << " of file '" << e.getFile()     \
-                  << "' in function '" << e.getFunction() << "'";                         \
-      }                                                                                   \
-      stdcout << " - Message: " << e.what() << std::endl;                               \
     }                                                                                     \
-  }                                                                                       \
-  /* catch std:: exceptions */                                                            \
-  catch (std::exception& e)                                                               \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
+    catch (...)                                                                           \
     {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unexpected std::exception\n";                             \
-      stdcout << " - Message: " << e.what() << std::endl;                                 \
+      TEST::printLastException(stdcout);                                                  \
     }                                                                                     \
-  }                                                                                       \
-  /* catch all other exceptions */                                                        \
-  catch (...)                                                                             \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
-    {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unidentified and unexpected exception - No message."      \
-                << std::endl;                                                             \
-    }                                                                                     \
-  }                                                                                       \
-  /* check validity of temporary files if known */                                        \
-  if (!TEST::validate(TEST::tmp_file_list))                                               \
-  {                                                                                       \
-    TEST::all_tests = false;                                                              \
-  }                                                                                       \
-  if (TEST::verbose == 0)                                                                 \
-  {                                                                                       \
-    stdcout << "Output of successful tests were suppressed. Set the environment variable 'OPENMS_TEST_VERBOSE=True' to enable them." << std::endl; \
-  }                                                                                       \
-  /* check for exit code */                                                               \
-  if (!TEST::all_tests)                                                                   \
-  {                                                                                       \
-    stdcout << "FAILED" << std::endl;                                                   \
-    if (TEST::add_message != "") stdcout << "Message: "                                 \
-                                           << TEST::add_message                           \
-                                           << std::endl;                                  \
-    stdcout << "Failed lines: ";                                                        \
-    for (OpenMS::Size i = 0; i < TEST::failed_lines_list.size(); ++i)                     \
-    {                                                                                     \
-      stdcout << TEST::failed_lines_list[i] << " ";                                     \
-    }                                                                                     \
-    stdcout << std::endl;                                                               \
-    return 1;                                                                             \
-  }                                                                                       \
-  else                                                                                    \
-  {                                                                                       \
-    /* remove temporary files*/                                                           \
-    TEST::removeTempFiles();                                                              \
-    stdcout << "PASSED";                                                                \
-    if (TEST::add_message != "") stdcout << " (" << TEST::add_message << ")";           \
-    stdcout << std::endl;                                                               \
-    return 0;                                                                             \
-  }                                                                                       \
+    return TEST::endTestPostProcess(stdcout);                                             \
   }
 
 /**	@brief Begin of a subtest with a given name.  @sa #END_SECTION.
@@ -625,68 +561,12 @@ namespace TEST = OpenMS::Internal::ClassTest;
   break;                                                                                  \
   }                                                                                       \
   }                                                                                       \
-  catch (::OpenMS::Exception::BaseException& e)                                           \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
-    {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unexpected exception of type '" << e.getName() << "'";  \
-      if ((e.getLine() > 0) && (std::strcmp(e.getFile(), "") != 0))                       \
-      {                                                                                   \
-        stdcout << " thrown in line " << e.getLine() << " of file '" << e.getFile()     \
-                  << "' in function '" << e.getFunction() << "'";                         \
-      }                                                                                   \
-      stdcout << " - Message: " << e.what() << std::endl;                               \
-    }                                                                                     \
-  }                                                                                       \
-  /* catch std:: exceptions */                                                            \
-  catch (std::exception& e)                                                               \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
-    {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught std::exception" << std::endl;                           \
-      stdcout << " - Message: " << e.what() << std::endl;                               \
-    }                                                                                     \
-  }                                                                                       \
-  /* catch all other exceptions */                                                        \
-  catch (...)                                                                             \
-  {                                                                                       \
-    TEST::this_test = false;                                                              \
-    TEST::test = false;                                                                   \
-    TEST::all_tests = false;                                                              \
-    {                                                                                     \
-      TEST::initialNewline();                                                             \
-      stdcout << "Error: Caught unidentified and unexpected exception - No message."    \
-                << std::endl;                                                             \
-    }                                                                                     \
-  }                                                                                       \
-  TEST::all_tests = TEST::all_tests && TEST::test;                                        \
-  {                                                                                       \
-    if (TEST::test)                                                                       \
-    {                                                                                     \
-      stdcout << ": passed\n";                                                            \
-    }                                                                                     \
-    else                                                                                  \
-    {                                                                                     \
-      stdcout << ": failed\n";                                                            \
-    }                                                                                     \
-  }                                                                                       \
-  /* issue a warning if no tests were performed (unless in destructor)*/                  \
-  if (TEST::test_count == 0)                                                              \
-  {                                                                                       \
-    if (OpenMS::String(TEST::test_name).has('~'))                                         \
-                       stdcout << "Warning: no subtests performed in '"                   \
-                               << TEST::test_name                                         \
-                               << "' (line "                                              \
-                               << __LINE__                                                \
-                               << ")!\n";                                                 \
-  }                                                                                       \
-  stdcout << std::endl;
+  catch (...)  \
+  {   \
+    TEST::printLastException(stdcout);\
+  } \
+  TEST::endSectionPostProcess(stdcout, __LINE__);
+
 
 //@}
 


### PR DESCRIPTION
## Description

fixes #6499 by moving code from a TEST macro to a function; this saves a LOT of intermediate code as generated by the preprocessor when compiling; thus uses way less RAM and compiles much faster.

some measurements on Windows. Just look at RAM usage and compile time for the tests...

`before` (sorted by RAM usage):
```
                                  wall_time PeakWorkingSetSize                     cpp
1783  0 days, 00:05:37.510 (337.51 seconds)          5.759 GiB ConstRefVector_test.cpp
1782  0 days, 00:03:20.382 (200.38 seconds)          4.653 GiB     AASequence_test.cpp
1781  0 days, 00:04:53.587 (293.59 seconds)          3.989 GiB         String_test.cpp
1106   0 days, 00:00:53.870 (53.87 seconds)          3.791 GiB      ClassTest_test.cpp
1780  0 days, 00:04:38.675 (278.68 seconds)          3.393 GiB      DataValue_test.cpp
1769  0 days, 00:04:09.599 (249.60 seconds)          3.151 GiB     MSSpectrum_test.cpp
```

`after` (sorted by RAM usage):
```
                                wall_time PeakWorkingSetSize                                   cpp
1776  0 days, 00:00:35.711 (35.71 seconds)          1.393 GiB             MRMFeatureFilter_test.cpp
1163  0 days, 00:00:21.520 (21.52 seconds)          1.063 GiB                    ClassTest_test.cpp
535   0 days, 00:00:29.133 (29.13 seconds)          940.2 MiB                      IDBoostGraph.cpp
588   0 days, 00:00:48.257 (48.26 seconds)          880.5 MiB BayesianProteinInferenceAlgorithm.cpp
1167  0 days, 00:00:27.579 (27.58 seconds)            772 MiB                     ProteomicsLFQ.cpp
658   0 days, 00:00:25.496 (25.50 seconds)          766.9 MiB                   LevMarqFitter1D.cpp
```

compiles up 10x faster and uses 4x less RAM.
For all tests, compile time on VS2022 in Release mode reduces from 6 to 2 min on my machine (3x faster).

Execution time of tests did not change (in my limited testing on my machine).

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
