### PR TITLE
[Fix] pyopenms assets don't copy folders

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -56,7 +56,10 @@ function(_copy_assets _asset_dir _regex _target_dir)
   foreach(_asset_file ${_assets})
     # make path relative
     file(RELATIVE_PATH _relative_path ${_asset_dir} ${_asset_file})
-    configure_file(${_asset_file} ${_target_dir}/${_relative_path} COPYONLY)
+    # check if the asset is a directory
+    if(NOT IS_DIRECTORY ${_asset_file})
+      configure_file(${_asset_file} ${_target_dir}/${_relative_path} COPYONLY)
+    endif()
   endforeach()
 endfunction()
 


### PR DESCRIPTION
## Description

Fixes #6458.
In the `_copy_assets` function `configure_file` expects a file and fails if a directory is given (e.g. a `__pycache__` folder. Here, a check is implemented to prevent that.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
