### PR TITLE
Allow different sizes of compressed output in zlib unit tests

### DIFF
--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -64,21 +64,23 @@ START_SECTION((static void compressString(std::string& raw_data, std::string& co
 {
   std::string compressed_data;
 
+  // Because implementations of zlib and alternatives differ, we just test if 
+  // the compressed data requires less space.
   ZlibCompression::compressString(raw_data, compressed_data);
   TEST_EQUAL(raw_data.size(), 58)
-  TEST_EQUAL(compressed_data.size(), 14)
+  TEST_TRUE(compressed_data.size() < raw_data.size())
 
   ZlibCompression::compressString(raw_data2, compressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
-  TEST_EQUAL(compressed_data.size(), 72)
+  TEST_TRUE(compressed_data.size() < raw_data2.size())
 
   ZlibCompression::compressString(raw_data3, compressed_data);
   TEST_EQUAL(raw_data3.size(), 105)
-  TEST_EQUAL(compressed_data.size(), 97)
+  TEST_TRUE(compressed_data.size() < raw_data3.size())
 
   ZlibCompression::compressString(raw_data4, compressed_data);
   TEST_EQUAL(raw_data4.size(), 1052)
-  TEST_EQUAL(compressed_data.size(), 335)
+  TEST_TRUE(compressed_data.size() < raw_data4.size())
 }
 END_SECTION
 
@@ -91,20 +93,16 @@ START_SECTION((static void compressString(const QByteArray& raw_data, QByteArray
   QByteArray compressed_data;
 
   ZlibCompression::compressString(raw_data_q, compressed_data);
-  TEST_EQUAL(raw_data.size(), 58)
-  TEST_EQUAL(compressed_data.size(), 14)
+  TEST_TRUE(compressed_data.size() < raw_data_q.size())
 
   ZlibCompression::compressString(raw_data_q2, compressed_data);
-  TEST_EQUAL(raw_data_q2.size(), 64)
-  TEST_EQUAL(compressed_data.size(), 72)
+  TEST_TRUE(compressed_data.size() < raw_data_q2.size())
 
   ZlibCompression::compressString(raw_data_q3, compressed_data);
-  TEST_EQUAL(raw_data_q3.size(), 105)
-  TEST_EQUAL(compressed_data.size(), 97)
+  TEST_TRUE(compressed_data.size() < raw_data_q3.size())
 
   ZlibCompression::compressString(raw_data_q4, compressed_data);
-  TEST_EQUAL(raw_data_q4.size(), 1052)
-  TEST_EQUAL(compressed_data.size(), 335)
+  TEST_TRUE(compressed_data.size() < raw_data_q4.size())
 }
 END_SECTION
 
@@ -116,28 +114,28 @@ START_SECTION((static void uncompressString(const void * compressed_data, size_t
   ZlibCompression::compressString(raw_data, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data.size(), 58)
-  TEST_EQUAL(compressed_data.size(), 14)
+  TEST_TRUE(compressed_data.size() < raw_data.size())  
   TEST_EQUAL(uncompressed_data.size(), 58)
   TEST_TRUE(uncompressed_data == raw_data)
 
   ZlibCompression::compressString(raw_data2, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
-  TEST_EQUAL(compressed_data.size(), 72)
+  TEST_TRUE(compressed_data.size() < raw_data.size())  
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data2)
 
   ZlibCompression::compressString(raw_data3, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data3.size(), 105)
-  TEST_EQUAL(compressed_data.size(), 97)
+  TEST_TRUE(compressed_data.size() < raw_data.size())  
   TEST_EQUAL(uncompressed_data.size(), 105)
   TEST_TRUE(uncompressed_data == raw_data3)
 
   ZlibCompression::compressString(raw_data4, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data4.size(), 1052)
-  TEST_EQUAL(compressed_data.size(), 335)
+  TEST_TRUE(compressed_data.size() < raw_data.size())  
   TEST_EQUAL(uncompressed_data.size(), 1052)
   TEST_TRUE(uncompressed_data == raw_data4)
 }
@@ -155,29 +153,29 @@ START_SECTION((static void uncompressString(const QByteArray& compressed_data, Q
 
   ZlibCompression::compressString(raw_data_q, compressed_data);
   ZlibCompression::uncompressString(compressed_data, uncompressed_data);
-  TEST_EQUAL(raw_data.size(), 58)
-  TEST_EQUAL(compressed_data.size(), 14)
+  TEST_EQUAL(raw_data_q.size(), 58)
+  TEST_TRUE(compressed_data.size() < raw_data_q.size())  
   TEST_EQUAL(uncompressed_data.size(), 58)
   TEST_TRUE(uncompressed_data == raw_data_q)
 
   ZlibCompression::compressString(raw_data_q2, compressed_data);
   ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data_q2.size(), 64)
-  TEST_EQUAL(compressed_data.size(), 72)
+  TEST_TRUE(compressed_data.size() < raw_data_q2.size())  
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data_q2)
 
   ZlibCompression::compressString(raw_data_q3, compressed_data);
   ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data_q3.size(), 105)
-  TEST_EQUAL(compressed_data.size(), 97)
+  TEST_TRUE(compressed_data.size() < raw_data_q3.size())  
   TEST_EQUAL(uncompressed_data.size(), 105)
   TEST_TRUE(uncompressed_data == raw_data_q3)
 
   ZlibCompression::compressString(raw_data_q4, compressed_data);
   ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data_q4.size(), 1052)
-  TEST_EQUAL(compressed_data.size(), 335)
+  TEST_TRUE(compressed_data.size() < raw_data_q4.size())  
   TEST_EQUAL(uncompressed_data.size(), 1052)
   TEST_TRUE(uncompressed_data == raw_data_q4)
 }

--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -121,21 +121,21 @@ START_SECTION((static void uncompressString(const void * compressed_data, size_t
   ZlibCompression::compressString(raw_data2, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
-  TEST_TRUE(compressed_data.size() < raw_data.size())  
+  TEST_TRUE(compressed_data.size() < raw_data2.size())  
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data2)
 
   ZlibCompression::compressString(raw_data3, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data3.size(), 105)
-  TEST_TRUE(compressed_data.size() < raw_data.size())  
+  TEST_TRUE(compressed_data.size() < raw_data3.size())  
   TEST_EQUAL(uncompressed_data.size(), 105)
   TEST_TRUE(uncompressed_data == raw_data3)
 
   ZlibCompression::compressString(raw_data4, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data4.size(), 1052)
-  TEST_TRUE(compressed_data.size() < raw_data.size())  
+  TEST_TRUE(compressed_data.size() < raw_data4.size())  
   TEST_EQUAL(uncompressed_data.size(), 1052)
   TEST_TRUE(uncompressed_data == raw_data4)
 }

--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -72,7 +72,7 @@ START_SECTION((static void compressString(std::string& raw_data, std::string& co
 
   ZlibCompression::compressString(raw_data2, compressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
-  TEST_TRUE(compressed_data.size() < raw_data2.size())
+  TEST_TRUE(compressed_data.size() >= raw_data2.size())
 
   ZlibCompression::compressString(raw_data3, compressed_data);
   TEST_EQUAL(raw_data3.size(), 105)
@@ -96,7 +96,7 @@ START_SECTION((static void compressString(const QByteArray& raw_data, QByteArray
   TEST_TRUE(compressed_data.size() < raw_data_q.size())
 
   ZlibCompression::compressString(raw_data_q2, compressed_data);
-  TEST_TRUE(compressed_data.size() < raw_data_q2.size())
+  TEST_TRUE(compressed_data.size() >= raw_data_q2.size())
 
   ZlibCompression::compressString(raw_data_q3, compressed_data);
   TEST_TRUE(compressed_data.size() < raw_data_q3.size())

--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -121,7 +121,7 @@ START_SECTION((static void uncompressString(const void * compressed_data, size_t
   ZlibCompression::compressString(raw_data2, compressed_data);
   ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
-  TEST_TRUE(compressed_data.size() < raw_data2.size())  
+  TEST_TRUE(compressed_data.size() >= raw_data2.size())  //  "ABCD..." string is difficult to compress
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data2)
 
@@ -161,7 +161,7 @@ START_SECTION((static void uncompressString(const QByteArray& compressed_data, Q
   ZlibCompression::compressString(raw_data_q2, compressed_data);
   ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data_q2.size(), 64)
-  TEST_TRUE(compressed_data.size() < raw_data_q2.size())  
+  TEST_TRUE(compressed_data.size() >= raw_data_q2.size())  // difficult to compress...
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data_q2)
 


### PR DESCRIPTION
## Description

- unit test only checks for reduced size of compressed data (not the exact size). Reason: zlib-ng is more efficient at same compression level and produces smaller compressed data

TODO: tool tests

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
