### PR TITLE
Build pyopenmswheels nightly

### DIFF
--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -69,3 +69,10 @@ jobs:
         gh workflow run openms-ci-full --ref develop
       env:
         GH_TOKEN: ${{ github.token }}
+        
+    - name: Build wheels
+      if: steps.compare_branches.outputs.behind == 'true' || inputs.force
+      run: |
+        gh workflow run pyopenms-wheels --ref nightly
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new step in the `.github/workflows/update_nightly.yml` file to build `pyopenms` wheels nightly.
- The new step triggers the `pyopenms-wheels` workflow if the branch is behind or if the build is forced.
- Utilized GitHub Actions environment variable `GH_TOKEN` for authentication.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update_nightly.yml</strong><dd><code>Add step to build pyopenms wheels nightly in GitHub Actions</code></dd></summary>
<hr>

.github/workflows/update_nightly.yml
<li>Added a step to build wheels if the branch is behind or if forced.<br> <li> Utilized GitHub Actions to trigger the <code>pyopenms-wheels</code> workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7503/files#diff-3ace9f2af1911f6a5c26a30d82287229912ccb00be7e378adadb15a09527a5d9">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

