### PR TITLE
[Feature] DataFrame export for MSSpectrum and MSChromatogram

### DIFF
--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -734,12 +734,6 @@ class _MSChromatogramDF(_MSChromatogram):
 
         df['comment'] = _np.full(cnt, self.getComment(), dtype=_np.dtype('U100'))
 
-        df['max_intensity'] = _np.full(cnt, self.getMaxIntensity(), dtype=_np.dtype('uint64'))
-
-        df['min_rt'] = _np.full(cnt, self.getMinRT(), dtype=_np.dtype('double'))
-
-        df['max_rt'] = _np.full(cnt, self.getMinRT(), dtype=_np.dtype('double'))
-
         df['native_id'] = _np.full(cnt, self.getNativeID(), dtype=_np.dtype('U100'))
 
         if export_meta_values:

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -627,7 +627,7 @@ def _add_meta_values(df: _pd.DataFrame, object: any) -> _pd.DataFrame:
     
     Args:
         df (pd.DataFrame): DataFrame to which metavalues will be added.
-        obj (any): Object from which metavalues will be extracted.
+        object (any): Object from which metavalues will be extracted.
     
     Returns:
         pd.DataFrame: DataFrame with added meta values.

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -656,16 +656,11 @@ class _MSSpectrumDF(_MSSpectrum):
         Returns:
             pd.DataFrame: DataFrame representation of the MSSpectrum.
         """
-        def extract_peak_data(s: _MSSpectrum):
-            for p in s:
-                yield p.getMZ(), p.getIntensity()
+        mzs, intensities = self.get_peaks()
 
-        cnt = self.size()
-        dtypes = [('mz', _np.dtype('double')), ('intensity', _np.dtype('uint64'))]
+        df = _pd.DataFrame({'mz': mzs, 'intensity': intensities})
 
-        arr = _np.fromiter(iter=extract_peak_data(self), dtype=dtypes, count=cnt)
-
-        df = _pd.DataFrame(arr)
+        cnt = df.shape[0]
 
         df['ms_level'] = _np.full(cnt, self.getMSLevel(), dtype=_np.dtype('uint16'))
 
@@ -676,7 +671,7 @@ class _MSSpectrumDF(_MSSpectrum):
         df['native_id'] = _np.full(cnt, self.getNativeID(), dtype=_np.dtype('U100'))
 
         if export_peptide_identifications:
-            peps = self.getPeptideIdentifications()  # type: list[PeptideIdentification]
+            peps = self.getPeptideIdentifications()
             seq = ''
             if peps:
                 hits = peps[0].getHits()

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -134,6 +134,8 @@ class _ConsensusMapDF(_ConsensusMap):
         """
         return _pd.concat([self.get_metadata_df(), self.get_intensity_df()], axis=1)
 
+# fix class module and name to show up correctly in readthedocs page generated with sphinx autodoc
+# needs to link back to rst page of original class, which is pyopenms.ConsensusMap, NOT pyopenms._dataframes._ConsensusMapDF (wh)
 ConsensusMap = _ConsensusMapDF
 ConsensusMap.__module__ = _ConsensusMap.__module__
 ConsensusMap.__name__ = 'ConsensusMap'

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -6,6 +6,7 @@ from . import ConsensusFeature as _ConsensusFeature
 from . import FeatureMap as _FeatureMap
 from . import Feature as _Feature
 from . import MSExperiment as _MSExperiment
+from . import PeakMap as _PeakMap
 from . import PeptideIdentification as _PeptideIdentification
 from . import ControlledVocabulary as _ControlledVocabulary
 from . import File as _File
@@ -134,6 +135,8 @@ class _ConsensusMapDF(_ConsensusMap):
         return _pd.concat([self.get_metadata_df(), self.get_intensity_df()], axis=1)
 
 ConsensusMap = _ConsensusMapDF
+ConsensusMap.__module__ = _ConsensusMap.__module__
+ConsensusMap.__name__ = 'ConsensusMap'
 
 # TODO tell the advanced user that they could change this, in case they have different needs.
 # TODO check if type could be inferred in the first pass
