### PR TITLE
Fix asan bug in SageAdapter.cpp

### DIFF
--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -594,7 +594,7 @@ protected:
       // check if spectrum reference is a string that just contains a number        
       try
       {
-        ids[0].getSpectrumReference().toInt64();
+        scanNrAsInt = id.getSpectrumReference().toInt64();
       }
       catch (...)
       {

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -588,16 +588,18 @@ protected:
       ++cnt;
     }
 
-    char* p;
     for (auto& id : peptide_identifications)
     {
-      // check if spectrum reference is a string that just contains an integer
-      long scanNrAsInt = strtol(id.getSpectrumReference().c_str(), &p, 10);
-      if (!*p)
+      // check if spectrum reference is a string that just contains a number        
+      try
+      {
+        ids[0].getSpectrumReference().toInt64();
+      }
+      catch (...)
       {
         // lookup full native ID in corresponding file for given spectrum number
-        id.setSpectrumReference( file2specnr2nativeid[idxToFile[id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX)]].at(scanNrAsInt));
-      }
+        id.setSpectrumReference( file2specnr2nativeid[idxToFile[id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX)]].at(scanNrAsInt) );                    
+      }          
     }
 
     IdXMLFile().store(output_file, protein_identifications, peptide_identifications);

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -590,6 +590,7 @@ protected:
 
     for (auto& id : peptide_identifications)
     {
+      Int64 scanNrAsInt = 0;
       // check if spectrum reference is a string that just contains a number        
       try
       {

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -591,16 +591,16 @@ protected:
     for (auto& id : peptide_identifications)
     {
       Int64 scanNrAsInt = 0;
-      // check if spectrum reference is a string that just contains a number        
+      
       try
-      {
+      { // check if spectrum reference is a string that just contains a number        
         scanNrAsInt = id.getSpectrumReference().toInt64();
+        // no exception -> conversion to int was successful. Now lookup full native ID in corresponding file for given spectrum number.
+        id.setSpectrumReference( file2specnr2nativeid[idxToFile[id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX)]].at(scanNrAsInt) );                              
       }
       catch (...)
       {
-        // lookup full native ID in corresponding file for given spectrum number
-        id.setSpectrumReference( file2specnr2nativeid[idxToFile[id.getMetaValue(Constants::UserParam::ID_MERGE_INDEX)]].at(scanNrAsInt) );                    
-      }          
+      }
     }
 
     IdXMLFile().store(output_file, protein_identifications, peptide_identifications);


### PR DESCRIPTION
## Description

==150298==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffe1eb21095 at pc 0x55b8cffffab9 bp 0x7ffe1eb1f020 sp 0x7ffe1eb1f010
READ of size 1 at 0x7ffe1eb21095 thread T0
    #0 0x55b8cffffab8 in TOPPSageAdapter::main_(int, char const**) /home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/topp/SageAdapter.cpp:596
    #1 0x7f8c0e165ad6 in OpenMS::TOPPBase::main(int, char const**) /home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/openms/source/APPLICATIONS/TOPPBase.cpp:435
    #2 0x55b8cffd83c3 in main /home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/topp/SageAdapter.cpp:614
    #3 0x7f8bf6a80c86 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21c86)
    #4 0x55b8cffd8069 in _start (/home/jenkins/ws/openms/ntly/xtras/a9154670/build/bin/SageAdapter+0x21b069)

Address 0x7ffe1eb21095 is located in stack of thread T0 at offset 8021 in frame
    #0 0x55b8cfff93dd in TOPPSageAdapter::main_(int, char const**) /home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/topp/SageAdapter.cpp:421

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
