### PR TITLE
Pypifixes

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -27,7 +27,7 @@ jobs:
         cmake-version: '3.25.x'
 
     - name: Reduce PATH
-      run: echo "PATH=C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts;C:\hostedtoolcache\windows\Python\3.7.9\x64;C:\hostedtoolcache\windows\Ruby\2.5.8\x64\bin;C:\Program Files\Java\jdk8u265-b01\bin;C:\ProgramData\kind;C:\vcpkg;C:\cf-cli;C:\Program Files (x86)\NSIS;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0;C:\windows\System32\OpenSSH;C:\ProgramData\Chocolatey\bin;C:\Program Files\Docker;C:\Program Files\PowerShell\7;C:\Program Files\OpenSSL\bin;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      run: echo "DISTUTILS_USE_SDK=1" #"PATH=C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts;C:\hostedtoolcache\windows\Python\3.7.9\x64;C:\hostedtoolcache\windows\Ruby\2.5.8\x64\bin;C:\Program Files\Java\jdk8u265-b01\bin;C:\ProgramData\kind;C:\vcpkg;C:\cf-cli;C:\Program Files (x86)\NSIS;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0;C:\windows\System32\OpenSSH;C:\ProgramData\Chocolatey\bin;C:\Program Files\Docker;C:\Program Files\PowerShell\7;C:\Program Files\OpenSSL\bin;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -560,7 +560,7 @@ jobs:
       if: "contains(github.ref, 'develop') || contains(github.ref, 'nightly')"
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository_url: https://pypi.cs.uni-tuebingen.de/
+        repository-url: https://pypi.cs.uni-tuebingen.de/
         user: openms
         password: ${{ secrets.abiservices_pypi_pw }}
         packages-dir: ${{ github.workspace }}/wheels

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -7,6 +7,11 @@ name: pyopenms-wheels-and-packages
 # events but only for the master branch
 on:
   workflow_dispatch:
+    inputs:
+      upload-to-pypi:
+        type: boolean
+        description: actually upload the release package to pypi.org
+        default: false
   push:
     tags:
       - 'Release*'
@@ -573,7 +578,8 @@ jobs:
             ls -la wheels/
 
     - name: Publish package to nightly PyPI
-      if: "contains(github.ref, 'develop') || contains(github.ref, 'nightly')"
+        # Upload the wheels to our pypi server for develop, nightly and release branches (unless it's explictly stated to upload it to pypi.org)
+      if: contains(github.ref, 'develop') || contains(github.ref, 'nightly') || (contains(github.ref, 'Release') && !inputs.upload-to-pypi)
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://pypi.cs.uni-tuebingen.de/
@@ -582,9 +588,10 @@ jobs:
         packages-dir: ${{ github.workspace }}/wheels
 
     - name: Publish package to PyPI
-      if: "contains(github.ref, 'Release')"
+      if: contains(github.ref, 'Release') && inputs.upload-to-pypi
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
+        repository-url: https://test.pypi.org/
         password: ${{ secrets.pypi_api_token_release }}
         packages-dir: ${{ github.workspace }}/wheels

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -579,7 +579,7 @@ jobs:
 
     - name: Publish package to nightly PyPI
         # Upload the wheels to our pypi server for develop, nightly and release branches (unless it's explictly stated to upload it to pypi.org)
-      if: contains(github.ref, 'develop') || contains(github.ref, 'nightly') || (contains(github.ref, 'Release') && !inputs.upload-to-pypi)
+      if: contains(github.ref, 'develop') || contains(github.ref, 'nightly') || (contains(github.ref, 'Release') && inputs.upload-to-pypi == 'false')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://pypi.cs.uni-tuebingen.de/

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -26,8 +26,12 @@ jobs:
       with:
         cmake-version: '3.25.x'
 
-    - name: Reduce PATH
-      run: echo "DISTUTILS_USE_SDK=1" #"PATH=C:\hostedtoolcache\windows\Python\3.7.9\x64\Scripts;C:\hostedtoolcache\windows\Python\3.7.9\x64;C:\hostedtoolcache\windows\Ruby\2.5.8\x64\bin;C:\Program Files\Java\jdk8u265-b01\bin;C:\ProgramData\kind;C:\vcpkg;C:\cf-cli;C:\Program Files (x86)\NSIS;C:\windows\system32;C:\windows;C:\windows\System32\Wbem;C:\windows\System32\WindowsPowerShell\v1.0;C:\windows\System32\OpenSSH;C:\ProgramData\Chocolatey\bin;C:\Program Files\Docker;C:\Program Files\PowerShell\7;C:\Program Files\OpenSSL\bin;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Program Files (x86)\Microsoft Visual Studio\2019\\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Reduce PATH # This fixes a bug described in https://github.com/facebook/watchman/commit/59bcfbf91d2a24ab580b8a78e384f133cc202383
+      run: echo "DISTUTILS_USE_SDK=1"
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
@@ -116,7 +120,7 @@ jobs:
 
           # build pyopenms distribution
           cmake --version
