### PR TITLE
make more parameters advanced in MetaProSIP

### DIFF
--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2085,9 +2085,9 @@ protected:
 
     registerFlag_("use_averagine_ids", "Use averagine peptides as model to perform pattern detection on unidentified peptides.", true);
 
-    registerFlag_("report_natural_peptides", "Whether purely natural peptides are reported in the quality report.", false);
+    registerFlag_("report_natural_peptides", "Whether purely natural peptides are reported in the quality report.", true);
 
-    registerFlag_("filter_monoisotopic", "Try to filter out mono-isotopic patterns to improve detection of low RIA patterns", false);
+    registerFlag_("filter_monoisotopic", "Try to filter out mono-isotopic patterns to improve detection of low RIA patterns", true);
 
     registerFlag_("cluster", "Perform grouping", true);
 

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2046,7 +2046,7 @@ protected:
 
     registerDoubleOption_("rt_tolerance_s", "<tol>", 30.0, "Tolerance window around feature rt for XIC extraction", false, true);
 
-    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false), true;
+    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false, true;
 
     registerDoubleOption_("correlation_threshold", "<tol>", 0.7, "Correlation threshold for reporting a RIA", false, true);
 

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2042,19 +2042,19 @@ protected:
 
     registerInputFile_("r_executable", "<file>", "R", "Path to the R executable (default: 'R')", false, false, {"is_executable"});
 
-    registerDoubleOption_("mz_tolerance_ppm", "<tol>", 10.0, "Tolerance in ppm", false);
+    registerDoubleOption_("mz_tolerance_ppm", "<tol>", 10.0, "Tolerance in ppm", false, true);
 
-    registerDoubleOption_("rt_tolerance_s", "<tol>", 30.0, "Tolerance window around feature rt for XIC extraction", false);
+    registerDoubleOption_("rt_tolerance_s", "<tol>", 30.0, "Tolerance window around feature rt for XIC extraction", false, true);
 
-    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false);
+    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false), true;
 
-    registerDoubleOption_("correlation_threshold", "<tol>", 0.7, "Correlation threshold for reporting a RIA", false);
+    registerDoubleOption_("correlation_threshold", "<tol>", 0.7, "Correlation threshold for reporting a RIA", false, true);
 
-    registerDoubleOption_("xic_threshold", "<tol>", 0.7, "Minimum correlation to mono-isotopic peak for retaining a higher isotopic peak. If featureXML from reference file is used it should be disabled (set to -1) as no mono-isotopic peak is expected to be present.", false);
+    registerDoubleOption_("xic_threshold", "<tol>", 0.7, "Minimum correlation to mono-isotopic peak for retaining a higher isotopic peak. If featureXML from reference file is used it should be disabled (set to -1) as no mono-isotopic peak is expected to be present.", false, true);
 
-    registerDoubleOption_("decomposition_threshold", "<tol>", 0.7, "Minimum R-squared of decomposition that must be achieved for a peptide to be reported.", false);
+    registerDoubleOption_("decomposition_threshold", "<tol>", 0.7, "Minimum R-squared of decomposition that must be achieved for a peptide to be reported.", false, true);
 
-    registerDoubleOption_("weight_merge_window", "<tol>", 5.0, "Decomposition coefficients within +- this rate window will be combined", false);
+    registerDoubleOption_("weight_merge_window", "<tol>", 5.0, "Decomposition coefficients within +- this rate window will be combined", false, true);
 
     registerDoubleOption_("min_correlation_distance_to_averagine", "<tol>", -1.0, "Minimum difference in correlation between incorporation pattern and averagine pattern. Positive values filter all RIAs passing the correlation threshold but that also show a better correlation to an averagine peptide. Disabled for values <= -1", false, true);
 
@@ -2064,14 +2064,14 @@ protected:
     registerDoubleOption_("pattern_18O_TIC_threshold", "<threshold>", 0.95, "The most intense peaks of the theoretical pattern contributing to at least this TIC fraction are taken into account.", false, true);
     registerIntOption_("heatmap_bins", "<threshold>", 20, "Number of RIA bins for heat map generation.", false, true);
 
-    registerStringOption_("plot_extension", "<extension>", "png", "Extension used for plots (png|svg|pdf).", false);
+    registerStringOption_("plot_extension", "<extension>", "png", "Extension used for plots (png|svg|pdf).", false, true);
     StringList valid_extensions;
     valid_extensions.push_back("png");
     valid_extensions.push_back("svg");
     valid_extensions.push_back("pdf");
     setValidStrings_("plot_extension", valid_extensions);
 
