### PR TITLE
[FEATURE] Concurrent MSGF+ database indexing

### DIFF
--- a/share/OpenMS/examples/TOPPAS/QualityControl.toppas
+++ b/share/OpenMS/examples/TOPPAS/QualityControl.toppas
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.7.0" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/Param_1_7_0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="info" description="">
-    <ITEM name="version" value="3.1.0-pre-disabled-20231206" type="string" description="" required="false" advanced="false" />
+    <ITEM name="version" value="3.1.0-pre-disabled-20231216" type="string" description="" required="false" advanced="false" />
     <ITEM name="num_vertices" value="24" type="int" description="" required="false" advanced="false" />
     <ITEM name="num_edges" value="30" type="int" description="" required="false" advanced="false" />
     <ITEM name="description" value="&lt;![CDATA[&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Arial&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; color:#000000;&quot;&gt;note: do not run this workflow with multiple jobs in parallel, otherwise you will encounter this issue with MSGF+: https://github.com/OpenMS/OpenMS/issues/7255&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; color:#000000;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;]]&gt;" type="string" description="" required="false" advanced="false" />
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;]]&gt;" type="string" description="" required="false" advanced="false" />
   </NODE>
   <NODE name="vertices" description="">
     <NODE name="0" description="">

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -455,7 +455,10 @@ protected:
       process_params << java_memory 
                      << "-cp" << executable
                      << "edu.ucsd.msjava.msdbsearch.BuildSA"
-                     << "-d" << db_name.toQString();
+                     << "-d" << db_name.toQString()
+                     << "-tda" << 0; // do NOT add & index a reverse DB (i.e. '-tda=2'), since this DB may already contain FW+BW,
+                                     // and duplicating again will cause MSGF+ to error with 'too many redundant proteins'
+      
       // collect all output since MSGF+ might return 'success' even though it did not like the command arguments (e.g. if the version is too old)
       // If no output file is produced, we can print the stderr below.
       String proc_stdout, proc_stderr;

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -442,7 +442,7 @@ protected:
         case QLockFile::UnknownError:
           msg = "Another error happened, for instance a full partition prevented writing out the lock file.";
       };
-      OPENMS_LOG_ERROR << "An error occurred while trying to acquire a file lock: " << msg << " using the file '" << lockfile
+      OPENMS_LOG_ERROR << "An error occurred while trying to acquire a file lock: " << msg << " using the file '" << lockfile.toStdString()
                        << "'.\nPlease check the previous error message and contact OpenMS support if you cannot solve the problem.";
       return false;
     }

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -417,7 +417,7 @@ protected:
     const String db_indexfile = FileHandler::stripExtension(db_name) + ".canno";
     const QString lockfile = (db_name + ".lock").toQString();
     QLockFile lock_db(lockfile);
-    OPENMS_LOG_DEBUG << "Checking for db index, using a lock file ...";
+    OPENMS_LOG_DEBUG << "Checking for db index, using a lock file ..." << std::endl;
     if (!lock_db.lock())
     {
       String msg;
@@ -456,8 +456,8 @@ protected:
                      << "-cp" << executable
                      << "edu.ucsd.msjava.msdbsearch.BuildSA"
                      << "-d" << db_name.toQString()
-                     << "-tda" << 0; // do NOT add & index a reverse DB (i.e. '-tda=2'), since this DB may already contain FW+BW,
-                                     // and duplicating again will cause MSGF+ to error with 'too many redundant proteins'
+                     << "-tda" << "0"; // do NOT add & index a reverse DB (i.e. '-tda=2'), since this DB may already contain FW+BW,
+                                       // and duplicating again will cause MSGF+ to error with 'too many redundant proteins'
       
       // collect all output since MSGF+ might return 'success' even though it did not like the command arguments (e.g. if the version is too old)
       // If no output file is produced, we can print the stderr below.
@@ -476,6 +476,7 @@ protected:
 
     // free lock, since database index exists at this point
     lock_db.unlock();
+    OPENMS_LOG_DEBUG << "... releasing DB lock" << std::endl;
     return true;
   }
 

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -191,9 +191,10 @@ protected:
 
     vector<String> all_mods;
     ModificationsDB::getInstance()->getAllSearchModifications(all_mods);
-    registerStringList_("fixed_modifications", "<mods>", ListUtils::create<String>("Carbamidomethyl (C)", ','), "Fixed modifications, specified using Unimod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'", false);
+    registerStringList_("fixed_modifications", "<mods>", {"Carbamidomethyl (C)"}, "Fixed modifications, specified using Unimod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'", false);
     setValidStrings_("fixed_modifications", all_mods);
