### PR TITLE
q-value based filtering of features in PLFQ

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h
@@ -211,6 +211,14 @@ public:
        */
       static Result findDecoyString(const ProteinIdentification& proteins);
     };
+
+    /// calculates the FDR with a basic and faster algorithm
+    /// Just goes through the sorted scores and counts the number of decoys and targets and annotates the FDR for
+    /// this score as it goes. Q-values are optionally annotated by calculating the cumulative minimum in reversed
+    /// order afterwards. Since I never understood our other algorithm, I can not explain the difference.
+    /// @note Formula used depends on Param "conservative": false -> (D+1)/T, true (e.g. used in Fido) -> (D+1)/(T+D)
+    void calculateFDRBasic(std::map<double,double>& scores_to_FDR, ScoreToTgtDecLabelPairs& scores_labels, bool qvalue, bool higher_score_better) const;
+
 private:
 
     /// Not implemented
@@ -236,13 +244,6 @@ private:
     void calculateEstimatedQVal_(std::map<double, double> &scores_to_FDR,
                                  ScoreToTgtDecLabelPairs &scores_labels,
                                  bool higher_score_better) const;
-
-    /// calculates the FDR with a basic and faster algorithm
-    /// Just goes through the sorted scores and counts the number of decoys and targets and annotates the FDR for
-    /// this score as it goes. Q-values are optionally annotated by calculating the cumulative minimum in reversed
-    /// order afterwards. Since I never understood our other algorithm, I can not explain the difference.
-    /// @note Formula used depends on Param "conservative": false -> (D+1)/T, true (e.g. used in Fido) -> (D+1)/(T+D)
-    void calculateFDRBasic_(std::map<double,double>& scores_to_FDR, ScoreToTgtDecLabelPairs& scores_labels, bool qvalue, bool higher_score_better) const;
 
     /// calculates the error area around the x=x line between two consecutive values of expected and actual
     /// i.e. it assumes exp2 > exp1

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -1047,7 +1047,7 @@ namespace OpenMS
              [&protID](const PeptideIdentification& id){return protID.getIdentifier() == id.getIdentifier();}, all_hits,
              [&c](const PeptideHit& hit){return c == hit.getCharge();});
             map<double, double> scores_to_fdr;
-            calculateFDRBasic_(scores_to_fdr, scores_labels, q_value, higher_score_better);
+            calculateFDRBasic(scores_to_fdr, scores_labels, q_value, higher_score_better);
             IDScoreGetterSetter::setPeptideScoresForMap_(scores_to_fdr, cmap, include_unassigned_peptides, score_type, higher_score_better, add_decoy_peptides, c, protID.getIdentifier());
           }
         }
@@ -1055,7 +1055,7 @@ namespace OpenMS
         {
           IDScoreGetterSetter::getPeptideScoresFromMap_(scores_labels, cmap, include_unassigned_peptides, [&protID](const PeptideIdentification& id){return protID.getIdentifier() == id.getIdentifier();}, all_hits);
           map<double, double> scores_to_fdr;
-          calculateFDRBasic_(scores_to_fdr, scores_labels, q_value, higher_score_better);
+          calculateFDRBasic(scores_to_fdr, scores_labels, q_value, higher_score_better);
           IDScoreGetterSetter::setPeptideScoresForMap_(scores_to_fdr, cmap, include_unassigned_peptides, score_type, higher_score_better, add_decoy_peptides, protID.getIdentifier());
         }
       }
@@ -1064,7 +1064,7 @@ namespace OpenMS
     {
       IDScoreGetterSetter::getPeptideScoresFromMap_(scores_labels, cmap, include_unassigned_peptides, all_hits);
       map<double, double> scores_to_fdr;
-      calculateFDRBasic_(scores_to_fdr, scores_labels, q_value, higher_score_better);
+      calculateFDRBasic(scores_to_fdr, scores_labels, q_value, higher_score_better);
       IDScoreGetterSetter::setPeptideScoresForMap_(scores_to_fdr, cmap, include_unassigned_peptides, score_type, higher_score_better, add_decoy_peptides);
     }
   }
@@ -1101,7 +1101,7 @@ namespace OpenMS
         }
       }
       IDScoreGetterSetter::getScores_(scores_labels, id.getIndistinguishableProteins(), decoy_accs);
