### PR TITLE
pyOpenMS: Log warnings in pure Python code with warnings.warn instead of print

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -87,6 +87,7 @@ the authors tag in the respective file header.
  - Patricia Scheil
  - Peter Kunszt
  - Petra Gutenbrunner
+ - Ralf Gabriels
  - Rene Hussong
  - Ruben Grünberg
  - Samuel Wein

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@ Fixes:
 - MSGFPlusAdapter: allow concurrent creation of indexed database (#7272)
 - ParamEditor: fixed error for the subsection parameter (ParamNode) to go through store function (#7180)
 - TOPPAS: open files in TOPPView (#7213)
+- pyOpenMS: Log warnings in pure Python code with warnings.warn instead of print (#7418)
 
 Misc:
 - OpenMSInfo reports the ILP solver (CoinOr or glpk) (#7156)

--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -23,6 +23,8 @@ Please cite:
 """
 from __future__ import print_function
 
+import warnings
+
 from ._sysinfo import *  # pylint: disable=wildcard-import; lgtm(py/polluting-import)
 from ._version import version as __version__
 
@@ -36,7 +38,7 @@ if os.path.exists(default_openms_data_path):
     if not env_openms_data_path:
         os.environ["OPENMS_DATA_PATH"] = default_openms_data_path
     else:
-        print(
+        warnings.warn(
             "Warning: OPENMS_DATA_PATH environment variable already exists. "
             "pyOpenMS will use it ({env}) to locate data in the OpenMS share folder "
             "(e.g., the unimod database), instead of the default ({default})."
@@ -44,7 +46,7 @@ if os.path.exists(default_openms_data_path):
         )
 else:
     if not env_openms_data_path:
-         print(
+        warnings.warn(
             "Warning: OPENMS_DATA_PATH environment variable not found and no share directory was installed. "
             "Some functionality might not work as expected."
         )


### PR DESCRIPTION
## Description

Revisit of #6979. Replacing `print` statements in `pyopenms/__init__.py` with `warnings.warn` for info regarding the `OPENMS_DATA_PATH` environment variable.

If I understand correctly, #6979 was closed because it proposed to use the `logging` module, leading to multiple ways of logging implemented in pyOpenMS. I here propose to use `warnings.warn` instead in the pure Python code. Especially in the case of the `OPENMS_DATA_PATH` warnings, this makes sense.

Currently, using pyOpenMS with multiprocessing leads to a wall of warnings that cannot be disabled due to the use of `print`. With the proposed changes, developers of tools using pyOpenMS can choose to ignore these warnings when desired with

```python
from warnings import filterwarnings

filterwarnings(
    "ignore",
    message="OPENMS_DATA_PATH environment variable already exists",
    category=UserWarning,
    module="pyopenms",
)
```



## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
