### PR TITLE
[fix] enable adducts in NASE test

### DIFF
--- a/src/tests/topp/NucleicAcidSearchEngine_1.ini
+++ b/src/tests/topp/NucleicAcidSearchEngine_1.ini
@@ -24,7 +24,7 @@
         <ITEM name="max_charge" value="-14" type="int" description="Maximum precursor charge to be considered" required="false" advanced="false" />
         <ITEM name="include_unknown_charge" value="true" type="string" description="Include MS2 spectra with unknown precursor charge - try to match them in any possible charge between &apos;min_charge&apos; and &apos;max_charge&apos;, at the risk of a higher error rate" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="use_avg_mass" value="false" type="string" description="Use average instead of monoisotopic precursor masses (appropriate for low-resolution instruments)" required="false" advanced="false" restrictions="true,false" />
-        <ITEM name="use_adducts" value="false" type="string" description="Consider possible salt adducts (see &apos;precursor:potential_adducts&apos;) when matching precursor masses" required="false" advanced="false" restrictions="true,false" />
+        <ITEM name="use_adducts" value="true" type="string" description="Consider possible salt adducts (see &apos;precursor:potential_adducts&apos;) when matching precursor masses" required="false" advanced="false" restrictions="true,false" />
         <ITEMLIST name="potential_adducts" type="string" description="Adducts considered to explain mass differences. Format: &apos;Element:Charge(+/-)&apos;, i.e. the number of &apos;+&apos; or &apos;-&apos; indicates the charge, e.g. &apos;Ca:++&apos; indicates +2. Only used if &apos;precursor:use_adducts&apos; is set." required="false" advanced="false">
           <LISTITEM value="K:+"/>
           <LISTITEM value="Na:+"/>


### PR DESCRIPTION
## Description

Added adducts to NASE test. Catches regressions like https://github.com/OpenMS/OpenMS/issues/6757.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
