### PR TITLE
fix error related to empty spectra in bruker files

### DIFF
--- a/src/openms/source/FORMAT/GNPSMGFFile.cpp
+++ b/src/openms/source/FORMAT/GNPSMGFFile.cpp
@@ -338,6 +338,8 @@ namespace OpenMS
       const int best_speci = pepts[0].second;
       auto best_spec = specs_list[map_index2file_index[best_mapi]][best_speci];
 
+      if (best_spec.empty()) continue; // some Bruker files have MS2 spectra without peaks. skip those during exprot
+
       // write block output header
       writeMSMSBlockHeader_(
         output_file,
@@ -349,6 +351,8 @@ namespace OpenMS
         best_speci,
         best_spec.getRT()
       );
+
+      // OPENMS_LOG_DEBUG << "Best spectrum (index/RT): " << best_speci << "\t" << best_spec.getRT() << std::endl;
 
       // store outputted spectra in MSExperiment
       MSExperiment exp;


### PR DESCRIPTION
## Description

skips empty spectra from export. previously an exception was thrown

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
