### PR TITLE
allow percolatoradapter to properly handle a corner cases when same peptide had the same scan number in merged files

### DIFF
--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -381,7 +381,6 @@ protected:
     }
   }
 
-    
   void readPoutAsMap_(const String& pout_file, std::map<String, PercolatorResult>& pep_map)
   {
     CsvFile csv_file(pout_file, '\t');
@@ -391,7 +390,7 @@ protected:
     {
       csv_file.getRow(i, row);
       PercolatorResult res(row);
-      String spec_ref = res.PSMId + res.peptide;
+      String spec_ref = res.PSMId + res.peptide; // note: PSMid from percolator is composed of filename + spectrum native id
       writeDebug_("PSM identifier in pout file: " + spec_ref, 10);
 
       // retain only the best result in the unlikely case that a PSMId+peptide combination occurs multiple times
@@ -1048,12 +1047,13 @@ protected:
         pep_id.setHigherScoreBetter(scoreType == "svm");
         
         String scan_identifier = PercolatorInfile::getScanIdentifier(pep_id, index);
+        String file_identifier = pep_id.getMetaValue("file_origin", String());
         
         //check each PeptideHit for compliance with one of the PercolatorResults (by sequence)
         for (PeptideHit& hit : pep_id.getHits())
         {
           String peptide_sequence = hit.getSequence().toBracketString(false, true);
-          String psm_identifier = scan_identifier + peptide_sequence;
+          String psm_identifier = file_identifier + scan_identifier + peptide_sequence;
 
           //Only for super debug
           writeDebug_("PSM identifier in PeptideHit: " + psm_identifier, 10);


### PR DESCRIPTION
## Description

Allows percolator to properly map back percolated results in cases of merged files with same peptide and same scan number.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
