### PR TITLE
Trigger openms-ci-full after merging from develop

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -22,7 +22,7 @@ jobs:
         path: OpenMS
       
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.13
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.25.x'
 
@@ -138,7 +138,7 @@ jobs:
         path: OpenMS
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.13
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.25.x'
 
@@ -292,7 +292,7 @@ jobs:
         path: OpenMS
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v1.13
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: '3.25.x'
 

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -55,3 +55,8 @@ jobs:
         git push origin nightly -f
       env:
         GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}
+
+    - name: Call CI
+      if: steps.compare_branches.outputs.behind == 'true' || inputs.force
+      run: |
+        gh workflow run openms-ci-full --ref nightly

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -60,3 +60,5 @@ jobs:
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
         gh workflow run openms-ci-full --ref nightly
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -60,5 +60,3 @@ jobs:
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
         gh workflow run openms-ci-full --ref nightly
-      env:
-        GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -60,3 +60,5 @@ jobs:
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force
       run: |
         gh workflow run openms-ci-full --ref nightly
+      env:
+        GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
