### PR TITLE
[FIX] make FileConverter more robust

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Library:
 
 Fixes:
 - more robust parsing of mzIdentML (#7153)
+- more robust FileConverter (#7176)
 - MSFragger: allow relative path to database (#7155)
 
 

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -249,6 +249,9 @@ protected:
     //-------------------------------------------------------------
 
     MSExperiment exp;
+    assert(exp.empty());
+    const MSExperiment empty_exp; ///< to determine if 'exp' was modified (loading and storing an MSExp with metadata but empty spectra/chroms should be valid), i.e. checking exp.empty() is not sufficient
+
     FeatureMap fm;
     ConsensusMap cm;
 
@@ -460,6 +463,12 @@ protected:
 
     if (out_type == FileTypes::MZML)
     {
+      if (exp == empty_exp)
+      {
+        OPENMS_LOG_ERROR << "No input data: no MS1/MS2 data present! Cannot write mzML. Please use another input/output format combination.";
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
+
       //add data processing entry
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::
                                                  CONVERSION_MZML));
@@ -517,6 +526,12 @@ protected:
     }
     else if (out_type == FileTypes::MZDATA)
     {
+      if (exp == empty_exp)
+      {
+        OPENMS_LOG_ERROR << "No input data: no MS1/MS2 data present! Cannot write mzData. Please use another input/output format combination.";
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
+
       //annotate output with data processing info
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::
                                                  CONVERSION_MZDATA));
@@ -525,6 +540,12 @@ protected:
     }
     else if (out_type == FileTypes::MZXML)
     {
+      if (exp == empty_exp)
+      {
+        OPENMS_LOG_ERROR << "No input data: no MS1/MS2 data present! Cannot write mzXML. Please use another input/output format combination.";
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
+
       //annotate output with data processing info
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::
                                                  CONVERSION_MZXML));
@@ -535,6 +556,11 @@ protected:
     }
     else if (out_type == FileTypes::DTA2D)
     {
+      if (exp == empty_exp)
+      {
+        OPENMS_LOG_ERROR << "No input data: no MS1/MS2 data present! Cannot write DTA2D. Please use another input/output format combination.";
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
       //add data processing entry
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::
                                                  FORMAT_CONVERSION));
@@ -653,6 +679,11 @@ protected:
         OPENMS_LOG_ERROR << "Internal error: cannot decide on container (Consensus or Feature)! This is a bug. Please report it!";
         return INTERNAL_ERROR;
       }
+      if (fm.empty() && cm.empty())
+      {
+        OPENMS_LOG_ERROR << "No input data: either Consensus or Feature data present! Cannot write EDTA. Please use another input/output format combination.";
+        return ExitCodes::INCOMPATIBLE_INPUT_DATA;
+      }
       if (!fm.empty())
       {
         FileHandler().storeFeatures(out, fm, {FileTypes::EDTA});
@@ -717,6 +748,13 @@ protected:
       writeLogError_("Error: Unknown output file type given. Aborting!");
       printUsage_();
       return ILLEGAL_PARAMETERS;
+    }
+
+    // last check if output file was written:
+    if (!File::exists(out))
+    {
+      OPENMS_LOG_ERROR << "Internal error: Conversion did not create an output file! This is a bug. Please report it!";
+      return INTERNAL_ERROR;
     }
 
     return EXECUTION_OK;


### PR DESCRIPTION
## Description

... against misuse (i.e. incompatible in/out) to avoid producing empty output containers (metadata makes it non-empty) or even no output file.


Before this PR you could:
`FileConverter -in some.mzML -out my.edta` and it would not write an output file, yet succeed.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
