### PR TITLE
FindCoin.cmake: reverse logic of #6877, to allow pre-configured OpenMS source builds …

### DIFF
--- a/cmake/Modules/FindCOIN.cmake
+++ b/cmake/Modules/FindCOIN.cmake
@@ -43,21 +43,20 @@ include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
 set(COIN_ROOT_DIR "" CACHE PATH "COIN root directory")
 
 # find the coin include directory from contrib or system
-find_path(COIN_INCLUDE_DIR coin/CoinUtilsConfig.h coinutils/coin/CoinUtilsConfig.h
+find_path(COIN_INCLUDE_DIR_SYS coin/CoinUtilsConfig.h coinutils/coin/CoinUtilsConfig.h
         HINTS
         ${COIN_ROOT_DIR}/include
         )
-if (COIN_INCLUDE_DIR)
+if (COIN_INCLUDE_DIR_SYS)
   set(CF_COIN_INCLUDE_SUBDIR_DEF 1 CACHE BOOL "If the subdir for including coin-or headers is 'coin/' (1) or 'coin-or/' (undefined).")
-endif()
-if (NOT COIN_INCLUDE_DIR)
+else()
   # find for vcpkg -- look in 'coin-or'
-  find_path(COIN_INCLUDE_DIR coin-or/CoinUtilsConfig.h
+  find_path(COIN_INCLUDE_DIR_VCPKG coin-or/CoinUtilsConfig.h
           HINTS
           ${COIN_ROOT_DIR}/include
           )
 endif()
-
+set(CF_COIN_INCLUDE "${COIN_INCLUDE_DIR_SYS} ${COIN_INCLUDE_DIR_VCPKG}")
 
 # helper macro to find specific coin sub-libraries
 macro(_coin_find_lib _libname _lib_file_names _lib_file_names_debug)

--- a/cmake/Modules/FindCOIN.cmake
+++ b/cmake/Modules/FindCOIN.cmake
@@ -42,22 +42,22 @@ include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
 # hint from the user
 set(COIN_ROOT_DIR "" CACHE PATH "COIN root directory")
 
-# find for vcpkg
-find_path(COIN_INCLUDE_DIR coin-or/CoinUtilsConfig.h
+# find the coin include directory from contrib or system
+find_path(COIN_INCLUDE_DIR coin/CoinUtilsConfig.h coinutils/coin/CoinUtilsConfig.h
         HINTS
         ${COIN_ROOT_DIR}/include
         )
-
+if (COIN_INCLUDE_DIR)
+  set(CF_COIN_INCLUDE_SUBDIR_DEF 1 CACHE BOOL "If the subdir for including coin-or headers is 'coin/' (1) or 'coin-or/' (undefined).")
+endif()
 if (NOT COIN_INCLUDE_DIR)
-  # find the coin include directory from contrib or system
-  find_path(COIN_INCLUDE_DIR coin-or/CoinUtilsConfig.h coin/CoinUtilsConfig.h coinutils/coin/CoinUtilsConfig.h
+  # find for vcpkg -- look in 'coin-or'
+  find_path(COIN_INCLUDE_DIR coin-or/CoinUtilsConfig.h
           HINTS
           ${COIN_ROOT_DIR}/include
           )
-  if (COIN_INCLUDE_DIR)
-    set(CF_COIN_INCLUDE_SUBDIR_DEF 1 CACHE BOOL "If the subdir for including coin-or headers is coin (1) or coin-or (undefined).")
-  endif()
 endif()
+
 
 # helper macro to find specific coin sub-libraries
 macro(_coin_find_lib _libname _lib_file_names _lib_file_names_debug)


### PR DESCRIPTION
…to run without weird error messages
i.e. `Could not find header xy...'



## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