-    registerStringOption_("qc_output_directory", "<directory>", "", "Output directory for the quality report", false);
+    registerStringOption_("qc_output_directory", "<directory>", "", "Output directory for the quality report", false, true);
 
     registerStringOption_("labeling_element", "<parameter>", "C", "Which element (single letter code) is labeled.", false);
     StringList valid_element;
@@ -2081,7 +2081,7 @@ protected:
     valid_element.push_back("O");
     setValidStrings_("labeling_element", valid_element);
 
-    registerFlag_("use_unassigned_ids", "Include identifications not assigned to a feature in pattern detection.", false);
+    registerFlag_("use_unassigned_ids", "Include identifications not assigned to a feature in pattern detection.", false, true);
 
     registerFlag_("use_averagine_ids", "Use averagine peptides as model to perform pattern detection on unidentified peptides.", false);
 
@@ -2089,7 +2089,7 @@ protected:
 
     registerFlag_("filter_monoisotopic", "Try to filter out mono-isotopic patterns to improve detection of low RIA patterns", false);
 
-    registerFlag_("cluster", "Perform grouping", false);
+    registerFlag_("cluster", "Perform grouping", false, true);
 
     registerDoubleOption_("observed_peak_fraction", "<threshold>", 0.5, "Fraction of observed/expected peaks.", false, true);
 

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2081,15 +2081,15 @@ protected:
     valid_element.push_back("O");
     setValidStrings_("labeling_element", valid_element);
 
-    registerFlag_("use_unassigned_ids", "Include identifications not assigned to a feature in pattern detection.", false, true);
+    registerFlag_("use_unassigned_ids", "Include identifications not assigned to a feature in pattern detection.", true);
 
-    registerFlag_("use_averagine_ids", "Use averagine peptides as model to perform pattern detection on unidentified peptides.", false);
+    registerFlag_("use_averagine_ids", "Use averagine peptides as model to perform pattern detection on unidentified peptides.", true);
 
     registerFlag_("report_natural_peptides", "Whether purely natural peptides are reported in the quality report.", false);
 
     registerFlag_("filter_monoisotopic", "Try to filter out mono-isotopic patterns to improve detection of low RIA patterns", false);
 
-    registerFlag_("cluster", "Perform grouping", false, true);
+    registerFlag_("cluster", "Perform grouping", true);
 
     registerDoubleOption_("observed_peak_fraction", "<threshold>", 0.5, "Fraction of observed/expected peaks.", false, true);
 

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2046,7 +2046,7 @@ protected:
 
     registerDoubleOption_("rt_tolerance_s", "<tol>", 30.0, "Tolerance window around feature rt for XIC extraction", false, true);
 
-    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false, true;
+    registerDoubleOption_("intensity_threshold", "<tol>", 10.0, "Intensity threshold to collect peaks in the MS1 spectrum.", false, true);
 
     registerDoubleOption_("correlation_threshold", "<tol>", 0.7, "Correlation threshold for reporting a RIA", false, true);
 


### PR DESCRIPTION
### **User description**
## Description

make more parameters advanced

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Updated MetaProSIP tool to allow more parameters to be configured as advanced, enhancing user control over the tool's behavior.
- Parameters such as 'mz_tolerance_ppm', 'rt_tolerance_s', and others now include an advanced flag, allowing for more detailed configuration based on user expertise.
- Boolean flags like 'cluster' and 'use_unassigned_ids' are now also marked as advanced, providing finer control over their usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetaProSIP.cpp</strong><dd><code>Enhance MetaProSIP with Advanced Configuration Options</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/topp/MetaProSIP.cpp
<li>Changed several parameter registration methods to include an <br>'advanced' flag.<br> <li> Updated parameters include 'mz_tolerance_ppm', 'rt_tolerance_s', <br>'intensity_threshold', 'correlation_threshold', 'xic_threshold', <br>'decomposition_threshold', 'weight_merge_window', 'plot_extension', <br>'qc_output_directory', and 'use_unassigned_ids'.<br> <li> Added 'advanced' flag to boolean flags like 'cluster'.<br> <li> Ensured that all modified parameters and flags now support advanced <br>configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7492/files#diff-7fd3f3a8eac3e23c45ecd072fd7e1d9d345b5799d3ff72f1a61bf7fcb5562341">+11/-11</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

