### PR TITLE
[FIX] TOPPView: fix crash when viewing certain Chromatograms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ Library:
 - better documentation for all SpectraFilter... tools (#7183)
 
 Fixes:
+- TOPPView: fix crash when viewing certain Chromatograms (#7220)
 - more robust parsing of mzIdentML (#7153)
 - more robust FileConverter (#7176)
 - MSFragger: allow relative path to database (#7155)

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -287,8 +287,10 @@ namespace OpenMS
     // update intensity, m/z and RT according to chromatograms as well:
     for (ChromatogramType& cp : chromatograms_)
     {
+      // update range of EACH chrom, if we need them individually later
+      cp.updateRanges();
 
-      // ignore TICs and ECs (as these are usually positioned at 0 and therefor lead to a large white margin in plots if included)
+      // ignore TICs and ECs for the whole experiments range (as these are usually positioned at 0 and therefor lead to a large white margin in plots if included)
       if (cp.getChromatogramType() == ChromatogramSettings::TOTAL_ION_CURRENT_CHROMATOGRAM ||
         cp.getChromatogramType() == ChromatogramSettings::EMISSION_CHROMATOGRAM)
       {
@@ -299,7 +301,6 @@ namespace OpenMS
 
       // ranges
       this->extendMZ(cp.getMZ());// MZ
-      cp.updateRanges();
       this->extend(cp);// RT and intensity from chroms's range
     }
   }

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData1DChrom.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData1DChrom.h
@@ -36,6 +36,11 @@ namespace OpenMS
 
     RangeAllType getRangeForArea(const RangeAllType partial_range) const override
     {
+      if (partial_range.RangeRT::isEmpty())
+      {
+        auto chrom = getCurrentChrom();
+        return RangeAllType().assign(chrom.getRange());
+      }
       const auto& chrom = getCurrentChrom();
       auto chrom_filtered = MSExperiment::ChromatogramType();
       chrom_filtered.insert(chrom_filtered.begin(), chrom.RTBegin(partial_range.getMinRT()), chrom.RTEnd(partial_range.getMaxRT()));

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData1DChrom.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData1DChrom.h
@@ -36,10 +36,12 @@ namespace OpenMS
 
     RangeAllType getRangeForArea(const RangeAllType partial_range) const override
     {
+      // update ranges based on given RT range
       if (partial_range.RangeRT::isEmpty())
-      {
-        auto chrom = getCurrentChrom();
-        return RangeAllType().assign(chrom.getRange());
+      { // .. unless RT is empty, then we use the whole RT range
+        auto r = RangeAllType(partial_range);
+        r.extend(getCurrentChrom().getRange());
+        return r;
       }
       const auto& chrom = getCurrentChrom();
       auto chrom_filtered = MSExperiment::ChromatogramType();


### PR DESCRIPTION
## Description

fixes #7220

which are actually two unrelated problems:
1) when viewing a TIC chrom, its ranges were not precomputed and lead to inverse iterator ranges (+inf RT to -inf RT).
2) when creating a new 1D paint window for Chroms for the first time, there is no RT range, hence updating it does not work.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
