### PR TITLE
[FEATURE] ProtDigest with indices, simpler ModPepGen

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -41,9 +41,8 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <vector>
 #include <map>
+#include <unordered_map>
 #include <set>
-
-#include <boost/container/flat_map.hpp>
 
 namespace OpenMS
 {
@@ -55,7 +54,7 @@ namespace OpenMS
 
   public:
     // struct needed to wrap the template for pyOpenMS
-    struct MapToResidueType { boost::container::flat_map<const ResidueModification*, const Residue*> val; };
+    struct MapToResidueType { std::unordered_map<const ResidueModification*, const Residue*> val; };
 
       /**
       * @brief Retrieve modifications from strings

--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -108,7 +108,7 @@ namespace OpenMS
 
   private:
     /// take a vector of AASequences @p original_sequences, and for each mod in @p mods, add a version with mod at index @p idx_to_modify. In-place, with the original sequences recieving the first mod in @p mods.
-    static void applyAllModsAtIdxAndExtend_(std::vector<AASequence>& original_sequences, int idx_to_modify, std::vector<const ResidueModification*>& mods, const MapToResidueType& var_mods);
+    static void applyAllModsAtIdxAndExtend_(std::vector<AASequence>& original_sequences, int idx_to_modify, const std::vector<const ResidueModification*>& mods, const MapToResidueType& var_mods);
     /// applies a modification @p m to the @p current_peptide at @p current_index. Overwrites mod if it exists. Looks up in var_mods for existing modified Residue pointers.
     static void applyModToPep_(AASequence& current_peptide, int current_index, const ResidueModification* m, const MapToResidueType& var_mods);
   };

--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -83,6 +83,9 @@ namespace OpenMS
      bool keep_original=true);
 
   protected:
+    static const int N_TERM_MODIFICATION_INDEX = -1; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
+    static const int C_TERM_MODIFICATION_INDEX = -2; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
+
     // Lookup datastructure to allow lock-free generation of modified peptides
     static MapToResidueType createResidueModificationToResidueMap_(const std::vector<const ResidueModification*>& mods);
 
@@ -103,6 +106,10 @@ namespace OpenMS
       std::vector<AASequence>& all_modified_peptides, 
       bool keep_original=true);
 
+  private:
+    static void addMods_(int idx, std::vector<const ResidueModification*>& mods, std::vector<std::pair<unsigned, std::vector<AASequence>>> mod_peps, Size max_depth, const MapToResidueType& var_mods);
+    static void applyAllModsAtIdxAndExtend_(std::vector<AASequence>& original_sequences, int idx_to_modify, std::vector<const ResidueModification*>& mods, const MapToResidueType& var_mods);
+    static void applyModToPep_(AASequence& current_peptide, int current_index, const ResidueModification* m, const MapToResidueType& var_mods);
   };
 }
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -113,5 +113,3 @@ namespace OpenMS
     static void applyModToPep_(AASequence& current_peptide, int current_index, const ResidueModification* m, const MapToResidueType& var_mods);
   };
 }
-
-

--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -88,16 +88,6 @@ namespace OpenMS
     // Lookup datastructure to allow lock-free generation of modified peptides
     static MapToResidueType createResidueModificationToResidueMap_(const std::vector<const ResidueModification*>& mods);
 
-
-    // Recursively generate all combinatoric placements at compatible sites
-    static void recurseAndGenerateVariableModifiedPeptides_(
-      const std::vector<int>& subset_indices, 
-      const std::map<int, std::vector<const ResidueModification*> >& map_compatibility, 
-      const MapToResidueType& var_mods,
-      int depth, 
-      const AASequence& current_peptide, 
-      std::vector<AASequence>& modified_peptides);
-
     // Fast implementation of modification placement. No combinatoric placement is needed in this case - just every site is modified once by each compatible modification. Already modified residues are skipped
     static void applyAtMostOneVariableModification_(
       const MapToResidueType& var_mods, 

--- a/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h
@@ -83,8 +83,8 @@ namespace OpenMS
      bool keep_original=true);
 
   protected:
-    static const int N_TERM_MODIFICATION_INDEX = -1; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
-    static const int C_TERM_MODIFICATION_INDEX = -2; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
+    static const int N_TERM_MODIFICATION_INDEX; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
+    static const int C_TERM_MODIFICATION_INDEX; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
 
     // Lookup datastructure to allow lock-free generation of modified peptides
     static MapToResidueType createResidueModificationToResidueMap_(const std::vector<const ResidueModification*>& mods);
@@ -107,8 +107,9 @@ namespace OpenMS
       bool keep_original=true);
 
   private:
-    static void addMods_(int idx, std::vector<const ResidueModification*>& mods, std::vector<std::pair<unsigned, std::vector<AASequence>>> mod_peps, Size max_depth, const MapToResidueType& var_mods);
+    /// take a vector of AASequences @p original_sequences, and for each mod in @p mods, add a version with mod at index @p idx_to_modify. In-place, with the original sequences recieving the first mod in @p mods.
     static void applyAllModsAtIdxAndExtend_(std::vector<AASequence>& original_sequences, int idx_to_modify, std::vector<const ResidueModification*>& mods, const MapToResidueType& var_mods);
+    /// applies a modification @p m to the @p current_peptide at @p current_index. Overwrites mod if it exists. Looks up in var_mods for existing modified Residue pointers.
     static void applyModToPep_(AASequence& current_peptide, int current_index, const ResidueModification* m, const MapToResidueType& var_mods);
   };
 }

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
@@ -43,7 +43,7 @@
 namespace OpenMS
 {
   /**
-     @brief Class for the enzymatic digestion of proteins
+     @brief Class for the enzymatic digestion of proteins represented as AASequence or String
 
      Digestion can be performed using simple regular expressions,
      e.g. [KR] | [^P]
@@ -65,7 +65,7 @@ namespace OpenMS
     void setEnzyme(const String& name);
 
     /** 
-       @brief: Performs the enzymatic digestion of a protein.
+       @brief Performs the enzymatic digestion of a protein represented as AASequence
 
        @param protein Sequence to digest
        @param output Digestion products (peptides)
@@ -75,6 +75,18 @@ namespace OpenMS
 
     */
     Size digest(const AASequence& protein, std::vector<AASequence>& output, Size min_length = 1, Size max_length = 0) const;
+
+    /** 
+       @brief Performs the enzymatic digestion of a protein represented as AASequence
+
+       @param protein Sequence to digest
+       @param output Digestion products (start and end indices of peptides)
+       @param min_length Minimal length of reported products
+       @param max_length Maximal length of reported products (0 = no restriction)
+       @return Number of discarded digestion products (which are not matching length restrictions)
+
+    */
+    Size digest(const AASequence& protein, std::vector<std::pair<size_t,size_t>>& output, Size min_length = 1, Size max_length = 0) const;
 
     /// Returns the number of peptides a digestion of @p protein would yield under the current enzyme and missed cleavage settings.
     Size peptideCount(const AASequence& protein);

--- a/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
@@ -32,11 +32,14 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
+#include "OpenMS/CHEMISTRY/AASequence.h"
+#include "OpenMS/CHEMISTRY/ResidueModification.h"
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+
 using std::vector;
-using std::map;
+using std::pair;
 
 namespace OpenMS
 {
@@ -174,21 +177,9 @@ namespace OpenMS
       return;
     }
 
-    const int N_TERM_MODIFICATION_INDEX = -1; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
-    const int C_TERM_MODIFICATION_INDEX = -2; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
-
-    //keep a list of all possible modifications of this peptide
-    vector<AASequence> modified_peptides;
-
-    // only add unmodified version if flag is set (default)
-    if (keep_unmodified)
-    {
-      modified_peptides.push_back(peptide);
-    }
-
     // iterate over each residue and build compatibility mapping describing
     // which amino acid (peptide index) is compatible with which modification
-    map<int, vector<const ResidueModification*> > map_compatibility;
+    vector<std::pair<int, vector<const ResidueModification*> > > mod_compatibility;
 
     // set terminal modifications for modifications without amino acid preference
     for (auto const& mr : var_mods.val)
@@ -199,18 +190,19 @@ namespace OpenMS
       {
         if (!peptide.hasNTerminalModification())
         {
-          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(v);
+          mod_compatibility.emplace_back(N_TERM_MODIFICATION_INDEX, v);
         }
       }
       else if (v->getTermSpecificity() == ResidueModification::C_TERM)
       {
         if (!peptide.hasCTerminalModification())
         {
-          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(v);
+          mod_compatibility.emplace_back(C_TERM_MODIFICATION_INDEX, v);
         }
       }
     }
 
