### PR TITLE
[GHA] use custom NSIS for Windows installer

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -169,9 +169,10 @@ jobs:
 
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             choco install doxygen.portable ghostscript graphviz -y --no-progress
-            # TODO save this zip somewhere on our infrastructure or github since the project is deprecated
-            curl --no-progress-meter -L -o UltraModernUI_2.0b6.zip  https://github.com/SuperPat45/UltraModernUI/releases/download/2.0b6/UltraModernUI_2.0b6.zip
-            7z -y x UltraModernUI_2.0b6.zip -o"C:/Program Files (x86)/NSIS/"
+            # uses a custom NSIS, which provides 8-k string support and has UltraModernUI integrated already
+            curl --no-progress-meter -L -o NSIS.tar.gz https://github.com/OpenMS/NSIS/raw/main/NSIS.tar.gz
+            ## overwrite existing NSIS (which has only 1k-string support)
+            7z x -so NSIS.tar.gz | 7z x -si -ttar -o"C:/Program Files (x86)/NSIS/"
           fi
         fi
 


### PR DESCRIPTION
## Description

by default GHActions is using a default NSIS 3.x, which does not support LargeStrings. This will cause our installers to fail to add stuff to $PATH during installation time on the target machine, if the PATH is reasonably filled.
Solution: wait for https://github.com/mkevenaar/chocolatey-packages/issues/221 or use the 'special build' of NSIS which supports 8k-strings.
--> let's use a custom NSIS (https://github.com/OpenMS/NSIS) in the meantime.

@JeeH-K could you make this NSIS version from https://github.com/OpenMS/NSIS/raw/main/NSIS.tar.gz also available for the Jenkins machines, so we can test if our nightly installers behave correctly afterwards. Thanks!


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
