### PR TITLE
Remove BOOST_USE_STATIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ enable_testing()
 # OPENMS_COVERAGE
 #------------------------------------------------------------------------------
 option(MT_ENABLE_OPENMP "Enable OpenMP support" ON)
-option(BOOST_USE_STATIC "Use Boost static libraries." ON)
 option(HAS_XSERVER "Indicates if an X server is available. If set to Off it will disable certain tests and the doc target." ON)
 option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)

--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -32,17 +32,12 @@
 # $Authors: Chris Bielow, Stephan Aiche $
 # --------------------------------------------------------------------------
 
-#------------------------------------------------------------------------------
-## export a single option indicating if boost static libs should be preferred
-option(BOOST_USE_STATIC "Use Boost static libraries." ON)
-
-#------------------------------------------------------------------------------
+#---------------------------------------------------------------------------
 ## Wraps the common find boost code into a single call
 ## @param .. simply add all required components to the call
-## @note This macro will define BOOST_MOC_ARGS that should be added to all moc
-##       calls (see https://bugreports.qt-project.org/browse/QTBUG-22829)
+## @note This macro will define BOOST_MOC_ARGS that should be added to all
+##     moc calls (see https://bugreports.qt-project.org/browse/QTBUG-22829)
 macro(find_boost)
-  set(Boost_USE_STATIC_LIBS ${BOOST_USE_STATIC})
   set(Boost_USE_MULTITHREADED  ON)
   set(Boost_USE_STATIC_RUNTIME OFF)
   add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
@@ -50,12 +45,21 @@ macro(find_boost)
   
   ## since boost 1.66 they add an architecture tag if you build with layout=versioned and since 1.69 even when you
   ## build with layout=tagged (which we do in the contrib)
+  ## TODO check if still necessary with latest CMake 3.20+. Might cause problems with ARM otherwise.
+  ## Note: This probably only affects 1.66 to 1.72 anyway because since 1.71 or so they have a BoostConfig.cmake
+  ##  that renders the FindBoost module unused.
   if(NOT Boost_ARCHITECTURE)
     set(Boost_ARCHITECTURE "-x64")
   endif()
 
   # help boost finding it's packages
+  ## TODO remove? We could just require a new enough CMake.
+  ##  Behaviour is pretty much undefined anyway when using a boost
+  ##  that is newer than its CMake.
   set(Boost_ADDITIONAL_VERSIONS
+    "1.81.1" "1.81.0" "1.81"
+    "1.80.1" "1.80.0" "1.80"
+    "1.79.1" "1.79.0" "1.79"
     "1.78.1" "1.78.0" "1.78"
     "1.77.1" "1.77.0" "1.77"
     "1.76.1" "1.76.0" "1.76"


### PR DESCRIPTION
I think the build system is flexible enough to handle both static and dynamic. Dynamic will be preferred by default. It still can be set by the well-documented Boost_USE_STATIC_LIBS variable.

Let's see if there are any hiccups in CI.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
