### PR TITLE
Fix win installer

### DIFF
--- a/cmake/Windows/NSIS.template.in
+++ b/cmake/Windows/NSIS.template.in
@@ -568,28 +568,6 @@ SectionGroup "Register File Extensions" SEC_RegisterExt
 
 SectionGroupEnd
 
-# TODO make selectable or remove altogether by shipping the vcredist dlls instead of installer.
-Section "Microsoft Visual Studio Runtime" SEC_VSRuntime
-    SectionIn 1 3
-    SetOutPath $TEMP
-    SetOverwrite on
-
-    File "${VS_REDISTRIBUTABLE_PATH}\${VS_REDISTRIBUTABLE_EXE}"
-    # this requires admin privileges!
-    #${If} $IsAdmin == 1
-        ClearErrors
-        ExecWait '$TEMP\${VS_REDISTRIBUTABLE_EXE} /install /passive /norestart' $0
-        StrCmp $0 0 vs_install_success
-        StrCmp $0 1638 vs_install_success
-        MessageBox MB_OK|MB_ICONEXCLAMATION "The installation of the Visual Studio redistributable package '${VS_REDISTRIBUTABLE_EXE}' failed! OpenMS will not work unless this package is installed! The package is located at '$TEMP\${VS_REDISTRIBUTABLE_EXE}'. Try to execute it as administrator - there will likely be an error which you can blame Microsoft for. If you cannot fix it contact the OpenMS developers!"
-    #${Else}
-    #    MessageBox MB_OK|MB_ICONEXCLAMATION "Single user install was selected. '${VS_REDISTRIBUTABLE_EXE}' was not installed since it requires admin rights! OpenMS will probably not work unless this package is installed! The package is located at '$TEMP\${VS_REDISTRIBUTABLE_EXE}'. Try to execute it as administrator - there will likely be an error which you can blame Microsoft for. If you cannot fix it contact the OpenMS developers!"
-    #${EndIf}
-
-	vs_install_success:
-
-SectionEnd
-
 ## This is done by NsisMultiUser plugin now
 Section -post SEC0008
      SetOutPath $INSTDIR
@@ -711,7 +689,7 @@ Function .onInit
     !if ${PLATFORM} == 64
     ${If} ${RunningX64}
     ${else}
-      MessageBox mb_iconstop "You are running a 32bit operating system. The executables of this setup are 64bit, and thus cannot be run after installation. Use a 64bit OS, or use the 32bit setup of OpenMS."
+      MessageBox mb_iconstop "You are running a 32bit operating system. The executables of this setup are 64bit, and thus cannot be run after installation. Use a 64bit OS (there is no 32bit installer for OpenMS anymore)."
       Abort
     ${EndIf}
     !endif
@@ -783,7 +761,7 @@ FunctionEnd
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_ThirdParty} "Install third party libraries (e.g., ProteoWizard)."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_dotnet} "Install .NET and Microsoft Visual Studio Runtime for Proteowizard. (may require the installer to be run in admin mode). Deactivate if you are not admin and think this is installed already (or will be installed later) by an admin."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_RegisterExt} "Register certain file types (e.g., '.mzML') with TOPPView.exe."
-!insertmacro MUI_DESCRIPTION_TEXT ${SEC_VSRuntime} "Install the required Microsoft Visual Studio runtime (may require the installer to be run in admin mode). Deactivate if you are not admin and think this is installed already (or will be installed later) by an admin."
+#!insertmacro MUI_DESCRIPTION_TEXT ${SEC_VSRuntime} "Install the required Microsoft Visual Studio runtime (may require the installer to be run in admin mode). Deactivate if you are not admin and think this is installed already (or will be installed later) by an admin."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ################

--- a/cmake/Windows/NSIS.template.in
+++ b/cmake/Windows/NSIS.template.in
@@ -36,13 +36,6 @@ SetCompressor /SOLID lzma
 ###   SCRIPT   ###
 ##################
 
