### PR TITLE
fix: json reader entries for output files, should be strings

### DIFF
--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -99,7 +99,7 @@ namespace OpenMS
           {
             value = node.get<bool>() ? "true" : "false";
           }
-          else if (entry.tags.count("input file") || entry.tags.count("output file"))
+          else if (entry.tags.count("input file"))
           {
             value = node["path"].get<std::string>();
           }
@@ -118,7 +118,7 @@ namespace OpenMS
         }
         else if (entry.value.valueType() == ParamValue::ValueType::STRING_LIST)
         {
-          if (entry.tags.count("input file") || entry.tags.count("output file"))
+          if (entry.tags.count("input file"))
           {
             value = node["path"].get<std::vector<std::string>>();
           }


### PR DESCRIPTION
## Description

The JSON-ini reader wasn't obeying  the typical CWL JSON schema for input values.

Outputs are given as strings, (this was accidentally of type 'File' to match input data)
