### PR TITLE
fix: xvfb not starting when xvfb is already running

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -75,7 +75,7 @@ jobs:
         echo $DO_PACKAGE
         if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
           echo "tp_folder=Linux" >> $GITHUB_OUTPUT
-          echo "xvfb=xvfb-run" >> $GITHUB_OUTPUT
+          echo "xvfb=xvfb-run -a" >> $GITHUB_OUTPUT
           echo "static_boost=OFF" >> $GITHUB_OUTPUT
           if [ "$DO_PACKAGE" = true ]; then
             echo "pkg_type=deb" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
We can see on the CI that XVFB sometimes doesn't start.
I suspect it has something to do with the DISPLAY-number being blocked.

Adding `-a` will just count up until it finds a free DISPLAY-number ([doc](https://manpages.ubuntu.com/manpages/xenial/man1/xvfb-run.1.html))

