### PR TITLE
Update SemanticValidator.h

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h
@@ -48,11 +48,11 @@ public:
         String accession;
         String name;
         String value;
-        bool has_value;
+        bool has_value{};
         String unit_accession;
-        bool has_unit_accession;
+        bool has_unit_accession{};
         String unit_name;
-        bool has_unit_name;
+        bool has_unit_name{};
       };
 
       /**


### PR DESCRIPTION
## Description

maybe fixes UBSan error:
/home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h:46:14: runtime error: load of value 192, which is not a valid value for type 'bool'
/home/jenkins/ws/openms/ntly/xtras/a9154670/source/src/openms/include/OpenMS/FORMAT/VALIDATORS/SemanticValidator.h:46:14: runtime error: load of value 32, which is not a valid value for type 'bool'

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
