### PR TITLE
Enable mass trace quantification method median with smoothing enabled

### DIFF
--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -342,7 +342,8 @@ namespace OpenMS
           case MT_QUANT_AREA:
             return computeFwhmAreaSmooth();
           case MT_QUANT_MEDIAN:
-            throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+            // median quantification (e.g. for direct infusion data) should work indepentently from smoothing
+            return computeMedianIntensity_();
           case MT_QUANT_HEIGHT:
             return getMaxIntensity(true);
           default:


### PR DESCRIPTION
## Description

With `FeatureFinderMetabo` quantification method `median` AND smoothing enabled, an exception is raised that this method is not implemented yet. However, for some applications like direct infusion median is the appropriate method and should be allowed even if smoothing is enabled (default). Here, the intensity is computed with the median method regardless of smoothing. The feature intensities are the same in both cases. This fixes an unnecessary error with this combination of parameters and should make it easier for people who need to use the median quantification method, they don't need to disable smoothing.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
