### PR TITLE
Add Apple Silicon support to CI

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -46,6 +46,14 @@ jobs:
             # TODO implement support for other versions
             compiler_ver: 14.2
 
+          - os: macos-14
+            # Since the appleclang version is dependent on the XCode versions that are installed
+            #  on the GH runners, use this as the choice for a specific version
+            # TODO currently unused but XCode/appleclang is the default
+            compiler: xcode
+            # TODO implement support for other versions
+            compiler_ver: 14.2
+
           # Make sure the compilers are available in that version on the GH runners
           # We are not installing anything.
           - os: ubuntu-22.04

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -198,7 +198,6 @@ jobs:
           
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
-          brew link qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -195,10 +195,11 @@ jobs:
         fi
 
         if [[ "${{ matrix.os }}" == macos-* ]]; then
-          # Qt5_DIR set by Install Qt5 step
-          echo "cmake_prefix=$Qt5_DIR/lib/cmake;$Qt5_DIR" >> $GITHUB_OUTPUT
+          
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
+          brew link qt@5
+          echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -52,7 +52,7 @@ jobs:
             # TODO currently unused but XCode/appleclang is the default
             compiler: xcode
             # TODO implement support for other versions
-            compiler_ver: 14.2
+            compiler_ver: 15.0.1
 
           # Make sure the compilers are available in that version on the GH runners
           # We are not installing anything.

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -78,16 +78,9 @@ jobs:
       run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_OUTPUT
       id: extract_branch
 
-    - id: cpus
-      name: Get the number of CPUs that the current process has access to
-      run: |
-        from os import environ, sched_getaffinity
-  
-        num_cpus = len(sched_getaffinity(0))
-        output_file = environ["GITHUB_OUTPUT"]
-        with open(output_file, "a", encoding="utf-8") as output_stream:
-            output_stream.write(f"count={num_cpus}\n")
-      shell: python
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v1
+      id: cpu-cores
 
     - id: set-vars
       name: Set extra variables
@@ -309,7 +302,7 @@ jobs:
           OPENMP: "ON"
           BOOST_USE_STATIC: ${{ steps.set-vars.outputs.static_boost }}
           #  BUILD_FLAGS: "-p:CL_MPCount=2" # For VS Generator and MSBuild
-          BUILD_FLAGS: "-j${{ steps.cpus.outputs.count }}" # Ninja will otherwise use all cores (doesn't go well in GHA). TODO make dependent on runner
+          BUILD_FLAGS: "-j${{ steps.cpu-cores.outputs.count }}" # Ninja will otherwise use all cores (doesn't go well in GHA). TODO make dependent on runner
           CMAKE_CCACHE_EXE: "ccache"
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -199,6 +199,7 @@ jobs:
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
+          echo "Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5" >> $GITHUB_PATH
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -146,8 +146,8 @@ jobs:
         # NOTE: x64 is hardcoded. No support for 32bit
         arch: x64
 
-    - if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'windows')
-      name: Install Qt (Windows and macOS)
+    - if: startsWith(matrix.os, 'windows')
+      name: Install Qt (Windows)
       uses: jurplel/install-qt-action@v3
       with:
         version: '5.15.2' # 5.12.7 is broken https://bugreports.qt.io/browse/QTBUG-81715, > 5.15.2 is not available on official archives (https://github.com/miurahr/aqtinstall/issues/636)
@@ -198,7 +198,7 @@ jobs:
           # Qt5_DIR set by Install Qt5 step
           echo "cmake_prefix=$Qt5_DIR/lib/cmake;$Qt5_DIR" >> $GITHUB_OUTPUT
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
-          brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp
+          brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -199,7 +199,7 @@ jobs:
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
-          echo "Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5" >> $GITHUB_PATH
+          echo "Qt5_DIR=$(ls $(brew --prefix qt@5)/*)/lib/cmake/Qt5" >> $GITHUB_PATH
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -204,7 +204,7 @@ jobs:
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
-          echo "Qt5_DIR=$(ls $(brew --prefix qt@5)/*)/lib/cmake/Qt5" >> $GITHUB_ENV
+          echo "Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5" >> $GITHUB_ENV
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -46,7 +46,7 @@ jobs:
             # TODO implement support for other versions
             compiler_ver: 14.2
 
-          - os: macos-14
+          - os: macos-14-arm64
             # Since the appleclang version is dependent on the XCode versions that are installed
             #  on the GH runners, use this as the choice for a specific version
             # TODO currently unused but XCode/appleclang is the default
