### PR TITLE
Improves the design of IdentificationData a bit

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -1379,24 +1379,14 @@ public:
 
     /// @name Filter functions for class IdentificationData
     ///@{
-
-    /*!
-      @brief Helper function for filtering observation matches (e.g. PSMs) in IdentificationData
-
-      Depending on parameter @p cleanup_affected, the data structure may be cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
-
-      @param id_data Data to be filtered
-      @param func Functor that returns true for items to be removed
-      @param cleanup_affected Will filtering invalidate other parts of @p id_data that need to be cleaned up?
-    */
+/*
     template <typename PredicateType>
     static void filterObservationMatchesByFunctor(
         IdentificationData& id_data, PredicateType&& func, bool cleanup_affected = false)
     {
-      id_data.removeFromSetIf_(id_data.observation_matches_, func);
-      if (cleanup_affected) id_data.cleanup();
+      id_data.removeObservationMatchesIf(func, cleanup_affected);
     }
-
+*/
     /*!
       @brief Filter IdentificationData to keep only the best match (e.g. PSM) for each observation (e.g. spectrum)
 

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -1379,14 +1379,6 @@ public:
 
     /// @name Filter functions for class IdentificationData
     ///@{
-/*
-    template <typename PredicateType>
-    static void filterObservationMatchesByFunctor(
-        IdentificationData& id_data, PredicateType&& func, bool cleanup_affected = false)
-    {
-      id_data.removeObservationMatchesIf(func, cleanup_affected);
-    }
-*/
     /*!
       @brief Filter IdentificationData to keep only the best match (e.g. PSM) for each observation (e.g. spectrum)
 

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -205,46 +205,10 @@ namespace OpenMS
 
       bool allow_missing = false;
 
-      IdentifiedMolecule translate(IdentifiedMolecule old) const
-      {
-        switch (old.getMoleculeType())
-        {
-          case MoleculeType::PROTEIN:
-          {
-            auto pos = identified_peptide_refs.find(old.getIdentifiedPeptideRef());
-            if (pos != identified_peptide_refs.end()) return pos->second;
-          }
-          break;
-          case MoleculeType::COMPOUND:
-          {
-            auto pos = identified_compound_refs.find(old.getIdentifiedCompoundRef());
-            if (pos != identified_compound_refs.end()) return pos->second;
-          }
-          break;
-          case MoleculeType::RNA:
-          {
-            auto pos = identified_oligo_refs.find(old.getIdentifiedOligoRef());
-            if (pos != identified_oligo_refs.end()) return pos->second;
-          }
-          break;
-          default:
-            throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                          "invalid molecule type",
-                                          String(old.getMoleculeType()));
-        }
-        if (allow_missing) return old;
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "no match for reference");
-      }
+      IdentifiedMolecule translate(IdentifiedMolecule old) const;
 
-      ObservationMatchRef translate(ObservationMatchRef old) const
-      {
-        auto pos = observation_match_refs.find(old);
-        if (pos != observation_match_refs.end()) return pos->second;
-        if (allow_missing) return old;
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                            "no match for reference");
-      }
+      ObservationMatchRef translate(ObservationMatchRef old) const;
+
     };
 
     /// Default constructor
@@ -522,6 +486,17 @@ namespace OpenMS
 
     /// Get range of matches (cf. @p equal_range) for a given observation
     std::pair<ObservationMatchRef, ObservationMatchRef> getMatchesForObservation(ObservationRef obs_ref) const;
+
+    /*!
+      @brief Helper function for filtering observation matches (e.g. PSMs) in IdentificationData
+
+      Depending on parameter @p cleanup_affected, the data structure may be cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
+
+      @param func Functor that returns true for items to be removed
+      @param cleanup_affected Will filtering invalidate other parts of @p id_data that need to be cleaned up?
+    */
+    template <typename PredicateType>
+    void removeObservationMatchesIf(PredicateType&& func, bool cleanup_affected = false);
 
     /*!
       @brief Look up a score type by name.
@@ -813,87 +788,8 @@ namespace OpenMS
       return ref;
     }
 
-    /// Check whether a reference points to an element in a container
-    template <typename RefType, typename ContainerType>
-    static bool isValidReference_(RefType ref, ContainerType& container)
-    {
-      for (auto it = container.begin(); it != container.end(); ++it)
-      {
-        if (ref == it) return true;
-      }
-      return false;
-    }
-
-    /// Check validity of a reference based on a look-up table of addresses
-    template <typename RefType>
-    static bool isValidHashedReference_(
-      RefType ref, const AddressLookup& lookup)
-    {
-      return lookup.count(ref);
-    }
-
-    /// Remove elements from a set (or ordered multi_index_container) if they fulfill a predicate
-    template <typename ContainerType, typename PredicateType>
-    static void removeFromSetIf_(ContainerType& container, PredicateType predicate)
-    {
-      for (auto it = container.begin(); it != container.end(); )
-      {
-        if (predicate(it))
-        {
-          it = container.erase(it);
-        }
-        else
-        {
-          ++it;
-        }
-      }
-    }
-
-    /// Remove elements from a set (or ordered multi_index_container) if they don't occur in a look-up table
-    template <typename ContainerType>
-    static void removeFromSetIfNotHashed_(
-      ContainerType& container, const AddressLookup& lookup)
-    {
-      removeFromSetIf_(container, [&lookup](typename ContainerType::iterator it)
-                       {
-                         return !lookup.count(uintptr_t(&(*it)));
-                       });
-    }
-
-    /// Recreate the address look-up table for a container
-    template <typename ContainerType>
-    static void updateAddressLookup_(const ContainerType& container,
-                                     AddressLookup& lookup)
-    {
-      lookup.clear();
-      lookup.reserve(container.size());
-      for (const auto& element : container)
-      {
-        lookup.insert(uintptr_t(&element));
-      }
-    }
-
-    /// Helper function to add a meta value to an element in a multi-index container
-    template <typename RefType, typename ContainerType>
-    void setMetaValue_(const RefType ref, const String& key, const DataValue& value,
-                       ContainerType& container, const AddressLookup& lookup = AddressLookup())
-    {
-      if (!no_checks_ && ((lookup.empty() && !isValidReference_(ref, container)) ||
-                          (!lookup.empty() && !isValidHashedReference_(ref, lookup))))
-      {
-        String msg = "invalid reference for the given container";
-        throw Exception::IllegalArgument(__FILE__, __LINE__,
-                                         OPENMS_PRETTY_FUNCTION, msg);
-      }
-      container.modify(ref, [&key, &value](typename ContainerType::value_type& element)
-      {
-        element.setMetaValue(key, value);
-      });
-    }
-
-
-    // these classes need access to manipulate data:
-    friend class IDFilter;
+    // these classes need access to manipulate data: TODO remove! breaks encapsulation and design/architecture
     friend class MapAlignmentTransformer;
   };
+  
 }

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -527,6 +527,13 @@ namespace OpenMS
       if (cleanup_affected) cleanup();
     }
 
+    template <typename PredicateType>
+    void applyToObservations(PredicateType&& func)
+    {
+      for (auto it = observations_.begin(); it != observations_.end(); ++it)
+        observations_.modify(it, func);   
+    }
+
     /*!
       @brief Look up a score type by name.
 
@@ -817,8 +824,6 @@ namespace OpenMS
       return ref;
     }
 
-    // these classes need access to manipulate data: TODO remove! breaks encapsulation and design/architecture
-    friend class MapAlignmentTransformer;
   };
   
 }

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -532,7 +532,7 @@ namespace OpenMS
     {
       auto count = parents_.size();
       removeFromSetIf_(parents_, func);
-      if (count != observation_matches_.size()) cleanup();
+      if (count != parents_.size()) cleanup();
     }
 
     template <typename PredicateType>

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -508,23 +508,31 @@ namespace OpenMS
     /*!
       @brief Helper function for filtering observation matches (e.g. PSMs) in IdentificationData
 
-      Depending on parameter @p cleanup_affected, the data structure may be cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
+      If other parts are invalidated by filtering, the data structure is automatically cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
 
       @param func Functor that returns true for container elements to be removed
-      @param cleanup_affected Will filtering invalidate other parts of @p id_data that need to be cleaned up?
     */
     template <typename PredicateType>
