### PR TITLE
CometAdapter fix for Comet 2024.01.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ Fixes:
 - FileConverter: more robust (#7176)
 - MSFragger: allow relative path to database (#7155)
 - MSGFPlusAdapter: allow concurrent creation of indexed database (#7272)
+- CometAdapter: work around bug in Comet 2024.01 rev. 0 to avoid empty results (#7540)
 - ParamEditor: fixed error for the subsection parameter (ParamNode) to go through store function (#7180)
 - TOPPView: fix crash when viewing certain Chromatograms (#7220)
 - TOPPView: in 2D view, show correct adjacent layers in context menu, if user clicked to the right of the last MS1 scan (now shows the 4 rightmost MS1 scans, used to show the 4 leftmost scans) (#7423)

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -286,9 +286,8 @@ protected:
     isotope_error["-1/0/1/2/3"] = 5;
 
     // comet_version is something like "# comet_version 2017.01 rev. 1"
-    auto comet_year_str = StringUtils::removeWhitespaces(String(comet_version));
     QRegularExpression comet_version_regex("(\\d{4})\\.(\\d*)rev");
-    if (auto match = comet_version_regex.match(comet_year_str.toQString()); match.hasMatch())
+    if (auto match = comet_version_regex.match(comet_version.toQString().remove(' ')); match.hasMatch())
     {
       const int comet_year = match.captured(1).toInt();
       if (comet_version.hasSubstring("2024.01 rev. 0"))

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -282,7 +282,16 @@ protected:
     isotope_error["-8/-4/0/4/8"] = 4;
     isotope_error["-1/0/1/2/3"] = 5;
 
-    os << "peptide_mass_tolerance = " << getDoubleOption_("precursor_mass_tolerance") << "\n";
+    double precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
+    if (comet_version.hasSubstring("2024.01 rev. 0"))
+    { // workaround for Comet bug in v2024.01.0, which introduces “peptide_mass_tolerance_lower” and “peptide_mass_tolerance_upper” parameters
+      // but deprecates “peptide_mass_tolerance”. It's still supported but buggy: it causes the search to return empty results since lower-upper
+      // boundaries are inverted, e.g. a '10' in param.txt is internally translated to 10 to -10 instead of -10 to 10. So we fix by giving a negative tolerance, see
+      // https://github.com/UWPR/Comet/issues/59 ;; should only affect this version
+      OPENMS_LOG_INFO << "Comet 2024.01 rev. 0 detected. Using negation workaround for precursor_mass_tolerance." << endl;
+      precursor_mass_tolerance *= -1;
+    }    
+    os << "peptide_mass_tolerance = " << precursor_mass_tolerance << "\n";
     os << "peptide_mass_units = " << precursor_error_units[getStringOption_("precursor_error_units")] << "\n";                  // 0=amu, 1=mmu, 2=ppm
     os << "mass_type_parent = " << 1 << "\n";                    // 0=average masses, 1=monoisotopic masses
     os << "mass_type_fragment = " << 1 << "\n";                  // 0=average masses, 1=monoisotopic masses
@@ -498,7 +507,7 @@ protected:
     os << "spectrum_batch_size = " << getIntOption_("spectrum_batch_size") << "\n";                 // max. // of spectra to search at a time; 0 to search the entire scan range in one loop
     os << "max_duplicate_proteins = 20\n";                       // maximum number of protein names to report for each peptide identification; -1 reports all duplicates
     os << "equal_I_and_L = 1\n";
-    os << "output_suffix = " << "" << "\n";                      // add a suffix to output base names i.e. suffix "-C" generates base-C.pep.xml from base.mzXML input
+    os << "output_suffix =\n";                                   // add a suffix to output base names i.e. suffix "-C" generates base-C.pep.xml from base.mzXML input
     os << "mass_offsets = " << ListUtils::concatenate(getDoubleList_("mass_offsets"), " ") << "\n"; // one or more mass offsets to search (values subtracted from deconvoluted precursor mass)
     os << "precursor_NL_ions =\n"; //  one or more precursor neutral loss masses, will be added to xcorr analysis 
 


### PR DESCRIPTION
## Description

partially fixes #7531 (that's the most we can do).
We still warn against using Comet 2024.01.0, but our CometAdapter should now be able to handle future versions which use
`peptide_mass_tolerance_lower`  and `peptide_mass_tolerance_upper`.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Implemented a workaround for a bug in Comet 2024.01 rev. 0 by negating the `precursor_mass_tolerance` parameter to avoid empty search results.
- Added logging to inform users when the workaround is applied.
- Fixed a formatting issue with the `output_suffix` parameter in `CometAdapter`.
- Updated the CHANGELOG to document the workaround for the Comet 2024.01 rev. 0 bug.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CometAdapter.cpp</strong><dd><code>Workaround for Comet 2024.01.0 bug in `CometAdapter`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/topp/CometAdapter.cpp

<li>Added workaround for a bug in Comet 2024.01 rev. 0 by negating <br><code>precursor_mass_tolerance</code>.<br> <li> Updated logging to inform about the workaround.<br> <li> Fixed formatting issue with <code>output_suffix</code> parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7540/files#diff-e1e99b4ea946a2cc81f22c595d19a1791202d46dccb4df3783971aa0c089e150">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG</strong><dd><code>Update CHANGELOG for CometAdapter bug workaround</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG

<li>Documented the workaround for the Comet 2024.01 rev. 0 bug in <br><code>CometAdapter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7540/files#diff-ecec88c33adb7591ee6aa88e29b62ad52ef443611cba5e0f0ecac9b5725afdba">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

