### PR TITLE
fix ASAN in ElementsDB

### DIFF
--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -646,7 +646,7 @@ namespace OpenMS
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
                                     "Replacing element with atomic number " + String(old->getAtomicNumber()) + " has different new atomic number: " + String(new_e->getAtomicNumber()));
     }
-    // ... overwrite and free
+    // ... overwrite
     *(const_cast<Element*>(old)) = *new_e;
   }
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -121,7 +121,7 @@ namespace OpenMS
                              bool replace_existing)
   {
     if (hasElement(an) && !replace_existing)
-    {
+    {      
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Element with atomic number ") + an + " already exists");
     }
     buildElement_(name, symbol, an, abundance, mass);
@@ -164,7 +164,8 @@ namespace OpenMS
     auto elem = container.find(key);
     if (elem != container.end())
     {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(key), "Already exists!");
+      delete replacement;
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(key), "Already exists!");      
     }
     container[key] = replacement;
   }
@@ -626,25 +627,27 @@ namespace OpenMS
     storeIsotopes_(name, symbol, an, mass, isotopes);
   }
 
-  void overwrite(const Element* old, std::unique_ptr<const Element>& new_e)
+  void overwrite(const Element* old, const Element* new_e)
   {
     if (old->getSymbol() != new_e->getSymbol())
     { // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
+      delete(new_e);
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
                                     "Replacing element with name " + old->getName() + " and symbol " + old->getSymbol() + " has different new symbol: " + new_e->getSymbol());
     }
     if (old->getName() != new_e->getName())
     { // -- this would invalidate the lookup, since e_ptr->getName().at("Oxygen")->getName() == 'Something'
+      delete(new_e);
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(), "Replacing element with name " + old->getName() + " has different new name: " + new_e->getName());
     }
     if (old->getAtomicNumber() != new_e->getAtomicNumber())
     { // -- this would invalidate the lookup, since e_ptr->getAtomicNumbers().at(12)->getAtomicNumber() == 14
+      delete(new_e);
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
                                     "Replacing element with atomic number " + String(old->getAtomicNumber()) + " has different new atomic number: " + String(new_e->getAtomicNumber()));
     }
-    // ... overwrite
+    // ... overwrite and free
     *(const_cast<Element*>(old)) = *new_e;
-    new_e.release();
   }
 
   void ElementDB::addElementToMaps_(const string& name, const string& symbol, const unsigned int an, const Element* e)
@@ -656,9 +659,9 @@ namespace OpenMS
       // in order to ensure that existing elements are still valid and memory
       // addresses do not change, we have to modify the Element in place
       // instead of replacing it.
-      unique_ptr<const Element> pe;
-      pe.reset(e);
-      overwrite(atomic_numbers_[an], pe);
+
+      overwrite(atomic_numbers_[an], e);
+      delete(e);
     }
     else
     {
@@ -685,14 +688,14 @@ namespace OpenMS
       iso_container.push_back(Peak1D(atomic_mass, 1.0));
       iso_isotopes.set(iso_container);  
 
-      auto iso_e = make_unique<const Element>(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
       if (auto has_elem = names_.find(iso_name); has_elem != names_.end())
       { // already exists: overwrite (affects all maps, since they all point to the same thing)
-        overwrite(has_elem->second, iso_e);
+        Element iso_e(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
+        overwrite(has_elem->second, &iso_e);
       }
       else
       {
-        auto ele = iso_e.release();
+        auto* ele = new Element(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
         checkedAddNoReplace(names_, iso_name, ele);
         checkedAddNoReplace(symbols_, iso_symbol, ele);
       }

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -129,7 +129,7 @@ START_SECTION(void addElement(const std::string& name,
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 15.99940532316)
   map<unsigned int, double> oxygen_abundance = {{16u, 0.7}, {19u, 0.3}};
   map<unsigned int, double> oxygen_mass = {{16u, 15.994915000000001}, {19u, 19.01}};
-  e_ptr->addElement("Oxygen", "O", 8u, oxygen_abundance, oxygen_mass, true);
+  e_ptr->addElement("Oxygen", "O", 8u, oxygen_abundance, oxygen_mass, true); // true: replace existing
 
   const Element * new_oxygen = e_ptr->getElement(8);
   // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
@@ -138,7 +138,7 @@ START_SECTION(void addElement(const std::string& name,
 
   // cannot add invalid element (name and symbol conflict when compared existing element 
   // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
-  TEST_EXCEPTION(Exception::InvalidValue, e_ptr->addElement("Oxygen", "P", 8u, oxygen_abundance, oxygen_mass, true))
+  TEST_EXCEPTION(Exception::InvalidValue, e_ptr->addElement("Oxygen", "P", 8u, oxygen_abundance, oxygen_mass, true)) // true: replace existing
 
 }
 END_SECTION


### PR DESCRIPTION
## Description

fixes ASAN error in elementsdb

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
