### PR TITLE
[Feature] Loading XML from remote locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,6 @@
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR) ## if you change this, also update doc/doxygen/install/install-<OS>.doxygen
 
-# Handle default build type
-get_property(multiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if(NOT multiConfig AND NOT DEFINED CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build.")
-endif()
-
 project("OpenMS_host" LANGUAGES CXX)
 
 # required for cmake < 3.13 if ccache is used
@@ -83,6 +77,7 @@ option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
 option(NO_WEBENGINE_WIDGETS "Do not use QtWebengineWidgets. Disables Javascript views in TOPPView." OFF)
 option(WITH_HDF5 "Build HDF5 parts of OpenMS." OFF)
+option(WITH_S3 "Build with S3 loading support" OFF)
 
 if(MSVC)
   option(MT_ENABLE_NESTED_OPENMP "Enable nested parallelism." OFF)
@@ -195,9 +190,6 @@ else()
 	set(OPENMS_64BIT_ARCHITECTURE 0 CACHE INTERNAL "Architecture-bits")
 	message(STATUS "Architecture: 32 bit")
 endif()
-
-# Force build type into the cache (needs to be set beforehand)
-set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 
 #------------------------------------------------------------------------------
 # Project specific compiler flags

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -172,6 +172,12 @@ if (WITH_HDF5)
   find_package(HDF5 MODULE REQUIRED COMPONENTS C CXX)
 endif()
 
+# AWS S3
+if (WITH_S3)
+  # Find the AWS SDK for C++
+  find_package(AWSSDK REQUIRED COMPONENTS s3)
+endif()
+
 #------------------------------------------------------------------------------
 # Done finding contrib libraries
 #------------------------------------------------------------------------------

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -107,6 +107,11 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   tdl::tdl
   )
 
+if (WITH_S3)
+  ## lol.. disgusting cmake.. how would one link to a subset of the AWS SDK?
+  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES PRIVATE ${AWSSDK_LINK_LIBRARIES})
+endif()
+
 ## ----------
 ## No need to for this at the moment: no Qt plugins required anymore. Left here for reference.
 ## ----------

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/S3ChunkedInputSource.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/S3ChunkedInputSource.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2002-2023, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#pragma once
+#include <xercesc/sax/InputSource.hpp>
+#include <xercesc/util/BinInputStream.hpp>
+#include <aws/s3/model/GetObjectResult.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <zlib.h>
+#include <bzlib.h>
+
+#include <string>
+
+
+namespace OpenMS {
+    class S3ChunkedInputSource : public xercesc::InputSource {
+    public:
+        S3ChunkedInputSource(const std::string& s3uri);
+        xercesc::BinInputStream* makeStream() const override;
+    private:
+        void initializeAwsSdk_();
+
+        void cleanupAwsSdk_();
+
+        void parseS3Uri_(std::string s3Uri);
+
+        std::string m_bucketName;
+        std::string m_objectKey;
+    };
+
+    class S3ChunkedBinInputStream : public xercesc::BinInputStream {
+    public:
+        explicit S3ChunkedBinInputStream(
+            const Aws::S3::S3Client& client,
+            const Aws::S3::Model::GetObjectRequest& req,
+            unsigned long chunkSize = 1024 * 1024 * 100 // 100 MB should be a good default for most cases
+        );
+
+        XMLFilePos curPos() const override;
+
+        // Note: Typical maxToRead is 48 KB (48 * 1024)
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) override;
+
+        const XMLCh* getContentType() const override;
+
+    private:
+        Aws::S3::Model::GetObjectRequest m_req; ///< Copy of the request (bucket + key + range) where the range will be updated
+        Aws::S3::S3Client m_client; ///< Client to use for the request (with credentials etc.)
+        XMLFilePos m_position; ///< Current position in the stream important for curPos()
+        unsigned long m_chunkSize; ///< Size of each chunk to request from S3
+        unsigned long m_currentChunkEnd; ///< End of the current chunk
+        unsigned long m_totalSize; ///< Total size of the object to download/stream
+        Aws::S3::Model::GetObjectResult m_currentChunk; ///< Current chunk of the object as returned by S3
+    };
+
+    class S3ChunkedGzipBinInputStream : public xercesc::BinInputStream {
+    public:
+        S3ChunkedGzipBinInputStream(
+            const Aws::S3::S3Client& client,
+            const Aws::S3::Model::GetObjectRequest& req,
+            unsigned long chunkSize = 1024 * 1024 * 100
+        );
+
+        ~S3ChunkedGzipBinInputStream();
+
+        XMLFilePos curPos() const override;
+
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) override;
+
+        const XMLCh* getContentType() const override;
+
+    private:
+        Aws::S3::Model::GetObjectRequest m_req; ///< Copy of the request (bucket + key + range) where the range will be updated
+        Aws::S3::S3Client m_client; ///< Client to use for the request (with credentials etc.)
+        XMLFilePos m_position; ///< Current position in the stream important for curPos()
+        unsigned long m_chunkSize; ///< Size of each chunk to request from S3
+        unsigned long m_currentChunkEnd; ///< End of the current chunk
+        unsigned long m_totalSize; ///< Total size of the object to download/stream
+        Aws::S3::Model::GetObjectResult m_currentChunk; ///< Current chunk of the object as returned by S3
+        XMLByte m_decompressedBuffer[1024]; ///< Current decompressed buffer
+        z_stream m_zStream; ///< zlib stream for decompression
+    };
+
+    class S3ChunkedBzip2BinInputStream : public xercesc::BinInputStream {
+    public:
+        S3ChunkedBzip2BinInputStream(
+            const Aws::S3::S3Client& client,
+            const Aws::S3::Model::GetObjectRequest& req,
+            unsigned long chunkSize = 1024 * 1024 * 100
+        );
+
+        ~S3ChunkedBzip2BinInputStream();
+
+        XMLFilePos curPos() const override;
+
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) override;
+
+        const XMLCh* getContentType() const override;
+
+    private:
+        Aws::S3::Model::GetObjectRequest m_req; ///< Copy of the request (bucket + key + range) where the range will be updated
+        Aws::S3::S3Client m_client; ///< Client to use for the request (with credentials etc.)
+        XMLFilePos m_position; ///< Current position in the stream important for curPos()
+        unsigned long m_chunkSize; ///< Size of each chunk to request from S3
+        unsigned long m_currentChunkEnd; ///< End of the current chunk
+        unsigned long m_totalSize; ///< Total size of the object to download/stream
+        Aws::S3::Model::GetObjectResult m_currentChunk; ///< Current chunk of the object as returned by S3
+        XMLByte m_decompressedBuffer[1024]; ///< Current decompressed buffer
+        bz_stream m_bzStream; ///< zlib stream for decompression
+    };
+}

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/S3InputSource.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/S3InputSource.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2002-2023, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#pragma once
+#include <xercesc/sax/InputSource.hpp>
+#include <xercesc/util/BinInputStream.hpp>
+#include <aws/core/utils/memory/stl/AWSStreamFwd.h>
+#include <aws/s3/model/GetObjectResult.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <zlib.h>
+#include <bzlib.h>
+
+#include <string>
+
+
+namespace OpenMS {
+    class S3InputSource : public xercesc::InputSource {
+    public:
+        S3InputSource(const std::string& s3uri);
+        xercesc::BinInputStream* makeStream() const override;
+    private:
+        void initializeAwsSdk_();
+
+        void cleanupAwsSdk_();
+
+        void parseS3Uri_(std::string s3Uri);
+
+        std::string m_bucketName;
+        std::string m_objectKey;
+    };
+
+    class S3BinInputStream : public xercesc::BinInputStream {
+    public:
+        explicit S3BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome);
+
+        XMLFilePos curPos() const override;
+
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) override;
+
+        const XMLCh* getContentType() const override;
+
+    private:
+        std::shared_ptr<Aws::S3::Model::GetObjectOutcome> m_getObjectOutcome;
+        Aws::IOStream* m_stream;
+        XMLFilePos m_position;
+    };
+
+    class S3GzipBinInputStream : public xercesc::BinInputStream {
+    public:
+        S3GzipBinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome);
+
+        ~S3GzipBinInputStream();
+
+        XMLFilePos curPos() const override;
+
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) override;
+
+        const XMLCh* getContentType() const override;
+
+    private:
+        std::shared_ptr<Aws::S3::Model::GetObjectOutcome> m_getObjectOutcome;
+        Aws::IOStream* m_stream;
+        z_stream m_zStream;
+        Bytef m_buffer[1024];  // Decompressing buffer for reading from the S3 stream
+        XMLFilePos m_position;
+    };
+
+    class S3Bzip2BinInputStream : public xercesc::BinInputStream
+    {
+    public:
+        S3Bzip2BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome);
+        ~S3Bzip2BinInputStream();
+
+        XMLFilePos curPos() const;
+        XMLSize_t readBytes(XMLByte* const toFill, const XMLSize_t maxToRead);
+        const XMLCh* getContentType() const;
+
+    private:
+        std::shared_ptr<Aws::S3::Model::GetObjectOutcome> m_getObjectOutcome;
+        Aws::IOStream* m_stream;
+        bz_stream m_bzStream;
+        char m_buffer[1024];  // Decompressing buffer for reading from the stream
+        XMLFilePos m_position;
+    };
+}

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/sources.cmake
@@ -12,6 +12,8 @@ set(sources_list_h
   MSDataTransformingConsumer.h
   MSDataWritingConsumer.h
   NoopMSDataConsumer.h
+  S3InputSource.h
+  S3ChunkedInputSource.h
   SiriusFragmentAnnotation.h
   SiriusMzTabWriter.h
   SwathFileConsumer.h

--- a/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
+++ b/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
@@ -73,11 +73,18 @@ public:
     /// set the file_name_ according to absolute path of the file loaded from preferably done whilst loading
     void setLoadedFilePath(const String & file_name);
 
+    /// set the file_name_ according to absolute path of the file loaded from preferably done whilst loading
+    /// does no checking, so it can also be a Network file path
+    void setLoadedNetFilePath(const String & file_name);
+
     /// get the file_name_ which is the absolute path to the file loaded from
     const String & getLoadedFilePath() const;
 
     /// set the file_type according to the type of the file loaded from (see FileHandler::Type) preferably done whilst loading
     void setLoadedFileType(const String & file_name);
+
+    /// set the file_type according to the type of the file loaded from (see FileHandler::Type) preferably done whilst loading
+    void setLoadedFileType(FileTypes::Type type);
 
     /// get the file_type (e.g. featureXML, consensusXML, mzData, mzXML, mzML, ...) of the file loaded from
     const FileTypes::Type & getLoadedFileType() const;

--- a/src/openms/source/FORMAT/DATAACCESS/S3ChunkedInputSource.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/S3ChunkedInputSource.cpp
@@ -1,0 +1,483 @@
+// Copyright (c) 2002-2023, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/FORMAT/DATAACCESS/S3ChunkedInputSource.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
+
+
+namespace OpenMS {
+
+    S3ChunkedInputSource::S3ChunkedInputSource(const std::string& s3uri)
+    {
+        initializeAwsSdk_();
+        parseS3Uri_(s3uri);
+    }
+
+    xercesc::BinInputStream* S3ChunkedInputSource::makeStream() const {
+        Aws::Client::ClientConfiguration clientConfig;
+
+        Aws::S3::S3Client s3Client(clientConfig);
+
+        Aws::S3::Model::HeadObjectRequest request;
+        request.WithBucket(m_bucketName).WithKey(m_objectKey);
+
+        auto outcome = s3Client.HeadObject(request);
+        std::string encoding;
+        if (outcome.IsSuccess()) {
+            auto metadata = outcome.GetResult().GetMetadata();
+            auto encodingIter = metadata.find("Content-Encoding");
+            if (encodingIter != metadata.end()) {
+                encoding = encodingIter->second;
+            }
+            else
+            {
+                // First request to get the first magic bytes
+                Aws::S3::Model::GetObjectRequest firstRequest;
+                firstRequest.WithBucket(m_bucketName).WithKey(m_objectKey);
+                firstRequest.SetRange("bytes=0-2");
+
+                auto firstOutcome = s3Client.GetObject(firstRequest);
+
+                if (firstOutcome.IsSuccess()) {
+                    Aws::IOStream& firstStream = firstOutcome.GetResult().GetBody();
+                    unsigned char header[3];
+                    firstStream.read(reinterpret_cast<char*>(header), sizeof(header));
+                    if (header[0] == 0x1F && header[1] == 0x8B) {
+                        // The file is gzip compressed
+                        encoding = "gzip";
+                    } else if (header[0] == 'B' && header[1] == 'Z' && header[2] == 'h') {
+                        // The file is bzip2 compressed
+                        encoding = "bzip2";
+                    }
+                } else {
+                    OPENMS_LOG_ERROR << "Error: AWS SDK GetObject for magic bytes: " <<
+                        firstOutcome.GetError().GetExceptionName() << " " <<
+                        firstOutcome.GetError().GetMessage() << std::endl;
+                    return nullptr;
+                }
+            }
+        } else {
+            OPENMS_LOG_ERROR << "Error: AWS SDK HeadObject: " <<
+                outcome.GetError().GetExceptionName() << " " <<
+                outcome.GetError().GetMessage() << std::endl;
+            return nullptr;
+        }
+
+        Aws::S3::Model::GetObjectRequest getObjectRequest;
+        getObjectRequest.WithBucket(m_bucketName).WithKey(m_objectKey);
+
+        auto getObjectOutcome = new Aws::S3::Model::GetObjectOutcome(s3Client.GetObject(getObjectRequest));
+        if (getObjectOutcome->IsSuccess()) {
+            if (encoding == "gzip") {
+                return new S3ChunkedGzipBinInputStream(s3Client, getObjectRequest);
+            } else if (encoding == "bzip2") {
+                return new S3ChunkedBzip2BinInputStream(s3Client, getObjectRequest);
+            } else {
+                // The object is not compressed, or it is compressed with a different format
+                return new S3ChunkedBinInputStream(s3Client, getObjectRequest);
+            }
+        } else {
+            OPENMS_LOG_ERROR << "Error: AWS SDK GetObject: " <<
+                getObjectOutcome->GetError().GetExceptionName() << " " <<
+                getObjectOutcome->GetError().GetMessage() << std::endl;
+            return nullptr;
+        }
+    }
+
+    void S3ChunkedInputSource::initializeAwsSdk_() {
+        Aws::SDKOptions options;
+        Aws::InitAPI(options);
+    }
+
+    void S3ChunkedInputSource::cleanupAwsSdk_() {
+        Aws::ShutdownAPI(Aws::SDKOptions());
+    }
+
+    void S3ChunkedInputSource::parseS3Uri_(std::string s3Uri) {
+        // Remove the "s3://" prefix if present
+        if (s3Uri.compare(0, 5, "s3://") == 0) {
+            s3Uri = s3Uri.substr(5);
+        }
+
+        // Find the first occurrence of '/' character
+        size_t slashPos = s3Uri.find('/');
+        if (slashPos == std::string::npos) {
+            // Invalid S3 URI format
+            // Handle error
+            return;
+        }
+
+        m_bucketName = s3Uri.substr(0, slashPos);
+        m_objectKey = s3Uri.substr(slashPos + 1);
+    }
+
+    S3ChunkedBinInputStream::S3ChunkedBinInputStream(const Aws::S3::S3Client& client, const Aws::S3::Model::GetObjectRequest& req, unsigned long chunkSize)
+        : m_req(req), m_client(client), m_position(0), m_chunkSize(chunkSize)
+    {
+        // load first chunk
+        m_req.SetRange("bytes=0-" + std::to_string(m_chunkSize - 1));
+        Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+        if (outcome.IsSuccess()) {
+            m_currentChunk = outcome.GetResultWithOwnership();
+        } else {
+            OPENMS_LOG_ERROR << "Error: AWS SDK GetObject: " << outcome.GetError().GetExceptionName() << ": " << outcome.GetError().GetMessage() << std::endl;
+        }
+        m_currentChunkEnd = m_chunkSize - 1;
+        std::string contentRange = m_currentChunk.GetContentRange();
+        // Process the ContentRange header...
+        // Example: bytes 0-524287/2000000
+        size_t slashPos = contentRange.find('/');
+        if (slashPos != std::string::npos) {
+            std::string totalSizeStr = contentRange.substr(slashPos + 1);
+            m_totalSize = std::stoull(totalSizeStr);
+        } else {
+            OPENMS_LOG_ERROR << "Error: AWS SDK GetObject: Invalid ContentRange header" << std::endl;
+        }
+    }
+
+    XMLFilePos S3ChunkedBinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3ChunkedBinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+        auto currentBodyStream = &m_currentChunk.GetBody();
+        unsigned long totalBytesRead = 0;
+        // while maxToRead is not reached
+        while (totalBytesRead < maxToRead) {
+            // try to read from current chunk
+            if (currentBodyStream->good())
+            {
+                currentBodyStream->read(reinterpret_cast<char*>(toFill + totalBytesRead), maxToRead - totalBytesRead);
+                totalBytesRead += currentBodyStream->gcount();
+                m_position += currentBodyStream->gcount();
+            }
+            else if (currentBodyStream->eof())
+            {
+                // if the end of the current chunk was already behind the total size, loading a new chunk is not necessary.
+                // we're done.
+                if (m_currentChunkEnd >= m_totalSize)
+                {
+                    return static_cast<XMLSize_t>(totalBytesRead);
+                }
+                // we reached the end of the current chunk
+                // load next chunk
+                m_req.SetRange("bytes=" + std::to_string(m_currentChunkEnd + 1) + "-" + std::to_string(m_currentChunkEnd + m_chunkSize));
+                m_currentChunkEnd = m_currentChunkEnd + m_chunkSize;
+                Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+                if (outcome.IsSuccess()) {
+                    m_currentChunk = outcome.GetResultWithOwnership();
+                    currentBodyStream = &m_currentChunk.GetBody();
+                } else {
+                    OPENMS_LOG_ERROR << "Error: " << outcome.GetError().GetExceptionName() << ": " << outcome.GetError().GetMessage() << std::endl;
+                }
+            }
+            else
+            {
+                OPENMS_LOG_ERROR << "Error: AWS SDK result stream: " << currentBodyStream->rdstate() << std::endl;
+            }
+        }
+        return static_cast<XMLSize_t>(totalBytesRead);
+    }
+
+    const XMLCh* S3ChunkedBinInputStream::getContentType() const { return nullptr; }
+
+    S3ChunkedGzipBinInputStream::S3ChunkedGzipBinInputStream(const Aws::S3::S3Client& client, const Aws::S3::Model::GetObjectRequest& req, unsigned long chunkSize)
+        : m_req(req), m_client(client), m_position(0), m_chunkSize(chunkSize), m_decompressedBuffer(), m_zStream()
+    {
+        // Create a GZIP decompression stream
+        m_zStream.zalloc = Z_NULL;
+        m_zStream.zfree = Z_NULL;
+        m_zStream.opaque = Z_NULL;
+        m_zStream.avail_in = 0;
+        m_zStream.next_in = Z_NULL;
+
+        int windowBits = 15 + 16; // Default windowBits for gzip
+        if (inflateInit2(&m_zStream, windowBits) != Z_OK) {
+            // Handle error
+            throw new std::runtime_error("Error occurred during initializing Gzip stream. Zlib error message: " + std::string(m_zStream.msg));
+        }
+
+        // load first chunk
+        m_req.SetRange("bytes=0-" + std::to_string(m_chunkSize - 1));
+        Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+        if (outcome.IsSuccess()) {
+            m_currentChunk = outcome.GetResultWithOwnership();
+        } else {
+            throw new std::runtime_error("Error getting chunk. AWS SDK error message: " + outcome.GetError().GetMessage());
+        }
+        m_currentChunkEnd = m_chunkSize - 1;
+        std::string contentRange = m_currentChunk.GetContentRange();
+        // Process the ContentRange header...
+        // Example: bytes 0-524287/2000000
+        size_t slashPos = contentRange.find('/');
+        if (slashPos != std::string::npos) {
+            std::string totalSizeStr = contentRange.substr(slashPos + 1);
+            m_totalSize = std::stoull(totalSizeStr);
+        } else {
+            throw new std::runtime_error("Error: AWS SDK GetObject: Invalid ContentRange header: " + contentRange);
+        }
+    }
+
+    S3ChunkedGzipBinInputStream::~S3ChunkedGzipBinInputStream() {
+        inflateEnd(&m_zStream);
+    }
+
+    XMLFilePos S3ChunkedGzipBinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3ChunkedGzipBinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+        auto currentBodyStream = &m_currentChunk.GetBody();
+        unsigned long totalBytesRead = 0;
+        // while maxToRead is not reached
+        while (totalBytesRead < maxToRead) {
+            unsigned long remainingBytes = maxToRead - totalBytesRead;
+            // read from current chunk
+            if (currentBodyStream->good())
+            {
+                do {
+                    m_zStream.avail_out = remainingBytes;
+                    m_zStream.next_out = reinterpret_cast<Bytef*>(toFill + totalBytesRead);
+
+                    if (m_zStream.avail_in == 0)
+                    { // no bytes from last call in the zlib buffer anymore.
+                        // Read more from current chunk if available
+                        if (currentBodyStream->good()) {
+                            currentBodyStream->read(reinterpret_cast<char*>(m_decompressedBuffer), 1024);
+                            m_zStream.avail_in = currentBodyStream->gcount();
+                            m_zStream.next_in = reinterpret_cast<Bytef*>(m_decompressedBuffer);
+                        }
+                        else {
+                            // Handle error or end of stream
+                            break;
+                        }
+                    }
+
+                    int ret = inflate(&m_zStream, Z_NO_FLUSH);
+                    if (ret == Z_STREAM_END) {
+                        // Reached end of compressed data
+                        unsigned long bytesRead = remainingBytes - m_zStream.avail_out;
+                        totalBytesRead += bytesRead;
+                        m_position += bytesRead;
+                        remainingBytes = m_zStream.avail_out;
+                        break;
+                    }
+                    else if (ret != Z_OK) {
+                        OPENMS_LOG_ERROR << "Error occurred during decompression. Zlib error code: " << ret << std::endl;
+                        break;
+                    }
+
+                    unsigned long bytesRead = remainingBytes - m_zStream.avail_out;
+                    totalBytesRead += bytesRead;
+                    m_position += bytesRead;
+                    remainingBytes = m_zStream.avail_out;  // Update remainingBytes after each call to inflate
+                } while (remainingBytes > 0);  // Continue the loop while there is still space in toFill
+            }
+            else if (currentBodyStream->eof())
+            {
+                // if the end of the current chunk was already behind the total size, loading a new chunk is not necessary
+                if (m_currentChunkEnd >= m_totalSize)
+                {
+                    // We've reached the end of the file, but there might still be data in the zlib buffer.
+                    m_zStream.avail_out = remainingBytes;
+                    m_zStream.next_out = reinterpret_cast<Bytef*>(toFill + totalBytesRead);
+
+                    int ret;
+                    do { // emptying remaining data in zlib buffer
+                        ret = inflate(&m_zStream, Z_NO_FLUSH);
+                        if (ret == Z_STREAM_END) {
+                            // Reached end of compressed data
+                            unsigned long bytesRead = remainingBytes - m_zStream.avail_out;
+                            totalBytesRead += bytesRead;
+                            m_position += bytesRead;
+                            remainingBytes = m_zStream.avail_out;
+                            break;
+                        }
+                        else if (ret == Z_OK) {
+                            // toFill is full
+                            unsigned long bytesRead = remainingBytes - m_zStream.avail_out;
+                            totalBytesRead += bytesRead;
+                            m_position += bytesRead;
+                            remainingBytes = m_zStream.avail_out;
+                            break;
+                        }
+                        else if (ret != Z_BUF_ERROR) {
+                            OPENMS_LOG_ERROR << "Error occurred during decompression. Zlib error code: " << ret << std::endl;
+                            break;
+                        }
+                    } while (true);
+                    return static_cast<XMLSize_t>(totalBytesRead);
+                }
+                // we reached the end of the current chunk
+                // load next chunk
+                m_req.SetRange("bytes=" + std::to_string(m_currentChunkEnd + 1) + "-" + std::to_string(m_currentChunkEnd + m_chunkSize));
+                m_currentChunkEnd = m_currentChunkEnd + m_chunkSize;
+                Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+                if (outcome.IsSuccess()) {
+                    m_currentChunk = outcome.GetResultWithOwnership();
+                    currentBodyStream = &m_currentChunk.GetBody();
+                } else {
+                    OPENMS_LOG_ERROR << "Error loading chunk from S3: " << outcome.GetError().GetExceptionName() << ": " << outcome.GetError().GetMessage() << std::endl;
+                }
+            }
+            else
+            { // neither good nor eof -> error
+                OPENMS_LOG_ERROR << "Error in AWS S3 SDK result stream: " << currentBodyStream->rdstate() << std::endl;
+            }
+        }
+        return static_cast<XMLSize_t>(totalBytesRead);
+    }
+
+    const XMLCh* S3ChunkedGzipBinInputStream::getContentType() const {return nullptr;};
+
+    S3ChunkedBzip2BinInputStream::S3ChunkedBzip2BinInputStream(const Aws::S3::S3Client& client, const Aws::S3::Model::GetObjectRequest& req, unsigned long chunkSize)
+        : m_req(req), m_client(client), m_position(0), m_chunkSize(chunkSize), m_decompressedBuffer(), m_bzStream()
+    {
+        // Create a GZIP decompression stream
+        m_bzStream.bzalloc = NULL;
+        m_bzStream.bzfree = NULL;
+        m_bzStream.opaque = NULL;
+        m_bzStream.avail_in = 0;
+        m_bzStream.next_in = NULL;
+
+        if (BZ2_bzDecompressInit(&m_bzStream, 0, 0) != BZ_OK) {
+            throw new std::runtime_error("Error occurred during bzip decompression");
+        }
+
+        // load first chunk
+        m_req.SetRange("bytes=0-" + std::to_string(m_chunkSize - 1));
+        Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+        if (outcome.IsSuccess()) {
+            m_currentChunk = outcome.GetResultWithOwnership();
+        } else {
+            throw new std::runtime_error("Error getting chunk. AWS SDK error message: " + outcome.GetError().GetMessage());
+        }
+        m_currentChunkEnd = m_chunkSize - 1;
+        std::string contentRange = m_currentChunk.GetContentRange();
+        // Process the ContentRange header...
+        // Example: bytes 0-524287/2000000
+        size_t slashPos = contentRange.find('/');
+        if (slashPos != std::string::npos) {
+            std::string totalSizeStr = contentRange.substr(slashPos + 1);
+            m_totalSize = std::stoull(totalSizeStr);
+        } else {
+            throw new std::runtime_error("Error: AWS SDK GetObject: Invalid ContentRange header: " + contentRange);
+        }
+    }
+
+    S3ChunkedBzip2BinInputStream::~S3ChunkedBzip2BinInputStream() {
+        BZ2_bzDecompressEnd(&m_bzStream);
+    }
+
+    XMLFilePos S3ChunkedBzip2BinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3ChunkedBzip2BinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+        auto currentBodyStream = &m_currentChunk.GetBody();
+        unsigned long totalBytesRead = 0;
+        // while maxToRead is not reached
+        while (totalBytesRead < maxToRead) {
+            unsigned long remainingBytes = maxToRead - totalBytesRead;
+            // read from current chunk
+            if (currentBodyStream->good())
+            {
+                do {
+                    m_bzStream.avail_out = remainingBytes;
+                    m_bzStream.next_out = reinterpret_cast<char*>(toFill + totalBytesRead);
+
+                    if (m_bzStream.avail_in == 0)
+                    { // no bytes from last call in the zlib buffer anymore.
+                        // Read more from current chunk if available
+                        if (currentBodyStream->good()) {
+                            currentBodyStream->read(reinterpret_cast<char*>(m_decompressedBuffer), 1024);
+                            m_bzStream.avail_in = currentBodyStream->gcount();
+                            m_bzStream.next_in = reinterpret_cast<char*>(m_decompressedBuffer);
+                        }
+                        else {
+                            // Handle error or end of stream
+                            break;
+                        }
+                    }
+
+                    int ret = BZ2_bzDecompress(&m_bzStream);
+                    if (ret == BZ_STREAM_END) {
+                        // Reached end of compressed data
+                        unsigned long bytesRead = remainingBytes - m_bzStream.avail_out;
+                        totalBytesRead += bytesRead;
+                        m_position += bytesRead;
+                        remainingBytes = m_bzStream.avail_out;
+                        break;
+                    }
+                    else if (ret != BZ_OK) {
+                        OPENMS_LOG_ERROR << "Error occurred during decompression. Bzip2 error code: " << ret << std::endl;
+                        break;
+                    }
+
+                    unsigned long bytesRead = remainingBytes - m_bzStream.avail_out;
+                    totalBytesRead += bytesRead;
+                    m_position += bytesRead;
+                    remainingBytes = m_bzStream.avail_out;  // Update remainingBytes after each call to inflate
+                } while (remainingBytes > 0);  // Continue the loop while there is still space in toFill
+            }
+            else if (currentBodyStream->eof())
+            {
+                // if the end of the current chunk was already behind the total size, loading a new chunk is not necessary
+                if (m_currentChunkEnd >= m_totalSize)
+                {
+                    // We've reached the end of the file, but there might still be data in the zlib buffer.
+                    m_bzStream.avail_out = remainingBytes;
+                    m_bzStream.next_out = reinterpret_cast<char*>(toFill + totalBytesRead);
+
+                    int ret;
+                    do { // emptying remaining data in zlib buffer
+                        ret = BZ2_bzDecompress(&m_bzStream);
+                        if (ret == BZ_STREAM_END) {
+                            // Reached end of compressed data
+                            unsigned long bytesRead = remainingBytes - m_bzStream.avail_out;
+                            totalBytesRead += bytesRead;
+                            m_position += bytesRead;
+                            remainingBytes = m_bzStream.avail_out;
+                            break;
+                        }
+                        else if (ret == BZ_OK) {
+                            // toFill is full
+                            unsigned long bytesRead = remainingBytes - m_bzStream.avail_out;
+                            totalBytesRead += bytesRead;
+                            m_position += bytesRead;
+                            remainingBytes = m_bzStream.avail_out;
+                            break;
+                        }
+                        else if (ret != BZ_OK && ret != BZ_STREAM_END) {
+                            OPENMS_LOG_ERROR << "Error occurred during decompression. Bzib2 error code: " << ret << std::endl;
+                            break;
+                        }
+                    } while (true);
+                    return static_cast<XMLSize_t>(totalBytesRead);
+                }
+                // we reached the end of the current chunk
+                // load next chunk
+                m_req.SetRange("bytes=" + std::to_string(m_currentChunkEnd + 1) + "-" + std::to_string(m_currentChunkEnd + m_chunkSize));
+                m_currentChunkEnd = m_currentChunkEnd + m_chunkSize;
+                Aws::S3::Model::GetObjectOutcome outcome = m_client.GetObject(m_req);
+                if (outcome.IsSuccess()) {
+                    m_currentChunk = outcome.GetResultWithOwnership();
+                    currentBodyStream = &m_currentChunk.GetBody();
+                } else {
+                    OPENMS_LOG_ERROR << "Error loading chunk from S3: " << outcome.GetError().GetExceptionName() << ": " << outcome.GetError().GetMessage() << std::endl;
+                }
+            }
+            else
+            { // neither good nor eof -> error
+                OPENMS_LOG_ERROR << "Error in AWS S3 SDK result stream: " << currentBodyStream->rdstate() << std::endl;
+            }
+        }
+        return static_cast<XMLSize_t>(totalBytesRead);
+    }
+
+    const XMLCh* S3ChunkedBzip2BinInputStream::getContentType() const {return nullptr;};
+
+}; // namespace OpenMS

