### PR TITLE
add html in selectversion.js

### DIFF
--- a/doc/doxygen/common/selectversion.js
+++ b/doc/doxygen/common/selectversion.js
@@ -66,7 +66,7 @@ function parseDirectoryListing(stringOfHtml) {
 
     docs = docs.map((x) => '<a class="verslink" href="'
         + urlrootdir
-        + '/release/' + x + '/' + 'html/' + patharr[patharr.length - 1] + '">'
+        + '/release/' + x + '/html/' + patharr[patharr.length - 1] + '">'
         + x
         + '</a>');
         

--- a/doc/doxygen/common/selectversion.js
+++ b/doc/doxygen/common/selectversion.js
@@ -76,7 +76,7 @@ function parseDirectoryListing(stringOfHtml) {
     // TODO Style nightly differently to make sure users see it?
     docs.unshift('<a class="verslink" href="'
         + urlrootdir
-        + '/nightly/' + patharr[patharr.length - 1] + '">'
+        + '/nightly/' + 'html/' + patharr[patharr.length - 1] + '">'
         + 'nightly'
         + '</a>');
         

--- a/doc/doxygen/common/selectversion.js
+++ b/doc/doxygen/common/selectversion.js
@@ -66,7 +66,7 @@ function parseDirectoryListing(stringOfHtml) {
 
     docs = docs.map((x) => '<a class="verslink" href="'
         + urlrootdir
-        + '/release/' + x + '/' + patharr[patharr.length - 1] + '">'
+        + '/release/' + x + '/' + 'html/' + patharr[patharr.length - 1] + '">'
         + x
         + '</a>');
         


### PR DESCRIPTION
### **User description**
https://github.com/OpenMS/OpenMS-docs/issues/231

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->
https://github.com/OpenMS/OpenMS-docs/issues/231

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Enhancement


___

### **Description**
- Updated the URL structure in `selectversion.js` to include an additional `html` directory when generating links for different versions of the documentation.
- Adjusted the path concatenation logic to ensure the correct URL format.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selectversion.js</strong><dd><code>Update URL structure in `selectversion.js` for documentation links</code></dd></summary>
<hr>

doc/doxygen/common/selectversion.js

<li>Modified the URL structure in the <code>docs</code> array to include an additional <br><code>html</code> directory.<br> <li> Adjusted the path concatenation logic to reflect the new URL <br>structure.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7534/files#diff-a24744cbfc6eeae5b5f41f8d7fa79f91a1cf6914d32ef1bb61ba6989a50f983b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

