### PR TITLE
Fix a few AddressSanitizer complaints due to uninitialized variables

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TOPDOWN/DeconvolvedSpectrum.h
@@ -147,7 +147,7 @@ namespace OpenMS
     /// precursor raw peak (not deconvolved one)
     Precursor precursor_peak_;
     /// activation method for file output
-    Precursor::ActivationMethod activation_method_;
+    Precursor::ActivationMethod activation_method_ = Precursor::ActivationMethod::CID;
     /// scan number and precursor scan number
     int scan_number_ = 0, precursor_scan_number_ = 0;
   };

--- a/src/openms/include/OpenMS/ANALYSIS/TOPDOWN/PeakGroup.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TOPDOWN/PeakGroup.h
@@ -300,7 +300,7 @@ namespace OpenMS
     /// scan number
     int scan_number_ = 0;
     /// is positive or not
-    bool is_positive_;
+    bool is_positive_ = false;
     /// if this peak group has been targeted
     bool is_targeted_ = false;
     /// information on the deconvolved mass

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
@@ -50,8 +50,8 @@ namespace OpenMS
         std::pair<SignedSize, SignedSize> cross_link_position; ///< index in alpha, beta or between alpha, alpha in loop-links
         double cross_linker_mass = 0;
         String cross_linker_name;
-        ResidueModification::TermSpecificity term_spec_alpha;
-        ResidueModification::TermSpecificity term_spec_beta;
+        ResidueModification::TermSpecificity term_spec_alpha = ResidueModification::TermSpecificity::ANYWHERE;
+        ResidueModification::TermSpecificity term_spec_beta = ResidueModification::TermSpecificity::ANYWHERE;
         int precursor_correction = 0;
 
         ProteinProteinCrossLinkType getType() const
@@ -189,8 +189,8 @@ namespace OpenMS
       struct XLPrecursor
       {
         float precursor_mass;
-        unsigned int alpha_index;
-        unsigned int beta_index;
+        unsigned int alpha_index = 0;
+        unsigned int beta_index = 0;
         String alpha_seq;
         String beta_seq;
       };
@@ -241,9 +241,9 @@ namespace OpenMS
        */
       struct AASeqWithMass
       {
-        double peptide_mass;
+        double peptide_mass = 0;
         AASequence peptide_seq;
-        PeptidePosition position;
+        PeptidePosition position = PeptidePosition::INTERNAL;
         String unmodified_seq;
       };
 

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
@@ -188,7 +188,7 @@ namespace OpenMS
        */
       struct XLPrecursor
       {
-        float precursor_mass;
+        float precursor_mass{};
         unsigned int alpha_index = 0;
         unsigned int beta_index = 0;
         String alpha_seq;


### PR DESCRIPTION
## Description

Initialized a few variables in classes related to OpenPepXL and FLASHDeconv. More specifically in OPXLDataStructs, PeakGroup and DeconvolvedSpectrum.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