--- a/src/openms/source/FORMAT/DATAACCESS/S3InputSource.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/S3InputSource.cpp
@@ -1,0 +1,296 @@
+// Copyright (c) 2002-2023, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Julianus Pfeuffer $
+// $Authors: Julianus Pfeuffer $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/DATAACCESS/S3InputSource.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
+
+namespace OpenMS {
+
+    S3InputSource::S3InputSource(const std::string& s3uri)
+    {
+        initializeAwsSdk_();
+        parseS3Uri_(s3uri);
+    }
+
+    xercesc::BinInputStream* S3InputSource::makeStream() const {
+        Aws::Client::ClientConfiguration clientConfig;
+        //clientConfig.region = Aws::Region::US_EAST_1;
+
+        // Create the default AWS SDK client
+        //Aws::Auth::DefaultAWSCredentialsProviderChain credentialsProvider;
+
+        // If the credentials and region are set in the AWS config file, they will be loaded here
+        //clientConfig.credentialsProvider = Aws::MakeShared<Aws::Auth::DefaultAWSCredentialsProviderChain>("AllocationTag", credentialsProvider);
+
+        Aws::S3::S3Client s3Client(clientConfig);
+
+        Aws::S3::Model::HeadObjectRequest request;
+        request.WithBucket(m_bucketName).WithKey(m_objectKey);
+
+        auto outcome = s3Client.HeadObject(request);
+        std::string encoding;
+        if (outcome.IsSuccess()) {
+            auto metadata = outcome.GetResult().GetMetadata();
+            auto encodingIter = metadata.find("Content-Encoding");
+            if (encodingIter != metadata.end()) {
+                encoding = encodingIter->second;
+            }
+            else
+            {
+                // First request to get the first magic bytes
+                Aws::S3::Model::GetObjectRequest firstRequest;
+                firstRequest.WithBucket(m_bucketName).WithKey(m_objectKey);
+                firstRequest.SetRange("bytes=0-2");
+
+                auto firstOutcome = s3Client.GetObject(firstRequest);
+
+                if (firstOutcome.IsSuccess()) {
+                    Aws::IOStream& firstStream = firstOutcome.GetResult().GetBody();
+                    unsigned char header[3];
+                    firstStream.read(reinterpret_cast<char*>(header), sizeof(header));
+                    if (header[0] == 0x1F && header[1] == 0x8B) {
+                        // The file is gzip compressed
+                        encoding = "gzip";
+                    } else if (header[0] == 'B' && header[1] == 'Z' && header[2] == 'h') {
+                        // The file is bzip2 compressed
+                        encoding = "bzip2";
+                    }
+                } else {
+                    // Handle error here
+                    std::cerr << "Error: AWS SDK GetObject for magic bytes: " <<
+                        firstOutcome.GetError().GetExceptionName() << " " <<
+                        firstOutcome.GetError().GetMessage() << std::endl;
+                    return nullptr;
+                }
+            }
+        } else {
+            // Handle error here
+            std::cerr << "Error: AWS SDK HeadObject: " <<
+                outcome.GetError().GetExceptionName() << " " <<
+                outcome.GetError().GetMessage() << std::endl;
+            return nullptr;
+        }
+
+        Aws::S3::Model::GetObjectRequest getObjectRequest;
+        getObjectRequest.WithBucket(m_bucketName).WithKey(m_objectKey);
+
+        auto getObjectOutcome = new Aws::S3::Model::GetObjectOutcome(s3Client.GetObject(getObjectRequest));
+        if (getObjectOutcome->IsSuccess()) {
+            if (encoding == "gzip") {
+                // The object is gzipped
+                std::cout << "The file is gzip compressed" << std::endl;
+                return new S3GzipBinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            } else if (encoding == "bzip2") {
+                // The object is bzipped
+                std::cout << "The file is bzip compressed" << std::endl;
+                return new S3Bzip2BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            } else {
+                // The object is not compressed, or it is compressed with a different format
+                std::cout << "The file is uncompressed" << std::endl;
+                return new S3BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            }
+            /* Reading magic bytes does not work since it consumes the stream -.-
+            // Read the first few bytes of the file
+            unsigned char buffer[3];
+            getObjectOutcome->GetResult().GetBody().read(reinterpret_cast<char*>(buffer), sizeof(buffer));
+            if (buffer[0] == 0x1F && buffer[1] == 0x8B) {
+                // The file is gzip compressed
+                std::cout << "The file is gzip compressed" << std::endl;
+                return new S3GzipBinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            } else if (buffer[0] == 'B' && buffer[1] == 'Z' && buffer[2] == 'h') {
+                // The file is bzip2 compressed
+                std::cout << "The file is bzip2 compressed" << std::endl;
+                return new S3Bzip2BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            } else {
+                std::cout << "The file is uncompressed" << std::endl;
+                return new S3BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome>(getObjectOutcome));
+            }
+            */
+        } else {
+            // Handle error here
+            std::cerr << "Error: AWS SDK GetObject: " <<
+                getObjectOutcome->GetError().GetExceptionName() << " " <<
+                getObjectOutcome->GetError().GetMessage() << std::endl;
+            return nullptr;
+        }
+    }
+
+    void S3InputSource::initializeAwsSdk_() {
+        Aws::SDKOptions options;
+        Aws::InitAPI(options);
+    }
+
+    void S3InputSource::cleanupAwsSdk_() {
+        Aws::ShutdownAPI(Aws::SDKOptions());
+    }
+
+    void S3InputSource::parseS3Uri_(std::string s3Uri) {
+        // Remove the "s3://" prefix if present
+        if (s3Uri.compare(0, 5, "s3://") == 0) {
+            s3Uri = s3Uri.substr(5);
+        }
+
+        // Find the first occurrence of '/' character
+        size_t slashPos = s3Uri.find('/');
+        if (slashPos == std::string::npos) {
+            // Invalid S3 URI format
+            // Handle error
+            return;
+        }
+
+        m_bucketName = s3Uri.substr(0, slashPos);
+        m_objectKey = s3Uri.substr(slashPos + 1);
+    }
+
+    /*
+    void S3InputSource::readAwsConfiguration_() {
+        m_clientConfig.region = Aws::Environment::GetEnv("AWS_REGION");
+        m_clientConfig.endpointOverride = Aws::Environment::GetEnv("AWS_ENDPOINT");
+        m_clientConfig.scheme = Aws::Environment::GetEnv("AWS_SCHEME");
+        m_clientConfig.verifySSL = Aws::Utils::StringUtils::ConvertToBool(Aws::Environment::GetEnv("AWS_VERIFY_SSL"));
+        // Set other configuration options as needed
+    }*/
+
+    S3BinInputStream::S3BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome)
+    : m_getObjectOutcome(getObjectOutcome), m_stream(&getObjectOutcome->GetResult().GetBody()), m_position(0) {}
+
+    XMLFilePos S3BinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3BinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+
+        if (m_stream && toFill) {
+            if (m_stream->good()) {
+                m_stream->read(reinterpret_cast<char*>(toFill), maxToRead);
+                std::streamsize bytesRead = m_stream->gcount();
+                m_position += bytesRead;
+                return static_cast<XMLSize_t>(bytesRead);
+            } else {
+                return 0;
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    const XMLCh* S3BinInputStream::getContentType() const { return nullptr; }
+
+
+
+    S3GzipBinInputStream::S3GzipBinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome)
+        : m_getObjectOutcome(getObjectOutcome), m_stream(&getObjectOutcome->GetResult().GetBody()), m_zStream(), m_position(0)
+    {
+        // Create a GZIP decompression stream
+        m_zStream.zalloc = Z_NULL;
+        m_zStream.zfree = Z_NULL;
+        m_zStream.opaque = Z_NULL;
+        m_zStream.avail_in = 0;
+        m_zStream.next_in = Z_NULL;
+
+
+        int windowBits = 15 + 16; // Default windowBits for gzip
+        if (inflateInit2(&m_zStream, windowBits) != Z_OK) {
+            // Handle error
+            throw new std::runtime_error("Error occurred during decompression. Zlib error message: " + std::string(m_zStream.msg));
+        }
+        
+    }
+
+    S3GzipBinInputStream::~S3GzipBinInputStream() {
+        inflateEnd(&m_zStream);
+    }
+
+    XMLFilePos S3GzipBinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3GzipBinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+            m_zStream.avail_out = static_cast<uInt>(maxToRead);
+            m_zStream.next_out = reinterpret_cast<Bytef*>(toFill);
+
+            // although maxToRead is usually 48kB we cannot know for sure
+            // and must loop over smaller fixed buffer sizes for decompression
+            while (m_zStream.avail_out > 0) {
+                // Read more data from the stream
+                if (m_zStream.avail_in == 0) {
+                    m_stream->read(reinterpret_cast<char*>(m_buffer), sizeof(m_buffer));
+                    std::streamsize bytesRead = m_stream->gcount();
+                    m_position += bytesRead;
+
+                    m_zStream.avail_in = static_cast<uInt>(bytesRead);
+                    m_zStream.next_in = m_buffer;
+                }
+
+                int result = inflate(&m_zStream, Z_NO_FLUSH);
+                if (result == Z_STREAM_END) {
+                    // Reached the end of the compressed data
+                    break;
+                } else if (result != Z_OK) {
+                    // Error occurred during decompression
+                    // Handle error
+                    std::cerr << "Error occurred during decompression. Zlib error message: " + std::string(m_zStream.msg) << std::endl;
+                    return 0;
+                }
+            }
+
+            XMLSize_t bytesRead = maxToRead - m_zStream.avail_out;
+            return bytesRead;
+        }
+
+    const XMLCh* S3GzipBinInputStream::getContentType() const {return nullptr;};
+
+    S3Bzip2BinInputStream::S3Bzip2BinInputStream(std::shared_ptr<Aws::S3::Model::GetObjectOutcome> getObjectOutcome)
+        : m_getObjectOutcome(getObjectOutcome), m_stream(&getObjectOutcome->GetResult().GetBody()), m_bzStream(), m_position(0)
+    {
+        m_bzStream.bzalloc = NULL;
+        m_bzStream.bzfree = NULL;
+        m_bzStream.opaque = NULL;
+        m_bzStream.avail_in = 0;
+        m_bzStream.next_in = NULL;
+
+        if (BZ2_bzDecompressInit(&m_bzStream, 0, 0) != BZ_OK) {
+            throw new std::runtime_error("Error occurred during decompression");
+        }
+    }
+
+    S3Bzip2BinInputStream::~S3Bzip2BinInputStream() {
+        BZ2_bzDecompressEnd(&m_bzStream);
+    }
+
+    XMLFilePos S3Bzip2BinInputStream::curPos() const { return m_position; }
+
+    XMLSize_t S3Bzip2BinInputStream::readBytes(XMLByte* const toFill, const XMLSize_t maxToRead) {
+        m_bzStream.avail_out = static_cast<unsigned int>(maxToRead);
+        m_bzStream.next_out = reinterpret_cast<char*>(toFill);
+
+        while (m_bzStream.avail_out > 0) {
+            if (m_bzStream.avail_in == 0) {
+                m_stream->read(m_buffer, sizeof(m_buffer));
+                std::streamsize bytesRead = m_stream->gcount();
+                m_position += bytesRead;
+
+                m_bzStream.avail_in = static_cast<unsigned int>(bytesRead);
+                m_bzStream.next_in = m_buffer;
+            }
+
+            int result = BZ2_bzDecompress(&m_bzStream);
+            if (result == BZ_STREAM_END) {
+                break;
+            } else if (result != BZ_OK) {
+                std::cerr << "Error occurred during decompression" << std::endl;
+                return 0;
+            }
+        }
+
+        XMLSize_t bytesRead = maxToRead - m_bzStream.avail_out;
+        return bytesRead;
+    }
+
+    const XMLCh* S3Bzip2BinInputStream::getContentType() const {return nullptr;}
+
+}; // namespace OpenMS

