### PR TITLE
Add action to replace Jenkins at updating the nightly branch every night

### DIFF
--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+  - cron: '7 1 * * *'
+jobs:
+  make_nightly:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: merge_to_nightly
+      uses: robotology/gh-action-nightly-merge@1.4.0
+      with:
+        stable_branch: 'develop'
+        development_branch: 'nightly'
+        ff_only: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Currently we handle the updating of the nightly branch from the develop branch in Jenkins. This adds a github action to do it instead.