### PR TITLE
add option to filter spectra by peptide

### DIFF
--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -224,7 +224,7 @@ protected:
     registerStringOption_("best:spectrum_per_peptide", "<String>", "false", "Keep one spectrum per peptide. Value determines if same sequence but different charges or modifications are treated as separate peptides or the same peptide. (default: false = filter disabled).", false);
     setValidStrings_("best:spectrum_per_peptide", {"false", "sequence", "sequence+charge", "sequence+modification", "sequence+charge+modification"});    
     registerIntOption_("best:n_protein_hits", "<integer>", 0, "Keep only the 'n' highest scoring protein hits (for n > 0).", false);
-    setMinInt_("best:n_protein_hits", 0);    
+    setMinInt_("best:n_protein_hits", 0);
     registerFlag_("best:strict", "Keep only the highest scoring peptide hit.\n"
                                  "Similar to n_peptide_hits=1, but if there are ties between two or more highest scoring hits, none are kept.");
     registerStringOption_("best:n_to_m_peptide_hits", "[min]:[max]", ":", "Peptide hit rank range to extracts", false, true);

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -221,8 +221,10 @@ protected:
     setMinInt_("best:n_spectra", 0);
     registerIntOption_("best:n_peptide_hits", "<integer>", 0, "Keep only the 'n' highest scoring peptide hits per spectrum (for n > 0).", false);
     setMinInt_("best:n_peptide_hits", 0);
+    registerStringOption_("best:spectrum_per_peptide", "<String>", "false", "Keep one spectrum per peptide. Value determines if same sequence but different charges or modifications are treated as separate peptides or the same peptide. (default: false = filter disabled).", false);
+    setValidStrings_("best:spectrum_per_peptide", {"false", "sequence", "sequence+charge", "sequence+modification", "sequence+charge+modification"});    
     registerIntOption_("best:n_protein_hits", "<integer>", 0, "Keep only the 'n' highest scoring protein hits (for n > 0).", false);
-    setMinInt_("best:n_protein_hits", 0);
+    setMinInt_("best:n_protein_hits", 0);    
     registerFlag_("best:strict", "Keep only the highest scoring peptide hit.\n"
                                  "Similar to n_peptide_hits=1, but if there are ties between two or more highest scoring hits, none are kept.");
     registerStringOption_("best:n_to_m_peptide_hits", "[min]:[max]", ":", "Peptide hit rank range to extracts", false, true);
@@ -605,6 +607,25 @@ protected:
     {
       OPENMS_LOG_INFO << "Filtering by best n peptide hits..." << endl;
       IDFilter::keepNBestHits(peptides, best_n_pep);
+    }
+
+    String spectrum_per_peptide = getStringOption_("best:spectrum_per_peptide");
+    if (spectrum_per_peptide != "false")
+    {
+      OPENMS_LOG_INFO << "Keeping best spectrum per " << spectrum_per_peptide << endl;
+      if (spectrum_per_peptide == "sequence") // group by sequence and return best spectrum (->smallest number of spectra)
+      {
+        IDFilter::keepBestPerPeptide(peptides, true, true, 1);
+      } else if (spectrum_per_peptide == "sequence+modification")
+      {
+        IDFilter::keepBestPerPeptide(peptides, false, true, 1);
+      } else if (spectrum_per_peptide == "sequence+charge")
+      {
+        IDFilter::keepBestPerPeptide(peptides, true, false, 1);
+      } else if (spectrum_per_peptide == "sequence+charge+modification") // group by sequence, modificationm, charge combination and return best spectrum (->largest number of spectra)
+      {
+        IDFilter::keepBestPerPeptide(peptides, false, false, 1);
+      }
     }
 
     Int min_rank = 0, max_rank = 0;


### PR DESCRIPTION
## Description

add option to keep one spectrum per peptide sequence, seq+charge or seq+charge+modification.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