@@ -297,6 +300,8 @@ class _FeatureMapDF(_FeatureMap):
         return result
 
 FeatureMap = _FeatureMapDF
+FeatureMap.__module__ = _FeatureMap.__module__
+FeatureMap.__name__ = 'FeatureMap'
 
 
 class _MSExperimentDF(_MSExperiment):
@@ -479,8 +484,13 @@ class _MSExperimentDF(_MSExperiment):
 
         return ms1_df, ms2_df
     
-MSExperiment = _MSExperimentDF
 PeakMap = _MSExperimentDF
+PeakMap.__module__ = _PeakMap.__module__
+PeakMap.__name__ = 'PeakMap'
+
+MSExperiment = _MSExperimentDF
+MSExperiment.__module__ = _MSExperiment.__module__
+MSExperiment.__name__ = 'MSExperiment'
 
 
 # TODO think about the best way for such top-level function. IMHO in python, encapsulation in a stateless class in unnecessary.
@@ -685,6 +695,8 @@ class _MSSpectrumDF(_MSSpectrum):
         return df
 
 MSSpectrum = _MSSpectrumDF
+MSSpectrum.__module__ = _MSSpectrum.__module__
+MSSpectrum.__name__ = 'MSSpectrum'
 
 class _ChromatogramType(_Enum):
     MASS_CHROMATOGRAM = 0
@@ -742,3 +754,5 @@ class _MSChromatogramDF(_MSChromatogram):
         return df
 
 MSChromatogram = _MSChromatogramDF
+MSChromatogram.__module__ = _MSChromatogram.__module__
+MSChromatogram.__name__ = 'MSChromatogram'

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -655,9 +655,17 @@ class _MSSpectrumDF(_MSSpectrum):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def get_df(self, export_meta_values: bool = True, export_peptide_identifications: bool = False) -> _pd.DataFrame:
+    def get_df(self, export_meta_values: bool = True, export_peptide_identifications: bool = True) -> _pd.DataFrame:
         """
         Returns a DataFrame representation of the MSSpectrum.
+
+        mz: The mass-to-charge ratio (m/z) values of the peaks in the mass spectrum.
+        intensity: The intensity (abundance) of the peaks in the mass spectrum.
+        ms_level: The MS level of the mass spectrum (1 for MS1, 2 for MS2, etc.).
+        precursor_mz: The mass-to-charge of the precursor ion.
+        precursor_charge: The charge of the precursor ion.
+        native_id: The native identifier of the spectrum.
+        spectrum: The spectrum of annotated peptide identification hit.
 
         Args:
             export_meta_values (bool): Whether to export meta values.
@@ -717,6 +725,14 @@ class _MSChromatogramDF(_MSChromatogram):
     def get_df(self, export_meta_values: bool = True) -> _pd.DataFrame:
         """
         Returns a DataFrame representation of the MSChromatogram.
+
+        time: The retention time (in seconds) of the chromatographic peaks.
+        intensity: The intensity (abundance) of the signal at each time point.
+        chromatogram_type: The type of chromatogram.
+        precursor_mz: The mass-to-charge of the precursor ion.
+        precursor_charge: The charge of the precursor ion.
+        comment: A comment assigned to the chromatogram.
+        native_id: The chromatogram native identifier.
 
         Args:
             export_meta_values (bool): Whether to export meta values.

--- a/src/pyOpenMS/pyopenms/_dataframes.py
+++ b/src/pyOpenMS/pyopenms/_dataframes.py
@@ -676,8 +676,8 @@ class _MSSpectrumDF(_MSSpectrum):
             if peps:
                 hits = peps[0].getHits()
                 if hits:
-                    seq = hits[0].getSequence()
-            df['sequence'] = _np.full(cnt, seq, dtype=_np.dtype('U200'))
+                    seq = hits[0].getSequence().toString()
+            df['sequence'] = _np.full(cnt, seq, dtype=_np.dtype(f'U{len(seq)}'))
 
         if export_meta_values:
             df = _add_meta_values(df, self)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3187,6 +3187,29 @@ def testMSChromatogram():
     assert ii[0] == 200.0
     assert ii[1] == 400.0
 
