### PR TITLE
[FIX] All Zero MS1 Feature Scores

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
@@ -154,7 +154,6 @@ protected:
     void MS1Extraction_(const OpenSwath::SpectrumAccessPtr& ms1_map,
                         const std::vector< OpenSwath::SwathMap > & swath_maps,
                         std::vector< MSChromatogram >& ms1_chromatograms,
-                        Interfaces::IMSDataConsumer * chromConsumer,
                         const ChromExtractParams & cp,
                         const OpenSwath::LightTargetedExperiment& transition_exp,
                         const TransformationDescription& trafo_inverse,
@@ -493,6 +492,7 @@ protected:
      * @note This should be wrapped in an OpenMP critical block
     */
     void writeOutFeaturesAndChroms_(std::vector< OpenMS::MSChromatogram > & chromatograms,
+                                    std::vector< MSChromatogram >& ms1_chromatograms,
                                     const FeatureMap & featureFile,
                                     FeatureMap& out_featureFile,
                                     bool store_features,

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -535,7 +535,7 @@ namespace OpenMS
     if (ms1_only)
     {
       std::vector< MSChromatogram > ms1_chromatograms;
-      MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, chromConsumer, ms1_cp,
+      MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, ms1_cp,
                      transition_exp, trafo_inverse, ms1_only, ms1_isotopes);
 
       FeatureMap featureFile;
@@ -548,7 +548,7 @@ namespace OpenMS
 
       // write features to output if so desired
       std::vector< OpenMS::MSChromatogram > chromatograms;
-      writeOutFeaturesAndChroms_(chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
+      writeOutFeaturesAndChroms_(chromatograms, ms1_chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
     }
 
     // (iii) map transitions to individual DIA windows for cases where this is
@@ -782,7 +782,7 @@ namespace OpenMS
             if (ms1_map_ != nullptr)
             {
               OpenSwath::SpectrumAccessPtr threadsafe_ms1 = ms1_map_->lightClone();
-              MS1Extraction_(threadsafe_ms1, swath_maps, ms1_chromatograms, chromConsumer, ms1_cp,
+              MS1Extraction_(threadsafe_ms1, swath_maps, ms1_chromatograms, ms1_cp,
                   transition_exp_used, trafo_inverse, ms1_only, ms1_isotopes);
             }
 
@@ -815,7 +815,7 @@ namespace OpenMS
             // output file and one output map).
             #pragma omp critical (osw_write_out)
             {
-              writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), featureFile, out_featureFile, store_features, chromConsumer);
+              writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), ms1_chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
             }
           }
 
@@ -840,11 +840,23 @@ namespace OpenMS
 
   void OpenSwathWorkflow::writeOutFeaturesAndChroms_(
     std::vector< OpenMS::MSChromatogram > & chromatograms,
+    std::vector< MSChromatogram >& ms1_chromatograms,
     const FeatureMap & featureFile,
     FeatureMap& out_featureFile,
     bool store_features,
     Interfaces::IMSDataConsumer * chromConsumer)
   {
+    // write out MS1 chromatograms to output if so desired
+    for (Size j = 0; j < ms1_chromatograms.size(); j++)
+    {
+      if (ms1_chromatograms[j].empty()) continue; // skip empty chromatograms
+      {
+        // write MS1 chromatograms to disk
+        chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
+      }
+    }
+
+
     // write chromatograms to output if so desired
     for (Size chrom_idx = 0; chrom_idx < chromatograms.size(); ++chrom_idx)
     {
@@ -875,7 +887,6 @@ namespace OpenMS
   void OpenSwathWorkflowBase::MS1Extraction_(const OpenSwath::SpectrumAccessPtr& ms1_map,
                                              const std::vector< OpenSwath::SwathMap > & /* swath_maps */,
                                              std::vector< MSChromatogram >& ms1_chromatograms,
-                                             Interfaces::IMSDataConsumer* chromConsumer,
                                              const ChromExtractParams& cp,
                                              const OpenSwath::LightTargetedExperiment& transition_exp,
                                              const TransformationDescription& trafo_inverse,
@@ -893,20 +904,6 @@ namespace OpenMS
         cp.ppm, cp.im_extraction_window, cp.extraction_function);
     extractor.return_chromatogram(chrom_list, coordinates, transition_exp_used,
         SpectrumSettings(), ms1_chromatograms, true, cp.im_extraction_window);
-
-    for (Size j = 0; j < coordinates.size(); j++)
-    {
-      if (ms1_chromatograms[j].empty()) continue; // skip empty chromatograms
-
-#ifdef _OPENMP
-#pragma omp critical (osw_write_out)
-#endif
-      {
-        // write MS1 chromatograms to disk
-        chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
-      }
-    } // end of for coordinates
-
   }
 
   void OpenSwathWorkflow::scoreAllChromatograms_(
@@ -1209,7 +1206,7 @@ namespace OpenMS
       std::vector< MSChromatogram > ms1_chromatograms;
       if (ms1_map_ != nullptr)
       {
-        MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, chromConsumer, cp_ms1,
+        MS1Extraction_(ms1_map_, swath_maps, ms1_chromatograms, cp_ms1,
             transition_exp, trafo_inverse);
       }
 
@@ -1344,7 +1341,7 @@ namespace OpenMS
 #pragma omp critical (osw_write_out)
 #endif
             {
-              writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), featureFile, out_featureFile, store_features, chromConsumer);
+              writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), ms1_chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
             }
           }
         }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -850,10 +850,8 @@ namespace OpenMS
     for (Size j = 0; j < ms1_chromatograms.size(); j++)
     {
       if (ms1_chromatograms[j].empty()) continue; // skip empty chromatograms
-      {
-        // write MS1 chromatograms to disk
-        chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
-      }
+      // write MS1 chromatograms to disk
+      chromConsumer->consumeChromatogram( ms1_chromatograms[j] );
     }
 
 


### PR DESCRIPTION
## Description

This is related to PR #6648.

I discussed with @hroest, and we decided the best approach to fix the issue of zero scored MS1 Features is to write MS1 chromatograms to disk at the end, the same time when MS2 chromatograms get written out. 

Instead of writing out MS1 chromatgorams in [MS1Extraction_](https://github.com/OpenMS/OpenMS/blob/be2814f4cb9cb0d69641537166f9cc8b9ec9b450/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp#L875) it is now done in [writeOutFeaturesAndChroms_](https://github.com/OpenMS/OpenMS/blob/be2814f4cb9cb0d69641537166f9cc8b9ec9b450/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp#L841) instead.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