-# pwiz needs alternative VS runtime libraries (32bit for Agilent libraries)
-!define VS_PWIZ_REDISTRIBUTABLE_EXE "vcredist2010_x86_sp1.exe"
-
-# additional pwiz redistributables
-!define VS_PWIZ_ADD1_REDISTRIBUTABLE_EXE "vcredist2012_x64_upd4.exe"
-!define VS_PWIZ_ADD2_REDISTRIBUTABLE_EXE "vcredist2013_x64_upd2.exe"
-
 # which extensions to connect to TOPPView and TOPPAS
 !macro OpenMSGUIExtensions _action
   !insertmacro ${_action} ".mzData" "TOPPView"
@@ -79,7 +72,7 @@ SetCompressor /SOLID lzma
 # We could also define the following
 #CONTACT
 #URL_HELP_LINK
-	
+    
 
 # MultiUser defines
 !define MULTIUSER_INSTALLMODE_INSTDIR "${PRODUCT_NAME}-${VERSION}" # Otherwise it would just be PRODUCT_NAME
@@ -314,7 +307,7 @@ Section "Documentation" SEC_Doc
     # open uninstall log file
     !insertmacro UNINSTALL.LOG_OPEN_INSTALL
 
-	# html docs
+    # html docs
     !if ${DEBUG_SKIP_DOCU} == 0
 
       File /r "${OPENMSDOCDIR}\html\*.*"
@@ -327,97 +320,15 @@ SectionEnd
 ## Third party libs
 ## TODO switch to packagedir
 SectionGroup "ThirdParty" SEC_ThirdParty
-	!if ${DEBUG_NO_THIRDPARTY} == 0
-		Section "Proteowizard" SEC_pwiz
-		    SectionIn 1 3
+    !if ${DEBUG_NO_THIRDPARTY} == 0
+        Section "Proteowizard" SEC_pwiz
+            SectionIn 1 3
             SetOverwrite on
             CreateDirectory "$INSTDIR\share\OpenMS\THIRDPARTY\pwiz-bin"
             SetOutPath "$INSTDIR\share\OpenMS\THIRDPARTY\pwiz-bin"
-			!insertmacro UNINSTALL.LOG_OPEN_INSTALL
-
-            File /r "${THIRDPARTYDIR}\pwiz-bin\*.*"
-
-            !insertmacro UNINSTALL.LOG_CLOSE_INSTALL
-        SectionEnd
-
-        Section ".NET and VSRuntime for Proteowizard" SEC_dotnet
-            SectionIn 1 3
-            SetOverwrite on
             !insertmacro UNINSTALL.LOG_OPEN_INSTALL
 