+    chrom.setNativeID('chrom_0')
+    chrom.setMetaValue('FWHM', 5.0)
+    prec = pyopenms.Precursor()
+    prec.setMZ(100.0)
+    prec.setCharge(1)
+    chrom.setPrecursor(prec)
+    prod = pyopenms.Product()
+    prod.setMZ(50.0)
+    chrom.setProduct(prod)
+    chrom.setComment('comment')
+
+    df = chrom.get_df()
+    assert df.shape == (2, 9)
+    assert df.loc[0, 'time'] == 1000.0
+    assert df.loc[1, 'intensity'] == 400
+    assert df.loc[0, 'chromatogram_type'] == 'MASS_CHROMATOGRAM'
+    assert df.loc[1, 'precursor_mz'] == 100.0
+    assert df.loc[0, 'precursor_charge'] == 1
+    assert df.loc[1, 'product_mz'] == 50.0
+    assert df.loc[0, 'comment'] == 'comment'
+    assert df.loc[1, 'native_id'] == 'chrom_0'
+    assert df.loc[0, 'FWHM'] == 5
+
     chrom.clear(False)
     data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
     data_i = np.array( [50.0, 80.0] ).astype(np.float32)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2868,7 +2868,7 @@ def testMSSpectrum():
     pepid.setHits([hit])
     spec.setPeptideIdentifications([pepid])
 
-    df = spec.get_df(export_peptide_identifications=True)
+    df = spec.get_df()
     assert df.shape == (2, 8)
     assert df.loc[0, 'mz'] == 1000.0
     assert df.loc[1, 'intensity'] == 400.0

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3351,6 +3351,41 @@ def testMRMTransitionGroup():
     mrmgroup.addTransition(pyopenms.ReactionMonitoringTransition(), "tr1")
     assert len(mrmgroup.getTransitions()) == 1
 
