### PR TITLE
Aligning Parameters/ New SpectrumGenerator

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -31,7 +31,6 @@ namespace OpenMS
   public:
 
 
-
     /** @brief Peptide with all important infos needed for the FI-structure
      */
     struct Peptide {
@@ -162,6 +161,7 @@ namespace OpenMS
                        SpectrumMatchesTopN& sms);
 
 protected:
+
 
   /**@brief One entry in the fragment index
    */

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -125,7 +125,8 @@ namespace OpenMS
      *                  it contains both tolerance and open-search-window
      * @return a pair of indexes defining all possible peptides which the current peak could hit
      */
-    std::pair<size_t, size_t> getPeptidesInPrecursorRange(float precursor_mass, const std::pair<float, float>& window);
+    std::pair<size_t, size_t> getPeptidesInPrecursorRange(float precursor_mass,
+                                                          const std::pair<float, float>& window);
 
     /**
      * A match between a single query peak and a database fragment
@@ -146,7 +147,9 @@ namespace OpenMS
      * @param peak_charge The charge of the peak. Is used to calculate the mass from the mz
      * @return a vector of Hits(matching peptide_idx_range and matching fragment_mz_) containing the idx of the hitted peptide and the mass of the hit
      */
-    std::vector<Hit> query(const Peak1D& peak, const std::pair<size_t, size_t>& peptide_idx_range, const uint16_t peak_charge);
+    std::vector<Hit> query(const Peak1D& peak,
+                           const std::pair<size_t,size_t>& peptide_idx_range,
+                           uint16_t peak_charge);
 
     /**
      * @brief: queries one complete experimental spectra against the Database. Loops over all precursor charges
@@ -155,7 +158,8 @@ namespace OpenMS
      * @param spectrum experimental spectrum
      * @param sms[out] The n best Spectrum matches
      */
-    void querySpectrum(const MSSpectrum& spectrum, SpectrumMatchesTopN& sms);
+    void querySpectrum(const MSSpectrum& spectrum,
+                       SpectrumMatchesTopN& sms);
 
 protected:
 
@@ -219,7 +223,10 @@ private:
      * @param[out] sms The Top m SpectrumMatches
      * @param charge Applied charge
      */
-    void searchDifferentPrecursorRanges(const MSSpectrum& spectrum, float precursor_mass, SpectrumMatchesTopN& sms, uint16_t charge);
+    void searchDifferentPrecursorRanges(const MSSpectrum& spectrum,
+                                        float precursor_mass,
+                                        SpectrumMatchesTopN& sms,
+                                        uint16_t charge);
 
     /** @brief places the k-largest elements in the front of the input array. Inside of the k-largest elements and outside the elements are not sorted
      *
@@ -258,7 +265,7 @@ private:
     uint16_t max_precursor_charge_; ///< maximal possible precursor charge
     uint16_t max_fragment_charge_;  ///< The maximal possible charge of the fragments
     uint32_t max_processed_hits_;   ///< The amount of PSM that will be used. the rest is filtered out
-    bool open_search;               ///< true if a unrestrictive open search for potential PTM is performed
+    bool open_search_;               ///< true if a unrestrictive open search for potential PTM is performed
     float open_precursor_window_lower_; ///< Defines the lower bound of the precursor-mass range
     float open_precursor_window_upper_; ///< Defines the upper bound of the precursor-mass range
 

--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -114,9 +114,6 @@ namespace OpenMS
     /// helper for getPrefixAndSuffixIonsMZ. For given Ion-Type and charge calculates a peaks
     static void addPrefixAndSuffixIons_(std::vector< float >& spectrum, const AASequence& peptide, Residue::ResidueType res_type, int charge) ;
 
-
-
-
     bool add_b_ions_;
     bool add_y_ions_;
     bool add_a_ions_;

--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -60,6 +60,10 @@ namespace OpenMS
     /// assignment operator
     TheoreticalSpectrumGenerator& operator=(const TheoreticalSpectrumGenerator& tsg);
 
+
+    /// @throw Exception::InvalidParameter   Nothing so far.
+    void getPrefixAndSuffixIonsMZtest(std::vector<float>& spectrum, const AASequence& peptide, int charge) const;
+
     /** @name Acessors
      */
     //@{
@@ -75,9 +79,12 @@ namespace OpenMS
     /// @throw Exception::InvalidParameter   If fragmentation method is anything else than 'CID', 'HCID', 'ECD' or 'ETD'.
     static MSSpectrum generateSpectrum(const Precursor::ActivationMethod& fm, const AASequence& seq, int precursor_charge);
 
+
     /// overwrite
     void updateMembers_() override;
     //@}
+
+
 
     protected:
 
@@ -98,6 +105,11 @@ namespace OpenMS
 
     /// helper to add full neutral loss ladders (for single peaks), also adds charges and ion names to the DataArrays, if the add_metainfo parameter is set to true
     void addLossesFaster_(PeakSpectrum& spectrum, double mz, const std::set<EmpiricalFormula>& f_losses, int ion_ordinal, DataArrays::StringDataArray& ion_names, DataArrays::IntegerDataArray& charges, const std::map<EmpiricalFormula, String>& formula_str_cache, double intensity, const Residue::ResidueType res_type, bool add_metainfo, int charge) const;
