### PR TITLE
build contrib container from SHA of submodule

### DIFF
--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -29,7 +29,19 @@ jobs:
       - name: Downcase REPO
         run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
-      - name: Checkout Dockerfiles
+      - name: Checkout repository because we need to build contrib
+        uses: actions/checkout@v3
+        if: startsWith(steps.extract_branch.outputs.branch, 'release/')
+      - name: Build contrib container using the correct submodule hash
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          context: contrib
+          file: dockerfiles/Dockerfile
+          tags: |
+            ghcr.io/contrib:${{ steps.tag_name.outputs.tag }}
+        if: startsWith(steps.extract_branch.outputs.branch, 'release/')        
+      - name: Checkout Library and Executable Dockerfiles
         shell: bash # uses git bash on windows
         run: |
             git clone https://github.com/OpenMS/dockerfiles


### PR DESCRIPTION
## Description

attempt to build a contrib container that matches the SHA of the OpenMS/OpenMS release contrib submodule 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