@@ -65,6 +65,8 @@ jobs:
             compiler_ver: 15
 
     runs-on: ${{ matrix.os }}
+    env: 
+      TERM: xterm-256color
 
     steps:
     - uses: actions/checkout@v4
@@ -75,6 +77,17 @@ jobs:
       shell: bash
       run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_OUTPUT
       id: extract_branch
+
+    - id: cpus
+      name: Get the number of CPUs that the current process has access to
+      run: |
+        from os import environ, sched_getaffinity
+  
+        num_cpus = len(sched_getaffinity(0))
+        output_file = environ["GITHUB_OUTPUT"]
+        with open(output_file, "a", encoding="utf-8") as output_stream:
+            output_stream.write(f"count={num_cpus}\n")
+      shell: python
 
     - id: set-vars
       name: Set extra variables
@@ -195,18 +208,15 @@ jobs:
         fi
 
         if [[ "${{ matrix.os }}" == macos-* ]]; then
-          
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
-          echo "Qt5_DIR=$(ls $(brew --prefix qt@5)/*)/lib/cmake/Qt5" >> $GITHUB_PATH
+          echo "Qt5_DIR=$(ls $(brew --prefix qt@5)/*)/lib/cmake/Qt5" >> $GITHUB_ENV
           if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
             brew install python3 --force --overwrite
             brew install --quiet doxygen ghostscript graphviz
           fi
         fi
-
-
 
     - if: startsWith(matrix.os, 'windows')
       name: Cache contrib (Windows)
@@ -230,12 +240,12 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ccache
-        key: ${{ runner.os }}-ccache-${{ steps.extract_branch.outputs.RUN_NAME }}-${{ github.run_number }}
+        key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ steps.extract_branch.outputs.RUN_NAME }}-${{ github.run_number }}
         # Restoring: From current branch/PR, otherwise from nightly, otherwise from any branch.
         restore-keys: |
-          ${{ runner.os }}-ccache-${{ steps.extract_branch.outputs.RUN_NAME }}
-          ${{ runner.os }}-ccache-nightly
-          ${{ runner.os }}-ccache-
+          ${{ runner.os }}-${{ runner.arch }}-ccache-${{ steps.extract_branch.outputs.RUN_NAME }}
+          ${{ runner.os }}-${{ runner.arch }}-ccache-nightly
+          ${{ runner.os }}-${{ runner.arch }}-ccache-
 
     - name: Add THIRDPARTY
       shell: bash
@@ -285,7 +295,7 @@ jobs:
           CI_PROVIDER: "GitHub-Actions"
           CMAKE_GENERATOR: "Ninja"
           SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
-          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ matrix.compiler }}-class-topp-${{ github.run_number }}"
+          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-class-topp-${{ github.run_number }}"
           ENABLE_STYLE_TESTING: "OFF"
           ENABLE_TOPP_TESTING: "ON"
           ENABLE_CLASS_TESTING: "ON"
@@ -299,7 +309,7 @@ jobs:
           OPENMP: "ON"
           BOOST_USE_STATIC: ${{ steps.set-vars.outputs.static_boost }}
           #  BUILD_FLAGS: "-p:CL_MPCount=2" # For VS Generator and MSBuild
-          BUILD_FLAGS: "-j2" # Ninja will otherwise use all cores (doesn't go well in GHA). TODO make dependent on runner
+          BUILD_FLAGS: "-j${{ steps.cpus.outputs.count }}" # Ninja will otherwise use all cores (doesn't go well in GHA). TODO make dependent on runner
           CMAKE_CCACHE_EXE: "ccache"
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -318,7 +328,7 @@ jobs:
       env:
           SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
           CI_PROVIDER: "GitHub-Actions"
-          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ matrix.compiler }}-class-topp-${{ github.run_number }}"
+          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-class-topp-${{ github.run_number }}"
           # The rest of the vars should be saved in the CMakeCache
 
 
@@ -345,14 +355,14 @@ jobs:
           PACKAGE_TYPE: ${{ steps.set-vars.outputs.pkg_type }}
           SEARCH_ENGINES_DIRECTORY: "${{ github.workspace }}/_thirdparty"
           CI_PROVIDER: "GitHub-Actions"
-          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ matrix.compiler }}-class-topp-${{ github.run_number }}"
+          BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-class-topp-${{ github.run_number }}"
 
     # WARNING: Here you have to make sure that only one matrix configuration per OS produces packages. See set-vars steps.
     - if: steps.set-vars.outputs.pkg_type != 'none'
       name: Upload packages as artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: installer-${{ steps.set-vars.outputs.tp_folder }}
