### PR TITLE
Fix/thiolmasses

### DIFF
--- a/share/OpenMS/CHEMISTRY/Custom_RNA_modifications.tsv
+++ b/share/OpenMS/CHEMISTRY/Custom_RNA_modifications.tsv
@@ -5,6 +5,7 @@
 name	short_name	new_nomenclature	originating_base	rnamods_abbrev	html_abbrev	formula	monoisotopic_mass	average_mass	alternatives
 3' terminal phosphate	3'-p	33N	pppN	p	p	H2PO3	0.0	0.0
 5' terminal phosphate	5'-p	55N	pppN	p	p	H2PO3	0.0	0.0
+5' terminal phsophorothioate	5'-p*	55N	pppN	p	p	H2PO2S	0.0	0.0
 2',3' terminal cyclophosphate	3'-c	33cN	pppN	p	p	PO2	0.0	0.0
 generic methyladenosine ("m_A")	mA		A	a	a	C11O4N5H15	281.1124	281.2719
 generic methylcytidine ("m_C")	mC		C	c	c	C10O5N3H15	257.1012	257.2467
@@ -37,3 +38,8 @@ thio-adenosine	A*	A*	A	A	A	C10O4N5H13	267.0968	267.2449
 thio-cytidine	C*	C*	C	C	C	C9O5N3H13	243.0855	243.2197
 thio-guanosine	G*	G*	G	G	G	C10O5N5H13	283.0917	283.2442
 thio-uridine	U*	U*	U	U	U	C9O6N2H12	244.0695	244.2043
