### PR TITLE
MSGF+ min_peaks option added

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CLANGDVER=14.0.0
 
 # Install tools for VSCode, Intellisense, JRE for Thirdparties, etc. using apt-get
-RUN apt-get -q update && apt-get install -yq gdb zip tar unzip curl wget php openjdk-11-jre python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get -q update && apt-get install -yq gdb zip tar unzip curl wget php openjdk-11-jre mono-complete python3-pip && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/clangd/clangd/releases/download/$CLANGDVER/clangd-linux-$CLANGDVER.zip && unzip clangd-linux-$CLANGDVER.zip -d /opt/ && mv /opt/clangd_$CLANGDVER /opt/clangd/ && rm clangd-linux-$CLANGDVER.zip 
 #

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3188,7 +3188,7 @@ set_tests_properties("TOPP_QCCalculator_2_out" PROPERTIES DEPENDS "TOPP_QCCalcul
 #------------------------------------------------------------------------------
 # PSMFeatureExtractor
 add_test("TOPP_PSMFeatureExtractor_1" ${TOPP_BIN_PATH}/PSMFeatureExtractor -test -in ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.idXML ${DATA_DIR_TOPP}/THIRDPARTY/XTandemAdapter_1_out.idXML -multiple_search_engines -skip_db_check -out_type idXML -out PSMFeatureExtractor_1_out.tmp.idXML)
-add_test("TOPP_PSMFeatureExtractor_1_out" ${DIFF} -whitelist "InferenceEngineVersion" "date=" -in1 PSMFeatureExtractor_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/PSMFeatureExtractor_1_out.idXML)
+add_test("TOPP_PSMFeatureExtractor_1_out" ${DIFF} -whitelist "InferenceEngineVersion" "MSGFPlusAdapter:" "date=" -in1 PSMFeatureExtractor_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/PSMFeatureExtractor_1_out.idXML)
 set_tests_properties("TOPP_PSMFeatureExtractor_1_out" PROPERTIES DEPENDS "TOPP_PSMFeatureExtractor_1")
 
 add_test("TOPP_PSMFeatureExtractor_2" ${TOPP_BIN_PATH}/PSMFeatureExtractor -test -in ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.idXML ${DATA_DIR_TOPP}/THIRDPARTY/XTandemAdapter_1_out.idXML -multiple_search_engines -skip_db_check -out_type mzid -out PSMFeatureExtractor_2_out.tmp.mzid)

--- a/src/tests/topp/PSMFeatureExtractor_1_out.idXML
+++ b/src/tests/topp/PSMFeatureExtractor_1_out.idXML
@@ -34,6 +34,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:min_peptide_length" value="6"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_peptide_length" value="40"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:matches_per_spec" value="1"/>
+				<UserParam type="int" name="MSGFPlusAdapter:1:min_peaks" value="10"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:add_features" value="false"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_mods" value="2"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_missed_cleavages" value="-1"/>

--- a/src/tests/topp/PSMFeatureExtractor_2_out.mzid
+++ b/src/tests/topp/PSMFeatureExtractor_2_out.mzid
@@ -83,6 +83,7 @@
 			<userParam name="MSGFPlusAdapter:1:min_peptide_length" unitName="xsd:integer" value="6"/>
 			<userParam name="MSGFPlusAdapter:1:max_peptide_length" unitName="xsd:integer" value="40"/>
 			<userParam name="MSGFPlusAdapter:1:matches_per_spec" unitName="xsd:integer" value="1"/>
+			<userParam name="MSGFPlusAdapter:1:min_peaks" unitName="xsd:integer" value="10"/>
 			<userParam name="MSGFPlusAdapter:1:add_features" unitName="xsd:string" value="false"/>
 			<userParam name="MSGFPlusAdapter:1:max_mods" unitName="xsd:integer" value="2"/>
 			<userParam name="MSGFPlusAdapter:1:max_missed_cleavages" unitName="xsd:integer" value="-1"/>

--- a/src/tests/topp/PSMFeatureExtractor_3_out.idXML
+++ b/src/tests/topp/PSMFeatureExtractor_3_out.idXML
@@ -34,6 +34,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:min_peptide_length" value="6"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_peptide_length" value="40"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:matches_per_spec" value="1"/>
+				<UserParam type="int" name="MSGFPlusAdapter:1:min_peaks" value="10"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:add_features" value="false"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_mods" value="2"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_missed_cleavages" value="-1"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -34,6 +34,7 @@
 				<UserParam type="int" name="MSGFPlusAdapter:1:min_peptide_length" value="6"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_peptide_length" value="40"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:matches_per_spec" value="1"/>
+				<UserParam type="int" name="MSGFPlusAdapter:1:min_peaks" value="10"/>
 				<UserParam type="string" name="MSGFPlusAdapter:1:add_features" value="false"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_mods" value="2"/>
 				<UserParam type="int" name="MSGFPlusAdapter:1:max_missed_cleavages" value="-1"/>

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -174,6 +174,9 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
+    registerIntOption_("min_peaks", "<num>", 10, "Minimum number of ions a spectrum must have to be examined"); 
+    setMinInt_("min_peaks", 10); 
+
     registerStringOption_("add_features", "<true/false>", "true", "Output additional features (MS-GF+ parameter '-addFeatures'). This is required by Percolator and hence by default enabled.", false, false);
     setValidStrings_("add_features", ListUtils::create<String>("true,false"));
     
@@ -575,6 +578,7 @@ protected:
                    << "-ntt" << QString::number(tryptic_code)
                    << "-minLength" << QString::number(getIntOption_("min_peptide_length"))
                    << "-maxLength" << QString::number(getIntOption_("max_peptide_length"))
+                   << "-minNumPeaks" << QString::number(getIntOption_("min_peaks"))
                    << "-minCharge" << QString::number(min_precursor_charge)
                    << "-maxCharge" << QString::number(max_precursor_charge)
                    << "-maxMissedCleavages" << QString::number(getIntOption_("max_missed_cleavages"))

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -174,7 +174,7 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
-    registerIntOption_("min_peaks", "<num>", 10, "Minimum number of ions a spectrum must have to be examined"); 
+    registerIntOption_("min_peaks", "<num>", 10, "Minimum number of ions a spectrum must have to be examined", false); 
     setMinInt_("min_peaks", 10); 
 
     registerStringOption_("add_features", "<true/false>", "true", "Output additional features (MS-GF+ parameter '-addFeatures'). This is required by Percolator and hence by default enabled.", false, false);


### PR DESCRIPTION
## Description

MSGF+ supports a minimum number of peaks for spectra to be analyzed. Here, in this PR we include the option to make it more consistent and standardised with SAGE and COMET.   

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