+        name: format('installer-{0}{1}', steps.set-vars.outputs.tp_folder, runner.arch == 'arm64' && '-arm64' || '')
         path: |
           ${{ github.workspace }}/OpenMS/bld/*.exe
           ${{ github.workspace }}/OpenMS/bld/*.deb
@@ -393,7 +403,7 @@ jobs:
       name: Upload KNIME payload and descriptors as artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: knime-${{ steps.set-vars.outputs.tp_folder }}
+        name: ${{ format('knime-{0}{1}', steps.set-vars.outputs.tp_folder, runner.arch == 'arm64' && '-arm64' || '') }}
         path: ${{ github.workspace }}/OpenMS/bld/knime/**/*
 
   deploy-installer:
@@ -408,10 +418,14 @@ jobs:
       
       # WOW, you cannot download with wildcard. INCREDIBLY ANNOYING https://github.com/actions/download-artifact/issues/6
       # Maybe in the next 3 years......
-      - name: Download macos installer artifacts
+      - name: Download macOS installer artifacts
         uses: actions/download-artifact@v4
         with:
           name: installer-MacOS
+      - name: Download macOS Silicon installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: installer-MacOS-arm64
       - name: Download win installer artifacts
         uses: actions/download-artifact@v4
         with:
@@ -430,10 +444,10 @@ jobs:
         run: |
           echo "Upload"
           if [[ "${{ env.RUN_NAME }}" == "nightly" ]]; then
-            folder=nightlyGHA                                                    # TODO: Change back when we deactivate Jenkins
+            folder=nightlyGHA                       # TODO: Change back when we deactivate Jenkins
           elif [[ "${{ env.RUN_NAME }}" == "release/*" ]]; then
             tmpfolder=${{ env.RUN_NAME }}
-            folder=${tmpfolder/release/RC_GHA}                                   # TODO: change back to RC after proper release
+            folder=${tmpfolder/release/RC_GHA}      # TODO: change back to RC after proper release
           else
             folder=experimental/${{ env.RUN_NAME }}
           fi
@@ -461,14 +475,13 @@ jobs:
           rm $GITHUB_WORKSPACE/docs/documentation.zip
           echo "Upload"
           if [[ "${{ env.RUN_NAME }}" == "nightly" ]]; then
-            folder=nightlyGHA                                                    # TODO: Change back when we deactivate Jenkins
+            folder=nightlyGHA                      # TODO: Change back when we deactivate Jenkins
           elif [[ "${{ env.RUN_NAME }}" == "release/*" ]]; then
             tmpfolder=${{ env.RUN_NAME }}
-            folder=${tmpfolder/release/RC_GHA}                                   # TODO: change back to RC after proper release
+            folder=${tmpfolder/release/RC_GHA}     # TODO: change back to RC after proper release
           else
             folder=experimental/${{ env.RUN_NAME }}
           fi
-          echo $folder
 
           mkdir -p ~/.ssh/
           echo "$PASS" > ~/.ssh/private.key
@@ -496,10 +509,15 @@ jobs:
 
       # WOW, you cannot download with wildcard. INCREDIBLY ANNOYING https://github.com/actions/download-artifact/issues/6
       # Maybe in the next 3 years......
-      - name: Download macos installer artifacts
+      - name: Download macOS installer artifacts
         uses: actions/download-artifact@v4
         with:
           name: knime-MacOS
+          path: ${{ env.PLUGIN_SOURCE }}
+      - name: Download macOS Silicon installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: knime-MacOS-arm64
           path: ${{ env.PLUGIN_SOURCE }}
       - name: Download win installer artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -46,7 +46,7 @@ jobs:
             # TODO implement support for other versions
             compiler_ver: 14.2
 
-          - os: macos-14-arm64
+          - os: macos-14
             # Since the appleclang version is dependent on the XCode versions that are installed
             #  on the GH runners, use this as the choice for a specific version
             # TODO currently unused but XCode/appleclang is the default


### PR DESCRIPTION
Todo:
Make distinction for GitHub between arm and x8664 in:
- [x] packaging, to upload packages for both and name them different (naming should prob. already done by cmake correctly)
-  [x] ccache or other caches or anything that depends on the OS name only but should depend on OS+arch. Maybe we can use synonymous macos-14-arm64 runner label or so?
- [ ] pyopenms and maybe conda (still on Jenkins anyway)