### PR TITLE
Create AssignSourceGroups.cmake

### DIFF
--- a/cmake/AssignSourceGroups.cmake
+++ b/cmake/AssignSourceGroups.cmake
@@ -1,0 +1,14 @@
+# Function to automatically create source groups for files based on their directory structure
+function(assign_source_groups)
+    foreach(FILE_PATH ${ARGN})
+        # Get the directory part of the file path
+        get_filename_component(PARENT_DIR "${FILE_PATH}" DIRECTORY)
+        # Replace the base source or include directory path to form the group structure
+        string(REPLACE "${CMAKE_SOURCE_DIR}/source/OPENSWATHALGO/" "" GROUP "${PARENT_DIR}")
+        string(REPLACE "${CMAKE_SOURCE_DIR}/include/OpenMS/OPENSWATHALGO/" "" GROUP "${GROUP}")
+        string(REPLACE "/" "\\" GROUP "${GROUP}")
+
+        # Assign the file to the appropriate source group
+        source_group("${GROUP}" FILES "${FILE_PATH}")
+    endforeach()
+endfunction()

--- a/cmake/AssignSourceGroups.cmake
+++ b/cmake/AssignSourceGroups.cmake
@@ -1,14 +1,18 @@
-# Function to automatically create source groups for files based on their directory structure
-function(assign_source_groups)
-    foreach(FILE_PATH ${ARGN})
-        # Get the directory part of the file path
-        get_filename_component(PARENT_DIR "${FILE_PATH}" DIRECTORY)
-        # Replace the base source or include directory path to form the group structure
-        string(REPLACE "${CMAKE_SOURCE_DIR}/source/OPENSWATHALGO/" "" GROUP "${PARENT_DIR}")
-        string(REPLACE "${CMAKE_SOURCE_DIR}/include/OpenMS/OPENSWATHALGO/" "" GROUP "${GROUP}")
-        string(REPLACE "/" "\\" GROUP "${GROUP}")
-
-        # Assign the file to the appropriate source group
-        source_group("${GROUP}" FILES "${FILE_PATH}")
+# Function to add files to a source group, stripping a base path if necessary
+function(add_to_source_group base_path group_prefix files)
+    set(sources_with_path "")
+    foreach(file ${files})
+        list(APPEND sources_with_path "${base_path}/${file}")
     endforeach()
+
+    # Create a formatted group name by removing the base path and replacing slashes
+    string(REPLACE "${CMAKE_SOURCE_DIR}/" "" group_name "${base_path}")
+    string(REPLACE "/" "\\" group_name "${group_name}")
+
+    # Prefix the group name if provided
+    if(NOT "${group_prefix}" STREQUAL "")
+        set(group_name "${group_prefix}\\${group_name}")
+    endif()
+
+    source_group("${group_name}" FILES ${sources_with_path})
 endfunction()


### PR DESCRIPTION
## Description

Small helper to assign source groups based on files added. Simplifies refactoring.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