-            Var /GLOBAL netSilentArgs
-            StrCpy $netSilentArgs ""
-            IfSilent 0 +2
-                StrCpy $netSilentArgs "/q /norestart"
-
-            ## download .NET 3.5 and 4.0 (required by pwiz)
-
-            inetc::get /BANNER "Getting .NET 3.5 SP1 installer." \
-                    "http://www.microsoft.com/downloads/info.aspx?na=41&SrcFamilyId=AB99342F-5D1A-413D-8319-81DA479AB0D7&SrcDisplayLang=en&u=http%3a%2f%2fdownload.microsoft.com%2fdownload%2f0%2f6%2f1%2f061F001C-8752-4600-A198-53214C69B51F%2fdotnetfx35setup.exe" \
-                    "$EXEDIR\NET3.5_SP1_installer.exe"
-            Pop $0
-            StrCmp $0 "OK" dl35ok net35_install_success
-            MessageBox MB_OK|MB_ICONEXCLAMATION "Downloading 'Microsoft .NET 3.5 SP1' failed. You must download and install it manually in order for Proteowizard to work!" /SD IDOK
-
-            dl35ok:
-                ClearErrors
-                ExecWait '"$EXEDIR\NET3.5_SP1_installer.exe" $netSilentArgs' $0
-                StrCmp $0 0 net35_install_success
-                MessageBox MB_OK|MB_ICONEXCLAMATION "The installation of the Microsoft .NET 3.5 SP1' package failed! You must download and install it manually in order for Proteowizard to work!" /SD IDOK
-
-            net35_install_success:
-                ## .NET 3.5 installed, yeah!
-
-                inetc::get /BANNER "Getting .NET 4.0 installer." \
-                        "http://www.microsoft.com/downloads/info.aspx?na=41&SrcFamilyId=AB99342F-5D1A-413D-8319-81DA479AB0D7&SrcDisplayLang=en&u=http%3a%2f%2fdownload.microsoft.com%2fdownload%2f9%2f5%2fA%2f95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE%2fdotNetFx40_Full_x86_x64.exe" \
-                        "$EXEDIR\NET4.0_installer.exe"
-
-                Pop $0
-                StrCmp $0 "OK" dl40ok net40_install_success
-                MessageBox MB_OK|MB_ICONEXCLAMATION "Downloading 'Microsoft .NET 4.0' failed. You must download and install it manually in order for Proteowizard to work!" /SD IDOK
-
-            dl40ok:
-                ClearErrors
-                ExecWait '"$EXEDIR\NET4.0_installer.exe" $netSilentArgs' $0
-                StrCmp $0 0 net40_install_success
-                MessageBox MB_OK|MB_ICONEXCLAMATION "The installation of the Microsoft .NET 4.0' package failed! You must download and install it manually in order for Proteowizard to work!" /SD IDOK
-
-            net40_install_success:
-                ## .NET 4.0 installed, yeah!
-
-                ## pwiz now requires vs 2010 32bit (!) runtime libraries installed (Agilent libraries)
-                ## 2017: now also 2012 and 2013 of the corresponding platform
-                SetOutPath $TEMP
-                SetOverwrite on
-
-                File  "${THIRDPARTYDIR}\${VS_PWIZ_REDISTRIBUTABLE_EXE}"
-                ClearErrors
-                ExecWait '$TEMP\${VS_PWIZ_REDISTRIBUTABLE_EXE} /passive /norestart' $0
-                StrCmp $0 0 vs_pwiz_install_success
-                StrCmp $0 1638 vs_pwiz_install_success
-                MessageBox MB_OK "The installation of the Visual Studio redistributable package '${VS_PWIZ_REDISTRIBUTABLE_EXE}' failed! Proteowizard will not work unless this package is installed! The package is located at '$TEMP\${VS_PWIZ_REDISTRIBUTABLE_EXE}'. Try to execute it as administrator - there will likely be an error which you can blame Microsoft for. If you cannot fix it contact the OpenMS developers!"
-
-            vs_pwiz_install_success:
-
-                File  "${THIRDPARTYDIR}\${VS_PWIZ_ADD1_REDISTRIBUTABLE_EXE}"
-                ClearErrors
-                ExecWait '$TEMP\${VS_PWIZ_ADD1_REDISTRIBUTABLE_EXE} /passive /norestart' $0
-                StrCmp $0 0 vs_pwiz_add1_install_success
-                StrCmp $0 1638 vs_pwiz_add1_install_success
-                MessageBox MB_OK "The installation of the Visual Studio redistributable package '${VS_PWIZ_ADD1_REDISTRIBUTABLE_EXE}' failed! Proteowizard will not work unless this package is installed! The package is located at '$TEMP\${VS_PWIZ_ADD1_REDISTRIBUTABLE_EXE}'. Try to execute it as administrator - there will likely be an error which you can blame Microsoft for. If you cannot fix it contact the OpenMS developers!"
-
-            vs_pwiz_add1_install_success:
-
-                File  "${THIRDPARTYDIR}\${VS_PWIZ_ADD2_REDISTRIBUTABLE_EXE}"
-                ClearErrors
-                ExecWait '$TEMP\${VS_PWIZ_ADD2_REDISTRIBUTABLE_EXE} /install /passive /norestart' $0
-                StrCmp $0 0 vs_pwiz_add2_install_success
-                StrCmp $0 1638 vs_pwiz_add2_install_success
-                MessageBox MB_OK "The installation of the Visual Studio redistributable package '${VS_PWIZ_ADD2_REDISTRIBUTABLE_EXE}' failed! Proteowizard will not work unless this package is installed! The package is located at '$TEMP\${VS_PWIZ_ADD2_REDISTRIBUTABLE_EXE}'. Try to execute it as administrator - there will likely be an error which you can blame Microsoft for. If you cannot fix it contact the OpenMS developers!"
-
-            ## reasons why the install might fail:
-
-            vs_pwiz_add2_install_success:
+            File /r "${THIRDPARTYDIR}\pwiz-bin\*.*"
 
             !insertmacro UNINSTALL.LOG_CLOSE_INSTALL
         SectionEnd