-    void removeObservationMatchesIf(PredicateType&& func, bool cleanup_affected)
+    void removeObservationMatchesIf(PredicateType&& func)
     {
+      auto count = observation_matches_.size();
       removeFromSetIf_(observation_matches_, func);
-      if (cleanup_affected) cleanup();
+      if (count != observation_matches_.size()) cleanup();
     }
 
+    /*!
+      @brief Helper function for filtering parent sequences (e.g. protein sequences) in IdentificationData
+
+      If other parts are invalidated by filtering, the data structure is automatically cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
+
+      @param func Functor that returns true for container elements to be removed
+    */
     template <typename PredicateType>
-    void removeParentSequencesIf(PredicateType&& func, bool cleanup_affected)
+    void removeParentSequencesIf(PredicateType&& func)
     {
+      auto count = parents_.size();
       removeFromSetIf_(parents_, func);
-      if (cleanup_affected) cleanup();
+      if (count != observation_matches_.size()) cleanup();
     }
 
     template <typename PredicateType>

--- a/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
+++ b/src/openms/include/OpenMS/METADATA/ID/IdentificationData.h
@@ -91,6 +91,24 @@ namespace OpenMS
 
     @ingroup Metadata
   */
+
+  /// Remove elements from a set (or ordered multi_index_container) if they fulfill a predicate (TODO: deprecate and use std::erase_if with C++20 adoption)
+  template <typename ContainerType, typename PredicateType>
+  static void removeFromSetIf_(ContainerType& container, PredicateType predicate)
+  {
+    for (auto it = container.begin(); it != container.end(); )
+    {
+      if (predicate(it))
+      {
+        it = container.erase(it);
+      }
+      else
+      {
+        ++it;
+      }
+    }
+  }
+
   class OPENMS_DLLAPI IdentificationData: public MetaInfoInterface
   {
   public:
@@ -492,11 +510,22 @@ namespace OpenMS
 
       Depending on parameter @p cleanup_affected, the data structure may be cleaned up (IdentificationData::cleanup) to remove any invalidated references at the end of this operation.
 
-      @param func Functor that returns true for items to be removed
+      @param func Functor that returns true for container elements to be removed
       @param cleanup_affected Will filtering invalidate other parts of @p id_data that need to be cleaned up?
     */
     template <typename PredicateType>
-    void removeObservationMatchesIf(PredicateType&& func, bool cleanup_affected = false);
+    void removeObservationMatchesIf(PredicateType&& func, bool cleanup_affected)
+    {
+      removeFromSetIf_(observation_matches_, func);
+      if (cleanup_affected) cleanup();
+    }
+
+    template <typename PredicateType>
+    void removeParentSequencesIf(PredicateType&& func, bool cleanup_affected)
+    {
+      removeFromSetIf_(parents_, func);
+      if (cleanup_affected) cleanup();
+    }
 
     /*!
       @brief Look up a score type by name.

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
@@ -216,18 +216,14 @@ namespace OpenMS
     bool store_original_rt)
   {
     // update RTs in-place:
-    for (IdentificationData::ObservationRef it = id_data.observations_.begin();
-         it != id_data.observations_.end(); ++it)
-    {
-      id_data.observations_.modify(it, [&](IdentificationData::Observation& obs)
-                                   {
-                                     if (store_original_rt)
-                                     {
-                                       storeOriginalRT_(obs, obs.rt);
-                                     }
-                                     obs.rt = trafo.apply(obs.rt);
-                                   });
-    }
+    id_data.applyToObservations([&](IdentificationData::Observation& obs)
+      {
+        if (store_original_rt)
+        {
+          storeOriginalRT_(obs, obs.rt);
+        }
+        obs.rt = trafo.apply(obs.rt);
+      });
   }
 
 }

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -901,7 +901,7 @@ namespace OpenMS
     // predicate to compare the the score of observation matches to a cutoff
     // returns false if the current score is worse than the cutoff
     // returns true otherwise
-    auto is_worse_than_cutoff = [&](IdentificationData::ScoreTypeRef it)->bool 
+    auto is_worse_than_cutoff = [&](IdentificationData::ObservationMatchRef it)->bool 
     { 
       pair<double, bool> score = it->getScore(score_ref);
       return !score.second || score_ref->isBetterScore(cutoff, score.first);

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -901,7 +901,7 @@ namespace OpenMS
     // predicate to compare the the score of observation matches to a cutoff
     // returns false if the current score is worse than the cutoff
     // returns true otherwise
-    auto is_worse_than_cutoff = [&](auto it)->bool 
+    auto is_worse_than_cutoff = [&](IdentificationData::ScoreTypeRef it)->bool 
     { 
       pair<double, bool> score = it->getScore(score_ref);
       return !score.second || score_ref->isBetterScore(cutoff, score.first);

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -879,7 +879,7 @@ namespace OpenMS
     auto best_match_it = best_matches.begin();
 
     // predicate to compare the best match(es) to all (ordered) observation matches
-    // returns false if the current om is a best match (-> not not be removed)
+    // returns false if the current om is a best match (-> not to be removed)
     // returns true if an inferior om was found (-> will be removed)
     auto is_worse_score = [&](IdentificationData::ObservationMatchRef it)->bool 
     { 

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -881,7 +881,7 @@ namespace OpenMS
     // predicate to compare the best match(es) to all (ordered) observation matches
     // returns false if the current om is a best match (-> not to be removed)
     // returns true if an inferior om was found (-> will be removed)
-    auto is_worse_score = [&](IdentificationData::ObservationMatchRef it)->bool 
+    auto has_worse_score = [&](IdentificationData::ObservationMatchRef it)->bool 
     { 
       if (it == *best_match_it)
       {

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -875,50 +875,55 @@ namespace OpenMS
 
     vector<IdentificationData::ObservationMatchRef> best_matches =
       id_data.getBestMatchPerObservation(score_ref);
+
     auto best_match_it = best_matches.begin();
-    for (auto it = id_data.observation_matches_.begin();
-         it != id_data.observation_matches_.end(); )
-    {
+
+    // predicate to compare the best match(es) to all (ordered) observation matches
+    // returns false if the current om is a best match (-> not not be removed)
+    // returns true if an inferior om was found (-> will be removed)
+    auto is_worse_score = [&](IdentificationData::ObservationMatchRef it)->bool 
+    { 
       if (it == *best_match_it)
       {
-        ++it;
         ++best_match_it;
+        return false;
       }
-      else
-      {
-        it = id_data.observation_matches_.erase(it);
-      }
-    }
-
-    id_data.cleanup();
+      return true;
+    };
+    
+    id_data.removeObservationMatchesIf(is_worse_score, true);
   }
 
   void IDFilter::filterObservationMatchesByScore(
     IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref,
     double cutoff)
   {
-    id_data.removeFromSetIf_(
-      id_data.observation_matches_, [&](IdentificationData::ObservationMatchRef it) -> bool
-      {
-        pair<double, bool> score = it->getScore(score_ref);
-        return !score.second || score_ref->isBetterScore(cutoff, score.first);
-      });
-
-    id_data.cleanup();
+    // predicate to compare the the score of observation matches to a cutoff
+    // returns false if the current score is worse than the cutoff
+    // returns true otherwise
+    auto is_worse_than_cutoff = [&](auto it)->bool 
+    { 
+      pair<double, bool> score = it->getScore(score_ref);
+      return !score.second || score_ref->isBetterScore(cutoff, score.first);
+    };
+    
+    id_data.removeObservationMatchesIf(is_worse_than_cutoff, true);
   }
-
 
   void IDFilter::removeDecoys(IdentificationData& id_data)
   {
     Size n_parents = id_data.getParentSequences().size();
-    id_data.removeFromSetIf_(
-      id_data.parents_,
-      [&](IdentificationData::ParentSequenceRef it) -> bool
-      {
-        return it->is_decoy;
-      });
 
-    if (id_data.getParentSequences().size() < n_parents) id_data.cleanup();
+    // predicate to compare the the score of observation matches to a cutoff
+    // returns false if the current score is worse than the cutoff
+    // returns true otherwise
+    auto is_decoy = [&](IdentificationData::ParentSequenceRef it)->bool 
+    { 
+      return it->is_decoy;
+    };
+    
+    id_data.removeParentSequencesIf(is_decoy, false);
+    if (id_data.getParentSequences().size() < n_parents) id_data.cleanup(); // only clean up if sth. removed
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -915,8 +915,8 @@ namespace OpenMS
     Size n_parents = id_data.getParentSequences().size();
 
     // predicate to compare the target/decoy status of a parent sequence
-    // returns false if the current score is worse than the cutoff
-    // returns true otherwise
+    // returns true if decoy
+    // returns false if target
     auto is_decoy = [&](IdentificationData::ParentSequenceRef it)->bool 
     { 
       return it->is_decoy;

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -891,29 +891,27 @@ namespace OpenMS
       return true;
     };
     
-    id_data.removeObservationMatchesIf(is_worse_score, true);
+    id_data.removeObservationMatchesIf(has_worse_score);
   }
 
   void IDFilter::filterObservationMatchesByScore(
     IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref,
     double cutoff)
   {
-    // predicate to compare the the score of observation matches to a cutoff
-    // returns false if the current score is worse than the cutoff
-    // returns true otherwise
+    // predicate to compare the score of observation matches to a cutoff
+    // returns true if the current score is worse than the cutoff
+    // returns false otherwise
     auto is_worse_than_cutoff = [&](IdentificationData::ObservationMatchRef it)->bool 
     { 
       pair<double, bool> score = it->getScore(score_ref);
       return !score.second || score_ref->isBetterScore(cutoff, score.first);
     };
     
-    id_data.removeObservationMatchesIf(is_worse_than_cutoff, true);
+    id_data.removeObservationMatchesIf(is_worse_than_cutoff);
   }
 
   void IDFilter::removeDecoys(IdentificationData& id_data)
   {
-    Size n_parents = id_data.getParentSequences().size();
-
     // predicate to compare the target/decoy status of a parent sequence
     // returns true if decoy
     // returns false if target
@@ -922,8 +920,7 @@ namespace OpenMS
       return it->is_decoy;
     };
     
-    id_data.removeParentSequencesIf(is_decoy, false);
-    if (id_data.getParentSequences().size() < n_parents) id_data.cleanup(); // only clean up if sth. removed
+    id_data.removeParentSequencesIf(is_decoy);
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -881,7 +881,7 @@ namespace OpenMS
     // predicate to compare the best match(es) to all (ordered) observation matches
     // returns false if the current om is a best match (-> not to be removed)
     // returns true if an inferior om was found (-> will be removed)
-    auto has_worse_score = [&](IdentificationData::ObservationMatchRef it)->bool 
+    auto has_worse_score = [&best_match_it](IdentificationData::ObservationMatchRef it)->bool 
     { 
       if (it == *best_match_it)
       {
@@ -914,7 +914,7 @@ namespace OpenMS
   {
     Size n_parents = id_data.getParentSequences().size();
 
-    // predicate to compare the the score of observation matches to a cutoff
+    // predicate to compare the target/decoy status of a parent sequence
     // returns false if the current score is worse than the cutoff
     // returns true otherwise
     auto is_decoy = [&](IdentificationData::ParentSequenceRef it)->bool 

--- a/src/openms/source/METADATA/ID/IdentificationData.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationData.cpp
@@ -60,23 +60,6 @@ namespace OpenMS
     return lookup.count(ref);
   }
 
-  /// Remove elements from a set (or ordered multi_index_container) if they fulfill a predicate
-  template <typename ContainerType, typename PredicateType>
-  static void removeFromSetIf_(ContainerType& container, PredicateType predicate)
-  {
-    for (auto it = container.begin(); it != container.end(); )
-    {
-      if (predicate(it))
-      {
-        it = container.erase(it);
-      }
-      else
-      {
-        ++it;
-      }
-    }
-  }
-
   /// Remove elements from a set (or ordered multi_index_container) if they don't occur in a look-up table
   template <typename ContainerType>
   static void removeFromSetIfNotHashed_(
@@ -1300,13 +1283,6 @@ namespace OpenMS
     if (allow_missing) return old;
     throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                         "no match for reference");
-  }
-  
-  template <typename PredicateType>
-  void IdentificationData::removeObservationMatchesIf(PredicateType&& func, bool cleanup_affected)
-  {
-    removeFromSetIf_(observation_matches_, func);
-    if (cleanup_affected) cleanup();
   }
 
 } // end namespace OpenMS


### PR DESCRIPTION
## Description

- Use C++ style dependency injection/strategy pattern to removed circular dependency caused by making id filtering / map transformation algorithms friends of the ID class.
- moved some local template code to the implementation file

Note that now data and algorithm are separated and could be used, e.g., in external projects that link to OpenMS.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
