### PR TITLE
only calculate features if not already annotated by comet

### DIFF
--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -180,8 +180,8 @@ namespace OpenMS
     {
 
       feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
-      feature_set.push_back("COMET:deltCn"); // recalculated deltCn = (current_XCorr - 2nd_best_XCorr) / max(current_XCorr, 1)
-      feature_set.push_back("COMET:deltLCn"); // deltLCn = (current_XCorr - worst_XCorr) / max(current_XCorr, 1)
+      feature_set.push_back("COMET:deltaCn"); // recalculated deltaCn = (current_XCorr - 2nd_best_XCorr) / max(current_XCorr, 1)
+      feature_set.push_back("COMET:deltaLCn"); // deltaLCn = (current_XCorr - worst_XCorr) / max(current_XCorr, 1)
       feature_set.push_back("COMET:lnExpect"); // log(E-value)
       feature_set.push_back("MS:1002252"); // unchanged XCorr
       feature_set.push_back("MS:1002255"); // unchanged Sp = number of candidate peptides
@@ -203,33 +203,52 @@ namespace OpenMS
         
         for (vector<PeptideHit>::iterator hit = it->getHits().begin(); hit != it->getHits().end(); ++hit)
         {
+
           double xcorr = hit->getMetaValue("MS:1002252").toString().toDouble();
-          double delta_cn = (xcorr - second_xcorr) / max(1.0, xcorr);
-          double delta_last_cn = (xcorr - worst_xcorr) / max(1.0, xcorr);
-          hit->setMetaValue("COMET:deltCn", delta_cn);
-          hit->setMetaValue("COMET:deltLCn", delta_last_cn);
+
+          if (!hit->metaValueExists("COMET:deltaCn"))
+          {
+            double delta_cn = (xcorr - second_xcorr) / max(1.0, xcorr);
+            hit->setMetaValue("COMET:deltaCn", delta_cn);
+          }
+
+          if (!hit->metaValueExists("COMET:deltaLCn"))
+          {
+            double delta_last_cn = (xcorr - worst_xcorr) / max(1.0, xcorr);
+            hit->setMetaValue("COMET:deltaLCn", delta_last_cn);
+          }
           
           double ln_expect = log(hit->getMetaValue("MS:1002257").toString().toDouble());
           hit->setMetaValue("COMET:lnExpect", ln_expect);
-         
-          double ln_num_sp;   
-          if (hit->metaValueExists("num_matched_peptides"))
+
+          if (!hit->metaValueExists("COMET:lnNumSP"))
           {
-            double num_sp = hit->getMetaValue("num_matched_peptides").toString().toDouble();
-            ln_num_sp = log(max(1.0, num_sp));  // if recorded, one can be safely assumed
+            double ln_num_sp;   
+            if (hit->metaValueExists("num_matched_peptides"))
+            {
+              double num_sp = hit->getMetaValue("num_matched_peptides").toString().toDouble();
+              ln_num_sp = log(max(1.0, num_sp));  // if recorded, one can be safely assumed
+            }
+            else // fallback TODO: remove?
+            {
+              ln_num_sp = hit->getMetaValue("MS:1002255").toString().toDouble();
+            }  
+            hit->setMetaValue("COMET:lnNumSP", ln_num_sp);
           }
-          else // fallback
+
+          if (!hit->metaValueExists("COMET:lnRankSP"))
+          {          
+            double ln_rank_sp = log(max(1.0, hit->getMetaValue("MS:1002256").toString().toDouble()));
+            hit->setMetaValue("COMET:lnRankSP", ln_rank_sp);
+          }
+
+          if (!hit->metaValueExists("COMET:IonFrac"))
           {
-            ln_num_sp = hit->getMetaValue("MS:1002255").toString().toDouble();
+            double num_matched_ions = hit->getMetaValue("MS:1002258").toString().toDouble();
+            double num_total_ions = hit->getMetaValue("MS:1002259").toString().toDouble();
+            double ion_frac = num_matched_ions / num_total_ions;
+            hit->setMetaValue("COMET:IonFrac", ion_frac);
           }
-          double ln_rank_sp = log(max(1.0, hit->getMetaValue("MS:1002256").toString().toDouble()));
-          hit->setMetaValue("COMET:lnNumSP", ln_num_sp);
-          hit->setMetaValue("COMET:lnRankSP", ln_rank_sp);
-          
-          double num_matched_ions = hit->getMetaValue("MS:1002258").toString().toDouble();
-          double num_total_ions = hit->getMetaValue("MS:1002259").toString().toDouble();
-          double ion_frac = num_matched_ions / num_total_ions;
-          hit->setMetaValue("COMET:IonFrac", ion_frac);
         }
       }
     }

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1212,6 +1212,7 @@ namespace OpenMS
         if (search_engine_ == "Comet")
         {
           peptide_hit_.setMetaValue("MS:1002252", value); // name: Comet:xcorr
+          peptide_hit_.setMetaValue("COMET:xcorr", value); // name: COMET:xcorr
         }
         else
         {
@@ -1243,46 +1244,52 @@ namespace OpenMS
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("MS:1002253", value); // name: Comet:deltacn
+          peptide_hit_.setMetaValue("COMET:deltaCn", value);
         }
         else if (name == "spscore")
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("MS:1002255", value); // name: Comet:spscore
+          peptide_hit_.setMetaValue("COMET:spscore", value); // name: Comet:spscore
         }
         else if (name == "sprank")
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("MS:1002256", value); // name: Comet:sprank
+          peptide_hit_.setMetaValue("COMET:sprank", value); // name: Comet:sprank
         }
         else if (name == "deltacnstar")
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("MS:1002254", value); // name: Comet:deltacnstar
+          peptide_hit_.setMetaValue("COMET:deltacnstar", value); // name: Comet:deltacnstar
         }
         else if (name == "lnrSp")
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("Comet:lnrSp", value); // name: Comet:lnrSp
-        }
+          peptide_hit_.setMetaValue("COMET:lnRankSP", value); // name: COMET:lnRankSP
+        }              
         else if (name == "deltLCn")
         {
           value = attributeAsDouble_(attributes, "value");
-          peptide_hit_.setMetaValue("Comet:deltLCn", value); // name: Comet:deltLCn
+          peptide_hit_.setMetaValue("COMET:deltaLCn", value); // name: Comet:deltLCn
         }
         else if (name == "lnExpect")
         {
           value = attributeAsDouble_(attributes, "value");
-          peptide_hit_.setMetaValue("Comet:lnExpect", value); // name: Comet:lnExpect
+          peptide_hit_.setMetaValue("COMET:lnExpect", value); // name: Comet:lnExpect          
         }
         else if (name == "IonFrac")
         {
           value = attributeAsDouble_(attributes, "value");
           peptide_hit_.setMetaValue("Comet:IonFrac", value); // name: Comet:IonFrac
+          peptide_hit_.setMetaValue("COMET:IonFrac", value); // matched_ions / total_ions
         }
         else if (name == "lnNumSP")
         {
           value = attributeAsDouble_(attributes, "value");
-          peptide_hit_.setMetaValue("Comet:lnNumSP", value); // name: Comet:lnNumSP
+          peptide_hit_.setMetaValue("COMET:lnNumSP", value); // name: Comet:lnNumSP
         }        
       }
       else if (parse_unknown_scores_)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