--- a/src/openms/source/FORMAT/DATAACCESS/sources.cmake
+++ b/src/openms/source/FORMAT/DATAACCESS/sources.cmake
@@ -14,6 +14,8 @@ set(sources_list
   MSDataTransformingConsumer.cpp
   MSDataWritingConsumer.cpp
   NoopMSDataConsumer.cpp
+  S3InputSource.cpp
+  S3ChunkedInputSource.cpp
   SiriusFragmentAnnotation.cpp
 	SiriusMzTabWriter.cpp
   SwathFileConsumer.cpp

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -8,6 +8,11 @@
 
 #include <OpenMS/FORMAT/HANDLERS/IndexedMzMLDecoder.h>
 
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
+
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -65,6 +70,36 @@ namespace OpenMS
 
   int IndexedMzMLDecoder::parseOffsets(const String& filename, std::streampos indexoffset, OffsetVector& spectra_offsets, OffsetVector& chromatograms_offsets)
   {
+    /*if (filename.hasPrefix("s3://"))
+    {
+      // Initialize S3 SDK
+      Aws::SDKOptions options;
+      Aws::InitAPI(options);
+      Aws::Client::ClientConfiguration clientConfig;
+      Aws::S3::S3Client s3Client(clientConfig);
+
+      Aws::S3::Model::HeadObjectRequest request;
+      std::string s3Uri = filename.substr(5);
+
+        // Find the first occurrence of '/' character
+        size_t slashPos = s3Uri.find('/');
+        if (slashPos == std::string::npos) {
+            // Invalid S3 URI format
+            // Handle error
+            return;
+        }
+
+      std::string bucketName = s3Uri.substr(0, slashPos);
+      std::string objectKey = s3Uri.substr(slashPos + 1);
+      request.WithBucket(bucketName).WithKey(objectKey);
+      auto getObjectOutcome = new Aws::S3::Model::GetObjectOutcome(s3Client.GetObject(request));
+      if (getObjectOutcome->IsSuccess()) {
+        auto& remoteStream = getObjectOutcome->GetResultWithOwnership().GetBody();
+        
+
+      }
+    }*/
+    
     //-------------------------------------------------------------
     // Open file, jump to end and read last indexoffset bytes into buffer.
     //-------------------------------------------------------------

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -82,15 +82,18 @@ namespace OpenMS::Internal
       if (mode == LOAD)
       {
         error_message =  String("While loading '") + file_ + "': " + msg;
-	      // test if file has the wrong extension and is therefore passed to the wrong parser
-        // only makes sense if we are loading/parsing a file
-	      FileTypes::Type ft_name = FileHandler::getTypeByFileName(file_);
-        FileTypes::Type ft_content = FileHandler::getTypeByContent(file_);
-        if (ft_name != ft_content)
+        if (!file_.hasPrefix("http://") && !file_.hasPrefix("https://") && !file_.hasPrefix("ftp://") && !file_.hasPrefix("s3://"))
         {
-          error_message += String("\nProbable cause: The file suffix (") + FileTypes::typeToName(ft_name)
-                          + ") does not match the file content (" + FileTypes::typeToName(ft_content) + "). "
-                          + "Rename the file to fix this.";
+          // test if file has the wrong extension and is therefore passed to the wrong parser
+          // only makes sense if we are loading/parsing a file
+          FileTypes::Type ft_name = FileHandler::getTypeByFileName(file_);
+          FileTypes::Type ft_content = FileHandler::getTypeByContent(file_);
+          if (ft_name != ft_content)
+          {
+            error_message += String("\nProbable cause: The file suffix (") + FileTypes::typeToName(ft_name)
+                            + ") does not match the file content (" + FileTypes::typeToName(ft_content) + "). "
+                            + "Rename the file to fix this.";
+          }
         }
       }
       else if (mode == STORE)

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -142,8 +142,14 @@ namespace OpenMS
     map.reset();
 
     //set DocumentIdentifier
-    map.setLoadedFileType(filename);
-    map.setLoadedFilePath(filename);
+    if (filename.hasPrefix("http:") || filename.hasPrefix("https:") || filename.hasPrefix("ftp:") || filename.hasPrefix("s3:"))
+    {
+      map.setLoadedFileType(FileTypes::MZML);
+      map.setLoadedNetFilePath(filename);
+    } else {
+      map.setLoadedFileType(filename);
+      map.setLoadedFilePath(filename);
+    }
 
     Internal::MzMLHandler handler(map, filename, getVersion(), *this);
     handler.setOptions(options_);

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -49,6 +49,13 @@ namespace OpenMS
     }
   }
 