-          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=4 .
+          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} .
           cmake --build . --config Release --target pyopenms
 
           # copy to directory
@@ -144,6 +148,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: OpenMS
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
 
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
@@ -193,7 +201,7 @@ jobs:
         pushd bld
         # Use -DCMAKE_FIND_DEBUG_MODE=ON for debug
         cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
-        make -j4 OpenMS
+        make -j${{ steps.cpu-cores.outputs.count }} OpenMS
 
         mkdir pyopenms_whls
 
@@ -216,8 +224,8 @@ jobs:
           pip install -U pandas
 
           # build pyopenms distribution (macOS)
-          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=4 .
-          make -j4 pyopenms
+          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} .
+          make -j${{ steps.cpu-cores.outputs.count }} pyopenms
 
           # copy to directory
           cp pyOpenMS/dist/*.whl pyopenms_whls/
@@ -254,6 +262,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: OpenMS
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
 
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
@@ -303,7 +315,7 @@ jobs:
         pushd bld
         # Use -DCMAKE_FIND_DEBUG_MODE=ON for debug
         cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
-        make -j4 OpenMS
+        make -j${{ steps.cpu-cores.outputs.count }} OpenMS
 
         mkdir pyopenms_whls
 
@@ -326,8 +338,8 @@ jobs:
           pip install -U pandas
 
           # build pyopenms distribution (macOS)
-          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=4 .
-          make -j4 pyopenms
+          cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} .
+          make -j${{ steps.cpu-cores.outputs.count }} pyopenms
 
           # copy to directory
           cp pyOpenMS/dist/*.whl pyopenms_whls/
@@ -363,6 +375,10 @@ jobs:
       with:
         path: OpenMS
 
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
+
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
       with:
@@ -383,7 +399,7 @@ jobs:
         mkdir openms-build
         cd openms-build
         cmake -DCMAKE_BUILD_TYPE="Release" -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DCMAKE_PREFIX_PATH="/contrib-build/" $GITHUB_WORKSPACE/OpenMS
-        make -j4 OpenMS
+        make -j${{ steps.cpu-cores.outputs.count }} OpenMS
 
         # compile and configure OpenMS
         for py in $(echo "${PYTHON_VERSIONS}" | jq -r '.[]'); do
@@ -404,8 +420,8 @@ jobs:
           "$PYBIN/bin/pip" install -U autowrap
 
           # configure (don't copy deps since we use auditwheel)
-          cmake -DNO_DEPENDENCIES=ON -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DCMAKE_PREFIX_PATH="/contrib-build/" -DPYOPENMS=On -DPython_ROOT_DIR=$PYBIN -DPython_FIND_STRATEGY="LOCATION" -DPY_NUM_THREADS=4 $GITHUB_WORKSPACE/OpenMS
-          make -j4 pyopenms
+          cmake -DNO_DEPENDENCIES=ON -DOPENMS_CONTRIB_LIBS="/contrib-build/" -DCMAKE_PREFIX_PATH="/contrib-build/" -DPYOPENMS=On -DPython_ROOT_DIR=$PYBIN -DPython_FIND_STRATEGY="LOCATION" -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} $GITHUB_WORKSPACE/OpenMS
+          make -j${{ steps.cpu-cores.outputs.count }} pyopenms
           
           # ensure auditwheel can find the libraries
           export LD_LIBRARY_PATH=$LD_OLD_LIBRARY_PATH:`pwd`/lib


### PR DESCRIPTION
### **User description**
## Description

- Require manual confirmation to upload to pypi.org (actually test.pypi.org for now).
- Fix the old path-mangling hack required to get conda to play nice with windows
- remove hard-coded num threads for building, instead use the number of cores on runner.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a manual confirmation input (`upload-to-pypi`) to control whether the release package should be uploaded to pypi.org.
- Introduced a step to dynamically determine the number of CPU cores and scale the `make` and `cmake` build threads accordingly.
- Fixed a path issue on Windows by setting the `DISTUTILS_USE_SDK` environment variable.
- Updated the conditions for publishing packages to differentiate between test PyPI and the actual PyPI based on the `upload-to-pypi` input.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyopenms-wheels.yml</strong><dd><code>Enhance CI workflow with dynamic threading and manual PyPI upload</code></dd></summary>
<hr>

.github/workflows/pyopenms-wheels.yml
<li>Added manual confirmation input for uploading to PyPI.<br> <li> Introduced dynamic scaling of build threads based on CPU cores.<br> <li> Fixed path issue by setting <code>DISTUTILS_USE_SDK</code>.<br> <li> Updated conditions for publishing packages to PyPI and test PyPI.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7522/files#diff-084f20ae9727db0905c5fbbc32ef797e048c87887ccfc57b0f89b2bf82f45979">+38/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