+thio-deoxyadenosine	dA*	dA*	A			C10O3N5H13	251.1018	251.2424
+thio-deoxycytidine	dC*	dC*	C			C9O4N3H13	227.0906	227.2176
+thio-deoxyguanosine	dG*	dG*	G			C10O4N5H13	267.0968	267.2418
+thio-deoxyuridine	dU*	dU*	U			C9O5N2H12	228.0746	228.2024
+thio-thymidine	dT*	dT*	U			C10O5N2H14	242.0903	242.2290

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -236,10 +236,9 @@ namespace OpenMS
         return our_form + (H_form * charge) + local_five_prime + d_ion_to_full + ((seq_.back()->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case WIon:
-        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
-
+        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full + ((local_five_prime == EmpiricalFormula("H2PO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
       case XIon:
-        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
+        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full + ((local_five_prime == EmpiricalFormula("H2PO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case YIon:
         return our_form + (H_form * charge) + local_three_prime + y_ion_to_full;

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -211,6 +211,7 @@ namespace OpenMS
     {
       local_five_prime = five_prime_->getFormula() - H_form;
     }
+    cout << local_five_prime << endl;
 
     switch (type)
     {
@@ -236,9 +237,9 @@ namespace OpenMS
         return our_form + (H_form * charge) + local_five_prime + d_ion_to_full + ((seq_.back()->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case WIon:
-        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full + ((local_five_prime == EmpiricalFormula("H2PO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
+        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full + ((local_five_prime == EmpiricalFormula("HPO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
       case XIon:
-        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full + ((local_five_prime == EmpiricalFormula("H2PO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
+        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full + ((local_five_prime == EmpiricalFormula("HPO2S")) ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case YIon:
         return our_form + (H_form * charge) + local_three_prime + y_ion_to_full;

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -211,7 +211,6 @@ namespace OpenMS
     {
       local_five_prime = five_prime_->getFormula() - H_form;
     }
-    cout << local_five_prime << endl;
 
     switch (type)
     {

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -236,10 +236,10 @@ namespace OpenMS
         return our_form + (H_form * charge) + local_five_prime + d_ion_to_full + ((seq_.back()->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case WIon:
-        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full; // + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
+        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case XIon:
-        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full; // + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
+        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case YIon:
         return our_form + (H_form * charge) + local_three_prime + y_ion_to_full;

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -122,7 +122,14 @@ namespace OpenMS
     {
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, length, seq_.size() - 1);
     }
-    return NASequence({seq_.end() - length, seq_.end()}, nullptr, three_prime_);
+    // handle situation where we have a thiol at the 5' of our new NASequence (necessary for calculating X and W ions)
+    ConstRibonucleotidePtr threeEnd = nullptr;
+    if (seq_[seq_.size() - length - 1]->getCode().back() == '*')
+    {
+      static RibonucleotideDB* rdb = RibonucleotideDB::getInstance();
+      threeEnd = rdb->getRibonucleotide("5'-p*");
+    }
+    return NASequence({seq_.end() - length, seq_.end()}, threeEnd, three_prime_);
   }
 
   NASequence NASequence::getSubsequence(Size start, Size length) const
@@ -136,6 +143,17 @@ namespace OpenMS
 
     const RibonucleotideChainEnd* five_prime = ((start == 0) ? five_prime_ : nullptr);
     const RibonucleotideChainEnd* three_prime = ((start + length == size()) ? three_prime_ : nullptr);
+    // handle situation where we have a thiol at the 5' of our new NASequence (necessary for calculating X and W ions)
+    if (start > 0 && seq_[start - 1]->getCode().back() == '*' )
+    {
+      cout << seq_[start - 1]->getCode();
+      static RibonucleotideDB* rdb = RibonucleotideDB::getInstance();
+      five_prime = rdb->getRibonucleotide("5'-p*");
+      if (five_prime == nullptr)
+      {
+        OPENMS_LOG_WARN << "NASequence::getSubsequence: subsequence would have both phosphorothiol and other modification at 5', discarding other mod" << endl;
+      }
+    }
     vector<const Ribonucleotide*>::const_iterator it = seq_.begin() + start;
     return NASequence({it, it + length}, five_prime, three_prime);
   }
@@ -218,10 +236,10 @@ namespace OpenMS
         return our_form + (H_form * charge) + local_five_prime + d_ion_to_full + ((seq_.back()->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case WIon:
-        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full; //This calculation can't work for linkages with a thiol on the 5' side
+        return our_form + (H_form * charge) + local_three_prime + w_ion_to_full; // + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case XIon:
-        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full; //This calculation can't work for linkages with a thiol on the 5' side
+        return our_form + (H_form * charge) + local_three_prime + x_ion_to_full; // + ((five_prime_->getCode().back() == '*') ? EmpiricalFormula("SO-1") : EmpiricalFormula(""));
 
       case YIon:
         return our_form + (H_form * charge) + local_three_prime + y_ion_to_full;
@@ -312,6 +330,10 @@ namespace OpenMS
       {
         s = "p";
       }
+      else if (code == "5'-p*")
+      {
+        s = "*";
+      }
       else
       {
         s = "[" + code + "]";
@@ -370,6 +392,11 @@ namespace OpenMS
     if (*str_it == 'p') // special case for 5' phosphate
     {
       nas.setFivePrimeMod(rdb->getRibonucleotide("5'-p"));
+      ++str_it;
+    }
+    else if (*str_it == '*') // special case for 5' phosphorothioate
+    {
+      nas.setFivePrimeMod(rdb->getRibonucleotide("5'-p*"));
       ++str_it;
     }
     String::ConstIterator stop = s.end();

--- a/src/tests/class_tests/openms/source/NASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/NASequence_test.cpp
@@ -305,7 +305,8 @@ START_SECTION((EmpiricalFormula getFormula(NASequence::NASFragmentType type = NA
   TEST_EQUAL(seq.getFormula(NASequence::AminusB, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C5H5O3"));
   // Thiol stuff
   NASequence thiolseq = NASequence::fromString("*[dA*][dA]");
-  TEST_EQUAL(thiolseq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O10P2S1"));
+  TEST_EQUAL(thiolseq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O9P2S2"));
+  TEST_EQUAL(thiolseq.getFormula(NASequence::YIon, -1), EmpiricalFormula("C20H24N10O7P1S1"));
 
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/NASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/NASequence_test.cpp
@@ -217,6 +217,8 @@ START_SECTION((size_t size() const ))
   // don't count terminal phosphate in sequence length:
   seq = NASequence::fromString("pUGG");
   TEST_EQUAL(seq.size(), 3);
+  seq = NASequence::fromString("*UGG");
+  TEST_EQUAL(seq.size(), 3);
   seq = NASequence::fromString("UGGp");
   TEST_EQUAL(seq.size(), 3);
   seq = NASequence::fromString("pUGGp");
@@ -236,6 +238,10 @@ START_SECTION((bool hasFivePrimeMod() const ))
 {
   NASequence aaa = NASequence::fromString("AAA");
   TEST_EQUAL(aaa.hasFivePrimeMod(), false);
+  aaa = NASequence::fromString("pAAA");
+  TEST_EQUAL(aaa.hasFivePrimeMod(), true);
+  aaa = NASequence::fromString("*AAA");
+  TEST_EQUAL(aaa.hasFivePrimeMod(), true);
 }
 END_SECTION
 
@@ -279,6 +285,28 @@ START_SECTION((bool hasThreePrimeMod() const))
 {
   // tested via (void setThreePrimeMod(const RibonucleotideChainEnd* r))
   NOT_TESTABLE
+}
+END_SECTION
+
+
+START_SECTION((EmpiricalFormula getFormula(NASequence::NASFragmentType type = NASequence::Full, Int charge = 0) const))
+{
+  NASequence seq = NASequence::fromString("GG");
+  TEST_EQUAL(seq.getFormula(NASequence::Full, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H12N5O5"));
+  TEST_EQUAL(seq.getFormula(NASequence::Full, -2), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H11N5O5"));
+  TEST_EQUAL(seq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O15P2"));
+  TEST_EQUAL(seq.getFormula(NASequence::XIon, -1), EmpiricalFormula("C20H23N10O14P2"));
+  TEST_EQUAL(seq.getFormula(NASequence::YIon, -1), EmpiricalFormula("C10H12N5O6P") + EmpiricalFormula("C10H12N5O6"));
+  TEST_EQUAL(seq.getFormula(NASequence::ZIon, -1), EmpiricalFormula("C20H22N10O11P"));
+  TEST_EQUAL(seq.getFormula(NASequence::AIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H10N5O4"));
+  TEST_EQUAL(seq.getFormula(NASequence::BIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H12N5O5"));
+  TEST_EQUAL(seq.getFormula(NASequence::CIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H11N5O7P"));
+  TEST_EQUAL(seq.getFormula(NASequence::DIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H13N5O8P"));
+  TEST_EQUAL(seq.getFormula(NASequence::AminusB, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C5H5O3"));
+  // Thiol stuff
+  NASequence thiolseq = NASequence::fromString("*[dA*][dA]");
+  TEST_EQUAL(thiolseq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O10P2S1"));
+
 }
 END_SECTION
 
@@ -334,23 +362,6 @@ START_SECTION((double getAverageWeight(NASequence::NASFragmentType type = NASequ
   seq = NASequence::fromString("[ms2i6A]AACCGp");
   TEST_REAL_SIMILAR(seq.getAverageWeight(NASequence::WIon, -2) / 2, 1076.045 + 0.651);
   TEST_REAL_SIMILAR(seq.getAverageWeight(NASequence::YIon, -2) / 2, 1036.459 + 0.247);
-}
-END_SECTION
-
-START_SECTION((EmpiricalFormula getFormula(NASequence::NASFragmentType type = NASequence::Full, Int charge = 0) const))
-{
-  NASequence seq = NASequence::fromString("GG");
-  TEST_EQUAL(seq.getFormula(NASequence::Full, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H12N5O5"));
-  TEST_EQUAL(seq.getFormula(NASequence::Full, -2), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H11N5O5"));
-  TEST_EQUAL(seq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O15P2"));
-  TEST_EQUAL(seq.getFormula(NASequence::XIon, -1), EmpiricalFormula("C20H23N10O14P2"));
-  TEST_EQUAL(seq.getFormula(NASequence::YIon, -1), EmpiricalFormula("C10H12N5O6P") + EmpiricalFormula("C10H12N5O6"));
-  TEST_EQUAL(seq.getFormula(NASequence::ZIon, -1), EmpiricalFormula("C20H22N10O11P"));
-  TEST_EQUAL(seq.getFormula(NASequence::AIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H10N5O4"));
-  TEST_EQUAL(seq.getFormula(NASequence::BIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H12N5O5"));
-  TEST_EQUAL(seq.getFormula(NASequence::CIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H11N5O7P"));
-  TEST_EQUAL(seq.getFormula(NASequence::DIon, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C10H13N5O8P"));
-  TEST_EQUAL(seq.getFormula(NASequence::AminusB, -1), EmpiricalFormula("C10H12N5O7P") + EmpiricalFormula("C5H5O3"));
 }
 END_SECTION
 
@@ -415,25 +426,32 @@ END_SECTION
 
 START_SECTION((NASequence getSuffix(Size length) const))
 {
-  NASequence seq = NASequence::fromString("A[ms2i6A]AACCGp");
-  NASequence seq2 = NASequence::fromString("[ms2i6A]AACCGp");
-  NASequence seq3 = NASequence::fromString("AAACCG");
-  NASequence seq4 = NASequence::fromString("CCG");
+  NASequence seq = NASequence::fromString("A[ms2i6A]AACAGp");
+  NASequence seq2 = NASequence::fromString("[ms2i6A]AACAGp");
+  NASequence seq3 = NASequence::fromString("AAACAG");
+  NASequence seq4 = NASequence::fromString("CAG");
+  NASequence seq5 = NASequence::fromString("[C*]AG");
+  NASequence seq6 = NASequence::fromString("*AG");
   TEST_EQUAL(seq.getSuffix(6),seq2);
   TEST_EQUAL(seq3.getSuffix(3),seq4);
   TEST_NOT_EQUAL(seq.getSuffix(3),seq2);
   TEST_NOT_EQUAL(seq.getSuffix(3),seq4);
   TEST_EXCEPTION(Exception::IndexOverflow, seq.getSuffix(10));
+  // Check that we handle the weird case of thiol
+  TEST_STRING_EQUAL(seq5.getSuffix(2).toString(), seq6.toString() );
 }
 END_SECTION
 
 START_SECTION((NASequence getSubsequence(Size start, Size length) const))
 {
   NASequence seq = NASequence::fromString("pAUCGp");
+  NASequence seq5 = NASequence::fromString("[C*]AG");
   TEST_STRING_EQUAL(seq.getSubsequence().toString(), "pAUCGp");
   TEST_STRING_EQUAL(seq.getSubsequence(1).toString(), "UCGp");
   TEST_STRING_EQUAL(seq.getSubsequence(0, 2).toString(), "pAU");
   TEST_STRING_EQUAL(seq.getSubsequence(2, 1).toString(), "C");
+  //thiol stuff
+  TEST_STRING_EQUAL(seq5.getSubsequence(1).toString(), "*AG");
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/NASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/NASequence_test.cpp
@@ -307,7 +307,6 @@ START_SECTION((EmpiricalFormula getFormula(NASequence::NASFragmentType type = NA
   NASequence thiolseq = NASequence::fromString("*[dA*][dA]");
   TEST_EQUAL(thiolseq.getFormula(NASequence::WIon, -1), EmpiricalFormula("C20H25N10O9P2S2"));
   TEST_EQUAL(thiolseq.getFormula(NASequence::YIon, -1), EmpiricalFormula("C20H24N10O7P1S1"));
-
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

Fixes an issue where `getSuffix` returned the incorrect mass and composition for thiol backbones

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
