### PR TITLE
ParamEditor: Move getting-tags-part to avoid error from a node (subsection param)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Fixes:
 - more robust parsing of mzIdentML (#7153)
 - more robust FileConverter (#7176)
 - MSFragger: allow relative path to database (#7155)
+- ParamEditor: fixed error for the subsection parameter (ParamNode) to go through store function (#7180)
 
 
 Misc:

--- a/src/openms_gui/source/VISUAL/ParamEditor.cpp
+++ b/src/openms_gui/source/VISUAL/ParamEditor.cpp
@@ -774,15 +774,6 @@ namespace OpenMS
 
     String description = child->data(1, Qt::UserRole).toString();
 
-    std::vector<std::string> tag_list;
-    try // might throw ElementNotFound
-    {
-      tag_list = param_->getTags(path);
-    }
-    catch (...)
-    {
-    }
-
     if (child->text(2) == "")  // node
     {
       if (!description.empty())
@@ -792,6 +783,15 @@ namespace OpenMS
     }
     else     //item + section descriptions
     {
+      std::vector<std::string> tag_list;
+      try // might throw ElementNotFound
+      {
+        tag_list = param_->getTags(path);
+      }
+      catch (...)
+      {
+      }
+
       if (child->text(2) == "float")
       {
         param_->setValue(path, child->text(1).toDouble(), description, tag_list);


### PR DESCRIPTION
## Description

Fixing issue: #7162 
An error has occurred in Wizard due to the subsection in parameters. A subsection (node) doesn't have "tags" that ended up throwing the ElementNotFound exception. 


<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
