### PR TITLE
[FIX] OpenSwath MS1 scores on sqMass output

### DIFF
--- a/src/openms/source/FORMAT/DATAACCESS/MSDataSqlConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MSDataSqlConsumer.cpp
@@ -65,14 +65,14 @@ namespace OpenMS
 
   void MSDataSqlConsumer::flush()
   {
-    if (!spectra_.empty() ) 
+    if (!spectra_.empty() )
     {
       handler_->writeSpectra(spectra_);
       spectra_.clear();
       spectra_.reserve(flush_after_);
     }
 
-    if (!chromatograms_.empty() ) 
+    if (!chromatograms_.empty() )
     {
       handler_->writeChromatograms(chromatograms_);
       chromatograms_.clear();
@@ -97,14 +97,14 @@ namespace OpenMS
   void MSDataSqlConsumer::consumeChromatogram(ChromatogramType & c)
   {
     chromatograms_.push_back(c);
-    c.clear(false);
+    //c.clear(false);
     if (full_meta_)
     {
       peak_meta_.addChromatogram(c);
     }
     if (chromatograms_.size() >= flush_after_)
     {
-      flush();
+      //flush();
     }
   }
 


### PR DESCRIPTION
## Description
If '.sqMass' is asked for as output than the outputted .featureXML/.osw contains 0 values for MS1 intensity and peak_apex. Furthermore the scores are inaccurate. 



## Example
As an illustration of what I mean take a modified OpenSwathTest_23 as an example. 

Before the fix the `OpenSwathWorkflow_23.featureXML.tmp` output will be incorrect if I just change the `-out_chrom` parameter.
`TOPP_OpenSwathWorkflow_23" ${TOPP_BIN_PATH}/OpenSwathWorkflow -in ${DATA_DIR_TOPP}/OpenSwathWorkflow_23_input.mzML -tr ${DATA_DIR_TOPP}/OpenSwathWorkflow_23_input.tsv` **-out_chrom OpenSwathWorkflow_23.chrom.sqmass** `-out_features OpenSwathWorkflow_23.featureXML.tmp -readOptions workingInMemory -ion_mobility_window 0.1 -use_ms1_ion_mobility "false" -Scoring:Scores:use_ion_mobility_scores -pasef "-test" "-mz_extraction_window" "0.05" "-mz_extraction_window_unit" "Th" "-ms1_isotopes" "0" "-Scoring:TransitionGroupPicker:compute_peak_quality" "-Scoring:Scores:use_ms1_mi" "false" "-Scoring:Scores:use_mi_score" "false"`
[diff.txt](https://github.com/OpenMS/OpenMS/files/10561962/diff.txt)
[OpenSwathWorkflow_23.featureXML.txt](https://github.com/OpenMS/OpenMS/files/10561975/OpenSwathWorkflow_23.featureXML.txt)
## Solution 
Fix this problem by preventing "flush" when writing out MS1 spectra.This fix technically works however I am not sure if it the best way to address this problem. 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

