### PR TITLE
fixes #6652 (segfault when editing/deleting peak annotation)

### DIFF
--- a/src/openms_gui/source/VISUAL/LayerData1DPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData1DPeak.cpp
@@ -61,12 +61,12 @@ namespace OpenMS
   QMenu* LayerData1DPeak::getContextMenuAnnotation(Annotation1DItem* annot_item, bool& need_repaint)
   {
     auto* context_menu = new QMenu("Peak1D", nullptr);
-    context_menu->addAction("Edit", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope then the menu is evaluated!
+    context_menu->addAction("Edit", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope when the menu is evaluated!
       annot_item->editText();
       synchronizePeakAnnotations();
       need_repaint = true;
     });
-    context_menu->addAction("Delete", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope then the menu is evaluated!
+    context_menu->addAction("Delete", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope when the menu is evaluated!
       vector<Annotation1DItem*> as;
       as.push_back(annot_item);
       removePeakAnnotationsFromPeptideHit(as);

--- a/src/openms_gui/source/VISUAL/LayerData1DPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData1DPeak.cpp
@@ -61,12 +61,12 @@ namespace OpenMS
   QMenu* LayerData1DPeak::getContextMenuAnnotation(Annotation1DItem* annot_item, bool& need_repaint)
   {
     auto* context_menu = new QMenu("Peak1D", nullptr);
-    context_menu->addAction("Edit", [&]() {
+    context_menu->addAction("Edit", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope then the menu is evaluated!
       annot_item->editText();
       synchronizePeakAnnotations();
       need_repaint = true;
     });
-    context_menu->addAction("Delete", [&]() {
+    context_menu->addAction("Delete", [annot_item, &need_repaint, this]() { // this capture is tricky! Copy 'annot_item' since its a local variable and will be out of scope then the menu is evaluated!
       vector<Annotation1DItem*> as;
       as.push_back(annot_item);
       removePeakAnnotationsFromPeptideHit(as);


### PR DESCRIPTION
## Description

... caused by capturing local vars in a lambda by reference. The lambda however is evaluated after the local scope ends.
Boom! :/

Fixes #6652.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
