### PR TITLE
[FEATURE/FIX] TOPPView can show MSn ion mobility frames

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Library:
 - Splitting AssayGeneratorMetabo into two tools: In line with the changes to SiriusExport this tool has been split into two separate workflows. AssayGeneratorMetabo generates an assay library from mzML and feautreXML files using an heuristic approach picking the highest intensity MS2 peaks (like before). AssayGeneratorMetaboSirius takes an existing SIRIUS project directory as input to generate an assay library based on fragmentation trees. (#7234)
 - better documentation for all SpectraFilter... tools (#7183)
 - TOPPView: offer Ion mobility view from 2D spectra view (#7423)
+- TOPPView: view ion mobility frames, irrespective of its MS level (formerly only MS1 was supported) (#7427)
 
 
 Fixes:

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -91,7 +91,7 @@ public:
 
     /** @brief Pick and score features in a single experiment from chromatograms
      *
-     * Function for for wrapping in Python, only uses OpenMS datastructures and
+     * Function for wrapping in Python, only uses OpenMS datastructures and
      * does not return the map.
      *
      * @param chromatograms The input chromatograms

--- a/src/openms/include/OpenMS/KERNEL/DimMapper.h
+++ b/src/openms/include/OpenMS/KERNEL/DimMapper.h
@@ -761,6 +761,15 @@ namespace OpenMS
       return *dims_[(int)d];
     }
 
+    bool hasUnit(DIM_UNIT unit) const
+    {
+      for (int i = 0; i < N_DIM; ++i)
+      {
+        if (dims_[i]->getUnit() == unit) return true;
+      }
+      return false;
+    }
+
   protected:
     /// a minimal factory
     static std::unique_ptr<const DimBase> create_(DIM_UNIT u)

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -190,7 +190,7 @@ public:
     void setRT(double rt);
 
     /**
-      @brief Returns the ion mobility drift time (MSSpectrum::DRIFTTIME_NOT_SET means it is not set)
+      @brief Returns the ion mobility drift time (IMTypes::DRIFTTIME_NOT_SET means it is not set)
 
       @note Drift times may be stored directly as an attribute of the spectrum
       (if they relate to the spectrum as a whole). In case of ion mobility

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -64,7 +64,11 @@ namespace OpenMS
    
     The input @p im_frame must have a floatDataArray where IM values are annotated. If not, an exception is thrown.
 
-    To get some coarser binning, choose a smaller @p number_of_bins. The default creates a new bin (=spectrum in the output) for each distinct ion mobility value.
+    To get some coarser binning, choose a smaller @p number_of_bins.
+    @note If the number of bins is smaller than the number of distinct IM values, the resulting spectra may contain peaks with identical m/z values. I.e no averaging/subsummation in m/z is done here.
+          You may want to postprocess your data.
+
+    The default creates a new bin (=spectrum in the output) for each distinct ion mobility value.
       
     @param im_frame Concatenated spectrum representing a frame
     @param number_of_bins In how many bins should ion mobility values be sliced? Default(-1) assigns all peaks with identical ion-mobility values to a separate spectrum.
@@ -88,7 +92,7 @@ namespace OpenMS
 
     // check if data is sorted by IM... if not, sort
     if (!std::is_sorted(im_data.begin(), im_data.end()))
-    {
+    { // sorts the spectrum (and its binary data arrays) according to IM
       im_frame.sort([&im_data](const Size i1, const Size i2) {
         return im_data[i1] < im_data[i2];
       });
@@ -124,7 +128,7 @@ namespace OpenMS
           im_last = im;
           last_spec = addBinnedSpec(im);
         }
-        last_spec->push_back(im_frame[i]);// copy the peak
+        last_spec->push_back(im_frame[i]);// copy the m/z of the peak
       }
     }
     else
@@ -140,7 +144,7 @@ namespace OpenMS
         double right_end_of_bin = hist.rightBorderOfBin(i_bin);
         while (i_data < im_data.size() && im_data[i_data] < right_end_of_bin)
         {
-          last_spec->push_back(im_frame[i_data]);// copy the peak
+          last_spec->push_back(im_frame[i_data]);// copy the m/z of the peak
           ++i_data;                              // next peak
         }
       }
@@ -196,7 +200,7 @@ namespace OpenMS
   }
 
   
-  /// Process a stack of drift time spectra
+  /// private: Process a stack of drift time spectra
   void processDriftTimeStack(std::vector<const MSSpectrum*>& stack, MSExperiment& result)
   {
     if (stack.empty()) return;

--- a/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
@@ -208,10 +208,15 @@ namespace OpenMS
     using IntType = MSExperiment::ConstAreaIterator::PeakType::IntensityType;
     auto max_int = numeric_limits<IntType>::lowest();
     PeakIndex max_pi;
-    for (ExperimentType::ConstAreaIterator i = getPeakData()->areaBeginConst(area); i != getPeakData()->areaEndConst(); ++i)
+    
+    const auto map = *getPeakData();
+    // for IM data, use whatever is there. For RT/mz data, use MSlevel 1
+    const UInt MS_LEVEL = (! map.empty() && map.isIMFrame()) ? map[0].getMSLevel() : 1;
+
+    for (ExperimentType::ConstAreaIterator i = map.areaBeginConst(area, MS_LEVEL); i != map.areaEndConst(); ++i)
     {
       PeakIndex pi = i.getPeakIndex();
-      if (i->getIntensity() > max_int && filters.passes((*getPeakData())[pi.spectrum], pi.peak))
+      if (i->getIntensity() > max_int && filters.passes((map)[pi.spectrum], pi.peak))
       {
         max_int = i->getIntensity();
         max_pi = pi;

--- a/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot2DCanvas.cpp
@@ -996,11 +996,11 @@ namespace OpenMS
         context_menu->addSeparator();
       }
       
-      auto it_closest_MS1 = lp->getPeakData()->getClosestSpectrumInRT(e_units.getMinRT(), 1);
-      if (it_closest_MS1->containsIMData())
+      auto it_closest_MS = lp->getPeakData()->getClosestSpectrumInRT(e_units.getMinRT());
+      if (it_closest_MS->containsIMData())
       {
-        context_menu->addAction(("Switch to ion mobility view (RT: " + String(it_closest_MS1->getRT(), false) + ")").c_str(),
-                                [&]() {emit showCurrentPeaksAsIonMobility(*it_closest_MS1); });
+        context_menu->addAction(("Switch to ion mobility view (MSLevel: " + String(it_closest_MS->getMSLevel()) + ";RT: " + String(it_closest_MS->getRT(), false) + ")").c_str(),
+                                [&]() {emit showCurrentPeaksAsIonMobility(*it_closest_MS); });
       }
 
 


### PR DESCRIPTION
## Description

fixes #7426
Any MS level will now work.

Also amends #7423, by allowing to switch to the closest spec in RT (which could be an MS2 spectrum as well).


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
