### PR TITLE
[FIX] TOPPAS: open files in TOPPView

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,7 @@ Fixes:
 - more robust FileConverter (#7176)
 - MSFragger: allow relative path to database (#7155)
 - ParamEditor: fixed error for the subsection parameter (ParamNode) to go through store function (#7180)
-
+- TOPPAS: open files in TOPPView (#7213)
 
 Misc:
 - OpenMSInfo reports the ILP solver (CoinOr or glpk) (#7156)

--- a/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MISC/GUIHelpers.h
@@ -49,8 +49,9 @@ namespace OpenMS
                                               const FileTypes::Type fallback_extension);
 
 
-    /// Open TOPPView (e.g. from within TOPPAS)
-    OPENMS_GUI_DLLAPI void startTOPPView(const QStringList& args);
+    /// Open TOPPView (e.g. from within TOPPAS) as a detached process (i.e. will continue running when this process ends)
+    /// @return true if process started successfully
+    OPENMS_GUI_DLLAPI bool startTOPPView(QStringList args);
 
     /// Open a certain URL (in a browser)
     /// Will show a message box on failure

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -1511,7 +1511,10 @@ namespace OpenMS
       }
     }
     
-    GUIHelpers::startTOPPView(files);
+    if (!GUIHelpers::startTOPPView(files))
+    {
+      QMessageBox::warning(this, "Could not start TOPPView", "TOPPView failed to start. Please see the commandline for details.");
+    }
 
   }
 

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
       app_args.append("--args");
       app_args.append(args);
       args = app_args;
-      app_path = "/usr/bin/open"
+      app_path = "/usr/bin/open";
     }
     else
     { // we could not find the app, try it the Linux way

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -92,7 +92,7 @@ namespace OpenMS
     if (!QProcess::startDetached(app_path, args))
     {
       // execution failed
-      OPENMS_LOG_ERROR << "Could not start '" << app_path << "'. Please see above for error messages." << std::endl;
+      OPENMS_LOG_ERROR << "Could not start '" << app_path.toStdString() << "'. Please see above for error messages." << std::endl;
   #if defined(__APPLE__)
       OPENMS_LOG_ERROR << "Please check if TOPPAS and TOPPView are located in the same directory" << std::endl;
   #endif

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -89,18 +89,16 @@ namespace OpenMS
     app_path = (File::findSiblingTOPPExecutable("TOPPView")).toQString();
 #endif
 
-    qint64 pid = -1;
-    QProcess::startDetached(app_path, args, "", &pid);
-
-    if (pid == -1)
+    if (!QProcess::startDetached(app_path, args))
     {
       // execution failed
       OPENMS_LOG_ERROR << "Could not start '" << app_path << "'. Please see above for error messages." << std::endl;
   #if defined(__APPLE__)
       OPENMS_LOG_ERROR << "Please check if TOPPAS and TOPPView are located in the same directory" << std::endl;
   #endif
+      return false;
     }
-    return pid != -1;
+    return true;
   }
 
   void GUIHelpers::openURL(const QString& target)

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -92,7 +92,7 @@ namespace OpenMS
         return false;
       }
       QFileInfo fi(file);
-      auto& [it, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
+      const auto& [it, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
       if (!was_inserted) // duplicate
       {
         OPENMS_LOG_ERROR << "File '" << file << "' (resolved to '" << *it << "') appears twice in the input list!" << std::endl;

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -95,7 +95,7 @@ namespace OpenMS
       const auto& [it, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
       if (!was_inserted) // duplicate
       {
-        OPENMS_LOG_ERROR << "File '" << file << "' (resolved to '" << *it << "') appears twice in the input list!" << std::endl;
+        OPENMS_LOG_ERROR << "File '" << file.toStdString() << "' (resolved to '" << *it << "') appears twice in the input list!" << std::endl;
         return false;
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -84,10 +84,18 @@ namespace OpenMS
   bool TOPPASInputFileListVertex::fileNamesValid()
   {
     QStringList fl = getFileNames();
+    std::set<std::string> unique_names;
     foreach(const QString& file, fl)
     {
       if (!File::exists(file))
       {
+        return false;
+      }
+      QFileInfo fi(file);
+      auto& [it, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
+      if (!was_inserted) // duplicate
+      {
+        OPENMS_LOG_ERROR << "File '" << file << "' (resolved to '" << *it << "') appears twice in the input list!" << std::endl;
         return false;
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -92,10 +92,10 @@ namespace OpenMS
         return false;
       }
       QFileInfo fi(file);
-      const auto& [it, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
+      const auto& [it_unique, was_inserted] = unique_names.insert(fi.canonicalFilePath().toStdString());
       if (!was_inserted) // duplicate
       {
-        OPENMS_LOG_ERROR << "File '" << file.toStdString() << "' (resolved to '" << *it << "') appears twice in the input list!" << std::endl;
+        OPENMS_LOG_ERROR << "File '" << file.toStdString() << "' (resolved to '" << *it_unique << "') appears twice in the input list!" << std::endl;
         return false;
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -2098,11 +2098,11 @@ namespace OpenMS
                              + (strange_vertices.size() > 1 ? "s " : " ")
                              + strange_vertices.join(", ")
                              + (strange_vertices.size() > 1 ? " have " : " has ")
-                             + " invalid (non-existing) input files!");
+                             + " invalid (non-existing or duplicate) input files!");
       }
       else
       {
-        std::cerr << "Pipeline contains input file nodes with invalid (non-existing) input files!" << std::endl;
+        std::cerr << "Pipeline contains input file nodes with invalid (non-existing or duplicate) input files!" << std::endl;
       }
       return false;
     }


### PR DESCRIPTION
## Description

... did not work anymore since new Qt Versions kill the child process (TOPPView) when the QProcess object goes out of scope and the child was not detached.
This PR spawns a detached TOPPView.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
