### PR TITLE
update changelog helper for 2023

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,7 +26,7 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 - InternalCalibration: improve visualization of calibration plots (#7064)
 - report reading/writing throughput (MiB/sec) when loading/storing mzML (#7035)
 - restore TOPPAS tutorial (#7076)
-
+- Updated the changelog helper to set LD_LIBRARY_PATH automatically and other fixes
 
 Cleanup of old/unused tools and code:
 - Removed old tools and associated code in the library for InclusionExclusionListCreator, SvmTheoreticalSpectrumGenerator, PrecursorIonSelector, and MSSimulator

--- a/tools/changelog_helper.sh
+++ b/tools/changelog_helper.sh
@@ -39,7 +39,6 @@
 #
 # - Discontinued tools
 # - New tools
-# - Tools with changed status (TOPP <-> UTIL)
 # - Parameter changes from generated INI files
 #
 # Worked for me on MacOS comparing release 2.0 (built from source) vs.
@@ -74,7 +73,7 @@ TMP_FILE_COMM=${TMP_DIR}/common_tools.txt
 ls -la ${BIN_DIR_OLD}/ \
     | awk '{print $9}' \
     | sort \
-    | grep -v -e "Tutorial\|TOPPAS\|TOPPView\|INIFileEditor\|SEARCHENGINES\|OpenMSInfo\|GenericWrapper\|SwathWizard\|Testing" \
+    | grep -v -e "Tutorial\|TOPPAS\|TOPPView\|INIFileEditor\|SEARCHENGINES\|OpenMSInfo\|GenericWrapper\|SwathWizard\|FLASHDeconvWizard\|Testing" \
     | grep -v -e "\.$" \
     | grep -v -e "^$" \
     > ${TMP_FILE_OLD}
@@ -82,7 +81,7 @@ ls -la ${BIN_DIR_OLD}/ \
 ls -la ${BIN_DIR_NEW}/ \
     | awk '{print $9}' \
     | sort \
-    | grep -v -e "Tutorial\|TOPPAS\|TOPPView\|INIFileEditor\|SEARCHENGINES\|OpenMSInfo\|GenericWrapper\|SwathWizard\|Testing" \
+    | grep -v -e "Tutorial\|TOPPAS\|TOPPView\|INIFileEditor\|SEARCHENGINES\|OpenMSInfo\|GenericWrapper\|SwathWizard\|FLASHDeconvWizard\|Testing" \
     | grep -v -e "\.$" \
     | grep -v -e "^$"  \
     > ${TMP_FILE_NEW}
@@ -106,13 +105,12 @@ do
         | while read i
         do
             TOOL_NAME=$(echo $i | sed -E "s/^. //")
-            TOOL_DESCR=$(${BIN_DIR}/${TOOL_NAME} --help 2>&1 | grep " -- " | head -n 1 | sed -E 's/.* -- (.*)$/\1/' | sed -E 's/\.$//')
-            TOOL_STATUS=$(${BIN_DIR}/${TOOL_NAME} --help 2>&1 | grep -e "Common.*options" | sed -E 's/.*Common (.*) options.*/\1/')
+            TOOL_DESCR=$(LD_LIBRARY_PATH=${BIN_DIR}/../lib:${LD_LIBRARY_PATH} ${BIN_DIR}/${TOOL_NAME} --help 2>&1 | grep " -- " | head -n 1 | sed -E 's/.* -- (.*)$/\1/' | sed -E 's/\.$//')
             if [[ ${TOOL_DESCR} != "" ]]
             then
-                echo "  - ${TOOL_NAME} -- ${TOOL_DESCR} (${TOOL_STATUS})"
+                echo "  - ${TOOL_NAME} -- ${TOOL_DESCR}"
             else
-                echo "  - ${TOOL_NAME} (${TOOL_STATUS})"
+                echo "  - ${TOOL_NAME}"
             fi
 
 
@@ -122,20 +120,6 @@ done
 
 # store names of tools present in both old and new release in tmp file
 comm -12 ${TMP_FILE_OLD} ${TMP_FILE_NEW} > ${TMP_FILE_COMM}
-
-# find tools with changed status (TOPP / UTIL)
-echo
-echo "- STATUS CHANGED:"
-echo
-cat ${TMP_FILE_COMM} | while read t
-do
-    OLD_STATUS=$(${BIN_DIR_OLD}/$t --help 2>&1 | grep -e "Common.*options" | sed -E 's/.*Common (.*) options.*/\1/')
-    NEW_STATUS=$(${BIN_DIR_NEW}/$t --help 2>&1 | grep -e "Common.*options" | sed -E 's/.*Common (.*) options.*/\1/')
-    if [[ ${OLD_STATUS} != ${NEW_STATUS} ]]
-    then
-        echo "$t (${OLD_STATUS} -> ${NEW_STATUS})"
-    fi
-done
 
 # print changed parameters as tab-separated table
 echo
@@ -162,10 +146,11 @@ do
         # reset subsection prefix
         p=
         # generate pseudo ini file
-        ${BIN_DIR}/$t -write_ini - \
+        LD_LIBRARY_PATH=${BIN_DIR}/../lib:${LD_LIBRARY_PATH} ${BIN_DIR}/$t -write_ini - \
             | grep -v "name=\"version\"" \
             | sed -E 's/description="[^"]*"|required="[^"]*"|advanced="[^"]*"//g' \
             | sed -E 's/restrictions="[^"]*pyrophospho[^"]*"/ restrictions="..."/' \
+            | sed -E 's/tags="is_executable"//g' \
             | while read l
             do
                 # new NODE -> append subsection to prefix p


### PR DESCRIPTION
- update changelog helper to ignore TOPP/UTIL distinction
- Add FLASHDeconvWizard to the list of GUI apps to ignore
- Set the `LD_LIBRARY_PATH` automatically
- Tags: filter out "is_executable"

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