+    
     for (auto residue_it = peptide.begin(); residue_it != peptide.end(); ++residue_it)
     {
       // skip already modified residues
@@ -235,131 +227,48 @@ namespace OpenMS
         // Term specificity is ANYWHERE on the peptide, C_TERM or N_TERM
         // (currently no explicit support in OpenMS for protein C-term and
         // protein N-term)
+        // TODO This is not true anymore!
         const ResidueModification::TermSpecificity& term_spec = v->getTermSpecificity();
+        // TODO why are we not checking for existing modifications like in the N/C Term case above??
         if (term_spec == ResidueModification::ANYWHERE)
         {
-          map_compatibility[static_cast<int>(residue_index)].push_back(v);
+          mod_compatibility.emplace_back(residue_index, v);
         }
+        // TODO think about if it really is the same case as the one above.
         else if (term_spec == ResidueModification::C_TERM && residue_index == (peptide.size() - 1))
         {
-          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(v);
+          mod_compatibility.emplace_back(C_TERM_MODIFICATION_INDEX, v);
         }
         else if (term_spec == ResidueModification::N_TERM && residue_index == 0)
         {
-          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(v);
+          mod_compatibility.emplace_back(N_TERM_MODIFICATION_INDEX, v);
         }
       }
     }
 
-    // Check if no compatible site that can be modified by variable
-    // modification. If so just return peptides without variable modifications.
-    const Size compatible_mod_sites = map_compatibility.size();
-    if (compatible_mod_sites == 0)
+    Size max_placements = std::min(max_variable_mods_per_peptide, mod_compatibility.size());
+
+    vector<pair<unsigned, vector<AASequence>>> mod_peps_w_depth = {{0, {peptide}}};
+    for (auto& [idx, mods] : mod_compatibility)
     {
-      if (keep_unmodified)
+      // copy the complete sequences from last iteration
+      for (auto prev_res : mod_peps_w_depth)
       {
-        all_modified_peptides.push_back(peptide);
+        // extend mod_peps_w_depth by adding variants with the next mod, if max_placements is not reached
+        addMods_(idx, mods, mod_peps_w_depth, max_placements, var_mods);
       }
-      return;
     }
