### PR TITLE
Remove duplicate option names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,12 +13,14 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 #<number>, e.g. #4957 - a reference to an issue or pull request on GitHub, visit e.g. https://github.com/OpenMS/OpenMS/pull/XXXX (replace XXXX with number of interest) for details
 
 ------------------------------------------------------------------------------------------
-----                                OpenMS 3.2                                        ----
+----                                OpenMS 3.2.0   (released: under development)      ----
 ------------------------------------------------------------------------------------------
+
+What's new:
+- Breaking change: Rename of parameters for FeatureFinderCentroided (debug->advanced), and PeakPickerWavelet/TOFCalibration (optimization -> optimization:type) (#7154)
 
 Library:
 - Extend FileHandler to support load and store operations for our major datastructures (spectra, features, identifications, etc.). Replaced file type specific code with the more generic FileHandler calls to decouple the IO code from other parts of the library.
-
 
 ------------------------------------------------------------------------------------------
 ----                                OpenMS 3.1     (released 10/2023)                 ----
@@ -33,7 +35,7 @@ Important Notes:
 - We welcome your feedback and suggestions to help us improve and refine these experimental features.
 - For stability and production use, we recommend sticking with the latest stable release.
 
-Please use this opportunity to test and provide feedback on these new features, as your input will play a vital role in shaping their development. 
+Please use this opportunity to test and provide feedback on these new features, as your input will play a vital role in shaping their development.
 
 Thank you for being a part of our community and for helping us make OpenMS even better!
 
@@ -51,7 +53,7 @@ Fixes:
 - InternalCalibration: improve visualization of calibration plots (#7064)
 - Restore TOPPAS tutorial (#7076)
 - various low impact UBSan fixes
-- make mzData more robust against wrong 'length' attributes for binary data (#7113) 
+- make mzData more robust against wrong 'length' attributes for binary data (#7113)
 
 Misc:
 - Report reading/writing throughput (MiB/sec) when loading/storing mzML (#7035)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -122,9 +122,9 @@ namespace OpenMS
     defaults_.setMinFloat("user-seed:min_score", 0.0);
     defaults_.setMaxFloat("user-seed:min_score", 1.0);
     defaults_.setSectionDescription("user-seed", "Settings for user-specified seeds.");
-    //debug settings
-    defaults_.setValue("debug:pseudo_rt_shift", 500.0, "Pseudo RT shift used when .", {"advanced"});
-    defaults_.setMinFloat("debug:pseudo_rt_shift", 1.0);
+    //advanced/debugging settings
+    defaults_.setValue("advanced:pseudo_rt_shift", 500.0, "Pseudo RT shift used when .", {"advanced"});
+    defaults_.setMinFloat("advanced:pseudo_rt_shift", 1.0);
     this->defaultsToParam_();
   }
 

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.cpp
@@ -73,13 +73,13 @@ namespace OpenMS
     defaults_.setMinInt("thresholds:search_radius", 0);
 
     //Optimization parameters
-    defaults_.setValue("optimization", "no", "If the peak parameters position, intensity and left/right width" \
-                                             "shall be optimized set optimization to one_dimensional or two_dimensional.", {"advanced"});
+    defaults_.setValue("optimization:type", "no", "If the peak parameters position, intensity and left/right width" \
+                                                  "shall be optimized set optimization to one_dimensional or two_dimensional.", {"advanced"});
     std::vector<std::string> valid_opts;
     valid_opts.emplace_back("no");
     valid_opts.emplace_back("one_dimensional");
     valid_opts.emplace_back("two_dimensional");
-    defaults_.setValidStrings("optimization", valid_opts);
+    defaults_.setValidStrings("optimization:type", valid_opts);
     defaults_.setValue("optimization:penalties:position", 0.0, "penalty term for the fitting of the position:" \
                                                                "If it differs too much from the initial one it can be penalized ", {"advanced"});
     defaults_.setMinFloat("optimization:penalties:position", 0.0);
@@ -156,7 +156,7 @@ namespace OpenMS
     scale_ = (float)param_.getValue("peak_width");
     fwhm_bound_ = (float)param_.getValue("fwhm_lower_bound_factor") * scale_;
     peak_corr_bound_ = (float)param_.getValue("thresholds:correlation");
-    String opt = param_.getValue("optimization").toString();
+    String opt = param_.getValue("optimization:type").toString();
     if (opt == "one_dimensional")
     {
       optimization_ = true;

--- a/src/tests/topp/FeatureFinderCentroided_1_parameters.ini
+++ b/src/tests/topp/FeatureFinderCentroided_1_parameters.ini
@@ -52,7 +52,7 @@
           <ITEM name="mz_tolerance" value="1.1" type="float" description="Allowed m/z deviation of seeds from the user-specified seed position." restrictions="0:" />
           <ITEM name="min_score" value="0.5" type="float" description="Overwrites &apos;seed:min_score&apos; for user-specified seeds. The cutoff is typically a bit lower in this case." restrictions="0:1" />
         </NODE>
-        <NODE name="debug" description="">
+        <NODE name="advanced" description="">
           <ITEM name="pseudo_rt_shift" value="500" type="float" description="Pseudo RT shift used when ." tags="advanced" restrictions="1:" />
         </NODE>
       </NODE>

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -79,7 +79,7 @@
             <ITEM name="mz_tolerance" value="1.1" type="double" description="Allowed m/z deviation of seeds from the user-specified seed position." required="false" advanced="false" restrictions="0.0:" />
             <ITEM name="min_score" value="0.5" type="double" description="Overwrites &apos;seed:min_score&apos; for user-specified seeds. The cutoff is typically a bit lower in this case." required="false" advanced="false" restrictions="0.0:1.0" />
           </NODE>
-          <NODE name="debug" description="">
+          <NODE name="advanced" description="">
             <ITEM name="pseudo_rt_shift" value="500.0" type="double" description="Pseudo RT shift used when ." required="false" advanced="true" restrictions="1.0:" />
           </NODE>
         </NODE>

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -77,7 +77,7 @@
             <ITEM name="mz_tolerance" value="1.1" type="double" description="Allowed m/z deviation of seeds from the user-specified seed position." required="false" advanced="false" restrictions="0.0:" />
             <ITEM name="min_score" value="0.5" type="double" description="Overwrites &apos;seed:min_score&apos; for user-specified seeds. The cutoff is typically a bit lower in this case." required="false" advanced="false" restrictions="0.0:1.0" />
           </NODE>
-          <NODE name="debug" description="">
+          <NODE name="advanced" description="">
             <ITEM name="pseudo_rt_shift" value="500.0" type="double" description="Pseudo RT shift used when ." required="false" advanced="true" restrictions="1.0:" />
           </NODE>
         </NODE>

--- a/src/tests/topp/PeakPickerWavelet_deconv_parameters.ini
+++ b/src/tests/topp/PeakPickerWavelet_deconv_parameters.ini
@@ -5,7 +5,9 @@
       <ITEM name="write_peak_meta_data" value="true" type="string" description="Write additional information about the picked peaks (maximal intensity, left and right area...) into the mzML-file.Attention: this can blow up files,as 7 arrays are stored per spectrum!" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="centroid_percentage" value="0.8" type="float" description="Percentage of the maximum height that the raw data points must exceed to be taken into account for the calculation of the centroid. If it is 1 the centroid position corresponds to the position of the highest intensity." restrictions="0:1" />
-        <ITEM name="optimization" value="no" type="string" description="If the peak parameters position, intensity and left/right widthshall be optimized set optimization to yes."  restrictions="no,one_dimensional,two_dimensional" />
+        <NODE name="optimization">
+          <ITEM name="type" value="no" type="string" description="If the peak parameters position, intensity and left/right widthshall be optimized set optimization to yes."  restrictions="no,one_dimensional,two_dimensional" />
+        </NODE>
         <ITEM name="fwhm_lower_bound_factor" value="1" type="float" description="Minimal peak width" restrictions="0:" />
           <ITEM name="signal_to_noise" value="2" type="float" description="Minimal signal to noise ratio for a peak to be picked." restrictions="1:" />
         <NODE name="thresholds" description="">

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -19,7 +19,6 @@
         <ITEM name="estimate_peak_width" value="false" type="bool" description="Flag if the average peak width shall be estimated. Attention: when this flag is set, the peak_width is ignored." required="false" advanced="false" />
         <ITEM name="fwhm_lower_bound_factor" value="0.7" type="double" description="Factor that calculates the minimal fwhm value from the peak_width. All peaks with width smaller than fwhm_bound_factor * peak_width are discarded." required="false" advanced="true" restrictions="0:" />
         <ITEM name="fwhm_upper_bound_factor" value="20" type="double" description="Factor that calculates the maximal fwhm value from the peak_width. All peaks with width greater than fwhm_upper_bound_factor * peak_width are discarded." required="false" advanced="true" restrictions="0:" />
-        <ITEM name="optimization" value="no" type="string" description="If the peak parameters position, intensity and left/right widthshall be optimized set optimization to one_dimensional or two_dimensional." required="false" advanced="true" restrictions="no,one_dimensional,two_dimensional" />
         <NODE name="thresholds" description="">
           <ITEM name="peak_bound" value="10" type="double" description="Minimal peak intensity." required="false" advanced="true" restrictions="0:" />
           <ITEM name="peak_bound_ms2_level" value="10" type="double" description="Minimal peak intensity for MS/MS peaks." required="false" advanced="true" restrictions="0:" />
@@ -31,6 +30,7 @@
           <ITEM name="spacing" value="0.001" type="double" description="Spacing of the CWT. Note that the accuracy of the picked peak&apos;s centroid position depends in the Raw data spacing, i.e., 50% of raw peak distance at most." required="false" advanced="true" restrictions="0:" />
         </NODE>
         <NODE name="optimization" description="">
+          <ITEM name="type" value="no" type="string" description="If the peak parameters position, intensity and left/right widthshall be optimized set optimization to one_dimensional or two_dimensional." required="false" advanced="true" restrictions="no,one_dimensional,two_dimensional" />
           <ITEM name="iterations" value="15" type="int" description="maximal number of iterations for the fitting step" required="false" advanced="true" restrictions="1:" />
           <NODE name="penalties" description="">
             <ITEM name="position" value="0" type="double" description="penalty term for the fitting of the position:If it differs too much from the initial one it can be penalized " required="false" advanced="true" restrictions="0:" />


### PR DESCRIPTION
## Description

This is dealing with Issue #7127: Summary The parameter can have duplicated entries, if they are entered once as `ParamNode` and once as `ParamEntry`.

This PR will
- Rename duplicate options:
  - PeakPickerWavelet `algorithm:optimization` → `algorithm:optimization:type`
  - TOFCalibration `algorithm:optimization` → `algorithm:optimization:type`
  - FeatureFinderCentroided `algorithm:debug` → `algorithm:advanced`

This PR does not:
 - Add check and throw on duplicate parameters, follow up PR #7157