### PR TITLE
TOPPView: fix glitches in 1D view and layer names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,8 +26,9 @@ Library:
 - SiriusAdapter reworked to SiriusExport: Instead of running SIRIUS directly, this reworked tool takes multiple mzML and feautureXML (optional) files exporting a single SIRIUS .ms input file as well as an input table with compound info from features for the new AssayGeneratorMetaboSirius tool. (#7234)
 - Splitting AssayGeneratorMetabo into two tools: In line with the changes to SiriusExport this tool has been split into two separate workflows. AssayGeneratorMetabo generates an assay library from mzML and feautreXML files using an heuristic approach picking the highest intensity MS2 peaks (like before). AssayGeneratorMetaboSirius takes an existing SIRIUS project directory as input to generate an assay library based on fragmentation trees. (#7234)
 - better documentation for all SpectraFilter... tools (#7183)
-- TOPPView: offer Ion mobility view from 2D spectra view (#7423)
-- TOPPView: view ion mobility frames, irrespective of its MS level (formerly only MS1 was supported) (#7427)
+- TOPPView: 
+  - offer Ion mobility view from 2D spectra view (#7423)
+  - view ion mobility frames, irrespective of its MS level (formerly only MS1 was supported) (#7427)
 - OpenSwath: Add output on peak shape metrics to .osw file (#7222)
 
 New Tools:
@@ -41,8 +42,10 @@ Fixes:
 - MSGFPlusAdapter: allow concurrent creation of indexed database (#7272)
 - CometAdapter: work around bug in Comet 2024.01 rev. 0 to avoid empty results (#7540)
 - ParamEditor: fixed error for the subsection parameter (ParamNode) to go through store function (#7180)
-- TOPPView: fix crash when viewing certain Chromatograms (#7220)
-- TOPPView: in 2D view, show correct adjacent layers in context menu, if user clicked to the right of the last MS1 scan (now shows the 4 rightmost MS1 scans, used to show the 4 leftmost scans) (#7423)
+- TOPPView:
+   - fix crash when viewing certain Chromatograms (#7220)
+   - in 2D view, show correct adjacent layers in context menu, if user clicked to the right of the last MS1 scan (now shows the 4 rightmost MS1 scans, used to show the 4 leftmost scans) (#7423)
+   - fix glitches in 1D view and layer names (#7549)
 - TOPPAS: open files in TOPPView (#7213)
 - pyOpenMS: Log warnings in pure Python code with warnings.warn instead of print (#7418)
 - more robust parsing of mzIdentML (#7153)

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
@@ -418,6 +418,12 @@ public:
       return point;
     }
 
+    /// overload to call the 1D version (which has min-intensity of '0')
+    virtual const RangeType& getDataRange() const override
+    { 
+      return overall_data_range_1d_;
+    }
+
     /**
      * \brief Pushes a data point back into the valid data range of the current layer area. Useful for annotation items which were mouse-dragged outside the range by the user.
      * \tparam T A data point, e.g. Peak1D, which may be outside the data area

--- a/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Plot1DCanvas.h
@@ -587,7 +587,7 @@ protected:
     void drawAlignment_(QPainter& painter);
 
     /// internal method, called before calling parent function PlotCanvas::changeVisibleArea_
-    void changeVisibleAreaCommon_(const UnitRange& new_area, bool repaint, bool add_to_stack);
+    void changeVisibleArea1D_(const UnitRange& new_area, bool repaint, bool add_to_stack);
 
     // Docu in base class
     void changeVisibleArea_(VisibleArea new_area, bool repaint = true, bool add_to_stack = false) override;

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -499,7 +499,7 @@ namespace OpenMS
 
         @see overall_data_range_
     */
-    const RangeType& getDataRange() const;
+    virtual const RangeType& getDataRange() const;
 
     /**
         @brief Returns the first intensity scaling factor for 'snap to maximum intensity mode' (for the currently visible data range).

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -397,11 +397,16 @@ namespace OpenMS
       @param map Shared pointer to input map. It can be performed in constant time and does not double the required memory.
       @param od_map Shared pointer to on disk data which potentially caches some data to save memory (the map can be empty, but do not pass nullptr).
       @param filename This @em absolute filename is used to monitor changes in the file and reload the data
+      @param caption The caption of the layer (shown in the layer window)
       @param use_noise_cutoff Add a noise filter which removes low-intensity peaks
 
       @return If a new layer was created
     */
-    bool addPeakLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename = "", const bool use_noise_cutoff = false);
+    bool addPeakLayer(const ExperimentSharedPtrType& map,
+                      ODExperimentSharedPtrType od_map,
+                      const String& filename = "",
+                      const String& caption = "",
+                      const bool use_noise_cutoff = false);
 
     /**
       @brief Add a chrom data layer
@@ -409,10 +414,11 @@ namespace OpenMS
       @param map Shared pointer to input map. It can be performed in constant time and does not double the required memory.
       @param od_map Shared pointer to on disk data which potentially caches some data to save memory (the map can be empty, but do not pass nullptr).
       @param filename This @em absolute filename is used to monitor changes in the file and reload the data
+      @param caption The caption of the layer (shown in the layer window)
 
       @return If a new layer was created
     */
-    bool addChromLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename = "");
+    bool addChromLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename = "", const String& caption = "");
 
 
     /**
@@ -420,32 +426,36 @@ namespace OpenMS
 
         @param map Shared Pointer to input map. It can be performed in constant time and does not double the required memory.
         @param filename This @em absolute filename is used to monitor changes in the file and reload the data
+        @param caption The caption of the layer (shown in the layer window)
 
         @return If a new layer was created
     */
-    bool addLayer(FeatureMapSharedPtrType map, const String& filename = "");
+    bool addLayer(FeatureMapSharedPtrType map, const String& filename = "", const String& caption = "");
 
     /**
         @brief Add a consensus feature data layer
 
         @param map Shared Pointer to input map. It can be performed in constant time and does not double the required memory.
         @param filename This @em absolute filename is used to monitor changes in the file and reload the data
+        @param caption The caption of the layer (shown in the layer window)
 
         @return If a new layer was created
     */
-    bool addLayer(ConsensusMapSharedPtrType map, const String& filename = "");
+    bool addLayer(ConsensusMapSharedPtrType map, const String& filename = "", const String& caption = "");
     //@}
 
     /**
         @brief Add an identification data layer
 
-        @param peptides Input list of peptides, which has to be mutable and will be empty after adding. Swapping is used to insert the data. It can be performed in constant time and does not double
-       the required memory.
+        @param peptides Input list of peptides, which has to be mutable and will be empty after adding. 
+               Swapping is used to insert the data. It can be performed in constant time and does not double
+               the required memory.
         @param filename This @em absolute filename is used to monitor changes in the file and reload the data
+        @param caption The caption of the layer (shown in the layer window)
 
         @return If a new layer was created
     */
-    bool addLayer(std::vector<PeptideIdentification>& peptides, const String& filename = "");
+    bool addLayer(std::vector<PeptideIdentification>& peptides, const String& filename = "", const String& caption = "");
 
     /// Returns the minimum intensity of the active layer
     inline float getCurrentMinIntensity() const

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -909,31 +909,30 @@ namespace OpenMS
     {
       if (data_type == LayerDataBase::DT_FEATURE) // features
       {
-        if (!target_window->canvas()->addLayer(feature_map, filename))
+        if (!target_window->canvas()->addLayer(feature_map, filename, caption))
         {
           return;
         }
       }
       else if (data_type == LayerDataBase::DT_CONSENSUS) // consensus features
       {
-        if (!target_window->canvas()->addLayer(consensus_map, filename))
+        if (! target_window->canvas()->addLayer(consensus_map, filename, caption))
           return;
       }
       else if (data_type == LayerDataBase::DT_IDENT)
       {
-        if (!target_window->canvas()->addLayer(peptides, filename))
+        if (! target_window->canvas()->addLayer(peptides, filename, caption))
           return;
       }
       else // peaks or chrom
       {
-        if (data_type == LayerDataBase::DT_PEAK &&
-            !target_window->canvas()->addPeakLayer(peak_map, on_disc_peak_map, filename, use_intensity_cutoff))
+        if (data_type == LayerDataBase::DT_PEAK && ! target_window->canvas()->addPeakLayer(peak_map, on_disc_peak_map, filename, caption, use_intensity_cutoff))
         {
           return;
         }
         
         if (data_type == LayerDataBase::DT_CHROMATOGRAM &&
-            !target_window->canvas()->addChromLayer(peak_map, on_disc_peak_map, filename))
+            !target_window->canvas()->addChromLayer(peak_map, on_disc_peak_map, filename, caption))
         {
           return;
         }
@@ -960,6 +959,8 @@ namespace OpenMS
       {
         canvas->mergeIntoLayer(merge_layer, peptides);
       }
+      // combine layer names
+      canvas->setLayerName(merge_layer, canvas->getLayerName(merge_layer) + " + " + caption);
     }
 
     if (as_new_window)

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -190,12 +190,6 @@ namespace OpenMS
   void Plot1DCanvas::changeVisibleAreaCommon_(const UnitRange& new_area, bool repaint, bool add_to_stack)
   {
     auto corrected = correctGravityAxisOfVisibleArea_(new_area);
-    
-    if (intensity_mode_ != IM_PERCENTAGE) // not for Percentage mode, which is always [0,100]
-    { // make sure we stay inside the overall data range of the currently displayable 1D data
-      corrected.pushInto(overall_data_range_1d_);
-    }
-    
     PlotCanvas::changeVisibleArea_(visible_area_.cloneWith(corrected), repaint, add_to_stack);
   }
 

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -187,7 +187,7 @@ namespace OpenMS
     emit layerActivated(this);
   }
 
-  void Plot1DCanvas::changeVisibleAreaCommon_(const UnitRange& new_area, bool repaint, bool add_to_stack)
+  void Plot1DCanvas::changeVisibleArea1D_(const UnitRange& new_area, bool repaint, bool add_to_stack)
   {
     auto corrected = correctGravityAxisOfVisibleArea_(new_area);
     PlotCanvas::changeVisibleArea_(visible_area_.cloneWith(corrected), repaint, add_to_stack);
@@ -195,15 +195,15 @@ namespace OpenMS
 
   void Plot1DCanvas::changeVisibleArea_(const AreaXYType& new_area, bool repaint, bool add_to_stack)
   {
-    changeVisibleAreaCommon_(visible_area_.cloneWith(new_area).getAreaUnit(), repaint, add_to_stack);
+    changeVisibleArea1D_(visible_area_.cloneWith(new_area).getAreaUnit(), repaint, add_to_stack);
   }
   void Plot1DCanvas::changeVisibleArea_(const UnitRange& new_area, bool repaint, bool add_to_stack)
   {
-    changeVisibleAreaCommon_(new_area, repaint, add_to_stack);
+    changeVisibleArea1D_(new_area, repaint, add_to_stack);
   }
   void Plot1DCanvas::changeVisibleArea_(VisibleArea new_area, bool repaint, bool add_to_stack)
   {
-    changeVisibleAreaCommon_(new_area.getAreaUnit(), repaint, add_to_stack);
+    changeVisibleArea1D_(new_area.getAreaUnit(), repaint, add_to_stack);
   }
 
   void Plot1DCanvas::dataToWidget(const DPosition<2>& xy_point, QPoint& point, bool flipped)

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -129,8 +129,14 @@ namespace OpenMS
 
   void PlotCanvas::changeVisibleArea_(VisibleArea new_area, bool repaint, bool add_to_stack)
   {
-    // make sure we stay inside the overall data range
-    new_area.pushInto(overall_data_range_);
+    auto data_range = getDataRange(); // getDataRange() is virtual, since its special for 1D (0-based intensity)
+    if (intensity_mode_ == IM_PERCENTAGE)
+    { // new_area will have [0, 100], and we don't want to make that any smaller if the data only goes up to, say 50
+    }
+    else
+    { // make sure we stay inside the overall data range
+      new_area.pushInto(data_range);
+    }
 
     // store old zoom state
     if (add_to_stack)
@@ -144,14 +150,12 @@ namespace OpenMS
       zoomAdd_(new_area);
     }
 
-    if (new_area != visible_area_)
-    {
-      visible_area_ = new_area;
-      updateScrollbars_();
-      recalculateSnapFactor_();
-      emit visibleAreaChanged(new_area); // calls PlotWidget::updateAxes, which calls Plot(1D/2D/3D)Widget::recalculateAxes_
-      emit layerZoomChanged(this); // calls TOPPViewBase::zoomOtherWindows (for linked windows)
-    }
+    // always update, even if the area did not change, since the intensity mode might have changed
+    visible_area_ = new_area;
+    updateScrollbars_();
+    recalculateSnapFactor_();
+    emit visibleAreaChanged(new_area); // calls PlotWidget::updateAxes, which calls Plot(1D/2D/3D)Widget::recalculateAxes_
+    emit layerZoomChanged(this); // calls TOPPViewBase::zoomOtherWindows (for linked windows)
 
     if (repaint)
     {

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -392,22 +392,33 @@ namespace OpenMS
   }
 
 
-  void setBaseLayerParameters(LayerDataBase* new_layer, const Param& param, const String& filename)
+  void setBaseLayerParameters(LayerDataBase* new_layer, const Param& param, const String& filename, const String& caption)
   {
     new_layer->param = param;
     new_layer->filename = filename;
-    new_layer->setName(QFileInfo(filename.toQString()).completeBaseName());
+    if (! caption.empty())
+    {
+      new_layer->setName(caption);
+    }
+    else 
+    {
+      new_layer->setName(QFileInfo(filename.toQString()).completeBaseName());
+    }
   }
 
   bool PlotCanvas::addLayer(std::unique_ptr<LayerData1DBase> new_layer)
   {
-    setBaseLayerParameters(new_layer.get(), param_, new_layer->filename);
+    setBaseLayerParameters(new_layer.get(), param_, new_layer->filename, new_layer->getName());
     layers_.addLayer(std::move(new_layer));
 
     return finishAdding_();
   }
 
-  bool PlotCanvas::addPeakLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename, const bool use_noise_cutoff)
+  bool PlotCanvas::addPeakLayer(const ExperimentSharedPtrType& map,
+                                ODExperimentSharedPtrType od_map,
+                                const String& filename,
+                                const String& caption,
+                                const bool use_noise_cutoff)
   {
     if (map->getSpectra().empty())
     {
@@ -425,7 +436,7 @@ namespace OpenMS
     new_layer->setPeakData(map);
     new_layer->setOnDiscPeakData(std::move(od_map));
 
-    setBaseLayerParameters(new_layer.get(), param_, filename);
+    setBaseLayerParameters(new_layer.get(), param_, filename, caption);
     layers_.addLayer(std::move(new_layer));
 
     // calculate noise
@@ -450,7 +461,7 @@ namespace OpenMS
   }
 
   
-  bool PlotCanvas::addChromLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename)
+  bool PlotCanvas::addChromLayer(const ExperimentSharedPtrType& map, ODExperimentSharedPtrType od_map, const String& filename, const String& caption)
   {
     if (map->getChromatograms().empty())
     {
@@ -468,36 +479,36 @@ namespace OpenMS
     new_layer->setChromData(map);
     new_layer->setOnDiscPeakData(std::move(od_map));
 
-    setBaseLayerParameters(new_layer.get(), param_, filename);
+    setBaseLayerParameters(new_layer.get(), param_, filename, caption);
     layers_.addLayer(std::move(new_layer));
 
     return finishAdding_();
   }
 
-  bool PlotCanvas::addLayer(FeatureMapSharedPtrType map, const String& filename)
+  bool PlotCanvas::addLayer(FeatureMapSharedPtrType map, const String& filename, const String& caption)
   {
     LayerDataFeatureUPtr new_layer(new LayerDataFeature);
     new_layer->getFeatureMap() = std::move(map);
 
-    setBaseLayerParameters(new_layer.get(), param_, filename);
+    setBaseLayerParameters(new_layer.get(), param_, filename, caption);
     layers_.addLayer(std::move(new_layer));
     return finishAdding_();
   }
 
-  bool PlotCanvas::addLayer(ConsensusMapSharedPtrType map, const String& filename)
+  bool PlotCanvas::addLayer(ConsensusMapSharedPtrType map, const String& filename, const String& caption)
   {
     LayerDataBaseUPtr new_layer(new LayerDataConsensus(map));
 
-    setBaseLayerParameters(new_layer.get(), param_, filename);
+    setBaseLayerParameters(new_layer.get(), param_, filename, caption);
     layers_.addLayer(std::move(new_layer));
     return finishAdding_();
   }
 
-  bool PlotCanvas::addLayer(vector<PeptideIdentification>& peptides, const String& filename)
+  bool PlotCanvas::addLayer(vector<PeptideIdentification>& peptides, const String& filename, const String& caption)
   {
     LayerDataIdent* new_layer(new LayerDataIdent); // ownership will be transferred to unique_ptr below; no need to delete
     new_layer->setPeptideIds(std::move(peptides));
-    setBaseLayerParameters(new_layer, param_, filename);
+    setBaseLayerParameters(new_layer, param_, filename, caption);
     layers_.addLayer(LayerDataBaseUPtr(new_layer));
     return finishAdding_();
   }


### PR DESCRIPTION
## Description

This PR fixes the following issues:

1) when generating theoretical spectra in TOPPView with intensities < 100, the 1D View showed them with weird intensities, especially in "Percentage" mode. Also "flipped" mode was broken, e.g.

2) custom captions for layer names were empty, e.g. no peptide sequence for theoretical spectra was visible

before:
![image](https://github.com/user-attachments/assets/d7bac7e4-a105-412c-b386-83613247bb5a)
after:
![image](https://github.com/user-attachments/assets/2c09c61b-2730-4077-8167-a223b45c6a3d)


### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