-
-    // generate powerset of max_variable_mods_per_peptide sized subset of all compatible modification sites
-    Size max_placements = std::min(max_variable_mods_per_peptide, compatible_mod_sites);
-    for (Size n_var_mods = 1; n_var_mods <= max_placements; ++n_var_mods)
-    {
-      // enumerate all modified peptides with n_var_mods variable modified residues
-      Size zeros = std::max((Size)0, compatible_mod_sites - n_var_mods);
-      vector<bool> subset_mask;
-
-      for (Size i = 0; i != compatible_mod_sites; ++i)
-      {
-        // create mask 000011 to select last (e.g. n_var_mods = 2) two compatible sites as subset from the set of all compatible sites
-        if (i < zeros)
-        {
-          subset_mask.push_back(false);
-        }
-        else
-        {
-          subset_mask.push_back(true);
-        }
-      }
-
-      // generate all subsets of compatible sites {000011, ... , 101000, 110000} with current number of allowed variable modifications per peptide
-      do
-      {
-        // create subset indices e.g.{4,12} from subset mask e.g. 1010000 corresponding to the positions in the peptide sequence
-        vector<int> subset_indices;
-        map<int, vector<const ResidueModification*> >::const_iterator mit = map_compatibility.begin();
-        for (Size i = 0; i != compatible_mod_sites; ++i, ++mit)
-        {
-          if (subset_mask[i])
-          {
-            subset_indices.push_back(mit->first);
-          }
-        }
-
-        // now enumerate all modifications
-        recurseAndGenerateVariableModifiedPeptides_(subset_indices, map_compatibility, var_mods, 0, peptide, modified_peptides);
-      } while (next_permutation(subset_mask.begin(), subset_mask.end()));
-    }
-    // add modified version of the current peptide to the list of all peptides
     
