### PR TITLE
MapAlignerPoseClustering log filenames during aligment

### DIFF
--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -198,6 +198,7 @@ protected:
         }
       }
       OPENMS_LOG_INFO << " done" << std::endl;
+      OPENMS_LOG_INFO << "Reference file: " << in_files[reference_index] << std::endl;
       file = in_files[reference_index];
     }
 
@@ -223,17 +224,14 @@ protected:
       algorithm.setReference(map_ref);
     }
 
-    ProgressLogger plog;
-    plog.setLogType(log_type_);
-
-    plog.startProgress(0, in_files.size(), "Aligning input maps");
-    Size progress(0); // thread-safe progress
     // TODO: it should all work on featureXML files, since we might need them for output anyway. Converting to consensusXML is just wasting memory!
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
     for (int i = 0; i < static_cast<int>(in_files.size()); ++i)
     {
+      OPENMS_LOG_INFO << "Aligning file " << i+1 << "/" << in_files.size() << ": " << in_files[i] << " ...";
+
       TransformationDescription trafo;
       if (in_type == FileTypes::FEATUREXML)
       {
@@ -299,11 +297,10 @@ protected:
 #pragma omp critical (MAPose_Progress)
 #endif
       {
-        plog.setProgress(++progress); // thread safe progress counter
+        OPENMS_LOG_INFO << " done" << std::endl;
       }
     }
 
-    plog.endProgress();
     return EXECUTION_OK;
   }
 


### PR DESCRIPTION
As mentioned in #6860 it would be very helpful to see which file gets currently aligned in order to catch corrupted files easily.
Replaced the progress logger with more meaningful information including file names.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
