### PR TITLE
Fix TV crash

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h
@@ -173,17 +173,19 @@ public:
       }
 
       text = "<font color=\"" + color_.name() + "\">" + text + "</font>";
-      QTextDocument td;
-      td.setHtml(text);
 
       // draw html text
-      painter.save();
-      double w = td.size().width();
-      double h = td.size().height();
-      painter.translate(position_widget.x() - w / 2, position_widget.y() - h / 2);
-      td.drawContents(&painter);
-      painter.restore();
-
+      {
+        QTextDocument td;
+        td.setHtml(text);
+        painter.save();
+        double w = td.size().width();
+        double h = td.size().height();
+        painter.translate(position_widget.x() - w / 2, position_widget.y() - h / 2);
+        td.drawContents(&painter);
+        painter.restore();
+      }
+      
       if (selected_)
       {
         drawBoundingBox_(painter);

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
@@ -42,7 +42,7 @@ namespace OpenMS
   Annotations1DContainer::Annotations1DContainer() = default;
 
   Annotations1DContainer::Annotations1DContainer(const Annotations1DContainer& rhs)
-    : Base(rhs)
+    : Base() // do not copy items here. They need cloning!
   {
     // copy annotations
     for (auto item : rhs)


### PR DESCRIPTION
## Description

... when adding a custom peak annotation in 1D view, then switching to another spectrum, and switching back to the old spectrum.
Caused by copying a raw pointer which is invalid when returning to the original spec.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