@@ -427,8 +338,7 @@ SectionGroup "ThirdParty" SEC_ThirdParty
         !system 'FOR /D %A IN ("${THIRDPARTYDIR}\*") DO @( IF NOT "%~nA" == "pwiz-bin" ((echo Section "%~nA" & echo SectionIn 1 3 & echo !insertmacro UNINSTALL.LOG_OPEN_INSTALL & echo SetOverwrite on & echo CreateDirectory "$INSTDIR\share\OpenMS\THIRDPARTY\%~nA" & echo SetOutPath "$INSTDIR\share\OpenMS\THIRDPARTY\%~nA" & echo File /r "%~A\*.*" & echo Var /GLOBAL %~nAInstalled & echo StrCpy $%~nAInstalled "1" & echo !insertmacro UNINSTALL.LOG_CLOSE_INSTALL & echo SectionEnd) >> "${filelist}"))'
         !include "${filelist}"
         !delfile "${filelist}"
-
-	!endif
+    !endif
 
 SectionGroupEnd
 
@@ -447,8 +357,8 @@ SectionEnd
 Function CreateShortcuts
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 
-	## warning: create shortcuts only AFTER installing files, OR renew SetOutPath
-	## otherwise all files will be installed to the default install directory
+    ## warning: create shortcuts only AFTER installing files, OR renew SetOutPath
+    ## otherwise all files will be installed to the default install directory
     !insertmacro CREATE_SMGROUP_SHORTCUT "OpenMS Documentation (html)" $INSTDIR\share\doc\html\index.html
 
     !insertmacro CREATE_SMGROUP_SHORTCUT TOPPView $INSTDIR\bin\TOPPView.exe
@@ -592,31 +502,16 @@ SectionEnd
 
 # hidden section, write install size as the final step
 Section "-Write Install Size"
-	!insertmacro MULTIUSER_RegistryAddInstallSizeInfo
+    !insertmacro MULTIUSER_RegistryAddInstallSizeInfo
 SectionEnd
 
 Function parseParameters
-
     ClearErrors
 
     ; /nothirdparty
     ${GetOptions} $cmdLineParams '/nothirdparty' $R0
-    IfErrors nopwiz 0
+    IfErrors parsedParams 0
       !insertmacro ClearSectionFlag ${SEC_ThirdParty} ${SF_SELECTED}
-      goto parsedParams
-
-    ; /nopwiz
-    nopwiz:
-        ${GetOptions} $cmdLineParams '/nopwiz' $R0
-        IfErrors nodotnet 0
-          !insertmacro ClearSectionFlag ${SEC_pwiz} ${SF_SELECTED}
-          goto parsedParams
-
-    ; /nodotnet
-    nodotnet:
-        ${GetOptions} $cmdLineParams '/nodotnet' $R0
-        IfErrors parsedParams 0
-          !insertmacro ClearSectionFlag ${SEC_dotnet} ${SF_SELECTED}
 
     parsedParams:
 
@@ -646,8 +541,6 @@ Function .onInit
             /currentuser$\t- (un)install for current user only, case-insensitive$\r$\n\
             /uninstall$\t- (installer only) run uninstaller, requires /allusers or /currentuser, case-insensitive$\r$\n\
             /nothirdparty$\t- does not install thirdparty tools, case-sensitive$\r$\n\
-            /nopwiz$\t- does not install proteowizard, case-sensitive$\r$\n\
-            /nodotnet$\t- does not try to install dotnet framework, case-sensitive$\r$\n\
             /S$\t- silent mode, requires /allusers or /currentuser, case-sensitive$\r$\n\
             /D$\t- (installer only) set install directory, must be last parameter, without quotes, case-sensitive$\r$\n\
             /?$\t- display this message$\r$\n\
@@ -759,9 +652,7 @@ FunctionEnd
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_TOPP} "TOPP (The OpenMS PiPeline) - chainable tools for data analysis"
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_Doc} "Documentation/Tutorials for TOPP, TOPPView and the OpenMS library itself."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_ThirdParty} "Install third party libraries (e.g., ProteoWizard)."
-!insertmacro MUI_DESCRIPTION_TEXT ${SEC_dotnet} "Install .NET and Microsoft Visual Studio Runtime for Proteowizard. (may require the installer to be run in admin mode). Deactivate if you are not admin and think this is installed already (or will be installed later) by an admin."
 !insertmacro MUI_DESCRIPTION_TEXT ${SEC_RegisterExt} "Register certain file types (e.g., '.mzML') with TOPPView.exe."
