### PR TITLE
make idxml user parameter output deterministic

### DIFF
--- a/src/openms/include/OpenMS/METADATA/MetaInfoRegistry.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoRegistry.h
@@ -163,7 +163,7 @@ public:
 private:
     /// internal counter, that stores the next index to assign
     UInt next_index_;
-    using MapString2IndexType = std::unordered_map<std::string, UInt>;
+    using MapString2IndexType = std::map<std::string, UInt>;
     using MapIndex2StringType = std::unordered_map<UInt, std::string>;
     
     /// map from name to index

--- a/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/sachsenb/OMS/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges=":" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/workspace/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges=":" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 				<UserParam type="string" name="extra_features" value="score,ln(delta_next),ln(delta_best),matched_peaks,longest_b,longest_y,longest_y_pct,ln(matched_intensity_pct),scored_candidates,ln(-poisson)"/>
-				<UserParam type="stringList" name="SageAdapter:1:in" value="[/home/sachsenb/OMS/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.mzML]"/>
+				<UserParam type="stringList" name="SageAdapter:1:in" value="[/workspace/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.mzML]"/>
 				<UserParam type="string" name="SageAdapter:1:out" value="SageAdapter_1_out.tmp.idXML"/>
-				<UserParam type="string" name="SageAdapter:1:database" value="/home/sachsenb/OMS/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta"/>
-				<UserParam type="string" name="SageAdapter:1:sage_executable" value="/home/sachsenb/OMS/OpenMS/THIRDPARTY/Linux/64bit/Sage/sage"/>
+				<UserParam type="string" name="SageAdapter:1:database" value="/workspace/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta"/>
+				<UserParam type="string" name="SageAdapter:1:sage_executable" value="/workspace/OpenMS/THIRDPARTY/Linux/64bit/Sage/sage"/>
 				<UserParam type="string" name="SageAdapter:1:decoy_prefix" value="DECOY_"/>
 				<UserParam type="int" name="SageAdapter:1:batch_size" value="0"/>
 				<UserParam type="string" name="SageAdapter:1:precursor_tol_unit" value="ppm"/>
@@ -55,7 +55,7 @@
 				<UserParam type="string" name="SageAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2023-07-20T14:48:59" search_engine="Sage" search_engine_version="sage (0.13.3)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2023-08-15T10:10:28" search_engine="Sage" search_engine_version="sage (0.13.4)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q99536|VAT1_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -69,13 +69,13 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="ln(-poisson)" value="1.1030057965071456"/>
 				<UserParam type="string" name="ln(matched_intensity_pct)" value="3.865689"/>
-				<UserParam type="string" name="longest_y" value="11"/>
-				<UserParam type="string" name="scored_candidates" value="1"/>
-				<UserParam type="string" name="longest_b" value="7"/>
-				<UserParam type="string" name="longest_y_pct" value="0.57894737"/>
-				<UserParam type="string" name="matched_peaks" value="31"/>
 				<UserParam type="string" name="ln(delta_best)" value="0.0"/>
 				<UserParam type="string" name="ln(delta_next)" value="4.568750819879955"/>
+				<UserParam type="string" name="longest_b" value="7"/>
+				<UserParam type="string" name="scored_candidates" value="1"/>
+				<UserParam type="string" name="matched_peaks" value="31"/>
+				<UserParam type="string" name="longest_y_pct" value="0.57894737"/>
+				<UserParam type="string" name="longest_y" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="0"/>


### PR DESCRIPTION
## Description

fixes sage output

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