+
+    static void addPrefixAndSuffixIons_(std::vector< float >& spectrum, const AASequence& peptide, Residue::ResidueType res_type, int charge) ;
+
+
+
 
     bool add_b_ions_;
     bool add_y_ions_;

--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -61,8 +61,13 @@ namespace OpenMS
     TheoreticalSpectrumGenerator& operator=(const TheoreticalSpectrumGenerator& tsg);
 
 
-    /// @throw Exception::InvalidParameter   Nothing so far.
-    void getPrefixAndSuffixIonsMZtest(std::vector<float>& spectrum, const AASequence& peptide, int charge) const;
+    /**
+     * Generates a simple tandem MS Spectrum,
+     * @param[out] spectrum Each peak is only represented as a peak
+     * @param peptide The input peptide
+     * @param charge The max charge of the peaks
+     */
+    void getPrefixAndSuffixIonsMZ(std::vector<float>& spectrum, const AASequence& peptide, int charge) const;
 
     /** @name Acessors
      */
@@ -106,6 +111,7 @@ namespace OpenMS
     /// helper to add full neutral loss ladders (for single peaks), also adds charges and ion names to the DataArrays, if the add_metainfo parameter is set to true
     void addLossesFaster_(PeakSpectrum& spectrum, double mz, const std::set<EmpiricalFormula>& f_losses, int ion_ordinal, DataArrays::StringDataArray& ion_names, DataArrays::IntegerDataArray& charges, const std::map<EmpiricalFormula, String>& formula_str_cache, double intensity, const Residue::ResidueType res_type, bool add_metainfo, int charge) const;
 
+    /// helper for getPrefixAndSuffixIonsMZ. For given Ion-Type and charge calculates a peaks
     static void addPrefixAndSuffixIons_(std::vector< float >& spectrum, const AASequence& peptide, Residue::ResidueType res_type, int charge) ;
 
 

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -457,9 +457,6 @@ namespace OpenMS
       trimHits(sms);
   }
 
-
-
-
   FragmentIndex::FragmentIndex() : DefaultParamHandler("FragmentIndex")
   {
     defaults_.setValue("add_y_ions", "true", "Add peaks of y-ions to the spectrum");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -557,6 +557,9 @@ namespace OpenMS
     defaults_.setValue("peptide:motif", "", "If set, only peptides that contain this motif (provided as RegEx) will be considered.");
     defaults_.setSectionDescription("peptide", "Peptide Options");
 
+    IntList isotopes = {0, 1};
+    defaults_.setValue("precursor:isotopes", isotopes, "Corrects for mono-isotopic peak misassignments. (E.g.: 1 = prec. may be misassigned to first isotopic peak)");
+
     defaultsToParam_();
 }
 

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -204,11 +204,11 @@ namespace OpenMS
           AASequence mod_peptide = AASequence(unmod_peptide); // copy the peptide
           ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
           ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, mod_peptides);
-          tsg.getPrefixAndSuffixIonsMZtest(b_y_ions, mod_peptides[pep.modification_idx_], 1);
+          tsg.getPrefixAndSuffixIonsMZ(b_y_ions, mod_peptides[pep.modification_idx_], 1);
         }
         else
         {
-         tsg.getPrefixAndSuffixIonsMZtest(b_y_ions, unmod_peptide, 1);
+          tsg.getPrefixAndSuffixIonsMZ(b_y_ions, unmod_peptide, 1);
         }
 
         for (const float& frag : b_y_ions)
@@ -233,11 +233,11 @@ namespace OpenMS
       OPENMS_LOG_INFO << "Creating DB with bucket_size " << bucketsize_ << endl;
 
       /// 2.) next sort after precursor mass and save the min_mz of each bucket
-      //#pragma omp parallel for
+      #pragma omp parallel for
       for (size_t i = 0; i < fi_fragments_.size(); i += bucketsize_)
       {
 
-        //#pragma omp critical
+        #pragma omp critical
         bucket_min_mz_.emplace_back(fi_fragments_[i].fragment_mz_);
 
         auto bucket_start = fi_fragments_.begin() + i;

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -161,8 +161,6 @@ namespace OpenMS
       fi_fragments_.reserve(fi_peptides_.size() * 2 * peptide_min_length_); //TODO: Does this make senese?
 
       // get the spectrum generator and set the ion-types
-      //TheoreticalSpectrumGenerator tsg;
-      //SimpleTSGXLMS tsg;
       TheoreticalSpectrumGenerator tsg;
 
       auto tsg_params = tsg.getParameters();
@@ -173,7 +171,6 @@ namespace OpenMS
       tsg_params.setValue("add_x_ions", this_params.getValue("add_x_ions"));
       tsg_params.setValue("add_y_ions", this_params.getValue("add_y_ions"));
       tsg_params.setValue("add_z_ions", this_params.getValue("add_z_ions"));
-      //tsg_params.setValue("add_first_prefix_ion", "true");
       tsg.setParameters(tsg_params);
 
 
@@ -216,7 +213,7 @@ namespace OpenMS
           if (fragment_min_mz_ > frag || frag > fragment_max_mz_  ) continue;
 
          #pragma omp critical (CreateFragment)
-          fi_fragments_.emplace_back(static_cast<UInt32>(peptide_idx),(float) frag);
+          fi_fragments_.emplace_back(static_cast<UInt32>(peptide_idx), frag);
         }        
       }
 
