### PR TITLE
[SageAdapter] Pass threads param as  (file) batch_size

### DIFF
--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -67,6 +67,8 @@ using namespace std;
 
     @brief Identifies peptides in MS/MS spectra via sage.
 
+    Setting the "threads" parameter to a non-zero value indicates how many files to load and search in parallel. Setting it to 0 defaults tp # of CPUs/2 (default in sage).
+
 <CENTER>
     <table>
         <tr>
@@ -383,7 +385,6 @@ protected:
       "The Sage executable. Provide a full or relative path, or make sure it can be found in your PATH environment.", true, false, {"is_executable"});
 
     registerStringOption_("decoy_prefix", "<prefix>", "DECOY_", "Prefix on protein accession used to distinguish decoy from target proteins.", false, false);
-    registerIntOption_("batch_size", "<int>", 0, "Number of files to load and search in parallel (default = # of CPUs/2)", false, false);
     
     registerStringOption_("precursor_tol_unit", "<unit>", "ppm", "Unit of precursor tolerance (ppm or Da)", false, false);
     setValidStrings_("precursor_tol_unit", ListUtils::create<String>("ppm,Da"));
@@ -452,7 +453,7 @@ protected:
     String output_file = getStringOption_("out");
     String output_folder = File::path(output_file);
     String fasta_file = getStringOption_("database");
-    int batch = getIntOption_("batch_size");
+    int batch = getIntOption_("threads");
     String decoy_prefix = getStringOption_("decoy_prefix");
 
     // create config

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -67,7 +67,7 @@ using namespace std;
 
     @brief Identifies peptides in MS/MS spectra via sage.
 
-    Setting the "threads" parameter to a non-zero value indicates how many files to load and search in parallel. Setting it to 0 defaults tp # of CPUs/2 (default in sage).
+    Setting the "threads" parameter to a non-zero value indicates how many files to load and search in parallel. Setting it to 0 defaults to # of CPUs/2 (default in sage).
 
 <CENTER>
     <table>


### PR DESCRIPTION
## Description

forward threads parameter to "batch_size" in sage

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