+    # add data for testing df output
+    ## test chromatogram df
+    rt, intensity = [[1.0], [5]]
+    chrom = pyopenms.MSChromatogram()
+    chrom.set_peaks([rt, intensity])
+    chrom.setNativeID("tr1")
+    mrmgroup.addChromatogram(chrom, 'tr1')
+
+    df = mrmgroup.get_chromatogram_df()
+    assert df.shape == (1, 8)
+    assert df.loc[0, 'time'] == 1.0
+    assert df.loc[0, 'intensity'] == 5
+    assert df.loc[0, 'chromatogram_type'] == 'MASS_CHROMATOGRAM'
+    assert df.loc[0, 'native_id'] == 'tr1'
+
+    ## feature
+    f = pyopenms.MRMFeature()
+    f.setRT(1.0)
+    f.setMetaValue(b'leftWidth', 0.5)
+    f.setMetaValue(b'rightWidth', 1.5)
+    f.setMetaValue(b'peak_apices_sum', 10.0)
+    f.setOverallQuality(0.5)
+    f.setUniqueId(1)
+    f.setIntensity(20.0)
+
+    df = mrmgroup.get_feature_df(meta_values=[b'leftWidth', b'rightWidth', b'peak_apices_sum'])
+    assert df.shape == (1, 8)
+    assert df.loc[0, 'leftWidth'] == 0.5
+    assert df.loc[0, 'rightWidth'] == 1.5
+    assert df.loc[0, 'peak_apices_sum'] == 10.0
+    assert df.loc[0, 'intensity'] == 10.0
+    assert df.loc[0, 'quality'] == 0.5
+    assert df.loc[0, 'RT'] == 1.0
+    assert df.index[0] == 1
+
 @report
 def testReactionMonitoringTransition():
     """

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2857,6 +2857,25 @@ def testMSSpectrum():
     assert ii[0] == 200.0
     assert ii[1] == 400.0
 
+    spec.setNativeID('scan=1')
+    prec = pyopenms.Precursor()
+    prec.setMZ(100.0)
+    prec.setCharge(1)
+    spec.setPrecursors([prec])
+    spec.setMetaValue('total ion current', 600)
+    pepid = pyopenms.PeptideIdentification()
+    hit = pyopenms.PeptideHit(1.0, 1, 0, pyopenms.AASequence.fromString('A'))
+    pepid.setHits([hit])
+    spec.setPeptideIdentifications([pepid])
+
+    df = spec.get_df(export_peptide_identifications=True)
+    assert df.shape == (2, 8)
+    assert df.loc[0, 'mz'] == 1000.0
+    assert df.loc[1, 'intensity'] == 400.0
+    assert df.loc[1, 'precursor_charge'] == 1
+    assert df.loc[1, 'sequence'] == 'A'
+    assert df.loc[0, 'total ion current'] == 600
+
     spec.clear(False)
     data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
     data_i = np.array( [50.0, 80.0] ).astype(np.float32)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2868,12 +2868,23 @@ def testMSSpectrum():
     pepid.setHits([hit])
     spec.setPeptideIdentifications([pepid])
 
+    data = np.array( [5, 8] ).astype(np.float32)
+    f_da = [ pyopenms.FloatDataArray() ]
+    f_da[0].set_data(data)
+    f_da[0].setName("Ion Mobility")
+    spec.setFloatDataArrays( f_da )
+    spec.setDriftTimeUnit( pyopenms.DriftTimeUnit.MILLISECOND )
+
     df = spec.get_df()
-    assert df.shape == (2, 8)
+    assert df.shape == (2, 10)
     assert df.loc[0, 'mz'] == 1000.0
-    assert df.loc[1, 'intensity'] == 400.0
-    assert df.loc[1, 'precursor_charge'] == 1
-    assert df.loc[1, 'sequence'] == 'A'
+    assert df.loc[0, 'intensity'] == 200.0
+    assert df.loc[0, 'ion_mobility'] == 5.0
+    assert df.loc[0, 'ion_mobility_unit'] == 'ms'
+    assert df.loc[0, 'precursor_mz'] == 100.0
+    assert df.loc[0, 'precursor_charge'] == 1
+    assert df.loc[0, 'native_id'] == 'scan=1'
+    assert df.loc[0, 'sequence'] == 'A'
     assert df.loc[0, 'total ion current'] == 600
 
     spec.clear(False)


### PR DESCRIPTION
## **User description**
## Description

For the upcoming pyopenms visualization module we need more OpenMS objects exported as DataFrames. Here, MSSpectrum and MSChromatogram get new methods for DataFrame export.

TODO: add tests

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

## **Type**
enhancement, tests


___

## **Description**
- Added DataFrame export capabilities to `MSSpectrum` and `MSChromatogram` classes in pyOpenMS.
- Implemented new classes `_MSSpectrumDF` and `_MSChromatogramDF` to handle the DataFrame conversions.
- Enhanced the module and class naming within the documentation to align with Sphinx autodoc requirements.
- Created comprehensive tests to validate the new DataFrame functionalities and ensure data integrity.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_dataframes.py</strong><dd><code>Implement DataFrame Export for MSSpectrum and MSChromatogram</code></dd></summary>
<hr>
      
src/pyOpenMS/pyopenms/_dataframes.py

<li>Added new classes <code>_MSSpectrumDF</code> and <code>_MSChromatogramDF</code> for DataFrame <br>export functionalities.<br> <li> Added DataFrame export methods to <code>MSSpectrum</code> and <code>MSChromatogram</code>.<br> <li> Updated class module and name attributes to ensure correct <br>documentation generation.<br> <li> Added utility function <code>_add_meta_values</code> to append meta values to <br>DataFrames.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7481/files#diff-430a5767c0a5065fbde4c38a60286b16598929f6f396a775ac7218b7da491379">+165/-1</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test000.py</strong><dd><code>Add Tests for MSSpectrum and MSChromatogram DataFrame Exports</code></dd></summary>
<hr>
      
src/pyOpenMS/tests/unittests/test000.py

<li>Added tests for the new DataFrame export functionalities of <code>MSSpectrum</code> <br>and <code>MSChromatogram</code>.<br> <li> Ensured that the DataFrame contains correct values and structure as <br>expected.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7481/files#diff-9b64f80ffadfaff913d4cd4a67264c1b950fc47ad83ebf98bcaf1431d6479354">+42/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