-    all_modified_peptides.insert(
-      all_modified_peptides.end(), 
-      make_move_iterator(modified_peptides.begin()), 
-      make_move_iterator(modified_peptides.end())); 
-      
-  }
-
-
-  // static
-  void ModifiedPeptideGenerator::recurseAndGenerateVariableModifiedPeptides_(
-    const vector<int>& subset_indices, 
-    const map<int, vector<const ResidueModification*> >& map_compatibility, 
-    const MapToResidueType& var_mods, 
-    int depth, 
-    const AASequence& current_peptide, 
-    vector<AASequence>& modified_peptides)
-  {
-    const int N_TERM_MODIFICATION_INDEX = -1; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
-    const int C_TERM_MODIFICATION_INDEX = -2; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
-
-    // cout << depth << " " << subset_indices.size() << " " << current_peptide.toString() << endl;
-
-    // end of recursion. Add the modified peptide and return
-    if (depth == (int)subset_indices.size())
+    // move sequences from mod_peps_w_depth into result. Skip the initial peptide if desired.
+    for (auto& [depth, seqs] : mod_peps_w_depth)
     {
-      modified_peptides.push_back(current_peptide);
-      return;
-    }
-
-    // get modifications compatible to residue at current peptide position
-    const int current_index = subset_indices[depth];
-
-    map<int, vector<const ResidueModification*> >::const_iterator pos_mod_it = map_compatibility.find(current_index);
-    const vector<const ResidueModification*>& mods = pos_mod_it->second; // we don't need to check for .end as entry is guaranteed to exist
-
-    for (const ResidueModification* m : mods)
-    {
-
-      // copy peptide and apply modification
-      AASequence new_peptide = current_peptide;
-      if (current_index == C_TERM_MODIFICATION_INDEX)
+      if (depth != 0 || keep_unmodified)
       {
-        new_peptide.setCTerminalModification(m);
+        all_modified_peptides.insert(
+          all_modified_peptides.end(), 
+          make_move_iterator(seqs.begin()), 
+          make_move_iterator(seqs.end())); 
       }
-      else if (current_index == N_TERM_MODIFICATION_INDEX)
-      {
-        new_peptide.setNTerminalModification(m);
-      }
-      else
-      {
-        const Residue* r = var_mods.val.at(m); // map modification to the modified residue
-        new_peptide.setModification(current_index, r); // set modified Residue          
-      }
-
-      // recurse with modified peptide
-      recurseAndGenerateVariableModifiedPeptides_(subset_indices, map_compatibility, var_mods, depth + 1, new_peptide, modified_peptides);
     }
   }
 
@@ -379,6 +288,7 @@ namespace OpenMS
     for (auto residue_it = peptide.end() - 1; residue_it != peptide.begin() - 1; --residue_it)
     {
       // skip already modified residues
+      // TODO We do not do this in the n > 1 variant!!
       if (residue_it->isModified())
       {
         continue;
@@ -421,5 +331,57 @@ namespace OpenMS
       }
     }
   }