+  void DocumentIdentifier::setLoadedNetFilePath(const String & file_name)
+  {
+    // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
+    // i.e., a call to this will report unmatched strings
+    file_path_ = file_name;
+  }
+
   const String & DocumentIdentifier::getLoadedFilePath() const
   {
     return file_path_;
@@ -57,6 +64,11 @@ namespace OpenMS
   void DocumentIdentifier::setLoadedFileType(const String & file_name)
   {
     file_type_ = FileHandler::getTypeByContent(file_name);
+  }
+
+  void DocumentIdentifier::setLoadedFileType(FileTypes::Type type)
+  {
+    file_type_ = type;
   }
 
   const FileTypes::Type & DocumentIdentifier::getLoadedFileType() const

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -967,6 +967,27 @@ START_SECTION([EXTRA] load xsd:integer types)
 }
 END_SECTION
 
+START_SECTION([EXTRA] load from s3 gzipped)
+{
+  MzMLFile file;
+  PeakMap exp;
+  // just load without crashing...
+  file.load("s3://jpmstest/MapAlignmentAlgorithmPoseClustering_in1.mzML.gz", exp);
+  TEST_EQUAL(exp.size(), 2035)
+  
+}
+END_SECTION
+
+START_SECTION([EXTRA] load from s3 uncompressed)
+{
+  MzMLFile file;
+  PeakMap exp;
+  // just load without crashing...
+  file.load("s3://jpmstest/BSA1_F1.mzML", exp);
+  TEST_EQUAL(exp.size(), 767)
+  
+}
+END_SECTION
 
 START_SECTION((template <typename MapType> void store(const String& filename, const MapType& map) const))
 {


### PR DESCRIPTION
S3: AWS SDK if present
FTP/HTTP(S): Xerces NetAccessor, i.e. if built with libcurl support (apt, brew = default, but not in contrib)

TODO:
- Safer CMake and conditional compilation
- Support Indexed MzML

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
