### PR TITLE
Fix plotting.py for existing annotations from SpectrumAnnotator

### DIFF
--- a/src/pyOpenMS/pyopenms/plotting.py
+++ b/src/pyOpenMS/pyopenms/plotting.py
@@ -190,6 +190,7 @@ Plot a single spectrum with plot_spectrum or two with mirror_plot_spectrum, usin
 import math
 from typing import Dict, Optional, Tuple, Union, List, Set
 import itertools
+import logging
 
 colors = {'a': '#388E3C', 'b': '#1976D2', 'c': '#00796B',
           'x': '#7B1FA2', 'y': '#D32F2F', 'z': '#F57C00',
@@ -248,14 +249,17 @@ def _annotate_ion(mz: float, intensity: float, annotation: Optional[str],
     """
 
     # No annotation -> Just return peak styling information.
-    if annotation is None:
+    if not annotation:
         return colors.get(None), zorders.get(None)
     # Else: Add the textual annotation.
-    ion_type = annotation[0]
+    ion_type = ''
+    if annotation:
+     ion_type = annotation[0]
     if ion_type == '[': # precursor ion
         ion_type = 'p'
     if ion_type not in colors and color_ions:
-        raise ValueError('Ion type not supported')
+        logging.warning(f'Ion type {ion_type} not supported')
+        return colors.get(None), zorders.get(None)
 
     color = (colors[ion_type] if color_ions else
              colors[None])
@@ -273,6 +277,7 @@ def _annotate_ion(mz: float, intensity: float, annotation: Optional[str],
         ax.text(mz, annotation_pos, str(annotation), color=color,
                 zorder=zorder, **kws)
 
+    print(color)
     return color, zorder
 
 
@@ -343,7 +348,7 @@ def plot_spectrum(spectrum: "MSSpectrum", color_ions: bool = True,
         if mirror_intensity:
             peak_intensity *= -1
 
-        matched = matched_peaks is not None and i_peak in matched_peaks
+        matched = (matched_peaks is not None and i_peak in matched_peaks) or annotations is not None
 
         color, zorder = _annotate_ion(
             peak_mz, peak_intensity, peak_annotation, color_ions, annotate_ions,

--- a/src/pyOpenMS/pyopenms/plotting.py
+++ b/src/pyOpenMS/pyopenms/plotting.py
@@ -277,7 +277,6 @@ def _annotate_ion(mz: float, intensity: float, annotation: Optional[str],
         ax.text(mz, annotation_pos, str(annotation), color=color,
                 zorder=zorder, **kws)
 
-    print(color)
     return color, zorder
 
 


### PR DESCRIPTION
## Description

Before, it raised exceptions, and after fixing it didn't color.
Now, matched peaks take precendence but already present annotations can still be plotted.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