@@ -482,7 +479,6 @@ namespace OpenMS
 
     defaults_.setValue("add_z_ions", "false", "Add peaks of z-ions to the spectrum");
     defaults_.setValidStrings("add_z_ions", {"true","false"});
-
 
     defaults_.setValue("precursor:mass_tolerance", 10.0, "Tolerance for precursor-m/z in search");
     std::vector<std::string> precursor_mass_tolerance_unit_valid_strings;

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -461,6 +461,9 @@ namespace OpenMS
       trimHits(sms);
   }
 
+
+
+
   FragmentIndex::FragmentIndex() : DefaultParamHandler("FragmentIndex")
   {
     defaults_.setValue("add_y_ions", "true", "Add peaks of y-ions to the spectrum");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -190,7 +190,7 @@ namespace OpenMS
 
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
-     // #pragma omp parallel for private(mod_peptides, b_y_ions)
+     #pragma omp parallel for private(mod_peptides, b_y_ions)
       for(size_t peptide_idx = 0; peptide_idx < fi_peptides_.size(); peptide_idx++)
       {
         const Peptide& pep = fi_peptides_[peptide_idx];
@@ -216,7 +216,7 @@ namespace OpenMS
         {
           if (fragment_min_mz_ > frag.mz || frag.mz > fragment_max_mz_  ) continue;
 
-         // #pragma omp critical (CreateFragment)
+         #pragma omp critical (CreateFragment)
           fi_fragments_.emplace_back(static_cast<UInt32>(peptide_idx),(float) frag.mz);
         }        
       }

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/CHEMISTRY/AAIndex.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/DigestionEnzyme.h>
-#include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
@@ -191,7 +190,7 @@ namespace OpenMS
 
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
-      #pragma omp parallel for private(mod_peptides, b_y_ions)
+     // #pragma omp parallel for private(mod_peptides, b_y_ions)
       for(size_t peptide_idx = 0; peptide_idx < fi_peptides_.size(); peptide_idx++)
       {
         const Peptide& pep = fi_peptides_[peptide_idx];
@@ -205,19 +204,19 @@ namespace OpenMS
           ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
           ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, mod_peptides);
           //tsg.getSpectrum(b_y_ions, mod_peptides[pep.modification_idx_], 1,1);
-          tsg.getLinearIonSpectrum(b_y_ions, mod_peptides[pep.modification_idx_], mod_peptides[pep.modification_idx_].size(), 1, 1);
+          tsg.getLinearIonSpectrum(b_y_ions, mod_peptides[pep.modification_idx_], mod_peptides[pep.modification_idx_].size(), 1, 0);
         }
         else
         {
          //tsg.getSpectrum(b_y_ions, unmod_peptide, 1,1);
-          tsg.getLinearIonSpectrum(b_y_ions, unmod_peptide, unmod_peptide.size(), 1, 1);
+          tsg.getLinearIonSpectrum(b_y_ions, unmod_peptide, unmod_peptide.size(), 1, 0);
         }
 
         for (const SimpleTSGXLMS::SimplePeak& frag : b_y_ions)
         {
           if (fragment_min_mz_ > frag.mz || frag.mz > fragment_max_mz_  ) continue;
 
-          #pragma omp critical (CreateFragment)
+         // #pragma omp critical (CreateFragment)
           fi_fragments_.emplace_back(static_cast<UInt32>(peptide_idx),(float) frag.mz);
         }        
       }
@@ -235,11 +234,11 @@ namespace OpenMS
       OPENMS_LOG_INFO << "Creating DB with bucket_size " << bucketsize_ << endl;
 
       /// 2.) next sort after precursor mass and save the min_mz of each bucket
-      #pragma omp parallel for
+      //#pragma omp parallel for
       for (size_t i = 0; i < fi_fragments_.size(); i += bucketsize_)
       {
 
-        #pragma omp critical
+        //#pragma omp critical
         bucket_min_mz_.emplace_back(fi_fragments_[i].fragment_mz_);
 
         auto bucket_start = fi_fragments_.begin() + i;
@@ -257,7 +256,8 @@ namespace OpenMS
       OPENMS_LOG_INFO << "Fragment index built!" << endl;
   }
 