-#!insertmacro MUI_DESCRIPTION_TEXT ${SEC_VSRuntime} "Install the required Microsoft Visual Studio runtime (may require the installer to be run in admin mode). Deactivate if you are not admin and think this is installed already (or will be installed later) by an admin."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ################
@@ -813,7 +704,7 @@ Section "-Uninstall"
     ${un.RefreshShellIcons}
 
     ## delete all installed files
-	!insertmacro UNINSTALL.NEW_UNINSTALL
+    !insertmacro UNINSTALL.NEW_UNINSTALL
 
     # remove directories which are now empty (in case some were forgotten)
     Push "$INSTDIR"

--- a/cmake/Windows/NSIS.template.in
+++ b/cmake/Windows/NSIS.template.in
@@ -291,7 +291,7 @@ Section "TOPP tools" SEC_TOPP
     #open uninstall log file
     !insertmacro UNINSTALL.LOG_OPEN_INSTALL
 
-    # Since Qt 5.14 we probably do not need qt.conf if the plugins are in the standard location "plugins"
+    # Since Qt 5.14 we do not need qt.conf if the plugins are in the standard location "plugins"
     # Qt is built "-relocatable" since then.
     #File "${OPENMSBINDIR}\qt.conf"
 

--- a/cmake/package_nsis.cmake
+++ b/cmake/package_nsis.cmake
@@ -34,6 +34,13 @@
 
 ## Windows installer
 
+## check if we are packaging at least Qt 5.15 (5.14 may also work but is untested), which is "-relocatable", i.e. can find ./bin/plugins/platforms/qwindows.dll without a qt.conf (which we do not ship anymore)
+message(STATUS "Packaging: Checking Qt version ... found: ${Qt5Core_VERSION}")
+if (Qt5Core_VERSION VERSION_LESS 5.15.0)
+  message(FATAL_ERROR "Minimum supported Qt5 version is 5.15!")
+endif()
+
+
 ## With VS2019 the architecture HAS TO BE specified with the "–A" option or CMAKE_GENERATOR_PLATFORM var.
 ## Therefore the legacy way of adding a suffix to the Generator is not valid anymore.
 ## Read value of CMAKE_VS_PLATFORM_NAME instead

--- a/cmake/package_nsis.cmake
+++ b/cmake/package_nsis.cmake
@@ -29,7 +29,7 @@
 #
 # --------------------------------------------------------------------------
 # $Maintainer: Julianus Pfeuffer $
-# $Authors: Julianus Pfeuffer $
+# $Authors: Julianus Pfeuffer, Chris Bielow $
 # --------------------------------------------------------------------------
 
 ## Windows installer
@@ -52,115 +52,14 @@ else()
   set(ARCH "x64")
 endif()
 
-if (NOT VC_REDIST_EXE)
-	set(VC_REDIST_EXE "vcredist_${ARCH}.exe")
-endif()
 
-# Find redistributable to be installed by NSIS
-if (NOT VC_REDIST_PATH)
-	if (MSVC_TOOLSET_VERSION EQUAL 141)
-		set(VS_VERSION 15)
-	elseif(MSVC_TOOLSET_VERSION EQUAL 142)
-		set(VS_VERSION 16)
-	elseif(MSVC_TOOLSET_VERSION EQUAL 143)
-		set(VS_VERSION 17)
-	endif()
 
-	if (DEFINED ENV{VCINSTALLDIR})
-		## according to https://docs.microsoft.com/de-de/cpp/windows/redistributing-visual-cpp-files?view=msvc-160
-		get_filename_component(VC_ROOT_PATH "$ENV{VCINSTALLDIR}Redist/MSVC/v${MSVC_TOOLSET_VERSION}" ABSOLUTE)
-		file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
-		if (NOT VC_REDIST_ABS_PATH)
-			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
-		endif()
-		if (NOT VC_REDIST_ABS_PATH)
-			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
-		endif()
+#### Install System runtime libraries into /bin, so NSIS picks them up; this saves us from shipping a VC-Redist.exe with the installer
+set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+set (CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION ${INSTALL_LIB_DIR})
+message(STATUS "\nInstalling system libs to '${INSTALL_LIB_DIR}'\n")
+include(InstallRequiredSystemLibraries)
 
