### PR TITLE
parse relationship as xref

### DIFF
--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -316,7 +316,9 @@ namespace OpenMS
         {
           term.obsolete = true;
         }
-        else if (line_wo_spaces.hasPrefix("xref:value-type") || line_wo_spaces.hasPrefix("xref_analog:value-type"))
+        else if (line_wo_spaces.hasPrefix("xref:value-type") 
+          || line_wo_spaces.hasPrefix("xref_analog:value-type")
+        )
         {
           line_wo_spaces.remove('\\');
           if (line_wo_spaces.hasSubstring("value-type:xsd:string"))
@@ -373,6 +375,63 @@ namespace OpenMS
           }
           cerr << "ControlledVocabulary: OBOFile: unknown xsd type: " << line_wo_spaces << ", ignoring" << "\n";
         }
+        else if (line_wo_spaces.hasPrefix("relationship:has_value_type")) // since newer obo type in relationship instead of xref
+        {
+          if (line_wo_spaces.hasSubstring("xsd:string"))
+          {
+            term.xref_type = CVTerm::XSD_STRING;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:integer") || line_wo_spaces.hasSubstring("value-type:xsd:int"))
+          {
+            term.xref_type = CVTerm::XSD_INTEGER;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:decimal") ||
+              line_wo_spaces.hasSubstring("xsd:float") ||
+              line_wo_spaces.hasSubstring("xsd:double"))
+          {
+            term.xref_type = CVTerm::XSD_DECIMAL;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:negativeInteger"))
+          {
+            term.xref_type = CVTerm::XSD_NEGATIVE_INTEGER;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:positiveInteger"))
+          {
+            term.xref_type = CVTerm::XSD_POSITIVE_INTEGER;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:nonNegativeInteger"))
+          {
+            term.xref_type = CVTerm::XSD_NON_NEGATIVE_INTEGER;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:nonPositiveInteger"))
+          {
+            term.xref_type = CVTerm::XSD_NON_POSITIVE_INTEGER;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:boolean") 
+          || line_wo_spaces.hasSubstring("xsd:bool"))
+          {
+            term.xref_type = CVTerm::XSD_BOOLEAN;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:date"))
+          {
+            term.xref_type = CVTerm::XSD_DATE;
+            continue;
+          }
+          if (line_wo_spaces.hasSubstring("xsd:anyURI"))
+          {
+            term.xref_type = CVTerm::XSD_ANYURI;
+            continue;
+          }
+          cerr << "ControlledVocabulary: OBOFile: unknown xsd type: " << line_wo_spaces << ", ignoring" << "\n";
+        }       
         else if (line_wo_spaces.hasPrefix("xref:binary-data-type") || line_wo_spaces.hasPrefix("xref_analog:binary-data-type"))
         {
           line_wo_spaces.remove('\\');


### PR DESCRIPTION
### **User description**
## Description

newer PSI ontologies use "relationship" instead of xref. Probably for compatibility with owl...  

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for parsing `relationship:has_value_type` in OBO files to accommodate newer PSI ontologies.
- Extended the parsing logic to handle various XSD types (e.g., `xsd:string`, `xsd:integer`, `xsd:decimal`, etc.) under the `relationship` prefix.
- Ensured backward compatibility with existing `xref` and `xref_analog` parsing to maintain functionality with older OBO files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ControlledVocabulary.cpp</strong><dd><code>Add support for parsing `relationship:has_value_type` in OBO files</code></dd></summary>
<hr>

src/openms/source/FORMAT/ControlledVocabulary.cpp
<li>Added support for parsing <code>relationship:has_value_type</code> in OBO files.<br> <li> Extended parsing logic to handle various XSD types under <code>relationship</code>.<br> <li> Ensured backward compatibility with existing <code>xref</code> and <code>xref_analog</code> <br>parsing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7508/files#diff-4ea101d363e0b97b0447c97c04676e010dcc98ecb4803e55bae4e42bb2d9b19a">+60/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