-  std::pair<size_t, size_t > FragmentIndex::getPeptidesInPrecursorRange(float precursor_mass, const std::pair<float, float>& window)
+  std::pair<size_t, size_t > FragmentIndex::getPeptidesInPrecursorRange(float precursor_mass,
+                                                                       const std::pair<float, float>& window)
   {
       float prec_tol = precursor_mz_tolerance_unit_ppm_ ? Math::ppmToMass(precursor_mz_tolerance_, precursor_mass) : precursor_mz_tolerance_ ;
 
@@ -266,7 +266,9 @@ namespace OpenMS
       return make_pair(std::distance(fi_peptides_.begin(), left_it), std::distance(fi_peptides_.begin(), right_it));
   }
 
-  vector<FragmentIndex::Hit> FragmentIndex::query(const OpenMS::Peak1D& peak, const pair<size_t, size_t>& peptide_idx_range, uint16_t peak_charge)
+  vector<FragmentIndex::Hit> FragmentIndex::query(const OpenMS::Peak1D& peak,
+                                                  const pair<size_t, size_t>& peptide_idx_range,
+                                                  uint16_t peak_charge)
   {
       float adjusted_mass = peak.getMZ() * (float)peak_charge -((peak_charge-1) * Constants::PROTON_MASS_U);
 
@@ -369,13 +371,16 @@ namespace OpenMS
       }
   }
 