-		message(STATUS "VS Redist locations (1st try): '${VC_REDIST_ABS_PATH}'")
-	endif()
-
-	if (NOT VC_REDIST_ABS_PATH AND DEFINED ENV{VCToolsRedistDir}) ## if still not found, try to use older methods
-		## We have to glob recurse in the parent folder because there is a version number in the end.
-		## Unfortunately in my case the default version (latest) does not include the redist?!
-		## TODO Not sure if this environment variable always exists. In the VS command line it should! Fallback vswhere or VCINSTALLDIR/Redist/MSVC?
-		get_filename_component(VC_ROOT_PATH "$ENV{VCToolsRedistDir}.." ABSOLUTE)
-		file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
-		if (NOT VC_REDIST_ABS_PATH)
-			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
-		endif()
-		if (NOT VC_REDIST_ABS_PATH)
-			file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
-		endif()
-
-		message(STATUS "VS Redist locations (2nd try): '${VC_REDIST_ABS_PATH}'")
-	endif()
-
-	if (NOT VC_REDIST_ABS_PATH) ## if still not found try vswhere
-
-		include(${OPENMS_HOST_DIRECTORY}/cmake/Windows/VSWhere.cmake)
-
-		toolchain_ensure_vswhere()
-
-		execute_process(COMMAND ${VSWHERE_PATH} -products * -latest -version "${VS_VERSION}" -property installationPath
-		OUTPUT_VARIABLE VC_ROOT_PATH
-		ERROR_VARIABLE VSWHERE_ERROR
-		RESULT_VARIABLE VSWHERE_RESULT
-		COMMAND_ECHO STDOUT
-		)
-		string(STRIP ${VC_ROOT_PATH} VC_ROOT_PATH)
-		cmake_path(SET VC_ROOT_PATH NORMALIZE ${VC_ROOT_PATH})
-
-		if (VSWHERE_RESULT EQUAL 0)
-			message("Globbing for vc_redist.${ARCH}.exe in ${VC_ROOT_PATH}")
-			file(GLOB_RECURSE VC_REDIST_ABS_PATH FOLLOW_SYMLINKS "${VC_ROOT_PATH}/vc_redist.${ARCH}.exe")
-			if (NOT VC_REDIST_ABS_PATH)
-				file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist_${ARCH}.exe")
-			endif()
-			if (NOT VC_REDIST_ABS_PATH)
-				file(GLOB_RECURSE VC_REDIST_ABS_PATH "${VC_ROOT_PATH}/vcredist.${ARCH}.exe")
-			endif()
-			message(STATUS "VS Redist locations (3rd try): ${VC_REDIST_ABS_PATH}")
-		endif()
-	endif()
-
-	if (VC_REDIST_ABS_PATH)
-		## arbitrarily pick first of the found redists
-		list(GET VC_REDIST_ABS_PATH 0 VC_REDIST_ABS_PATH)
-		get_filename_component(VC_REDIST_PATH "${VC_REDIST_ABS_PATH}" DIRECTORY)
-		get_filename_component(VC_REDIST_EXE "${VC_REDIST_ABS_PATH}" NAME)
-		message(STATUS "   ... picked first directory: ${VC_REDIST_PATH}")
-	endif()
-endif()
-
-if (NOT VC_REDIST_PATH) ## if still not found: error
-	message(FATAL_ERROR "Variable VC_REDIST_PATH missing. Are you on a proper VS 2019+ command line?")
-endif()
-
-if(EXISTS ${SEARCH_ENGINES_DIRECTORY})
-  file(GLOB PWIZ_VCREDIST "${SEARCH_ENGINES_DIRECTORY}/*.exe")
-  install(FILES ${PWIZ_VCREDIST}
-          DESTINATION ${INSTALL_SHARE_DIR}/THIRDPARTY
-		  PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-		              GROUP_READ GROUP_EXECUTE
-					  WORLD_READ WORLD_EXECUTE
-		)
-endif()
-
-#TODO try following instead once CMake generates NSIS commands for us. Installs dll instead of redist though.
-# This means we would need to change the NSIS script to just copy them over.
-
-# ########################################################### System runtime libraries
-# Multiple ways to achieve that:
-# - Currently: We package the vc_Redist installer exe from the VS directory
-# - In package_general, we could adapt PRE and POST_EX/INCLUDES as well as maybe
-#   DIRECTORIES to include them (from System32? or from VS directory?)
-# - The code below also might achieve it.
-# set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
-# include(InstallRequiredSystemLibraries)
-# install(PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
-#         DESTINATION OpenMS-${CPACK_PACKAGE_VERSION}/${PACKAGE_LIB_DIR}/
-#         COMPONENT library)
 
 ## Careful: the configured file needs to lie exactly in the Build directory so that it is found by the NSIS_template
 configure_file(${PROJECT_SOURCE_DIR}/cmake/Windows/Cfg_Settings.nsh.in ${PROJECT_BINARY_DIR}/Cfg_Settings.nsh.in.conf @ONLY)