-      calculateFDRBasic_(scores_to_FDR, scores_labels, q_value, higher_score_better);
+      calculateFDRBasic(scores_to_FDR, scores_labels, q_value, higher_score_better);
       if (!scores_labels.empty())
         IDScoreGetterSetter::setScores_(scores_to_FDR, id.getIndistinguishableProteins(), score_type, false);
     }
@@ -1115,7 +1115,7 @@ namespace OpenMS
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No scores could be extracted!");
     }
-    calculateFDRBasic_(scores_to_FDR, scores_labels, q_value, higher_score_better);
+    calculateFDRBasic(scores_to_FDR, scores_labels, q_value, higher_score_better);
     if (!scores_labels.empty())
     {
       IDScoreGetterSetter::setScores_(scores_to_FDR, id, score_type, false, add_decoy_proteins);
@@ -1215,7 +1215,7 @@ namespace OpenMS
       pairs.push_back(seq_to_score_label.second);
     }
     std::map<double,double> score_to_fdr;
-    calculateFDRBasic_(score_to_fdr, pairs, q_value, higher_better);
+    calculateFDRBasic(score_to_fdr, pairs, q_value, higher_better);
     // convert scores in unordered map to FDR/qvalues
     for (auto & seq_to_score_label : seq_to_score_labels)
     {
@@ -1252,7 +1252,7 @@ namespace OpenMS
       pairs.push_back(seq_to_score_label.second);
     }
     map<double,double> score_to_fdr;
-    calculateFDRBasic_(score_to_fdr, pairs, q_value, higher_better);
+    calculateFDRBasic(score_to_fdr, pairs, q_value, higher_better);
     // convert scores in unordered map to FDR/qvalues
     for (auto & seq_to_score_label : seq_to_score_labels)
     {
@@ -1339,7 +1339,7 @@ namespace OpenMS
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No scores could be extracted for FDR!");
     }
-    calculateFDRBasic_(scores_to_FDR, scores_labels, q_value, higher_score_better);
+    calculateFDRBasic(scores_to_FDR, scores_labels, q_value, higher_score_better);
     if (!scores_labels.empty())
       IDScoreGetterSetter::setScores_<PeptideIdentification>(scores_to_FDR, ids, score_type, false, add_decoy_peptides);
     scores_to_FDR.clear();
@@ -1466,7 +1466,7 @@ namespace OpenMS
     if (groups_too)
     {
       IDScoreGetterSetter::getPickedProteinGroupScores_(picked_scores, scores_labels, id.getIndistinguishableProteins(), decoy_string, prefix);
-      calculateFDRBasic_(scores_to_FDR, scores_labels, q_value, higher_score_better);
+      calculateFDRBasic(scores_to_FDR, scores_labels, q_value, higher_score_better);
       IDScoreGetterSetter::setScores_(scores_to_FDR, id.getIndistinguishableProteins(), score_type, false);
       scores_to_FDR.clear();
       scores_labels.clear();
@@ -1482,7 +1482,7 @@ namespace OpenMS
     {
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No scores could be extracted for FDR calculation!");
     }
-    calculateFDRBasic_(scores_to_FDR, scores_labels, q_value, higher_score_better);
+    calculateFDRBasic(scores_to_FDR, scores_labels, q_value, higher_score_better);
     IDScoreGetterSetter::setScores_(scores_to_FDR, id, score_type, false, add_decoy_proteins);
     scores_to_FDR.clear();
     scores_labels.clear();
@@ -1658,7 +1658,7 @@ namespace OpenMS
   }
 
   /*
-   void FalseDiscoveryRate::calculateFDRBasic_(
+   void FalseDiscoveryRate::calculateFDRBasic(
     std::map<double,double>& scores_to_FDR,
     ScoreToTgtDecLabelPairs& scores_labels,
     std::vector<size_t>& ordering,
@@ -1677,7 +1677,7 @@ namespace OpenMS
 
   }*/
 
-  void FalseDiscoveryRate::calculateFDRBasic_(
+  void FalseDiscoveryRate::calculateFDRBasic(
       std::map<double,double>& scores_to_FDR,
       ScoreToTgtDecLabelPairs& scores_labels,
       bool qvalue,


### PR DESCRIPTION
## Description

- p-value based thresholds were converted to q-value thresholds
- FDR calculation

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