-  void FragmentIndex::searchDifferentPrecursorRanges(const MSSpectrum& spectrum, float precursor_mass, SpectrumMatchesTopN& sms, uint16_t charge)
+  void FragmentIndex::searchDifferentPrecursorRanges(const MSSpectrum& spectrum,
+                                                     float precursor_mass,
+                                                     SpectrumMatchesTopN& sms,
+                                                     uint16_t charge)
   {
       int16_t  min_isotope_error_applied;
       int16_t  max_isotope_error_applied;
       float precursor_window_upper_applied;
       float precursor_window_lower_applied;
-      if (open_search)
+      if (open_search_)
       {
         min_isotope_error_applied = 0;
         max_isotope_error_applied = 0;
@@ -407,7 +412,8 @@ namespace OpenMS
       trimHits(sms);
   }
 
-  void FragmentIndex::querySpectrum(const OpenMS::MSSpectrum& spectrum, OpenMS::FragmentIndex::SpectrumMatchesTopN& sms)
+  void FragmentIndex::querySpectrum(const OpenMS::MSSpectrum& spectrum,
+                                    OpenMS::FragmentIndex::SpectrumMatchesTopN& sms)
   {
       if (!isBuild())
       {
@@ -475,33 +481,49 @@ namespace OpenMS
     defaults_.setValue("add_z_ions", "false", "Add peaks of z-ions to the spectrum");
     defaults_.setValidStrings("add_z_ions", {"true","false"});
 
-    vector<String> all_enzymes;
-    ProteaseDB::getInstance()->getAllNames(all_enzymes);
+
+    defaults_.setValue("precursor:mass_tolerance", 10.0, "Tolerance for precursor-m/z in search");
+    std::vector<std::string> precursor_mass_tolerance_unit_valid_strings;
+    precursor_mass_tolerance_unit_valid_strings.emplace_back("ppm");
+    precursor_mass_tolerance_unit_valid_strings.emplace_back("Da");
+    defaults_.setValue("precursor:mass_tolerance_unit", "ppm", "Unit of precursor mass tolerance.");
+    defaults_.setValidStrings("precursor:mass_tolerance_unit", precursor_mass_tolerance_unit_valid_strings);
+
+    defaults_.setValue("fragment:mass_tolerance", 10.0, "Fragment mass tolerance");
+    std::vector<std::string> fragment_mass_tolerance_unit_valid_strings;
+    fragment_mass_tolerance_unit_valid_strings.emplace_back("ppm");
+    fragment_mass_tolerance_unit_valid_strings.emplace_back("Da");
+    defaults_.setValue("fragment:mass_tolerance_unit", "ppm", "Unit of fragment m");
+    defaults_.setValidStrings("fragment:mass_tolerance_unit", fragment_mass_tolerance_unit_valid_strings);
+
+    defaults_.setValue("precursor:min_charge", 2, "min precursor charge");
+    defaults_.setValue("precursor:max_charge", 5, "max precursor charge");
+
+    defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
+    defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
 
     vector<String> all_mods;
     ModificationsDB::getInstance()->getAllSearchModifications(all_mods);
+    defaults_.setValue("modifications:fixed", std::vector<std::string>{"Carbamidomethyl (C)"}, "Fixed modifications, specified using UniMod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)'");
+    defaults_.setValidStrings("modifications:fixed", ListUtils::create<std::string>(all_mods));
+    defaults_.setValue("modifications:variable", std::vector<std::string>{"Oxidation (M)"}, "Variable modifications, specified using UniMod (www.unimod.org) terms, e.g. 'Oxidation (M)'");
+    defaults_.setValidStrings("modifications:variable", ListUtils::create<std::string>(all_mods));
+    defaults_.setValue("modifications:variable_max_per_peptide", 2, "Maximum number of residues carrying a variable modification per candidate peptide");
 
-    vector<string> tolerance_units{"Da", "ppm"}; // TODO: check if same string in other OpenMS files
+    vector<String> all_enzymes;
+    ProteaseDB::getInstance()->getAllNames(all_enzymes);
     defaults_.setValue("enzyme", "Trypsin", "Enzyme for digestion");
     defaults_.setValidStrings("enzyme", ListUtils::create<std::string>(all_enzymes));
+
+
     defaults_.setValue("peptide:missed_cleavages", 1, "Missed cleavages for digestion");
-    defaults_.setValue("peptide:min_mass", 100, "Minimal peptide mass for database");
-    defaults_.setValue("peptide:max_mass", 9000, "Maximal peptide mass for database"); //Todo: set unlimited option
     defaults_.setValue("peptide:min_size", 7, "Minimal peptide length for database");
     defaults_.setValue("peptide:max_size", 40, "Maximal peptide length for database");
-    defaults_.setValue("fragment_min_mz", 150, "Minimal fragment mz for database");
-    defaults_.setValue("fragment_max_mz", 2000, "Maximal fragment mz for database");
-    defaults_.setValue("precursor:mass_tolerance", 10, "Tolerance for precursor-m/z in search");
-    defaults_.setValue("fragment:mass_tolerance", 10, "Tolerance for fragment-m/z in search");
-    defaults_.setValue("precursor:mass_tolerance_unit", "ppm", "Unit of tolerance for precursor-m/z");
-    defaults_.setValidStrings("precursor:mass_tolerance_unit", tolerance_units);
-    defaults_.setValue("fragment:mass_tolerance_unit", "ppm", "Unit of tolerance for fragment-m/z");
-    defaults_.setValidStrings("fragment:mass_tolerance_unit", tolerance_units);
-    defaults_.setValue("modifications_fixed", std::vector<std::string>{"Carbamidomethyl (C)"}, "Fixed modifications, specified using UniMod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)'");
-    defaults_.setValidStrings("modifications_fixed", ListUtils::create<std::string>(all_mods));
-    defaults_.setValue("modifications_variable", std::vector<std::string>{"Oxidation (M)"}, "Variable modifications, specified using UniMod (www.unimod.org) terms, e.g. 'Oxidation (M)'");
-    defaults_.setValidStrings("modifications_variable", ListUtils::create<std::string>(all_mods));
-    defaults_.setValue("max_variable_mods_per_peptide", 2, "Maximum number of residues carrying a variable modification per candidate peptide");
+
+    defaults_.setValue("peptide:min_mass", 100, "Minimal peptide mass for database");
+    defaults_.setValue("peptide:max_mass", 9000, "Maximal peptide mass for database"); //Todo: set unlimited option
+
+
     is_build_ = false; // TODO: remove this and build on construction
 
     //Search-related params
@@ -509,13 +531,29 @@ namespace OpenMS
     defaults_.setValue("min_matched_peaks", 5, "Minimal number of matched ions to report a PSM");
     defaults_.setValue("min_isotope_error", -1, "Precursor isotope error");
     defaults_.setValue("max_isotope_error", 1, "precursor isotope error");
-    defaults_.setValue("precursor:min_charge", 2, "min precursor charge");
-    defaults_.setValue("precursor:max_charge", 5, "max precursor charge");
+
     defaults_.setValue("fragment:max_charge", 4, "max fragment charge");
     defaults_.setValue("max_processed_hits", 50, "The number of initial hits for which we calculate a score");
     defaults_.setValue("open_search", "false", "Open or standard search");
     defaults_.setValue("open_precursor_window_lower_", -100.0, "lower bound of the open precursor window");
     defaults_.setValue("open_precursor_window_upper_", 200.0, "upper bound of the open precursor window");
+
+    //defaults from the searchEngine that are not needed for this class, but otherwise we would generate a warning
+    defaults_.setValue("decoys", "false", "Should decoys be generated?");
+    defaults_.setValidStrings("decoys", {"true","false"} );
+    defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
+    defaults_.setValidStrings("annotate:PSM",
+                              std::vector<std::string>{
+                                "ALL",
+                                Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM,
+                                Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM,
+                                Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
+                                Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION}
+    );
+    defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
+    defaults_.setSectionDescription("report", "Reporting Options");
+    defaults_.setValue("peptide:motif", "", "If set, only peptides that contain this motif (provided as RegEx) will be considered.");
+    defaults_.setSectionDescription("peptide", "Peptide Options");
 
     defaultsToParam_();
 }
@@ -534,17 +572,17 @@ namespace OpenMS
     peptide_max_mass_ = param_.getValue("peptide:max_mass");
     peptide_min_length_ = param_.getValue("peptide:min_size");
     peptide_max_length_ = param_.getValue("peptide:max_size");
-    fragment_min_mz_ = param_.getValue("fragment_min_mz");
-    fragment_max_mz_ = param_.getValue("fragment_max_mz");
+    fragment_min_mz_ = param_.getValue("fragment:min_mz");
+    fragment_max_mz_ = param_.getValue("fragment:max_mz");
 
     precursor_mz_tolerance_ = param_.getValue("precursor:mass_tolerance");
     fragment_mz_tolerance_ = param_.getValue("fragment:mass_tolerance");
     precursor_mz_tolerance_unit_ppm_ = param_.getValue("precursor:mass_tolerance_unit").toString() == "ppm";
     fragment_mz_tolerance_unit_ppm_ = param_.getValue("fragment:mass_tolerance_unit").toString() == "ppm";
 
-    modifications_fixed_ = ListUtils::toStringList<std::string>(param_.getValue("modifications_fixed"));
-    modifications_variable_ = ListUtils::toStringList<std::string>(param_.getValue("modifications_variable"));
-    max_variable_mods_per_peptide_ = param_.getValue("max_variable_mods_per_peptide");
+    modifications_fixed_ = ListUtils::toStringList<std::string>(param_.getValue("modifications:fixed"));
+    modifications_variable_ = ListUtils::toStringList<std::string>(param_.getValue("modifications:variable"));
+    max_variable_mods_per_peptide_ = param_.getValue("modifications:variable_max_per_peptide");
 
     min_matched_peaks_ = param_.getValue("min_matched_peaks");
     min_isotope_error_ = param_.getValue("min_isotope_error");
@@ -553,7 +591,7 @@ namespace OpenMS
     max_precursor_charge_ = param_.getValue("precursor:max_charge");
     max_fragment_charge_ = param_.getValue("fragment:max_charge");
     max_processed_hits_ = param_.getValue("max_processed_hits");
-    open_search = param_.getValue("open_search").toBool();
+    open_search_ = param_.getValue("open_search").toBool();
     open_precursor_window_lower_ = param_.getValue("open_precursor_window_lower_");
     open_precursor_window_upper_ = param_.getValue("open_precursor_window_upper_");
   }

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
@@ -99,8 +99,7 @@ namespace OpenMS
     defaults_.setValue("enzyme", "Trypsin", "The enzyme used for peptide digestion.");
     defaults_.setValidStrings("enzyme", ListUtils::create<std::string>(all_enzymes));
 
-    defaults_.setValue("decoys", "false", "Should decoys be generated?");
-    defaults_.setValidStrings("decoys", {"true","false"} );
+
 
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
     defaults_.setValidStrings("annotate:PSM", 
@@ -122,6 +121,34 @@ namespace OpenMS
 
     defaults_.setValue("report:top_hits", 1, "Maximum number of top scoring hits per spectrum that are reported.");
     defaults_.setSectionDescription("report", "Reporting Options");
+
+    // Add parameters which are only used by FragmentIndex
+    defaults_.setValue("peptide:min_mass", 100, "Minimal peptide mass for database");
+    defaults_.setValue("peptide:max_mass", 9000, "Maximal peptide mass for database");
+    defaults_.setValue("min_matched_peaks", 5, "Minimal number of matched ions to report a PSM");
+    defaults_.setValue("min_isotope_error", -1, "Precursor isotope error");
+    defaults_.setValue("max_isotope_error", 1, "precursor isotope error");
+    defaults_.setValue("fragment:max_charge", 4, "max fragment charge");
+    defaults_.setValue("max_processed_hits", 50, "The number of initial hits for which we calculate a score");
+    std::vector<std::string> open_search_option;
+    fragment_mass_tolerance_unit_valid_strings.emplace_back("true");
+    fragment_mass_tolerance_unit_valid_strings.emplace_back("false");
+    defaults_.setValue("open_search", "false", "Open or standard search");
+    defaults_.setValidStrings("open_search", open_search_option);
+    defaults_.setValue("open_precursor_window_lower_", -100.0, "lower bound of the open precursor window");
+    defaults_.setValue("open_precursor_window_upper_", 200.0, "upper bound of the open precursor window");
+    defaults_.setValue("add_y_ions", "true", "Add peaks of y-ions to the spectrum");
+    defaults_.setValidStrings("add_y_ions", {"true","false"});
+    defaults_.setValue("add_b_ions", "true", "Add peaks of b-ions to the spectrum");
+    defaults_.setValidStrings("add_b_ions", {"true","false"});
+    defaults_.setValue("add_a_ions", "false", "Add peaks of a-ions to the spectrum");
+    defaults_.setValidStrings("add_a_ions", {"true","false"});
+    defaults_.setValue("add_c_ions", "false", "Add peaks of c-ions to the spectrum");
+    defaults_.setValidStrings("add_c_ions", {"true","false"});
+    defaults_.setValue("add_x_ions", "false", "Add peaks of  x-ions to the spectrum");
+    defaults_.setValidStrings("add_x_ions", {"true","false"});
+    defaults_.setValue("add_z_ions", "false", "Add peaks of z-ions to the spectrum");
+    defaults_.setValidStrings("add_z_ions", {"true","false"});
 
     defaultsToParam_();
   }
@@ -452,12 +479,8 @@ void PeptideSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     //TODO: Can we do it with p.setValue or is there a more sophisticated way?
     startProgress(0, 1, "Building fragment index...");    
     FragmentIndex fragment_index_;
-    auto p = fragment_index_.getParameters();
-    p.setValue("max_processed_hits", report_top_hits_);
-    p.setValue("fragment_min_mz", param_.getValue("fragment:min_mz"));
-    p.setValue("fragment_max_mz", param_.getValue("fragment:max_mz"));
-
-    fragment_index_.setParameters(p);
+    auto this_params = getParameters();
+    fragment_index_.setParameters(this_params);
     fragment_index_.build(fasta_db);
     endProgress();
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
@@ -480,8 +480,8 @@ void PeptideSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     //TODO: Can we do it with p.setValue or is there a more sophisticated way?
     startProgress(0, 1, "Building fragment index...");    
     FragmentIndex fragment_index_;
-    auto this_params = getParameters();
-    fragment_index_.setParameters(this_params);
+    auto params = getParameters();
+    fragment_index_.setParameters(params);
     fragment_index_.build(fasta_db);
     endProgress();
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineAlgorithm.cpp
@@ -99,7 +99,8 @@ namespace OpenMS
     defaults_.setValue("enzyme", "Trypsin", "The enzyme used for peptide digestion.");
     defaults_.setValidStrings("enzyme", ListUtils::create<std::string>(all_enzymes));
 
-
+    defaults_.setValue("decoys", "false", "Should decoys be generated?");
+    defaults_.setValidStrings("decoys", {"true","false"} );
 
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
     defaults_.setValidStrings("annotate:PSM", 

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -927,7 +927,7 @@ namespace OpenMS
   }
 
 
-  void TheoreticalSpectrumGenerator::getPrefixAndSuffixIonsMZtest(std::vector<float>& spectrum, const AASequence& peptide, int charge) const
+  void TheoreticalSpectrumGenerator::getPrefixAndSuffixIonsMZ(std::vector<float>& spectrum, const AASequence& peptide, int charge) const
   {
     for (Int z = charge; z >= 1; --z)
     {

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -17,8 +17,6 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 
-
-
 using namespace std;
 
 namespace OpenMS
@@ -926,7 +924,6 @@ namespace OpenMS
     }
   }
 
-
   void TheoreticalSpectrumGenerator::getPrefixAndSuffixIonsMZ(std::vector<float>& spectrum, const AASequence& peptide, int charge) const
   {
     for (Int z = charge; z >= 1; --z)
@@ -957,10 +954,7 @@ namespace OpenMS
       }
     }
 
