### PR TITLE
Fix mac runner brew issues

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -150,6 +150,9 @@ jobs:
     - name: Setup build tools (and system contrib on Linux)
       id: tools-prefix
       shell: bash
+      env: 
+        # We need to add this, otherwise brew "helpfully" updates all of the GitHub preinstalled packages, which can cause issues
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
           sudo add-apt-repository universe
@@ -189,7 +192,7 @@ jobs:
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
 
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
-            brew install python@3.12 --force --overwrite
+            brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz
           fi
         fi


### PR DESCRIPTION
This fixes an issue where brew updates packages already present on the runner after we install packages. This was a problem because it could lead to brew trying to overwrite links to things like /usr/local/bin/2to3 with versions installed as a dependency of updates to preinstalled packages (the azure integration specifically requires python3.11 at the time of writing). When we install python with brew we can specify to clobber everything that might already be in /usr/local/.
