### PR TITLE
fix compile warnings

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h
@@ -23,8 +23,8 @@
 namespace OpenMS
 {
 
-  class RangeMobility;
-  class RangeMZ;
+  struct RangeMobility;
+  struct RangeMZ;
 
   /** @brief A class that calls the ion mobility scoring routines
    *

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -26,8 +26,8 @@
 //logging
 #include <OpenMS/CONCEPT/LogStream.h>
 
-class RangeMZ;
-class RangeMobility;
+struct RangeMZ;
+struct RangeMobility;
 
 namespace OpenMS
 {


### PR DESCRIPTION
### **User description**
## Description

e.g.,
/Users/runner/work/OpenMS/OpenMS/OpenMS/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h:27:3: warning: class 'RangeMZ' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
bug_fix


___

### **Description**
- Changed the declaration of `RangeMobility` and `RangeMZ` from `class` to `struct` in two header files to fix mismatched tags warning.
- This change addresses compiler warnings about mismatched tags which could potentially lead to linker errors under the Microsoft C++ ABI.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IonMobilityScoring.h</strong><dd><code>Fix mismatched tags by changing class to struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h
<li>Changed declaration of <code>RangeMobility</code> and <code>RangeMZ</code> from <code>class</code> to <code>struct</code>.


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7484/files#diff-d06d4ebfde756747a800ce7e6a37a2e9e8befdb0d78d31ff088c8fa7546aa749">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>OpenSwathScoring.h</strong><dd><code>Standardize data type declaration to struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
<li>Changed declaration of <code>RangeMZ</code> and <code>RangeMobility</code> from <code>class</code> to <code>struct</code>.


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7484/files#diff-76aa7ebbfda644e8856b5025fafaca97958c16a02e5d960308284c01dbeed5a5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

