### PR TITLE
fix memory leak in ElementDB (when overwriting existing elements) and…

### DIFF
--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -38,8 +38,10 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CHEMISTRY/Element.h>
+
 #include <iostream>
 #include <cmath>
+#include <memory>
 
 using namespace std;
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -155,6 +155,18 @@ namespace OpenMS
     else return 0.0;
   }
 
+  
+  template<class CONT, class KEY, class REPL>
+  void checkedAddNoReplace(CONT& container, const KEY& key, REPL replacement)
+  {
+    auto elem = container.find(key);
+    if (elem != container.end())
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(key), "Already exists!");
+    }
+    container[key] = replacement;
+  }
+
   void ElementDB::storeElements_()
   {	
     map<unsigned int, double> hydrogen_abundance = {{1u, 0.999885}, {2u, 0.000115}, {3u, 0.0}};
@@ -592,13 +604,14 @@ namespace OpenMS
 
     // special case for deuterium and tritium
     const Element* deuterium = getElement("(2)H");
-    symbols_["D"] = deuterium;
+    checkedAddNoReplace(symbols_, "D", deuterium);
     const Element* tritium = getElement("(3)H");
-    symbols_["T"] = tritium;
+    checkedAddNoReplace(symbols_, "T", tritium);
 
     // Pu, Am, Cm, Bk, Cf, Es, Fm, Md, No, Lr, Rf, Db, Sg, Bh, Hs, Mt, Ds, Rg, Cn, Nh, Fl, Mc, Lv, Ts and Og Abundances are not known.
 
   }
+
 
   void ElementDB::buildElement_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
   {
@@ -609,6 +622,27 @@ namespace OpenMS
     Element* e = new Element(name, symbol, an, avg_weight, mono_weight, isotopes);
     addElementToMaps_(name, symbol, an, e);
     storeIsotopes_(name, symbol, an, mass, isotopes);
+  }
+
+  void overwrite(const Element* old, std::unique_ptr<const Element>& new_e)
+  {
+    if (old->getSymbol() != new_e->getSymbol())
+    { // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
+                                    "Replacing element with name " + old->getName() + " and symbol " + old->getSymbol() + " has different new symbol: " + new_e->getSymbol());
+    }
+    if (old->getName() != new_e->getName())
+    { // -- this would invalidate the lookup, since e_ptr->getName().at("Oxygen")->getName() == 'Something'
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(), "Replacing element with name " + old->getName() + " has different new name: " + new_e->getName());
+    }
+    if (old->getAtomicNumber() != new_e->getAtomicNumber())
+    { // -- this would invalidate the lookup, since e_ptr->getAtomicNumbers().at(12)->getAtomicNumber() == 14
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
+                                    "Replacing element with atomic number " + String(old->getAtomicNumber()) + " has different new atomic number: " + String(new_e->getAtomicNumber()));
+    }
+    // ... overwrite
+    *(const_cast<Element*>(old)) = *new_e;
+    new_e.release();
   }
 
   void ElementDB::addElementToMaps_(const string& name, const string& symbol, const unsigned int an, const Element* e)
@@ -622,15 +656,15 @@ namespace OpenMS
         // in order to ensure that existing elements are still valid and memory
         // addresses do not change, we have to modify the Element in place
         // instead of replacing it.
-        const Element* const_ele = atomic_numbers_[an];
-        Element* element = const_cast<Element*>(const_ele);
-        *element = *e; // copy all data from input to the existing element
+        unique_ptr<const Element> pe;
+        pe.reset(e);
+        overwrite(atomic_numbers_[an], pe);
       }
       else
       {
-        names_[name] = e;
-        symbols_[symbol] = e;
-        atomic_numbers_[an] = e;
+        checkedAddNoReplace(names_, name, e);
+        checkedAddNoReplace(symbols_, symbol, e);
+        checkedAddNoReplace(atomic_numbers_, an, e);
       }
     }
   }
@@ -652,9 +686,17 @@ namespace OpenMS
       iso_container.push_back(Peak1D(atomic_mass, 1.0));
       iso_isotopes.set(iso_container);  
 
-      Element* iso_e = new Element(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
-      names_[iso_name] = iso_e;
-      symbols_[iso_symbol] = iso_e;
+      auto iso_e = make_unique<const Element>(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
+      if (auto has_elem = names_.find(iso_name); has_elem != names_.end())
+      { // already exists: overwrite (affects all maps, since they all point to the same thing)
+        overwrite(has_elem->second, iso_e);
+      }
+      else
+      {
+        auto ele = iso_e.release();
+        checkedAddNoReplace(names_, iso_name, ele);
+        checkedAddNoReplace(symbols_, iso_symbol, ele);
+      }
     } 
   }
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -135,6 +135,11 @@ START_SECTION(void addElement(const std::string& name,
   // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
   TEST_EQUAL(oxygen, new_oxygen)
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 16.8994405) // average weight has changed
+
+  // cannot add invalid element (name and symbol conflict when compared existing element 
+  // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
+  TEST_EXCEPTION(Exception::InvalidValue, e_ptr->addElement("Oxygen", "P", 8u, oxygen_abundance, oxygen_mass, true))
+
 }
 END_SECTION
 


### PR DESCRIPTION
… make it more robust against invalid element configurations (where elements and symbols are inconsistent)

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
