### PR TITLE
make mzData more robust against wrong 'length' attributes for binary data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,8 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 - InternalCalibration: improve visualization of calibration plots (#7064)
 - report reading/writing throughput (MiB/sec) when loading/storing mzML (#7035)
 - restore TOPPAS tutorial (#7076)
+- restore developer quick guide in Doxygen docu - see https://openms.de/current_doxygen/html/index.html (#7109)
+- make mzData more robust against wrong 'length' attributes for binary data (#7113) 
 - Updated the changelog helper to set LD_LIBRARY_PATH automatically and other fixes
 
 Cleanup of old/unused tools and code:

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
@@ -92,7 +92,7 @@ protected:
 
       /**@name temporary datastructures to hold parsed data */
       //@{
-      /// The number of peaks in the current spectrum
+      /// The number of peaks in the current spectrum (according to the length attribute -- which should not be trusted)
       UInt peak_count_;
       /// The current spectrum
       SpectrumType spec_;


### PR DESCRIPTION
as recently found in some PRIDE data...
e.g. https://ftp.pride.ebi.ac.uk/pride/data/archive/2013/11/PXD000455/PRIDE_Exp_mzData_Ac_31212.xml.gz

example:
```
<mzArrayBinary>
        <data length="2656" endian="little" precision="64">oGtfQC9CYEAWinQ/p+NtQAEVjiDV03RA+s+aHz9yfUCjdOlfMjGCQNv9KsB3ImBAUUzeALPCa0D60tufC0J0QIm0jT+RknpAMVwdADE6gkDW4lMADEFlQFAZ/z5j4mtAuAGfH4ZzdkAf2PFfoFJ8QOEnDqD/EYBArrzkf3JjYkB6VPzfkctwQMuFyr+Ws3JAxmrz/ypjfUB2NuSfGaOAQFyRmKAGI2dAiL1QwHaia0CXHeIftsNzQEPLun+sgX1AuyU5YBf6gEDymeyfJ2RlQLPsSWDzo3FAI/lKIOVSdUAxX16AfaN6QD6zJEBNAYBAuyU5YNdhYEBdo+VAD4FqQMJM27+yMndAHM9nQP1CfEC9NEWA86GBQCTVd35RillAf4eiQB8gb0CJtI0/UYV2QEoKLICpY3xA2/0qwBdTgEBhjh6/tyNlQDFfXoB9xG1A+MYQABzldED+8zRgEDN7QOVC5V/LZH5ALESHwBHkY0AwYp8ACgVuQHMqGQBqJXRAwVJdwMtDe0DhJM0f07OBQDunWaDdiVVADk5Ev7bGVUCQ9j/AWgpWQN0J9l/nSVdAv0NRoE+QV0DiAzv+C81XQPGfbqDAQlhAmPkOfuKYWEC9/iQ+d9BYQKmhDcAGBFlAru/DQUJJWUCbHam+89BZQOQViJ6UTVpAdCfYf52IWkANObaeIclaQHQn2H+dUVtAI9i4/l2JW0AIOe//48ZbQMZq8/+qDFxAibSNP1FIXECQwB9+/olcQFde8j/5yVxAuCIxQQ0MXUAqVg3C3ERdQG0bRkHwiV1A8nhafuDHXUA+sOO/QBBeQGKFWz6SS15ARgckYd+EXkC8B+i+nM1eQIeKcf4mDV9Aq5hKP+FQX0AHJ6JfW41fQEwceSCyx19AbAn5oGcIYECKzFzg8oNgQNKpK59loWBAste7P97AYEBVT+YffeZgQG8PQkC+A2FAjNgngGImYUDQnWD/dWFhQI7MI3+whGFA+s+aH/+mYUB7ZkmAGsRhQO+NIQC442FAKCmwACYEYkAcz2dAPSJiQN4hxQCJhWJATRB1HwCnYkD922W/bsFiQCsXKv9a5GJAkgVM4FYFY0CdR8X/nSJjQIi6D0BqQ2NAKCmwAKZmY0DCTxxAP4VjQMmRzsBIomNAaverAF/EY0AuOIO/3/9jQI3V5v9VJGRAg4qqX2lEZEBu+rMfqWVkQJMa2gBsg2RAaverAF+kZECvzjEg+8JkQBefAmC85WRAO4+K/zsCZUBaf0sA/oFlQGK7e4DupGVAnE1HADfEZUByGMxfoeRlQMRDGD+NA2ZATRO2nwwjZkDT3AphNUVmQJtWCoHcY2ZAHLRXH4+HZkDsaYe/JqRmQPTDCOFRx2ZAj+Gxn8XkZkBQHEC/bwJnQJLqO78oRmdA7pbkgF1iZ0AawFsgQYFnQCHqPgCppGdAatlaX6TGZ0AFNufgmeVnQPW6RWAsB2hA+cCO/wIjaECvsOB+wD5oQP3YJD/iYWhAdlH0wEeDaEDEQxg/DaNoQLb103/WwmhAZtmTwObhaEA/pyA/m/9oQN4hxQAJI2lAnkFD/4REaUCy2vy/6mBpQDduMT+3f2lA2/eov96iaUAc0qjAycJpQGSyuP9I42lAQde+gF4DakBzKhkAKilqQN4hxQAJQ2pAwkzbv7JjakBOKETAoaJqQI7MI3+wwmpA2/eov97jakDZBu5AHQFrQM6pZAAoI2tAczCbAMNEa0DfFcH/1mtrQAIqHEEqh2tAUz2Zf3QCbEBagoyAiiJsQD+toj80RGxAFY21v7NlbECOyeL+o4FsQHMtWoA2o2xAp3oy/2jFbEAFFVW/UuZsQNv3qL/eGG1ALEfIQJ4/bUCw5gDBHFttQAc/cQB9hG1Ap3oy/+ikbUBxAz4/DCluQJQRF4BGRW5A5ldzgOBmbkDGavP/qoJuQO6W5IBdpG5AY7g6AGLIbkCUF5mAX+FuQH1aRX9oRW9AW3nJ/+Rub0BLBKp/EIRvQGGOHr+3o29Am1YKgVzFb0Bjtfl/1eVvQMyaWOCrA3BA+tUcINgTcEDmV3OA4CJwQBSWeEAZN3BAP62iPzRGcEBbfAqAMVNwQJcaoZ+pY3BAmzi532FzcEAlBRbAlIRwQKqbi79tk3BAQbyuX/ChcEAwR4/fm7FwQLkWLUCb33BA19mQf+bzcECeXFMgcwNxQDFfXoC9E3FAhJz3/3EkcUCrs1pgDzlxQEn1nV+URHFAgIEgQAZccUAnF2NgXYVxQMVwdQAElXFASfWdX1S0cUCR8/4/jsRxQLoQqz/C1XFAiskbYKYhckDvjSEAeJZyQG8MAcCxpHJAUDdQ4N0hc0CfVtEfmjNzQHQn2H+dQXNA51Hxf0dZc0B0J9h/3XNzQHU8ZqCyhXNAvjEEAMeUc0DU00fgT6RzQKSJd4CntXNAwVJdwIvTc0CN0qV/ieNzQJo+O+B6AHRATBx5ILIzdEDSx3xA4Et0QO+QYoAEVnRADVGFP0NldEDkSGdgpHN0QApI+x9giXRAuAchIF+WdEDMlxdg37R0QIi6D0DqxHRAmC8vwP70dEAvTRHgtAR1QMl2vp9aFXVAlQuVf20ldUDzrnrAfDd1QApI+x9gRXVATRB1H4BjdUD4xhAAHHR1QC1BRkBFhXVAI/lKIGWTdUBWZHRAEqV1QDiDv1/MtHVAeEKvP8kRdkCiemtg6yR2QNTWiGAcU3ZA4STNH5OUdkCaPjvgeqR2QJxQiIADtHZAatyb3/DTdkDdBrXf2uV2QHlXPWDeQ3dA2e4eoDtVd0BE3Qcg9WN3QHMtWoB2dXdAelG7X0Wjd0BVTKWfcLR3QPjGEABc1HdAEW+dfzsWeEA4g79fzCh4QDeJQWAlM3hADmYTYNhBeEAdyeU/ZFN4QA1RhT9DZHhAP62iP3SAeEBPH4E//JR4QJ1Hxf/dy3hAL1BSYAHjeEBenWNANhZ5QD+toj+0InlA8parH9s1eUDfFcH/1mF5QPSltz8XcnlA9bpFYKyCeUCEnziAPpV5QJkprb8lo3lAuyU5YBe2eUAwR4/fW9R5QJ9ZEqCm5XlA5DCYvwL2eUDJdr6fmgZ6QIrJG2CmEnpAWn9LAH4hekARct7/x2R6QPKWqx9b43pAzqYjgBsAe0D52F2g5Ax7QDqVDAAVJXtAtObHX1pTe0AOZhNg2IZ7QC0+BcB4lntADmYTYFike0ApJm+AmfV7QM6mI4BbI3xAnE1HAHczfEB5Vz1g3m98QBKEK6CQsXxA+tUcIJjUfEDX3NH/MgV9QEoKLIDpJn1A19zR//I0fUBehZSfVER9QLPviuD/Vn1AcAnAPyWNfUC1+1WAL/V9QKmhDcCGRX5AVUylnzBUfkDnVDIA1NV+QIF7nj9tO39AFY21vzNUf0BYcD/gQWR/QM+goX/ClH9AHt5zYLmzf0D85ChAlGKAQN0MN+BzcoBACDwwgJB6gECsrdhflpGAQFRSJ6DJEYFADFcHQLwegUDxnC0gtDqBQGXEBaARqYFA2/rpPyv4gUBOJQNAFRODQA==</data>
```

The ‘length’ attribute is off by a factor of 8, i.e. it reports the number of bytes of the decoded array. However it should report the number of doubles (according to the mzData spec doc: `Finally, the number of floating point numbers stored in the encoded array is specified in the “length” attribute.`)


## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