-    registerStringList_("variable_modifications", "<mods>", ListUtils::create<String>("Oxidation (M)", ','), "Variable modifications, specified using Unimod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'", false);
+    registerStringList_("variable_modifications", "<mods>", {"Oxidation (M)"}, "Variable modifications, specified using Unimod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'",
+                        false);
     setValidStrings_("variable_modifications", all_mods);
 
     registerFlag_("legacy_conversion", "Use the indirect conversion of MS-GF+ results to idXML via export to TSV. Try this only if the default conversion takes too long or uses too much memory.", true);
@@ -425,7 +426,7 @@ protected:
     }
 
     String java_executable = getStringOption_("java_executable");
-    String db_name = getDBFilename();
+    const String db_name = getDBFilename();
 
     vector<String> fixed_mods = getStringList_("fixed_modifications");
     vector<String> variable_mods = getStringList_("variable_modifications");
@@ -581,7 +582,7 @@ protected:
 
         // handle the search parameters
         ProteinIdentification::SearchParameters search_parameters;
-        search_parameters.db = getStringOption_("database");
+        search_parameters.db = db_name;
         search_parameters.charges = "+" + String(min_precursor_charge) + "-+" + String(max_precursor_charge);
         search_parameters.mass_type = ProteinIdentification::MONOISOTOPIC;
         search_parameters.fixed_modifications = fixed_mods;

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/SYSTEM/JavaInfo.h>
 
 #include <QProcessEnvironment>
+#include <QLockFile>
 
 #include <algorithm>
 #include <fstream>
@@ -62,8 +63,9 @@
     generate a number of auxiliary files in the same directory as the database (e.g. for "db.fasta": "db.canno", "db.cnlap", "db.csarr" and "db.cseq" will be generated).
     It is advisable to keep these files for future MS-GF+ searches, to save the indexing step.@n
 
-    @note When a new database is used for the first time, make sure to run only one MS-GF+ search against it! Otherwise one process will start the 
-    indexing and the others will crash due to incomplete index files. After a database has been indexed, multiple MS-GF+ processes can use it in parallel.
+    @note This Adapter uses an internal locking mechanism (a file lock), to ensure that MSGF+ does not attempt to create the database index
+    in parallel (which would fail badly) when multiple instances of this Adapter are run concurrently on the same FASTA database.
+    After the database has been indexed, multiple MS-GF+ processes (even without this Adapters locking) can use it in parallel.
 
     This adapter supports relative database filenames, which (when not found in the current working directory) are looked up in the directories specified 
     by 'OpenMS.ini:id_db_dir' (see @subpage TOPP_advanced).
@@ -410,6 +412,70 @@ protected:
     id.setHigherScoreBetter(false);
   }
 
+  bool createLockedDBIndex(const String& db_name, const QString java_executable, const QString java_memory, const QString executable)
+  {
+    const String db_indexfile = FileHandler::stripExtension(db_name) + ".canno";
+    const QString lockfile = (db_name + ".lock").toQString();
+    QLockFile lock_db(lockfile);
+    OPENMS_LOG_DEBUG << "Checking for db index, using a lock file ...";
+    if (!lock_db.lock())
+    {
+      String msg;
+      switch (lock_db.error())
+      {
+        case QLockFile::NoError:
+          msg = "The lock was acquired successfully.";
+          break;
+        case QLockFile::LockFailedError:
+          msg = "The lock could not be acquired because another process holds it.";
+          break;
+        case QLockFile::PermissionError: // if we cannot create the log, hopefully noone else can (who runs on different accounts anyways?)
+          // so we may dare to check for existance of the index (even though we are not locked right now)
+          msg = "The lock file could not be created, for lack of permissions in the parent directory.";
+          if (!File::exists(db_indexfile))
+          {
+            OPENMS_LOG_ERROR << msg << " Checking index anyway: No database index found! Please make the directory writable or pre-create an DB index." << std::endl;
+            return false;
+          }
+          OPENMS_LOG_DEBUG << msg << " Checking index anyway: found it!" << std::endl;
+          return true;
+        case QLockFile::UnknownError:
+          msg = "Another error happened, for instance a full partition prevented writing out the lock file.";
+      };
+      OPENMS_LOG_ERROR << "An error occurred while trying to acquire a file lock: " << msg << " using the file '" << lockfile
+                       << "'.\nPlease check the previous error message and contact OpenMS support if you cannot solve the problem.";
+      return false;
+    }
+    // we have a lock: now check if we need to create a new index (which only one instance should do)
+    if (!File::exists(db_indexfile))
+    {
+      OPENMS_LOG_INFO << "\nNo database index found! Creating index while holding a lock ..." << std::endl;
+      QStringList process_params; // the actual process is Java, not MS-GF+!
+      // java -Xmx3500M -cp MSGFPlus.jar edu.ucsd.msjava.msdbsearch.BuildSA -d DatabaseFile
+      process_params << java_memory 
+                     << "-cp" << executable
+                     << "edu.ucsd.msjava.msdbsearch.BuildSA"
+                     << "-d" << db_name.toQString();
+      // collect all output since MSGF+ might return 'success' even though it did not like the command arguments (e.g. if the version is too old)
+      // If no output file is produced, we can print the stderr below.
+      String proc_stdout, proc_stderr;
+
+      TOPPBase::ExitCodes exit_code = runExternalProcess_(java_executable, process_params, proc_stdout, proc_stderr);
+      if (exit_code != EXECUTION_OK)
+      {
+        // if there was sth like a segfault, runExternalProcess_ will write a warning about the type of error,
+        //  but not print the output of the program.
+        OPENMS_LOG_ERROR << "The output of MSGF+'s Index Database Creation was:\nSTDOUT:\n" << proc_stdout << "\nSTDERR:\n" << proc_stderr << endl;
+        return false;
+      }
+      OPENMS_LOG_INFO << " ... done" << std::endl;
+    }
+
+    // free lock, since database index exists at this point
+    lock_db.unlock();
+    return true;
+  }
+
   ExitCodes main_(int, const char**) override
   {
     //-------------------------------------------------------------
@@ -425,18 +491,7 @@ protected:
       return ILLEGAL_PARAMETERS;
     }
 
