### PR TITLE
[pyOpenMS ]fixing grid error from plotting.py  (due to matplotlib update)

### DIFF
--- a/src/pyOpenMS/pyopenms/plotting.py
+++ b/src/pyOpenMS/pyopenms/plotting.py
@@ -193,9 +193,10 @@ import itertools
 
 colors = {'a': '#388E3C', 'b': '#1976D2', 'c': '#00796B',
           'x': '#7B1FA2', 'y': '#D32F2F', 'z': '#F57C00',
-          '?': '#212121', 'f': '#212121', None: '#212121'}
-zorders = {'a': 3, 'b': 4, 'c': 3, 'x': 3, 'y': 4, 'z': 3, '?': 2, 'f': 5,
-           None: 1}
+          'p': '#512DA8', '?': '#212121', 'f': '#212121', None: '#212121'}
+zorders = {'a': 3, 'b': 4, 'c': 3, 'x': 3, 'y': 4, 'z': 3,
+           'p': 3, '?': 2, 'f': 5, None: 1}
+
 
 
 # TODO switch to forward declarations via from __future__ import annotations
@@ -251,6 +252,8 @@ def _annotate_ion(mz: float, intensity: float, annotation: Optional[str],
         return colors.get(None), zorders.get(None)
     # Else: Add the textual annotation.
     ion_type = annotation[0]
+    if ion_type == '[': # precursor ion
+        ion_type = 'p'
     if ion_type not in colors and color_ions:
         raise ValueError('Ion type not supported')
 

--- a/src/pyOpenMS/pyopenms/plotting.py
+++ b/src/pyOpenMS/pyopenms/plotting.py
@@ -353,9 +353,9 @@ def plot_spectrum(spectrum: "MSSpectrum", color_ions: bool = True,
     ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
     ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())
     if grid in (True, 'both', 'major'):
-        ax.grid(b=True, which='major', color='#9E9E9E', linewidth=0.2)
+        ax.grid(visible=True, which='major', color='#9E9E9E', linewidth=0.2)
     if grid in (True, 'both', 'minor'):
-        ax.grid(b=True, which='minor', color='#9E9E9E', linewidth=0.2)
+        ax.grid(visible=True, which='minor', color='#9E9E9E', linewidth=0.2)
     ax.set_axisbelow(True)
 
     ax.tick_params(axis='both', which='both', labelsize='small')

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -258,7 +258,8 @@ setup(
     },
 	install_requires=[
           'numpy',
-          'pandas'
+          'pandas',
+          'matplotlib'
     ],
 
     version=package_version,

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -259,7 +259,7 @@ setup(
 	install_requires=[
           'numpy',
           'pandas',
-          'matplotlib'
+          'matplotlib>=3.5'
     ],
 
     version=package_version,


### PR DESCRIPTION
Fixing two issues. in #6701 
1. With the matplotlib update, parameter "b" in grid has changed it's name to "visible"
2. Add precursor ion in ion type

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