-
     std::sort(spectrum.begin(), spectrum.end());
-
-
     return;
   }
 
@@ -992,9 +986,7 @@ namespace OpenMS
       for (; i < peptide.size(); ++i)
       {
         mono_weight += peptide[i].getMonoWeight(Residue::Internal);
-        double pos(mono_weight / charge);
-        spectrum.emplace_back(pos);
-
+        spectrum.emplace_back(mono_weight / charge);
       }
     }
     else // if (res_type == Residue::XIon || res_type == Residue::YIon || res_type == Residue::ZIon)
@@ -1016,9 +1008,7 @@ namespace OpenMS
       for (Size j = peptide.size(); j >= 1; --j)
       {
         mono_weight += peptide[j-1].getMonoWeight(Residue::Internal);
-        double pos(mono_weight / charge);
-
-        spectrum.emplace_back(pos);
+        spectrum.emplace_back(mono_weight / charge);
 
       }
     }

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -17,6 +17,8 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/CONCEPT/RAIICleanup.h>
 
+
+
 using namespace std;
 
 namespace OpenMS
@@ -922,6 +924,105 @@ namespace OpenMS
       }
       spectrum.emplace_back(mono_pos / (double)charge, pre_int_NH3_);
     }
+  }
+
+
+  void TheoreticalSpectrumGenerator::getPrefixAndSuffixIonsMZtest(std::vector<float>& spectrum, const AASequence& peptide, int charge) const
+  {
+    for (Int z = charge; z >= 1; --z)
+    {
+      if (add_b_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::BIon, z);
+      }
+      if (add_y_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::YIon, z);
+      }
+      if (add_a_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::AIon,  z );
+      }
+      if (add_x_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::XIon, z);
+      }
+      if (add_c_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::CIon, z);
+      }
+      if (add_z_ions_)
+      {
+        addPrefixAndSuffixIons_(spectrum, peptide, Residue::ZIon, z);
+      }
+    }
+
+
+    std::sort(spectrum.begin(), spectrum.end());
+
+
+    return;
+  }
+
+  void TheoreticalSpectrumGenerator::addPrefixAndSuffixIons_(std::vector<float>& spectrum, const OpenMS::AASequence& peptide, Residue::ResidueType res_type, int charge)
+  {
+    if (peptide.empty())
+    {
+      cout << "Warning: Attempt at creating Prefix and Suffix Ions Spectrum from empty string!" << endl;
+      return;
+    }
+
+    if (res_type == Residue::AIon || res_type == Residue::BIon || res_type == Residue::CIon)
+    {
+      double mono_weight(Constants::PROTON_MASS_U * charge);
+      if (peptide.hasNTerminalModification())
+      {
+        mono_weight += peptide.getNTerminalModification()->getDiffMonoMass();
+      }
+
+      switch (res_type)
+      {
+        case Residue::AIon: mono_weight += Residue::getInternalToAIon().getMonoWeight(); break;
+        case Residue::BIon: mono_weight += Residue::getInternalToBIon().getMonoWeight(); break;
+        case Residue::CIon: mono_weight += Residue::getInternalToCIon().getMonoWeight(); break;
+        default: break;
+      }
+
+      Size i = 0;
+      for (; i < peptide.size(); ++i)
+      {
+        mono_weight += peptide[i].getMonoWeight(Residue::Internal);
+        double pos(mono_weight / charge);
+        spectrum.emplace_back(pos);
+
+      }
+    }
+    else // if (res_type == Residue::XIon || res_type == Residue::YIon || res_type == Residue::ZIon)
+    {
+      double mono_weight(Constants::PROTON_MASS_U * charge);
+      if (peptide.hasCTerminalModification())
+      {
+        mono_weight += peptide.getCTerminalModification()->getDiffMonoMass();
+      }
+
+      switch (res_type)
+      {
+        case Residue::XIon: mono_weight += Residue::getInternalToXIon().getMonoWeight(); break;
+        case Residue::YIon: mono_weight += Residue::getInternalToYIon().getMonoWeight(); break;
+        case Residue::ZIon: mono_weight += Residue::getInternalToZIon().getMonoWeight(); break;
+        default: break;
+      }
+
+      for (Size i = peptide.size()-1; i >= 0; --i)
+      {
+        mono_weight += peptide[i].getMonoWeight(Residue::Internal);
+        double pos(mono_weight / charge);
+
+        spectrum.emplace_back(pos);
+
+      }
+    }
+    return;
   }
 
   void TheoreticalSpectrumGenerator::updateMembers_()

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -1008,8 +1008,7 @@ namespace OpenMS
       for (Size j = peptide.size(); j >= 1; --j)
       {
         mono_weight += peptide[j-1].getMonoWeight(Residue::Internal);
-        spectrum.emplace_back(mono_weight / charge);
-
+        spectrum.emplace_back((float)mono_weight / charge);
       }
     }
     return;

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -1013,9 +1013,9 @@ namespace OpenMS
         default: break;
       }
 