--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -20,6 +20,7 @@
   - @subpage TOPP_TOPPAS - An assistant for GUI-driven TOPP workflow design.
   - @subpage TOPP_INIFileEditor - An editor for %OpenMS configuration files.
   - @subpage TOPP_SwathWizard - A user-friendly step-by-step wizard for SWATH data analysis
+  - @subpage TOPP_FLASHDeconvWizard - A user-friendly step-by-step wizard for the @ref TOPP_FLASHDeconv tool
   
   <b>File Converter</b>
   - @subpage TOPP_FileConverter - Converts between different MS file formats.

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/FLASHDeconvWizard.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/FLASHDeconvWizard.cpp
@@ -11,8 +11,8 @@
 
   @brief An assistant for FLASHDeconv execution.
 
-  The implementation of FLASHDeconvWizard is heavily inspired by the SwathWizard.
-  The Wizard helps the user to run FLASHDeconv for Top-down proteomics analysis. (@ref TOPP_FLASHDeconv tool)
+  The implementation of FLASHDeconvWizard is heavily inspired by the @ref TOPP_SwathWizard .
+  The Wizard helps the user to run @ref TOPP_FLASHDeconv for Top-down proteomics analysis.
 
   Users can enter the required input data (mzML MS/MS data) in dedicated fields, usually by drag'n'droping files from the
   operating systems' file explorer (Explorer, Nautilus, Finder...).


### PR DESCRIPTION
## Description

Fixes the Windows installer by:
1) ship VS runtime dll's in the ./bin directory (thus not requiring to install a vs_runtime.exe during install time -- which was disabled in the old installer anyway for some reason)
2) pwiz: 
    2.1) avoiding unneccessary .NET installs (which are not required for pwiz since any Win10 should ship them by default)
    2.2) avoiding unncessary .vs runtime installs since pwiz ships them in its own ./bin directory for a while now
3) force use of Qt5.15 when creating an installer, since Qt5.15 can find its qwindows.dll in ./bin/plugins/platforms on its own (using any prior version would crash any GUI tool with "The application failed to start ...  qt platform plugin "windows" "
![image](https://github.com/OpenMS/OpenMS/assets/6008722/55485f3d-3ce4-4039-b149-c6bd266801a3)

upon start on the target machine)


Plus some minor doc fixes (FlashDeconvWizard was not mentioned in the docs).


these commits:
f4823ac7a20c694617e44724cdf25ac3ff228385
541a759ffa81f725ab141f263beafeeb16c85cbf
302b69fc7d3c0bf802640c78ac435531baff6432
(and also 4856d5a6b62836b9082a44da647aa01b0b89beb6 from #7192)

should be backported to Release 3.0 and 3.1 to create working installers.

Also note: by default GHActions is using a default NSIS 3.x, which does not support LargeStrings. This will cause our installers to fail to add stuff to $PATH during installation time on the target machine, if the PATH is reasonably filled.
Solution: wait for https://github.com/mkevenaar/chocolatey-packages/issues/221 or use the 'special build' of NSIS which supports 8k-strings.
--> let's use a custom NSIS (https://github.com/OpenMS/NSIS) in the meantime.

## Checklist

- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
