### PR TITLE
TOPPView: fix Ctrl-w and Ctrl-a not working and support recent dir for File->Open

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/EnhancedWorkspace.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/EnhancedWorkspace.h
@@ -60,6 +60,14 @@ public:
     /// Destructor
     ~EnhancedWorkspace() override;
 
+    /// Adds a subwindow to the QMdiArea
+    /// Qt will add a System menu (which shows when you right-click on the subwindows' local top bar).
+    /// This menu will contain a shortcut for Ctrl-W, which makes our custom Ctrl-W in TOPPView's menu ambiguous.
+    /// Upon pressing it, you will get a `QAction::event: Ambiguous shortcut overload: Ctrl+W` on the console and no triggered signal.
+    /// To prevent this we simply set the SystemMenu to null (no menu will show when you right-click).
+    /// If you do not want that, call Qt's overload of addSubWindow
+    QMdiSubWindow* addSubWindow(QWidget* widget);
+
     /// arrange all windows horizontally
     void tileHorizontal();
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1632,11 +1632,6 @@ namespace OpenMS
 
   QStringList TOPPViewBase::chooseFilesDialog_(const String& path_overwrite)
   {
-    // store active sub window
-    // TODO Why is this done? And why only here?
-    QMdiSubWindow* old_active = ws_.currentSubWindow();
-    RAIICleanup clean([&]() { ws_.setActiveSubWindow(old_active); });
-
     QString open_path = current_path_.toQString();
     if (!path_overwrite.empty())
     {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1402,6 +1402,7 @@ namespace OpenMS
   void TOPPViewBase::showPlotWidgetInWindow(PlotWidget* sw)
   {
     ws_.addSubWindow(sw);
+
     connect(sw->canvas(), &PlotCanvas::preferencesChange, this, &TOPPViewBase::updateLayerBar);
     connect(sw->canvas(), &PlotCanvas::layerActivated, this, &TOPPViewBase::layerActivated);
     connect(sw->canvas(), &PlotCanvas::layerModficationChange, this, &TOPPViewBase::updateLayerBar);

--- a/src/openms_gui/source/VISUAL/EnhancedWorkspace.cpp
+++ b/src/openms_gui/source/VISUAL/EnhancedWorkspace.cpp
@@ -54,6 +54,16 @@ namespace OpenMS
 
   EnhancedWorkspace::~EnhancedWorkspace() = default;
 
+  QMdiSubWindow* EnhancedWorkspace::addSubWindow(QWidget* widget)
+  {
+    auto subwindow = QMdiArea::addSubWindow(widget);
+    if (subwindow)
+    {
+      subwindow->setSystemMenu(nullptr);
+    }
+    return subwindow;
+  }
+
   void EnhancedWorkspace::tileHorizontal()
   {
     // primitive horizontal tiling

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -545,8 +545,8 @@ namespace OpenMS
       getCurrentLayer().getCurrentAnnotations().removeSelectedItems();
       update_(OPENMS_PRETTY_FUNCTION);
     }
-    // 'a' pressed && in zoom mode (Ctrl pressed) => select all annotation items
-    else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_A))
+    // 'b' pressed && in zoom mode (Ctrl pressed) => select all annotation items
+    else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_B))
     {
       e->accept();
       getCurrentLayer().getCurrentAnnotations().selectAll();

--- a/src/openms_gui/source/VISUAL/TOPPViewMenu.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewMenu.cpp
@@ -74,7 +74,9 @@ namespace OpenMS
     m_file->setToolTipsVisible(true);
     parent->menuBar()->addMenu(m_file);
 
-    m_file->addAction("&Open file", parent, &TOPPViewBase::openFilesByDialog, Qt::CTRL + Qt::Key_O);
+    m_file->addAction( // we explicitly pass an empty Path here using a Lambda, since using the default `..., parent, &TOPPViewBase::openFilesByDialog, ...`)
+                       // passes a "0" as argument (Qt bug?)
+      "&Open file", parent, [parent]() { parent->openFilesByDialog(""); }, Qt::CTRL + Qt::Key_O);
     m_file->addAction("Open &example file", parent, [parent]() { parent->openFilesByDialog(File::getOpenMSDataPath() + "/examples/"); }, Qt::CTRL + Qt::Key_E);
     addAction_(m_file->addAction("&Close tab", parent, &TOPPViewBase::closeTab, Qt::CTRL + Qt::Key_W),
                TV_STATUS::HAS_CANVAS);


### PR DESCRIPTION
## Description

fixes #6670.
 - Ctrl-W is fixed
 - Ctrl-A was ambiguous. Solved by moving selection of all annotations in 1D to `Ctrl-B` (fix for the docs is is here https://github.com/OpenMS/OpenMS-docs/pull/191).

fixes #6642:
 - this used to work previously, but (recently?) Qt seems to pass a `0` by default as first argument, which disabled the automatic switch to the current directory of the shown layer. This is fixed now.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