-      for (Size i = peptide.size()-1; i >= 0; --i)
+      for (Size j = peptide.size(); j >= 1; --j)
       {
-        mono_weight += peptide[i].getMonoWeight(Residue::Internal);
+        mono_weight += peptide[j-1].getMonoWeight(Residue::Internal);
         double pos(mono_weight / charge);
 
         spectrum.emplace_back(pos);

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -25,6 +25,7 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <iostream>
 
+
 using namespace OpenMS;
 using namespace std;
 
@@ -354,10 +355,20 @@ tolTest.setParameters(param);
 
 tolTest.build(entries);
 
+TheoreticalSpectrumGenerator tsg2;
+
+
+
+
+
+
 TheoreticalSpectrumGenerator tsg;
 PeakSpectrum b_y_ions;
+vector<float> b_y_ionzzz;
 AASequence peptide = AASequence::fromString("EVAEAATGEDASSPPPK");
 tsg.getSpectrum(b_y_ions, peptide,1,1);
+tsg.getPrefixAndSuffixIonsMZtest(b_y_ionzzz, peptide, 1);
+
 MSSpectrum theo_spec;
 Precursor theo_prec;
 theo_prec.setCharge(1);

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -364,10 +364,11 @@ TheoreticalSpectrumGenerator tsg2;
 
 TheoreticalSpectrumGenerator tsg;
 PeakSpectrum b_y_ions;
-vector<float> b_y_ionzzz;
+
 AASequence peptide = AASequence::fromString("EVAEAATGEDASSPPPK");
+
 tsg.getSpectrum(b_y_ions, peptide,1,1);
-tsg.getPrefixAndSuffixIonsMZtest(b_y_ionzzz, peptide, 1);
+
 
 MSSpectrum theo_spec;
 Precursor theo_prec;

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -356,12 +356,6 @@ tolTest.setParameters(param);
 tolTest.build(entries);
 
 TheoreticalSpectrumGenerator tsg2;
-
-
-
-
-
-
 TheoreticalSpectrumGenerator tsg;
 PeakSpectrum b_y_ions;
 


### PR DESCRIPTION
## Description

The Parameters of FragmentIndex and PeptideSearchEngineAlgo do now align, such that latter can simply pass the parameters to FragmentIndex.
Added a new function to TheoreticalSpectrumGenerator, which only returns a vector of floats representing a spectrum.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
