### PR TITLE
Fix gcc13 error and warnings

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h
@@ -36,7 +36,6 @@
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-
 #include <map>
 #include <vector>
 
@@ -48,41 +47,37 @@ namespace OpenMS
     The main function is apply(), which aggregates several peptide identifications into one.
 
     Derived classes should implement apply_(), which takes a list of peptide identifications and produces a map of peptide sequences with accompanying scores (and charge states).
-    Currently there are two derived classes, OpenMS::ConsensusIDAlgorithmIdentity and OpenMS::ConsensusIDAlgorithmSimilarity. They serve as abstract base classes for algorithms that score only identical peptide sequences together and algorithms that take similarities between peptides into account, respectively.
+    Currently there are two derived classes, OpenMS::ConsensusIDAlgorithmIdentity and OpenMS::ConsensusIDAlgorithmSimilarity. They serve as abstract base classes for algorithms that score only
+    identical peptide sequences together and algorithms that take similarities between peptides into account, respectively.
 
     See also the documentation of the TOPP tool, @ref TOPP_ConsensusID, for more information (e.g. on the @p filter: parameters).
 
     @htmlinclude OpenMS_ConsensusIDAlgorithm.parameters
-    
+
     @ingroup Analysis_ID
   */
-  class OPENMS_DLLAPI ConsensusIDAlgorithm :
-    public DefaultParamHandler
+  class OPENMS_DLLAPI ConsensusIDAlgorithm : public DefaultParamHandler
   {
   public:
     /**
         @brief Calculates the consensus ID for a set of peptide identifications of one spectrum or (consensus) feature.
 
         Make sure that the score type (PeptideIdentification::getScoreType()) and the score orientation (PeptideIdentification::isHigherScoreBetter()) are set properly!
-        
+
         @param ids Peptide identifications (input: more than one, output: one)
         @param number_of_runs Number of ID runs (default: size of "ids")
         @param se_info map from run identifiers to search engine infos to retain original search engine information
         @todo we could pass the score_types that we want to carry over in the map as well (right now it always takes main)
      */
-    void apply(std::vector<PeptideIdentification>& ids,
-               const std::map<String, String>& se_info,
-               Size number_of_runs = 0);
+    void apply(std::vector<PeptideIdentification>& ids, const std::map<String, String>& se_info, Size number_of_runs = 0);
 
-    void apply(std::vector<PeptideIdentification>& ids,
-               Size number_of_runs = 0);
+    void apply(std::vector<PeptideIdentification>& ids, Size number_of_runs = 0);
 
     /// Virtual destructor
     ~ConsensusIDAlgorithm() override;
 
   protected:
-    struct HitInfo
-    {
+    struct HitInfo {
       Int charge;
       std::vector<double> scores;
       std::vector<String> types;
@@ -92,15 +87,14 @@ namespace OpenMS
       std::set<PeptideEvidence> evidence;
       double final_score;
       double support;
-      //TODO: we could gather spectrum_refs here as well,
-      // to support passing of spectrum_ref if ALL refs of a group are the same
-      // For now, we do it in the ConsensusID TOPP tool class in cases where we
-      // know that refs will be the same.
+      // TODO: we could gather spectrum_refs here as well,
+      //  to support passing of spectrum_ref if ALL refs of a group are the same
+      //  For now, we do it in the ConsensusID TOPP tool class in cases where we
+      //  know that refs will be the same.
     };
 
     /// Mapping: peptide sequence -> (charge, scores)
-    typedef std::map<AASequence, HitInfo>
-      SequenceGrouping;
+    typedef std::map<AASequence, HitInfo> SequenceGrouping;
 
     /// Number of peptide hits considered per ID run (input parameter)
     Size considered_hits_;
@@ -116,7 +110,7 @@ namespace OpenMS
 
     /// Keep old scores?
     bool keep_old_scores_;
-   
+
     /// Default constructor
     ConsensusIDAlgorithm();
 
@@ -127,16 +121,13 @@ namespace OpenMS
        @param se_info mapping from run identifier to search engine to carry over infos to result
        @param results Algorithm results (output). For each peptide sequence, two scores are expected: the actual consensus score and the "support" value, in this order.
     */
-    virtual void apply_(std::vector<PeptideIdentification>& ids,
-                        const std::map<String, String>& se_info,
-                        SequenceGrouping& results) = 0;
+    virtual void apply_(std::vector<PeptideIdentification>& ids, const std::map<String, String>& se_info, SequenceGrouping& results) = 0;
 
     /// Docu in base class
     void updateMembers_() override;
 
     /// Compare (and possibly update) charge state information
-    void compareChargeStates_(Int& recorded_charge, Int new_charge, 
-                              const AASequence& peptide);
+    void compareChargeStates_(Int& recorded_charge, Int new_charge, const AASequence& peptide);
 
   private:
     /// Not implemented
@@ -144,8 +135,6 @@ namespace OpenMS
 
     /// Not implemented
     ConsensusIDAlgorithm& operator=(const ConsensusIDAlgorithm&) = delete;
-
   };
 
 } // namespace OpenMS
-

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h
@@ -139,11 +139,11 @@ namespace OpenMS
                               const AASequence& peptide);
 
   private:
-   /// Not implemented
-    ConsensusIDAlgorithm(const ConsensusIDAlgorithm&);
+    /// Not implemented
+    ConsensusIDAlgorithm(const ConsensusIDAlgorithm&) = delete;
 
     /// Not implemented
-    ConsensusIDAlgorithm& operator=(const ConsensusIDAlgorithm&);
+    ConsensusIDAlgorithm& operator=(const ConsensusIDAlgorithm&) = delete;
 
   };
 

--- a/src/openms/include/OpenMS/COMPARISON/CLUSTERING/HashGrid.h
+++ b/src/openms/include/OpenMS/COMPARISON/CLUSTERING/HashGrid.h
@@ -32,19 +32,17 @@
 // $Authors: Bastian Blank $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/DATASTRUCTURES/DPosition.h>
+#include <boost/array.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/unordered/unordered_map.hpp>
 #include <cmath>
 #include <iterator>
 #include <limits>
 
-#include <boost/array.hpp>
-#include <boost/functional/hash.hpp>
-#include <boost/unordered/unordered_map.hpp>
-
-#include <OpenMS/CONCEPT/Types.h>
-#include <OpenMS/DATASTRUCTURES/DPosition.h>
-
 #ifndef OPENMS_COMPARISON_CLUSTERING_HASHGRID_H
-#define OPENMS_COMPARISON_CLUSTERING_HASHGRID_H
+  #define OPENMS_COMPARISON_CLUSTERING_HASHGRID_H
 
 namespace OpenMS
 {
@@ -58,10 +56,10 @@ namespace OpenMS
    *
    * @tparam Cluster Type to be stored in the hash grid. (e.g. HierarchicalClustering::Cluster)
    */
-  template <typename Cluster>
+  template<typename Cluster>
   class HashGrid
   {
-public:
+  public:
     /**
      * @brief Coordinate for stored pairs.
      */
@@ -87,20 +85,20 @@ public:
     typedef typename CellContent::mapped_type mapped_type;
     typedef typename CellContent::value_type value_type;
 
-private:
+  private:
     /**
      * @brief Element iterator for the hash grid.
      */
     class Iterator
     {
-private:
+    private:
       friend class HashGrid;
 
       typedef typename Grid::iterator grid_iterator;
       typedef typename CellContent::iterator cell_iterator;
 
       /** @name Typedefs for STL compliance, these replace std::iterator
-      */
+       */
       //@{
       /// The iterator's category type
       using iterator_category = std::input_iterator_tag;
@@ -115,7 +113,7 @@ private:
       //@}
 
 
-      Grid & grid_;
+      Grid& grid_;
       grid_iterator grid_it_;
       cell_iterator cell_it_;
 
@@ -137,18 +135,17 @@ private:
         }
       }
 
-public:
-      explicit Iterator(Grid & grid) :
-        grid_(grid), grid_it_(grid.end())
-      {}
+    public:
+      explicit Iterator(Grid& grid) : grid_(grid), grid_it_(grid.end())
+      {
+      }
 
-      Iterator(Grid & grid, grid_iterator grid_it, cell_iterator cell_it) :
-        grid_(grid), grid_it_(grid_it), cell_it_(cell_it)
+      Iterator(Grid& grid, grid_iterator grid_it, cell_iterator cell_it) : grid_(grid), grid_it_(grid_it), cell_it_(cell_it)
       {
         searchNextCell_();
       }
 
-      Iterator & operator++()
+      Iterator& operator++()
       {
         ++cell_it_;
         searchNextCell_();
@@ -162,23 +159,30 @@ public:
         return ret;
       }
 
-      bool operator==(const Iterator & rhs) const
-      { return grid_it_ == rhs.grid_it_ && cell_it_ == rhs.cell_it_; }
+      bool operator==(const Iterator& rhs) const
+      {
+        return grid_it_ == rhs.grid_it_ && cell_it_ == rhs.cell_it_;
+      }
 
-      bool operator!=(const Iterator & rhs) const
-      { return !(*this == rhs); }
+      bool operator!=(const Iterator& rhs) const
+      {
+        return !(*this == rhs);
+      }
 
-      value_type & operator*() const
-      { return *cell_it_; }
+      value_type& operator*() const
+      {
+        return *cell_it_;
+      }
 
-      value_type * operator->() const
-      { return &*cell_it_; }
+      value_type* operator->() const
+      {
+        return &*cell_it_;
+      }
 
       const CellIndex index() const
       {
         return grid_it_->first;
       }
-
     };
 
     /**
@@ -186,14 +190,14 @@ public:
      */
     class ConstIterator
     {
-private:
+    private:
       friend class HashGrid;
 
       typedef typename Grid::const_iterator grid_iterator;
       typedef typename CellContent::const_iterator cell_iterator;
 
       /** @name Typedefs for STL compliance, these replace std::iterator
-      */
+       */
       //@{
       /// The iterator's category type
       using iterator_category = std::input_iterator_tag;
@@ -207,7 +211,7 @@ private:
       using difference_type = std::ptrdiff_t;
       //@}
 
-      const Grid & grid_;
+      const Grid& grid_;
       grid_iterator grid_it_;
       cell_iterator cell_it_;
 
@@ -229,22 +233,21 @@ private:
         }
       }
 
-public:
-      ConstIterator(const Grid & grid) :
-        grid_(grid), grid_it_(grid.end())
-      {}
+    public:
+      ConstIterator(const Grid& grid) : grid_(grid), grid_it_(grid.end())
+      {
+      }
 
-      ConstIterator(const Grid & grid, grid_iterator grid_it, cell_iterator cell_it) :
-        grid_(grid), grid_it_(grid_it), cell_it_(cell_it)
+      ConstIterator(const Grid& grid, grid_iterator grid_it, cell_iterator cell_it) : grid_(grid), grid_it_(grid_it), cell_it_(cell_it)
       {
         searchNextCell_();
       }
 
-      ConstIterator(const Iterator & it) :
-        grid_(it.grid_), grid_it_(it.grid_it_), cell_it_(it.cell_it_)
-      {}
+      ConstIterator(const Iterator& it) : grid_(it.grid_), grid_it_(it.grid_it_), cell_it_(it.cell_it_)
+      {
+      }
 
-      ConstIterator & operator++()
+      ConstIterator& operator++()
       {
         ++cell_it_;
         searchNextCell_();
@@ -258,26 +261,33 @@ public:
         return ret;
       }
 
-      bool operator==(const ConstIterator & rhs) const
-      { return grid_it_ == rhs.grid_it_ && cell_it_ == rhs.cell_it_; }
+      bool operator==(const ConstIterator& rhs) const
+      {
+        return grid_it_ == rhs.grid_it_ && cell_it_ == rhs.cell_it_;
+      }
 
-      bool operator!=(const ConstIterator & rhs) const
-      { return !(*this == rhs); }
+      bool operator!=(const ConstIterator& rhs) const
+      {
+        return !(*this == rhs);
+      }
 
-      const value_type & operator*() const
-      { return *cell_it_; }
+      const value_type& operator*() const
+      {
+        return *cell_it_;
+      }
 
-      const value_type * operator->() const
-      { return &*cell_it_; }
+      const value_type* operator->() const
+      {
+        return &*cell_it_;
+      }
 
       const CellIndex index() const
       {
         return grid_it_->first;
       }
-
     };
 
-public:
+  public:
     typedef ConstIterator const_iterator;
     typedef Iterator iterator;
     typedef typename Grid::const_iterator const_grid_iterator;
@@ -286,12 +296,11 @@ public:
     typedef typename CellContent::iterator cell_iterator;
     typedef typename CellContent::size_type size_type;
 
-private:
+  private:
     Grid cells_;
     CellIndex grid_dimension_;
 
-public:
-
+  public:
     /**
      * @brief Dimension of cells.
      */
@@ -300,25 +309,22 @@ public:
     /**
      * @brief Upper-right corner of key space for cells.
      */
-    const CellIndex & grid_dimension;
+    const CellIndex& grid_dimension;
 
-public:
-    explicit HashGrid(const ClusterCenter & c_dimension) :
-      cells_(), 
-      grid_dimension_(), 
-      cell_dimension(c_dimension), 
-      grid_dimension(grid_dimension_)
-    {}
+  public:
+    explicit HashGrid(const ClusterCenter& c_dimension) : cells_(), grid_dimension_(), cell_dimension(c_dimension), grid_dimension(grid_dimension_)
+    {
+    }
 
     /**
      * @brief Inserts a (2-dimensional coordinate, value) pair.
      * @param v Pair to be inserted.
      * @return Iterator that points to the inserted pair.
      */
-    cell_iterator insert(const value_type & v)
+    cell_iterator insert(const value_type& v)
     {
       const CellIndex cellkey = cellindexAtClustercenter_(v.first);
-      CellContent & cell = cells_[cellkey];
+      CellContent& cell = cells_[cellkey];
       updateGridDimension_(cellkey);
       return cell.insert(v);
     }
@@ -328,7 +334,7 @@ public:
      */
     void erase(iterator pos)
     {
-      CellContent & cell = pos.grid_it_->second;
+      CellContent& cell = pos.grid_it_->second;
       cell.erase(pos.cell_it_);
     }
 
@@ -337,18 +343,22 @@ public:
      * @param key Key of element to be erased.
      * @return Number of elements erased.
      */
-    size_type erase(const key_type & key)
+    size_type erase(const key_type& key)
     {
       const CellIndex cellkey = cellindexAtClustercenter_(key);
       auto cell = cells_.find(cellkey);
-      if (cell == cells_.end()) return 0;
+      if (cell == cells_.end())
+        return 0;
       return cell->second.erase(key);
     }
 
     /**
      * @brief Clears the map.
      */
-    void clear() { cells_.clear(); }
+    void clear()
+    {
+      cells_.clear();
+    }
 
     /**
      * @brief Returns iterator to first element.
@@ -356,7 +366,8 @@ public:
     iterator begin()
     {
       grid_iterator grid_it = cells_.begin();
-      if (grid_it == cells_.end()) return end();
+      if (grid_it == cells_.end())
+        return end();
 
       cell_iterator cell_it = grid_it->second.begin();
       return iterator(cells_, grid_it, cell_it);
@@ -368,7 +379,8 @@ public:
     const_iterator begin() const
     {
       const_grid_iterator grid_it = cells_.begin();
-      if (grid_it == cells_.end()) return end();
+      if (grid_it == cells_.end())
+        return end();
 
       const_cell_iterator cell_it = grid_it->second.begin();
       return const_iterator(cells_, grid_it, cell_it);
@@ -416,46 +428,70 @@ public:
     /**
      * @brief Returns iterator to first grid cell.
      */
-    const_grid_iterator grid_begin() const { return cells_.begin(); }
+    const_grid_iterator grid_begin() const
+    {
+      return cells_.begin();
+    }
 
     /**
      * @brief Returns iterator to on after last grid cell.
      */
-    const_grid_iterator grid_end() const { return cells_.end(); }
+    const_grid_iterator grid_end() const
+    {
+      return cells_.end();
+    }
 
     /**
      * @brief Returns the grid cell at given index.
      */
-    const typename Grid::mapped_type & grid_at(const CellIndex & x) const { return cells_.at(x); }
+    const typename Grid::mapped_type& grid_at(const CellIndex& x) const
+    {
+      return cells_.at(x);
+    }
 
     /**
      * @warning Currently needed non-const by HierarchicalClustering.
-    */
-    typename Grid::mapped_type & grid_at(const CellIndex & x) { return cells_.at(x); }
+     */
+    typename Grid::mapped_type& grid_at(const CellIndex& x)
+    {
+      return cells_.at(x);
+    }
 
     /**
      * @brief Returns the grid cell at given index if present, otherwise the grid_end iterator.
-    */
-    const_grid_iterator grid_find(const CellIndex & x) const { return cells_.find(x); }
+     */
+    const_grid_iterator grid_find(const CellIndex& x) const
+    {
+      return cells_.find(x);
+    }
 
     /**
-    * @brief Returns the grid cell at given index if present, otherwise the grid_end iterator.
-    */
-    grid_iterator grid_find(const CellIndex & x) { return cells_.find(x); }
+     * @brief Returns the grid cell at given index if present, otherwise the grid_end iterator.
+     */
+    grid_iterator grid_find(const CellIndex& x)
+    {
+      return cells_.find(x);
+    }
 
 
     /**
      * @warning Currently needed non-const by HierarchicalClustering.
      */
-    grid_iterator grid_begin() { return cells_.begin(); }
+    grid_iterator grid_begin()
+    {
+      return cells_.begin();
+    }
     /**
      * @warning Currently needed non-const by HierarchicalClustering.
      */
-    grid_iterator grid_end() { return cells_.end(); }
+    grid_iterator grid_end()
+    {
+      return cells_.end();
+    }
 
-private:
+  private:
     // XXX: Replace with proper operator
-    CellIndex cellindexAtClustercenter_(const ClusterCenter & key)
+    CellIndex cellindexAtClustercenter_(const ClusterCenter& key)
     {
       CellIndex ret;
       typename CellIndex::iterator it = ret.begin();
@@ -463,13 +499,14 @@ private:
       for (; it != ret.end(); ++it, ++lit, ++rit)
       {
         double t = std::floor(*lit / *rit);
-        if (t < std::numeric_limits<Int64>::min() || t > std::numeric_limits<Int64>::max()) throw Exception::OutOfRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+        if (t < std::numeric_limits<Int64>::min() || t > std::numeric_limits<Int64>::max())
+          throw Exception::OutOfRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
         *it = static_cast<Int64>(t);
       }
       return ret;
     }
 
-    void updateGridDimension_(const CellIndex & d)
+    void updateGridDimension_(const CellIndex& d)
     {
       typename CellIndex::const_iterator it_new = d.begin();
       typename CellIndex::iterator it_cur = grid_dimension_.begin();
@@ -479,12 +516,11 @@ private:
           *it_cur = *it_new;
       }
     }
-
   };
 
   /** Hash value for OpenMS::DPosition. */
-  template <UInt N, typename T>
-  std::size_t hash_value(const DPosition<N, T> & b)
+  template<UInt N, typename T>
+  std::size_t hash_value(const DPosition<N, T>& b)
   {
     boost::hash<T> hasher;
     std::size_t hash = 0;
@@ -493,6 +529,6 @@ private:
     return hash;
   }
 
-}
+} // namespace OpenMS
 
 #endif /* OPENMS_COMPARISON_CLUSTERING_HASHGRID_H */

--- a/src/openms/include/OpenMS/COMPARISON/CLUSTERING/HashGrid.h
+++ b/src/openms/include/OpenMS/COMPARISON/CLUSTERING/HashGrid.h
@@ -91,14 +91,29 @@ private:
     /**
      * @brief Element iterator for the hash grid.
      */
-    class Iterator :
-      public std::iterator<std::input_iterator_tag, value_type>
+    class Iterator
     {
 private:
       friend class HashGrid;
 
       typedef typename Grid::iterator grid_iterator;
       typedef typename CellContent::iterator cell_iterator;
+
+      /** @name Typedefs for STL compliance, these replace std::iterator
+      */
+      //@{
+      /// The iterator's category type
+      using iterator_category = std::input_iterator_tag;
+      /// The iterator's value type
+      using value_type = HashGrid::value_type;
+      /// The reference type as returned by operator*()
+      using reference = value_type&;
+      /// The pointer type as returned by operator->()
+      using pointer = value_type*;
+      /// The difference type
+      using difference_type = std::ptrdiff_t;
+      //@}
+
 
       Grid & grid_;
       grid_iterator grid_it_;
@@ -169,14 +184,28 @@ public:
     /**
      * @brief Constant element iterator for the hash grid.
      */
-    class ConstIterator :
-      public std::iterator<std::input_iterator_tag, const value_type>
+    class ConstIterator
     {
 private:
       friend class HashGrid;
 
       typedef typename Grid::const_iterator grid_iterator;
       typedef typename CellContent::const_iterator cell_iterator;
+
+      /** @name Typedefs for STL compliance, these replace std::iterator
+      */
+      //@{
+      /// The iterator's category type
+      using iterator_category = std::input_iterator_tag;
+      /// The iterator's value type
+      using value_type = HashGrid::value_type;
+      /// The reference type as returned by operator*()
+      using reference = value_type&;
+      /// The pointer type as returned by operator->()
+      using pointer = value_type*;
+      /// The difference type
+      using difference_type = std::ptrdiff_t;
+      //@}
 
       const Grid & grid_;
       grid_iterator grid_it_;

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DefaultParamHandler.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DefaultParamHandler.h
@@ -102,7 +102,7 @@ public:
     virtual ~DefaultParamHandler();
 
     /// Assignment operator.
-    virtual DefaultParamHandler& operator=(const DefaultParamHandler& rhs);
+    DefaultParamHandler& operator=(const DefaultParamHandler& rhs);
 
     /// Equality operator
     virtual bool operator==(const DefaultParamHandler& rhs) const;

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DefaultParamHandler.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DefaultParamHandler.h
@@ -37,7 +37,6 @@
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/OpenMSConfig.h>
-
 #include <vector>
 
 namespace OpenMS
@@ -91,7 +90,7 @@ namespace OpenMS
   */
   class OPENMS_DLLAPI DefaultParamHandler
   {
-public:
+  public:
     /// Constructor with name that is displayed in error messages
     DefaultParamHandler(const String& name);
 
@@ -134,18 +133,18 @@ public:
     const std::vector<String>& getSubsections() const;
 
     /**
-    * @brief Writes all parameters to meta values
-    *
-    * Parameters are written with 'name' as key and 'value' as value
-    *
-    * @param write_this  Params to be written
-    * @param write_here  a MetaInfoInterface object into which the meta values will be written
-    * @param key_prefix  Will be added in front of the parameter name for the meta value key.
-    *                    If the prefix isn't empty and doesn't end with a colon one will be added.
-    */
+     * @brief Writes all parameters to meta values
+     *
+     * Parameters are written with 'name' as key and 'value' as value
+     *
+     * @param write_this  Params to be written
+     * @param write_here  a MetaInfoInterface object into which the meta values will be written
+     * @param key_prefix  Will be added in front of the parameter name for the meta value key.
+     *                    If the prefix isn't empty and doesn't end with a colon one will be added.
+     */
     static void writeParametersToMetaValues(const Param& write_this, MetaInfoInterface& write_here, const String& key_prefix = "");
 
-protected:
+  protected:
     /**
         @brief This method is used to update extra member variables at the end of the setParameters() method.
 
@@ -162,7 +161,7 @@ protected:
     */
     void defaultsToParam_();
 
-    ///Container for current parameters
+    /// Container for current parameters
     Param param_;
 
     /**
@@ -199,10 +198,10 @@ protected:
           */
     bool warn_empty_defaults_;
 
-private:
+  private:
     /// Hidden default C'tor (class name parameter is required!)
     DefaultParamHandler();
 
-  }; //class
+  }; // class
 
-} // namespace OPENMS
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/BASELINE/MorphologicalFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/BASELINE/MorphologicalFilter.h
@@ -37,10 +37,9 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
-
 #include <algorithm>
 #include <iterator>
 
@@ -55,18 +54,17 @@ namespace OpenMS
         It is using unary operator *, and the like.  This is not a full implementation of the
         iterator concept, it can only do what is needed for MorphologicalFilter.
     */
-    template <typename IteratorT>
+    template<typename IteratorT>
     class /* OPENMS_DLLAPI */ IntensityIteratorWrapper
     {
-public:
+    public:
       typedef std::forward_iterator_tag iterator_category;
       typedef typename IteratorT::value_type::IntensityType value_type;
-      typedef typename IteratorT::value_type::IntensityType & reference;
-      typedef typename IteratorT::value_type::IntensityType * pointer;
+      typedef typename IteratorT::value_type::IntensityType& reference;
+      typedef typename IteratorT::value_type::IntensityType* pointer;
       typedef typename IteratorT::difference_type difference_type;
 
-      IntensityIteratorWrapper(const IteratorT & rhs) :
-        base(rhs)
+      IntensityIteratorWrapper(const IteratorT& rhs) : base(rhs)
       {
       }
 
@@ -75,18 +73,18 @@ public:
         return base->getIntensity();
       }
 
-      template <typename IndexT>
-      value_type operator[](const IndexT & index)
+      template<typename IndexT>
+      value_type operator[](const IndexT& index)
       {
         return base[index].getIntensity();
       }
 
-      difference_type operator-(IntensityIteratorWrapper & rhs) const
+      difference_type operator-(IntensityIteratorWrapper& rhs) const
       {
         return base - rhs.base;
       }
 
-      IntensityIteratorWrapper & operator++()
+      IntensityIteratorWrapper& operator++()
       {
         ++base;
         return *this;
@@ -99,28 +97,28 @@ public:
         return tmp;
       }
 
-      bool operator==(const IntensityIteratorWrapper & rhs) const
+      bool operator==(const IntensityIteratorWrapper& rhs) const
       {
         return base == rhs.base;
       }
 
-      bool operator!=(const IntensityIteratorWrapper & rhs) const
+      bool operator!=(const IntensityIteratorWrapper& rhs) const
       {
         return base != rhs.base;
       }
 
-protected:
+    protected:
       IteratorT base;
     };
 
     /// make-function so that we need no write out all those type names to get the wrapped iterator.
-    template <typename IteratorT>
-    IntensityIteratorWrapper<IteratorT> intensityIteratorWrapper(const IteratorT & rhs)
+    template<typename IteratorT>
+    IntensityIteratorWrapper<IteratorT> intensityIteratorWrapper(const IteratorT& rhs)
     {
       return IntensityIteratorWrapper<IteratorT>(rhs);
     }
 
-  }
+  } // namespace Internal
 
   /**
       @brief This class implements baseline filtering operations using methods
@@ -157,25 +155,21 @@ protected:
 
       @ingroup SignalProcessing
   */
-  class OPENMS_DLLAPI MorphologicalFilter :
-    public ProgressLogger,
-    public DefaultParamHandler
+  class OPENMS_DLLAPI MorphologicalFilter : public ProgressLogger, public DefaultParamHandler
   {
-public:
-
+  public:
     /// Constructor
-    MorphologicalFilter() :
-      ProgressLogger(),
-      DefaultParamHandler("MorphologicalFilter"),
-      struct_size_in_datapoints_(0)
+    MorphologicalFilter() : ProgressLogger(), DefaultParamHandler("MorphologicalFilter"), struct_size_in_datapoints_(0)
     {
-      //structuring element
+      // structuring element
       defaults_.setValue("struc_elem_length", 3.0, "Length of the structuring element. This should be wider than the expected peak width.");
       defaults_.setValue("struc_elem_unit", "Thomson", "The unit of the 'struct_elem_length'.");
-      defaults_.setValidStrings("struc_elem_unit", {"Thomson","DataPoints"});
-      //methods
-      defaults_.setValue("method", "tophat", "Method to use, the default is 'tophat'.  Do not change this unless you know what you are doing.  The other methods may be useful for tuning the parameters, see the class documentation of MorpthologicalFilter.");
-      defaults_.setValidStrings("method", {"identity","erosion","dilation","opening","closing","gradient","tophat","bothat","erosion_simple","dilation_simple"});
+      defaults_.setValidStrings("struc_elem_unit", {"Thomson", "DataPoints"});
+      // methods
+      defaults_.setValue("method", "tophat",
+                         "Method to use, the default is 'tophat'.  Do not change this unless you know what you are doing.  The other methods may be useful for tuning the parameters, see the class "
+                         "documentation of MorpthologicalFilter.");
+      defaults_.setValidStrings("method", {"identity", "erosion", "dilation", "opening", "closing", "gradient", "tophat", "bothat", "erosion_simple", "dilation_simple"});
 
       defaultsToParam_();
     }
@@ -196,20 +190,20 @@ public:
 
     @exception Exception::IllegalArgument The given method is not one of the values defined in the @em method parameter.
     */
-    template <typename InputIterator, typename OutputIterator>
+    template<typename InputIterator, typename OutputIterator>
     void filterRange(InputIterator input_begin, InputIterator input_end, OutputIterator output_begin)
     {
       // the buffer is static only to avoid reallocation
       static std::vector<typename InputIterator::value_type> buffer;
       const UInt size = input_end - input_begin;
 
-      //determine the struct size in data points if not already set
+      // determine the struct size in data points if not already set
       if (struct_size_in_datapoints_ == 0)
       {
         struct_size_in_datapoints_ = (UInt)(double)param_.getValue("struc_elem_length");
       }
 
-      //apply the filtering
+      // apply the filtering
       std::string method = param_.getValue("method");
       if (method == "identity")
       {
@@ -225,36 +219,44 @@ public:
       }
       else if (method == "opening")
       {
-        if (buffer.size() < size) buffer.resize(size);
+        if (buffer.size() < size)
+          buffer.resize(size);
         applyErosion_(struct_size_in_datapoints_, input_begin, input_end, buffer.begin());
         applyDilation_(struct_size_in_datapoints_, buffer.begin(), buffer.begin() + size, output_begin);
       }
       else if (method == "closing")
       {
-        if (buffer.size() < size) buffer.resize(size);
+        if (buffer.size() < size)
+          buffer.resize(size);
         applyDilation_(struct_size_in_datapoints_, input_begin, input_end, buffer.begin());
         applyErosion_(struct_size_in_datapoints_, buffer.begin(), buffer.begin() + size, output_begin);
       }
       else if (method == "gradient")
       {
-        if (buffer.size() < size) buffer.resize(size);
+        if (buffer.size() < size)
+          buffer.resize(size);
         applyErosion_(struct_size_in_datapoints_, input_begin, input_end, buffer.begin());
         applyDilation_(struct_size_in_datapoints_, input_begin, input_end, output_begin);
-        for (UInt i = 0; i < size; ++i) output_begin[i] -= buffer[i];
+        for (UInt i = 0; i < size; ++i)
+          output_begin[i] -= buffer[i];
       }
       else if (method == "tophat")
       {
-        if (buffer.size() < size) buffer.resize(size);
+        if (buffer.size() < size)
+          buffer.resize(size);
         applyErosion_(struct_size_in_datapoints_, input_begin, input_end, buffer.begin());
         applyDilation_(struct_size_in_datapoints_, buffer.begin(), buffer.begin() + size, output_begin);
-        for (UInt i = 0; i < size; ++i) output_begin[i] = input_begin[i] - output_begin[i];
+        for (UInt i = 0; i < size; ++i)
+          output_begin[i] = input_begin[i] - output_begin[i];
       }
       else if (method == "bothat")
       {
-        if (buffer.size() < size) buffer.resize(size);
+        if (buffer.size() < size)
+          buffer.resize(size);
         applyDilation_(struct_size_in_datapoints_, input_begin, input_end, buffer.begin());
         applyErosion_(struct_size_in_datapoints_, buffer.begin(), buffer.begin() + size, output_begin);
-        for (UInt i = 0; i < size; ++i) output_begin[i] = input_begin[i] - output_begin[i];
+        for (UInt i = 0; i < size; ++i)
+          output_begin[i] = input_begin[i] - output_begin[i];
       }
       else if (method == "erosion_simple")
       {
@@ -282,36 +284,37 @@ public:
                 number.
         </ul>
     */
-    void filter(MSSpectrum & spectrum)
+    void filter(MSSpectrum& spectrum)
     {
-      //make sure the right peak type is set
+      // make sure the right peak type is set
       spectrum.setType(SpectrumSettings::PROFILE);
 
-      //Abort if there is nothing to do
-      if (spectrum.size() <= 1) { return; }
+      // Abort if there is nothing to do
+      if (spectrum.size() <= 1)
+      {
+        return;
+      }
 
-      //Determine structuring element size in datapoints (depending on the unit)
+      // Determine structuring element size in datapoints (depending on the unit)
       if (param_.getValue("struc_elem_unit") == "Thomson")
       {
         const double struc_elem_length = (double)param_.getValue("struc_elem_length");
-        const double mz_diff = spectrum.back().getMZ() - spectrum.begin()->getMZ();        
-        struct_size_in_datapoints_ = (UInt)(ceil(struc_elem_length*(double)(spectrum.size() - 1)/mz_diff));
+        const double mz_diff = spectrum.back().getMZ() - spectrum.begin()->getMZ();
+        struct_size_in_datapoints_ = (UInt)(ceil(struc_elem_length * (double)(spectrum.size() - 1) / mz_diff));
       }
       else
       {
         struct_size_in_datapoints_ = (UInt)(double)param_.getValue("struc_elem_length");
       }
-      //make it odd (needed for the algorithm)
-      if (!Math::isOdd(struct_size_in_datapoints_)) ++struct_size_in_datapoints_;
+      // make it odd (needed for the algorithm)
+      if (!Math::isOdd(struct_size_in_datapoints_))
+        ++struct_size_in_datapoints_;
 
-      //apply the filtering and overwrite the input data
+      // apply the filtering and overwrite the input data
       std::vector<Peak1D::IntensityType> output(spectrum.size());
-      filterRange(Internal::intensityIteratorWrapper(spectrum.begin()),
-                  Internal::intensityIteratorWrapper(spectrum.end()),
-                  output.begin()
-                  );
+      filterRange(Internal::intensityIteratorWrapper(spectrum.begin()), Internal::intensityIteratorWrapper(spectrum.end()), output.begin());
 
-      //overwrite output with data
+      // overwrite output with data
       for (Size i = 0; i < spectrum.size(); ++i)
       {
         spectrum[i].setIntensity(output[i]);
@@ -324,7 +327,7 @@ public:
         The size of the structuring element is computed for each spectrum individually, if it is given in 'Thomson'.
         See the filtering method for MSSpectrum for details.
     */
-    void filterExperiment(PeakMap & exp)
+    void filterExperiment(PeakMap& exp)
     {
       startProgress(0, exp.size(), "filtering baseline");
       for (UInt i = 0; i < exp.size(); ++i)
@@ -335,30 +338,30 @@ public:
       endProgress();
     }
 
-protected:
-
-    ///Member for struct size in data points
+  protected:
+    /// Member for struct size in data points
     UInt struct_size_in_datapoints_;
 
     /** @brief Applies erosion.  This implementation uses van Herk's method.
     Only 3 min/max comparisons are required per data point, independent of
     struc_size.
     */
-    template <typename InputIterator, typename OutputIterator>
+    template<typename InputIterator, typename OutputIterator>
     void applyErosion_(Int struc_size, InputIterator input, InputIterator input_end, OutputIterator output)
     {
       typedef typename InputIterator::value_type ValueType;
       const Int size = input_end - input;
-      const Int struc_size_half = struc_size / 2;           // yes, integer division
+      const Int struc_size_half = struc_size / 2; // yes, integer division
 
       static std::vector<ValueType> buffer;
-      if (Int(buffer.size()) < struc_size) buffer.resize(struc_size);
+      if (Int(buffer.size()) < struc_size)
+        buffer.resize(struc_size);
 
-      Int anchor;           // anchoring position of the current block
-      Int i;                // index relative to anchor, used for 'for' loops
-      Int ii = 0;           // input index
-      Int oi = 0;           // output index
-      ValueType current;           // current value
+      Int anchor;        // anchoring position of the current block
+      Int i;             // index relative to anchor, used for 'for' loops
+      Int ii = 0;        // input index
+      Int oi = 0;        // output index
+      ValueType current; // current value
 
       // we just can't get the case distinctions right in these cases, resorting to simple method.
       if (size <= struc_size || size <= 5)
@@ -369,26 +372,27 @@ protected:
       {
         // lower margin area
         current = input[0];
-        for (++ii; ii < struc_size_half; ++ii) if (current > input[ii]) current = input[ii];
+        for (++ii; ii < struc_size_half; ++ii)
+          if (current > input[ii])
+            current = input[ii];
         for (; ii < std::min(Int(struc_size), size); ++ii, ++oi)
         {
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
       {
         // middle (main) area
-        for (anchor = struc_size;
-             anchor <= size - struc_size;
-             anchor += struc_size
-             )
+        for (anchor = struc_size; anchor <= size - struc_size; anchor += struc_size)
         {
           ii = anchor;
           current = input[ii];
           buffer[0] = current;
           for (i = 1; i < struc_size; ++i, ++ii)
           {
-            if (current > input[ii]) current = input[ii];
+            if (current > input[ii])
+              current = input[ii];
             buffer[i] = current;
           }
           ii = anchor - 1;
@@ -396,10 +400,12 @@ protected:
           current = input[ii];
           for (i = 1; i < struc_size; ++i, --ii, --oi)
           {
-            if (current > input[ii]) current = input[ii];
+            if (current > input[ii])
+              current = input[ii];
             output[oi] = std::min(buffer[struc_size - i], current);
           }
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
@@ -408,10 +414,13 @@ protected:
         ii = size - 1;
         oi = ii;
         current = input[ii];
-        for (--ii; ii >= size - struc_size_half; --ii) if (current > input[ii]) current = input[ii];
+        for (--ii; ii >= size - struc_size_half; --ii)
+          if (current > input[ii])
+            current = input[ii];
         for (; ii >= std::max(size - Int(struc_size), 0); --ii, --oi)
         {
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           output[oi] = current;
         }
         anchor = size - struc_size;
@@ -420,7 +429,8 @@ protected:
         buffer[0] = current;
         for (i = 1; i < struc_size; ++i, ++ii)
         {
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           buffer[i] = current;
         }
         ii = anchor - 1;
@@ -428,12 +438,14 @@ protected:
         current = input[ii];
         for (i = 1; (ii >= 0) && (i < struc_size); ++i, --ii, --oi)
         {
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           output[oi] = std::min(buffer[struc_size - i], current);
         }
         if (ii >= 0)
         {
-          if (current > input[ii]) current = input[ii];
+          if (current > input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
@@ -444,21 +456,22 @@ protected:
     Only 3 min/max comparisons are required per data point, independent of
     struc_size.
     */
-    template <typename InputIterator, typename OutputIterator>
+    template<typename InputIterator, typename OutputIterator>
     void applyDilation_(Int struc_size, InputIterator input, InputIterator input_end, OutputIterator output)
     {
       typedef typename InputIterator::value_type ValueType;
       const Int size = input_end - input;
-      const Int struc_size_half = struc_size / 2;           // yes, integer division
+      const Int struc_size_half = struc_size / 2; // yes, integer division
 
       static std::vector<ValueType> buffer;
-      if (Int(buffer.size()) < struc_size) buffer.resize(struc_size);
+      if (Int(buffer.size()) < struc_size)
+        buffer.resize(struc_size);
 
-      Int anchor;           // anchoring position of the current block
-      Int i;                // index relative to anchor, used for 'for' loops
-      Int ii = 0;           // input index
-      Int oi = 0;           // output index
-      ValueType current;           // current value
+      Int anchor;        // anchoring position of the current block
+      Int i;             // index relative to anchor, used for 'for' loops
+      Int ii = 0;        // input index
+      Int oi = 0;        // output index
+      ValueType current; // current value
 
       // we just can't get the case distinctions right in these cases, resorting to simple method.
       if (size <= struc_size || size <= 5)
@@ -469,26 +482,27 @@ protected:
       {
         // lower margin area
         current = input[0];
-        for (++ii; ii < struc_size_half; ++ii) if (current < input[ii]) current = input[ii];
+        for (++ii; ii < struc_size_half; ++ii)
+          if (current < input[ii])
+            current = input[ii];
         for (; ii < std::min(Int(struc_size), size); ++ii, ++oi)
         {
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
       {
         // middle (main) area
-        for (anchor = struc_size;
-             anchor <= size - struc_size;
-             anchor += struc_size
-             )
+        for (anchor = struc_size; anchor <= size - struc_size; anchor += struc_size)
         {
           ii = anchor;
           current = input[ii];
           buffer[0] = current;
           for (i = 1; i < struc_size; ++i, ++ii)
           {
-            if (current < input[ii]) current = input[ii];
+            if (current < input[ii])
+              current = input[ii];
             buffer[i] = current;
           }
           ii = anchor - 1;
@@ -496,10 +510,12 @@ protected:
           current = input[ii];
           for (i = 1; i < struc_size; ++i, --ii, --oi)
           {
-            if (current < input[ii]) current = input[ii];
+            if (current < input[ii])
+              current = input[ii];
             output[oi] = std::max(buffer[struc_size - i], current);
           }
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
@@ -508,10 +524,13 @@ protected:
         ii = size - 1;
         oi = ii;
         current = input[ii];
-        for (--ii; ii >= size - struc_size_half; --ii) if (current < input[ii]) current = input[ii];
+        for (--ii; ii >= size - struc_size_half; --ii)
+          if (current < input[ii])
+            current = input[ii];
         for (; ii >= std::max(size - Int(struc_size), 0); --ii, --oi)
         {
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           output[oi] = current;
         }
         anchor = size - struc_size;
@@ -520,7 +539,8 @@ protected:
         buffer[0] = current;
         for (i = 1; i < struc_size; ++i, ++ii)
         {
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           buffer[i] = current;
         }
         ii = anchor - 1;
@@ -528,12 +548,14 @@ protected:
         current = input[ii];
         for (i = 1; (ii >= 0) && (i < struc_size); ++i, --ii, --oi)
         {
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           output[oi] = std::max(buffer[struc_size - i], current);
         }
         if (ii >= 0)
         {
-          if (current < input[ii]) current = input[ii];
+          if (current < input[ii])
+            current = input[ii];
           output[oi] = current;
         }
       }
@@ -541,47 +563,48 @@ protected:
     }
 
     /// Applies erosion.  Simple implementation, possibly faster if struc_size is very small, and used in some special cases.
-    template <typename InputIterator, typename OutputIterator>
+    template<typename InputIterator, typename OutputIterator>
     void applyErosionSimple_(Int struc_size, InputIterator input_begin, InputIterator input_end, OutputIterator output_begin)
     {
       typedef typename InputIterator::value_type ValueType;
       const int size = input_end - input_begin;
-      const Int struc_size_half = struc_size / 2;           // yes integer division
+      const Int struc_size_half = struc_size / 2; // yes integer division
       for (Int index = 0; index < size; ++index)
       {
         Int start = std::max(0, index - struc_size_half);
-        Int stop  = std::min(size - 1, index + struc_size_half);
+        Int stop = std::min(size - 1, index + struc_size_half);
         ValueType value = input_begin[start];
-        for (Int i = start + 1; i <= stop; ++i) if (value > input_begin[i]) value = input_begin[i];
+        for (Int i = start + 1; i <= stop; ++i)
+          if (value > input_begin[i])
+            value = input_begin[i];
         output_begin[index] = value;
       }
       return;
     }
 
     /// Applies dilation.  Simple implementation, possibly faster if struc_size is very small, and used in some special cases.
-    template <typename InputIterator, typename OutputIterator>
+    template<typename InputIterator, typename OutputIterator>
     void applyDilationSimple_(Int struc_size, InputIterator input_begin, InputIterator input_end, OutputIterator output_begin)
     {
       typedef typename InputIterator::value_type ValueType;
       const int size = input_end - input_begin;
-      const Int struc_size_half = struc_size / 2;           // yes integer division
+      const Int struc_size_half = struc_size / 2; // yes integer division
       for (Int index = 0; index < size; ++index)
       {
         Int start = std::max(0, index - struc_size_half);
-        Int stop   = std::min(size - 1, index + struc_size_half);
+        Int stop = std::min(size - 1, index + struc_size_half);
         ValueType value = input_begin[start];
-        for (Int i = start + 1; i <= stop; ++i) if (value < input_begin[i]) value = input_begin[i];
+        for (Int i = start + 1; i <= stop; ++i)
+          if (value < input_begin[i])
+            value = input_begin[i];
         output_begin[index] = value;
       }
       return;
     }
 
-private:
-
+  private:
     /// copy constructor not implemented
-    MorphologicalFilter(const MorphologicalFilter & source);
-
+    MorphologicalFilter(const MorphologicalFilter& source);
   };
 
 } // namespace OpenMS
-

--- a/src/openms/include/OpenMS/FILTERING/BASELINE/MorphologicalFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/BASELINE/MorphologicalFilter.h
@@ -56,10 +56,10 @@ namespace OpenMS
         iterator concept, it can only do what is needed for MorphologicalFilter.
     */
     template <typename IteratorT>
-    class /* OPENMS_DLLAPI */ IntensityIteratorWrapper :
-      public std::iterator<std::forward_iterator_tag, typename IteratorT::value_type::IntensityType>
+    class /* OPENMS_DLLAPI */ IntensityIteratorWrapper
     {
 public:
+      typedef std::forward_iterator_tag iterator_category;
       typedef typename IteratorT::value_type::IntensityType value_type;
       typedef typename IteratorT::value_type::IntensityType & reference;
       typedef typename IteratorT::value_type::IntensityType * pointer;

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -34,18 +34,17 @@
 
 #pragma once
 
-#include <OpenMS/config.h>
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/METADATA/PeptideIdentification.h>
-#include <OpenMS/METADATA/PeptideEvidence.h>
-#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ID/IdentificationData.h>
-
+#include <OpenMS/METADATA/PeptideEvidence.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/config.h>
 #include <algorithm>
 #include <climits>
 #include <functional>
@@ -78,8 +77,7 @@ namespace OpenMS
   */
   class OPENMS_DLLAPI IDFilter
   {
-public:
-
+  public:
     /// Constructor
     IDFilter() = default;
 
@@ -99,18 +97,16 @@ public:
     ///@{
 
     /// Is the score of this hit at least as good as the given value?
-    template <class HitType>
-    struct HasGoodScore
-    {
+    template<class HitType>
+    struct HasGoodScore {
       typedef HitType argument_type; // for use as a predicate
 
       double score;
       bool higher_score_better;
 
-      HasGoodScore(double score_, bool higher_score_better_) :
-        score(score_),
-        higher_score_better(higher_score_better_)
-      {}
+      HasGoodScore(double score_, bool higher_score_better_) : score(score_), higher_score_better(higher_score_better_)
+      {
+      }
 
       bool operator()(const HitType& hit) const
       {
@@ -127,15 +123,13 @@ public:
 
        Ranks are counted from one (best), so zero is not a valid cut-off.
     */
-    template <class HitType>
-    struct HasMaxRank
-    {
+    template<class HitType>
+    struct HasMaxRank {
       typedef HitType argument_type; // for use as a predicate
 
       Size rank;
 
-      HasMaxRank(Size rank_):
-        rank(rank_)
+      HasMaxRank(Size rank_) : rank(rank_)
       {
         if (rank_ == 0)
         {
@@ -159,61 +153,59 @@ public:
 
        If the value is empty (DataValue::EMPTY), only the existence of a meta value with the given key is checked.
     */
-    template <class HitType>
-    struct HasMetaValue
-    {
+    template<class HitType>
+    struct HasMetaValue {
       typedef HitType argument_type; // for use as a predicate
 
       String key;
       DataValue value;
 
-      HasMetaValue(const String& key_, const DataValue& value_):
-        key(key_),
-        value(value_)
-      {}
+      HasMetaValue(const String& key_, const DataValue& value_) : key(key_), value(value_)
+      {
+      }
 
       bool operator()(const HitType& hit) const
       {
         DataValue found = hit.getMetaValue(key);
-        if (found.isEmpty()) return false; // meta value "key" not set
-        if (value.isEmpty()) return true; // "key" is set, value doesn't matter
+        if (found.isEmpty())
+          return false; // meta value "key" not set
+        if (value.isEmpty())
+          return true; // "key" is set, value doesn't matter
         return found == value;
       }
     };
 
     /// Does a meta value of this hit have at most the given value?
-    template <class HitType>
-    struct HasMaxMetaValue
-    {
+    template<class HitType>
+    struct HasMaxMetaValue {
       typedef HitType argument_type; // for use as a predicate
 
       String key;
       double value;
 
-      HasMaxMetaValue(const String& key_, const double& value_):
-        key(key_),
-        value(value_)
-      {}
+      HasMaxMetaValue(const String& key_, const double& value_) : key(key_), value(value_)
+      {
+      }
 
       bool operator()(const HitType& hit) const
       {
         DataValue found = hit.getMetaValue(key);
-        if (found.isEmpty()) return false; // meta value "key" not set
+        if (found.isEmpty())
+          return false; // meta value "key" not set
         return double(found) <= value;
       }
     };
 
     /// Is this a decoy hit?
-    template <class HitType>
-    struct HasDecoyAnnotation
-    {
+    template<class HitType>
+    struct HasDecoyAnnotation {
       typedef HitType argument_type; // for use as a predicate
 
       struct HasMetaValue<HitType> target_decoy, is_decoy;
 
-      HasDecoyAnnotation():
-        target_decoy("target_decoy", "decoy"), is_decoy("isDecoy", "true")
-      {}
+      HasDecoyAnnotation() : target_decoy("target_decoy", "decoy"), is_decoy("isDecoy", "true")
+      {
+      }
 
       bool operator()(const HitType& hit) const
       {
@@ -229,22 +221,22 @@ public:
 
        @note This predicate also works for peptide evidence (class PeptideEvidence).
     */
-    template <class HitType>
-    struct HasMatchingAccessionUnordered
-    {
+    template<class HitType>
+    struct HasMatchingAccessionUnordered {
       typedef HitType argument_type; // for use as a predicate
 
       const std::unordered_set<String>& accessions;
 
-      HasMatchingAccessionUnordered(const std::unordered_set<String>& accessions_):
-        accessions(accessions_)
-      {}
+      HasMatchingAccessionUnordered(const std::unordered_set<String>& accessions_) : accessions(accessions_)
+      {
+      }
 
       bool operator()(const PeptideHit& hit) const
       {
         for (const auto& it : hit.extractProteinAccessionsSet())
         {
-          if (accessions.count(it) > 0) return true;
+          if (accessions.count(it) > 0)
+            return true;
         }
         return false;
       }
@@ -265,22 +257,22 @@ public:
 
        @note This predicate also works for peptide evidence (class PeptideEvidence).
     */
-    template <class HitType>
-    struct HasMatchingAccession
-    {
+    template<class HitType>
+    struct HasMatchingAccession {
       typedef HitType argument_type; // for use as a predicate
 
       const std::set<String>& accessions;
 
-      HasMatchingAccession(const std::set<String>& accessions_):
-        accessions(accessions_)
-      {}
+      HasMatchingAccession(const std::set<String>& accessions_) : accessions(accessions_)
+      {
+      }
 
       bool operator()(const PeptideHit& hit) const
       {
         for (const auto& it : hit.extractProteinAccessionsSet())
         {
-          if (accessions.count(it) > 0) return true;
+          if (accessions.count(it) > 0)
+            return true;
         }
         return false;
       }
@@ -301,23 +293,23 @@ public:
 
        @note Currently implemented for Fasta Entries and Peptide Evidences
     */
-    template <class HitType, class Entry>
-    struct GetMatchingItems
-    {
-      typedef HitType argument_type; // for use as a predicate
-      typedef std::map<String, Entry*> ItemMap;//Store pointers to avoid copying data
+    template<class HitType, class Entry>
+    struct GetMatchingItems {
+      typedef HitType argument_type;            // for use as a predicate
+      typedef std::map<String, Entry*> ItemMap; // Store pointers to avoid copying data
       ItemMap items;
 
       GetMatchingItems(std::vector<Entry>& records)
       {
-        for(typename std::vector<Entry>::iterator rec_it = records.begin();
-            rec_it != records.end(); ++rec_it)
+        for (typename std::vector<Entry>::iterator rec_it = records.begin(); rec_it != records.end(); ++rec_it)
         {
           items[getKey(*rec_it)] = &(*rec_it);
         }
       }
 
-      GetMatchingItems(){}
+      GetMatchingItems()
+      {
+      }
 
       const String& getKey(const FASTAFile::FASTAEntry& entry) const
       {
@@ -336,12 +328,12 @@ public:
 
       const Entry& getValue(const PeptideEvidence& evidence) const
       {
-        if(!exists(evidence)){
-          throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Accession: '"+ getHitKey(evidence) + "'. peptide evidence accession not in data");
+        if (!exists(evidence))
+        {
+          throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Accession: '" + getHitKey(evidence) + "'. peptide evidence accession not in data");
         }
         return *(items.find(getHitKey(evidence))->second);
       }
-
     };
 
     ///@}
@@ -388,43 +380,38 @@ public:
 
     class PeptideDigestionFilter
     {
-     private:
+    private:
       EnzymaticDigestion& digestion_;
       Int min_cleavages_;
       Int max_cleavages_;
 
-     public:
+    public:
       typedef PeptideHit argument_type;
-      PeptideDigestionFilter(EnzymaticDigestion& digestion, Int min, Int max) :
-      digestion_(digestion), min_cleavages_(min), max_cleavages_(max)
-      {}
+      PeptideDigestionFilter(EnzymaticDigestion& digestion, Int min, Int max) : digestion_(digestion), min_cleavages_(min), max_cleavages_(max)
+      {
+      }
 
-      static inline Int disabledValue(){ return -1; }
+      static inline Int disabledValue()
+      {
+        return -1;
+      }
 
       /// Filter function on min max cutoff values to be used with remove_if
       /// returns true if peptide should be removed (does not pass filter)
       bool operator()(PeptideHit& p) const
       {
-        const auto& fun = [&](const Int missed_cleavages)
-        {
-
-          bool max_filter = max_cleavages_ != disabledValue() ?
-                            missed_cleavages > max_cleavages_ : false;
-          bool min_filter = min_cleavages_ != disabledValue() ?
-                            missed_cleavages < min_cleavages_ : false;
+        const auto& fun = [&](const Int missed_cleavages) {
+          bool max_filter = max_cleavages_ != disabledValue() ? missed_cleavages > max_cleavages_ : false;
+          bool min_filter = min_cleavages_ != disabledValue() ? missed_cleavages < min_cleavages_ : false;
           return max_filter || min_filter;
         };
-        return digestion_.filterByMissedCleavages(
-          p.getSequence().toUnmodifiedString(),
-          fun);
+        return digestion_.filterByMissedCleavages(p.getSequence().toUnmodifiedString(), fun);
       }
 
       void filterPeptideSequences(std::vector<PeptideHit>& hits)
       {
-        hits.erase(std::remove_if(hits.begin(), hits.end(), (*this)),
-                   hits.end());
+        hits.erase(std::remove_if(hits.begin(), hits.end(), (*this)), hits.end());
       }
-
     };
 
 
@@ -433,29 +420,23 @@ public:
 
        Keeps all valid products
      */
-    struct DigestionFilter
-    {
+    struct DigestionFilter {
       typedef PeptideEvidence argument_type;
 
       // Build an accession index to avoid the linear search cost
-      GetMatchingItems<PeptideEvidence, FASTAFile::FASTAEntry>accession_resolver_;
+      GetMatchingItems<PeptideEvidence, FASTAFile::FASTAEntry> accession_resolver_;
       ProteaseDigestion& digestion_;
       bool ignore_missed_cleavages_;
       bool methionine_cleavage_;
 
-      DigestionFilter(std::vector<FASTAFile::FASTAEntry>& entries,
-                      ProteaseDigestion& digestion,
-                      bool ignore_missed_cleavages,
-                      bool methionine_cleavage) :
-        accession_resolver_(entries),
-        digestion_(digestion),
-        ignore_missed_cleavages_(ignore_missed_cleavages),
-        methionine_cleavage_(methionine_cleavage)
-      {}
+      DigestionFilter(std::vector<FASTAFile::FASTAEntry>& entries, ProteaseDigestion& digestion, bool ignore_missed_cleavages, bool methionine_cleavage) :
+          accession_resolver_(entries), digestion_(digestion), ignore_missed_cleavages_(ignore_missed_cleavages), methionine_cleavage_(methionine_cleavage)
+      {
+      }
 
       bool operator()(const PeptideEvidence& evidence) const
       {
-        if(!evidence.hasValidLimits())
+        if (!evidence.hasValidLimits())
         {
           OPENMS_LOG_WARN << "Invalid limits! Peptide '" << evidence.getProteinAccession() << "' not filtered" << std::endl;
           return true;
@@ -463,9 +444,8 @@ public:
 
         if (accession_resolver_.exists(evidence))
         {
-          return digestion_.isValidProduct(
-            AASequence::fromString(accession_resolver_.getValue(evidence).sequence),
-            evidence.getStart(), evidence.getEnd() - evidence.getStart(), ignore_missed_cleavages_, methionine_cleavage_);
+          return digestion_.isValidProduct(AASequence::fromString(accession_resolver_.getValue(evidence).sequence), evidence.getStart(), evidence.getEnd() - evidence.getStart(),
+                                           ignore_missed_cleavages_, methionine_cleavage_);
         }
         else
         {
@@ -475,8 +455,7 @@ public:
           }
           else
           {
-            OPENMS_LOG_WARN << "Peptide accession '" << evidence.getProteinAccession()
-                     << "' not found in fasta file!" << std::endl;
+            OPENMS_LOG_WARN << "Peptide accession '" << evidence.getProteinAccession() << "' not found in fasta file!" << std::endl;
           }
           return true;
         }
@@ -484,9 +463,8 @@ public:
 
       void filterPeptideEvidences(std::vector<PeptideIdentification>& peptides)
       {
-        IDFilter::FilterPeptideEvidences<IDFilter::DigestionFilter>(*this,peptides);
+        IDFilter::FilterPeptideEvidences<IDFilter::DigestionFilter>(*this, peptides);
       }
-
     };
 
     ///@}
@@ -496,9 +474,8 @@ public:
     ///@{
 
     /// Is the list of hits of this peptide/protein ID empty?
-    template <class IdentificationType>
-    struct HasNoHits
-    {
+    template<class IdentificationType>
+    struct HasNoHits {
       typedef IdentificationType argument_type; // for use as a predicate
 
       bool operator()(const IdentificationType& id) const
@@ -530,32 +507,30 @@ public:
     ///@{
 
     /// Remove items that satisfy a condition from a container (e.g. vector)
-    template <class Container, class Predicate>
+    template<class Container, class Predicate>
     static void removeMatchingItems(Container& items, const Predicate& pred)
     {
-      items.erase(std::remove_if(items.begin(), items.end(), pred),
-                  items.end());
+      items.erase(std::remove_if(items.begin(), items.end(), pred), items.end());
     }
 
     /// Keep items that satisfy a condition in a container (e.g. vector), removing all others
-    template <class Container, class Predicate>
+    template<class Container, class Predicate>
     static void keepMatchingItems(Container& items, const Predicate& pred)
     {
-      items.erase(std::remove_if(items.begin(), items.end(), std::not_fn(pred)),
-                  items.end());
+      items.erase(std::remove_if(items.begin(), items.end(), std::not_fn(pred)), items.end());
     }
 
     /// Move items that satisfy a condition to a container (e.g. vector)
-    template <class Container, class Predicate>
+    template<class Container, class Predicate>
     static void moveMatchingItems(Container& items, const Predicate& pred, Container& target)
     {
-        auto part = std::partition(items.begin(), items.end(), std::not_fn(pred));
-        std::move(part, items.end(), std::back_inserter(target));
-        items.erase(part, items.end());
+      auto part = std::partition(items.begin(), items.end(), std::not_fn(pred));
+      std::move(part, items.end(), std::back_inserter(target));
+      items.erase(part, items.end());
     }
 
     /// Remove Hit items that satisfy a condition in one of our ID containers (e.g. vector of Peptide or ProteinIDs)
-    template <class IDContainer, class Predicate>
+    template<class IDContainer, class Predicate>
     static void removeMatchingItemsUnroll(IDContainer& items, const Predicate& pred)
     {
       for (auto& item : items)
@@ -565,7 +540,7 @@ public:
     }
 
     /// Keep Hit items that satisfy a condition in one of our ID containers (e.g. vector of Peptide or ProteinIDs)
-    template <class IDContainer, class Predicate>
+    template<class IDContainer, class Predicate>
     static void keepMatchingItemsUnroll(IDContainer& items, const Predicate& pred)
     {
       for (auto& item : items)
@@ -574,7 +549,7 @@ public:
       }
     }
 
-    template <class MapType, class Predicate>
+    template<class MapType, class Predicate>
     static void keepMatchingPeptideHits(MapType& prot_and_pep_ids, Predicate& pred)
     {
       for (auto& feat : prot_and_pep_ids)
@@ -584,7 +559,7 @@ public:
       keepMatchingItemsUnroll(prot_and_pep_ids.getUnassignedPeptideIdentifications(), pred);
     }
 
-    template <class MapType, class Predicate>
+    template<class MapType, class Predicate>
     static void removeMatchingPeptideHits(MapType& prot_and_pep_ids, Predicate& pred)
     {
       for (auto& feat : prot_and_pep_ids)
@@ -594,7 +569,7 @@ public:
       removeMatchingItemsUnroll(prot_and_pep_ids.getUnassignedPeptideIdentifications(), pred);
     }
 
-    template <class MapType, class Predicate>
+    template<class MapType, class Predicate>
     static void removeMatchingPeptideIdentifications(MapType& prot_and_pep_ids, Predicate& pred)
     {
       for (auto& feat : prot_and_pep_ids)
@@ -611,12 +586,11 @@ public:
     ///@{
 
     /// Returns the total number of peptide/protein hits in a vector of peptide/protein identifications
-    template <class IdentificationType>
+    template<class IdentificationType>
     static Size countHits(const std::vector<IdentificationType>& ids)
     {
       Size counter = 0;
-      for (typename std::vector<IdentificationType>::const_iterator id_it =
-             ids.begin(); id_it != ids.end(); ++id_it)
+      for (typename std::vector<IdentificationType>::const_iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
       {
         counter += id_it->getHits().size();
       }
@@ -636,22 +610,19 @@ public:
 
        @return true if a hit was present, false otherwise
     */
-    template <class IdentificationType>
-    static bool getBestHit(
-      const std::vector<IdentificationType>& identifications,
-      bool assume_sorted, typename IdentificationType::HitType& best_hit)
+    template<class IdentificationType>
+    static bool getBestHit(const std::vector<IdentificationType>& identifications, bool assume_sorted, typename IdentificationType::HitType& best_hit)
     {
-      if (identifications.empty()) return false;
+      if (identifications.empty())
+        return false;
 
-      typename std::vector<IdentificationType>::const_iterator best_id_it =
-        identifications.end();
-      typename std::vector<typename IdentificationType::HitType>::const_iterator
-        best_hit_it;
+      typename std::vector<IdentificationType>::const_iterator best_id_it = identifications.end();
+      typename std::vector<typename IdentificationType::HitType>::const_iterator best_hit_it;
 
-      for (typename std::vector<IdentificationType>::const_iterator id_it =
-             identifications.begin(); id_it != identifications.end(); ++id_it)
+      for (typename std::vector<IdentificationType>::const_iterator id_it = identifications.begin(); id_it != identifications.end(); ++id_it)
       {
-        if (id_it->getHits().empty()) continue;
+        if (id_it->getHits().empty())
+          continue;
 
         if (best_id_it == identifications.end()) // no previous "best" hit
         {
@@ -664,18 +635,14 @@ public:
         }
 
         bool higher_better = best_id_it->isHigherScoreBetter();
-        for (typename std::vector<typename IdentificationType::HitType>::
-               const_iterator hit_it = id_it->getHits().begin(); hit_it !=
-               id_it->getHits().end(); ++hit_it)
+        for (typename std::vector<typename IdentificationType::HitType>::const_iterator hit_it = id_it->getHits().begin(); hit_it != id_it->getHits().end(); ++hit_it)
         {
-          if ((higher_better && (hit_it->getScore() >
-                                 best_hit_it->getScore())) ||
-              (!higher_better && (hit_it->getScore() <
-                                  best_hit_it->getScore())))
+          if ((higher_better && (hit_it->getScore() > best_hit_it->getScore())) || (!higher_better && (hit_it->getScore() < best_hit_it->getScore())))
           {
             best_hit_it = hit_it;
           }
-          if (assume_sorted) break; // only consider the first hit
+          if (assume_sorted)
+            break; // only consider the first hit
         }
       }
 
@@ -695,16 +662,14 @@ public:
        @param sequences Output
        @param ignore_mods Extract sequences without modifications?
     */
-    static void extractPeptideSequences(
-      const std::vector<PeptideIdentification>& peptides,
-      std::set<String>& sequences, bool ignore_mods = false);
+    static void extractPeptideSequences(const std::vector<PeptideIdentification>& peptides, std::set<String>& sequences, bool ignore_mods = false);
 
     /**
      * @brief Extracts all proteins not matched by PSMs in features
      * @param cmap the Input ConsensusMap
      * @return extracted ProteinHits for every IDRun
      */
-    static std::map<String,std::vector<ProteinHit>> extractUnassignedProteins(ConsensusMap& cmap);
+    static std::map<String, std::vector<ProteinHit>> extractUnassignedProteins(ConsensusMap& cmap);
 
     /**
        @brief remove peptide evidences based on a filter
@@ -712,21 +677,14 @@ public:
        @param peptides a collection of peptide evidences
      */
     template<class EvidenceFilter>
-    static void FilterPeptideEvidences(
-      EvidenceFilter& filter,
-      std::vector<PeptideIdentification>& peptides)
+    static void FilterPeptideEvidences(EvidenceFilter& filter, std::vector<PeptideIdentification>& peptides)
     {
-      for(std::vector<PeptideIdentification>::iterator pep_it = peptides.begin();
-          pep_it != peptides.end(); ++pep_it)
+      for (std::vector<PeptideIdentification>::iterator pep_it = peptides.begin(); pep_it != peptides.end(); ++pep_it)
       {
-        for(std::vector<PeptideHit>::iterator hit_it = pep_it->getHits().begin();
-            hit_it != pep_it->getHits().end(); ++hit_it )
+        for (std::vector<PeptideHit>::iterator hit_it = pep_it->getHits().begin(); hit_it != pep_it->getHits().end(); ++hit_it)
         {
           std::vector<PeptideEvidence> evidences;
-          remove_copy_if(hit_it->getPeptideEvidences().begin(),
-                         hit_it->getPeptideEvidences().end(),
-                         back_inserter(evidences),
-                         std::not_fn(filter));
+          remove_copy_if(hit_it->getPeptideEvidences().begin(), hit_it->getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(filter));
           hit_it->setPeptideEvidences(evidences);
         }
       }
@@ -739,11 +697,10 @@ public:
     ///@{
 
     /// Updates the hit ranks on all peptide or protein IDs
-    template <class IdentificationType>
+    template<class IdentificationType>
     static void updateHitRanks(std::vector<IdentificationType>& ids)
     {
-      for (typename std::vector<IdentificationType>::iterator it = ids.begin();
-           it != ids.end(); ++it)
+      for (typename std::vector<IdentificationType>::iterator it = ids.begin(); it != ids.end(); ++it)
       {
         it->assignRanks();
       }
@@ -754,13 +711,9 @@ public:
     static void removeUnreferencedProteins(ConsensusMap& cmap, bool include_unassigned);
 
     /// Removes protein hits from @p proteins that are not referenced by a peptide in @p peptides
-    static void removeUnreferencedProteins(
-      std::vector<ProteinIdentification>& proteins,
-      const std::vector<PeptideIdentification>& peptides);
+    static void removeUnreferencedProteins(std::vector<ProteinIdentification>& proteins, const std::vector<PeptideIdentification>& peptides);
     /// Removes protein hits from @p proteins that are not referenced by a peptide in @p peptides
-    static void removeUnreferencedProteins(
-        ProteinIdentification& proteins,
-        const std::vector<PeptideIdentification>& peptides);
+    static void removeUnreferencedProteins(ProteinIdentification& proteins, const std::vector<PeptideIdentification>& peptides);
 
     /**
        @brief Removes references to missing proteins
@@ -769,10 +722,7 @@ public:
 
        If @p remove_peptides_without_reference is set, peptide hits without any remaining protein reference are removed.
     */
-    static void updateProteinReferences(
-      std::vector<PeptideIdentification>& peptides,
-      const std::vector<ProteinIdentification>& proteins,
-      bool remove_peptides_without_reference = false);
+    static void updateProteinReferences(std::vector<PeptideIdentification>& peptides, const std::vector<ProteinIdentification>& proteins, bool remove_peptides_without_reference = false);
 
     /**
        @brief Removes references to missing proteins
@@ -781,9 +731,7 @@ public:
 
        If @p remove_peptides_without_reference is set, peptide hits without any remaining protein reference are removed.
     */
-    static void updateProteinReferences(
-        ConsensusMap& cmap,
-        bool remove_peptides_without_reference = false);
+    static void updateProteinReferences(ConsensusMap& cmap, bool remove_peptides_without_reference = false);
 
     /**
        @brief Removes references to missing proteins
@@ -792,10 +740,7 @@ public:
 
        If @p remove_peptides_without_reference is set, peptide hits without any remaining protein reference are removed.
     */
-    static void updateProteinReferences(
-        ConsensusMap& cmap,
-        const ProteinIdentification& ref_run,
-        bool remove_peptides_without_reference = false);
+    static void updateProteinReferences(ConsensusMap& cmap, const ProteinIdentification& ref_run, bool remove_peptides_without_reference = false);
 
     /**
        @brief Update protein groups after protein hits were filtered
@@ -805,9 +750,7 @@ public:
 
        @return Returns whether the groups are still valid (which is the case if only whole groups, if any, were removed).
     */
-    static bool updateProteinGroups(
-      std::vector<ProteinIdentification::ProteinGroup>& groups,
-      const std::vector<ProteinHit>& hits);
+    static bool updateProteinGroups(std::vector<ProteinIdentification::ProteinGroup>& groups, const std::vector<ProteinHit>& hits);
 
     /**
        @brief Update protein hits after protein groups were filtered
@@ -815,9 +758,7 @@ public:
        @param groups Available protein groups with protein accessions to keep
        @param hits Input/output hits (all others are removed from the groups)
     */
-    static void removeUngroupedProteins(
-        const std::vector<ProteinIdentification::ProteinGroup>& groups,
-        std::vector<ProteinHit>& hits);
+    static void removeUngroupedProteins(const std::vector<ProteinIdentification::ProteinGroup>& groups, std::vector<ProteinHit>& hits);
     ///@}
 
 
@@ -825,7 +766,7 @@ public:
     ///@{
 
     /// Removes peptide or protein identifications that have no hits in them
-    template <class IdentificationType>
+    template<class IdentificationType>
     static void removeEmptyIdentifications(std::vector<IdentificationType>& ids)
     {
       struct HasNoHits<IdentificationType> empty_filter;
@@ -837,15 +778,12 @@ public:
 
       Only peptide/protein hits with a score at least as good as @p threshold_score are kept. Score orientation (are higher scores better?) is taken into account.
     */
-    template <class IdentificationType>
-    static void filterHitsByScore(std::vector<IdentificationType>& ids,
-                                  double threshold_score)
+    template<class IdentificationType>
+    static void filterHitsByScore(std::vector<IdentificationType>& ids, double threshold_score)
     {
-      for (typename std::vector<IdentificationType>::iterator id_it =
-             ids.begin(); id_it != ids.end(); ++id_it)
+      for (typename std::vector<IdentificationType>::iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
       {
-        struct HasGoodScore<typename IdentificationType::HitType> score_filter(
-          threshold_score, id_it->isHigherScoreBetter());
+        struct HasGoodScore<typename IdentificationType::HitType> score_filter(threshold_score, id_it->isHigherScoreBetter());
         keepMatchingItems(id_it->getHits(), score_filter);
       }
     }
@@ -856,21 +794,18 @@ public:
       Only protein groups with a score at least as good as @p threshold_score are kept.
       Score orientation (@p higher_better) should be taken from the protein hits and assumed equal.
     */
-    static void filterGroupsByScore(std::vector<ProteinIdentification::ProteinGroup>& grps,
-                                  double threshold_score, bool higher_better);
+    static void filterGroupsByScore(std::vector<ProteinIdentification::ProteinGroup>& grps, double threshold_score, bool higher_better);
 
     /**
       @brief Filters peptide or protein identifications according to the score of the hits.
 
       Only peptide/protein hits with a score at least as good as @p threshold_score are kept. Score orientation (are higher scores better?) is taken into account.
     */
-    template <class IdentificationType>
-    static void filterHitsByScore(IdentificationType& id,
-                                  double threshold_score)
+    template<class IdentificationType>
+    static void filterHitsByScore(IdentificationType& id, double threshold_score)
     {
-        struct HasGoodScore<typename IdentificationType::HitType> score_filter(
-            threshold_score, id.isHigherScoreBetter());
-        keepMatchingItems(id.getHits(), score_filter);
+      struct HasGoodScore<typename IdentificationType::HitType> score_filter(threshold_score, id.isHigherScoreBetter());
+      keepMatchingItems(id.getHits(), score_filter);
     }
 
     /**
@@ -878,14 +813,14 @@ public:
 
       The score orientation (are higher scores better?) is taken into account.
     */
-    template <class IdentificationType>
+    template<class IdentificationType>
     static void keepNBestHits(std::vector<IdentificationType>& ids, Size n)
     {
-      for (typename std::vector<IdentificationType>::iterator id_it =
-             ids.begin(); id_it != ids.end(); ++id_it)
+      for (typename std::vector<IdentificationType>::iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
       {
         id_it->sort();
-        if (n < id_it->getHits().size()) id_it->getHits().resize(n);
+        if (n < id_it->getHits().size())
+          id_it->getHits().resize(n);
       }
     }
 
@@ -903,27 +838,22 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    template <class IdentificationType>
-    static void filterHitsByRank(std::vector<IdentificationType>& ids,
-                                 Size min_rank, Size max_rank)
+    template<class IdentificationType>
+    static void filterHitsByRank(std::vector<IdentificationType>& ids, Size min_rank, Size max_rank)
     {
       updateHitRanks(ids);
       if (min_rank > 1)
       {
-        struct HasMaxRank<typename IdentificationType::HitType>
-          rank_filter(min_rank - 1);
-        for (typename std::vector<IdentificationType>::iterator id_it =
-               ids.begin(); id_it != ids.end(); ++id_it)
+        struct HasMaxRank<typename IdentificationType::HitType> rank_filter(min_rank - 1);
+        for (typename std::vector<IdentificationType>::iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
         {
           removeMatchingItems(id_it->getHits(), rank_filter);
         }
       }
       if (max_rank >= min_rank)
       {
-        struct HasMaxRank<typename IdentificationType::HitType>
-          rank_filter(max_rank);
-        for (typename std::vector<IdentificationType>::iterator id_it =
-               ids.begin(); id_it != ids.end(); ++id_it)
+        struct HasMaxRank<typename IdentificationType::HitType> rank_filter(max_rank);
+        for (typename std::vector<IdentificationType>::iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
         {
           keepMatchingItems(id_it->getHits(), rank_filter);
         }
@@ -937,13 +867,11 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    template <class IdentificationType>
+    template<class IdentificationType>
     static void removeDecoyHits(std::vector<IdentificationType>& ids)
     {
-      struct HasDecoyAnnotation<typename IdentificationType::HitType>
-        decoy_filter;
-      for (typename std::vector<IdentificationType>::iterator id_it =
-             ids.begin(); id_it != ids.end(); ++id_it)
+      struct HasDecoyAnnotation<typename IdentificationType::HitType> decoy_filter;
+      for (typename std::vector<IdentificationType>::iterator id_it = ids.begin(); id_it != ids.end(); ++id_it)
       {
         removeMatchingItems(id_it->getHits(), decoy_filter);
       }
@@ -956,9 +884,8 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    template <class IdentificationType>
-    static void removeHitsMatchingProteins(std::vector<IdentificationType>& ids,
-                                           const std::set<String> accessions)
+    template<class IdentificationType>
+    static void removeHitsMatchingProteins(std::vector<IdentificationType>& ids, const std::set<String> accessions)
     {
       struct HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
       for (auto& id_it : ids)
@@ -974,9 +901,8 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    template <class IdentificationType>
-    static void keepHitsMatchingProteins(std::vector<IdentificationType>& ids,
-                                         const std::set<String>& accessions)
+    template<class IdentificationType>
+    static void keepHitsMatchingProteins(std::vector<IdentificationType>& ids, const std::set<String>& accessions)
     {
       struct HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
       for (auto& id_it : ids)
@@ -997,8 +923,7 @@ public:
        @param peptides Input/output
        @param strict If set, keep the best hit only if its score is unique - i.e. ties are not allowed. (Otherwise all hits with the best score is kept.)
     */
-    static void keepBestPeptideHits(
-      std::vector<PeptideIdentification>& peptides, bool strict = false);
+    static void keepBestPeptideHits(std::vector<PeptideIdentification>& peptides, bool strict = false);
 
     /**
        @brief Filters peptide identifications according to peptide sequence length.
@@ -1008,9 +933,7 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void filterPeptidesByLength(
-      std::vector<PeptideIdentification>& peptides, Size min_length,
-      Size max_length = UINT_MAX);
+    static void filterPeptidesByLength(std::vector<PeptideIdentification>& peptides, Size min_length, Size max_length = UINT_MAX);
 
     /**
        @brief Filters peptide identifications according to charge state.
@@ -1020,17 +943,13 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void filterPeptidesByCharge(
-      std::vector<PeptideIdentification>& peptides, Int min_charge,
-      Int max_charge);
+    static void filterPeptidesByCharge(std::vector<PeptideIdentification>& peptides, Int min_charge, Int max_charge);
 
     /// Filters peptide identifications by precursor RT, keeping only IDs in the given range
-    static void filterPeptidesByRT(std::vector<PeptideIdentification>& peptides,
-                                   double min_rt, double max_rt);
+    static void filterPeptidesByRT(std::vector<PeptideIdentification>& peptides, double min_rt, double max_rt);
 
     /// Filters peptide identifications by precursor m/z, keeping only IDs in the given range
-    static void filterPeptidesByMZ(std::vector<PeptideIdentification>& peptides,
-                                   double min_mz, double max_mz);
+    static void filterPeptidesByMZ(std::vector<PeptideIdentification>& peptides, double min_mz, double max_mz);
 
     /**
        @brief Filter peptide identifications according to mass deviation.
@@ -1043,9 +962,7 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void filterPeptidesByMZError(
-      std::vector<PeptideIdentification>& peptides, double mass_error,
-      bool unit_ppm);
+    static void filterPeptidesByMZError(std::vector<PeptideIdentification>& peptides, double mass_error, bool unit_ppm);
 
 
     /**
@@ -1054,12 +971,10 @@ public:
        @param filter filter function on PeptideEvidence level
        @param peptides PeptideIdentification that will be scanned and filtered
      */
-    template <class Filter>
-    static void filterPeptideEvidences(
-      Filter& filter,
-      std::vector<PeptideIdentification>& peptides);
+    template<class Filter>
+    static void filterPeptideEvidences(Filter& filter, std::vector<PeptideIdentification>& peptides);
 
-	  /**
+    /**
        @brief Filters peptide identifications according to p-values from RTPredict.
 
        Filters the peptide hits by the probability (p-value) of a correct peptide identification having a deviation between observed and predicted RT equal to or greater than allowed.
@@ -1070,23 +985,15 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void filterPeptidesByRTPredictPValue(
-      std::vector<PeptideIdentification>& peptides,
-      const String& metavalue_key, double threshold = 0.05);
+    static void filterPeptidesByRTPredictPValue(std::vector<PeptideIdentification>& peptides, const String& metavalue_key, double threshold = 0.05);
 
     /// Removes all peptide hits that have at least one of the given modifications
-    static void removePeptidesWithMatchingModifications(
-      std::vector<PeptideIdentification>& peptides,
-      const std::set<String>& modifications);
+    static void removePeptidesWithMatchingModifications(std::vector<PeptideIdentification>& peptides, const std::set<String>& modifications);
 
-    static void removePeptidesWithMatchingRegEx(
-      std::vector<PeptideIdentification>& peptides,
-      const String& regex);
+    static void removePeptidesWithMatchingRegEx(std::vector<PeptideIdentification>& peptides, const String& regex);
 
     /// Keeps only peptide hits that have at least one of the given modifications
-    static void keepPeptidesWithMatchingModifications(
-      std::vector<PeptideIdentification>& peptides,
-      const std::set<String>& modifications);
+    static void keepPeptidesWithMatchingModifications(std::vector<PeptideIdentification>& peptides, const std::set<String>& modifications);
 
     /**
        @brief Removes all peptide hits with a sequence that matches one in @p bad_peptides.
@@ -1095,10 +1002,7 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void removePeptidesWithMatchingSequences(
-      std::vector<PeptideIdentification>& peptides,
-      const std::vector<PeptideIdentification>& bad_peptides,
-      bool ignore_mods = false);
+    static void removePeptidesWithMatchingSequences(std::vector<PeptideIdentification>& peptides, const std::vector<PeptideIdentification>& bad_peptides, bool ignore_mods = false);
 
     /**
        @brief Removes all peptide hits with a sequence that does not match one in @p good_peptides.
@@ -1107,50 +1011,40 @@ public:
 
        @note The ranks of the hits may be invalidated.
     */
-    static void keepPeptidesWithMatchingSequences(
-      std::vector<PeptideIdentification>& peptides,
-      const std::vector<PeptideIdentification>& good_peptides,
-      bool ignore_mods = false);
+    static void keepPeptidesWithMatchingSequences(std::vector<PeptideIdentification>& peptides, const std::vector<PeptideIdentification>& good_peptides, bool ignore_mods = false);
 
-   /// Removes all peptides that are not annotated as unique for a protein (by PeptideIndexer)
-    static void keepUniquePeptidesPerProtein(std::vector<PeptideIdentification>&
-                                             peptides);
+    /// Removes all peptides that are not annotated as unique for a protein (by PeptideIndexer)
+    static void keepUniquePeptidesPerProtein(std::vector<PeptideIdentification>& peptides);
 
     /**
        @brief Removes duplicate peptide hits from each peptide identification, keeping only unique hits (per ID).
 
-       By default, hits are considered duplicated if they compare as equal using PeptideHit::operator==. However, if @p seq_only is set, only the sequences (incl. modifications) are compared. In both cases, the first occurrence of each hit in a peptide ID is kept, later ones are removed.
+       By default, hits are considered duplicated if they compare as equal using PeptideHit::operator==. However, if @p seq_only is set, only the sequences (incl. modifications) are compared. In both
+       cases, the first occurrence of each hit in a peptide ID is kept, later ones are removed.
     */
-    static void removeDuplicatePeptideHits(std::vector<PeptideIdentification>&
-                                           peptides, bool seq_only = false);
+    static void removeDuplicatePeptideHits(std::vector<PeptideIdentification>& peptides, bool seq_only = false);
 
- ///@}
+    ///@}
 
 
     /// @name Filter functions for MS/MS experiments
     ///@{
 
     /// Filters an MS/MS experiment according to score thresholds
-    static void filterHitsByScore(PeakMap& experiment,
-                                  double peptide_threshold_score,
-                                  double protein_threshold_score)
+    static void filterHitsByScore(PeakMap& experiment, double peptide_threshold_score, double protein_threshold_score)
     {
       // filter protein hits:
-      filterHitsByScore(experiment.getProteinIdentifications(),
-                        protein_threshold_score);
+      filterHitsByScore(experiment.getProteinIdentifications(), protein_threshold_score);
       // don't remove empty protein IDs - they contain search metadata and may
       // be referenced by peptide IDs (via run ID)
 
       // filter peptide hits:
-      for (PeakMap::Iterator exp_it = experiment.begin();
-           exp_it != experiment.end(); ++exp_it)
+      for (PeakMap::Iterator exp_it = experiment.begin(); exp_it != experiment.end(); ++exp_it)
       {
-        filterHitsByScore(exp_it->getPeptideIdentifications(),
-                          peptide_threshold_score);
+        filterHitsByScore(exp_it->getPeptideIdentifications(), peptide_threshold_score);
         removeEmptyIdentifications(exp_it->getPeptideIdentifications());
         // TODO super-duper inefficient.
-        updateProteinReferences(exp_it->getPeptideIdentifications(),
-                                experiment.getProteinIdentifications());
+        updateProteinReferences(exp_it->getPeptideIdentifications(), experiment.getProteinIdentifications());
       }
       // @TODO: remove proteins that aren't referenced by peptides any more?
     }
@@ -1163,21 +1057,16 @@ public:
       std::vector<PeptideIdentification> all_peptides; // IDs from all spectra
 
       // filter peptide hits:
-      for (PeakMap::Iterator exp_it = experiment.begin();
-           exp_it != experiment.end(); ++exp_it)
+      for (PeakMap::Iterator exp_it = experiment.begin(); exp_it != experiment.end(); ++exp_it)
       {
-        std::vector<PeptideIdentification>& peptides =
-          exp_it->getPeptideIdentifications();
+        std::vector<PeptideIdentification>& peptides = exp_it->getPeptideIdentifications();
         keepNBestHits(peptides, n);
         removeEmptyIdentifications(peptides);
-        updateProteinReferences(peptides,
-                                experiment.getProteinIdentifications());
-        all_peptides.insert(all_peptides.end(), peptides.begin(),
-                            peptides.end());
+        updateProteinReferences(peptides, experiment.getProteinIdentifications());
+        all_peptides.insert(all_peptides.end(), peptides.begin(), peptides.end());
       }
       // update protein hits:
-      removeUnreferencedProteins(experiment.getProteinIdentifications(),
-                                 all_peptides);
+      removeUnreferencedProteins(experiment.getProteinIdentifications(), all_peptides);
     }
 
     /// Filter identifications by "N best" PeptideIdentification objects (better PeptideIdentification means better [best] PeptideHit than other).
@@ -1185,7 +1074,7 @@ public:
     static void keepNBestSpectra(std::vector<PeptideIdentification>& peptides, Size n);
 
     /// Filters a Consensus/FeatureMap by keeping the N best peptide hits for every spectrum
-    template <class MapType>
+    template<class MapType>
     static void keepNBestPeptideHits(MapType& map, Size n)
     {
       // The rank predicate needs annotated ranks, not sure if they are always updated. Use the following instead,
@@ -1197,7 +1086,7 @@ public:
       keepNBestHits(map.getUnassignedPeptideIdentifications(), n);
     }
 
-    template <class MapType>
+    template<class MapType>
     static void removeEmptyIdentifications(MapType& prot_and_pep_ids)
     {
       const auto pred = HasNoHits<PeptideIdentification>();
@@ -1208,19 +1097,19 @@ public:
     static void keepBestPerPeptide(std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
     {
       annotateBestPerPeptide(pep_ids, ignore_mods, ignore_charges, nr_best_spectrum);
-      HasMetaValue<PeptideHit> best_per_peptide{"best_per_peptide", 1};
+      HasMetaValue<PeptideHit> best_per_peptide {"best_per_peptide", 1};
       keepMatchingItemsUnroll(pep_ids, best_per_peptide);
     }
 
     static void keepBestPerPeptidePerRun(std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
     {
       annotateBestPerPeptidePerRun(prot_ids, pep_ids, ignore_mods, ignore_charges, nr_best_spectrum);
-      HasMetaValue<PeptideHit> best_per_peptide{"best_per_peptide", 1};
+      HasMetaValue<PeptideHit> best_per_peptide {"best_per_peptide", 1};
       keepMatchingItemsUnroll(pep_ids, best_per_peptide);
     }
 
-    //TODO allow skipping unassigned?
-    template <class MapType>
+    // TODO allow skipping unassigned?
+    template<class MapType>
     static void annotateBestPerPeptidePerRun(MapType& prot_and_pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
     {
       const auto& prot_ids = prot_and_pep_ids.getProteinIdentifications();
@@ -1239,17 +1128,18 @@ public:
       annotateBestPerPeptidePerRunWithData(best_peps_per_run, prot_and_pep_ids.getUnassignedPeptideIdentifications(), ignore_mods, ignore_charges, nr_best_spectrum);
     }
 
-    template <class MapType>
+    template<class MapType>
     static void keepBestPerPeptidePerRun(MapType& prot_and_pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
     {
       annotateBestPerPeptidePerRun(prot_and_pep_ids, ignore_mods, ignore_charges, nr_best_spectrum);
-      HasMetaValue<PeptideHit> best_per_peptide{"best_per_peptide", 1};
+      HasMetaValue<PeptideHit> best_per_peptide {"best_per_peptide", 1};
       keepMatchingPeptideHits(prot_and_pep_ids, best_per_peptide);
     }
 
     /// Annotates PeptideHits from PeptideIdentification if it is the best peptide hit for its peptide sequence
     /// Adds metavalue "bestForItsPeps" which can be used for additional filtering.
-    static void annotateBestPerPeptidePerRun(const std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
+    static void annotateBestPerPeptidePerRun(const std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges,
+                                             Size nr_best_spectrum)
     {
       RunToSequenceToChargeToPepHitP best_peps_per_run;
       for (const auto& id : prot_ids)
@@ -1262,9 +1152,10 @@ public:
     /// Annotates PeptideHits from PeptideIdentification if it is the best peptide hit for its peptide sequence
     /// Adds metavalue "bestForItsPeps" which can be used for additional filtering.
     /// To be used when a RunToSequenceToChargeToPepHitP map is already available
-    static void annotateBestPerPeptidePerRunWithData(RunToSequenceToChargeToPepHitP& best_peps_per_run, std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
+    static void annotateBestPerPeptidePerRunWithData(RunToSequenceToChargeToPepHitP& best_peps_per_run, std::vector<PeptideIdentification>& pep_ids, bool ignore_mods, bool ignore_charges,
+                                                     Size nr_best_spectrum)
     {
-      for (auto &pep : pep_ids)
+      for (auto& pep : pep_ids)
       {
         SequenceToChargeToPepHitP& best_pep = best_peps_per_run[pep.getIdentifier()];
         annotateBestPerPeptideWithData(best_pep, pep, ignore_mods, ignore_charges, nr_best_spectrum);
@@ -1289,86 +1180,77 @@ public:
     /// To be used when a SequenceToChargeToPepHitP map is already available
     static void annotateBestPerPeptideWithData(SequenceToChargeToPepHitP& best_pep, PeptideIdentification& pep, bool ignore_mods, bool ignore_charges, Size nr_best_spectrum)
     {
-        bool higher_score_better = pep.isHigherScoreBetter();
-        //make sure that first = best hit
-        pep.sort();
+      bool higher_score_better = pep.isHigherScoreBetter();
+      // make sure that first = best hit
+      pep.sort();
 
-        auto pepIt = pep.getHits().begin();
-        auto pepItEnd = nr_best_spectrum == 0 || pep.getHits().size() <= nr_best_spectrum ? pep.getHits().end() : pep.getHits().begin() + nr_best_spectrum;
-        for (; pepIt != pepItEnd; ++pepIt)
+      auto pepIt = pep.getHits().begin();
+      auto pepItEnd = nr_best_spectrum == 0 || pep.getHits().size() <= nr_best_spectrum ? pep.getHits().end() : pep.getHits().begin() + nr_best_spectrum;
+      for (; pepIt != pepItEnd; ++pepIt)
+      {
+        PeptideHit& hit = *pepIt;
+
+        String lookup_seq;
+        if (ignore_mods)
         {
-          PeptideHit &hit = *pepIt;
+          lookup_seq = hit.getSequence().toUnmodifiedString();
+        }
+        else
+        {
+          lookup_seq = hit.getSequence().toString();
+        }
 
-          String lookup_seq;
-          if (ignore_mods)
-          {
-            lookup_seq = hit.getSequence().toUnmodifiedString();
-          }
-          else
-          {
-            lookup_seq = hit.getSequence().toString();
-          }
+        int lookup_charge = 0;
+        if (!ignore_charges)
+        {
+          lookup_charge = hit.getCharge();
+        }
 
-          int lookup_charge = 0;
-          if (!ignore_charges)
-          {
-            lookup_charge = hit.getCharge();
-          }
+        // try to insert
+        auto it_inserted = best_pep.emplace(std::move(lookup_seq), ChargeToPepHitP());
+        auto it_inserted_chg = it_inserted.first->second.emplace(lookup_charge, &hit);
 
-          // try to insert
-          auto it_inserted = best_pep.emplace(std::move(lookup_seq), ChargeToPepHitP());
-          auto it_inserted_chg = it_inserted.first->second.emplace(lookup_charge, &hit);
-
-          PeptideHit* &p = it_inserted_chg.first->second; //now this gets either the old one if already present, or this
-          if (!it_inserted_chg.second) //was already present -> possibly update
+        PeptideHit*& p = it_inserted_chg.first->second; // now this gets either the old one if already present, or this
+        if (!it_inserted_chg.second)                    // was already present -> possibly update
+        {
+          if ((higher_score_better && (hit.getScore() > p->getScore())) || (!higher_score_better && (hit.getScore() < p->getScore())))
           {
-            if (
-                (higher_score_better && (hit.getScore() > p->getScore())) ||
-                (!higher_score_better && (hit.getScore() < p->getScore()))
-                )
-            {
-              p->setMetaValue("best_per_peptide", 0);
-              hit.setMetaValue("best_per_peptide", 1);
-              p = &hit;
-            }
-            else //note that this was def. not the best
-            {
-              // TODO if it is only about filtering, we can omit writing this metavalue (absence = false)
-              hit.setMetaValue("best_per_peptide", 0);
-            }
-          }
-          else //newly inserted -> first for that sequence (and optionally charge)
-          {
+            p->setMetaValue("best_per_peptide", 0);
             hit.setMetaValue("best_per_peptide", 1);
+            p = &hit;
+          }
+          else // note that this was def. not the best
+          {
+            // TODO if it is only about filtering, we can omit writing this metavalue (absence = false)
+            hit.setMetaValue("best_per_peptide", 0);
           }
         }
+        else // newly inserted -> first for that sequence (and optionally charge)
+        {
+          hit.setMetaValue("best_per_peptide", 1);
+        }
+      }
     }
 
     /// Filters an MS/MS experiment according to the given proteins
-    static void keepHitsMatchingProteins(
-      PeakMap& experiment,
-      const std::vector<FASTAFile::FASTAEntry>& proteins)
+    static void keepHitsMatchingProteins(PeakMap& experiment, const std::vector<FASTAFile::FASTAEntry>& proteins)
     {
       std::set<String> accessions;
-      for (std::vector<FASTAFile::FASTAEntry>::const_iterator it =
-             proteins.begin(); it != proteins.end(); ++it)
+      for (std::vector<FASTAFile::FASTAEntry>::const_iterator it = proteins.begin(); it != proteins.end(); ++it)
       {
         accessions.insert(it->identifier);
       }
 
       // filter protein hits:
-      keepHitsMatchingProteins(experiment.getProteinIdentifications(),
-                               accessions);
+      keepHitsMatchingProteins(experiment.getProteinIdentifications(), accessions);
       updateHitRanks(experiment.getProteinIdentifications());
 
       // filter peptide hits:
-      for (PeakMap::Iterator exp_it = experiment.begin();
-           exp_it != experiment.end(); ++exp_it)
+      for (PeakMap::Iterator exp_it = experiment.begin(); exp_it != experiment.end(); ++exp_it)
       {
         if (exp_it->getMSLevel() == 2)
         {
-          keepHitsMatchingProteins(exp_it->getPeptideIdentifications(),
-                                   accessions);
+          keepHitsMatchingProteins(exp_it->getPeptideIdentifications(), accessions);
           removeEmptyIdentifications(exp_it->getPeptideIdentifications());
           updateHitRanks(exp_it->getPeptideIdentifications());
         }
@@ -1390,9 +1272,7 @@ public:
       @param id_data Data to be filtered
       @param score_ref Reference to the score type defining "best" matches
     */
-    static void keepBestMatchPerObservation(
-      IdentificationData& id_data,
-      IdentificationData::ScoreTypeRef score_ref);
+    static void keepBestMatchPerObservation(IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref);
 
     /*!
       @brief Filter observation matches (e.g. PSMs) in IdentificationData by score
@@ -1405,9 +1285,7 @@ public:
       @param score_ref Reference to the score type used for filtering
       @param cutoff Score cut-off for filtering
     */
-    static void filterObservationMatchesByScore(
-      IdentificationData& id_data,
-      IdentificationData::ScoreTypeRef score_ref, double cutoff);
+    static void filterObservationMatchesByScore(IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref, double cutoff);
 
     /*!
       @brief Filter IdentificationData to remove parent sequences annotated as decoys
@@ -1416,7 +1294,6 @@ public:
     */
     static void removeDecoys(IdentificationData& id_data);
     ///@}
-
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -48,10 +48,11 @@
 
 #include <algorithm>
 #include <climits>
-#include <vector>
-#include <set>
+#include <functional>
 #include <map>
+#include <set>
 #include <unordered_set>
+#include <vector>
 
 namespace OpenMS
 {
@@ -540,7 +541,7 @@ public:
     template <class Container, class Predicate>
     static void keepMatchingItems(Container& items, const Predicate& pred)
     {
-      items.erase(std::remove_if(items.begin(), items.end(), std::not1(pred)),
+      items.erase(std::remove_if(items.begin(), items.end(), std::not_fn(pred)),
                   items.end());
     }
 
@@ -548,7 +549,7 @@ public:
     template <class Container, class Predicate>
     static void moveMatchingItems(Container& items, const Predicate& pred, Container& target)
     {
-        auto part = std::partition(items.begin(), items.end(), std::not1(pred));
+        auto part = std::partition(items.begin(), items.end(), std::not_fn(pred));
         std::move(part, items.end(), std::back_inserter(target));
         items.erase(part, items.end());
     }
@@ -725,7 +726,7 @@ public:
           remove_copy_if(hit_it->getPeptideEvidences().begin(),
                          hit_it->getPeptideEvidences().end(),
                          back_inserter(evidences),
-                         std::not1(filter));
+                         std::not_fn(filter));
           hit_it->setPeptideEvidences(evidences);
         }
       }

--- a/src/openms/include/OpenMS/KERNEL/AreaIterator.h
+++ b/src/openms/include/OpenMS/KERNEL/AreaIterator.h
@@ -58,8 +58,7 @@ namespace OpenMS
         @note This iterator iterates over spectra with same MS level as the MS level of the begin() spectrum in Param! You can explicitly set another MS level as well.
     */
     template <class ValueT, class ReferenceT, class PointerT, class SpectrumIteratorT, class PeakIteratorT>
-    class AreaIterator :
-      public std::iterator<std::forward_iterator_tag, ValueT>
+    class AreaIterator
     {
 public:
       typedef double CoordinateType;
@@ -143,9 +142,11 @@ public:
 
 
 
-      /** @name Typedefs for STL compliance
+      /** @name Typedefs for STL compliance, these replace std::iterator
       */
       //@{
+      /// The iterator's category type
+      typedef std::forward_iterator_tag iterator_category;
       /// The iterator's value type
       typedef ValueT value_type;
       /// The reference type as returned by operator*()

--- a/src/openms/include/OpenMS/KERNEL/AreaIterator.h
+++ b/src/openms/include/OpenMS/KERNEL/AreaIterator.h
@@ -57,10 +57,10 @@ namespace OpenMS
 
         @note This iterator iterates over spectra with same MS level as the MS level of the begin() spectrum in Param! You can explicitly set another MS level as well.
     */
-    template <class ValueT, class ReferenceT, class PointerT, class SpectrumIteratorT, class PeakIteratorT>
+    template<class ValueT, class ReferenceT, class PointerT, class SpectrumIteratorT, class PeakIteratorT>
     class AreaIterator
     {
-public:
+    public:
       typedef double CoordinateType;
       typedef ValueT PeakType;
       typedef SpectrumIteratorT SpectrumIteratorType;
@@ -70,7 +70,7 @@ public:
       /// Required values must be set in the C'tor. Optional values can be set via member functions (which allow chaining).
       class Param
       {
-        friend AreaIterator;   // allow access to private members (avoids writing get-accessors)
+        friend AreaIterator; // allow access to private members (avoids writing get-accessors)
       public:
         /**
          * \brief C'tor with mandatory parameters
@@ -79,8 +79,7 @@ public:
          * \param end The last spectrum with a valid RT/IM time
          * \param ms_level Only peaks from spectra with this ms_level are used
          */
-        Param(SpectrumIteratorType first, SpectrumIteratorType begin, SpectrumIteratorType end, uint8_t ms_level)
-          : first_(first), current_scan_(begin), end_scan_(end), ms_level_(ms_level)
+        Param(SpectrumIteratorType first, SpectrumIteratorType begin, SpectrumIteratorType end, uint8_t ms_level) : first_(first), current_scan_(begin), end_scan_(end), ms_level_(ms_level)
         {
         }
 
@@ -99,15 +98,35 @@ public:
          */
         //@{
         /// low m/z boundary
-        Param& lowMZ(CoordinateType low_mz) { low_mz_ = low_mz; return *this;}
+        Param& lowMZ(CoordinateType low_mz)
+        {
+          low_mz_ = low_mz;
+          return *this;
+        }
         /// high m/z boundary
-        Param& highMZ(CoordinateType high_mz) { high_mz_ = high_mz; return *this;}
+        Param& highMZ(CoordinateType high_mz)
+        {
+          high_mz_ = high_mz;
+          return *this;
+        }
         /// low ion mobility boundary
-        Param& lowIM(CoordinateType low_im) { low_im_ = low_im; return *this;}
+        Param& lowIM(CoordinateType low_im)
+        {
+          low_im_ = low_im;
+          return *this;
+        }
         /// high ion mobility boundary
-        Param& highIM(CoordinateType high_im) { high_im_ = high_im; return *this;}
+        Param& highIM(CoordinateType high_im)
+        {
+          high_im_ = high_im;
+          return *this;
+        }
         /// Only scans of this MS level are iterated over
-        Param& msLevel(int8_t ms_level) { ms_level_ = ms_level; return *this;}
+        Param& msLevel(int8_t ms_level)
+        {
+          ms_level_ = ms_level;
+          return *this;
+        }
         //@}
 
       protected:
@@ -131,19 +150,18 @@ public:
         /// high mobility boundary
         CoordinateType high_im_ = std::numeric_limits<CoordinateType>::max();
         /// Only scans of this MS level are iterated over
-        int8_t ms_level_{};
+        int8_t ms_level_ {};
         /// Flag that indicates that this iterator is the end iterator
         bool is_end_ = false;
 
       private:
         /// only used internally for end()
-        Param() = default; 
+        Param() = default;
       };
 
 
-
       /** @name Typedefs for STL compliance, these replace std::iterator
-      */
+       */
       //@{
       /// The iterator's category type
       typedef std::forward_iterator_tag iterator_category;
@@ -158,14 +176,15 @@ public:
       //@}
 
       /// Constructor for the begin iterator
-      explicit AreaIterator(const Param& p) :
-        p_(p)
+      explicit AreaIterator(const Param& p) : p_(p)
       {
         nextScan_();
       }
 
       /// Default constructor (for the end iterator)
-      AreaIterator() : p_(Param::end()) {}
+      AreaIterator() : p_(Param::end())
+      {
+      }
 
       /// Destructor
       ~AreaIterator() = default;
@@ -174,7 +193,7 @@ public:
       AreaIterator(const AreaIterator& rhs) = default;
 
       /// Assignment operator
-      AreaIterator& operator=(const AreaIterator & rhs)
+      AreaIterator& operator=(const AreaIterator& rhs)
       {
         p_.is_end_ = rhs.p_.is_end_;
         // only copy iterators, if the assigned iterator is not the end iterator
@@ -187,10 +206,11 @@ public:
       }
 
       /// Test for equality
-      bool operator==(const AreaIterator & rhs) const
+      bool operator==(const AreaIterator& rhs) const
       {
         // Both end iterators => equal
-        if (p_.is_end_ && rhs.p_.is_end_) return true;
+        if (p_.is_end_ && rhs.p_.is_end_)
+          return true;
 
         // Normal and end iterator => not equal
         if (p_.is_end_ ^ rhs.p_.is_end_)
@@ -201,7 +221,7 @@ public:
       }
 
       /// Test for inequality
-      bool operator!=(const AreaIterator & rhs) const
+      bool operator!=(const AreaIterator& rhs) const
       {
         return !(*this == rhs);
       }
@@ -209,8 +229,9 @@ public:
       /// Step forward by one (prefix operator)
       AreaIterator& operator++()
       {
-        //no increment if this is the end iterator
-        if (p_.is_end_) return *this;
+        // no increment if this is the end iterator
+        if (p_.is_end_)
+          return *this;
 
         ++p_.current_peak_;
         // test whether we arrived at the end of the current scan
@@ -267,18 +288,16 @@ public:
         }
       }
 
-private:
+    private:
       /// advances the iterator to the next valid peak in the next valid spectrum
       void nextScan_()
       {
         using MSLevelType = decltype(p_.current_scan_->getMSLevel());
-        RangeMobility mb{p_.low_im_, p_.high_im_};
+        RangeMobility mb {p_.low_im_, p_.high_im_};
         while (true)
         {
           // skip over invalid MS levels and Mobility
-          while (p_.current_scan_ != p_.end_scan_ &&
-                 (p_.current_scan_->getMSLevel() != (MSLevelType)p_.ms_level_ ||
-                  !mb.containsMobility(p_.current_scan_->getDriftTime())))
+          while (p_.current_scan_ != p_.end_scan_ && (p_.current_scan_->getMSLevel() != (MSLevelType)p_.ms_level_ || !mb.containsMobility(p_.current_scan_->getDriftTime())))
           {
             ++p_.current_scan_;
           }
@@ -301,6 +320,5 @@ private:
       Param p_;
     };
 
-  }
-}
-
+  } // namespace Internal
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/Contaminants.h
+++ b/src/openms/include/OpenMS/QC/Contaminants.h
@@ -34,11 +34,10 @@
 
 #pragma once
 
-#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/QC/QCBase.h>
-
 #include <unordered_set>
 
 
@@ -50,42 +49,41 @@ namespace OpenMS
    * This class checks whether a peptide is a contaminant (given a protein DB) and adds that result as metavalue "is_contaminant"
    * to the first hit of each PeptideIdentification.
    */
-  class OPENMS_DLLAPI Contaminants: public QCBase
+  class OPENMS_DLLAPI Contaminants : public QCBase
   {
   public:
     /// structure for storing results
-    struct ContaminantsSummary
-    {
+    struct ContaminantsSummary {
       ///(\#contaminants in assigned/ \#peptides in assigned)
       double assigned_contaminants_ratio;
-      
+
       ///(\#contaminants in unassigned/ \#peptides in unassigned)
       double unassigned_contaminants_ratio;
-      
+
       ///(\#all contaminants/ \#peptides in all)
       double all_contaminants_ratio;
-      
+
       ///(intensity of contaminants in assigned/ intensity of peptides in assigned)
       double assigned_contaminants_intensity_ratio;
-      
+
       ///(features without peptideidentification or with peptideidentifications but without hits; all features)
       std::pair<Int64, Int64> empty_features;
     };
-    
+
     /// Constructor
     Contaminants() = default;
-    
+
     /// Destructor
     virtual ~Contaminants() = default;
-    
+
     /**
      * @brief Checks if the peptides are in the contaminant database.
-     * 
+     *
      * "is_contaminant" metavalue is added to the first hit of each PeptideIdentification of each feature
      * and to the first hit of all unsigned PeptideIdentifications.
-     * The enzyme and number of missed cleavages used to digest the given protein DB is taken 
+     * The enzyme and number of missed cleavages used to digest the given protein DB is taken
      * from the ProteinIdentification[0].getSearchParameters() within the given FeatureMap.
-     * 
+     *
      * @param features Input FeatureMap with peptideidentifications of features
      * @param contaminants Vector of FASTAEntries that need to be digested to check whether a peptide is a contaminant or not
      * @exception Exception::MissingInformation if the contaminants database is empty
@@ -94,29 +92,29 @@ namespace OpenMS
      * @warning LOG_WARN if the FeatureMap is empty
      */
     void compute(FeatureMap& features, const std::vector<FASTAFile::FASTAEntry>& contaminants);
-    
+
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// returns results
     const std::vector<Contaminants::ContaminantsSummary>& getResults();
-    
+
     /**
      * @brief Returns the input data requirements of the compute(...) function
      * @return Status for POSTFDRFEAT and CONTAMINANTS
      */
     Status requirements() const override;
-    
+
   private:
     /// name of the metric
     const String name_ = "Contaminants";
-    
+
     /// container that stores results
     std::vector<Contaminants::ContaminantsSummary> results_;
-    
+
     /// unordered set that contains the contaminant sequences
     std::unordered_set<String> digested_db_;
-    
+
     /**
      * @brief
      * checks if the peptide is in the contaminant database

--- a/src/openms/include/OpenMS/QC/Contaminants.h
+++ b/src/openms/include/OpenMS/QC/Contaminants.h
@@ -105,7 +105,7 @@ namespace OpenMS
      * @brief Returns the input data requirements of the compute(...) function
      * @return Status for POSTFDRFEAT and CONTAMINANTS
      */
-    Status requires() const override;
+    Status requirements() const override;
     
   private:
     /// name of the metric

--- a/src/openms/include/OpenMS/QC/FWHM.h
+++ b/src/openms/include/OpenMS/QC/FWHM.h
@@ -72,7 +72,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    Status requires() const override;
+    Status requirements() const override;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/FeatureSummary.h
+++ b/src/openms/include/OpenMS/QC/FeatureSummary.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include <OpenMS/QC/QCBase.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/QC/QCBase.h>
 
 /**
  * @brief Detected Compounds as a Metabolomics QC metric
@@ -57,22 +57,21 @@ namespace OpenMS
     virtual ~FeatureSummary() = default;
 
     // stores feature summary values calculated by compute function
-    struct OPENMS_DLLAPI Result
-    {
+    struct OPENMS_DLLAPI Result {
       UInt feature_count = 0;
       float rt_shift_mean = 0;
 
       bool operator==(const Result& rhs) const;
     };
 
-     /**
-    @brief computes a summary of a featureXML file
+    /**
+   @brief computes a summary of a featureXML file
 
-    @param feature_map FeatureMap
-    @return result object with summary values: 
-            number of detected compounds (detected_compounds),
-            retention time shift mean (rt_shift_mean)
-    **/
+   @param feature_map FeatureMap
+   @return result object with summary values:
+           number of detected compounds (detected_compounds),
+           retention time shift mean (rt_shift_mean)
+   **/
     Result compute(const FeatureMap& feature_map);
 
     const String& getName() const override;
@@ -82,4 +81,4 @@ namespace OpenMS
   private:
     const String name_ = "Summary of features from featureXML file";
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/FeatureSummary.h
+++ b/src/openms/include/OpenMS/QC/FeatureSummary.h
@@ -77,7 +77,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     const String name_ = "Summary of features from featureXML file";

--- a/src/openms/include/OpenMS/QC/FragmentMassError.h
+++ b/src/openms/include/OpenMS/QC/FragmentMassError.h
@@ -44,7 +44,7 @@ namespace OpenMS
   class MSExperiment;
   class PeptideIdentification;
   class WindowMower;
-  
+
   class OPENMS_DLLAPI FragmentMassError : public QCBase
   {
   public:
@@ -57,8 +57,7 @@ namespace OpenMS
     /**
      * @brief Structure for storing results: average and variance of all FragmentMassErrors in ppm
      */
-    struct Statistics
-    {
+    struct Statistics {
       double average_ppm = 0;
       double variance_ppm = 0;
     };
@@ -110,33 +109,30 @@ namespace OpenMS
      * @throws Exception::MissingInformation If no fragmentation method given in a MS2 precursor
      * @throws Exception::InvalidParameter If the fragmentation method is not ECD, ETD, CID or HCD
      */
-    void compute(std::vector<PeptideIdentification>& pep_ids,
-                 const ProteinIdentification::SearchParameters& search_params,
-                 const MSExperiment& exp,
-                 const QCBase::SpectraMap& map_to_spectrum,
-                 ToleranceUnit tolerance_unit = ToleranceUnit::AUTO,
-                 double tolerance = 20);
+    void compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum,
+                 ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20);
 
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// returns results
     const std::vector<Statistics>& getResults() const;
 
 
     /**
-    * @brief Returns the input data requirements of the compute(...) function
-    * @return Status for RAWMZML and POSTFDRFEAT
-    */
+     * @brief Returns the input data requirements of the compute(...) function
+     * @return Status for RAWMZML and POSTFDRFEAT
+     */
     QCBase::Status requirements() const override;
 
   private:
     /// container that stores results
     std::vector<Statistics> results_;
 
-    static void calculateFME_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, bool& print_warning, double tolerance, FragmentMassError::ToleranceUnit tolerance_unit, double& accumulator_ppm, UInt32& counter_ppm, WindowMower& window_mower_filter);
+    static void calculateFME_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, bool& print_warning, double tolerance,
+                              FragmentMassError::ToleranceUnit tolerance_unit, double& accumulator_ppm, UInt32& counter_ppm, WindowMower& window_mower_filter);
 
     static void calculateVariance_(FragmentMassError::Statistics& result, const PeptideIdentification& pep_id, const UInt num_ppm);
   };
 
-} //namespace OpenMS
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/FragmentMassError.h
+++ b/src/openms/include/OpenMS/QC/FragmentMassError.h
@@ -128,7 +128,7 @@ namespace OpenMS
     * @brief Returns the input data requirements of the compute(...) function
     * @return Status for RAWMZML and POSTFDRFEAT
     */
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     /// container that stores results

--- a/src/openms/include/OpenMS/QC/IdentificationSummary.h
+++ b/src/openms/include/OpenMS/QC/IdentificationSummary.h
@@ -97,7 +97,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     const String name_ = "Summary of detected Proteins and Peptides from idXML file";

--- a/src/openms/include/OpenMS/QC/IdentificationSummary.h
+++ b/src/openms/include/OpenMS/QC/IdentificationSummary.h
@@ -34,9 +34,9 @@
 
 #pragma once
 
-#include <OpenMS/QC/QCBase.h>
-#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/QC/QCBase.h>
 #include <vector>
 /**
  * @brief Detected Proteins/Peptides as a Proteomics QC metric
@@ -59,15 +59,13 @@ namespace OpenMS
 
     // small struct for unique peptide / protein identifications (considering sequence only)
     // count: number of unique identifications, fdr_threshold: significance threshold if score type is FDR, else -1
-    struct OPENMS_DLLAPI UniqueID
-    {
+    struct OPENMS_DLLAPI UniqueID {
       UInt count = 0;
       float fdr_threshold = -1.0;
     };
-    
+
     // stores identification summary values calculated by compute function
-    struct OPENMS_DLLAPI Result
-    {
+    struct OPENMS_DLLAPI Result {
       UInt peptide_spectrum_matches = 0;
       UniqueID unique_peptides;
       UniqueID unique_proteins;
@@ -78,22 +76,21 @@ namespace OpenMS
       bool operator==(const Result& rhs) const;
     };
 
-     /**
-    @brief computes a summary of an idXML file
+    /**
+   @brief computes a summary of an idXML file
 
-    @param prot_ids vector with ProteinIdentifications
-    @param pep_ids vector with PeptideIdentifications
-    @return result object with summary values:
-            total number of PSM (peptide_spectrum_matches),
-            number of identified peptides with given FDR threshold (unique_peptides),
-            number of identified proteins with given FDR threshold (unique_proteins),
-            missed cleavages mean (missed_cleavages_mean),
-            identification score mean of protein hits (protein_hit_scores_mean),
-            identified peptide lengths mean (peptide_length_mean)
+   @param prot_ids vector with ProteinIdentifications
+   @param pep_ids vector with PeptideIdentifications
+   @return result object with summary values:
+           total number of PSM (peptide_spectrum_matches),
+           number of identified peptides with given FDR threshold (unique_peptides),
+           number of identified proteins with given FDR threshold (unique_proteins),
+           missed cleavages mean (missed_cleavages_mean),
+           identification score mean of protein hits (protein_hit_scores_mean),
+           identified peptide lengths mean (peptide_length_mean)
 
-    **/
-    Result compute(std::vector<ProteinIdentification>& prot_ids,
-                   std::vector<PeptideIdentification>& pep_ids);
+   **/
+    Result compute(std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids);
 
     const String& getName() const override;
 
@@ -102,4 +99,4 @@ namespace OpenMS
   private:
     const String name_ = "Summary of detected Proteins and Peptides from idXML file";
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/MissedCleavages.h
+++ b/src/openms/include/OpenMS/QC/MissedCleavages.h
@@ -90,7 +90,7 @@ namespace OpenMS
      * @brief Returns the input data requirements of the compute(...) function
      * @return Status for POSTFDRFEAT;
      */
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     /// container that stores results

--- a/src/openms/include/OpenMS/QC/MissedCleavages.h
+++ b/src/openms/include/OpenMS/QC/MissedCleavages.h
@@ -35,13 +35,12 @@
 
 #pragma once
 
-#include <OpenMS/QC/QCBase.h>
+#include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
-#include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
-
-#include <vector>
+#include <OpenMS/QC/QCBase.h>
 #include <map>
+#include <vector>
 namespace OpenMS
 {
   class FeatureMap;
@@ -61,11 +60,12 @@ namespace OpenMS
     typedef std::map<UInt32, UInt32> MapU32;
     /// collects number of missed cleavages from PeptideIdentification in a result map (missed cleavages: occurences)
     void get_missed_cleavages_from_peptide_identification_(const ProteaseDigestion& digestor, MapU32& result, const UInt32& max_mc, PeptideIdentification& pep_id);
+
   public:
-    ///constructor
+    /// constructor
     MissedCleavages() = default;
 
-    ///destructor
+    /// destructor
     virtual ~MissedCleavages() = default;
 
     /**
@@ -82,7 +82,7 @@ namespace OpenMS
 
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// returns the result as maps of number of missed_cleavages to counts; one map for each call to compute(...)
     const std::vector<std::map<UInt32, UInt32>>& getResults() const;
 

--- a/src/openms/include/OpenMS/QC/Ms2IdentificationRate.h
+++ b/src/openms/include/OpenMS/QC/Ms2IdentificationRate.h
@@ -142,7 +142,7 @@ namespace OpenMS
      * @brief Returns the input data requirements of the compute(...) function
      * @return Status for RAWMZML and POSTFDRFEAT
      */
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
     void addMetaDataMetricsToMzTab(MzTabMetaData& meta) const;
   };

--- a/src/openms/include/OpenMS/QC/Ms2IdentificationRate.h
+++ b/src/openms/include/OpenMS/QC/Ms2IdentificationRate.h
@@ -34,8 +34,9 @@
 
 #pragma once
 
-#include <OpenMS/CONCEPT/Types.h>
 #include "OpenMS/QC/QCBase.h"
+
+#include <OpenMS/CONCEPT/Types.h>
 #include <string>
 #include <vector>
 
@@ -48,7 +49,7 @@ namespace OpenMS
 
   /**
    @brief This class is a metric for the QualityControl-ToppTool.
-   
+
    This class computes the MS2 Identification Rate (as #identified PSMs divided by total number of MS2 scans) given a FeatureMap and an MSExperiment.
    Only pep-ids with FDR metavalue 'target_decoy' equal to 'target' are counted, unless assume_all_target flag is set (assumes all pep-ids are target peptides)
 
@@ -57,8 +58,7 @@ namespace OpenMS
   {
   public:
     /// Structure for storing results
-    struct IdentificationRateData
-    {
+    struct IdentificationRateData {
       Size num_peptide_identification = 0;
       Size num_ms2_spectra = 0;
       double identification_rate = 0.;
@@ -67,7 +67,7 @@ namespace OpenMS
   private:
     /// name of the metric
     const String name_ = "Ms2IdentificationRate";
-    
+
     /// container that stores results
     std::vector<IdentificationRateData> rate_result_;
 
@@ -75,24 +75,24 @@ namespace OpenMS
     Size getMS2Count_(const MSExperiment& exp);
 
     /*
-    * @brief Checks pepID for target/decoy
-    *
-    * Only checks the first (!) hit, all other hits are ignored
-    * Is static so that it can be used with MapUtilities::applyFunctionOnPeptideIDs() without creating a new object for each ID
-    *
-    * @param id             pepID to be checked
-    * @param all_targets    always returns true (if the hits aren't empty)
-    * @return               true/false
-    * @throws               MissingInformation if target/decoy annotation is missing
-    */
+     * @brief Checks pepID for target/decoy
+     *
+     * Only checks the first (!) hit, all other hits are ignored
+     * Is static so that it can be used with MapUtilities::applyFunctionOnPeptideIDs() without creating a new object for each ID
+     *
+     * @param id             pepID to be checked
+     * @param all_targets    always returns true (if the hits aren't empty)
+     * @return               true/false
+     * @throws               MissingInformation if target/decoy annotation is missing
+     */
     static bool isTargetPeptide_(const PeptideIdentification& id, bool all_targets);
 
     /*
-    * @brief Calculates id-rate and writes the result into a IdentificationRateData object which is appended to rate_result_
-    *
-    * @param ms2_spectra_count  number of found ms2 spectra
-    * @param pep_ids_count      number of found (target) peptide identifications
-    */
+     * @brief Calculates id-rate and writes the result into a IdentificationRateData object which is appended to rate_result_
+     *
+     * @param ms2_spectra_count  number of found ms2 spectra
+     * @param pep_ids_count      number of found (target) peptide identifications
+     */
     void writeResults_(Size pep_ids_count, Size ms2_spectra_count);
 
   public:
@@ -134,7 +134,7 @@ namespace OpenMS
 
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// returns results
     const std::vector<IdentificationRateData>& getResults() const;
 

--- a/src/openms/include/OpenMS/QC/Ms2SpectrumStats.h
+++ b/src/openms/include/OpenMS/QC/Ms2SpectrumStats.h
@@ -97,7 +97,7 @@ namespace OpenMS
     /// returns the name of the metric
     const String& getName() const override;
     /// define the required input file: featureXML after FDR (=POSTFDRFEAT), MzML-file (MSExperiment) with all MS2-Spectra (=RAWMZML)
-    Status requires() const override;
+    Status requirements() const override;
 
   private:
     /// name of the metric

--- a/src/openms/include/OpenMS/QC/Ms2SpectrumStats.h
+++ b/src/openms/include/OpenMS/QC/Ms2SpectrumStats.h
@@ -34,10 +34,9 @@
 
 #pragma once
 
-#include <OpenMS/QC/QCBase.h>
-
-#include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/QC/QCBase.h>
 
 
 namespace OpenMS
@@ -50,7 +49,7 @@ namespace OpenMS
   /**
     @brief  QC metric to determine the number of MS2 scans per MS1 scan over RT
 
-    Ms2SpectrumStats collects data from MS2 scans and stores the result into PeptideIdentifications, 
+    Ms2SpectrumStats collects data from MS2 scans and stores the result into PeptideIdentifications,
     which already exist in the FeatureMap, or are newly created as empty PeptideIdentifications (with no sequence).
 
     The following meta-values are computed:
@@ -67,11 +66,10 @@ namespace OpenMS
   class OPENMS_DLLAPI Ms2SpectrumStats : public QCBase
   {
   public:
-    struct ScanEvent
-    {
-      ScanEvent(UInt32 sem, bool ms2)
-        : scan_event_number(sem), ms2_presence(ms2) 
-      {}
+    struct ScanEvent {
+      ScanEvent(UInt32 sem, bool ms2) : scan_event_number(sem), ms2_presence(ms2)
+      {
+      }
       UInt32 scan_event_number;
       bool ms2_presence;
     };
@@ -102,9 +100,9 @@ namespace OpenMS
   private:
     /// name of the metric
     const String name_ = "Ms2SpectrumStats";
-    
+
     /// ms2_included_ contains for every spectrum the information "ScanEventNumber" and presence MS2-scan in PeptideIDs
-    std::vector<ScanEvent> ms2_included_{};
+    std::vector<ScanEvent> ms2_included_ {};
 
     /// compute "ScanEventNumber" for every spectrum: MS1=0, MS2=1-n, write into ms2_included_
     void setScanEventNumber_(const MSExperiment& exp);
@@ -118,4 +116,4 @@ namespace OpenMS
     /// calculate highest intensity (base peak intensity)
     static MSSpectrum::PeakType::IntensityType getBPI_(const MSSpectrum& spec);
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/MzCalibration.h
+++ b/src/openms/include/OpenMS/QC/MzCalibration.h
@@ -34,9 +34,8 @@
 
 #pragma once
 
-#include <OpenMS/QC/QCBase.h>
-
 #include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/QC/QCBase.h>
 
 namespace OpenMS
 {
@@ -57,39 +56,37 @@ namespace OpenMS
     **/
   class OPENMS_DLLAPI MzCalibration : public QCBase
   {
-    public:
-      /// Constructor
-      MzCalibration();
+  public:
+    /// Constructor
+    MzCalibration();
 
-      /// Destructor
-      virtual ~MzCalibration() = default;
+    /// Destructor
+    virtual ~MzCalibration() = default;
 
-      /**
-      * @brief Writes results as meta values to the PeptideIdentification of the given FeatureMap
-      * @param features FeatureMap with m/z-values of PeptideIdentification after calibration, meta values are added here
-      * @param exp PeakMap of the original experiment. Can be empty (i.e. not available).
-      * @param map_to_spectrum Map to find index of spectrum given by meta value at PepID
-      * @throws Exception::InvalidParameter PeptideID is missing meta value 'spectrum_reference'
-      * @throws Exception::IllegalArgument Spectrum for a PepID has MSLevel of 1
-      * @throws Exception::MissingInformation Meta value 'mz_raw' missing from MSExperiment 
-      **/
-      void compute(FeatureMap& features, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum);
+    /**
+     * @brief Writes results as meta values to the PeptideIdentification of the given FeatureMap
+     * @param features FeatureMap with m/z-values of PeptideIdentification after calibration, meta values are added here
+     * @param exp PeakMap of the original experiment. Can be empty (i.e. not available).
+     * @param map_to_spectrum Map to find index of spectrum given by meta value at PepID
+     * @throws Exception::InvalidParameter PeptideID is missing meta value 'spectrum_reference'
+     * @throws Exception::IllegalArgument Spectrum for a PepID has MSLevel of 1
+     * @throws Exception::MissingInformation Meta value 'mz_raw' missing from MSExperiment
+     **/
+    void compute(FeatureMap& features, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum);
 
-      /// define the required input files
-      /// only FeatureXML after FDR is ultimately necessary
-      Status requirements() const override;
+    /// define the required input files
+    /// only FeatureXML after FDR is ultimately necessary
+    Status requirements() const override;
 
-      /// Returns the name of the metric.
-      const String& getName() const override;
+    /// Returns the name of the metric.
+    const String& getName() const override;
 
-    private:
-      /// calculate the m/z values and m/z errors and add them to the PeptideIdentification
-      void addMzMetaValues_(PeptideIdentification& peptide_ID, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum);
+  private:
+    /// calculate the m/z values and m/z errors and add them to the PeptideIdentification
+    void addMzMetaValues_(PeptideIdentification& peptide_ID, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum);
 
-      double mz_raw_;
-      double mz_ref_;
-      bool no_mzml_;
+    double mz_raw_;
+    double mz_ref_;
+    bool no_mzml_;
   };
-}
-
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/MzCalibration.h
+++ b/src/openms/include/OpenMS/QC/MzCalibration.h
@@ -77,7 +77,7 @@ namespace OpenMS
 
       /// define the required input files
       /// only FeatureXML after FDR is ultimately necessary
-      Status requires() const override;
+      Status requirements() const override;
 
       /// Returns the name of the metric.
       const String& getName() const override;

--- a/src/openms/include/OpenMS/QC/PSMExplainedIonCurrent.h
+++ b/src/openms/include/OpenMS/QC/PSMExplainedIonCurrent.h
@@ -44,7 +44,7 @@ namespace OpenMS
   class MSExperiment;
   class PeptideIdentification;
   class WindowMower;
-  
+
   class OPENMS_DLLAPI PSMExplainedIonCurrent : public QCBase
   {
   public:
@@ -57,8 +57,7 @@ namespace OpenMS
     /**
      * @brief Structure for storing results: average and variance over all PSMs
      */
-    struct Statistics
-    {
+    struct Statistics {
       double average_correctness = 0;
       double variance_correctness = 0;
     };
@@ -80,7 +79,8 @@ namespace OpenMS
      * @throws Exceptions::MissingInformation If fragment mass tolerance is missing in metadata of FeatureMap (& no ToleranceUnit is given)
      * @throws Exception::InvalidParameter PeptideID is missing meta value 'spectrum_reference'
      * @throws Exception::IllegalArgument Spectrum for a PepID has ms-level of 1
-     * @throws Exception::MissingInformation If PSMExplainedIonCurrent couldn't be calculated for any spectrum. (i.e. all spectra are: empty, contain only peaks with intensity 0 or the matching pep_id has no hits)
+     * @throws Exception::MissingInformation If PSMExplainedIonCurrent couldn't be calculated for any spectrum. (i.e. all spectra are: empty, contain only peaks with intensity 0 or the matching pep_id
+     * has no hits)
      * @throws Exception::InvalidParameter If the fragmentation method is not ECD, ETD, CID or HCD
      */
     void compute(FeatureMap& fmap, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20);
@@ -99,30 +99,32 @@ namespace OpenMS
      * @throws Exceptions::MissingInformation If fragment mass tolerance is missing in metadata of FeatureMap (& no ToleranceUnit is given)
      * @throws Exception::InvalidParameter PeptideID is missing meta value 'spectrum_reference'
      * @throws Exception::IllegalArgument Spectrum for a PepID has ms-level of 1
-     * @throws Exception::MissingInformation If PSMExplainedIonCurrent couldn't be calculated for any spectrum. (i.e. all spectra are: empty, contain only peaks with intensity 0 or the matching pep_id has no hits)
+     * @throws Exception::MissingInformation If PSMExplainedIonCurrent couldn't be calculated for any spectrum. (i.e. all spectra are: empty, contain only peaks with intensity 0 or the matching pep_id
+     * has no hits)
      * @throws Exception::InvalidParameter If the fragmentation method is not ECD, ETD, CID or HCD
      */
-    void compute(std::vector<PeptideIdentification> & pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20);
+    void compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum,
+                 ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20);
 
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// returns results
     const std::vector<Statistics>& getResults() const;
 
 
     /**
-    * @brief Returns the input data requirements of the compute(...) function
-    * @return Status for RAWMZML and POSTFDRFEAT
-    */
+     * @brief Returns the input data requirements of the compute(...) function
+     * @return Status for RAWMZML and POSTFDRFEAT
+     */
     QCBase::Status requirements() const override;
 
   private:
     /// container that stores results
-    std::vector<Statistics> results_{};
+    std::vector<Statistics> results_ {};
 
-    static double annotatePSMExplainedIonCurrent_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, WindowMower& filter, PSMExplainedIonCurrent::ToleranceUnit tolerance_unit, double tolerance);
+    static double annotatePSMExplainedIonCurrent_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, WindowMower& filter,
+                                                  PSMExplainedIonCurrent::ToleranceUnit tolerance_unit, double tolerance);
   };
 
-} //namespace OpenMS
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/PSMExplainedIonCurrent.h
+++ b/src/openms/include/OpenMS/QC/PSMExplainedIonCurrent.h
@@ -115,7 +115,7 @@ namespace OpenMS
     * @brief Returns the input data requirements of the compute(...) function
     * @return Status for RAWMZML and POSTFDRFEAT
     */
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     /// container that stores results

--- a/src/openms/include/OpenMS/QC/PeptideMass.h
+++ b/src/openms/include/OpenMS/QC/PeptideMass.h
@@ -65,7 +65,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    Status requires() const override;
+    Status requirements() const override;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/QCBase.h
+++ b/src/openms/include/OpenMS/QC/QCBase.h
@@ -130,7 +130,7 @@ namespace OpenMS
     /**
      *@brief Returns the input data requirements of the compute(...) function
      */
-    virtual Status requires() const = 0;
+    virtual Status requirements() const = 0;
 
 
     /// tests if a metric has the required input files

--- a/src/openms/include/OpenMS/QC/QCBase.h
+++ b/src/openms/include/OpenMS/QC/QCBase.h
@@ -37,7 +37,6 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/DATASTRUCTURES/FlagSet.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
-
 #include <algorithm>
 #include <map>
 
@@ -58,8 +57,7 @@ namespace OpenMS
     /**
      * @brief Enum to encode a file type as a bit.
      */
-    enum class Requires 
-      : UInt64 // 64 bit unsigned type for bitwise and/or operations (see below)
+    enum class Requires : UInt64 // 64 bit unsigned type for bitwise and/or operations (see below)
     {
       NOTHING,      //< default, does not require anything
       RAWMZML,      //< mzML file is required
@@ -86,7 +84,7 @@ namespace OpenMS
 
     /**
      * @brief Map to find a spectrum via its NativeID
-    */
+     */
     class OPENMS_DLLAPI SpectraMap
     {
     public:
@@ -108,10 +106,10 @@ namespace OpenMS
 
       /// clear the map
       void clear();
-      
+
       /// check if empty
       bool empty() const;
-      
+
       /// get size of map
       Size size() const;
 
@@ -120,13 +118,13 @@ namespace OpenMS
     };
 
     using Status = FlagSet<Requires>;
-    
+
 
     /**
-    * @brief Returns the name of the metric
-    */
+     * @brief Returns the name of the metric
+     */
     virtual const String& getName() const = 0;
-    
+
     /**
      *@brief Returns the input data requirements of the compute(...) function
      */
@@ -141,13 +139,13 @@ namespace OpenMS
     static bool isLabeledExperiment(const ConsensusMap& cm);
 
     /// does the container have a PeptideIdentification in its members or as unassignedPepID ?
-    template <typename MAP>
+    template<typename MAP>
     static bool hasPepID(const MAP& fmap)
     {
-      if (!fmap.getUnassignedPeptideIdentifications().empty()) return true;
+      if (!fmap.getUnassignedPeptideIdentifications().empty())
+        return true;
 
-      return std::any_of(fmap.cbegin(), fmap.cend(), [](const auto& f) 
-              { return !f.getPeptideIdentifications().empty();});
+      return std::any_of(fmap.cbegin(), fmap.cend(), [](const auto& f) { return !f.getPeptideIdentifications().empty(); });
     }
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/RTAlignment.h
+++ b/src/openms/include/OpenMS/QC/RTAlignment.h
@@ -45,29 +45,29 @@ namespace OpenMS
   /**
     @brief Take the original retention time before map alignment and use the alignment's trafoXML
            for calculation of the new alignment retention times.
-           
+
     Sets meta values "rt_raw" and "rt_align" in PeptideIdentifications of the featureMap's PepIDs.
     It does <b>not</b> change the RT of the features.
-    
+
     **/
   class OPENMS_DLLAPI RTAlignment : public QCBase
   {
-    public:
+  public:
     /// Constructor
     RTAlignment() = default;
-    
+
     /// Destructor
     virtual ~RTAlignment() = default;
 
     /**
      @brief Calculates retention time after map alignment
             and sets meta values "rt_raw" and "rt_align" in all PepIDs (on features and all unassigned PepIDs)
-    
+
      @param fm: FeatureMap to receive the new metavalues
      @param trafo: Transformation information to get needed data from
     **/
     void compute(FeatureMap& fm, const TransformationDescription& trafo) const;
-    
+
     /**
     @brief Calculates retention time after map alignment
     and sets meta values "rt_raw" and "rt_align" in all PepIDs
@@ -79,12 +79,12 @@ namespace OpenMS
 
     /// returns the name of the metric
     const String& getName() const override;
-    
+
     /// define the required input file: featureXML before map alignment (=POSTFDRFEAT), trafoXML after map alignment (=TRAFOALIGN)
     Status requirements() const override;
-    
+
   private:
     /// name of the metric
     const String name_ = "RTAlignment";
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/RTAlignment.h
+++ b/src/openms/include/OpenMS/QC/RTAlignment.h
@@ -81,7 +81,7 @@ namespace OpenMS
     const String& getName() const override;
     
     /// define the required input file: featureXML before map alignment (=POSTFDRFEAT), trafoXML after map alignment (=TRAFOALIGN)
-    Status requires() const override;
+    Status requirements() const override;
     
   private:
     /// name of the metric

--- a/src/openms/include/OpenMS/QC/SpectrumCount.h
+++ b/src/openms/include/OpenMS/QC/SpectrumCount.h
@@ -69,4 +69,4 @@ namespace OpenMS
   private:
     const String name_ = "SpectrumCount";
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/QC/SpectrumCount.h
+++ b/src/openms/include/OpenMS/QC/SpectrumCount.h
@@ -64,7 +64,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
   private:
     const String name_ = "SpectrumCount";

--- a/src/openms/include/OpenMS/QC/TIC.h
+++ b/src/openms/include/OpenMS/QC/TIC.h
@@ -92,7 +92,7 @@ namespace OpenMS
 
     const std::vector<MSChromatogram>& getResults() const ;
 
-    QCBase::Status requires() const override;
+    QCBase::Status requirements() const override;
 
     /// append QC data for given metrics to mzTab's MTD section
     void addMetaDataMetricsToMzTab(MzTabMetaData& meta, std::vector<Result>& tics);

--- a/src/openms/include/OpenMS/QC/TIC.h
+++ b/src/openms/include/OpenMS/QC/TIC.h
@@ -62,19 +62,18 @@ namespace OpenMS
     virtual ~TIC() = default;
 
     // stores TIC values calculated by compute function
-    struct OPENMS_DLLAPI Result
-    {
-      std::vector<UInt> intensities;  // TIC intensities
+    struct OPENMS_DLLAPI Result {
+      std::vector<UInt> intensities; // TIC intensities
       std::vector<float> relative_intensities;
       std::vector<float> retention_times; // TIC RTs in seconds
-      UInt area = 0;  // Area under TIC
-      UInt fall = 0;  // MS1 signal fall (10x) count
-      UInt jump = 0;  // MS1 signal jump (10x) count
+      UInt area = 0;                      // Area under TIC
+      UInt fall = 0;                      // MS1 signal fall (10x) count
+      UInt jump = 0;                      // MS1 signal jump (10x) count
 
       bool operator==(const Result& rhs) const;
     };
 
-    
+
     /**
     @brief Compute Total Ion Count and applies the resampling algorithm, if a bin size in RT seconds greater than 0 is given.
 
@@ -90,7 +89,7 @@ namespace OpenMS
 
     const String& getName() const override;
 
-    const std::vector<MSChromatogram>& getResults() const ;
+    const std::vector<MSChromatogram>& getResults() const;
 
     QCBase::Status requirements() const override;
 
@@ -100,4 +99,4 @@ namespace OpenMS
   private:
     const String name_ = "TIC";
   };
-}
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/BaseModel.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/BaseModel.h
@@ -46,13 +46,10 @@ namespace OpenMS
     Every derived class has to implement the static functions
     "T* create()" and "const String getProductName()" (see DefaultParamHandler for details)
   */
-  template <UInt D>
-  class BaseModel :
-    public DefaultParamHandler
+  template<UInt D>
+  class BaseModel : public DefaultParamHandler
   {
-
-public:
-
+  public:
     typedef double IntensityType;
     typedef double CoordinateType;
     typedef DPosition<D> PositionType;
@@ -61,16 +58,13 @@ public:
 
 
     /// Default constructor.
-    BaseModel() :
-      DefaultParamHandler("BaseModel")
+    BaseModel() : DefaultParamHandler("BaseModel")
     {
       defaults_.setValue("cutoff", 0.0, "Low intensity cutoff of the model.  Peaks below this intensity are not considered part of the model.");
     }
 
     /// copy constructor
-    BaseModel(const BaseModel & source) :
-      DefaultParamHandler(source),
-      cut_off_(source.cut_off_)
+    BaseModel(const BaseModel& source) : DefaultParamHandler(source), cut_off_(source.cut_off_)
     {
     }
 
@@ -80,9 +74,10 @@ public:
     }
 
     /// assignment operator
-    BaseModel & operator=(const BaseModel & source)
+    BaseModel& operator=(const BaseModel& source)
     {
-      if (&source == this) return *this;
+      if (&source == this)
+        return *this;
 
       DefaultParamHandler::operator=(source);
       cut_off_ = source.cut_off_;
@@ -94,10 +89,10 @@ public:
     static void registerChildren();
 
     /// access model predicted intensity at position @p pos
-    virtual IntensityType getIntensity(const PositionType & pos) const = 0;
+    virtual IntensityType getIntensity(const PositionType& pos) const = 0;
 
     /// check if position @p pos is part of the model regarding the models cut-off.
-    virtual bool isContained(const PositionType & pos) const
+    virtual bool isContained(const PositionType& pos) const
     {
       return getIntensity(pos) >= cut_off_;
     }
@@ -106,8 +101,8 @@ public:
     predicted intensity at its current position, calling virtual void
     getIntensity().
     */
-    template <typename PeakType>
-    void fillIntensity(PeakType & peak) const
+    template<typename PeakType>
+    void fillIntensity(PeakType& peak) const
     {
       peak.setIntensity(getIntensity(peak.getPosition()));
     }
@@ -115,7 +110,7 @@ public:
     /**@brief Convenience function that applies fillIntensity() to an iterator
     range.
     */
-    template <class PeakIterator>
+    template<class PeakIterator>
     void fillIntensities(PeakIterator begin, PeakIterator end) const
     {
       for (PeakIterator it = begin; it != end; ++it)
@@ -138,10 +133,10 @@ public:
     }
 
     /// get reasonable set of samples from the model (i.e. for printing)
-    virtual void getSamples(SamplesType & cont) const = 0;
+    virtual void getSamples(SamplesType& cont) const = 0;
 
     /// fill stream with reasonable set of samples from the model (i.e. for printing)
-    virtual void getSamples(std::ostream & os)
+    virtual void getSamples(std::ostream& os)
     {
       SamplesType samples;
       getSamples(samples);
@@ -151,14 +146,12 @@ public:
       }
     }
 
-protected:
+  protected:
     IntensityType cut_off_;
 
     void updateMembers_() override
     {
       cut_off_ = (double)param_.getValue("cutoff");
     }
-
   };
-}
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/BaseModel.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/BaseModel.h
@@ -80,7 +80,7 @@ public:
     }
 
     /// assignment operator
-    virtual BaseModel & operator=(const BaseModel & source)
+    BaseModel & operator=(const BaseModel & source)
     {
       if (&source == this) return *this;
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h
@@ -34,8 +34,8 @@
 
 #pragma once
 
-#include <OpenMS/DATASTRUCTURES/IsotopeCluster.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/DATASTRUCTURES/IsotopeCluster.h>
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/MATH/STATISTICS/BasicStatistics.h>
@@ -56,12 +56,9 @@ namespace OpenMS
 
   @ingroup FeatureFinder
   */
-  class OPENMS_DLLAPI Fitter1D :
-    public DefaultParamHandler,
-    public FeatureFinderDefs
+  class OPENMS_DLLAPI Fitter1D : public DefaultParamHandler, public FeatureFinderDefs
   {
-public:
-
+  public:
     /// IndexSet
     typedef IsotopeCluster::IndexSet IndexSet;
     /// IndexSet with charge information
@@ -95,18 +92,15 @@ public:
     /// register all derived classes here
     static void registerChildren();
 
-protected:
-
+  protected:
     /// standard derivation in bounding box
-    CoordinateType tolerance_stdev_box_;    
+    CoordinateType tolerance_stdev_box_;
     /// basic statistics
     Math::BasicStatistics<> statistics_;
     /// interpolation step size
     CoordinateType interpolation_step_;
 
     void updateMembers_() override;
-
   };
 
-}
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h
@@ -87,7 +87,7 @@ public:
     ~Fitter1D() override;
 
     /// assignment operator
-    virtual Fitter1D& operator=(const Fitter1D& source);
+    Fitter1D& operator=(const Fitter1D& source);
 
     /// return interpolation model
     virtual QualityType fit1d(const RawDataArrayType& /* range */, std::unique_ptr<InterpolationModel>& /* model */);

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
@@ -34,21 +34,18 @@
 
 #pragma once
 
-#include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h>
-
-
-#include <algorithm>
-
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/Fitter1D.h>
+#include <algorithm>
 
 // forward decl
 namespace Eigen
 {
-    template<typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
-    class Matrix;
-    using MatrixXd = Matrix<double, -1, -1, 0, -1, -1>;
-    using VectorXd = Matrix<double, -1, 1, 0, -1, 1>;
-}
+  template<typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+  class Matrix;
+  using MatrixXd = Matrix<double, -1, -1, 0, -1, -1>;
+  using VectorXd = Matrix<double, -1, 1, 0, -1, 1>;
+} // namespace Eigen
 
 namespace OpenMS
 {
@@ -56,47 +53,50 @@ namespace OpenMS
   /**
     @brief Abstract class for 1D-model fitter using Levenberg-Marquardt algorithm for parameter optimization.
       */
-  class OPENMS_DLLAPI LevMarqFitter1D :
-    public Fitter1D
+  class OPENMS_DLLAPI LevMarqFitter1D : public Fitter1D
   {
-
-public:
-
+  public:
     typedef std::vector<double> ContainerType;
 
     /** Generic functor for LM-Optimization */
-    //TODO: This is copy and paste from TraceFitter.h. Make a generic wrapper for LM optimization
+    // TODO: This is copy and paste from TraceFitter.h. Make a generic wrapper for LM optimization
     class GenericFunctor
     {
     public:
-      int inputs() const { return m_inputs; }
-      int values() const { return m_values; }
+      int inputs() const
+      {
+        return m_inputs;
+      }
+      int values() const
+      {
+        return m_values;
+      }
 
-      GenericFunctor(int dimensions, int num_data_points)
-      : m_inputs(dimensions), m_values(num_data_points) {}
+      GenericFunctor(int dimensions, int num_data_points) : m_inputs(dimensions), m_values(num_data_points)
+      {
+      }
 
-      virtual ~GenericFunctor() {}
+      virtual ~GenericFunctor()
+      {
+      }
 
-      virtual int operator()(const Eigen::VectorXd &x, Eigen::VectorXd &fvec) const = 0;
+      virtual int operator()(const Eigen::VectorXd& x, Eigen::VectorXd& fvec) const = 0;
 
       // compute Jacobian matrix for the different parameters
-      virtual int df(const Eigen::VectorXd &x, Eigen::MatrixXd &J) const = 0;
+      virtual int df(const Eigen::VectorXd& x, Eigen::MatrixXd& J) const = 0;
 
     protected:
       const int m_inputs, m_values;
     };
 
     /// Default constructor
-    LevMarqFitter1D() :
-      Fitter1D()
+    LevMarqFitter1D() : Fitter1D()
     {
       this->defaults_.setValue("max_iteration", 500, "Maximum number of iterations using by Levenberg-Marquardt algorithm.", {"advanced"});
     }
 
     /// copy constructor
-    LevMarqFitter1D(const LevMarqFitter1D & source) :
-      Fitter1D(source),
-      max_iteration_(source.max_iteration_)
+    LevMarqFitter1D(const LevMarqFitter1D& source) : Fitter1D(source), max_iteration_(source.max_iteration_)
     {
     }
 
@@ -106,9 +106,10 @@ public:
     }
 
     /// assignment operator
-    LevMarqFitter1D & operator=(const LevMarqFitter1D & source)
+    LevMarqFitter1D& operator=(const LevMarqFitter1D& source)
     {
-      if (&source == this) return *this;
+      if (&source == this)
+        return *this;
 
       Fitter1D::operator=(source);
       max_iteration_ = source.max_iteration_;
@@ -116,8 +117,7 @@ public:
       return *this;
     }
 
-protected:
-
+  protected:
     /// Parameter indicates symmetric peaks
     bool symmetric_;
     /// Maximum number of iterations
@@ -131,7 +131,5 @@ protected:
     void optimize_(Eigen::VectorXd& x_init, GenericFunctor& functor) const;
 
     void updateMembers_() override;
-
   };
-}
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
@@ -106,7 +106,7 @@ public:
     }
 
     /// assignment operator
-    virtual LevMarqFitter1D & operator=(const LevMarqFitter1D & source)
+    LevMarqFitter1D & operator=(const LevMarqFitter1D & source)
     {
       if (&source == this) return *this;
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MaxLikeliFitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MaxLikeliFitter1D.h
@@ -67,7 +67,7 @@ public:
     }
 
     /// assignment operator
-    virtual MaxLikeliFitter1D & operator=(const MaxLikeliFitter1D & source)
+    MaxLikeliFitter1D & operator=(const MaxLikeliFitter1D & source)
     {
       if (&source == this) return *this;
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MaxLikeliFitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MaxLikeliFitter1D.h
@@ -43,21 +43,16 @@ namespace OpenMS
   /**
   @brief Abstract base class for all 1D-model fitters using maximum likelihood optimization.
   */
-  class OPENMS_DLLAPI MaxLikeliFitter1D :
-    public Fitter1D
+  class OPENMS_DLLAPI MaxLikeliFitter1D : public Fitter1D
   {
-
-public:
-
+  public:
     /// default constructor
-    MaxLikeliFitter1D() :
-      Fitter1D()
+    MaxLikeliFitter1D() : Fitter1D()
     {
     }
 
     /// copy constructor
-    MaxLikeliFitter1D(const MaxLikeliFitter1D & source) :
-      Fitter1D(source)
+    MaxLikeliFitter1D(const MaxLikeliFitter1D& source) : Fitter1D(source)
     {
     }
 
@@ -67,26 +62,20 @@ public:
     }
 
     /// assignment operator
-    MaxLikeliFitter1D & operator=(const MaxLikeliFitter1D & source)
+    MaxLikeliFitter1D& operator=(const MaxLikeliFitter1D& source)
     {
-      if (&source == this) return *this;
+      if (&source == this)
+        return *this;
 
       Fitter1D::operator=(source);
 
       return *this;
     }
 
-protected:
-
+  protected:
     /// fit an offset on the basis of the Pearson correlation coefficient
-    QualityType fitOffset_(std::unique_ptr<InterpolationModel>& model,
-                           const RawDataArrayType & set,
-                           const CoordinateType stdev1,
-                           const CoordinateType stdev2,
-                           const CoordinateType offset_step) const;
+    QualityType fitOffset_(std::unique_ptr<InterpolationModel>& model, const RawDataArrayType& set, const CoordinateType stdev1, const CoordinateType stdev2, const CoordinateType offset_step) const;
 
     void updateMembers_() override;
-
   };
-}
-
+} // namespace OpenMS

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -47,7 +47,6 @@ using std::vector;
 using std::make_pair;
 using std::min;
 using std::set;
-using std::iterator;
 
 namespace OpenMS
 {

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -33,52 +33,34 @@
 // --------------------------------------------------------------------------
 
 
-#include <OpenMS/DATASTRUCTURES/QTCluster.h>
-
-#include <OpenMS/DATASTRUCTURES/GridFeature.h>
 #include <OpenMS/CONCEPT/Macros.h>
-
-#include <numeric> // for make_pair
+#include <OpenMS/DATASTRUCTURES/GridFeature.h>
+#include <OpenMS/DATASTRUCTURES/QTCluster.h>
 #include <algorithm> // for set_intersection
-#include <iterator> // for inserter
+#include <iterator>  // for inserter
+#include <numeric>   // for make_pair
 
-using std::map;
-using std::vector;
 using std::make_pair;
+using std::map;
 using std::min;
 using std::set;
+using std::vector;
 
 namespace OpenMS
 {
-  QTCluster::BulkData::BulkData(const OpenMS::GridFeature* const center_point, 
-                                Size num_maps, double max_distance,
-                                Int x_coord, Int y_coord, Size id) :
-    center_point_(center_point),
-    id_(id),
-    neighbors_(),
-    tmp_neighbors_(),
-    max_distance_(max_distance),
-    num_maps_(num_maps),
-    x_coord_(x_coord),
-    y_coord_(y_coord),
-    annotations_()
-  {}
+  QTCluster::BulkData::BulkData(const OpenMS::GridFeature* const center_point, Size num_maps, double max_distance, Int x_coord, Int y_coord, Size id) :
+      center_point_(center_point), id_(id), neighbors_(), tmp_neighbors_(), max_distance_(max_distance), num_maps_(num_maps), x_coord_(x_coord), y_coord_(y_coord), annotations_()
+  {
+  }
 
-  QTCluster::QTCluster(QTCluster::BulkData* const data, bool use_IDs) :
-    quality_(0.0),
-    data_(data),
-    valid_(true),
-    changed_(false),
-    use_IDs_(use_IDs),
-    collect_annotations_(false),
-    finalized_(true)
+  QTCluster::QTCluster(QTCluster::BulkData* const data, bool use_IDs) : quality_(0.0), data_(data), valid_(true), changed_(false), use_IDs_(use_IDs), collect_annotations_(false), finalized_(true)
   {
     if (use_IDs)
     {
       data_->annotations_ = data_->center_point_->getAnnotations();
     }
     if (use_IDs_ && data_->center_point_->getAnnotations().size() != 1)
-    { 
+    {
       collect_annotations_ = true;
     }
   }
@@ -123,15 +105,13 @@ namespace OpenMS
 
   Size QTCluster::size() const
   {
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is not finalized")
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is not finalized")
     return data_->neighbors_.size() + 1; // + 1 for the center
   }
 
   bool QTCluster::operator<(const QTCluster& rhs) const
   {
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is not finalized")
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is not finalized")
 
     return quality_ < rhs.quality_;
   }
@@ -141,17 +121,15 @@ namespace OpenMS
     // get reference on member that is used in this function
     NeighborMapMulti& tmp_neighbors_ = data_->tmp_neighbors_;
 
-    OPENMS_PRECONDITION(!finalized_,
-        "Cannot perform operation on cluster that is not initialized")
+    OPENMS_PRECONDITION(!finalized_, "Cannot perform operation on cluster that is not initialized")
     // ensure we only add compatible peptide annotations
-    OPENMS_PRECONDITION(distance <= data_->max_distance_,
-        "Distance cannot be larger than max_distance")
+    OPENMS_PRECONDITION(distance <= data_->max_distance_, "Distance cannot be larger than max_distance")
 
     Size map_index = element->getMapIndex();
 
     // get reference on member that is used in this function
     const OpenMS::GridFeature& center_point = *(data_->center_point_);
-    
+
     // Ensure we only add compatible peptide annotations. If the cluster center
     // has an annotation, then each added neighbor should have at least one matching annotation.
     // If the center element has no annotation we add all elements
@@ -163,10 +141,10 @@ namespace OpenMS
       {
         set<AASequence> intersect;
         // overlap of at least one sequence is enough
-        std::set_intersection(center_point.getAnnotations().begin(), center_point.getAnnotations().end(),
-                              element->getAnnotations().begin(), element->getAnnotations().end(),
+        std::set_intersection(center_point.getAnnotations().begin(), center_point.getAnnotations().end(), element->getAnnotations().begin(), element->getAnnotations().end(),
                               std::inserter(intersect, intersect.begin()));
-        if (intersect.empty()) return;
+        if (intersect.empty())
+          return;
       }
     }
 
@@ -181,17 +159,16 @@ namespace OpenMS
     // Store best (closest) element:
     // Only add the element if either no element is present for the map or if
     // the element is closer than the current element for that map
-    //TODO This might be wrong now with multiple seqs.
+    // TODO This might be wrong now with multiple seqs.
     //  It might need consider the seqTable for every seq of the intersection!
     //  On the other hand this just fills data_->neighbors_ which says it only stores the BEST feature per map.
     if (map_index != center_point.getMapIndex())
     {
       NeighborMap& neighbors_ = data_->neighbors_;
-      
-      if (neighbors_.find(map_index) == neighbors_.end() ||
-          distance < neighbors_[map_index].distance)
+
+      if (neighbors_.find(map_index) == neighbors_.end() || distance < neighbors_[map_index].distance)
       {
-        neighbors_[map_index] = Neighbor{distance, element};
+        neighbors_[map_index] = Neighbor {distance, element};
         changed_ = true;
       }
     }
@@ -199,8 +176,7 @@ namespace OpenMS
 
   QTCluster::Elements QTCluster::getElements() const
   {
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is not finalized")
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is not finalized")
 
     // get the neighbors and then insert the cluster center
     Elements elements = getAllNeighbors();
@@ -214,8 +190,7 @@ namespace OpenMS
 
   bool QTCluster::update(const Elements& removed)
   {
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is not finalized")
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is not finalized")
 
     // check if the cluster center was removed:
     for (const auto& removed_element : removed)
@@ -265,9 +240,8 @@ namespace OpenMS
   double QTCluster::getCurrentQuality() const
   {
     // ensure cluster is finalized
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is finalized")
-  
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is finalized")
+
     return quality_;
   }
 
@@ -275,8 +249,7 @@ namespace OpenMS
   {
     // ensure cluster is not finalized as we cannot call optimizeAnnotations_
     // in that case
-    OPENMS_PRECONDITION(!finalized_,
-        "Cannot perform operation on cluster that is finalized")
+    OPENMS_PRECONDITION(!finalized_, "Cannot perform operation on cluster that is finalized")
 
     // get references on member that is used in this function
     NeighborMap& neighbors_ = data_->neighbors_;
@@ -286,8 +259,7 @@ namespace OpenMS
 
     Size num_other = data_->num_maps_ - 1;
     double internal_distance = 0.0;
-    if (!use_IDs_ || data_->center_point_->getAnnotations().size() == 1 ||
-        neighbors_.empty())
+    if (!use_IDs_ || data_->center_point_->getAnnotations().size() == 1 || neighbors_.empty())
     {
       // if the cluster center is annotated with one peptide ID, the neighbors can
       // consist only of features with compatible IDs, so we don't need to
@@ -311,8 +283,7 @@ namespace OpenMS
 
   QTCluster::Elements QTCluster::getAllNeighbors() const
   {
-    OPENMS_PRECONDITION(finalized_,
-        "Cannot perform operation on cluster that is not finalized")
+    OPENMS_PRECONDITION(finalized_, "Cannot perform operation on cluster that is not finalized")
 
     // copy the important info about the neighbors
     Elements elements;
@@ -336,28 +307,25 @@ namespace OpenMS
 
   double QTCluster::optimizeAnnotations_()
   {
-    OPENMS_PRECONDITION(collect_annotations_,
-        "QTCluster::optimizeAnnotations_ should only be called if we use collect_annotations_")
-    OPENMS_PRECONDITION(!data_->tmp_neighbors_.empty(),
-        "QTCluster::optimizeAnnotations_ needs to have working tmp_neighbors_")
-    OPENMS_PRECONDITION(!finalized_,
-        "QTCluster::optimizeAnnotations_ cannot work on finalized cluster")
+    OPENMS_PRECONDITION(collect_annotations_, "QTCluster::optimizeAnnotations_ should only be called if we use collect_annotations_")
+    OPENMS_PRECONDITION(!data_->tmp_neighbors_.empty(), "QTCluster::optimizeAnnotations_ needs to have working tmp_neighbors_")
+    OPENMS_PRECONDITION(!finalized_, "QTCluster::optimizeAnnotations_ cannot work on finalized cluster")
 
     // mapping: peptides -> best distance per input map
-    map<AASequence, map<Size,double> > seq_table;
+    map<AASequence, map<Size, double>> seq_table;
 
     makeSeqTable_(seq_table);
 
     // get copies of members that are used in this function
     Size num_maps_ = data_->num_maps_;
     double max_distance_ = data_->max_distance_;
-    
-    // combine annotation-specific and unspecific distances 
+
+    // combine annotation-specific and unspecific distances
     // (all unspecific ones are grouped as empty AASequence):
     auto unspecific = seq_table.find(AASequence());
     if (unspecific != seq_table.end())
     {
-      for (auto it = seq_table.begin(); it != seq_table.end(); ++it) //OMS_CODING_TEST_EXCLUDE
+      for (auto it = seq_table.begin(); it != seq_table.end(); ++it) // OMS_CODING_TEST_EXCLUDE
       {
         if (it == unspecific)
           continue;
@@ -367,7 +335,7 @@ namespace OpenMS
         {
           // try to add new entry
           auto mapidx_inserted = it->second.emplace(mapidx_unspecdist.first, mapidx_unspecdist.second);
-          if (!mapidx_inserted.second) //an entry for that map idx already existed for the sequence, check minimum of both
+          if (!mapidx_inserted.second) // an entry for that map idx already existed for the sequence, check minimum of both
           {
             mapidx_inserted.first->second = min(mapidx_inserted.first->second, mapidx_unspecdist.second);
           }
@@ -378,16 +346,13 @@ namespace OpenMS
     // compute distance totals -> best annotation set has smallest value:
     auto best_pos = seq_table.begin();
     double best_total = num_maps_ * max_distance_;
-    for (auto it = seq_table.begin(); it != seq_table.end(); ++it) //OMS_CODING_TEST_EXCLUDE
+    for (auto it = seq_table.begin(); it != seq_table.end(); ++it) // OMS_CODING_TEST_EXCLUDE
     {
       OPENMS_PRECONDITION(num_maps_ - 1 >= it->second.size(), "num_maps bigger than map size -1 (center)");
       // init value is #missing maps times max_distance
       // above, unspecific distances were incorporated into the rest already.
-      double total = std::accumulate(it->second.begin(), it->second.end(),
-                                     double(num_maps_ - 1 - it->second.size()) * max_distance_,
-                                    [] (double val, const std::map<Size, double>::value_type& p)
-                                              { return val + p.second; }
-                                    );
+      double total = std::accumulate(it->second.begin(), it->second.end(), double(num_maps_ - 1 - it->second.size()) * max_distance_,
+                                     [](double val, const std::map<Size, double>::value_type& p) { return val + p.second; });
       if (total < best_total)
       {
         best_pos = it;
@@ -397,15 +362,15 @@ namespace OpenMS
 
     if (best_pos != seq_table.end())
     {
-      //TODO can we accumulate the union of possible annotations and set the best as "representative"?
-      // Probably in another member and function though (e.g. after finalize),
-      // since annotations_ is used in recomputeNeighbors to filter the cluster for matching
-      // features of this "best" annotation.
-      // Actually I think during creation of the consensusFeature later, all IDs of the linked features
-      // (from the original full data) are copied anyway.
-      // Then it would make sense to save the "best" annotation "distance-wise" from this algorithm, to be used during
-      // IDConflictResolution (which is based on only ID scores).
-      // OR already consider the ID scores here and make a more elaborate scoring.
+      // TODO can we accumulate the union of possible annotations and set the best as "representative"?
+      //  Probably in another member and function though (e.g. after finalize),
+      //  since annotations_ is used in recomputeNeighbors to filter the cluster for matching
+      //  features of this "best" annotation.
+      //  Actually I think during creation of the consensusFeature later, all IDs of the linked features
+      //  (from the original full data) are copied anyway.
+      //  Then it would make sense to save the "best" annotation "distance-wise" from this algorithm, to be used during
+      //  IDConflictResolution (which is based on only ID scores).
+      //  OR already consider the ID scores here and make a more elaborate scoring.
       data_->annotations_ = {best_pos->first};
     }
 
@@ -423,11 +388,9 @@ namespace OpenMS
     std::set<AASequence>& annotations_ = data_->annotations_;
 
     neighbors_.clear();
-    for (NeighborMapMulti::const_iterator n_it = tmp_neighbors_.begin();
-         n_it != tmp_neighbors_.end(); ++n_it)
+    for (NeighborMapMulti::const_iterator n_it = tmp_neighbors_.begin(); n_it != tmp_neighbors_.end(); ++n_it)
     {
-      for (std::multimap<double, const GridFeature*>::const_iterator df_it =
-             n_it->second.begin(); df_it != n_it->second.end(); ++df_it)
+      for (std::multimap<double, const GridFeature*>::const_iterator df_it = n_it->second.begin(); df_it != n_it->second.end(); ++df_it)
       {
         std::set<AASequence> intersect;
         const std::set<AASequence>& current = df_it->second->getAnnotations();
@@ -435,32 +398,30 @@ namespace OpenMS
         // if no overlap with the re-calculated IDs in the center, do not re-add neighbor to the updated neighbors anymore.
         if (!intersect.empty() || current.empty())
         {
-          neighbors_[n_it->first] = Neighbor{df_it->first, df_it->second};
+          neighbors_[n_it->first] = Neighbor {df_it->first, df_it->second};
           break; // found the best element for this input map
         }
       }
     }
   }
 
-  void QTCluster::makeSeqTable_(map<AASequence, map<Size,double>>& seq_table) const
+  void QTCluster::makeSeqTable_(map<AASequence, map<Size, double>>& seq_table) const
   {
     // get reference on member that is used in this function
     NeighborMapMulti& tmp_neighbors_ = data_->tmp_neighbors_;
 
     // for all maps contributing to this cluster
-    for (NeighborMapMulti::iterator n_it = tmp_neighbors_.begin();
-         n_it != tmp_neighbors_.end(); ++n_it)
+    for (NeighborMapMulti::iterator n_it = tmp_neighbors_.begin(); n_it != tmp_neighbors_.end(); ++n_it)
     {
-      //for all neighbors relevant for this cluster in this map
+      // for all neighbors relevant for this cluster in this map
       Size map_index = n_it->first;
-      for (NeighborList::iterator df_it = n_it->second.begin();
-          df_it != n_it->second.end(); ++df_it)
+      for (NeighborList::iterator df_it = n_it->second.begin(); df_it != n_it->second.end(); ++df_it)
       {
         double dist = df_it->first;
         // for all IDs/annotations of the neighboring feature (skipped if empty)
         for (const auto& current : df_it->second->getAnnotations())
         {
-          auto seqit_inserted = seq_table.emplace(current, map<Size,double>{{map_index, dist}});
+          auto seqit_inserted = seq_table.emplace(current, map<Size, double> {{map_index, dist}});
           // check if a minimum distance was already set for this ID
           if (!seqit_inserted.second)
           {
@@ -479,7 +440,7 @@ namespace OpenMS
 
         if (df_it->second->getAnnotations().empty()) // unannotated feature
         {
-          auto seqit_inserted = seq_table.emplace(AASequence(), map<Size,double>{{map_index, dist}});
+          auto seqit_inserted = seq_table.emplace(AASequence(), map<Size, double> {{map_index, dist}});
           // check if a minimum distance was already set for empty ID = unannotated
           if (!seqit_inserted.second)
           {
@@ -507,8 +468,7 @@ namespace OpenMS
 
   void QTCluster::finalizeCluster()
   {
-    OPENMS_PRECONDITION(!finalized_,
-        "Try to finalize QTCluster that was not initialized or already finalized")
+    OPENMS_PRECONDITION(!finalized_, "Try to finalize QTCluster that was not initialized or already finalized")
 
     // calls computeQuality_ if something changed since initialization. In
     // turn, computeQuality_ calls optimizeAnnotations_ if necessary which
@@ -522,10 +482,8 @@ namespace OpenMS
 
   void QTCluster::initializeCluster()
   {
-    OPENMS_PRECONDITION(data_->tmp_neighbors_.empty(),
-        "Try to initialize QTCluster that was not finalized")
-    OPENMS_PRECONDITION(finalized_,
-        "Try to initialize QTCluster that was not finalized")
+    OPENMS_PRECONDITION(data_->tmp_neighbors_.empty(), "Try to initialize QTCluster that was not finalized")
+    OPENMS_PRECONDITION(finalized_, "Try to initialize QTCluster that was not finalized")
 
     finalized_ = false;
 

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -32,9 +32,8 @@
 // $Authors: Nico Pfeifer, Mathias Walzer, Hendrik Weisser $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FILTERING/ID/IDFilter.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
-
+#include <OpenMS/FILTERING/ID/IDFilter.h>
 #include <regex>
 
 using namespace std;
@@ -42,15 +41,14 @@ using namespace std;
 namespace OpenMS
 {
 
-  struct IDFilter::HasMinPeptideLength
-  {
+  struct IDFilter::HasMinPeptideLength {
     typedef PeptideHit argument_type; // for use as a predicate
 
     Size length_;
 
-    explicit HasMinPeptideLength(Size length):
-      length_(length)
-    {}
+    explicit HasMinPeptideLength(Size length) : length_(length)
+    {
+    }
 
     bool operator()(const PeptideHit& hit) const
     {
@@ -59,15 +57,14 @@ namespace OpenMS
   };
 
 
-  struct IDFilter::HasMinCharge
-  {
+  struct IDFilter::HasMinCharge {
     typedef PeptideHit argument_type; // for use as a predicate
 
     Int charge_;
 
-    explicit HasMinCharge(Int charge):
-      charge_(charge)
-    {}
+    explicit HasMinCharge(Int charge) : charge_(charge)
+    {
+    }
 
     bool operator()(const PeptideHit& hit) const
     {
@@ -76,37 +73,36 @@ namespace OpenMS
   };
 
 
-  struct IDFilter::HasLowMZError
-  {
+  struct IDFilter::HasLowMZError {
     typedef PeptideHit argument_type; // for use as a predicate
 
     double precursor_mz_, tolerance_;
 
-    HasLowMZError(double precursor_mz, double tolerance, bool unit_ppm):
-      precursor_mz_(precursor_mz), tolerance_(tolerance)
+    HasLowMZError(double precursor_mz, double tolerance, bool unit_ppm) : precursor_mz_(precursor_mz), tolerance_(tolerance)
     {
-      if (unit_ppm) this->tolerance_ *= precursor_mz / 1.0e6;
+      if (unit_ppm)
+        this->tolerance_ *= precursor_mz / 1.0e6;
     }
 
     bool operator()(const PeptideHit& hit) const
     {
       Int z = hit.getCharge();
-      if (z == 0) z = 1;
+      if (z == 0)
+        z = 1;
       double peptide_mz = hit.getSequence().getMZ(z);
       return fabs(precursor_mz_ - peptide_mz) <= tolerance_;
     }
   };
 
 
-  struct IDFilter::HasMatchingModification
-  {
+  struct IDFilter::HasMatchingModification {
     typedef PeptideHit argument_type; // for use as a predicate
 
     const set<String>& mods_;
 
-    explicit HasMatchingModification(const set<String>& mods):
-      mods_(mods)
-    {}
+    explicit HasMatchingModification(const set<String>& mods) : mods_(mods)
+    {
+    }
 
     bool operator()(const PeptideHit& hit) const
     {
@@ -120,7 +116,8 @@ namespace OpenMS
         if (seq[i].isModified())
         {
           String mod_name = seq[i].getModification()->getFullId();
-          if (mods_.count(mod_name) > 0) return true;
+          if (mods_.count(mod_name) > 0)
+            return true;
         }
       }
 
@@ -128,12 +125,14 @@ namespace OpenMS
       if (seq.hasNTerminalModification())
       {
         String mod_name = seq.getNTerminalModification()->getFullId();
-        if (mods_.count(mod_name) > 0) return true;
+        if (mods_.count(mod_name) > 0)
+          return true;
       }
       if (seq.hasCTerminalModification())
       {
         String mod_name = seq.getCTerminalModification()->getFullId();
-        if (mods_.count(mod_name) > 0) return true;
+        if (mods_.count(mod_name) > 0)
+          return true;
       }
 
       return false;
@@ -141,29 +140,25 @@ namespace OpenMS
   };
 
 
-  struct IDFilter::HasMatchingSequence
-  {
+  struct IDFilter::HasMatchingSequence {
     typedef PeptideHit argument_type; // for use as a predicate
 
     const set<String>& sequences_;
     bool ignore_mods_;
 
-    explicit HasMatchingSequence(const set<String>& sequences, bool ignore_mods = false):
-      sequences_(sequences), ignore_mods_(ignore_mods)
-    {}
+    explicit HasMatchingSequence(const set<String>& sequences, bool ignore_mods = false) : sequences_(sequences), ignore_mods_(ignore_mods)
+    {
+    }
 
     bool operator()(const PeptideHit& hit) const
     {
-      const String& query = (ignore_mods_ ?
-                             hit.getSequence().toUnmodifiedString() :
-                             hit.getSequence().toString());
+      const String& query = (ignore_mods_ ? hit.getSequence().toUnmodifiedString() : hit.getSequence().toString());
       return (sequences_.count(query) > 0);
     }
   };
 
 
-  struct IDFilter::HasNoEvidence
-  {
+  struct IDFilter::HasNoEvidence {
     typedef PeptideHit argument_type; // for use as a predicate
 
     bool operator()(const PeptideHit& hit) const
@@ -172,15 +167,14 @@ namespace OpenMS
     }
   };
 
-  struct IDFilter::HasRTInRange
-  {
+  struct IDFilter::HasRTInRange {
     typedef PeptideIdentification argument_type; // for use as a predicate
 
     double rt_min_, rt_max_;
 
-    HasRTInRange(double rt_min, double rt_max):
-      rt_min_(rt_min), rt_max_(rt_max)
-    {}
+    HasRTInRange(double rt_min, double rt_max) : rt_min_(rt_min), rt_max_(rt_max)
+    {
+    }
 
     bool operator()(const PeptideIdentification& id) const
     {
@@ -190,15 +184,14 @@ namespace OpenMS
   };
 
 
-  struct IDFilter::HasMZInRange
-  {
+  struct IDFilter::HasMZInRange {
     typedef PeptideIdentification argument_type; // for use as a predicate
 
     double mz_min_, mz_max_;
 
-    HasMZInRange(double mz_min, double mz_max):
-      mz_min_(mz_min), mz_max_(mz_max)
-    {}
+    HasMZInRange(double mz_min, double mz_max) : mz_min_(mz_min), mz_max_(mz_max)
+    {
+    }
 
     bool operator()(const PeptideIdentification& id) const
     {
@@ -208,9 +201,7 @@ namespace OpenMS
   };
 
 
-  void IDFilter::extractPeptideSequences(
-    const vector<PeptideIdentification>& peptides, set<String>& sequences,
-    bool ignore_mods)
+  void IDFilter::extractPeptideSequences(const vector<PeptideIdentification>& peptides, set<String>& sequences, bool ignore_mods)
   {
     for (const PeptideIdentification& pep : peptides)
     {
@@ -228,7 +219,7 @@ namespace OpenMS
     }
   }
 
-  map<String,vector<ProteinHit>> IDFilter::extractUnassignedProteins(ConsensusMap& cmap)
+  map<String, vector<ProteinHit>> IDFilter::extractUnassignedProteins(ConsensusMap& cmap)
   {
     // collect accessions that are referenced by peptides for each ID run:
     map<String, unordered_set<String>> run_to_accessions;
@@ -241,21 +232,19 @@ namespace OpenMS
         // extract protein accessions of each peptide hit:
         for (const PeptideHit& hit : pepid.getHits())
         {
-
           const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-          run_to_accessions[run_id].insert(current_accessions.begin(),
-                                           current_accessions.end());
+          run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
         }
       }
     }
 
     vector<ProteinIdentification>& prots = cmap.getProteinIdentifications();
 
-    map<String,vector<ProteinHit>> result{};
+    map<String, vector<ProteinHit>> result {};
     for (ProteinIdentification& prot : prots)
     {
       const String& run_id = prot.getIdentifier();
-      auto target = result.emplace(run_id, vector<ProteinHit>{});
+      auto target = result.emplace(run_id, vector<ProteinHit> {});
       const unordered_set<String>& accessions = run_to_accessions[run_id];
       struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
       moveMatchingItems(prot.getHits(), std::not_fn(acc_filter), target.first->second);
@@ -268,20 +257,16 @@ namespace OpenMS
     // collect accessions that are referenced by peptides for each ID run:
     map<String, unordered_set<String>> run_to_accessions;
 
-    auto add_references_to_map =
-        [&run_to_accessions](const PeptideIdentification& pepid)
-    {
+    auto add_references_to_map = [&run_to_accessions](const PeptideIdentification& pepid) {
       const String& run_id = pepid.getIdentifier();
       // extract protein accessions of each peptide hit:
       for (const PeptideHit& hit : pepid.getHits())
       {
-
         const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-        run_to_accessions[run_id].insert(current_accessions.begin(),
-                                         current_accessions.end());
+        run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
       }
     };
-    cmap.applyFunctionOnPeptideIDs(add_references_to_map,include_unassigned);
+    cmap.applyFunctionOnPeptideIDs(add_references_to_map, include_unassigned);
 
     vector<ProteinIdentification>& prots = cmap.getProteinIdentifications();
 
@@ -294,9 +279,7 @@ namespace OpenMS
     }
   }
 
-  void IDFilter::removeUnreferencedProteins(
-      ProteinIdentification& proteins,
-      const vector<PeptideIdentification>& peptides)
+  void IDFilter::removeUnreferencedProteins(ProteinIdentification& proteins, const vector<PeptideIdentification>& peptides)
   {
     // collect accessions that are referenced by peptides for each ID run:
     map<String, unordered_set<String>> run_to_accessions;
@@ -307,8 +290,7 @@ namespace OpenMS
       for (const PeptideHit& hit : pep.getHits())
       {
         const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-        run_to_accessions[run_id].insert(current_accessions.begin(),
-                                         current_accessions.end());
+        run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
       }
     }
 
@@ -318,9 +300,7 @@ namespace OpenMS
     keepMatchingItems(proteins.getHits(), acc_filter);
   }
 
-  void IDFilter::removeUnreferencedProteins(
-    vector<ProteinIdentification>& proteins,
-    const vector<PeptideIdentification>& peptides)
+  void IDFilter::removeUnreferencedProteins(vector<ProteinIdentification>& proteins, const vector<PeptideIdentification>& peptides)
   {
     // collect accessions that are referenced by peptides for each ID run:
     map<String, unordered_set<String>> run_to_accessions;
@@ -331,8 +311,7 @@ namespace OpenMS
       for (const PeptideHit& hit : pep.getHits())
       {
         const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-        run_to_accessions[run_id].insert(current_accessions.begin(),
-                                         current_accessions.end());
+        run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
       }
     }
 
@@ -345,10 +324,8 @@ namespace OpenMS
     }
   }
 
-  //TODO write version where you look up in a specific run (e.g. first inference run
-  void IDFilter::updateProteinReferences(
-      ConsensusMap& cmap,
-      bool remove_peptides_without_reference)
+  // TODO write version where you look up in a specific run (e.g. first inference run
+  void IDFilter::updateProteinReferences(ConsensusMap& cmap, bool remove_peptides_without_reference)
   {
     vector<ProteinIdentification>& proteins = cmap.getProteinIdentifications();
     // collect valid protein accessions for each ID run:
@@ -362,9 +339,7 @@ namespace OpenMS
       }
     }
 
-    auto check_prots_avail = [&run_to_accessions,&remove_peptides_without_reference]
-        (PeptideIdentification& pep) -> void
-    {
+    auto check_prots_avail = [&run_to_accessions, &remove_peptides_without_reference](PeptideIdentification& pep) -> void {
       const String& run_id = pep.getIdentifier();
       const unordered_set<String>& accessions = run_to_accessions[run_id];
       struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
@@ -374,10 +349,7 @@ namespace OpenMS
         // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
         // can't use "keepMatchingItems":
         vector<PeptideEvidence> evidences;
-        remove_copy_if(hit.getPeptideEvidences().begin(),
-                       hit.getPeptideEvidences().end(),
-                       back_inserter(evidences),
-                       std::not_fn(acc_filter));
+        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
         hit.setPeptideEvidences(evidences);
       }
 
@@ -390,10 +362,7 @@ namespace OpenMS
     cmap.applyFunctionOnPeptideIDs(check_prots_avail);
   }
 
-  void IDFilter::updateProteinReferences(
-      ConsensusMap& cmap,
-      const ProteinIdentification& ref_run,
-      bool remove_peptides_without_reference)
+  void IDFilter::updateProteinReferences(ConsensusMap& cmap, const ProteinIdentification& ref_run, bool remove_peptides_without_reference)
   {
     // collect valid protein accessions for each ID run:
     unordered_set<String> accessions_avail;
@@ -404,37 +373,29 @@ namespace OpenMS
     }
 
     // TODO could be refactored and pulled out
-    auto check_prots_avail = [&accessions_avail, &remove_peptides_without_reference]
-        (PeptideIdentification& pep) -> void
+    auto check_prots_avail = [&accessions_avail, &remove_peptides_without_reference](PeptideIdentification& pep) -> void {
+      const unordered_set<String>& accessions = accessions_avail;
+      struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
+      // check protein accessions of each peptide hit
+      for (PeptideHit& hit : pep.getHits())
       {
-          const unordered_set<String>& accessions = accessions_avail;
-          struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
-          // check protein accessions of each peptide hit
-          for (PeptideHit& hit : pep.getHits())
-          {
-            // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
-            // can't use "keepMatchingItems":
-            vector<PeptideEvidence> evidences;
-            remove_copy_if(hit.getPeptideEvidences().begin(),
-                           hit.getPeptideEvidences().end(),
-                           back_inserter(evidences),
-                           std::not_fn(acc_filter));
-            hit.setPeptideEvidences(evidences);
-          }
+        // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
+        // can't use "keepMatchingItems":
+        vector<PeptideEvidence> evidences;
+        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
+        hit.setPeptideEvidences(evidences);
+      }
 
-          if (remove_peptides_without_reference)
-          {
-            removeMatchingItems(pep.getHits(), HasNoEvidence());
-          }
-      };
+      if (remove_peptides_without_reference)
+      {
+        removeMatchingItems(pep.getHits(), HasNoEvidence());
+      }
+    };
 
     cmap.applyFunctionOnPeptideIDs(check_prots_avail);
-}
+  }
 
-  void IDFilter::updateProteinReferences(
-    vector<PeptideIdentification>& peptides,
-    const vector<ProteinIdentification>& proteins,
-    bool remove_peptides_without_reference)
+  void IDFilter::updateProteinReferences(vector<PeptideIdentification>& peptides, const vector<ProteinIdentification>& proteins, bool remove_peptides_without_reference)
   {
     // collect valid protein accessions for each ID run:
     map<String, unordered_set<String>> run_to_accessions;
@@ -458,10 +419,7 @@ namespace OpenMS
         // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
         // can't use "keepMatchingItems":
         vector<PeptideEvidence> evidences;
-        remove_copy_if(hit.getPeptideEvidences().begin(),
-                       hit.getPeptideEvidences().end(),
-                       back_inserter(evidences),
-                       std::not_fn(acc_filter));
+        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
         hit.setPeptideEvidences(evidences);
       }
 
@@ -473,11 +431,10 @@ namespace OpenMS
   }
 
 
-  bool IDFilter::updateProteinGroups(
-    vector<ProteinIdentification::ProteinGroup>& groups,
-    const vector<ProteinHit>& hits)
+  bool IDFilter::updateProteinGroups(vector<ProteinIdentification::ProteinGroup>& groups, const vector<ProteinHit>& hits)
   {
-    if (groups.empty()) return true; // nothing to update
+    if (groups.empty())
+      return true; // nothing to update
 
     // we'll do lots of look-ups, so use a suitable data structure:
     unordered_set<String> valid_accessions;
@@ -513,9 +470,7 @@ namespace OpenMS
     return valid;
   }
 
-  void IDFilter::removeUngroupedProteins(
-      const vector<ProteinIdentification::ProteinGroup>& groups,
-      vector<ProteinHit>& hits)
+  void IDFilter::removeUngroupedProteins(const vector<ProteinIdentification::ProteinGroup>& groups, vector<ProteinHit>& hits)
   {
     if (hits.empty())
     {
@@ -528,14 +483,10 @@ namespace OpenMS
       valid_accessions.insert(grp.accessions.begin(), grp.accessions.end());
     }
 
-    hits.erase(
-        std::remove_if(hits.begin(), hits.end(), std::not_fn(HasMatchingAccessionUnordered<ProteinHit>(valid_accessions))),
-        hits.end()
-        );
+    hits.erase(std::remove_if(hits.begin(), hits.end(), std::not_fn(HasMatchingAccessionUnordered<ProteinHit>(valid_accessions))), hits.end());
   }
 
-  void IDFilter::keepBestPeptideHits(vector<PeptideIdentification>& peptides,
-                                     bool strict)
+  void IDFilter::keepBestPeptideHits(vector<PeptideIdentification>& peptides, bool strict)
   {
     for (PeptideIdentification& pep : peptides)
     {
@@ -561,8 +512,7 @@ namespace OpenMS
         {
           // we could use keepMatchingHits() here, but it would be less
           // efficient (since the hits are already sorted by score):
-          for (vector<PeptideHit>::iterator hit_it = ++hits.begin();
-               hit_it != hits.end(); ++hit_it)
+          for (vector<PeptideHit>::iterator hit_it = ++hits.begin(); hit_it != hits.end(); ++hit_it)
           {
             if (!good_score(*hit_it))
             {
@@ -575,23 +525,16 @@ namespace OpenMS
     }
   }
 
-  void IDFilter::filterGroupsByScore(std::vector<ProteinIdentification::ProteinGroup>& grps,
-                                double threshold_score, bool higher_better)
+  void IDFilter::filterGroupsByScore(std::vector<ProteinIdentification::ProteinGroup>& grps, double threshold_score, bool higher_better)
   {
-    const auto& pred = [&threshold_score,&higher_better](ProteinIdentification::ProteinGroup& g)
-    {
-      return ((higher_better && (threshold_score >= g.probability))
-              || (!higher_better && (threshold_score < g.probability)));
+    const auto& pred = [&threshold_score, &higher_better](ProteinIdentification::ProteinGroup& g) {
+      return ((higher_better && (threshold_score >= g.probability)) || (!higher_better && (threshold_score < g.probability)));
     };
 
-    grps.erase(
-        std::remove_if(grps.begin(),grps.end(),pred),
-        grps.end()
-        );
+    grps.erase(std::remove_if(grps.begin(), grps.end(), pred), grps.end());
   }
 
-  void IDFilter::filterPeptidesByLength(vector<PeptideIdentification>& peptides,
-                                        Size min_length, Size max_length)
+  void IDFilter::filterPeptidesByLength(vector<PeptideIdentification>& peptides, Size min_length, Size max_length)
   {
     if (min_length > 0)
     {
@@ -613,8 +556,7 @@ namespace OpenMS
   }
 
 
-  void IDFilter::filterPeptidesByCharge(vector<PeptideIdentification>& peptides,
-                                        Int min_charge, Int max_charge)
+  void IDFilter::filterPeptidesByCharge(vector<PeptideIdentification>& peptides, Int min_charge, Int max_charge)
   {
     struct HasMinCharge charge_filter(min_charge);
     for (PeptideIdentification& pep : peptides)
@@ -633,24 +575,21 @@ namespace OpenMS
   }
 
 
-  void IDFilter::filterPeptidesByRT(vector<PeptideIdentification>& peptides,
-                                    double min_rt, double max_rt)
+  void IDFilter::filterPeptidesByRT(vector<PeptideIdentification>& peptides, double min_rt, double max_rt)
   {
     struct HasRTInRange rt_filter(min_rt, max_rt);
     keepMatchingItems(peptides, rt_filter);
   }
 
 
-  void IDFilter::filterPeptidesByMZ(vector<PeptideIdentification>& peptides,
-                                    double min_mz, double max_mz)
+  void IDFilter::filterPeptidesByMZ(vector<PeptideIdentification>& peptides, double min_mz, double max_mz)
   {
     struct HasMZInRange mz_filter(min_mz, max_mz);
     keepMatchingItems(peptides, mz_filter);
   }
 
 
-  void IDFilter::filterPeptidesByMZError(
-    vector<PeptideIdentification>& peptides, double mass_error, bool unit_ppm)
+  void IDFilter::filterPeptidesByMZError(vector<PeptideIdentification>& peptides, double mass_error, bool unit_ppm)
   {
     for (PeptideIdentification& pep : peptides)
     {
@@ -660,9 +599,7 @@ namespace OpenMS
   }
 
 
-  void IDFilter::filterPeptidesByRTPredictPValue(
-    vector<PeptideIdentification>& peptides, const String& metavalue_key,
-    double threshold)
+  void IDFilter::filterPeptidesByRTPredictPValue(vector<PeptideIdentification>& peptides, const String& metavalue_key, double threshold)
   {
     Size n_initial = 0, n_metavalue = 0; // keep track of numbers of hits
     struct HasMetaValue<PeptideHit> present_filter(metavalue_key, DataValue());
@@ -679,17 +616,13 @@ namespace OpenMS
 
     if (n_metavalue < n_initial)
     {
-      OPENMS_LOG_WARN << "Filtering peptides by RTPredict p-value removed "
-               << (n_initial - n_metavalue) << " of " << n_initial
-               << " hits (total) that were missing the required meta value ('"
-               << metavalue_key << "', added by RTPredict)." << endl;
+      OPENMS_LOG_WARN << "Filtering peptides by RTPredict p-value removed " << (n_initial - n_metavalue) << " of " << n_initial << " hits (total) that were missing the required meta value ('"
+                      << metavalue_key << "', added by RTPredict)." << endl;
     }
   }
 
 
-  void IDFilter::removePeptidesWithMatchingModifications(
-    vector<PeptideIdentification>& peptides,
-    const set<String>& modifications)
+  void IDFilter::removePeptidesWithMatchingModifications(vector<PeptideIdentification>& peptides, const set<String>& modifications)
   {
     struct HasMatchingModification mod_filter(modifications);
     for (PeptideIdentification& pep : peptides)
@@ -698,17 +631,12 @@ namespace OpenMS
     }
   }
 
-  void IDFilter::removePeptidesWithMatchingRegEx(
-    vector<PeptideIdentification>& peptides,
-    const String& regex)
+  void IDFilter::removePeptidesWithMatchingRegEx(vector<PeptideIdentification>& peptides, const String& regex)
   {
     const std::regex re(regex);
 
     // true if regex matches to parts or entire unmodified sequence
-    auto regex_matches = [&re](const PeptideHit& ph) -> bool
-      {
-        return std::regex_search(ph.getSequence().toUnmodifiedString(), re);
-      };
+    auto regex_matches = [&re](const PeptideHit& ph) -> bool { return std::regex_search(ph.getSequence().toUnmodifiedString(), re); };
 
     for (auto& pep : peptides)
     {
@@ -716,9 +644,7 @@ namespace OpenMS
     }
   }
 
-  void IDFilter::keepPeptidesWithMatchingModifications(
-    vector<PeptideIdentification>& peptides,
-    const set<String>& modifications)
+  void IDFilter::keepPeptidesWithMatchingModifications(vector<PeptideIdentification>& peptides, const set<String>& modifications)
   {
     struct HasMatchingModification mod_filter(modifications);
     for (PeptideIdentification& pep : peptides)
@@ -728,9 +654,7 @@ namespace OpenMS
   }
 
 
-  void IDFilter::removePeptidesWithMatchingSequences(
-    vector<PeptideIdentification>& peptides,
-    const vector<PeptideIdentification>& bad_peptides, bool ignore_mods)
+  void IDFilter::removePeptidesWithMatchingSequences(vector<PeptideIdentification>& peptides, const vector<PeptideIdentification>& bad_peptides, bool ignore_mods)
   {
     set<String> bad_seqs;
     extractPeptideSequences(bad_peptides, bad_seqs, ignore_mods);
@@ -742,9 +666,7 @@ namespace OpenMS
   }
 
 
-  void IDFilter::keepPeptidesWithMatchingSequences(
-    vector<PeptideIdentification>& peptides,
-    const vector<PeptideIdentification>& good_peptides, bool ignore_mods)
+  void IDFilter::keepPeptidesWithMatchingSequences(vector<PeptideIdentification>& peptides, const vector<PeptideIdentification>& good_peptides, bool ignore_mods)
   {
     set<String> good_seqs;
     extractPeptideSequences(good_peptides, good_seqs, ignore_mods);
@@ -756,14 +678,11 @@ namespace OpenMS
   }
 
 
-  void IDFilter::keepUniquePeptidesPerProtein(vector<PeptideIdentification>&
-                                              peptides)
+  void IDFilter::keepUniquePeptidesPerProtein(vector<PeptideIdentification>& peptides)
   {
     Size n_initial = 0, n_metavalue = 0; // keep track of numbers of hits
-    struct HasMetaValue<PeptideHit> present_filter("protein_references",
-                                                   DataValue());
-    struct HasMetaValue<PeptideHit> unique_filter("protein_references",
-                                                  DataValue("unique"));
+    struct HasMetaValue<PeptideHit> present_filter("protein_references", DataValue());
+    struct HasMetaValue<PeptideHit> unique_filter("protein_references", DataValue("unique"));
     for (PeptideIdentification& pep : peptides)
     {
       n_initial += pep.getHits().size();
@@ -775,17 +694,14 @@ namespace OpenMS
 
     if (n_metavalue < n_initial)
     {
-      OPENMS_LOG_WARN << "Filtering peptides by unique match to a protein removed "
-               << (n_initial - n_metavalue) << " of " << n_initial
-               << " hits (total) that were missing the required meta value "
-               << "('protein_references', added by PeptideIndexer)." << endl;
+      OPENMS_LOG_WARN << "Filtering peptides by unique match to a protein removed " << (n_initial - n_metavalue) << " of " << n_initial << " hits (total) that were missing the required meta value "
+                      << "('protein_references', added by PeptideIndexer)." << endl;
     }
   }
 
 
   // @TODO: generalize this to protein hits?
-  void IDFilter::removeDuplicatePeptideHits(vector<PeptideIdentification>&
-                                            peptides, bool seq_only)
+  void IDFilter::removeDuplicatePeptideHits(vector<PeptideIdentification>& peptides, bool seq_only)
   {
     for (PeptideIdentification& pep : peptides)
     {
@@ -807,8 +723,7 @@ namespace OpenMS
         // "sort" + "unique" from the standard library:
         for (PeptideHit& hit : pep.getHits())
         {
-          if (find(filtered_hits.begin(), filtered_hits.end(), hit) ==
-              filtered_hits.end())
+          if (find(filtered_hits.begin(), filtered_hits.end(), hit) == filtered_hits.end())
           {
             filtered_hits.push_back(hit);
           }
@@ -840,49 +755,44 @@ namespace OpenMS
     // there might be less spectra identified than n -> adapt
     n = std::min(n, peptides.size());
 
-    auto has_better_peptidehit =
-      [] (const PeptideIdentification& l, const PeptideIdentification& r)
+    auto has_better_peptidehit = [](const PeptideIdentification& l, const PeptideIdentification& r) {
+      if (r.getHits().empty())
       {
-        if (r.getHits().empty())
-        {
-          return true; // right has no hit? -> left is better
-        }
-        if (l.getHits().empty())
-        {
-          return false; // left has no hit but right has a hit? -> right is better
-        }
-        const bool higher_better = l.isHigherScoreBetter();
-        const double l_score = l.getHits()[0].getScore();
-        const double r_score = r.getHits()[0].getScore();
+        return true; // right has no hit? -> left is better
+      }
+      if (l.getHits().empty())
+      {
+        return false; // left has no hit but right has a hit? -> right is better
+      }
+      const bool higher_better = l.isHigherScoreBetter();
+      const double l_score = l.getHits()[0].getScore();
+      const double r_score = r.getHits()[0].getScore();
 
-        // both have hits? better score of best PSM is better
-        if (higher_better)
-        {
-          return l_score > r_score;
-        }
-        return l_score < r_score;
-      };
+      // both have hits? better score of best PSM is better
+      if (higher_better)
+      {
+        return l_score > r_score;
+      }
+      return l_score < r_score;
+    };
 
     std::partial_sort(peptides.begin(), peptides.begin() + n, peptides.end(), has_better_peptidehit);
     peptides.resize(n);
   }
 
-  void IDFilter::keepBestMatchPerObservation(
-    IdentificationData& id_data,
-    IdentificationData::ScoreTypeRef score_ref)
+  void IDFilter::keepBestMatchPerObservation(IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref)
   {
-    if (id_data.getObservationMatches().size() <= 1) return; // nothing to do
+    if (id_data.getObservationMatches().size() <= 1)
+      return; // nothing to do
 
-    vector<IdentificationData::ObservationMatchRef> best_matches =
-      id_data.getBestMatchPerObservation(score_ref);
+    vector<IdentificationData::ObservationMatchRef> best_matches = id_data.getBestMatchPerObservation(score_ref);
 
     auto best_match_it = best_matches.begin();
 
     // predicate to compare the best match(es) to all (ordered) observation matches
     // returns false if the current om is a best match (-> not to be removed)
     // returns true if an inferior om was found (-> will be removed)
-    auto has_worse_score = [&best_match_it](IdentificationData::ObservationMatchRef it)->bool 
-    { 
+    auto has_worse_score = [&best_match_it](IdentificationData::ObservationMatchRef it) -> bool {
       if (it == *best_match_it)
       {
         ++best_match_it;
@@ -890,23 +800,20 @@ namespace OpenMS
       }
       return true;
     };
-    
+
     id_data.removeObservationMatchesIf(has_worse_score);
   }
 
-  void IDFilter::filterObservationMatchesByScore(
-    IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref,
-    double cutoff)
+  void IDFilter::filterObservationMatchesByScore(IdentificationData& id_data, IdentificationData::ScoreTypeRef score_ref, double cutoff)
   {
     // predicate to compare the score of observation matches to a cutoff
     // returns true if the current score is worse than the cutoff
     // returns false otherwise
-    auto is_worse_than_cutoff = [&](IdentificationData::ObservationMatchRef it)->bool 
-    { 
+    auto is_worse_than_cutoff = [&](IdentificationData::ObservationMatchRef it) -> bool {
       pair<double, bool> score = it->getScore(score_ref);
       return !score.second || score_ref->isBetterScore(cutoff, score.first);
     };
-    
+
     id_data.removeObservationMatchesIf(is_worse_than_cutoff);
   }
 
@@ -915,11 +822,8 @@ namespace OpenMS
     // predicate to compare the target/decoy status of a parent sequence
     // returns true if decoy
     // returns false if target
-    auto is_decoy = [&](IdentificationData::ParentSequenceRef it)->bool 
-    { 
-      return it->is_decoy;
-    };
-    
+    auto is_decoy = [&](IdentificationData::ParentSequenceRef it) -> bool { return it->is_decoy; };
+
     id_data.removeParentSequencesIf(is_decoy);
   }
 

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -258,7 +258,7 @@ namespace OpenMS
       auto target = result.emplace(run_id, vector<ProteinHit>{});
       const unordered_set<String>& accessions = run_to_accessions[run_id];
       struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
-      moveMatchingItems(prot.getHits(), std::not1(acc_filter), target.first->second);
+      moveMatchingItems(prot.getHits(), std::not_fn(acc_filter), target.first->second);
     }
     return result;
   }
@@ -377,7 +377,7 @@ namespace OpenMS
         remove_copy_if(hit.getPeptideEvidences().begin(),
                        hit.getPeptideEvidences().end(),
                        back_inserter(evidences),
-                       not1(acc_filter));
+                       std::not_fn(acc_filter));
         hit.setPeptideEvidences(evidences);
       }
 
@@ -418,7 +418,7 @@ namespace OpenMS
             remove_copy_if(hit.getPeptideEvidences().begin(),
                            hit.getPeptideEvidences().end(),
                            back_inserter(evidences),
-                           not1(acc_filter));
+                           std::not_fn(acc_filter));
             hit.setPeptideEvidences(evidences);
           }
 
@@ -461,7 +461,7 @@ namespace OpenMS
         remove_copy_if(hit.getPeptideEvidences().begin(),
                        hit.getPeptideEvidences().end(),
                        back_inserter(evidences),
-                       not1(acc_filter));
+                       std::not_fn(acc_filter));
         hit.setPeptideEvidences(evidences);
       }
 
@@ -529,7 +529,7 @@ namespace OpenMS
     }
 
     hits.erase(
-        std::remove_if(hits.begin(), hits.end(), std::not1(HasMatchingAccessionUnordered<ProteinHit>(valid_accessions))),
+        std::remove_if(hits.begin(), hits.end(), std::not_fn(HasMatchingAccessionUnordered<ProteinHit>(valid_accessions))),
         hits.end()
         );
   }

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -32,12 +32,11 @@
 // $Authors: Ruben Grünberg $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/FORMAT/ParamCTDFile.h>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <limits>
-
-#include <OpenMS/FORMAT/ParamCTDFile.h>
 
 namespace OpenMS
 {
@@ -50,8 +49,8 @@ namespace OpenMS
       os.open(filename.c_str(), std::ofstream::out);
       if (!os)
       {
-        //Replace the OpenMS specific exception with a std exception
-        //Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
+        // Replace the OpenMS specific exception with a std exception
+        // Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
         throw std::ios::failure("Unable to create file: " + filename);
       }
       os_ptr = &os;
@@ -64,15 +63,15 @@ namespace OpenMS
     writeCTDToStream(os_ptr, param, tool_info);
   }
 
-  void ParamCTDFile::writeCTDToStream(std::ostream *os_ptr, const Param &param, const ToolInfo& tool_info) const
+  void ParamCTDFile::writeCTDToStream(std::ostream* os_ptr, const Param& param, const ToolInfo& tool_info) const
   {
     std::ostream& os = *os_ptr;
     os.precision(std::numeric_limits<double>::digits10);
 
-    //write ctd specific stuff
+    // write ctd specific stuff
     os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-    os << R"(<tool ctdVersion="1.7" version=")" << tool_info.version_ << R"(" name=")" << tool_info.name_
-       << R"(" docurl=")" << tool_info.docurl_ << R"(" category=")" << tool_info.category_ << "\" >\n";
+    os << R"(<tool ctdVersion="1.7" version=")" << tool_info.version_ << R"(" name=")" << tool_info.name_ << R"(" docurl=")" << tool_info.docurl_ << R"(" category=")" << tool_info.category_
+       << "\" >\n";
     os << "<description><![CDATA[" << tool_info.description_ << "]]></description>\n";
     os << "<manual><![CDATA[" << tool_info.description_ << "]]></manual>\n";
     os << "<citations>\n";
@@ -83,12 +82,10 @@ namespace OpenMS
     }
 
     os << "</citations>\n";
-    os << "<PARAMETERS version=\"" << schema_version_
-       << R"(" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS)"
-       << schema_location_
+    os << "<PARAMETERS version=\"" << schema_version_ << R"(" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS)" << schema_location_
        << "\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
 
-    //Write the xml stuff
+    // Write the xml stuff
     uint32_t indentations = 2;
     auto param_it = param.begin();
     for (auto last = param.end(); param_it != last; ++param_it)
@@ -129,70 +126,67 @@ namespace OpenMS
 
         switch (value_type)
         {
-        case ParamValue::INT_VALUE:
-          os << param_it->value.toString() << R"(" type="int")";
-        break;
-        case ParamValue::DOUBLE_VALUE:
-          os << param_it->value.toString() << R"(" type="double")";
-        break;
-        case ParamValue::STRING_VALUE:
-          if (tag_list.find("input file") != tag_list.end())
-          {
-            os << escapeXML(param_it->value.toString()) << R"(" type="input-file")";
-            tag_list.erase("input file");
-          }
-          else if (tag_list.find("output file") != tag_list.end())
-          {
-            os << escapeXML(param_it->value.toString()) << R"(" type="output-file")";
-            tag_list.erase("output file");
-          }
-          else if (tag_list.find("output prefix") != tag_list.end())
-          {
-            os << escapeXML(param_it->value.toString()) << R"(" type="output-prefix")";
-            tag_list.erase("output prefix");
-          }          
-          else if (param_it->valid_strings.size() == 2 &&
-                   param_it->valid_strings[0] == "true" &&
-                   param_it->valid_strings[1] == "false" &&
-                   param_it->value == "false")
-          {
-            stringParamIsFlag = true;
-            os << param_it->value.toString() << R"(" type="bool")";
-          }
-          else
-          {
-            std::string value = param_it->value.toString();
-            if (value.find('\t') != std::string::npos)
+          case ParamValue::INT_VALUE:
+            os << param_it->value.toString() << R"(" type="int")";
+            break;
+          case ParamValue::DOUBLE_VALUE:
+            os << param_it->value.toString() << R"(" type="double")";
+            break;
+          case ParamValue::STRING_VALUE:
+            if (tag_list.find("input file") != tag_list.end())
             {
-              replace(value, '\t', "&#x9;");
+              os << escapeXML(param_it->value.toString()) << R"(" type="input-file")";
+              tag_list.erase("input file");
             }
-            os << escapeXML(value) << R"(" type="string")";
-          }
-        break;
-        case ParamValue::STRING_LIST:
-          if (tag_list.find("input file") != tag_list.end())
-          {
-            os << R"(" type="input-file")";
-            tag_list.erase("input file");
-          }
-          else if (tag_list.find("output file") != tag_list.end())
-          {
-            os << R"(" type="output-file")";
-            tag_list.erase("output file");
-          }
-          else
-          {
-            os << R"(" type="string")";
-          }
-        break;
-        case ParamValue::INT_LIST:
-          os << R"(" type="int")";
-        break;
-        case ParamValue::DOUBLE_LIST:
-          os << R"(" type="double")";
-        break;
-        default:
-        break;
+            else if (tag_list.find("output file") != tag_list.end())
+            {
+              os << escapeXML(param_it->value.toString()) << R"(" type="output-file")";
+              tag_list.erase("output file");
+            }
+            else if (tag_list.find("output prefix") != tag_list.end())
+            {
+              os << escapeXML(param_it->value.toString()) << R"(" type="output-prefix")";
+              tag_list.erase("output prefix");
+            }
+            else if (param_it->valid_strings.size() == 2 && param_it->valid_strings[0] == "true" && param_it->valid_strings[1] == "false" && param_it->value == "false")
+            {
+              stringParamIsFlag = true;
+              os << param_it->value.toString() << R"(" type="bool")";
+            }
+            else
+            {
+              std::string value = param_it->value.toString();
+              if (value.find('\t') != std::string::npos)
+              {
+                replace(value, '\t', "&#x9;");
+              }
+              os << escapeXML(value) << R"(" type="string")";
+            }
+            break;
+          case ParamValue::STRING_LIST:
+            if (tag_list.find("input file") != tag_list.end())
+            {
+              os << R"(" type="input-file")";
+              tag_list.erase("input file");
+            }
+            else if (tag_list.find("output file") != tag_list.end())
+            {
+              os << R"(" type="output-file")";
+              tag_list.erase("output file");
+            }
+            else
+            {
+              os << R"(" type="string")";
+            }
+            break;
+          case ParamValue::INT_LIST:
+            os << R"(" type="int")";
+            break;
+          case ParamValue::DOUBLE_LIST:
+            os << R"(" type="double")";
+            break;
+          default:
+            break;
         }
 
         std::string description = param_it->description;
@@ -237,68 +231,62 @@ namespace OpenMS
           std::string restrictions;
           switch (value_type)
           {
-          case ParamValue::INT_VALUE:
-          case ParamValue::INT_LIST:
-          {
-            bool min_set = (param_it->min_int != -std::numeric_limits<int>::max());
-            bool max_set = (param_it->max_int != std::numeric_limits<int>::max());
-            if (max_set || min_set)
-            {
-              if (min_set)
+            case ParamValue::INT_VALUE:
+            case ParamValue::INT_LIST: {
+              bool min_set = (param_it->min_int != -std::numeric_limits<int>::max());
+              bool max_set = (param_it->max_int != std::numeric_limits<int>::max());
+              if (max_set || min_set)
               {
-                restrictions += std::to_string(param_it->min_int);
-              }
-              restrictions += ':';
-              if (max_set)
-              {
-                restrictions += std::to_string(param_it->max_int);
+                if (min_set)
+                {
+                  restrictions += std::to_string(param_it->min_int);
+                }
+                restrictions += ':';
+                if (max_set)
+                {
+                  restrictions += std::to_string(param_it->max_int);
+                }
               }
             }
-          }
             break;
 
-          case ParamValue::DOUBLE_VALUE:
-          case ParamValue::DOUBLE_LIST:
-          {
-            bool min_set = (param_it->min_float != -std::numeric_limits<double>::max());
-            bool max_set = (param_it->max_float != std::numeric_limits<double>::max());
-            if (max_set || min_set)
-            {
-              if (min_set)
+            case ParamValue::DOUBLE_VALUE:
+            case ParamValue::DOUBLE_LIST: {
+              bool min_set = (param_it->min_float != -std::numeric_limits<double>::max());
+              bool max_set = (param_it->max_float != std::numeric_limits<double>::max());
+              if (max_set || min_set)
               {
-                restrictions += std::to_string(param_it->min_float);
-              }
-              restrictions += ':';
-              if (max_set)
-              {
-                restrictions += std::to_string(param_it->max_float);
-              }
-            }
-          }
-            break;
-          case ParamValue::STRING_VALUE:
-          case ParamValue::STRING_LIST:
-            if (!param_it->valid_strings.empty())
-            {
-              restrictions = param_it->valid_strings.front();
-              for (auto it = param_it->valid_strings.begin() + 1, end = param_it->valid_strings.end();
-                   it != end; ++it)
-              {
-                restrictions += ",";
-                restrictions += *it;
+                if (min_set)
+                {
+                  restrictions += std::to_string(param_it->min_float);
+                }
+                restrictions += ':';
+                if (max_set)
+                {
+                  restrictions += std::to_string(param_it->max_float);
+                }
               }
             }
             break;
-          default:
-            break;
+            case ParamValue::STRING_VALUE:
+            case ParamValue::STRING_LIST:
+              if (!param_it->valid_strings.empty())
+              {
+                restrictions = param_it->valid_strings.front();
+                for (auto it = param_it->valid_strings.begin() + 1, end = param_it->valid_strings.end(); it != end; ++it)
+                {
+                  restrictions += ",";
+                  restrictions += *it;
+                }
+              }
+              break;
+            default:
+              break;
           }
 
           if (!restrictions.empty())
           {
-            if (param_it->tags.find("input file") != param_it->tags.end() ||
-                param_it->tags.find("output file") != param_it->tags.end() ||
-                param_it->tags.find("output prefix") != param_it->tags.end()                
-               )
+            if (param_it->tags.find("input file") != param_it->tags.end() || param_it->tags.find("output file") != param_it->tags.end() || param_it->tags.find("output prefix") != param_it->tags.end())
             {
               os << " supported_formats=\"" << escapeXML(restrictions) << "\"";
             }
@@ -320,30 +308,30 @@ namespace OpenMS
 
         switch (value_type)
         {
-        case ParamValue::STRING_LIST:
-          for (auto item : static_cast<const std::vector<std::string>& >(param_it->value))
-          {
-            if (item.find('\t') != std::string::npos)
+          case ParamValue::STRING_LIST:
+            for (auto item : static_cast<const std::vector<std::string>&>(param_it->value))
             {
-              replace(item, '\t', "&#x9;");
+              if (item.find('\t') != std::string::npos)
+              {
+                replace(item, '\t', "&#x9;");
+              }
+              os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << escapeXML(item) << "\"/>\n";
             }
-            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << escapeXML(item) << "\"/>\n";
-          }
-        break;
-        case ParamValue::INT_LIST:
-          for (int item : static_cast<const std::vector<int>& >(param_it->value))
-          {
-            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
-          }
-        break;
-        case ParamValue::DOUBLE_LIST:
-          for (double item : static_cast<const std::vector<double>& >(param_it->value))
-          {
-            os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
-          }
-        break;
-        default:
-        break;
+            break;
+          case ParamValue::INT_LIST:
+            for (int item : static_cast<const std::vector<int>&>(param_it->value))
+            {
+              os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
+            }
+            break;
+          case ParamValue::DOUBLE_LIST:
+            for (double item : static_cast<const std::vector<double>&>(param_it->value))
+            {
+              os << std::string(indentations + 2, ' ') << "<LISTITEM value=\"" << item << "\"/>\n";
+            }
+            break;
+          default:
+            break;
         }
 
         if (value_type > ParamValue::DOUBLE_VALUE && value_type)
@@ -363,24 +351,30 @@ namespace OpenMS
     }
 
     os << "</PARAMETERS>\n";
-    os << "</tool>" << std::endl; //forces a flush
+    os << "</tool>" << std::endl; // forces a flush
   }
 
-  std::string ParamCTDFile::escapeXML(const std::string &to_escape)
+  std::string ParamCTDFile::escapeXML(const std::string& to_escape)
   {
     std::string copy = to_escape;
-    if(copy.find('&') != std::string::npos) replace(copy, '&', "&amp;");
-    if(copy.find('>') != std::string::npos) replace(copy, '>', "&gt;");
-    if(copy.find('"') != std::string::npos) replace(copy, '"', "&quot;");
-    if(copy.find('<') != std::string::npos) replace(copy, '<', "&lt;");
-    if(copy.find('\'') != std::string::npos) replace(copy, '\'', "&apos;");
+    if (copy.find('&') != std::string::npos)
+      replace(copy, '&', "&amp;");
+    if (copy.find('>') != std::string::npos)
+      replace(copy, '>', "&gt;");
+    if (copy.find('"') != std::string::npos)
+      replace(copy, '"', "&quot;");
+    if (copy.find('<') != std::string::npos)
+      replace(copy, '<', "&lt;");
+    if (copy.find('\'') != std::string::npos)
+      replace(copy, '\'', "&apos;");
 
     return copy;
   }
 
-  void ParamCTDFile::replace(std::string &replace_in, char to_replace, const std::string &replace_with)
+  void ParamCTDFile::replace(std::string& replace_in, char to_replace, const std::string& replace_with)
   {
-    for(size_t i = 0; i < replace_in.size(); ++i) {
+    for (size_t i = 0; i < replace_in.size(); ++i)
+    {
       if (replace_in[i] == to_replace)
       {
         replace_in = replace_in.substr(0, i) + replace_with + replace_in.substr(i + 1);
@@ -388,4 +382,4 @@ namespace OpenMS
       }
     }
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/ParamCTDFile.cpp
+++ b/src/openms/source/FORMAT/ParamCTDFile.cpp
@@ -32,6 +32,7 @@
 // $Authors: Ruben Grünberg $
 // --------------------------------------------------------------------------
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <limits>

--- a/src/openms/source/QC/Contaminants.cpp
+++ b/src/openms/source/QC/Contaminants.cpp
@@ -32,12 +32,11 @@
 // $Authors: Dominik Schmitz, Chris Bielow$
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/Contaminants.h>
-
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/QC/Contaminants.h>
+#include <algorithm>
 #include <include/OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <include/OpenMS/METADATA/ProteinIdentification.h>
-#include <algorithm>
 
 using namespace std;
 
@@ -49,7 +48,8 @@ namespace OpenMS
     // empty FeatureMap
     if (features.empty())
     {
-      OPENMS_LOG_WARN << "FeatureMap is empty" << "\n";
+      OPENMS_LOG_WARN << "FeatureMap is empty"
+                      << "\n";
     }
     // empty contaminants database
     if (contaminants.empty())
@@ -135,7 +135,7 @@ namespace OpenMS
     // Additionally save the unassigned contaminants ratio and add the is_contaminant = 0/1 to the first hit of the unassigned peptideidentifications.
     for (auto& fu : features.getUnassignedPeptideIdentifications())
     {
-      if ( fu.getHits().empty())
+      if (fu.getHits().empty())
       {
         continue;
       }
@@ -166,27 +166,21 @@ namespace OpenMS
     // add the object to the results vector
     results_.push_back(final);
   }
-  
+
   const String& Contaminants::getName() const
   {
     return name_;
   }
-  
+
   const std::vector<Contaminants::ContaminantsSummary>& Contaminants::getResults()
   {
     return results_;
   }
-  
+
 
   // Check if peptide is in contaminants database or not and add the is_contaminant = 0/1.
   // If so, raise the contaminant ratio.
-  void Contaminants::compare_(const String& key,
-                              PeptideHit& pep_hit,
-                              Int64& total,
-                              Int64& cont,
-                              double& sum_total,
-                              double& sum_cont,
-                              double intensity)
+  void Contaminants::compare_(const String& key, PeptideHit& pep_hit, Int64& total, Int64& cont, double& sum_total, double& sum_cont, double intensity)
   {
     ++total;
     sum_total += intensity;
@@ -208,4 +202,4 @@ namespace OpenMS
   }
 
 
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/Contaminants.cpp
+++ b/src/openms/source/QC/Contaminants.cpp
@@ -202,7 +202,7 @@ namespace OpenMS
     pep_hit.setMetaValue("is_contaminant", 1);
   }
 
-  QCBase::Status Contaminants::requires() const
+  QCBase::Status Contaminants::requirements() const
   {
     return (QCBase::Status(QCBase::Requires::POSTFDRFEAT) | QCBase::Requires::CONTAMINANTS);
   }

--- a/src/openms/source/QC/FWHM.cpp
+++ b/src/openms/source/QC/FWHM.cpp
@@ -68,7 +68,7 @@ namespace OpenMS
     return name;
   }
   
-  QCBase::Status FWHM::requires() const
+  QCBase::Status FWHM::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/FWHM.cpp
+++ b/src/openms/source/QC/FWHM.cpp
@@ -32,8 +32,8 @@
 // $Authors: Chris Bielow $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/FWHM.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/QC/FWHM.h>
 
 namespace OpenMS
 {
@@ -57,7 +57,8 @@ namespace OpenMS
       }
       else
       {
-        //throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Metavalue 'FWHM' or 'model_FWHM' is missing for a feature in a FeatureMap. Please check your FeatureFinder reports FWHM using these metavalues or add a new mapping here.");
+        // throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Metavalue 'FWHM' or 'model_FWHM' is missing for a feature in a FeatureMap. Please check your FeatureFinder
+        // reports FWHM using these metavalues or add a new mapping here.");
       }
     }
   }
@@ -67,9 +68,9 @@ namespace OpenMS
     static const String& name = "FWHM";
     return name;
   }
-  
+
   QCBase::Status FWHM::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/FeatureSummary.cpp
+++ b/src/openms/source/QC/FeatureSummary.cpp
@@ -38,7 +38,7 @@
 using namespace std;
 
 namespace OpenMS
-{ 
+{
   FeatureSummary::Result FeatureSummary::compute(const FeatureMap& feature_map)
   {
     FeatureSummary::Result result;
@@ -63,14 +63,13 @@ namespace OpenMS
     {
       result.rt_shift_mean = 0;
     }
-    
+
     return result;
   }
 
   bool FeatureSummary::Result::operator==(const Result& rhs) const
   {
-    return feature_count == rhs.feature_count
-          && rt_shift_mean == rhs.rt_shift_mean;
+    return feature_count == rhs.feature_count && rt_shift_mean == rhs.rt_shift_mean;
   }
 
   /// Returns the name of the metric
@@ -85,4 +84,4 @@ namespace OpenMS
   {
     return QCBase::Status(QCBase::Requires::PREFDRFEAT);
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/FeatureSummary.cpp
+++ b/src/openms/source/QC/FeatureSummary.cpp
@@ -81,7 +81,7 @@ namespace OpenMS
 
   /// Returns required file input i.e. MzML.
   /// This is encoded as a bit in a Status object.
-  QCBase::Status FeatureSummary::requires() const
+  QCBase::Status FeatureSummary::requirements() const
   {
     return QCBase::Status(QCBase::Requires::PREFDRFEAT);
   }

--- a/src/openms/source/QC/FragmentMassError.cpp
+++ b/src/openms/source/QC/FragmentMassError.cpp
@@ -32,13 +32,9 @@
 // $Authors: Patricia Scheil, Swenja Wagner$
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/FragmentMassError.h>
-
-#include <cassert>
-#include <string>
-
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/DATASTRUCTURES/MatchedIterator.h>
@@ -48,12 +44,14 @@
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/MATH/STATISTICS/BasicStatistics.h>
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
-#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/QC/FragmentMassError.h>
+#include <cassert>
+#include <string>
 
 namespace OpenMS
 {
   // Using matched iterator for aligned spectra calculate mz errors
-  template <typename MIV>
+  template<typename MIV>
   void twoSpecErrors(MIV& mi, std::vector<double>& ppms, std::vector<double>& dalton, double& accumulator_ppm, UInt32& counter_ppm)
   {
     while (mi != mi.end())
@@ -72,7 +70,8 @@ namespace OpenMS
     }
   }
 
-  void FragmentMassError::calculateFME_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, bool& print_warning, double tolerance, FragmentMassError::ToleranceUnit tolerance_unit, double& accumulator_ppm, UInt32& counter_ppm, WindowMower& window_mower_filter)
+  void FragmentMassError::calculateFME_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, bool& print_warning, double tolerance,
+                                        FragmentMassError::ToleranceUnit tolerance_unit, double& accumulator_ppm, UInt32& counter_ppm, WindowMower& window_mower_filter)
   {
     if (pep_id.getHits().empty())
     {
@@ -122,7 +121,7 @@ namespace OpenMS
         {
           OPENMS_LOG_WARN << "No MS2 activation method provided. Using CID as fallback to compute fragment mass errors." << std::endl;
         }
-        print_warning = false;// only print it once
+        print_warning = false; // only print it once
         act_method = Precursor::ActivationMethod::CID;
       }
       act_method = *exp_spectrum.getPrecursors()[0].getActivationMethods().begin();
@@ -138,7 +137,8 @@ namespace OpenMS
     //-----------------------------------------------------------------------
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " is empty." << "\n";
+      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " is empty."
+                      << "\n";
       return;
     }
 
@@ -146,8 +146,8 @@ namespace OpenMS
     window_mower_filter.filterPeakSpectrum(exp_spectrum_filtered);
 
     // stores ppms for one spectrum
-    DoubleList ppms{};
-    DoubleList dalton{};
+    DoubleList ppms {};
+    DoubleList dalton {};
 
     // iterator, finds nearest peak of a target container to a given peak in a reference container
     if (tolerance_unit == FragmentMassError::ToleranceUnit::DA)
@@ -182,7 +182,8 @@ namespace OpenMS
   {
     if (pep_id.getHits().empty())
     {
-      OPENMS_LOG_WARN << "There is a Peptideidentification(RT: " << pep_id.getRT() << ", MZ: " << pep_id.getMZ() << ") without PeptideHits. " << "\n";
+      OPENMS_LOG_WARN << "There is a Peptideidentification(RT: " << pep_id.getRT() << ", MZ: " << pep_id.getMZ() << ") without PeptideHits. "
+                      << "\n";
       return;
     }
     for (const auto& ppm : (pep_id.getHits()[0].getMetaValue("fragment_mass_error_ppm")).toDoubleList())
@@ -204,10 +205,10 @@ namespace OpenMS
       return;
     }
     // accumulates ppm errors over all first PeptideHits
-    double accumulator_ppm{};
+    double accumulator_ppm {};
 
     // counts number of ppm errors
-    UInt32 counter_ppm{};
+    UInt32 counter_ppm {};
 
     //---------------------------------------------------------------------
     // Prepare MSExperiment
@@ -226,32 +227,29 @@ namespace OpenMS
     //------------------------------------------------------------------
     if (tolerance_unit == ToleranceUnit::AUTO)
     {
-      if (fmap.getProteinIdentifications().empty() )
+      if (fmap.getProteinIdentifications().empty())
       {
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
       }
       tolerance_unit = fmap.getProteinIdentifications()[0].getSearchParameters().fragment_mass_tolerance_ppm ? ToleranceUnit::PPM : ToleranceUnit::DA;
       tolerance = fmap.getProteinIdentifications()[0].getSearchParameters().fragment_mass_tolerance;
       if (tolerance <= 0.0)
       { // some engines, e.g. MSGF+ have no fragment tolerance parameter. It will be 0.0.
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
       }
     }
 
     bool print_warning {false};
 
     // computes the FragmentMassError
-    std::function<void(PeptideIdentification&)> fCompPPM =
-        [&exp, &map_to_spectrum, &print_warning, tolerance, tolerance_unit, &accumulator_ppm, &counter_ppm, &window_mower_filter](PeptideIdentification& pep_id)
-    {
+    std::function<void(PeptideIdentification&)> fCompPPM = [&exp, &map_to_spectrum, &print_warning, tolerance, tolerance_unit, &accumulator_ppm, &counter_ppm,
+                                                            &window_mower_filter](PeptideIdentification& pep_id) {
       calculateFME_(pep_id, exp, map_to_spectrum, print_warning, tolerance, tolerance_unit, accumulator_ppm, counter_ppm, window_mower_filter);
     };
 
-    auto fVar =
-        [&result, &counter_ppm](const PeptideIdentification& pep_id)
-    {
-      calculateVariance_(result, pep_id, counter_ppm);
-    };
+    auto fVar = [&result, &counter_ppm](const PeptideIdentification& pep_id) { calculateVariance_(result, pep_id, counter_ppm); };
 
     // computation of ppms
     fmap.applyFunctionOnPeptideIDs(fCompPPM);
@@ -269,10 +267,10 @@ namespace OpenMS
     fmap.applyFunctionOnPeptideIDs(fVar);
 
     results_.push_back(result);
-
   }
 
-  void FragmentMassError::compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit, double tolerance)
+  void FragmentMassError::compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp,
+                                  const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit, double tolerance)
   {
     Statistics result;
 
@@ -282,10 +280,10 @@ namespace OpenMS
       return;
     }
     // accumulates ppm errors over all first PeptideHits
-    double accumulator_ppm{};
+    double accumulator_ppm {};
 
     // counts number of ppm errors
-    UInt32 counter_ppm{};
+    UInt32 counter_ppm {};
 
     //---------------------------------------------------------------------
     // Prepare MSExperiment
@@ -308,11 +306,12 @@ namespace OpenMS
       tolerance = search_params.fragment_mass_tolerance;
       if (tolerance <= 0.0)
       { // some engines, e.g. MSGF+ have no fragment tolerance parameter. It will be 0.0.
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given. Please choose a fragment_mass_unit and tolerance manually.");
       }
     }
 
-    bool print_warning{ false };
+    bool print_warning {false};
 
     // computation of ppms
     // computes the FragmentMassError
@@ -352,6 +351,3 @@ namespace OpenMS
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }
 } // namespace OpenMS
-
-
-

--- a/src/openms/source/QC/FragmentMassError.cpp
+++ b/src/openms/source/QC/FragmentMassError.cpp
@@ -347,7 +347,7 @@ namespace OpenMS
   }
 
 
-  QCBase::Status FragmentMassError::requires() const
+  QCBase::Status FragmentMassError::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/IdentificationSummary.cpp
+++ b/src/openms/source/QC/IdentificationSummary.cpp
@@ -40,10 +40,9 @@
 using namespace std;
 
 namespace OpenMS
-{ 
+{
 
-  IdentificationSummary::Result IdentificationSummary::compute(vector<ProteinIdentification>& prot_ids,
-                                                               vector<PeptideIdentification>& pep_ids)
+  IdentificationSummary::Result IdentificationSummary::compute(vector<ProteinIdentification>& prot_ids, vector<PeptideIdentification>& pep_ids)
   {
     IdentificationSummary::Result result;
     set<String> peptides;
@@ -56,7 +55,8 @@ namespace OpenMS
       {
         result.peptide_spectrum_matches += 1;
         const auto& temp_hits = pep_id.getHits();
-        if (temp_hits.empty()) continue;
+        if (temp_hits.empty())
+          continue;
         peptides.insert(temp_hits[0].getSequence().toUnmodifiedString());
       }
     }
@@ -112,16 +112,11 @@ namespace OpenMS
 
   bool IdentificationSummary::Result::operator==(const Result& rhs) const
   {
-    return peptide_spectrum_matches == rhs.peptide_spectrum_matches
-          && unique_peptides.count == rhs.unique_peptides.count
-          && unique_peptides.fdr_threshold == rhs.unique_peptides.fdr_threshold
-          && unique_proteins.count == rhs.unique_proteins.count
-          && unique_proteins.fdr_threshold == rhs.unique_proteins.fdr_threshold
-          && missed_cleavages_mean == rhs.missed_cleavages_mean
-          && protein_hit_scores_mean == rhs.protein_hit_scores_mean
-          && peptide_length_mean == rhs.peptide_length_mean;
+    return peptide_spectrum_matches == rhs.peptide_spectrum_matches && unique_peptides.count == rhs.unique_peptides.count && unique_peptides.fdr_threshold == rhs.unique_peptides.fdr_threshold &&
+           unique_proteins.count == rhs.unique_proteins.count && unique_proteins.fdr_threshold == rhs.unique_proteins.fdr_threshold && missed_cleavages_mean == rhs.missed_cleavages_mean &&
+           protein_hit_scores_mean == rhs.protein_hit_scores_mean && peptide_length_mean == rhs.peptide_length_mean;
   }
- 
+
 
   /// Returns the name of the metric
   const String& IdentificationSummary::getName() const
@@ -135,4 +130,4 @@ namespace OpenMS
   {
     return QCBase::Status(QCBase::Requires::ID);
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/IdentificationSummary.cpp
+++ b/src/openms/source/QC/IdentificationSummary.cpp
@@ -131,7 +131,7 @@ namespace OpenMS
 
   /// Returns required file input i.e. MzML.
   /// This is encoded as a bit in a Status object.
-  QCBase::Status IdentificationSummary::requires() const
+  QCBase::Status IdentificationSummary::requirements() const
   {
     return QCBase::Status(QCBase::Requires::ID);
   }

--- a/src/openms/source/QC/MissedCleavages.cpp
+++ b/src/openms/source/QC/MissedCleavages.cpp
@@ -32,23 +32,21 @@
 // $Authors: Swenja Wagner, Patricia Scheil $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/MissedCleavages.h>
-
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
-
+#include <OpenMS/QC/MissedCleavages.h>
 #include <iostream>
 
 namespace OpenMS
 {
   typedef std::map<UInt32, UInt32> MapU32;
-  //digests the Sequence in PeptideHit and counts the number of missed cleavages
+  // digests the Sequence in PeptideHit and counts the number of missed cleavages
   void MissedCleavages::get_missed_cleavages_from_peptide_identification_(const ProteaseDigestion& digestor, MapU32& result, const UInt32& max_mc, PeptideIdentification& pep_id)
   {
     if (pep_id.getHits().empty())
     {
-      OPENMS_LOG_WARN << "There is a Peptideidentification(RT: " << pep_id.getRT() << ", MZ: " << pep_id.getMZ() <<  ") without PeptideHits.\n";
+      OPENMS_LOG_WARN << "There is a Peptideidentification(RT: " << pep_id.getRT() << ", MZ: " << pep_id.getMZ() << ") without PeptideHits.\n";
       return;
     }
     std::vector<AASequence> digest_output;
@@ -58,7 +56,8 @@ namespace OpenMS
     // warn if number of missed cleavages is greater than allowed maximum number of missed cleavages
     if (num_mc > max_mc)
     {
-      OPENMS_LOG_WARN << "Observed number of missed cleavages: " << num_mc << " is greater than: " << max_mc << " the allowed maximum number of missed cleavages during MS2-Search in: " << pep_id.getHits()[0].getSequence() << "\n";
+      OPENMS_LOG_WARN << "Observed number of missed cleavages: " << num_mc << " is greater than: " << max_mc
+                      << " the allowed maximum number of missed cleavages during MS2-Search in: " << pep_id.getHits()[0].getSequence() << "\n";
     }
 
     ++result[num_mc];
@@ -68,9 +67,9 @@ namespace OpenMS
 
   void MissedCleavages::compute(std::vector<ProteinIdentification>& prot_ids, std::vector<PeptideIdentification>& pep_ids)
   {
-    MapU32 result{};
-        
-    //Exception if ProteinIdentification is empty
+    MapU32 result {};
+
+    // Exception if ProteinIdentification is empty
     if (prot_ids.empty())
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Missing information in ProteinIdentifications.");
@@ -79,13 +78,13 @@ namespace OpenMS
     String enzyme = prot_ids[0].getSearchParameters().digestion_enzyme.getName();
     auto max_mc = prot_ids[0].getSearchParameters().missed_cleavages;
 
-    //Exception if digestion enzyme is not given
+    // Exception if digestion enzyme is not given
     if (enzyme == "unknown_enzyme")
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No digestion enzyme in ID data detected. No computation possible.");
     }
 
-    //create a digestor, which doesn't allow any missed cleavages
+    // create a digestor, which doesn't allow any missed cleavages
     ProteaseDigestion digestor;
     digestor.setEnzyme(enzyme);
     digestor.setMissedCleavages(0);
@@ -101,7 +100,7 @@ namespace OpenMS
 
   void MissedCleavages::compute(FeatureMap& fmap)
   {
-    MapU32 result{};
+    MapU32 result {};
 
     bool has_pepIDs = QCBase::hasPepID(fmap);
     if (!has_pepIDs)
@@ -118,7 +117,7 @@ namespace OpenMS
       return;
     }
 
-    //Exception if ProteinIdentification is empty
+    // Exception if ProteinIdentification is empty
     if (fmap.getProteinIdentifications().empty())
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Missing information in ProteinIdentifications.");
@@ -127,20 +126,19 @@ namespace OpenMS
     String enzyme = fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme.getName();
     auto max_mc = fmap.getProteinIdentifications()[0].getSearchParameters().missed_cleavages;
 
-    //Exception if digestion enzyme is not given
+    // Exception if digestion enzyme is not given
     if (enzyme == "unknown_enzyme")
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No digestion enzyme in FeatureMap detected. No computation possible.");
     }
 
-    //create a digestor, which doesn't allow any missed cleavages
+    // create a digestor, which doesn't allow any missed cleavages
     ProteaseDigestion digestor;
     digestor.setEnzyme(enzyme);
     digestor.setMissedCleavages(0);
 
     // small lambda function to apply get_missed_cleavages_from_peptide_identification on pep_ids
-    auto l = [&](PeptideIdentification& pep_id)
-    {
+    auto l = [&](PeptideIdentification& pep_id) {
       get_missed_cleavages_from_peptide_identification_(digestor, result, max_mc, pep_id);
       return;
     };
@@ -150,13 +148,13 @@ namespace OpenMS
     mc_result_.push_back(result);
   }
 
-  
+
   const String& MissedCleavages::getName() const
   {
     static const String& name = "MissedCleavages";
     return name;
   }
-  
+
 
   const std::vector<MapU32>& MissedCleavages::getResults() const
   {
@@ -168,4 +166,4 @@ namespace OpenMS
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }
-}// namespace OpenMS
+} // namespace OpenMS

--- a/src/openms/source/QC/MissedCleavages.cpp
+++ b/src/openms/source/QC/MissedCleavages.cpp
@@ -164,7 +164,7 @@ namespace OpenMS
   }
 
 
-  QCBase::Status MissedCleavages::requires() const
+  QCBase::Status MissedCleavages::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/Ms2IdentificationRate.cpp
+++ b/src/openms/source/QC/Ms2IdentificationRate.cpp
@@ -32,37 +32,31 @@
 // $Authors: Patricia Scheil, Swenja Wagner$
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/Ms2IdentificationRate.h>
-
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/MzTab.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-
+#include <OpenMS/QC/Ms2IdentificationRate.h>
 #include <algorithm>
 
 
 namespace OpenMS
 {
-  //computes number of peptide identifications, number of ms2 spectra and ratio
-  //data is stored in vector of structs
-  void Ms2IdentificationRate::compute(const FeatureMap& feature_map,const MSExperiment& exp, bool assume_all_target)
+  // computes number of peptide identifications, number of ms2 spectra and ratio
+  // data is stored in vector of structs
+  void Ms2IdentificationRate::compute(const FeatureMap& feature_map, const MSExperiment& exp, bool assume_all_target)
   {
-    //count ms2 spectra
+    // count ms2 spectra
     Size ms2_level_counter = getMS2Count_(exp);
 
-    //count peptideIdentifications
-    Size peptide_identification_counter{};
+    // count peptideIdentifications
+    Size peptide_identification_counter {};
 
-    auto f =
-      [assume_all_target, &peptide_identification_counter](const PeptideIdentification& id)
-    {
-      peptide_identification_counter += isTargetPeptide_(id, assume_all_target);
-    };
+    auto f = [assume_all_target, &peptide_identification_counter](const PeptideIdentification& id) { peptide_identification_counter += isTargetPeptide_(id, assume_all_target); };
 
-    //iterates through all PeptideIdentifications in FeatureMap, applies function f to all of them
+    // iterates through all PeptideIdentifications in FeatureMap, applies function f to all of them
     feature_map.applyFunctionOnPeptideIDs(f, true);
 
     writeResults_(peptide_identification_counter, ms2_level_counter);
@@ -70,11 +64,11 @@ namespace OpenMS
 
   void Ms2IdentificationRate::compute(const std::vector<PeptideIdentification>& pep_ids, const MSExperiment& exp, bool assume_all_target)
   {
-    //count ms2 spectra
+    // count ms2 spectra
     Size ms2_level_counter = getMS2Count_(exp);
 
-    //count peptideIdentifications
-    Size peptide_identification_counter{};
+    // count peptideIdentifications
+    Size peptide_identification_counter {};
 
     for (const auto& id : pep_ids)
     {
@@ -84,12 +78,12 @@ namespace OpenMS
     writeResults_(peptide_identification_counter, ms2_level_counter);
   }
 
-  
+
   const String& Ms2IdentificationRate::getName() const
   {
     return name_;
   }
-  
+
 
   const std::vector<OpenMS::Ms2IdentificationRate::IdentificationRateData>& Ms2IdentificationRate::getResults() const
   {
@@ -108,7 +102,7 @@ namespace OpenMS
     const auto& ms2_irs = this->getResults();
     for (Size i = 0; i < ms2_irs.size(); ++i)
     {
-      MzTabParameter ms2_ir{};
+      MzTabParameter ms2_ir {};
       ms2_ir.setCVLabel("MS2 identification rate");
       ms2_ir.setAccession("null");
       ms2_ir.setName("MS2_ID_Rate_" + String(i + 1));
@@ -123,7 +117,7 @@ namespace OpenMS
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MSExperiment is empty");
     }
 
-    Size ms2_counter{};
+    Size ms2_counter {};
     for (auto const& spec : exp.getSpectra())
     {
       if (spec.getMSLevel() == 2)
@@ -166,13 +160,13 @@ namespace OpenMS
       throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "There are more Identifications than MS2 spectra. Please check your data.");
     }
 
-    //compute ratio
+    // compute ratio
     double ratio = (double)pep_ids_count / ms2_spectra_count;
 
     // struct to store results
-    IdentificationRateData id_rate_data{};
+    IdentificationRateData id_rate_data {};
 
-    //store results
+    // store results
     id_rate_data.num_peptide_identification = pep_ids_count;
     id_rate_data.num_ms2_spectra = ms2_spectra_count;
     id_rate_data.identification_rate = ratio;

--- a/src/openms/source/QC/Ms2IdentificationRate.cpp
+++ b/src/openms/source/QC/Ms2IdentificationRate.cpp
@@ -97,7 +97,7 @@ namespace OpenMS
   }
 
 
-  QCBase::Status Ms2IdentificationRate::requires() const
+  QCBase::Status Ms2IdentificationRate::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/Ms2SpectrumStats.cpp
+++ b/src/openms/source/QC/Ms2SpectrumStats.cpp
@@ -165,7 +165,7 @@ namespace OpenMS
   }
 
   // required input files
-  QCBase::Status Ms2SpectrumStats::requires() const
+  QCBase::Status Ms2SpectrumStats::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/Ms2SpectrumStats.cpp
+++ b/src/openms/source/QC/Ms2SpectrumStats.cpp
@@ -31,12 +31,11 @@
 // $Authors: Juliane Schmachtenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/Ms2SpectrumStats.h>
-
-#include <OpenMS/QC/QCBase.h>
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/QC/Ms2SpectrumStats.h>
+#include <OpenMS/QC/QCBase.h>
 
 using namespace std;
 
@@ -53,26 +52,23 @@ namespace OpenMS
 
     setScanEventNumber_(exp);
     // if MS2-spectrum PeptideIdentifications found ->  ms2_included_ nullptr to PepID pointer
-    std::function<void(PeptideIdentification&)> l_f = [&exp,this,&map_to_spectrum] (PeptideIdentification& pep_id)
-    {
-      setPresenceAndScanEventNumber_(pep_id, exp, map_to_spectrum);
-    };
+    std::function<void(PeptideIdentification&)> l_f = [&exp, this, &map_to_spectrum](PeptideIdentification& pep_id) { setPresenceAndScanEventNumber_(pep_id, exp, map_to_spectrum); };
     features.applyFunctionOnPeptideIDs(l_f);
-    
+
     // if Ms2-spectrum not identified, add to unassigned PeptideIdentification without ID, contains only RT, mz and some meta values
     return getUnassignedPeptideIdentifications_(exp);
   }
-  
+
 
   void Ms2SpectrumStats::setScanEventNumber_(const MSExperiment& exp)
   {
     ms2_included_.clear();
     ms2_included_.reserve(exp.size());
-    UInt32 scan_event_number{ 0 };
+    UInt32 scan_event_number {0};
     for (const MSSpectrum& spec : exp.getSpectra())
     {
       if (spec.getMSLevel() == 1)
-      { // reset 
+      { // reset
         scan_event_number = 0;
         ms2_included_.emplace_back(scan_event_number, false);
       }
@@ -103,7 +99,7 @@ namespace OpenMS
     {
       throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No spectrum reference annotated at peptide identification!");
     }
-    
+
     UInt64 index = map_to_spectrum.at(peptide_ID.getMetaValue("spectrum_reference").toString());
     const MSSpectrum& spectrum = exp[index];
 
@@ -149,7 +145,7 @@ namespace OpenMS
   // calculate maximal and summed intensity
   MSSpectrum::PeakType::IntensityType Ms2SpectrumStats::getBPI_(const MSSpectrum& spec)
   {
-    PeakSpectrum::PeakType::IntensityType bpi{ 0 };
+    PeakSpectrum::PeakType::IntensityType bpi {0};
     auto it = spec.getBasePeak();
     if (it != spec.end())
     {
@@ -170,4 +166,4 @@ namespace OpenMS
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }
 
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/MzCalibration.cpp
+++ b/src/openms/source/QC/MzCalibration.cpp
@@ -151,7 +151,7 @@ namespace OpenMS
   }
 
   // required input files
-  QCBase::Status MzCalibration::requires() const
+  QCBase::Status MzCalibration::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/MzCalibration.cpp
+++ b/src/openms/source/QC/MzCalibration.cpp
@@ -32,23 +32,21 @@
 // $Authors: Juliane Schmachtenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/MzCalibration.h>
-
-#include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/METADATA/DataProcessing.h>
+#include <OpenMS/QC/MzCalibration.h>
 
 using namespace std;
- 
+
 namespace OpenMS
 {
-  MzCalibration::MzCalibration() :
-      mz_raw_{}, mz_ref_{}, no_mzml_(false)
+  MzCalibration::MzCalibration() : mz_raw_ {}, mz_ref_ {}, no_mzml_(false)
   {
   }
 
@@ -64,10 +62,7 @@ namespace OpenMS
     {
       no_mzml_ = false;
       // check for Calibration
-      auto is_not_elem = [](const boost::shared_ptr<const OpenMS::DataProcessing> &dp)
-      {
-        return (dp->getProcessingActions().count(DataProcessing::CALIBRATION) == 0);
-      };
+      auto is_not_elem = [](const boost::shared_ptr<const OpenMS::DataProcessing>& dp) { return (dp->getProcessingActions().count(DataProcessing::CALIBRATION) == 0); };
       auto vdp = exp[0].getDataProcessing(); // get a copy to avoid calling .begin() and .end() on two different temporaries
       if (all_of(vdp.begin(), vdp.end(), is_not_elem))
       {
@@ -77,28 +72,26 @@ namespace OpenMS
     }
 
     // set meta values for the first hit of all PeptideIdentifications of all features
-    for (Feature &feature : features)
+    for (Feature& feature : features)
     {
       if (feature.getPeptideIdentifications().empty())
       {
         continue;
       }
 
-      for (PeptideIdentification &peptide_ID : feature.getPeptideIdentifications())
+      for (PeptideIdentification& peptide_ID : feature.getPeptideIdentifications())
       {
         addMzMetaValues_(peptide_ID, exp, map_to_spectrum);
       }
     }
     // set meta values for the first hit of all unasssigned PeptideIdentifications
-    for (PeptideIdentification &unassigned_ID : features.getUnassignedPeptideIdentifications())
+    for (PeptideIdentification& unassigned_ID : features.getUnassignedPeptideIdentifications())
     {
       addMzMetaValues_(unassigned_ID, exp, map_to_spectrum);
     }
   }
 
-  void MzCalibration::addMzMetaValues_(PeptideIdentification &peptide_ID,
-                                       const PeakMap &exp,
-                                       const QCBase::SpectraMap &map_to_spectrum)
+  void MzCalibration::addMzMetaValues_(PeptideIdentification& peptide_ID, const PeakMap& exp, const QCBase::SpectraMap& map_to_spectrum)
   {
     if (peptide_ID.getHits().empty())
     {
@@ -115,10 +108,7 @@ namespace OpenMS
     {
       if (!peptide_ID.metaValueExists("spectrum_reference"))
       {
-        throw Exception::InvalidParameter(__FILE__,
-                                          __LINE__,
-                                          OPENMS_PRETTY_FUNCTION,
-                                          "No spectrum reference annotated at peptide identification!");
+        throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No spectrum reference annotated at peptide identification!");
       }
 
       // get spectrum from mapping and meta value
@@ -136,10 +126,7 @@ namespace OpenMS
       }
       else
       {
-        throw Exception::IllegalArgument(__FILE__,
-                                         __LINE__,
-                                         OPENMS_PRETTY_FUNCTION,
-                                         "The matching spectrum of the mzML is not an MS2 Spectrum.");
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The matching spectrum of the mzML is not an MS2 Spectrum.");
       }
 
       // set meta values
@@ -156,9 +143,9 @@ namespace OpenMS
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }
 
-  const String &MzCalibration::getName() const
+  const String& MzCalibration::getName() const
   {
     static const String& name = "MzCalibration";
     return name;
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/PSMExplainedIonCurrent.cpp
+++ b/src/openms/source/QC/PSMExplainedIonCurrent.cpp
@@ -32,11 +32,6 @@
 // $Authors: Tom Waschischeck$
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/PSMExplainedIonCurrent.h>
-
-#include <cfloat>
-#include <numeric>
-
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/MatchedIterator.h>
@@ -44,10 +39,13 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
+#include <OpenMS/QC/PSMExplainedIonCurrent.h>
+#include <cfloat>
+#include <numeric>
 
 namespace OpenMS
 {
-  template <typename MIV>
+  template<typename MIV>
   double sumOfMatchedIntensities(MIV& mi)
   {
     double sum = 0;
@@ -59,7 +57,8 @@ namespace OpenMS
     return sum;
   }
 
-  double PSMExplainedIonCurrent::annotatePSMExplainedIonCurrent_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, WindowMower& filter, PSMExplainedIonCurrent::ToleranceUnit tolerance_unit, double tolerance)
+  double PSMExplainedIonCurrent::annotatePSMExplainedIonCurrent_(PeptideIdentification& pep_id, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, WindowMower& filter,
+                                                                 PSMExplainedIonCurrent::ToleranceUnit tolerance_unit, double tolerance)
   {
     if (pep_id.getHits().empty())
     {
@@ -70,13 +69,13 @@ namespace OpenMS
     //---------------------------------------------------------------------
     // FIND DATA FOR THEORETICAL SPECTRUM
     //---------------------------------------------------------------------
-    
+
     // sequence
     const AASequence& seq = pep_id.getHits()[0].getSequence();
 
     // charge: re-calculated from masses since much more robust this way (PepID annotation of pep_id.getHits()[0].getCharge() could be wrong)
     Int charge = static_cast<Int>(round(seq.getMonoWeight() / pep_id.getMZ()));
-    
+
     //-----------------------------------------------------------------------
     // GET EXPERIMENTAL SPECTRUM MATCHING TO PEPTIDEIDENTIFICATION
     //-----------------------------------------------------------------------
@@ -112,7 +111,8 @@ namespace OpenMS
     //-----------------------------------------------------------------------
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " is empty." << "\n";
+      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " is empty."
+                      << "\n";
       return DBL_MAX;
     }
 
@@ -125,10 +125,11 @@ namespace OpenMS
     {
       sum_of_intensities += peak.getIntensity();
     }
-     
+
     if (sum_of_intensities <= 0)
     {
-      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " has only peaks with intensity 0." << "\n";
+      OPENMS_LOG_WARN << "The spectrum with RT: " + String(exp_spectrum.getRT()) + " has only peaks with intensity 0."
+                      << "\n";
       return DBL_MAX;
     }
 
@@ -182,21 +183,21 @@ namespace OpenMS
     {
       if (fmap.getProteinIdentifications().empty())
       {
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
       }
       tolerance_unit = fmap.getProteinIdentifications()[0].getSearchParameters().fragment_mass_tolerance_ppm ? ToleranceUnit::PPM : ToleranceUnit::DA;
       tolerance = fmap.getProteinIdentifications()[0].getSearchParameters().fragment_mass_tolerance;
       if (tolerance <= 0.0)
       { // some engines, e.g. MSGF+ have no fragment tolerance parameter. It will be 0.0.
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given in the FeatureMap. Please choose a fragment_mass_unit and tolerance manually.");
       }
     }
 
     std::vector<double> correctnesses;
 
-    std::function<void(PeptideIdentification&)> fCorrectness =
-      [&exp, &map_to_spectrum, &correctnesses, &wm_filter, tolerance, tolerance_unit](PeptideIdentification& pep_id)
-    {
+    std::function<void(PeptideIdentification&)> fCorrectness = [&exp, &map_to_spectrum, &correctnesses, &wm_filter, tolerance, tolerance_unit](PeptideIdentification& pep_id) {
       double correctness = annotatePSMExplainedIonCurrent_(pep_id, exp, map_to_spectrum, wm_filter, tolerance_unit, tolerance);
       if (correctness != DBL_MAX)
       {
@@ -217,7 +218,8 @@ namespace OpenMS
     results_.push_back(result);
   }
 
-  void PSMExplainedIonCurrent::compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit, double tolerance)
+  void PSMExplainedIonCurrent::compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp,
+                                       const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit, double tolerance)
   {
     Statistics result;
 
@@ -247,7 +249,8 @@ namespace OpenMS
       tolerance = search_params.fragment_mass_tolerance;
       if (tolerance <= 0.0)
       { // some engines, e.g. MSGF+ have no fragment tolerance parameter. It will be 0.0.
-        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No information about fragment mass tolerance given. Please choose a fragment_mass_unit and tolerance manually.");
+        throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                            "No information about fragment mass tolerance given. Please choose a fragment_mass_unit and tolerance manually.");
       }
     }
 
@@ -273,7 +276,7 @@ namespace OpenMS
     results_.push_back(result);
   }
 
-	const String& PSMExplainedIonCurrent::getName() const
+  const String& PSMExplainedIonCurrent::getName() const
   {
     static const String& name = "PSMExplainedIonCurrent";
     return name;
@@ -290,5 +293,4 @@ namespace OpenMS
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }
 
-};
-
+}; // namespace OpenMS

--- a/src/openms/source/QC/PSMExplainedIonCurrent.cpp
+++ b/src/openms/source/QC/PSMExplainedIonCurrent.cpp
@@ -285,7 +285,7 @@ namespace OpenMS
   }
 
 
-  QCBase::Status PSMExplainedIonCurrent::requires() const
+  QCBase::Status PSMExplainedIonCurrent::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/PeptideMass.cpp
+++ b/src/openms/source/QC/PeptideMass.cpp
@@ -33,22 +33,23 @@
 // $Authors: Chris Bielow $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/PeptideMass.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/QC/PeptideMass.h>
 
 namespace OpenMS
 {
   void PeptideMass::compute(FeatureMap& features)
   {
-    features.applyFunctionOnPeptideIDs([](PeptideIdentification& pi)
-    {
-      if (pi.getHits().empty())
-      {
-        return;
-      }
-      auto& hit = pi.getHits()[0];
-      hit.setMetaValue("mass", (pi.getMZ() - Constants::PROTON_MASS_U) * hit.getCharge());
-    }, true);
+    features.applyFunctionOnPeptideIDs(
+      [](PeptideIdentification& pi) {
+        if (pi.getHits().empty())
+        {
+          return;
+        }
+        auto& hit = pi.getHits()[0];
+        hit.setMetaValue("mass", (pi.getMZ() - Constants::PROTON_MASS_U) * hit.getCharge());
+      },
+      true);
   }
 
   const String& PeptideMass::getName() const
@@ -61,4 +62,4 @@ namespace OpenMS
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/PeptideMass.cpp
+++ b/src/openms/source/QC/PeptideMass.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
     return name;
   }
 
-  QCBase::Status PeptideMass::requires() const
+  QCBase::Status PeptideMass::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/QCBase.cpp
+++ b/src/openms/source/QC/QCBase.cpp
@@ -32,10 +32,10 @@
 // $Authors: Chris Bielow, Tom Waschischeck $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/QCBase.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/QC/QCBase.h>
 
 namespace OpenMS
 {
@@ -76,7 +76,7 @@ namespace OpenMS
   {
     return nativeid_to_index_.empty();
   }
-  
+
   Size QCBase::SpectraMap::size() const
   {
     return nativeid_to_index_.size();
@@ -92,7 +92,7 @@ namespace OpenMS
     }
     for (Size i = 0; i < (UInt64)QCBase::Requires::SIZE_OF_REQUIRES; ++i)
     {
-      if (this->requirements().isSuperSetOf(QCBase::Requires(i)) && !s.isSuperSetOf(QCBase::Requires(i)) )
+      if (this->requirements().isSuperSetOf(QCBase::Requires(i)) && !s.isSuperSetOf(QCBase::Requires(i)))
       {
         OPENMS_LOG_WARN << "Note: Metric '" << this->getName() << "' cannot run because input data '" << QCBase::names_of_requires[i] << "' is missing!\n";
       }
@@ -104,12 +104,11 @@ namespace OpenMS
   {
     bool iso_analyze = true;
     auto cm_dp = cm.getDataProcessing(); // get a copy to avoid calling .begin() and .end() on two different temporaries
-    if (all_of(cm_dp.begin(), cm_dp.end(), [](const OpenMS::DataProcessing& dp)
-    { return (dp.getSoftware().getName() != "IsobaricAnalyzer"); }))
+    if (all_of(cm_dp.begin(), cm_dp.end(), [](const OpenMS::DataProcessing& dp) { return (dp.getSoftware().getName() != "IsobaricAnalyzer"); }))
     {
       iso_analyze = false;
     }
     return iso_analyze;
   }
 
-} //namespace OpenMS
+} // namespace OpenMS

--- a/src/openms/source/QC/QCBase.cpp
+++ b/src/openms/source/QC/QCBase.cpp
@@ -86,13 +86,13 @@ namespace OpenMS
   // gives a warning with the name of the metric that can not be performed
   bool QCBase::isRunnable(const Status& s) const
   {
-    if (s.isSuperSetOf(this->requires()))
+    if (s.isSuperSetOf(this->requirements()))
     {
       return true;
     }
     for (Size i = 0; i < (UInt64)QCBase::Requires::SIZE_OF_REQUIRES; ++i)
     {
-      if (this->requires().isSuperSetOf(QCBase::Requires(i)) && !s.isSuperSetOf(QCBase::Requires(i)) )
+      if (this->requirements().isSuperSetOf(QCBase::Requires(i)) && !s.isSuperSetOf(QCBase::Requires(i)) )
       {
         OPENMS_LOG_WARN << "Note: Metric '" << this->getName() << "' cannot run because input data '" << QCBase::names_of_requires[i] << "' is missing!\n";
       }

--- a/src/openms/source/QC/RTAlignment.cpp
+++ b/src/openms/source/QC/RTAlignment.cpp
@@ -101,7 +101,7 @@ namespace OpenMS
   }
 
   // required input files
-  QCBase::Status RTAlignment::requires() const
+  QCBase::Status RTAlignment::requirements() const
   {
     return QCBase::Status() | QCBase::Requires::TRAFOALIGN | QCBase::Requires::POSTFDRFEAT;
   }

--- a/src/openms/source/QC/RTAlignment.cpp
+++ b/src/openms/source/QC/RTAlignment.cpp
@@ -31,16 +31,14 @@
 // $Authors: Juliane Schmachtenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/QC/RTAlignment.h>
-
-#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/QC/QCBase.h>
-
+#include <OpenMS/QC/RTAlignment.h>
 #include <algorithm>
 
 using namespace std;
@@ -58,7 +56,7 @@ namespace OpenMS
 
     // if featureMap after map alignment was handed, return Exception
     auto vdp = features.getDataProcessing(); // get a copy to avoid calling .begin() and .end() on two different temporaries
-    if (any_of(vdp.begin(), vdp.end(), [](const DataProcessing& dp){
+    if (any_of(vdp.begin(), vdp.end(), [](const DataProcessing& dp) {
           return (find(dp.getProcessingActions().begin(), dp.getProcessingActions().end(), DataProcessing::ProcessingAction::ALIGNMENT) != dp.getProcessingActions().end());
         }))
     {
@@ -70,8 +68,8 @@ namespace OpenMS
     {
       for (PeptideIdentification& peptide_ID : feature.getPeptideIdentifications())
       {
-          peptide_ID.setMetaValue("rt_align", trafo.apply(peptide_ID.getRT()));
-          peptide_ID.setMetaValue("rt_raw", peptide_ID.getRT());
+        peptide_ID.setMetaValue("rt_align", trafo.apply(peptide_ID.getRT()));
+        peptide_ID.setMetaValue("rt_raw", peptide_ID.getRT());
       }
       feature.setMetaValue("rt_align", trafo.apply(feature.getRT()));
       feature.setMetaValue("rt_raw", feature.getRT());
@@ -94,7 +92,7 @@ namespace OpenMS
       id.setMetaValue("rt_raw", id.getRT());
     }
   }
-  
+
   const String& RTAlignment::getName() const
   {
     return name_;
@@ -105,4 +103,4 @@ namespace OpenMS
   {
     return QCBase::Status() | QCBase::Requires::TRAFOALIGN | QCBase::Requires::POSTFDRFEAT;
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/SpectrumCount.cpp
+++ b/src/openms/source/QC/SpectrumCount.cpp
@@ -59,7 +59,7 @@ namespace OpenMS
 
   /// Returns required file input i.e. MzML.
   /// This is encoded as a bit in a Status object.
-  QCBase::Status SpectrumCount::requires() const
+  QCBase::Status SpectrumCount::requirements() const
   {
     return QCBase::Status(QCBase::Requires::RAWMZML);
   }

--- a/src/openms/source/QC/SpectrumCount.cpp
+++ b/src/openms/source/QC/SpectrumCount.cpp
@@ -33,8 +33,8 @@
 // --------------------------------------------------------------------------
 
 
-#include <OpenMS/QC/SpectrumCount.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/QC/SpectrumCount.h>
 using namespace std;
 
 namespace OpenMS
@@ -46,7 +46,7 @@ namespace OpenMS
     for (const auto& spectrum : exp)
     {
       const Size level = spectrum.getMSLevel();
-      ++counts[level];  // count MS level
+      ++counts[level]; // count MS level
     }
     return counts;
   }
@@ -63,4 +63,4 @@ namespace OpenMS
   {
     return QCBase::Status(QCBase::Requires::RAWMZML);
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/TIC.cpp
+++ b/src/openms/source/QC/TIC.cpp
@@ -33,14 +33,14 @@
 // --------------------------------------------------------------------------
 
 
-#include <OpenMS/QC/TIC.h>
 #include <OpenMS/FILTERING/TRANSFORMERS/LinearResamplerAlign.h>
 #include <OpenMS/FORMAT/MzTab.h>
+#include <OpenMS/QC/TIC.h>
 
 using namespace std;
 
 namespace OpenMS
-{ 
+{
 
   TIC::Result TIC::compute(const MSExperiment& exp, float bin_size, UInt ms_level)
   {
@@ -56,7 +56,7 @@ namespace OpenMS
 
       UInt max_int = *max_element(result.intensities.begin(), result.intensities.end());
 
-      for (const auto& i: result.intensities)
+      for (const auto& i : result.intensities)
       {
         if (max_int != 0)
         {
@@ -73,11 +73,11 @@ namespace OpenMS
       for (size_t i = 1; i < result.intensities.size(); ++i)
       {
         result.area += result.intensities[i];
-        if (result.intensities[i] > result.intensities[i-1] * 10) // detect 10x jumps between two subsequent scans
+        if (result.intensities[i] > result.intensities[i - 1] * 10) // detect 10x jumps between two subsequent scans
         {
           ++result.jump;
         }
-        if (result.intensities[i] < result.intensities[i-1] / 10) // detect 10x falls between two subsequent scans
+        if (result.intensities[i] < result.intensities[i - 1] / 10) // detect 10x falls between two subsequent scans
         {
           ++result.fall;
         }
@@ -88,11 +88,7 @@ namespace OpenMS
 
   bool TIC::Result::operator==(const Result& rhs) const
   {
-    return intensities == rhs.intensities
-          && retention_times == rhs.retention_times
-          && area == rhs.area
-          && fall == rhs.fall
-          && jump == rhs.jump;
+    return intensities == rhs.intensities && retention_times == rhs.retention_times && area == rhs.area && fall == rhs.fall && jump == rhs.jump;
   }
 
   /// Returns the name of the metric
@@ -117,7 +113,7 @@ namespace OpenMS
       {
         continue; // no MS1 spectra
       }
-      MzTabParameter tic{};
+      MzTabParameter tic {};
       tic.setCVLabel("total ion current");
       tic.setAccession("MS:1000285");
       tic.setName("TIC_" + String(i + 1));
@@ -132,4 +128,4 @@ namespace OpenMS
       meta.custom[meta.custom.size()] = tic;
     }
   }
-}
+} // namespace OpenMS

--- a/src/openms/source/QC/TIC.cpp
+++ b/src/openms/source/QC/TIC.cpp
@@ -103,7 +103,7 @@ namespace OpenMS
 
   /// Returns required file input i.e. MzML.
   /// This is encoded as a bit in a Status object.
-  QCBase::Status TIC::requires() const
+  QCBase::Status TIC::requirements() const
   {
     return QCBase::Status(QCBase::Requires::RAWMZML);
   }

--- a/src/tests/class_tests/openms/source/Contaminants_test.cpp
+++ b/src/tests/class_tests/openms/source/Contaminants_test.cpp
@@ -233,9 +233,9 @@ START_TEST(Contaminants, "$Id$")
   END_SECTION
   
   
-  START_SECTION(Status requires() const override)
+  START_SECTION(Status requirements() const override)
   {
-    TEST_EQUAL(temp.requires() == (QCBase::Status(QCBase::Requires::POSTFDRFEAT) | QCBase::Requires::CONTAMINANTS), true);
+    TEST_EQUAL(temp.requirements() == (QCBase::Status(QCBase::Requires::POSTFDRFEAT) | QCBase::Requires::CONTAMINANTS), true);
   }
   END_SECTION
 END_TEST

--- a/src/tests/class_tests/openms/source/Contaminants_test.cpp
+++ b/src/tests/class_tests/openms/source/Contaminants_test.cpp
@@ -36,12 +36,12 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-#include <OpenMS/QC/Contaminants.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/METADATA/DataProcessing.h>
-#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
-#include <OpenMS/CHEMISTRY/ProteaseDB.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/QC/Contaminants.h>
 
 ///////////////////////////
 
@@ -49,193 +49,186 @@ using namespace OpenMS;
 using namespace std;
 
 START_TEST(Contaminants, "$Id$")
-  FeatureMap fmap;
-  FeatureMap emptyFmap;
-  Feature f;
-  
-  fmap.getProteinIdentifications().resize(1);
-  DigestionEnzymeProtein noenzyme("unknown_enzyme",
-                           "",
-                           set<String>(),
-                           "");
-  // set no digestion enzyme
-  fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = noenzyme;
-  // set empty contaminants database
-  vector<FASTAFile::FASTAEntry> contaminantsFile;
-  
-  // fill the featureMap of features with set sequence and intensity
-  {
-    PeptideIdentification id;
-    PeptideIdentification scnd_id;
+FeatureMap fmap;
+FeatureMap emptyFmap;
+Feature f;
 
-    PeptideHit hit;
-    PeptideHit scnd_hit;
+fmap.getProteinIdentifications().resize(1);
+DigestionEnzymeProtein noenzyme("unknown_enzyme", "", set<String>(), "");
+// set no digestion enzyme
+fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = noenzyme;
+// set empty contaminants database
+vector<FASTAFile::FASTAEntry> contaminantsFile;
 
-    hit.setSequence(AASequence::fromString("AAAAAAAAAAK"));
-    id.setHits({hit});
-    f.setPeptideIdentifications({id});
-    f.setIntensity(12.0);
-    fmap.push_back(f);
+// fill the featureMap of features with set sequence and intensity
+{
+  PeptideIdentification id;
+  PeptideIdentification scnd_id;
 
-    hit.setSequence(AASequence::fromString("R"));
-    id.setHits({hit});
-    f.setPeptideIdentifications({id});
-    f.setIntensity(8.0);
-    fmap.push_back(f);
+  PeptideHit hit;
+  PeptideHit scnd_hit;
 
-    hit.setSequence(AASequence::fromString("R"));
-    scnd_hit.setSequence(AASequence::fromString("QQQQQQQQQQ"));
-    id.setHits({hit});
-    scnd_id.setHits({scnd_hit});
-    f.setPeptideIdentifications({id, scnd_id});
-    f.setIntensity(10.0);
-    fmap.push_back(f);
+  hit.setSequence(AASequence::fromString("AAAAAAAAAAK"));
+  id.setHits({hit});
+  f.setPeptideIdentifications({id});
+  f.setIntensity(12.0);
+  fmap.push_back(f);
 
-    hit.setSequence(AASequence::fromString("AAAAAAAAAAKR"));
-    id.setHits({hit});
-    f.setPeptideIdentifications({id});
-    f.setIntensity(20.0);
-    fmap.push_back(f);
+  hit.setSequence(AASequence::fromString("R"));
+  id.setHits({hit});
+  f.setPeptideIdentifications({id});
+  f.setIntensity(8.0);
+  fmap.push_back(f);
 
-    hit.setSequence(AASequence::fromString("AAAAAAAAAAKRAAAAAAAAAAKRCCCCCCCCCCKRCCCCCCCCCC"));
-    id.setHits({hit});
-    f.setPeptideIdentifications({id});
-    f.setIntensity(10.0);
-    fmap.push_back(f);
+  hit.setSequence(AASequence::fromString("R"));
+  scnd_hit.setSequence(AASequence::fromString("QQQQQQQQQQ"));
+  id.setHits({hit});
+  scnd_id.setHits({scnd_hit});
+  f.setPeptideIdentifications({id, scnd_id});
+  f.setIntensity(10.0);
+  fmap.push_back(f);
 
-    f.setPeptideIdentifications({});
-    fmap.push_back(f);
-  }
-  
-  // set the unassigned peptideidentifications
-  std::vector<PeptideIdentification> ids2(3);
-  PeptideHit hit2;
-  hit2.setSequence(AASequence::fromString("AAAAAAAAAAK"));
-  ids2[0].setHits({hit2});
-  hit2.setSequence(AASequence::fromString("RCCCCCCCCCCK"));
-  ids2[1].setHits({hit2});
-  hit2.setSequence(AASequence::fromString("DDDDDDDDDD"));
-  ids2[2].setHits({hit2});
+  hit.setSequence(AASequence::fromString("AAAAAAAAAAKR"));
+  id.setHits({hit});
+  f.setPeptideIdentifications({id});
+  f.setIntensity(20.0);
+  fmap.push_back(f);
 
-  //check the constructor
-  Contaminants* ptr = nullptr;
-  Contaminants* nullPointer = nullptr;
-  START_SECTION(Contaminants())
-    ptr = new Contaminants();
-    TEST_NOT_EQUAL(ptr, nullPointer)
-  END_SECTION
-  
-  START_SECTION(~Contaminants())
-    delete ptr;
-  END_SECTION
-  
-  START_SECTION((void compute(FeatureMap& features, const std::vector<FASTAFile::FASTAEntry>& contaminants)))
-  {
-    Contaminants conts1, conts2, conts3, conts4, conts5, conts6, conts7;
-  
-    // test exception when the contaminants database is empty
-    TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts1.compute(fmap, contaminantsFile), "No contaminants provided.");
-  
-    // set contaminant database "contaminantsFile"
-    FASTAFile::FASTAEntry contaminantsProtein("test_protein", "protein consists of only Alanine or Cytosine", "AAAAAAAAAAKRAAAAAAAAAAKRCCCCCCCCCCKRCCCCCCCCCC");
-    contaminantsFile.push_back(contaminantsProtein);
-  
-    // test exception when the proteinidentification in the FeatureMap is empty
-    TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts2.compute(emptyFmap, contaminantsFile), "No proteinidentifications in FeatureMap.");
-  
-    // test exception when no digestion enzyme is given
-    TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts6.compute(fmap, contaminantsFile), "No digestion enzyme in FeatureMap detected. No computation possible.");
-  
-    // tests without given missed cleavages and without given enzyme
-    fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("no cleavage");
-    conts3.compute(fmap, contaminantsFile);
-    std::vector<Contaminants::ContaminantsSummary> result3 = conts3.getResults();
-    ABORT_IF(result3.size() != 1);
-    TEST_REAL_SIMILAR(result3[0].assigned_contaminants_ratio, 1/6.0);
-    TEST_REAL_SIMILAR(result3[0].assigned_contaminants_intensity_ratio, 1/7.0);
-    TEST_REAL_SIMILAR(result3[0].all_contaminants_ratio, 1/6.0);
-    TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-  
-    // set digestion enzyme to trypsin
-    fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("trypsin");
-  
-    conts7.compute(fmap, contaminantsFile);
-    std::vector<Contaminants::ContaminantsSummary> result7 = conts7.getResults();
-    TEST_REAL_SIMILAR(result7[0].assigned_contaminants_ratio, 3/6.0);
-    TEST_REAL_SIMILAR(result7[0].assigned_contaminants_intensity_ratio, 3/7.0);
-    TEST_REAL_SIMILAR(result7[0].all_contaminants_ratio, 3/6.0);
-    TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-  
-    // fill the unassigned peptideidentifications
-    fmap.setUnassignedPeptideIdentifications(ids2);
-  
-    // tests without given missed cleavages but with set enzyme
-    conts4.compute(fmap, contaminantsFile);
-    std::vector<Contaminants::ContaminantsSummary> result4 = conts4.getResults();
-    ABORT_IF(result4.size() != 1);
-    TEST_REAL_SIMILAR(result4[0].assigned_contaminants_ratio, 3/6.0);
-    TEST_REAL_SIMILAR(result4[0].assigned_contaminants_intensity_ratio, 3/7.0);
-    TEST_REAL_SIMILAR(result4[0].unassigned_contaminants_ratio, 1/3.0);
-    TEST_REAL_SIMILAR(result4[0].all_contaminants_ratio, 4/9.0);
-    TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getHits()[0].getMetaValue("is_contaminant"), 0);
-  
-    // set missed cleavages to 1
-    fmap.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 1;
-  
-    // tests with set missed cleavages and set enzyme
-    // also checks if the empty feature count is as expected
-    conts5.compute(fmap, contaminantsFile);
-    std::vector<Contaminants::ContaminantsSummary> result5 = conts5.getResults();
-    ABORT_IF(result5.size() != 1);
-    TEST_REAL_SIMILAR(result5[0].assigned_contaminants_ratio, 4/6.0);
-    TEST_REAL_SIMILAR(result5[0].assigned_contaminants_intensity_ratio, 5/7.0);
-    TEST_REAL_SIMILAR(result5[0].unassigned_contaminants_ratio, 2/3.0);
-    TEST_REAL_SIMILAR(result5[0].all_contaminants_ratio, 6/9.0);
-    TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 1);
-    TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getHits()[0].getMetaValue("is_contaminant"), 0);
-    TEST_EQUAL(result5[0].empty_features.first, 1);
-    TEST_EQUAL(result5[0].empty_features.second, 6);
-  }
-  END_SECTION
-  
-  
-  Contaminants temp;
-  
-  START_SECTION(const String& getName() const override)
-  {
-    TEST_EQUAL(temp.getName(), "Contaminants")
-  }
-  END_SECTION
-  
-  
+  hit.setSequence(AASequence::fromString("AAAAAAAAAAKRAAAAAAAAAAKRCCCCCCCCCCKRCCCCCCCCCC"));
+  id.setHits({hit});
+  f.setPeptideIdentifications({id});
+  f.setIntensity(10.0);
+  fmap.push_back(f);
+
+  f.setPeptideIdentifications({});
+  fmap.push_back(f);
+}
+
+// set the unassigned peptideidentifications
+std::vector<PeptideIdentification> ids2(3);
+PeptideHit hit2;
+hit2.setSequence(AASequence::fromString("AAAAAAAAAAK"));
+ids2[0].setHits({hit2});
+hit2.setSequence(AASequence::fromString("RCCCCCCCCCCK"));
+ids2[1].setHits({hit2});
+hit2.setSequence(AASequence::fromString("DDDDDDDDDD"));
+ids2[2].setHits({hit2});
+
+// check the constructor
+Contaminants* ptr = nullptr;
+Contaminants* nullPointer = nullptr;
+START_SECTION(Contaminants())
+ptr = new Contaminants();
+TEST_NOT_EQUAL(ptr, nullPointer)
+END_SECTION
+
+START_SECTION(~Contaminants())
+delete ptr;
+END_SECTION
+
+START_SECTION((void compute(FeatureMap& features, const std::vector<FASTAFile::FASTAEntry>& contaminants)))
+{
+  Contaminants conts1, conts2, conts3, conts4, conts5, conts6, conts7;
+
+  // test exception when the contaminants database is empty
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts1.compute(fmap, contaminantsFile), "No contaminants provided.");
+
+  // set contaminant database "contaminantsFile"
+  FASTAFile::FASTAEntry contaminantsProtein("test_protein", "protein consists of only Alanine or Cytosine", "AAAAAAAAAAKRAAAAAAAAAAKRCCCCCCCCCCKRCCCCCCCCCC");
+  contaminantsFile.push_back(contaminantsProtein);
+
+  // test exception when the proteinidentification in the FeatureMap is empty
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts2.compute(emptyFmap, contaminantsFile), "No proteinidentifications in FeatureMap.");
+
+  // test exception when no digestion enzyme is given
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, conts6.compute(fmap, contaminantsFile), "No digestion enzyme in FeatureMap detected. No computation possible.");
+
+  // tests without given missed cleavages and without given enzyme
+  fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("no cleavage");
+  conts3.compute(fmap, contaminantsFile);
+  std::vector<Contaminants::ContaminantsSummary> result3 = conts3.getResults();
+  ABORT_IF(result3.size() != 1);
+  TEST_REAL_SIMILAR(result3[0].assigned_contaminants_ratio, 1 / 6.0);
+  TEST_REAL_SIMILAR(result3[0].assigned_contaminants_intensity_ratio, 1 / 7.0);
+  TEST_REAL_SIMILAR(result3[0].all_contaminants_ratio, 1 / 6.0);
+  TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+
+  // set digestion enzyme to trypsin
+  fmap.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("trypsin");
+
+  conts7.compute(fmap, contaminantsFile);
+  std::vector<Contaminants::ContaminantsSummary> result7 = conts7.getResults();
+  TEST_REAL_SIMILAR(result7[0].assigned_contaminants_ratio, 3 / 6.0);
+  TEST_REAL_SIMILAR(result7[0].assigned_contaminants_intensity_ratio, 3 / 7.0);
+  TEST_REAL_SIMILAR(result7[0].all_contaminants_ratio, 3 / 6.0);
+  TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+
+  // fill the unassigned peptideidentifications
+  fmap.setUnassignedPeptideIdentifications(ids2);
+
+  // tests without given missed cleavages but with set enzyme
+  conts4.compute(fmap, contaminantsFile);
+  std::vector<Contaminants::ContaminantsSummary> result4 = conts4.getResults();
+  ABORT_IF(result4.size() != 1);
+  TEST_REAL_SIMILAR(result4[0].assigned_contaminants_ratio, 3 / 6.0);
+  TEST_REAL_SIMILAR(result4[0].assigned_contaminants_intensity_ratio, 3 / 7.0);
+  TEST_REAL_SIMILAR(result4[0].unassigned_contaminants_ratio, 1 / 3.0);
+  TEST_REAL_SIMILAR(result4[0].all_contaminants_ratio, 4 / 9.0);
+  TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getHits()[0].getMetaValue("is_contaminant"), 0);
+
+  // set missed cleavages to 1
+  fmap.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 1;
+
+  // tests with set missed cleavages and set enzyme
+  // also checks if the empty feature count is as expected
+  conts5.compute(fmap, contaminantsFile);
+  std::vector<Contaminants::ContaminantsSummary> result5 = conts5.getResults();
+  ABORT_IF(result5.size() != 1);
+  TEST_REAL_SIMILAR(result5[0].assigned_contaminants_ratio, 4 / 6.0);
+  TEST_REAL_SIMILAR(result5[0].assigned_contaminants_intensity_ratio, 5 / 7.0);
+  TEST_REAL_SIMILAR(result5[0].unassigned_contaminants_ratio, 2 / 3.0);
+  TEST_REAL_SIMILAR(result5[0].all_contaminants_ratio, 6 / 9.0);
+  TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[1].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[2].getPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap[3].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap[4].getPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getHits()[0].getMetaValue("is_contaminant"), 1);
+  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getHits()[0].getMetaValue("is_contaminant"), 0);
+  TEST_EQUAL(result5[0].empty_features.first, 1);
+  TEST_EQUAL(result5[0].empty_features.second, 6);
+}
+END_SECTION
+
+
+Contaminants temp;
+
+START_SECTION(const String& getName() const override) {TEST_EQUAL(temp.getName(), "Contaminants")} END_SECTION
+
+
   START_SECTION(Status requirements() const override)
-  {
-    TEST_EQUAL(temp.requirements() == (QCBase::Status(QCBase::Requires::POSTFDRFEAT) | QCBase::Requires::CONTAMINANTS), true);
-  }
-  END_SECTION
+{
+  TEST_EQUAL(temp.requirements() == (QCBase::Status(QCBase::Requires::POSTFDRFEAT) | QCBase::Requires::CONTAMINANTS), true);
+}
+END_SECTION
 END_TEST

--- a/src/tests/class_tests/openms/source/FWHM_test.cpp
+++ b/src/tests/class_tests/openms/source/FWHM_test.cpp
@@ -79,10 +79,10 @@ START_SECTION(void compute(FeatureMap& features))
 }
 END_SECTION
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
   FWHM fw;
-  TEST_EQUAL(fw.requires() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
+  TEST_EQUAL(fw.requirements() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FWHM_test.cpp
+++ b/src/tests/class_tests/openms/source/FWHM_test.cpp
@@ -35,9 +35,8 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 ///////////////////////////
-#include <OpenMS/QC/FWHM.h>
-
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/QC/FWHM.h>
 
 ///////////////////////////
 
@@ -71,7 +70,7 @@ START_SECTION(void compute(FeatureMap& features))
   fm.push_back(f);
   f.clearMetaInfo();
   f.setMetaValue("model_FWHM", 98.1);
-  fm.push_back(f); 
+  fm.push_back(f);
   FWHM fw;
   fw.compute(fm);
   TEST_EQUAL(fm[0].getPeptideIdentifications()[0].getMetaValue("FWHM"), 123.4)
@@ -86,7 +85,7 @@ START_SECTION(QCBase::Status requirements() const override)
 }
 END_SECTION
 
-START_SECTION(const String & getName() const)
+START_SECTION(const String& getName() const)
 {
   TEST_EQUAL(FWHM().getName(), "FWHM");
 }

--- a/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
@@ -418,10 +418,10 @@ START_TEST(FragmentMassError, "$Id$")
   END_SECTION
 
 
-  START_SECTION(QCBase::Status requires() const override)
+  START_SECTION(QCBase::Status requirements() const override)
   {
     QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
-    TEST_EQUAL(frag_ma_err.requires() == stat, true)
+    TEST_EQUAL(frag_ma_err.requirements() == stat, true)
   }
   END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
@@ -36,11 +36,10 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-#include <OpenMS/QC/FragmentMassError.h>
-
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
+#include <OpenMS/QC/FragmentMassError.h>
 //////////////////////////
 
 using namespace OpenMS;
@@ -73,7 +72,7 @@ const PeptideIdentification createPeptideIdentification(const String& id, const 
   peptide_hit.setCharge(charge);
 
   PeptideIdentification peptide_id;
-  peptide_id.setMetaValue("spectrum_reference",id);
+  peptide_id.setMetaValue("spectrum_reference", id);
   peptide_id.setMZ(mz);
   peptide_id.setHits({peptide_hit});
 
@@ -82,349 +81,349 @@ const PeptideIdentification createPeptideIdentification(const String& id, const 
 
 START_TEST(FragmentMassError, "$Id$")
 
-  FragmentMassError* ptr = nullptr;
-  FragmentMassError* nulpt = nullptr;
-  START_SECTION(FragmentMassError())
+FragmentMassError* ptr = nullptr;
+FragmentMassError* nulpt = nullptr;
+START_SECTION(FragmentMassError())
+{
+  ptr = new FragmentMassError();
+  TEST_NOT_EQUAL(ptr, nulpt)
+}
+END_SECTION
+
+START_SECTION(~FragmentMassError())
+{
+  delete ptr;
+}
+END_SECTION
+
+
+FragmentMassError frag_ma_err;
+
+// tests compute function with fmap
+START_SECTION(void compute(FeatureMap& fmap, const MSExperiment& exp, const std::map<String, UInt64>& map_to_spectrum, const ToleranceUnit tolerance_unit = ToleranceUnit::AUTO,
+                           const double tolerance = 20))
+{
+  //--------------------------------------------------------------------
+  // create valid input data
+  //--------------------------------------------------------------------
+  // FeatureMap
+  FeatureMap fmap;
+
+  // empty PeptideIdentification
+  PeptideIdentification pep_id_empty;
+  pep_id_empty.setRT(6);
+
+  // empty Feature
+  Feature feat_empty;
+
+  // put valid data in fmap
+  fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888), createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264), pep_id_empty});
+  fmap.push_back(feat_empty);
+  // set ProteinIdentifications
+  ProteinIdentification protId;
+  ProteinIdentification::SearchParameters param;
+  param.fragment_mass_tolerance_ppm = false;
+  param.fragment_mass_tolerance = 0.3;
+  protId.setSearchParameters(param);
+  fmap.setProteinIdentifications({protId});
+
+  // MSExperiment
+  MSExperiment exp;
+
+  // create b- and y-ion spectrum of peptide sequence HIMALAYA with charge 1
+  // shift every peak by 5 ppm
+  PeakSpectrum ms_spec_2_himalaya = createMSSpectrum(2, 3.7, "XTandem::1");
+  TheoreticalSpectrumGenerator theo_gen_hi;
+  theo_gen_hi.getSpectrum(ms_spec_2_himalaya, AASequence::fromString("HIMALAYA"), 1, 1);
+  for (Peak1D& peak : ms_spec_2_himalaya)
+    peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
+
+  // create c- and z-ion spectrum of peptide sequence ALABAMA with charge 2
+  // shift every peak by 5 ppm
+  PeakSpectrum ms_spec_2_alabama = createMSSpectrum(2, 2, "XTandem::2", Precursor::ActivationMethod::ECD);
+  TheoreticalSpectrumGenerator theo_gen_al;
+  Param theo_gen_settings_al = theo_gen_al.getParameters();
+  theo_gen_settings_al.setValue("add_c_ions", "true");
+  theo_gen_settings_al.setValue("add_z_ions", "true");
+  theo_gen_settings_al.setValue("add_b_ions", "false");
+  theo_gen_settings_al.setValue("add_y_ions", "false");
+  theo_gen_al.setParameters(theo_gen_settings_al);
+  theo_gen_al.getSpectrum(ms_spec_2_alabama, AASequence::fromString("ALABAMA"), 2, 2);
+  for (Peak1D& peak : ms_spec_2_alabama)
+    peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
+
+  // empty MSSpectrum
+  MSSpectrum ms_spec_empty;
+
+  // put valid data in exp
+  exp.setSpectra({ms_spec_empty, ms_spec_2_alabama, ms_spec_2_himalaya});
+
+  // map the MSExperiment
+  QCBase::SpectraMap spectra_map(exp);
+
+  //--------------------------------------------------------------------
+  // test with valid input - default parameter
+  //--------------------------------------------------------------------
+  frag_ma_err.compute(fmap, exp, spectra_map);
+  std::vector<FragmentMassError::Statistics> result = frag_ma_err.getResults();
+
+  TEST_REAL_SIMILAR(result[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with valid input - ToleranceUnit PPM
+  //--------------------------------------------------------------------
+
+  FragmentMassError frag_ma_err_ppm;
+  frag_ma_err_ppm.compute(fmap, exp, spectra_map, QCBase::ToleranceUnit::PPM, 6);
+  std::vector<FragmentMassError::Statistics> result_ppm = frag_ma_err_ppm.getResults();
+
+  TEST_REAL_SIMILAR(result_ppm[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result_ppm[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with valid input and flags
+  //--------------------------------------------------------------------
+  FragmentMassError frag_ma_err_flag_da;
+  frag_ma_err_flag_da.compute(fmap, exp, spectra_map, QCBase::ToleranceUnit::DA, 1);
+  std::vector<FragmentMassError::Statistics> result_flag_da = frag_ma_err_flag_da.getResults();
+
+  TEST_REAL_SIMILAR(result_flag_da[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result_flag_da[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with missing toleranceUnit and toleranceValue in featureMap
+  //--------------------------------------------------------------------
+
+  // featureMap with missing ProteinIdentifications
   {
-    ptr = new FragmentMassError();
-    TEST_NOT_EQUAL(ptr, nulpt)
+    FeatureMap fmap_auto = fmap;
+    fmap_auto.getProteinIdentifications().clear();
+    TEST_EXCEPTION(Exception::MissingInformation, frag_ma_err.compute(fmap_auto, exp, spectra_map, QCBase::ToleranceUnit::AUTO))
   }
-  END_SECTION
 
-  START_SECTION(~FragmentMassError())
+  //--------------------------------------------------------------------
+  // test with no given fragmentation method
+  //--------------------------------------------------------------------
+  // create MSExperiment with no given fragmentation method
+  exp[0].setPrecursors({});
+  // falls back to CID
+  spectra_map.calculateMap(exp);
+  frag_ma_err.compute(fmap, exp, spectra_map);
+  TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with matching ms1 spectrum
+  //--------------------------------------------------------------------
+
+  // fmap with PeptideIdentification with RT matching to a MS1 Spectrum
+  fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::3")});
+
+  // set MS1 Spectrum to exp
+  exp.setSpectra({createMSSpectrum(1, 5, "XTandem::3")});
+  spectra_map.calculateMap(exp);
+
+  TEST_EXCEPTION(Exception::IllegalArgument, frag_ma_err.compute(fmap, exp, spectra_map))
+
+  //--------------------------------------------------------------------
+  // test with fragmentation method SORI, which is not supported
+  //--------------------------------------------------------------------
+
+  // put PeptideIdentification with RT matching to MSSpectrum with fragmentation method SORI to fmap
+  FeatureMap fmap_sori;
+  fmap_sori.setProteinIdentifications({protId});
+  fmap_sori.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::5")});
+
+  // MSExperiment with fragmentation method SORI (not supported)
+  exp.setSpectra({createMSSpectrum(2, 7, "XTandem::5", Precursor::ActivationMethod::SORI)});
+  spectra_map.calculateMap(exp);
+
+  TEST_EXCEPTION(Exception::InvalidParameter, frag_ma_err.compute(fmap_sori, exp, spectra_map))
+
+  //--------------------------------------------------------------------
+  // test if spectrum has no peaks
+  //--------------------------------------------------------------------
+
+  // put PeptideIdentification with RT matching to MSSpectrum with no peaks to fmap
+  fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::6")});
+
+  // MSExperiment without peaks
+  exp.setSpectra({createMSSpectrum(2, 4, "XTandem::6")});
+  spectra_map.calculateMap(exp);
+
+  FragmentMassError frag_ma_err_excp;
+  frag_ma_err_excp.compute(fmap, exp, spectra_map);
+  std::vector<FragmentMassError::Statistics> result_excp;
+  result_excp = frag_ma_err_excp.getResults();
+
+  TEST_REAL_SIMILAR(result_excp[0].average_ppm, 0)
+  TEST_REAL_SIMILAR(result_excp[0].variance_ppm, 0)
+}
+END_SECTION
+
+// tests compute function with pepIDs
+START_SECTION(void compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp,
+                           const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20));
+{
+  //--------------------------------------------------------------------
+  // create valid input data
+  //--------------------------------------------------------------------
+  // Peptide Identifications
+  std::vector<PeptideIdentification> pep_ids;
+
+  // empty PeptideIdentification
+  PeptideIdentification pep_id_empty;
+  pep_id_empty.setRT(6);
+
+  // put valid data in fmap
+  pep_ids = {createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888), createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264), pep_id_empty};
+
+  // Search Parameters
+  ProteinIdentification::SearchParameters param;
+  param.fragment_mass_tolerance_ppm = false;
+  param.fragment_mass_tolerance = 0.3;
+
+  // MSExperiment
+  MSExperiment exp;
+
+  // create b- and y-ion spectrum of peptide sequence HIMALAYA with charge 1
+  // shift every peak by 5 ppm
+  PeakSpectrum ms_spec_2_himalaya = createMSSpectrum(2, 3.7, "XTandem::1");
+  TheoreticalSpectrumGenerator theo_gen_hi;
+  theo_gen_hi.getSpectrum(ms_spec_2_himalaya, AASequence::fromString("HIMALAYA"), 1, 1);
+  for (Peak1D& peak : ms_spec_2_himalaya)
+    peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
+
+  // create c- and z-ion spectrum of peptide sequence ALABAMA with charge 2
+  // shift every peak by 5 ppm
+  PeakSpectrum ms_spec_2_alabama = createMSSpectrum(2, 2, "XTandem::2", Precursor::ActivationMethod::ECD);
+  TheoreticalSpectrumGenerator theo_gen_al;
+  Param theo_gen_settings_al = theo_gen_al.getParameters();
+  theo_gen_settings_al.setValue("add_c_ions", "true");
+  theo_gen_settings_al.setValue("add_z_ions", "true");
+  theo_gen_settings_al.setValue("add_b_ions", "false");
+  theo_gen_settings_al.setValue("add_y_ions", "false");
+  theo_gen_al.setParameters(theo_gen_settings_al);
+  theo_gen_al.getSpectrum(ms_spec_2_alabama, AASequence::fromString("ALABAMA"), 2, 2);
+  for (Peak1D& peak : ms_spec_2_alabama)
+    peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
+
+  // empty MSSpectrum
+  MSSpectrum ms_spec_empty;
+
+  // put valid data in exp
+  exp.setSpectra({ms_spec_empty, ms_spec_2_alabama, ms_spec_2_himalaya});
+
+  // map the MSExperiment
+  QCBase::SpectraMap spectra_map(exp);
+
+  //--------------------------------------------------------------------
+  // test with valid input - default parameter
+  //--------------------------------------------------------------------
+  frag_ma_err.compute(pep_ids, param, exp, spectra_map);
+  std::vector<FragmentMassError::Statistics> result = frag_ma_err.getResults();
+
+  TEST_REAL_SIMILAR(result[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with valid input - ToleranceUnit PPM
+  //--------------------------------------------------------------------
+
+  FragmentMassError frag_ma_err_ppm;
+  frag_ma_err_ppm.compute(pep_ids, param, exp, spectra_map, FragmentMassError::ToleranceUnit::PPM, 6);
+  std::vector<FragmentMassError::Statistics> result_ppm = frag_ma_err_ppm.getResults();
+
+  TEST_REAL_SIMILAR(result_ppm[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result_ppm[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with valid input and flags
+  //--------------------------------------------------------------------
+  FragmentMassError frag_ma_err_flag_da;
+  frag_ma_err_flag_da.compute(pep_ids, param, exp, spectra_map, FragmentMassError::ToleranceUnit::DA, 1);
+  std::vector<FragmentMassError::Statistics> result_flag_da = frag_ma_err_flag_da.getResults();
+
+  TEST_REAL_SIMILAR(result_flag_da[0].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(result_flag_da[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
+
+  //--------------------------------------------------------------------
+  // test with missing toleranceUnit and toleranceValue in featureMap
+  //--------------------------------------------------------------------
+
+  // Search params without FME info
   {
-    delete ptr;
+    ProteinIdentification::SearchParameters empty_params;
+    TEST_EXCEPTION(Exception::MissingInformation, frag_ma_err.compute(pep_ids, empty_params, exp, spectra_map, FragmentMassError::ToleranceUnit::AUTO))
   }
-  END_SECTION
 
+  //--------------------------------------------------------------------
+  // test with no given fragmentation method
+  //--------------------------------------------------------------------
+  // create MSExperiment with no given fragmentation method
+  exp[0].setPrecursors({});
+  // falls back to CID
+  spectra_map.calculateMap(exp);
+  frag_ma_err.compute(pep_ids, param, exp, spectra_map);
+  TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].average_ppm, 5.0)
+  TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].variance_ppm, 0.0) // offset is constant, i.e. no variance
 
-  FragmentMassError frag_ma_err;
+  //--------------------------------------------------------------------
+  // test with matching ms1 spectrum
+  //--------------------------------------------------------------------
 
-  //tests compute function with fmap
-  START_SECTION(void compute(FeatureMap& fmap, const MSExperiment& exp, const std::map<String,UInt64>& map_to_spectrum, const ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, const double tolerance = 20))
-  {
-    //--------------------------------------------------------------------
-    // create valid input data
-    //--------------------------------------------------------------------
-    // FeatureMap
-    FeatureMap fmap;
+  // PeptideIdentification with RT matching to a MS1 Spectrum
+  std::vector<PeptideIdentification> ms1_id({createPeptideIdentification("XTandem::3")});
 
-    // empty PeptideIdentification
-    PeptideIdentification pep_id_empty;
-    pep_id_empty.setRT(6);
+  // set MS1 Spectrum to exp
+  exp.setSpectra({createMSSpectrum(1, 5, "XTandem::3")});
+  spectra_map.calculateMap(exp);
 
-    // empty Feature
-    Feature feat_empty;
+  TEST_EXCEPTION(Exception::IllegalArgument, frag_ma_err.compute(ms1_id, param, exp, spectra_map))
 
-    // put valid data in fmap
-    fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888), createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264), pep_id_empty});
-    fmap.push_back(feat_empty);
-    // set ProteinIdentifications
-    ProteinIdentification protId;
-    ProteinIdentification::SearchParameters param;
-    param.fragment_mass_tolerance_ppm = false;
-    param.fragment_mass_tolerance = 0.3;
-    protId.setSearchParameters(param);
-    fmap.setProteinIdentifications( {protId} );
+  //--------------------------------------------------------------------
+  // test with fragmentation method SORI, which is not supported
+  //--------------------------------------------------------------------
 
-    // MSExperiment
-    MSExperiment exp;
+  // PeptideIdentification with RT matching to MSSpectrum with fragmentation method SORI
+  std::vector<PeptideIdentification> sori_id({createPeptideIdentification("XTandem::5")});
 
-    // create b- and y-ion spectrum of peptide sequence HIMALAYA with charge 1
-    // shift every peak by 5 ppm
-    PeakSpectrum ms_spec_2_himalaya = createMSSpectrum(2, 3.7, "XTandem::1");
-    TheoreticalSpectrumGenerator theo_gen_hi;
-    theo_gen_hi.getSpectrum(ms_spec_2_himalaya, AASequence::fromString("HIMALAYA"), 1, 1);
-    for(Peak1D& peak : ms_spec_2_himalaya) peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
+  // MSExperiment with fragmentation method SORI (not supported)
+  exp.setSpectra({createMSSpectrum(2, 7, "XTandem::5", Precursor::ActivationMethod::SORI)});
+  spectra_map.calculateMap(exp);
 
-    // create c- and z-ion spectrum of peptide sequence ALABAMA with charge 2
-    // shift every peak by 5 ppm
-    PeakSpectrum ms_spec_2_alabama = createMSSpectrum(2, 2, "XTandem::2", Precursor::ActivationMethod::ECD);
-    TheoreticalSpectrumGenerator theo_gen_al;
-    Param theo_gen_settings_al = theo_gen_al.getParameters();
-    theo_gen_settings_al.setValue("add_c_ions", "true");
-    theo_gen_settings_al.setValue("add_z_ions", "true");
-    theo_gen_settings_al.setValue("add_b_ions", "false");
-    theo_gen_settings_al.setValue("add_y_ions", "false");
-    theo_gen_al.setParameters(theo_gen_settings_al);
-    theo_gen_al.getSpectrum(ms_spec_2_alabama, AASequence::fromString("ALABAMA"), 2, 2);
-    for(Peak1D& peak : ms_spec_2_alabama) peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
-    
-    // empty MSSpectrum
-    MSSpectrum ms_spec_empty;
+  TEST_EXCEPTION(Exception::InvalidParameter, frag_ma_err.compute(sori_id, param, exp, spectra_map))
 
-    // put valid data in exp
-    exp.setSpectra({ms_spec_empty, ms_spec_2_alabama, ms_spec_2_himalaya});
-    
-    // map the MSExperiment
-    QCBase::SpectraMap spectra_map(exp);
+  //--------------------------------------------------------------------
+  // test if spectrum has no peaks
+  //--------------------------------------------------------------------
 
-    //--------------------------------------------------------------------
-    // test with valid input - default parameter
-    //--------------------------------------------------------------------
-    frag_ma_err.compute(fmap, exp, spectra_map);
-    std::vector<FragmentMassError::Statistics> result = frag_ma_err.getResults();
+  // PeptideIdentification with RT matching to MSSpectrum with no peaks
+  std::vector<PeptideIdentification> no_peaks_id({createPeptideIdentification("XTandem::6")});
 
-    TEST_REAL_SIMILAR(result[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0)  // offset is constant, i.e. no variance
+  // MSExperiment without peaks
+  exp.setSpectra({createMSSpectrum(2, 4, "XTandem::6")});
+  spectra_map.calculateMap(exp);
 
-    //--------------------------------------------------------------------
-    // test with valid input - ToleranceUnit PPM
-    //--------------------------------------------------------------------
+  FragmentMassError frag_ma_err_excp;
+  frag_ma_err_excp.compute(no_peaks_id, param, exp, spectra_map);
+  std::vector<FragmentMassError::Statistics> result_excp;
+  result_excp = frag_ma_err_excp.getResults();
 
-    FragmentMassError frag_ma_err_ppm;
-    frag_ma_err_ppm.compute(fmap, exp, spectra_map, QCBase::ToleranceUnit::PPM, 6);
-    std::vector<FragmentMassError::Statistics> result_ppm = frag_ma_err_ppm.getResults();
+  TEST_REAL_SIMILAR(result_excp[0].average_ppm, 0)
+  TEST_REAL_SIMILAR(result_excp[0].variance_ppm, 0)
+}
+END_SECTION
 
-    TEST_REAL_SIMILAR(result_ppm[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result_ppm[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with valid input and flags
-    //--------------------------------------------------------------------
-    FragmentMassError frag_ma_err_flag_da;
-    frag_ma_err_flag_da.compute(fmap, exp, spectra_map, QCBase::ToleranceUnit::DA, 1);
-    std::vector<FragmentMassError::Statistics> result_flag_da = frag_ma_err_flag_da.getResults();
-
-    TEST_REAL_SIMILAR(result_flag_da[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result_flag_da[0].variance_ppm, 0.0)  // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with missing toleranceUnit and toleranceValue in featureMap
-    //--------------------------------------------------------------------
-
-    // featureMap with missing ProteinIdentifications
-    {
-      FeatureMap fmap_auto = fmap;
-      fmap_auto.getProteinIdentifications().clear();
-      TEST_EXCEPTION(Exception::MissingInformation, frag_ma_err.compute(fmap_auto, exp, spectra_map, QCBase::ToleranceUnit::AUTO))
-    }
-    
-    //--------------------------------------------------------------------
-    // test with no given fragmentation method
-    //--------------------------------------------------------------------
-    // create MSExperiment with no given fragmentation method
-    exp[0].setPrecursors({});
-    // falls back to CID
-    spectra_map.calculateMap(exp);
-    frag_ma_err.compute(fmap, exp, spectra_map);
-    TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].variance_ppm, 0.0)  // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with matching ms1 spectrum
-    //--------------------------------------------------------------------
-
-    // fmap with PeptideIdentification with RT matching to a MS1 Spectrum
-    fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::3")});
-
-    // set MS1 Spectrum to exp
-    exp.setSpectra({createMSSpectrum(1, 5, "XTandem::3")});
-    spectra_map.calculateMap(exp);
-
-    TEST_EXCEPTION(Exception::IllegalArgument, frag_ma_err.compute(fmap, exp, spectra_map))
-
-    //--------------------------------------------------------------------
-    // test with fragmentation method SORI, which is not supported
-    //--------------------------------------------------------------------
-
-    // put PeptideIdentification with RT matching to MSSpectrum with fragmentation method SORI to fmap
-    FeatureMap fmap_sori;
-    fmap_sori.setProteinIdentifications( {protId} );
-    fmap_sori.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::5")});
-
-    // MSExperiment with fragmentation method SORI (not supported)
-    exp.setSpectra({createMSSpectrum(2, 7, "XTandem::5", Precursor::ActivationMethod::SORI)});
-    spectra_map.calculateMap(exp);
-
-    TEST_EXCEPTION(Exception::InvalidParameter, frag_ma_err.compute(fmap_sori, exp, spectra_map))
-
-    //--------------------------------------------------------------------
-    // test if spectrum has no peaks
-    //--------------------------------------------------------------------
-
-    // put PeptideIdentification with RT matching to MSSpectrum with no peaks to fmap
-    fmap.setUnassignedPeptideIdentifications({createPeptideIdentification("XTandem::6")});
-
-    // MSExperiment without peaks
-    exp.setSpectra({createMSSpectrum(2, 4, "XTandem::6")});
-    spectra_map.calculateMap(exp);
-
-    FragmentMassError frag_ma_err_excp;
-    frag_ma_err_excp.compute(fmap, exp, spectra_map);
-    std::vector<FragmentMassError::Statistics> result_excp;
-    result_excp = frag_ma_err_excp.getResults();
-
-    TEST_REAL_SIMILAR(result_excp[0].average_ppm, 0)
-    TEST_REAL_SIMILAR(result_excp[0].variance_ppm, 0)
-  }
-  END_SECTION
-
-    //tests compute function with pepIDs
-  START_SECTION(void compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20));
-  {
-    //--------------------------------------------------------------------
-    // create valid input data
-    //--------------------------------------------------------------------
-    // Peptide Identifications
-    std::vector<PeptideIdentification> pep_ids;
-
-    // empty PeptideIdentification
-    PeptideIdentification pep_id_empty;
-    pep_id_empty.setRT(6);
-
-    // put valid data in fmap
-    pep_ids = { createPeptideIdentification("XTandem::1", "HIMALAYA", 1, 888), createPeptideIdentification("XTandem::2", "ALABAMA", 2, 264), pep_id_empty };
-
-    // Search Parameters
-    ProteinIdentification::SearchParameters param;
-    param.fragment_mass_tolerance_ppm = false;
-    param.fragment_mass_tolerance = 0.3;
-
-    // MSExperiment
-    MSExperiment exp;
-
-    // create b- and y-ion spectrum of peptide sequence HIMALAYA with charge 1
-    // shift every peak by 5 ppm
-    PeakSpectrum ms_spec_2_himalaya = createMSSpectrum(2, 3.7, "XTandem::1");
-    TheoreticalSpectrumGenerator theo_gen_hi;
-    theo_gen_hi.getSpectrum(ms_spec_2_himalaya, AASequence::fromString("HIMALAYA"), 1, 1);
-    for (Peak1D& peak : ms_spec_2_himalaya) peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
-
-    // create c- and z-ion spectrum of peptide sequence ALABAMA with charge 2
-    // shift every peak by 5 ppm
-    PeakSpectrum ms_spec_2_alabama = createMSSpectrum(2, 2, "XTandem::2", Precursor::ActivationMethod::ECD);
-    TheoreticalSpectrumGenerator theo_gen_al;
-    Param theo_gen_settings_al = theo_gen_al.getParameters();
-    theo_gen_settings_al.setValue("add_c_ions", "true");
-    theo_gen_settings_al.setValue("add_z_ions", "true");
-    theo_gen_settings_al.setValue("add_b_ions", "false");
-    theo_gen_settings_al.setValue("add_y_ions", "false");
-    theo_gen_al.setParameters(theo_gen_settings_al);
-    theo_gen_al.getSpectrum(ms_spec_2_alabama, AASequence::fromString("ALABAMA"), 2, 2);
-    for (Peak1D& peak : ms_spec_2_alabama) peak.setMZ(Math::ppmToMass(peak.getMZ(), 5.0) + peak.getMZ());
-
-    // empty MSSpectrum
-    MSSpectrum ms_spec_empty;
-
-    // put valid data in exp
-    exp.setSpectra({ ms_spec_empty, ms_spec_2_alabama, ms_spec_2_himalaya });
-
-    // map the MSExperiment
-    QCBase::SpectraMap spectra_map(exp);
-
-    //--------------------------------------------------------------------
-    // test with valid input - default parameter
-    //--------------------------------------------------------------------
-    frag_ma_err.compute(pep_ids, param, exp, spectra_map);
-    std::vector<FragmentMassError::Statistics> result = frag_ma_err.getResults();
-
-    TEST_REAL_SIMILAR(result[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result[0].variance_ppm, 0.0)  // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with valid input - ToleranceUnit PPM
-    //--------------------------------------------------------------------
-
-    FragmentMassError frag_ma_err_ppm;
-    frag_ma_err_ppm.compute(pep_ids, param, exp, spectra_map, FragmentMassError::ToleranceUnit::PPM, 6);
-    std::vector<FragmentMassError::Statistics> result_ppm = frag_ma_err_ppm.getResults();
-
-    TEST_REAL_SIMILAR(result_ppm[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result_ppm[0].variance_ppm, 0.0) // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with valid input and flags
-    //--------------------------------------------------------------------
-    FragmentMassError frag_ma_err_flag_da;
-    frag_ma_err_flag_da.compute(pep_ids, param, exp, spectra_map, FragmentMassError::ToleranceUnit::DA, 1);
-    std::vector<FragmentMassError::Statistics> result_flag_da = frag_ma_err_flag_da.getResults();
-
-    TEST_REAL_SIMILAR(result_flag_da[0].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(result_flag_da[0].variance_ppm, 0.0)  // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with missing toleranceUnit and toleranceValue in featureMap
-    //--------------------------------------------------------------------
-
-    // Search params without FME info
-    {
-      ProteinIdentification::SearchParameters empty_params;
-      TEST_EXCEPTION(Exception::MissingInformation, frag_ma_err.compute(pep_ids, empty_params, exp, spectra_map, FragmentMassError::ToleranceUnit::AUTO))
-    }
-
-    //--------------------------------------------------------------------
-    // test with no given fragmentation method
-    //--------------------------------------------------------------------
-    // create MSExperiment with no given fragmentation method
-    exp[0].setPrecursors({});
-    // falls back to CID
-    spectra_map.calculateMap(exp);
-    frag_ma_err.compute(pep_ids, param, exp, spectra_map);
-    TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].average_ppm, 5.0)
-    TEST_REAL_SIMILAR(frag_ma_err.getResults()[1].variance_ppm, 0.0)  // offset is constant, i.e. no variance
-
-    //--------------------------------------------------------------------
-    // test with matching ms1 spectrum
-    //--------------------------------------------------------------------
-
-    // PeptideIdentification with RT matching to a MS1 Spectrum
-    std::vector<PeptideIdentification> ms1_id({ createPeptideIdentification("XTandem::3") });
-
-    // set MS1 Spectrum to exp
-    exp.setSpectra({ createMSSpectrum(1, 5, "XTandem::3") });
-    spectra_map.calculateMap(exp);
-
-    TEST_EXCEPTION(Exception::IllegalArgument, frag_ma_err.compute(ms1_id, param, exp, spectra_map))
-
-    //--------------------------------------------------------------------
-    // test with fragmentation method SORI, which is not supported
-    //--------------------------------------------------------------------
-
-    // PeptideIdentification with RT matching to MSSpectrum with fragmentation method SORI
-    std::vector<PeptideIdentification> sori_id({ createPeptideIdentification("XTandem::5") });
-
-    // MSExperiment with fragmentation method SORI (not supported)
-    exp.setSpectra({ createMSSpectrum(2, 7, "XTandem::5", Precursor::ActivationMethod::SORI) });
-    spectra_map.calculateMap(exp);
-
-    TEST_EXCEPTION(Exception::InvalidParameter, frag_ma_err.compute(sori_id, param, exp, spectra_map))
-
-    //--------------------------------------------------------------------
-    // test if spectrum has no peaks
-    //--------------------------------------------------------------------
-
-    // PeptideIdentification with RT matching to MSSpectrum with no peaks
-    std::vector<PeptideIdentification> no_peaks_id({ createPeptideIdentification("XTandem::6") });
-
-    // MSExperiment without peaks
-    exp.setSpectra({ createMSSpectrum(2, 4, "XTandem::6") });
-    spectra_map.calculateMap(exp);
-
-    FragmentMassError frag_ma_err_excp;
-    frag_ma_err_excp.compute(no_peaks_id, param, exp, spectra_map);
-    std::vector<FragmentMassError::Statistics> result_excp;
-    result_excp = frag_ma_err_excp.getResults();
-
-    TEST_REAL_SIMILAR(result_excp[0].average_ppm, 0)
-    TEST_REAL_SIMILAR(result_excp[0].variance_ppm, 0)
-  }
-  END_SECTION
-
-  START_SECTION(const String& getName() const override)
-  {
-    TEST_EQUAL(frag_ma_err.getName(), "FragmentMassError")
-  }
-  END_SECTION
+START_SECTION(const String& getName() const override) {TEST_EQUAL(frag_ma_err.getName(), "FragmentMassError")} END_SECTION
 
 
   START_SECTION(QCBase::Status requirements() const override)
-  {
-    QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
-    TEST_EQUAL(frag_ma_err.requirements() == stat, true)
-  }
-  END_SECTION
+{
+  QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
+  TEST_EQUAL(frag_ma_err.requirements() == stat, true)
+}
+END_SECTION
 
 END_TEST
-
-

--- a/src/tests/class_tests/openms/source/MissedCleavages_test.cpp
+++ b/src/tests/class_tests/openms/source/MissedCleavages_test.cpp
@@ -227,9 +227,9 @@ START_TEST(MissedCleavages, "$Id$")
   END_SECTION
   
 
-  START_SECTION(QCBase::Status requires() const override)
+  START_SECTION(QCBase::Status requirements() const override)
   {
-    TEST_EQUAL(QCBase::Status(QCBase::Requires::POSTFDRFEAT) == mc.requires(), true)
+    TEST_EQUAL(QCBase::Status(QCBase::Requires::POSTFDRFEAT) == mc.requirements(), true)
   }
   END_SECTION
 

--- a/src/tests/class_tests/openms/source/MissedCleavages_test.cpp
+++ b/src/tests/class_tests/openms/source/MissedCleavages_test.cpp
@@ -44,8 +44,8 @@
 #include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
-#include <OpenMS/QC/QCBase.h>
 #include <OpenMS/QC/MissedCleavages.h>
+#include <OpenMS/QC/QCBase.h>
 #include <string>
 #include <vector>
 
@@ -58,181 +58,171 @@ START_TEST(MissedCleavages, "$Id$")
 /////////////////////////////////////////////////////////////
 
 
-  //construct PeptideHits
-  PeptideHit pep_hit_no_cut;
-  pep_hit_no_cut.setSequence(AASequence::fromString("AAAAAAAAAAAAAK"));
-  PeptideHit pep_hit_one_cut;
-  pep_hit_one_cut.setSequence(AASequence::fromString("AAAAKAAAAAR"));
-  PeptideHit pep_hit_three_cuts;
-  pep_hit_three_cuts.setSequence(AASequence::fromString("AAAKAAARAAAKAAAR"));
+// construct PeptideHits
+PeptideHit pep_hit_no_cut;
+pep_hit_no_cut.setSequence(AASequence::fromString("AAAAAAAAAAAAAK"));
+PeptideHit pep_hit_one_cut;
+pep_hit_one_cut.setSequence(AASequence::fromString("AAAAKAAAAAR"));
+PeptideHit pep_hit_three_cuts;
+pep_hit_three_cuts.setSequence(AASequence::fromString("AAAKAAARAAAKAAAR"));
 
-  //construct vectors of PeptideHits
-  std::vector<PeptideHit> pep_hits_0 = {pep_hit_no_cut};
-  std::vector<PeptideHit> pep_hits_1 = {pep_hit_one_cut};
-  std::vector<PeptideHit> pep_hits_3 = {pep_hit_three_cuts};
-  std::vector<PeptideHit> pep_hits_empty = {};
+// construct vectors of PeptideHits
+std::vector<PeptideHit> pep_hits_0 = {pep_hit_no_cut};
+std::vector<PeptideHit> pep_hits_1 = {pep_hit_one_cut};
+std::vector<PeptideHit> pep_hits_3 = {pep_hit_three_cuts};
+std::vector<PeptideHit> pep_hits_empty = {};
 
-  //construct PeptideIdentification with PeptideHits
-  PeptideIdentification pep_id_0;
-  pep_id_0.setHits(pep_hits_0);
-  PeptideIdentification pep_id_1;
-  pep_id_1.setHits(pep_hits_1);
-  PeptideIdentification pep_id_empty;
-  pep_id_empty.setHits(pep_hits_empty);
-  PeptideIdentification pep_id_3;
-  pep_id_3.setHits(pep_hits_3);
+// construct PeptideIdentification with PeptideHits
+PeptideIdentification pep_id_0;
+pep_id_0.setHits(pep_hits_0);
+PeptideIdentification pep_id_1;
+pep_id_1.setHits(pep_hits_1);
+PeptideIdentification pep_id_empty;
+pep_id_empty.setHits(pep_hits_empty);
+PeptideIdentification pep_id_3;
+pep_id_3.setHits(pep_hits_3);
 
-  //construct vectors of PeptideIdentifications
-  std::vector<PeptideIdentification> pep_ids = {pep_id_0, pep_id_1, pep_id_empty};
-  std::vector<PeptideIdentification> pep_ids_1 = {pep_id_1, pep_id_1};
-  std::vector<PeptideIdentification> pep_ids_empty{};
-  std::vector<PeptideIdentification> pep_ids_3 = {pep_id_3};
+// construct vectors of PeptideIdentifications
+std::vector<PeptideIdentification> pep_ids = {pep_id_0, pep_id_1, pep_id_empty};
+std::vector<PeptideIdentification> pep_ids_1 = {pep_id_1, pep_id_1};
+std::vector<PeptideIdentification> pep_ids_empty {};
+std::vector<PeptideIdentification> pep_ids_3 = {pep_id_3};
 
-  //construct features with peptideIdentifications
-  Feature feat_empty_pi;
-  feat_empty_pi.setPeptideIdentifications(pep_ids_empty);
-  feat_empty_pi.setMetaValue("FWHM", 32.21);
+// construct features with peptideIdentifications
+Feature feat_empty_pi;
+feat_empty_pi.setPeptideIdentifications(pep_ids_empty);
+feat_empty_pi.setMetaValue("FWHM", 32.21);
 
-  Feature feat;
-  feat.setPeptideIdentifications(pep_ids);
-  feat.setMetaValue("FWHM", 32.21);
+Feature feat;
+feat.setPeptideIdentifications(pep_ids);
+feat.setMetaValue("FWHM", 32.21);
 
-  Feature feat_empty;
-  feat_empty.setMetaValue("FWHM", 32.21);
+Feature feat_empty;
+feat_empty.setMetaValue("FWHM", 32.21);
 
-  Feature feat_3;
-  feat_3.setPeptideIdentifications(pep_ids_3);
-  feat_3.setMetaValue("FWHM", 32.21);
+Feature feat_3;
+feat_3.setPeptideIdentifications(pep_ids_3);
+feat_3.setMetaValue("FWHM", 32.21);
 
-  //FeatureMap
-  FeatureMap feature_map;
-  FeatureMap feature_map_3;
-  FeatureMap feature_map_empty;
-  FeatureMap feature_map_no_protein;
-  FeatureMap feature_map_no_enzyme;
+// FeatureMap
+FeatureMap feature_map;
+FeatureMap feature_map_3;
+FeatureMap feature_map_empty;
+FeatureMap feature_map_no_protein;
+FeatureMap feature_map_no_enzyme;
 
-  //stores data in the FeatureMaps
-  feature_map.push_back(feat_empty_pi);
-  feature_map.push_back(feat);
-  feature_map.push_back(feat_empty);
-  feature_map.setUnassignedPeptideIdentifications(pep_ids_1);
-  feature_map.getProteinIdentifications().resize(1);
-  feature_map.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance() -> getEnzyme("trypsin");
-  feature_map.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 2;
+// stores data in the FeatureMaps
+feature_map.push_back(feat_empty_pi);
+feature_map.push_back(feat);
+feature_map.push_back(feat_empty);
+feature_map.setUnassignedPeptideIdentifications(pep_ids_1);
+feature_map.getProteinIdentifications().resize(1);
+feature_map.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("trypsin");
+feature_map.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 2;
 
-  //FeatureMap with more missed cleavages than allowed
-  feature_map_3.push_back(feat_3);
-  feature_map_3.getProteinIdentifications().resize(1);
-  feature_map_3.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme.setName("trypsin");
-  feature_map_3.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 2;
+// FeatureMap with more missed cleavages than allowed
+feature_map_3.push_back(feat_3);
+feature_map_3.getProteinIdentifications().resize(1);
+feature_map_3.getProteinIdentifications()[0].getSearchParameters().digestion_enzyme.setName("trypsin");
+feature_map_3.getProteinIdentifications()[0].getSearchParameters().missed_cleavages = 2;
 
-  //FeatureMap without ProteinIdentifications
-  feature_map_no_protein.push_back(feat);
+// FeatureMap without ProteinIdentifications
+feature_map_no_protein.push_back(feat);
 
-  //FeatureMap without given enzyme
-  feature_map_no_enzyme.push_back(feat);
-  ProteinIdentification prot_id;
-  feature_map_no_enzyme.setProteinIdentifications({prot_id});
+// FeatureMap without given enzyme
+feature_map_no_enzyme.push_back(feat);
+ProteinIdentification prot_id;
+feature_map_no_enzyme.setProteinIdentifications({prot_id});
 
-  //////////////////////////////////////////////////////////////////
-  //start Section
-  /////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////
+// start Section
+/////////////////////////////////////////////////////////////////
 
-  MissedCleavages* ptr = nullptr;
-  MissedCleavages* nulpt = nullptr;
-  START_SECTION(MissedCleavages())
-  {
+MissedCleavages* ptr = nullptr;
+MissedCleavages* nulpt = nullptr;
+START_SECTION(MissedCleavages())
+{
   ptr = new MissedCleavages();
   TEST_NOT_EQUAL(ptr, nulpt)
-  }
-  END_SECTION
+}
+END_SECTION
 
 
-  START_SECTION(~MissedCleavages())
-  {
+START_SECTION(~MissedCleavages())
+{
   delete ptr;
-  }
-  END_SECTION
+}
+END_SECTION
 
 
-  //tests compute function
-  START_SECTION(void compute(FeatureMap& fmap))
-  {
-    //test with valid input
-    MissedCleavages mc;
-    mc.compute(feature_map);
-    auto result = mc.getResults();
-
-    TEST_EQUAL(result[0].size(),2)
-    TEST_EQUAL(result[0][0], 1)
-    TEST_EQUAL(result[0][1], 3)
-
-    std::vector<UInt32> frequ;
-
-    //test if result is stored as MetaInformation in PeptideHits in FeatureMap
-    auto lam =
-        [&frequ](PeptideIdentification& pep_id)
-    {
-      if(pep_id.getHits().empty())
-      {
-        return;
-      }
-      if (pep_id.getHits()[0].metaValueExists("missed_cleavages"))
-      {
-        frequ.push_back(pep_id.getHits()[0].getMetaValue("missed_cleavages"));
-      }
-    };
-
-    feature_map.applyFunctionOnPeptideIDs(lam);
-    TEST_EQUAL(frequ.size(), 4)
-    TEST_EQUAL(frequ[0], 0)
-    TEST_EQUAL(frequ[1], 1)
-    TEST_EQUAL(frequ[2], 1)
-    TEST_EQUAL(frequ[3], 1)
-
-    //empty feature map
-    MissedCleavages mc_empty;
-    mc_empty.compute(feature_map_empty);
-    auto result_empty = mc_empty.getResults();
-
-    TEST_EQUAL(result_empty[0].empty(), true)
-
-    //Missing informations in ProteinIdentifications
-    //fmap.getProteinIdentifications().empty()
-    MissedCleavages mc_no_protein;
-    TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, mc_no_protein.compute(feature_map_no_protein), "Missing information in ProteinIdentifications.")
-
-    //no given enzyme
-    //enzyme == "unknown_enzyme"
-    MissedCleavages mc_no_enzyme;
-    TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, mc_no_enzyme.compute(feature_map_no_enzyme), "No digestion enzyme in FeatureMap detected. No computation possible.")
-
-    //Number of missed cleavages is greater than the allowed maximum number of missed cleavages.
-    MissedCleavages mc_3;
-    mc_3.compute(feature_map_3);
-    auto result_3 = mc_3.getResults();
-
-    TEST_EQUAL(result_3[0].size(),1)
-    TEST_EQUAL(result_3[0][3], 1)
-  }
-  END_SECTION
-  
-
+// tests compute function
+START_SECTION(void compute(FeatureMap& fmap))
+{
+  // test with valid input
   MissedCleavages mc;
+  mc.compute(feature_map);
+  auto result = mc.getResults();
 
-  START_SECTION(const String& getName() const override)
-  {
-    TEST_EQUAL(mc.getName(), "MissedCleavages")
-  }
-  END_SECTION
-  
+  TEST_EQUAL(result[0].size(), 2)
+  TEST_EQUAL(result[0][0], 1)
+  TEST_EQUAL(result[0][1], 3)
 
-  START_SECTION(QCBase::Status requirements() const override)
-  {
-    TEST_EQUAL(QCBase::Status(QCBase::Requires::POSTFDRFEAT) == mc.requirements(), true)
-  }
-  END_SECTION
+  std::vector<UInt32> frequ;
 
-/////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////
-END_TEST
+  // test if result is stored as MetaInformation in PeptideHits in FeatureMap
+  auto lam = [&frequ](PeptideIdentification& pep_id) {
+    if (pep_id.getHits().empty())
+    {
+      return;
+    }
+    if (pep_id.getHits()[0].metaValueExists("missed_cleavages"))
+    {
+      frequ.push_back(pep_id.getHits()[0].getMetaValue("missed_cleavages"));
+    }
+  };
+
+  feature_map.applyFunctionOnPeptideIDs(lam);
+  TEST_EQUAL(frequ.size(), 4)
+  TEST_EQUAL(frequ[0], 0)
+  TEST_EQUAL(frequ[1], 1)
+  TEST_EQUAL(frequ[2], 1)
+  TEST_EQUAL(frequ[3], 1)
+
+  // empty feature map
+  MissedCleavages mc_empty;
+  mc_empty.compute(feature_map_empty);
+  auto result_empty = mc_empty.getResults();
+
+  TEST_EQUAL(result_empty[0].empty(), true)
+
+  // Missing informations in ProteinIdentifications
+  // fmap.getProteinIdentifications().empty()
+  MissedCleavages mc_no_protein;
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, mc_no_protein.compute(feature_map_no_protein), "Missing information in ProteinIdentifications.")
+
+  // no given enzyme
+  // enzyme == "unknown_enzyme"
+  MissedCleavages mc_no_enzyme;
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, mc_no_enzyme.compute(feature_map_no_enzyme), "No digestion enzyme in FeatureMap detected. No computation possible.")
+
+  // Number of missed cleavages is greater than the allowed maximum number of missed cleavages.
+  MissedCleavages mc_3;
+  mc_3.compute(feature_map_3);
+  auto result_3 = mc_3.getResults();
+
+  TEST_EQUAL(result_3[0].size(), 1)
+  TEST_EQUAL(result_3[0][3], 1)
+}
+END_SECTION
+
+
+MissedCleavages mc;
+
+START_SECTION(const String& getName() const override) {TEST_EQUAL(mc.getName(), "MissedCleavages")} END_SECTION
+
+
+  START_SECTION(QCBase::Status requirements() const override) {TEST_EQUAL(QCBase::Status(QCBase::Requires::POSTFDRFEAT) == mc.requirements(), true)} END_SECTION
+
+  /////////////////////////////////////////////////////////////
+  /////////////////////////////////////////////////////////////
+  END_TEST

--- a/src/tests/class_tests/openms/source/Ms2IdentificationRate_test.cpp
+++ b/src/tests/class_tests/openms/source/Ms2IdentificationRate_test.cpp
@@ -286,10 +286,10 @@ START_SECTION(const String& getName() const override)
 END_SECTION
 
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
   QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
-  TEST_EQUAL(stat == ms2ir.requires(), true)
+  TEST_EQUAL(stat == ms2ir.requirements(), true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Ms2IdentificationRate_test.cpp
+++ b/src/tests/class_tests/openms/source/Ms2IdentificationRate_test.cpp
@@ -49,14 +49,13 @@
 using namespace OpenMS;
 
 
-
 START_TEST(Ms2IdentificationRate, "$Id$")
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
 
-//construct PeptideHits
+// construct PeptideHits
 PeptideHit pep_hit1_t1;
 pep_hit1_t1.setMetaValue("target_decoy", "target");
 PeptideHit pep_hit1_t2;
@@ -65,13 +64,13 @@ PeptideHit pep_hit2_d;
 pep_hit2_d.setMetaValue("target_decoy", "decoy");
 PeptideHit pep_hit_fdr;
 
-//construct vectors of PeptideHits
+// construct vectors of PeptideHits
 std::vector<PeptideHit> pep_hits_target = {pep_hit1_t1, pep_hit1_t2};
 std::vector<PeptideHit> pep_hits_decoy = {pep_hit2_d};
 std::vector<PeptideHit> pep_hits_empty = {};
 std::vector<PeptideHit> pep_hits_fdr = {pep_hit_fdr};
 
-//construct Peptideidentification with PeptideHits
+// construct Peptideidentification with PeptideHits
 PeptideIdentification pep_id_target;
 pep_id_target.setHits(pep_hits_target);
 PeptideIdentification pep_id_decoy;
@@ -82,12 +81,12 @@ PeptideIdentification pep_id_fdr;
 pep_id_fdr.setHits(pep_hits_fdr);
 
 std::vector<PeptideIdentification> pep_ids = {pep_id_target, pep_id_decoy, pep_id_empty};
-std::vector<PeptideIdentification> pep_ids_empty{};
+std::vector<PeptideIdentification> pep_ids_empty {};
 std::vector<PeptideIdentification> pep_ids_fdr = {pep_id_fdr};
 
-std::vector<PeptideIdentification> two_target_ids = { pep_id_target, pep_id_target, pep_id_decoy, pep_id_empty };
+std::vector<PeptideIdentification> two_target_ids = {pep_id_target, pep_id_target, pep_id_decoy, pep_id_empty};
 
-//construct features with peptideIdentifications
+// construct features with peptideIdentifications
 Feature feat_empty_pi;
 feat_empty_pi.setPeptideIdentifications(pep_ids_empty);
 Feature feat_target;
@@ -96,7 +95,7 @@ Feature feat_empty;
 Feature feat_fdr;
 feat_fdr.setPeptideIdentifications(pep_ids_fdr);
 
-//construct FeatureMap
+// construct FeatureMap
 FeatureMap fmap;
 fmap.push_back(feat_empty_pi);
 fmap.push_back(feat_target);
@@ -110,7 +109,7 @@ FeatureMap fmap_empty;
 
 fmap.setUnassignedPeptideIdentifications(pep_ids);
 
-//construct MSSpectrum
+// construct MSSpectrum
 MSSpectrum ms2;
 ms2.setMSLevel(2);
 MSSpectrum ms1;
@@ -119,25 +118,24 @@ std::vector<MSSpectrum> ms_spectra = {ms2, ms2, ms2, ms2, ms2, ms2, ms1};
 std::vector<MSSpectrum> ms1_spectra = {ms1};
 std::vector<MSSpectrum> ms2_2_spectra = {ms2};
 
-//construct MSExperiment
+// construct MSExperiment
 MSExperiment ms_exp;
 ms_exp.setSpectra(ms_spectra);
 
-//construct MSExperiment without MS2 spectra
+// construct MSExperiment without MS2 spectra
 MSExperiment ms1_exp;
 ms1_exp.setSpectra(ms1_spectra);
 
-//construct MSExperiment with two MS2 spectra
+// construct MSExperiment with two MS2 spectra
 MSExperiment ms2_2_exp;
 ms2_2_exp.setSpectra(ms2_2_spectra);
 
-//construct empty MSExperiment
+// construct empty MSExperiment
 MSExperiment ms_empty_exp;
 
 
-
 //////////////////////////////////////////////////////////////////
-//start Section
+// start Section
 /////////////////////////////////////////////////////////////////
 
 Ms2IdentificationRate* ptr = nullptr;
@@ -164,10 +162,10 @@ Ms2IdentificationRate ms2ir_ms2_2;
 Ms2IdentificationRate ms2ir_empty_msexp;
 Ms2IdentificationRate ms2ir_empty_fmap;
 
-//tests compute function with FeatureMap
-START_SECTION(void compute(FeatureMap const & feature_map, MSExperiment const & exp, bool force_index = false))
+// tests compute function with FeatureMap
+START_SECTION(void compute(FeatureMap const& feature_map, MSExperiment const& exp, bool force_index = false))
 {
-  //test with valid input
+  // test with valid input
   ms2ir.compute(fmap, ms_exp);
   std::vector<Ms2IdentificationRate::IdentificationRateData> result;
   result = ms2ir.getResults();
@@ -176,16 +174,16 @@ START_SECTION(void compute(FeatureMap const & feature_map, MSExperiment const & 
   {
     TEST_EQUAL(idrd.num_peptide_identification, 2)
     TEST_EQUAL(idrd.num_ms2_spectra, 6)
-    TEST_REAL_SIMILAR(idrd.identification_rate, 1./3)
+    TEST_REAL_SIMILAR(idrd.identification_rate, 1. / 3)
   }
 
-  //less ms2 spectra than identifictions
+  // less ms2 spectra than identifictions
   TEST_EXCEPTION_WITH_MESSAGE(Exception::Precondition, ms2ir_ms2_2.compute(fmap, ms2_2_exp), "There are more Identifications than MS2 spectra. Please check your data.")
 
-  //empty ms experiment
+  // empty ms experiment
   TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, ms2ir_empty_msexp.compute(fmap, ms_empty_exp), "MSExperiment is empty")
 
-  //empty feature map
+  // empty feature map
   ms2ir_empty_fmap.compute(fmap_empty, ms_exp);
   std::vector<Ms2IdentificationRate::IdentificationRateData> result_empty_fmap;
   result_empty_fmap = ms2ir_empty_fmap.getResults();
@@ -197,7 +195,7 @@ START_SECTION(void compute(FeatureMap const & feature_map, MSExperiment const & 
     TEST_REAL_SIMILAR(idrd_empty_fmap.identification_rate, 0)
   }
 
-  //no fdr
+  // no fdr
   TEST_EXCEPTION_WITH_MESSAGE(Exception::Precondition, ms2ir_fdr.compute(fmap_fdr, ms_exp), "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target")
 
   // force no fdr
@@ -209,10 +207,10 @@ START_SECTION(void compute(FeatureMap const & feature_map, MSExperiment const & 
   {
     TEST_EQUAL(idrd_force_fdr.num_peptide_identification, 1)
     TEST_EQUAL(idrd_force_fdr.num_ms2_spectra, 6)
-    TEST_REAL_SIMILAR(idrd_force_fdr.identification_rate, 1./6)
+    TEST_REAL_SIMILAR(idrd_force_fdr.identification_rate, 1. / 6)
   }
 
-  //no ms2 spectra
+  // no ms2 spectra
   TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, ms2ir_ms1.compute(fmap, ms1_exp), "No MS2 spectra found")
 }
 END_SECTION
@@ -225,10 +223,10 @@ Ms2IdentificationRate id_rate_no_index;
 Ms2IdentificationRate id_rate_force_no_index;
 Ms2IdentificationRate id_rate_ms1;
 
-//tests compute function with PeptideIdentifications
+// tests compute function with PeptideIdentifications
 START_SECTION(void compute(const std::vector<PeptideIdentification>& pep_ids, const MSExperiment& exp, bool force_index = false))
 {
-  //test with valid input
+  // test with valid input
   id_rate.compute(pep_ids, ms_exp);
   std::vector<Ms2IdentificationRate::IdentificationRateData> result;
   result = id_rate.getResults();
@@ -240,13 +238,13 @@ START_SECTION(void compute(const std::vector<PeptideIdentification>& pep_ids, co
     TEST_REAL_SIMILAR(idrd.identification_rate, 1. / 6)
   }
 
-  //less ms2 spectra than identifictions
+  // less ms2 spectra than identifictions
   TEST_EXCEPTION_WITH_MESSAGE(Exception::Precondition, id_rate_one_ms2.compute(two_target_ids, ms2_2_exp), "There are more Identifications than MS2 spectra. Please check your data.")
 
-  //empty ms experiment
+  // empty ms experiment
   TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, id_rate_empty_exp.compute(pep_ids, ms_empty_exp), "MSExperiment is empty")
 
-  //empty feature map
+  // empty feature map
   id_rate_no_ids.compute(pep_ids_empty, ms_exp);
   std::vector<Ms2IdentificationRate::IdentificationRateData> result_no_pep_ids;
   result_no_pep_ids = id_rate_no_ids.getResults();
@@ -258,8 +256,9 @@ START_SECTION(void compute(const std::vector<PeptideIdentification>& pep_ids, co
     TEST_REAL_SIMILAR(idrd_empty_fmap.identification_rate, 0)
   }
 
-  //no fdr
-  TEST_EXCEPTION_WITH_MESSAGE(Exception::Precondition, id_rate_no_index.compute(pep_ids_fdr, ms_exp), "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target")
+  // no fdr
+  TEST_EXCEPTION_WITH_MESSAGE(Exception::Precondition, id_rate_no_index.compute(pep_ids_fdr, ms_exp),
+                              "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target")
 
   // force no fdr
   id_rate_force_no_index.compute(pep_ids_fdr, ms_exp, true);
@@ -273,20 +272,16 @@ START_SECTION(void compute(const std::vector<PeptideIdentification>& pep_ids, co
     TEST_REAL_SIMILAR(idrd_force_fdr.identification_rate, 1. / 6)
   }
 
-  //no ms2 spectra
+  // no ms2 spectra
   TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, id_rate_ms1.compute(pep_ids, ms1_exp), "No MS2 spectra found")
 }
 END_SECTION
 
 
-START_SECTION(const String& getName() const override)
-{
-  TEST_EQUAL(ms2ir.getName(), "Ms2IdentificationRate")
-}
-END_SECTION
+START_SECTION(const String& getName() const override) {TEST_EQUAL(ms2ir.getName(), "Ms2IdentificationRate")} END_SECTION
 
 
-START_SECTION(QCBase::Status requirements() const override)
+  START_SECTION(QCBase::Status requirements() const override)
 {
   QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
   TEST_EQUAL(stat == ms2ir.requirements(), true)

--- a/src/tests/class_tests/openms/source/Ms2SpectrumStats_test.cpp
+++ b/src/tests/class_tests/openms/source/Ms2SpectrumStats_test.cpp
@@ -1,32 +1,32 @@
 // --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
+//                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
 // ETH Zurich, and Freie Universitaet Berlin 2002-2022.
-// 
+//
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
 //    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
+// For a full list of authors, refer to the file AUTHORS.
 // --------------------------------------------------------------------------
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow $
 // $Authors: Juliane Schmachtenberg, Chris Bielow $
@@ -37,11 +37,11 @@
 
 ///////////////////////////
 
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/QC/Ms2SpectrumStats.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/METADATA/DataProcessing.h>
+#include <OpenMS/QC/Ms2SpectrumStats.h>
 
 ///////////////////////////
 
@@ -70,13 +70,9 @@ START_SECTION(~Ms2SpectrumStats())
 END_SECTION
 
 Ms2SpectrumStats top;
-START_SECTION(const String& getName() const override)
-{
-  TEST_EQUAL(top.getName(), "Ms2SpectrumStats")
-}
-END_SECTION
+START_SECTION(const String& getName() const override) {TEST_EQUAL(top.getName(), "Ms2SpectrumStats")} END_SECTION
 
-START_SECTION(QCBase::Status requirements() const override)
+  START_SECTION(QCBase::Status requirements() const override)
 {
   TEST_EQUAL(top.requirements() == (QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT), true);
 }
@@ -84,40 +80,40 @@ END_SECTION
 
 START_SECTION(compute(const MSExperiment& exp, FeatureMap& features, const QCBase::SpectraMap& map_to_spectrum))
 {
-  //Valid FeatureMap
+  // Valid FeatureMap
   FeatureMap fmap;
   PeptideIdentification peptide_ID;
   vector<PeptideIdentification> identifications;
   vector<PeptideIdentification> unassignedIDs;
   Feature f1;
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::0");
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::0");
   identifications.push_back(peptide_ID);
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::1");
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::1");
   identifications.push_back(peptide_ID);
   f1.setPeptideIdentifications(identifications);
   identifications.clear();
   fmap.push_back(f1);
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::10");
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::10");
   identifications.push_back(peptide_ID);
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::12");
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::12");
   identifications.push_back(peptide_ID);
   f1.setPeptideIdentifications(identifications);
   fmap.push_back(f1);
-  //unassigned PeptideHits
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::1.5");
+  // unassigned PeptideHits
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::1.5");
   unassignedIDs.push_back(peptide_ID);
-  peptide_ID.setMetaValue("spectrum_reference","XTandem::2.5");
+  peptide_ID.setMetaValue("spectrum_reference", "XTandem::2.5");
   unassignedIDs.push_back(peptide_ID);
   fmap.setUnassignedPeptideIdentifications(unassignedIDs);
 
-  //MSExperiment
+  // MSExperiment
   PeakMap exp;
   MSSpectrum spec;
   Peak1D p;
   Precursor pre;
   pre.setMZ(5.5);
-  std::vector< MSSpectrum> spectra;
-  spec.setPrecursors({ pre });
+  std::vector<MSSpectrum> spectra;
+  spec.setPrecursors({pre});
 
   spec.setMSLevel(2);
   spec.setRT(0);
@@ -177,7 +173,7 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features, const QCBas
   spectra.push_back(spec);
   spec.clear(false);
 
-  //not identified
+  // not identified
   spec.setRT(20);
   spec.setNativeID("XTandem::20");
   p.setIntensity(5);
@@ -194,7 +190,7 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features, const QCBas
   vector<PeptideIdentification> new_unassigned_pep_ids;
   new_unassigned_pep_ids = top.compute(exp, fmap, map_to_spectrum);
 
-  //test features
+  // test features
   TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getMetaValue("ScanEventNumber"), 1);
   TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getMetaValue("identified"), 1);
   TEST_EQUAL(fmap[0].getPeptideIdentifications()[1].getMetaValue("ScanEventNumber"), 1);
@@ -204,7 +200,7 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features, const QCBas
   TEST_REAL_SIMILAR(fmap[1].getPeptideIdentifications()[1].getMetaValue("total_ion_count"), 10);
   TEST_REAL_SIMILAR(fmap[1].getPeptideIdentifications()[1].getMetaValue("base_peak_intensity"), 9);
   TEST_EQUAL(fmap[1].getPeptideIdentifications()[1].getMetaValue("ScanEventNumber"), 2);
-  //test unassigned
+  // test unassigned
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("ScanEventNumber"), 2);
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("identified"), 1);
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getMetaValue("ScanEventNumber"), 3);
@@ -216,18 +212,18 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features, const QCBas
   TEST_REAL_SIMILAR(new_unassigned_pep_ids[0].getMZ(), 5.5);
 
   // empty FeatureMap
-  FeatureMap fmap_empty{};
+  FeatureMap fmap_empty {};
   new_unassigned_pep_ids = top.compute(exp, fmap_empty, map_to_spectrum);
   TEST_EQUAL(new_unassigned_pep_ids.size(), 7);
 
   // empty PeptideIdentifications
   fmap_empty.clear();
   fmap_empty.push_back(f1); // need some non-empty feature
-  fmap_empty.setUnassignedPeptideIdentifications( {} );
+  fmap_empty.setUnassignedPeptideIdentifications({});
   new_unassigned_pep_ids = top.compute(exp, fmap_empty, map_to_spectrum);
   TEST_EQUAL(new_unassigned_pep_ids.size(), 5);
   // empty MSExperiment
-  PeakMap exp_empty{};
+  PeakMap exp_empty {};
   TEST_EXCEPTION(Exception::MissingInformation, top.compute(exp_empty, fmap, map_to_spectrum));
 
   // test exception PepID without 'spectrum_reference'
@@ -240,4 +236,3 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-

--- a/src/tests/class_tests/openms/source/Ms2SpectrumStats_test.cpp
+++ b/src/tests/class_tests/openms/source/Ms2SpectrumStats_test.cpp
@@ -76,9 +76,9 @@ START_SECTION(const String& getName() const override)
 }
 END_SECTION
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
-  TEST_EQUAL(top.requires() == (QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT), true);
+  TEST_EQUAL(top.requirements() == (QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MzCalibration_test.cpp
+++ b/src/tests/class_tests/openms/source/MzCalibration_test.cpp
@@ -35,10 +35,10 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 ///////////////////////////
-#include <OpenMS/QC/MzCalibration.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/DataProcessing.h>
+#include <OpenMS/QC/MzCalibration.h>
 ///////////////////////////
 
 START_TEST(MzCalibration, "$Id$")
@@ -61,8 +61,8 @@ END_SECTION
 
 START_SECTION(QCBase::Status requirements() const override)
 {
-    MzCalibration mzCal;
-    TEST_EQUAL(mzCal.requirements() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
+  MzCalibration mzCal;
+  TEST_EQUAL(mzCal.requirements() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 
@@ -70,22 +70,22 @@ END_SECTION
 PeakMap exp;
 MSSpectrum spec;
 Precursor pre;
-std::vector< MSSpectrum> spectra;
+std::vector<MSSpectrum> spectra;
 pre.setMetaValue("mz_raw", 5);
 spec.setMSLevel(2);
-spec.setPrecursors({ pre });
+spec.setPrecursors({pre});
 spec.setRT(0);
 spec.setNativeID("XTandem::1");
 spectra.push_back(spec);
 
 pre.setMetaValue("mz_raw", 6);
-spec.setPrecursors({ pre });
+spec.setPrecursors({pre});
 spec.setRT(0.5);
 spec.setNativeID("XTandem::2");
 spectra.push_back(spec);
 
 pre.setMetaValue("mz_raw", 7);
-spec.setPrecursors({ pre });
+spec.setPrecursors({pre});
 spec.setRT(1);
 spec.setNativeID("XTandem::3");
 spectra.push_back(spec);
@@ -96,8 +96,8 @@ MSExperiment exp_no_calibration = exp;
 
 // adding processing info
 DataProcessing p;
-p.setProcessingActions({ OpenMS::DataProcessing::CALIBRATION });
-boost::shared_ptr< DataProcessing > p_(new DataProcessing(p));
+p.setProcessingActions({OpenMS::DataProcessing::CALIBRATION});
+boost::shared_ptr<DataProcessing> p_(new DataProcessing(p));
 for (Size i = 0; i < exp.size(); ++i)
 {
   exp[i].getDataProcessing().push_back(p_);
@@ -108,7 +108,7 @@ for (Size i = 0; i < exp.getNrChromatograms(); ++i)
 }
 QCBase::SpectraMap spectra_map(exp);
 
-//FeatureMap
+// FeatureMap
 FeatureMap fmap_ref;
 PeptideHit peptide_hit;
 std::vector<PeptideHit> peptide_hits;
@@ -122,7 +122,7 @@ peptide_hits.push_back(peptide_hit);
 peptide_ID.setHits(peptide_hits);
 peptide_ID.setRT(0);
 peptide_ID.setMZ(5.5);
-peptide_ID.setMetaValue("spectrum_reference","XTandem::1");
+peptide_ID.setMetaValue("spectrum_reference", "XTandem::1");
 identifications.push_back(peptide_ID);
 peptide_hits.clear();
 peptide_hit.setSequence(AASequence::fromString("WWWW"));
@@ -130,23 +130,23 @@ peptide_hit.setCharge(3);
 peptide_hits.push_back(peptide_hit);
 peptide_ID.setHits(peptide_hits);
 peptide_ID.setRT(1);
-peptide_ID.setMetaValue("spectrum_reference","XTandem::3");
+peptide_ID.setMetaValue("spectrum_reference", "XTandem::3");
 identifications.push_back(peptide_ID);
 peptide_hits.clear();
 feature1.setPeptideIdentifications(identifications);
 fmap_ref.push_back(feature1);
-//unassigned PeptideHits
+// unassigned PeptideHits
 peptide_hit.setSequence(AASequence::fromString("YYYY"));
 peptide_hit.setCharge(2);
 peptide_hits.push_back(peptide_hit);
 peptide_ID.setHits(peptide_hits);
 peptide_hits.clear();
 peptide_ID.setRT(0.5);
-peptide_ID.setMetaValue("spectrum_reference","XTandem::2");
+peptide_ID.setMetaValue("spectrum_reference", "XTandem::2");
 unassignedIDs.push_back(peptide_ID);
 fmap_ref.setUnassignedPeptideIdentifications(unassignedIDs);
 MzCalibration cal;
-//tests compute function
+// tests compute function
 START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const QCBase::SpectraMap map_to_spectrum))
 {
   FeatureMap fmap = fmap_ref;
@@ -160,7 +160,7 @@ START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const 
   ABORT_IF(fmap.getUnassignedPeptideIdentifications().size() != 1);
   ABORT_IF(fmap.getUnassignedPeptideIdentifications()[0].getHits().size() != 1);
   // things that should now be there
-  for (const Feature& f:fmap)
+  for (const Feature& f : fmap)
   {
     for (const PeptideIdentification& pepID : f.getPeptideIdentifications())
     {
@@ -176,41 +176,41 @@ START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const 
     ABORT_IF(!upepID.getHits()[0].metaValueExists("mz_ref"));
   }
 
-  //test with valid input
+  // test with valid input
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("mz_raw"), 5);
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[1].getHits()[0].getMetaValue("mz_raw"), 7);
-  //test unassigned
+  // test unassigned
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("mz_raw"), 6);
 
-  //test refMZ
+  // test refMZ
   double ref = AASequence::fromString("AAAA").getMonoWeight(OpenMS::Residue::Full, 2) / 2;
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("mz_ref"), ref);
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[1].getHits()[0].getMetaValue("mz_ref"), AASequence::fromString("WWWW").getMonoWeight(OpenMS::Residue::Full, 3) / 3);
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[0].getHits()[0].getMetaValue("mz_ref"), AASequence::fromString("YYYY").getMonoWeight(OpenMS::Residue::Full, 2) / 2);
 
-  //test  mz_error
-  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"),(5-ref)/ref*1000000);
-  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("calibrated_mz_error_ppm"), (5.5-ref)/ref*1000000);
+  // test  mz_error
+  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"), (5 - ref) / ref * 1000000);
+  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("calibrated_mz_error_ppm"), (5.5 - ref) / ref * 1000000);
 
   // test empty MSExperiment
-  MSExperiment exp_empty{};
+  MSExperiment exp_empty {};
   QCBase::SpectraMap spectra_map_empty(exp_empty);
   fmap = fmap_ref; // reset FeatureMap
   cal.compute(fmap, exp_empty, spectra_map_empty);
-  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"), (5.5-ref)/ref*1000000);
+  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"), (5.5 - ref) / ref * 1000000);
 
   // test with exp where no calibration was performed
   fmap = fmap_ref;
   cal.compute(fmap, exp_no_calibration, spectra_map);
-  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"), (5.5-ref)/ref*1000000);
+  TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getHits()[0].getMetaValue("uncalibrated_mz_error_ppm"), (5.5 - ref) / ref * 1000000);
 
   // test empty FeatureMap
-  FeatureMap fmap_empty{};
+  FeatureMap fmap_empty {};
   cal.compute(fmap_empty, exp, spectra_map);
   TEST_EQUAL(fmap_empty.isMetaEmpty(), true);
 
   // test feature is empty
-  Feature feature_empty{};
+  Feature feature_empty {};
   fmap_empty.push_back(feature_empty);
   cal.compute(fmap_empty, exp, spectra_map);
   TEST_EQUAL(fmap_empty.isMetaEmpty(), true);
@@ -226,7 +226,7 @@ START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const 
 
   // test empty hit
   fmap_empty.clear();
-  peptide_ID.setHits(std::vector<PeptideHit>{});
+  peptide_ID.setHits(std::vector<PeptideHit> {});
   identifications.clear();
   identifications.push_back(peptide_ID);
   feature1.setPeptideIdentifications(identifications);
@@ -236,13 +236,13 @@ START_SECTION(void compute(FeatureMap& features, const MSExperiment& exp, const 
 
   // test wrong MS-Level exception
   fmap = fmap_ref; // reset FeatureMap
-  fmap[0].getPeptideIdentifications()[0].setMetaValue("spectrum_reference","XTandem::4");
+  fmap[0].getPeptideIdentifications()[0].setMetaValue("spectrum_reference", "XTandem::4");
   exp.getSpectra()[0].setNativeID("XTandem::4");
   exp.getSpectra()[0].setMSLevel(1);
   spectra_map.calculateMap(exp);
   TEST_EXCEPTION_WITH_MESSAGE(Exception::IllegalArgument, cal.compute(fmap, exp, spectra_map), "The matching spectrum of the mzML is not an MS2 Spectrum.");
 
-  //test exception PepID without 'spectrum_reference'
+  // test exception PepID without 'spectrum_reference'
   fmap = fmap_ref; // reset FeatureMap
   PeptideIdentification pep_no_spec_ref;
   PeptideHit dummy_hit;

--- a/src/tests/class_tests/openms/source/MzCalibration_test.cpp
+++ b/src/tests/class_tests/openms/source/MzCalibration_test.cpp
@@ -59,10 +59,10 @@ START_SECTION(~MzCalibration())
 delete ptr;
 END_SECTION
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
     MzCalibration mzCal;
-    TEST_EQUAL(mzCal.requires() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
+    TEST_EQUAL(mzCal.requirements() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
+++ b/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
@@ -36,11 +36,10 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-#include <OpenMS/QC/PSMExplainedIonCurrent.h>
-
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
+#include <OpenMS/QC/PSMExplainedIonCurrent.h>
 #include <cmath>
 #include <random>
 //////////////////////////
@@ -55,7 +54,7 @@ void addRandomPeaks(MSSpectrum& spec, double total_intensity = 1.0, Int number_o
 {
   double peak_intensity = total_intensity / number_of_peaks;
   spec.sortByPosition();
-  std::uniform_real_distribution<> distr((*spec.begin()).getMZ(), (*(spec.end()-1)).getMZ());
+  std::uniform_real_distribution<> distr((*spec.begin()).getMZ(), (*(spec.end() - 1)).getMZ());
   for (Int i = 0; i < number_of_peaks; ++i)
   {
     spec.emplace_back(distr(gen), peak_intensity);
@@ -80,7 +79,8 @@ const MSSpectrum createMSSpectrum(UInt ms_level, double rt, const String& id, Pr
 }
 
 // create a MSSpectrum with Precursor, MSLevel, RT and fill it with Peaks
-const MSSpectrum createMSSpectrum(UInt ms_level, double rt, const String& id, const AASequence& seq, Int charge, const Param& theo_gen_params, Precursor::ActivationMethod precursor_method = Precursor::ActivationMethod::CID)
+const MSSpectrum createMSSpectrum(UInt ms_level, double rt, const String& id, const AASequence& seq, Int charge, const Param& theo_gen_params,
+                                  Precursor::ActivationMethod precursor_method = Precursor::ActivationMethod::CID)
 {
   MSSpectrum ms_spec;
   ms_spec.setRT(rt);
@@ -88,7 +88,8 @@ const MSSpectrum createMSSpectrum(UInt ms_level, double rt, const String& id, co
   ms_spec.setNativeID(id);
 
   TheoreticalSpectrumGenerator t;
-  if (!theo_gen_params.empty()) t.setParameters(theo_gen_params);
+  if (!theo_gen_params.empty())
+    t.setParameters(theo_gen_params);
 
   t.getSpectrum(ms_spec, seq, 1, charge <= 2 ? 1 : 2);
   std::set<Precursor::ActivationMethod> am;
@@ -140,7 +141,7 @@ addRandomPeaks(ms_spec_2_alabama, 5.0); // add 5 to 10 -> correctness should be 
 MSSpectrum empty_spec;
 
 MSExperiment exp;
-exp.setSpectra({ empty_spec, ms_spec_2_alabama, ms_spec_2_himalaya });
+exp.setSpectra({empty_spec, ms_spec_2_alabama, ms_spec_2_himalaya});
 
 // MSExperiment with no given fragmentation method (falls back to CID)
 MSExperiment exp_no_pc(exp);
@@ -216,7 +217,7 @@ START_SECTION(void compute(FeatureMap& fmap, const MSExperiment& exp, const QCBa
   psm_corr.compute(fmap, exp, spectra_map);
   std::vector<PSMExplainedIonCurrent::Statistics> result = psm_corr.getResults();
 
-  TEST_REAL_SIMILAR(result[0].average_correctness, (13./20 + 10./15) / 2.)
+  TEST_REAL_SIMILAR(result[0].average_correctness, (13. / 20 + 10. / 15) / 2.)
   TEST_REAL_SIMILAR(result[0].variance_correctness, 0.000138)
 
   //--------------------------------------------------------------------
@@ -300,7 +301,8 @@ START_SECTION(void compute(FeatureMap& fmap, const MSExperiment& exp, const QCBa
 }
 END_SECTION
 
-START_SECTION(compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum, ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20))
+START_SECTION(compute(std::vector<PeptideIdentification>& pep_ids, const ProteinIdentification::SearchParameters& search_params, const MSExperiment& exp, const QCBase::SpectraMap& map_to_spectrum,
+                      ToleranceUnit tolerance_unit = ToleranceUnit::AUTO, double tolerance = 20))
 {
   spectra_map.calculateMap(exp);
   //--------------------------------------------------------------------
@@ -410,4 +412,3 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-

--- a/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
+++ b/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
@@ -400,10 +400,10 @@ START_SECTION(const std::vector<Statistics>& getResults() const)
 }
 END_SECTION
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
   QCBase::Status stat = QCBase::Status() | QCBase::Requires::RAWMZML | QCBase::Requires::POSTFDRFEAT;
-  TEST_EQUAL(psm_corr.requires() == stat, true)
+  TEST_EQUAL(psm_corr.requirements() == stat, true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeptideMass_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideMass_test.cpp
@@ -35,9 +35,8 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 ///////////////////////////
-#include <OpenMS/QC/PeptideMass.h>
-
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/QC/PeptideMass.h>
 
 ///////////////////////////
 

--- a/src/tests/class_tests/openms/source/PeptideMass_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideMass_test.cpp
@@ -80,10 +80,10 @@ START_SECTION(void compute(FeatureMap& features))
 }
 END_SECTION
 
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
   PeptideMass fw;
-  TEST_EQUAL(fw.requires() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
+  TEST_EQUAL(fw.requirements() == (QCBase::Status() | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/RTAlignment_test.cpp
+++ b/src/tests/class_tests/openms/source/RTAlignment_test.cpp
@@ -69,9 +69,9 @@ START_SECTION(~RTAlignment())
 END_SECTION
 
 RTAlignment rtA;
-START_SECTION(QCBase::Status requires() const override)
+START_SECTION(QCBase::Status requirements() const override)
 {
-  TEST_EQUAL(rtA.requires() == (QCBase::Status() | QCBase::Requires::TRAFOALIGN | QCBase::Requires::POSTFDRFEAT), true);
+  TEST_EQUAL(rtA.requirements() == (QCBase::Status() | QCBase::Requires::TRAFOALIGN | QCBase::Requires::POSTFDRFEAT), true);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/RTAlignment_test.cpp
+++ b/src/tests/class_tests/openms/source/RTAlignment_test.cpp
@@ -1,32 +1,32 @@
 // --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
+//                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
 // ETH Zurich, and Freie Universitaet Berlin 2002-2022.
-// 
+//
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
 //    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
+// For a full list of authors, refer to the file AUTHORS.
 // --------------------------------------------------------------------------
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow
 // $Authors: Juliane Schmachtenberg $
@@ -37,11 +37,11 @@
 
 ///////////////////////////
 
-#include <OpenMS/KERNEL/FeatureMap.h>
-#include <OpenMS/QC/RTAlignment.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/QC/RTAlignment.h>
 ///////////////////////////
 
 START_TEST(RTAlignment, "$Id$");
@@ -75,15 +75,11 @@ START_SECTION(QCBase::Status requirements() const override)
 }
 END_SECTION
 
-START_SECTION(const String& getName() const override)
-{
-  TEST_EQUAL(rtA.getName(), "RTAlignment")
-}
-END_SECTION
+START_SECTION(const String& getName() const override) {TEST_EQUAL(rtA.getName(), "RTAlignment")} END_SECTION
 
-START_SECTION((compute(FeatureMap& features, TransformationDescription& trafo)))
+  START_SECTION((compute(FeatureMap & features, TransformationDescription& trafo)))
 {
-  //Valid FeatureMap
+  // Valid FeatureMap
   FeatureMap fmap;
   PeptideIdentification peptide_ID;
   vector<PeptideIdentification> identifications;
@@ -102,57 +98,57 @@ START_SECTION((compute(FeatureMap& features, TransformationDescription& trafo)))
   identifications.push_back(peptide_ID);
   feature2.setPeptideIdentifications(identifications);
   fmap.push_back(feature2);
-  //unassigned PeptideHits
+  // unassigned PeptideHits
   peptide_ID.setRT(0.5);
   unassignedIDs.push_back(peptide_ID);
   peptide_ID.setRT(2.5);
   unassignedIDs.push_back(peptide_ID);
   fmap.setUnassignedPeptideIdentifications(unassignedIDs);
 
-  //Transformation
+  // Transformation
   TransformationDescription td;
   td.fitModel("identity", Param());
-  td.setDataPoints(vector<pair<double, double> > { { 0.0, 1.0 } , { 0.25, 1.5 }, { 0.5, 2.0 }, { 1.0, 3.0 } });
+  td.setDataPoints(vector<pair<double, double>> {{0.0, 1.0}, {0.25, 1.5}, {0.5, 2.0}, {1.0, 3.0}});
   td.fitModel("linear");
   RTAlignment rtA;
   rtA.compute(fmap, td);
-  //test features
+  // test features
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getMetaValue("rt_align"), 1);
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[0].getMetaValue("rt_raw"), 0);
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[1].getMetaValue("rt_align"), 3);
   TEST_REAL_SIMILAR(fmap[0].getPeptideIdentifications()[1].getMetaValue("rt_raw"), 1);
   TEST_REAL_SIMILAR(fmap[1].getPeptideIdentifications()[0].getMetaValue("rt_align"), 21);
   TEST_REAL_SIMILAR(fmap[1].getPeptideIdentifications()[0].getMetaValue("rt_raw"), 10);
-  //test unassigned
+  // test unassigned
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("rt_align"), 2);
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("rt_raw"), 0.5);
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[1].getMetaValue("rt_align"), 6);
   TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[1].getMetaValue("rt_raw"), 2.5);
 
-  //empty FeatureMap
-  FeatureMap fmap_empty{};
+  // empty FeatureMap
+  FeatureMap fmap_empty {};
   rtA.compute(fmap_empty, td);
-  //empty feature
-  Feature feature_empty{};
+  // empty feature
+  Feature feature_empty {};
   fmap_empty.push_back(feature_empty);
   rtA.compute(fmap_empty, td);
-  //empty PeptideIdentifications
+  // empty PeptideIdentifications
   identifications.clear();
   feature1.setPeptideIdentifications(identifications);
   fmap_empty.push_back(feature1);
   rtA.compute(fmap_empty, td);
-  //empty PeptideIdentification
-  PeptideIdentification peptide_ID_empty{};
+  // empty PeptideIdentification
+  PeptideIdentification peptide_ID_empty {};
   identifications.push_back(peptide_ID_empty);
   feature1.setPeptideIdentifications(identifications);
   fmap_empty.push_back(feature1);
   rtA.compute(fmap_empty, td);
 
-  //data processing: after alignment
-  DataProcessing processing_method{};
-  std::set<DataProcessing::ProcessingAction> dp{ DataProcessing::ProcessingAction::ALIGNMENT };
+  // data processing: after alignment
+  DataProcessing processing_method {};
+  std::set<DataProcessing::ProcessingAction> dp {DataProcessing::ProcessingAction::ALIGNMENT};
   processing_method.setProcessingActions(dp);
-  fmap.setDataProcessing({ processing_method });
+  fmap.setDataProcessing({processing_method});
   TEST_EXCEPTION_WITH_MESSAGE(Exception::IllegalArgument, rtA.compute(fmap, td), "Metric RTAlignment received a featureXML AFTER map alignment, but needs a featureXML BEFORE map alignment!");
 }
 END_SECTION
@@ -160,4 +156,3 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-

--- a/src/tests/class_tests/openms/source/TIC_test.cpp
+++ b/src/tests/class_tests/openms/source/TIC_test.cpp
@@ -37,8 +37,8 @@
 
 ///////////////////////////
 
-#include <OpenMS/QC/TIC.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/QC/TIC.h>
 
 ///////////////////////////
 
@@ -52,27 +52,27 @@ using namespace std;
 TIC* ptr = nullptr;
 TIC* nullPointer = nullptr;
 START_SECTION(TIC())
-  ptr = new TIC();
-  TEST_NOT_EQUAL(ptr, nullPointer)
+ptr = new TIC();
+TEST_NOT_EQUAL(ptr, nullPointer)
 END_SECTION
 
 START_SECTION(~TIC())
-  delete ptr;
+delete ptr;
 END_SECTION
 
 TIC tic;
 START_SECTION(const String& getName() const override)
-  TEST_EQUAL(tic.getName(), "TIC")
+TEST_EQUAL(tic.getName(), "TIC")
 END_SECTION
 
 START_SECTION(Status requirements() const override)
-  TEST_EQUAL((tic.requirements() == QCBase::Status(QCBase::Requires::RAWMZML)),true);
+TEST_EQUAL((tic.requirements() == QCBase::Status(QCBase::Requires::RAWMZML)), true);
 END_SECTION
 
-START_SECTION(void compute(const MSExperiment &exp, float bin_size))
-  // very simple test ATM, check if compute returns an empty Result struct
-  MSExperiment exp;
-  TEST_EQUAL(tic.compute(exp, 0) == TIC::Result(), true)
+START_SECTION(void compute(const MSExperiment& exp, float bin_size))
+// very simple test ATM, check if compute returns an empty Result struct
+MSExperiment exp;
+TEST_EQUAL(tic.compute(exp, 0) == TIC::Result(), true)
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/TIC_test.cpp
+++ b/src/tests/class_tests/openms/source/TIC_test.cpp
@@ -65,8 +65,8 @@ START_SECTION(const String& getName() const override)
   TEST_EQUAL(tic.getName(), "TIC")
 END_SECTION
 
-START_SECTION(Status requires() const override)
-  TEST_EQUAL((tic.requires() == QCBase::Status(QCBase::Requires::RAWMZML)),true);
+START_SECTION(Status requirements() const override)
+  TEST_EQUAL((tic.requirements() == QCBase::Status(QCBase::Requires::RAWMZML)),true);
 END_SECTION
 
 START_SECTION(void compute(const MSExperiment &exp, float bin_size))


### PR DESCRIPTION
This adds a missing header for gcc13

Also I renewed some lines of code, to satisfy warnings:
- removing std::iterator usage (see https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/ )
- renamed the function `requires` with `requirements`. `require` is a keyword in c++20 (not c++17), because of this, the compiler throws a lot of warnings.
- replaced `std::not1` with `std::not_fn`
- removed `virtual` from assignment operators. Removing them, should keep the same functionality everywhere in the code. The original intention is unclear, but the compiler was rightfully complaining about it a lot. This makes the code a lot less suspicious ;-)
