### PR TITLE
Numpy install 1.26.4 or earlier

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -103,7 +103,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install numpy<2.0
+          pip install --force-reinstall numpy<=1.26.4
           pip install -U wheel
 
           echo $CURRENT_PYTHON_EXECUTABLE
@@ -205,7 +205,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install numpy<2.0
+          pip install --force-reinstall numpy<=1.26.4
           pip install -U wheel
           pip install -U pandas
 
@@ -315,7 +315,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install numpy<2.0
+          pip install --force-reinstall numpy<=1.26.4
           pip install -U wheel
           pip install -U pandas
 
@@ -393,7 +393,7 @@ jobs:
           "$PYBIN/bin/pip" install -U Cython
           "$PYBIN/bin/pip" install -U setuptools
           "$PYBIN/bin/pip" install -U wheel
-          "$PYBIN/bin/pip" install numpy<2.0
+          "$PYBIN/bin/pip" install --force-reinstall numpy<=1.26.4
           "$PYBIN/bin/pip" install -U pytest
           "$PYBIN/bin/pip" install -U autowrap
 

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -103,7 +103,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install -U numpy
+          pip install numpy<2.0
           pip install -U wheel
 
           echo $CURRENT_PYTHON_EXECUTABLE
@@ -205,7 +205,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install -U numpy
+          pip install numpy<2.0
           pip install -U wheel
           pip install -U pandas
 
@@ -315,7 +315,7 @@ jobs:
           pip install -U pip
           pip install -U autowrap
           pip install -U pytest
-          pip install -U numpy
+          pip install numpy<2.0
           pip install -U wheel
           pip install -U pandas
 
@@ -393,7 +393,7 @@ jobs:
           "$PYBIN/bin/pip" install -U Cython
           "$PYBIN/bin/pip" install -U setuptools
           "$PYBIN/bin/pip" install -U wheel
-          "$PYBIN/bin/pip" install -U numpy
+          "$PYBIN/bin/pip" install numpy<2.0
           "$PYBIN/bin/pip" install -U pytest
           "$PYBIN/bin/pip" install -U autowrap
 

--- a/.github/workflows/test_pyopenms.yml
+++ b/.github/workflows/test_pyopenms.yml
@@ -1,9 +1,9 @@
-name: Test nightly pyOpenMS on different platforms
+name: Test pyOpenMS on different platforms
 
 on:
   workflow_dispatch: # Trigger manually
-  workflow_run:
-    workflows: [ pyopenms-wheels ]
+  workflow_run: # Trigger on pyoepnems-wheels
+    workflows: ["pyopenms-wheels-and-packages"]
     types:
       - completed
 

--- a/.github/workflows/test_pyopenms.yml
+++ b/.github/workflows/test_pyopenms.yml
@@ -2,7 +2,7 @@ name: Test pyOpenMS on different platforms
 
 on:
   workflow_dispatch: # Trigger manually
-  workflow_run: # Trigger on pyoepnems-wheels
+  workflow_run: # Trigger on pyopenms-wheels
     workflows: ["pyopenms-wheels-and-packages"]
     types:
       - completed

--- a/.github/workflows/test_pyopenms.yml
+++ b/.github/workflows/test_pyopenms.yml
@@ -2,7 +2,7 @@ name: Test pyOpenMS on different platforms
 
 on:
   workflow_dispatch: # Trigger manually
-  workflow_run: # Trigger on pyoepnems-wheels
+  workflow_run: # Trigger on pyopenems-wheels
     workflows: ["pyopenms-wheels-and-packages"]
     types:
       - completed

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -254,7 +254,7 @@ setup(
         'pyopenms': ['py.typed', '*.pyi']
     },
 	install_requires=[
-          'numpy<2.0',
+          'numpy<=1.26.4',
           'pandas',
           'matplotlib>=3.5'
     ],

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -254,7 +254,7 @@ setup(
         'pyopenms': ['py.typed', '*.pyi']
     },
 	install_requires=[
-          'numpy',
+          'numpy<2.0',
           'pandas',
           'matplotlib>=3.5'
     ],


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated `install_requires` in `setup.py` to specify `numpy<2.0`.
- Modified `.github/workflows/pyopenms-wheels.yml` to force reinstall `numpy<=1.26.4` in multiple pip install commands.
- Updated `.github/workflows/test_pyopenms.yml` to change the workflow name and adjust the trigger conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Specify numpy version constraint in setup.py</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/pyOpenMS/setup.py

- Updated `install_requires` to specify `numpy<2.0`.



</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7516/files#diff-1343deca77d77a5eb66c3fddd2f25c883ba408f22d13c33b760b691b5ea82d75">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyopenms-wheels.yml</strong><dd><code>Force reinstall specific numpy version in CI workflows</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/pyopenms-wheels.yml

<li>Added <code>--force-reinstall</code> flag and specified <code>numpy<=1.26.4</code> in multiple pip <br>install commands.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7516/files#diff-084f20ae9727db0905c5fbbc32ef797e048c87887ccfc57b0f89b2bf82f45979">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_pyopenms.yml</strong><dd><code>Update test workflow name and triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/test_pyopenms.yml

- Updated workflow name and trigger conditions.



</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7516/files#diff-770c7205b412d193b98c06200794e25724f74f96dcfd5b6a6a3726d6ea01cdea">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