+
+
+  void ModifiedPeptideGenerator::addMods_(int idx, vector<const ResidueModification*>& mods, vector<pair<unsigned, vector<AASequence>>> mod_peps, Size max_depth, const ModifiedPeptideGenerator::MapToResidueType& var_mods)
+  {
+    for (auto& [depth, prev_res] : mod_peps)
+    {
+      if (depth < max_depth)
+      {
+        applyAllModsAtIdxAndExtend_(prev_res, idx, mods, var_mods);
+        mod_peps.emplace_back(depth + 1, prev_res);
+      }
+    }
+  }
+
+
+  void ModifiedPeptideGenerator::applyAllModsAtIdxAndExtend_(vector<AASequence>& original_sequences, int idx_to_modify, vector<const ResidueModification*>& mods, const ModifiedPeptideGenerator::MapToResidueType& var_mods)
+  {
+    // TODO use vector resize to preallocate for the new variants
+    Size end = original_sequences.size();
+    for (Size cnt(1); cnt < mods.size(); ++cnt) // apply first mod later
+    {
+      for (Size i(0); i < end; i++)
+      {
+        original_sequences.emplace_back(original_sequences[i]); // copy to end
+        applyModToPep_(original_sequences.back(), idx_to_modify, mods[cnt], var_mods);
+      }
+    }
+    // Lastly apply first mod to initial copy
+    for (Size i(0); i < end; i++)
+    {
+      applyModToPep_(original_sequences[i], idx_to_modify, mods[0], var_mods);
+    }
+  }
+
+
+  void ModifiedPeptideGenerator::applyModToPep_(AASequence& current_peptide, int current_index, const ResidueModification* m, const ModifiedPeptideGenerator::MapToResidueType& var_mods)
+  {
+      if (current_index == C_TERM_MODIFICATION_INDEX)
+      {
+        current_peptide.setCTerminalModification(m);
+      }
+      else if (current_index == N_TERM_MODIFICATION_INDEX)
+      {
+        current_peptide.setNTerminalModification(m);
+      }
+      else
+      {
+        const Residue* r = var_mods.val.at(m); // map modification to the modified residue
+        current_peptide.setModification(current_index, r); // set modified Residue          
+      }
+  }
+
 }
 

--- a/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
@@ -253,10 +253,14 @@ namespace OpenMS
 
     // stores all variants with how many modifications they already have
     vector<pair<size_t, vector<AASequence>>> mod_peps_w_depth = {{0, {peptide}}};
