### PR TITLE
[FIX] mzML threading issue 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,11 +14,12 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 
 
 ------------------------------------------------------------------------------------------
-----                                OpenMS 3.1.0     (under development)              ----
+----                                OpenMS 3.1.0     (released: under development)    ----
 ------------------------------------------------------------------------------------------
 
 - require some advanced instruction sets for x64 CPUs: SSE3 (g++/clang) or AVX (MSVC); and NEON for ARM64 CPUs (#6978)
 - Base64 encoding/decoding using the SIMDe library (#6978)
+- fix a crash when loading mzML data with multiple threads which contains non-MS spectra, e.g. 'electromagnetic radiation spectrum' (#7011)
 
 Cleanup of old/unused tools and code:
 - Removed old tools and associated code in the library for InclusionExclusionListCreator, SvmTheoreticalSpectrumGenerator, PrecursorIonSelector, and MSSimulator

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -390,9 +390,6 @@ public:
       /// Writes the contents to a stream.
       virtual void writeTo(std::ostream & /*os*/);
 
-      /// Returns the last error description
-      String errorString();
-
       /// handler which support partial loading, implement this method
       virtual LOADDETAIL getLoadDetail() const;
 
@@ -469,9 +466,6 @@ public:
       void checkUniqueIdentifiers_(const std::vector<ProteinIdentification>& prot_ids) const;
 
 protected:
-      /// Error message of the last error
-      mutable String error_message_;
-
       /// File name
       String file_;
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -43,20 +43,20 @@ namespace OpenMS::Internal
 
     void MzMLHandlerHelper::warning(int mode, const String & msg, UInt line, UInt column)
     {
-      String error_message_;
+      String error_message;
       if (mode == 0)
       {
-        error_message_ =  String("While loading '") + "': " + msg;
+        error_message =  String("While loading '") + "': " + msg;
       }
       else if (mode == 1)
       {
-        error_message_ =  String("While storing '") + "': " + msg;
+        error_message =  String("While storing '") + "': " + msg;
       }
       if (line != 0 || column != 0)
       {
-        error_message_ += String("( in line ") + line + " column " + column + ")";
+        error_message += String("( in line ") + line + " column " + column + ")";
       }
-      OPENMS_LOG_WARN << error_message_ << std::endl;
+      OPENMS_LOG_WARN << error_message << std::endl;
     }
 
   String MzMLHandlerHelper::getCompressionTerm_(const PeakFileOptions& opt, MSNumpressCoder::NumpressConfig np, const String& indent, bool use_numpress)

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -104,70 +104,73 @@ namespace OpenMS::Internal
 
     void XMLHandler::fatalError(ActionMode mode, const String & msg, UInt line, UInt column) const
     {
+      String error_message;
       if (mode == LOAD)
       {
-        error_message_ =  String("While loading '") + file_ + "': " + msg;
+        error_message =  String("While loading '") + file_ + "': " + msg;
 	      // test if file has the wrong extension and is therefore passed to the wrong parser
         // only makes sense if we are loading/parsing a file
 	      FileTypes::Type ft_name = FileHandler::getTypeByFileName(file_);
         FileTypes::Type ft_content = FileHandler::getTypeByContent(file_);
         if (ft_name != ft_content)
         {
-          error_message_ += String("\nProbable cause: The file suffix (") + FileTypes::typeToName(ft_name)
+          error_message += String("\nProbable cause: The file suffix (") + FileTypes::typeToName(ft_name)
                           + ") does not match the file content (" + FileTypes::typeToName(ft_content) + "). "
                           + "Rename the file to fix this.";
         }
       }
       else if (mode == STORE)
       {
-        error_message_ =  String("While storing '") + file_ + "': " + msg;
+        error_message =  String("While storing '") + file_ + "': " + msg;
       }
       if (line != 0 || column != 0)
       {
-        error_message_ += String("( in line ") + line + " column " + column + ")";
+        error_message += String("( in line ") + line + " column " + column + ")";
       }
 
-      OPENMS_LOG_FATAL_ERROR << error_message_ << std::endl;
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, file_, error_message_);
+      OPENMS_LOG_FATAL_ERROR << error_message << std::endl;
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, file_, error_message);
     }
 
     void XMLHandler::error(ActionMode mode, const String & msg, UInt line, UInt column) const
     {
+      String error_message;
       if (mode == LOAD)
       {
-        error_message_ =  String("Non-fatal error while loading '") + file_ + "': " + msg;
+        error_message =  String("Non-fatal error while loading '") + file_ + "': " + msg;
       }
       else if (mode == STORE)
       {
-        error_message_ =  String("Non-fatal error while storing '") + file_ + "': " + msg;
+        error_message =  String("Non-fatal error while storing '") + file_ + "': " + msg;
       }
       if (line != 0 || column != 0)
       {
-        error_message_ += String("( in line ") + line + " column " + column + ")";
+        error_message += String("( in line ") + line + " column " + column + ")";
       }
-      OPENMS_LOG_ERROR << error_message_ << std::endl;
+      OPENMS_LOG_ERROR << error_message << std::endl;
     }
 
     void XMLHandler::warning(ActionMode mode, const String & msg, UInt line, UInt column) const
     {
+      String error_message;
       if (mode == LOAD)
       {
-        error_message_ =  String("While loading '") + file_ + "': " + msg;
+        error_message =  String("While loading '") + file_ + "': " + msg;
       }
       else if (mode == STORE)
       {
-        error_message_ =  String("While storing '") + file_ + "': " + msg;
+        error_message =  String("While storing '") + file_ + "': " + msg;
       }
       if (line != 0 || column != 0)
       {
-        error_message_ += String("( in line ") + line + " column " + column + ")";
+        error_message += String("( in line ") + line + " column " + column + ")";
       }
 
 // warn only in Debug mode but suppress warnings in release mode (more happy users)
 #ifdef OPENMS_ASSERTIONS
-      OPENMS_LOG_WARN << error_message_ << std::endl;
+      OPENMS_LOG_WARN << error_message << std::endl;
 #else
-      OPENMS_LOG_DEBUG << error_message_ << std::endl;
+      OPENMS_LOG_DEBUG << error_message << std::endl;
 #endif
 
     }
@@ -186,11 +189,6 @@ namespace OpenMS::Internal
 
     void XMLHandler::writeTo(std::ostream & /*os*/)
     {
-    }
-
-    String XMLHandler::errorString()
-    {
-      return error_message_;
     }
 
     SignedSize XMLHandler::cvStringToEnum_(const Size section, const String & term, const char * message, const SignedSize result_on_error)


### PR DESCRIPTION
## Description

remove dependency on member variable which is being accessed by multiple threads (race condition) when loading an mzML which triggers warnings/errors.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
