### PR TITLE
Add action to test nightly conda pyOpenMS

### DIFF
--- a/.github/workflows/test_pyopenms_conda_nightly.yml
+++ b/.github/workflows/test_pyopenms_conda_nightly.yml
@@ -1,0 +1,58 @@
+# Installs pyOpenMS from the conda nightly channel on Linux, macOS and Windows
+# on the python versions defined in the file python_versions.json
+# and runs a simple test
+
+name: test_pyopenms_conda_nightly
+
+on:
+  workflow_dispatch: # Trigger manually
+  workflow_run:
+    workflows: [ pyopenms-wheels ]
+    types:
+        - completed
+
+jobs:
+  test:
+    needs: read-python-versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:     
+      - name: Install Miniconda
+        shell: bash
+        run: |
+            if [[ "${{ runner.os }}" == "Linux" ]]; then
+              MINICONDA_FILENAME=Miniconda3-latest-Linux-x86_64.sh
+              curl -o $MINICONDA_FILENAME "https://repo.anaconda.com/miniconda/$MINICONDA_FILENAME"
+              bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
+            elif [[ "${{ runner.os }}" == "macOS" ]]; then
+              MINICONDA_FILENAME=Miniconda3-latest-MacOSX-x86_64.sh
+              curl -o $MINICONDA_FILENAME "https://repo.anaconda.com/miniconda/$MINICONDA_FILENAME"
+              bash ${MINICONDA_FILENAME} -b -f -p $HOME/miniconda3
+            elif [[ "${{ runner.os }}" == "Windows" ]]; then
+              MINICONDA_FILENAME=Miniconda3-latest-Windows-x86_64.exe
+              curl -o $MINICONDA_FILENAME "https://repo.anaconda.com/miniconda/$MINICONDA_FILENAME"
+              ./Miniconda3-latest-Windows-x86_64.exe //InstallationType=JustMe //RegisterPython=0 //S
+            fi
+          
+      - name: Setup conda paths
+        shell: bash
+        run: |
+          echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+          echo "$HOME/miniconda3/Scripts" >> $GITHUB_PATH
+          
+      - name: Run tests
+        run: |
+          PYTHON_VERSIONS=$(cat python_versions.json | jq -r '.[] | @sh')
+          for py in $PYTHON_VERSIONS
+          do
+            conda create -n pyoms-$py python=$py
+            source activate pyoms-$py
+            conda install -c openms pyopenms
+            python -c "import sys;
+            import pyopenms;
+            print(sys.version);
+            seq = pyopenms.AASequence.fromString('DFPIANGER');
+            print(seq.toString());
+            seq.getMonoWeight()"


### PR DESCRIPTION
Installs Miniconda on three VMs for the three OSes.
Installs pyOpenMS in different conda environments for the specified python versions in each VM.
Runs a trivial test.
Triggered by successful execution of the pyopenms-wheels workflow.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