-    for (auto& [idx, mods] : mod_compatibility)
+    auto rit = mod_compatibility.rbegin();
+    for (; rit != mod_compatibility.rend(); ++rit)
     {
+      const auto& idx = rit->first;
+      const auto& mods = rit->second;
       // copy the complete sequences from last iteration
-      for (auto [old_depth, old_variants] : mod_peps_w_depth)
+      auto tmp = mod_peps_w_depth;
+      for (auto& [old_depth, old_variants] : tmp)
       {
         // extends mod_peps_w_depth by adding variants with the next mod, if max_placements is not reached
         if (old_depth < max_placements)
@@ -340,7 +344,7 @@ namespace OpenMS
   }
 
 
-  void ModifiedPeptideGenerator::applyAllModsAtIdxAndExtend_(vector<AASequence>& original_sequences, int idx_to_modify, vector<const ResidueModification*>& mods, const ModifiedPeptideGenerator::MapToResidueType& var_mods)
+  void ModifiedPeptideGenerator::applyAllModsAtIdxAndExtend_(vector<AASequence>& original_sequences, int idx_to_modify, const vector<const ResidueModification*>& mods, const ModifiedPeptideGenerator::MapToResidueType& var_mods)
   {
     // TODO use vector resize to preallocate for the new variants
     Size end = original_sequences.size();

--- a/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
@@ -100,10 +100,12 @@ namespace OpenMS
     output.clear();
     std::vector<std::pair<size_t,size_t>> idcs; // small overhead filling intermediate vector first and iterating again
     Size wrong_size = digest(protein, idcs, min_length, max_length);
-    std::transform(idcs.begin(), idcs.end(), output.begin(), 
-      [&protein](std::pair<size_t, size_t>& start_end){
-        protein.getSubsequence(start_end.first, UInt(start_end.second - start_end.first));
-        }
+    output.reserve(idcs.size());
+    std::transform(idcs.begin(), idcs.end(), std::back_inserter(output),
+      [&protein](std::pair<size_t, size_t>& start_end)
+      {
+        return protein.getSubsequence(start_end.first, UInt(start_end.second - start_end.first));
+      }
     );
     return wrong_size;
   }

--- a/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <algorithm>
 #include <boost/regex.hpp>
 
 #include <limits>
@@ -97,6 +98,20 @@ namespace OpenMS
   {
     // initialization
     output.clear();
+    std::vector<std::pair<size_t,size_t>> idcs; // small overhead filling intermediate vector first and iterating again
+    Size wrong_size = digest(protein, idcs, min_length, max_length);
+    std::transform(idcs.begin(), idcs.end(), output.begin(), 
+      [&protein](std::pair<size_t, size_t>& start_end){
+        protein.getSubsequence(start_end.first, UInt(start_end.second - start_end.first));
+        }
+    );
+    return wrong_size;
+  }
+
+  Size ProteaseDigestion::digest(const AASequence& protein, vector<std::pair<size_t,size_t>>& output, Size min_length, Size max_length) const
+  {
+    // initialization
+    output.clear();
 
     // disable max length filter by setting to maximum length
     if (max_length == 0 || max_length > protein.size())
@@ -117,7 +132,7 @@ namespace OpenMS
       Size l = pep_positions[i] - begin;
       if (l >= min_length && l <= max_length)
       {
-        output.push_back(protein.getSubsequence(begin, l));
+        output.emplace_back(begin, pep_positions[i]);
       }
       else
       {
@@ -138,7 +153,7 @@ namespace OpenMS
           Size l = pep_positions[j + mcs] - begin;
           if (l >= min_length && l <= max_length)
           {
-            output.push_back(protein.getSubsequence(begin, l));
+            output.emplace_back(begin, pep_positions[j + mcs]);
           }
           else
           {

--- a/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
@@ -286,7 +286,7 @@ START_SECTION([EXTRA] multithreaded example)
   int nr_iterations (1e5);
   int test = 0;
   // many modifications
-  vector<String> all_mods = {"Carbamidomethyl (C)", "Oxidation (M)", "Phospho (S)", "Phospho (T)", "Phospho (Y)", "Carbamyl (K)", "Carbamyl (N-term)"};
+  vector<String> all_mods = {"Carbamidomethyl (C)", "Oxidation (M)", "Carbamyl (M)", "Phospho (S)", "Phospho (T)", "Carbamyl (T)", "Phospho (Y)", "Carbamyl (K)", "Carbamyl (N-term)"};
 
   ModifiedPeptideGenerator::MapToResidueType variable_mods = ModifiedPeptideGenerator::getModifications(all_mods);
 
@@ -297,18 +297,14 @@ START_SECTION([EXTRA] multithreaded example)
   for (int i = 0; i < nr_iterations; ++i)
   {
     vector<AASequence> modified_peptides;
-    modified_peptides.reserve(29);
-    ModifiedPeptideGenerator::applyVariableModifications(variable_mods, seq, 2, modified_peptides, true);
+    modified_peptides.reserve(199);
+    ModifiedPeptideGenerator::applyVariableModifications(variable_mods, seq, 4, modified_peptides, true);
     test += modified_peptides.size();
   }
-  TEST_EQUAL(test, 29 * nr_iterations)
+  TEST_EQUAL(test, 199 * nr_iterations)
 #endif
 }
-
-
 END_SECTION
-
-
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description

- Adds a variant for protein digestion that returns indices
- Heavily simplifies modified peptide generator by making it non-recursive, vector-based instead of map-based and incremental by using way more copies of previous results.
- Also found some inconsistencies regarding already existing mods and protein vs peptide terminal mods.

Untested

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