-    String java_executable = getStringOption_("java_executable");
-    const String db_name = getDBFilename();
-
-    vector<String> fixed_mods = getStringList_("fixed_modifications");
-    vector<String> variable_mods = getStringList_("variable_modifications");
-    bool no_mods = fixed_mods.empty() && variable_mods.empty();
-    Int max_mods = getIntOption_("max_mods");
-    if ((max_mods == 0) && !no_mods)
-    {
-      writeLogWarn_("Warning: Modifications are defined ('fixed_modifications'/'variable_modifications'), but the number of allowed modifications is zero ('max_mods'). Is that intended?");
-    }
-
+    const String java_executable = getStringOption_("java_executable");
     if (!getFlag_("force"))
     {
       if (!JavaInfo::canRun(java_executable))
@@ -448,6 +503,25 @@ protected:
     else
     {
       writeLogWarn_("The installation of Java was not checked.");
+    }
+    
+    const QString java_memory = "-Xmx" + QString::number(getIntOption_("java_memory")) + "m";
+    const QString executable = getStringOption_("executable").toQString();
+    
+    const String db_name = getDBFilename();
+    if (!createLockedDBIndex(db_name, java_executable.toQString(), java_memory, executable))
+    {
+      OPENMS_LOG_ERROR << "Could not create/verify database index. Aborting ..." << std::endl;
+      return ExitCodes::INTERNAL_ERROR;
+    }
+
+    vector<String> fixed_mods = getStringList_("fixed_modifications");
+    vector<String> variable_mods = getStringList_("variable_modifications");
+    bool no_mods = fixed_mods.empty() && variable_mods.empty();
+    Int max_mods = getIntOption_("max_mods");
+    if ((max_mods == 0) && !no_mods)
+    {
+      writeLogWarn_("Warning: Modifications are defined ('fixed_modifications'/'variable_modifications'), but the number of allowed modifications is zero ('max_mods'). Is that intended?");
     }
 
     // create temporary directory (and modifications file, if necessary):
@@ -470,8 +544,6 @@ protected:
     Int min_precursor_charge = getIntOption_("min_precursor_charge");
     Int max_precursor_charge = getIntOption_("max_precursor_charge");
     // parameters only needed for MS-GF+:
-    QString java_memory = "-Xmx" + QString::number(getIntOption_("java_memory")) + "m";
-    QString executable = getStringOption_("executable").toQString();
     // no need to handle "not found" case - would have given error during parameter parsing:
     Int fragment_method_code = ListUtils::getIndex<String>(fragment_methods_, getStringOption_("fragment_method"));
     Int instrument_code = ListUtils::getIndex<String>(instruments_, getStringOption_("instrument"));


### PR DESCRIPTION
## Description

fixes #7255 , allowing to run multiple MSGFPlusAdapters of OpenMS concurrently without having to worry about crashing when MSGF+ tries to create an indexed database.

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
