### PR TITLE
Wrap getvalidstrings

### DIFF
--- a/src/pyOpenMS/pxds/Param.pxd
+++ b/src/pyOpenMS/pxds/Param.pxd
@@ -75,6 +75,8 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Param.h>" namespace "OpenMS":
          void checkDefaults(libcpp_utf8_string name, Param defaults, libcpp_utf8_string prefix) except + nogil 
          void checkDefaults(libcpp_utf8_string name, Param defaults) except + nogil 
 
+         libcpp_vector[libcpp_utf8_string] getValidStrings(libcpp_utf8_string key) except + nogil
+
          void setValidStrings(libcpp_utf8_string key, libcpp_vector[libcpp_utf8_string] strings) except + nogil 
          void setMinInt(libcpp_utf8_string key, int min) except + nogil 
          void setMaxInt(libcpp_utf8_string key, int max) except + nogil 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1249,6 +1249,7 @@ def _testParam(p):
      Param.setMinInt
      Param.setSectionDescription
      Param.setValidStrings
+     Param.getValidStrings
      Param.setValue
      Param.size
      Param.update
@@ -1327,6 +1328,7 @@ def _testParam(p):
     p1.update(dd)
 
     p.setValidStrings
+    p.getValidStrings
     p.setMinFloat
     p.setMaxFloat
     p.setMinInt


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Added a new method declaration `getValidStrings` in `Param.pxd` to allow retrieval of valid strings for specific keys, enhancing the functionality of the Param class.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Param.pxd</strong><dd><code>Add getValidStrings Method Declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pyOpenMS/pxds/Param.pxd
<li>Added declaration for <code>getValidStrings</code> method to retrieve valid strings <br>for a given key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7491/files#diff-cf2cf39b344985b9fd1c3aa5a5b78dcd8a8aed0af8d9faa2397913da82f97bee">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

