### PR TITLE
fix MSIP part in KNIME

### DIFF
--- a/cmake/knime_package_support.cmake
+++ b/cmake/knime_package_support.cmake
@@ -253,8 +253,6 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=CometAdapter -DPARAM=comet_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
   # PercolatorAdapter
   COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=PercolatorAdapter -DPARAM=percolator_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
-  # MetaProSIP
-  COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=MetaProSIP -DPARAM=R_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
   DEPENDS create_ctds
 )
 

--- a/cmake/knime_package_support.cmake
+++ b/cmake/knime_package_support.cmake
@@ -253,6 +253,8 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=CometAdapter -DPARAM=comet_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
   # PercolatorAdapter
   COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=PercolatorAdapter -DPARAM=percolator_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
+  # MetaProSIP
+  COMMAND ${CMAKE_COMMAND} -D SCRIPT_DIR=${SCRIPT_DIRECTORY} -DTOOLNAME=MetaProSIP -DPARAM=R_executable -D CTD_PATH=${CTD_TP_PATH} -P ${SCRIPT_DIRECTORY}remove_parameter_from_ctd.cmake
   DEPENDS create_ctds
 )
 

--- a/src/topp/MetaProSIP.cpp
+++ b/src/topp/MetaProSIP.cpp
@@ -2040,7 +2040,22 @@ protected:
     registerInputFile_("in_featureXML", "<file>", "", "Feature data annotated with identifications (IDMapper)");
     setValidFormats_("in_featureXML", ListUtils::create<String>("featureXML"));
 
-    registerInputFile_("r_executable", "<file>", "R", "Path to the R executable (default: 'R')", false, false, {"is_executable"});
+    static const bool is_required(false);
+    static const bool is_advanced_option(true);
+    // executable
+    registerInputFile_("r_executable", "<executable>",
+        // choose the default value according to the platform where it will be executed
+        #ifdef OPENMS_WINDOWSPLATFORM
+                       "R.exe",
+        #else
+                       "R",
+        #endif
+                       "The R executable. Provide a full or relative path, or make sure it can be found in your PATH environment.", 
+                       is_required, 
+                       !is_advanced_option, 
+                       {"is_executable"}
+    );
+
 
     registerDoubleOption_("mz_tolerance_ppm", "<tol>", 10.0, "Tolerance in ppm", false, true);
 


### PR DESCRIPTION
### **User description**
## Description

change to R.exe on windows

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the `MetaProSIP.cpp` file to set the R executable path based on the operating system, using "R.exe" for Windows and "R" for other platforms.
- Modified the CMake configuration to include MetaProSIP in the list of tools for which the R executable parameter is removed.
- Introduced constants in the code for better readability and maintainability regarding option requirements and advanced status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MetaProSIP.cpp</strong><dd><code>Update R executable path handling for platform specificity</code></dd></summary>
<hr>

src/topp/MetaProSIP.cpp

<li>Updated the default R executable path based on the operating system.<br> <li> Added platform-specific logic for setting the R executable.<br> <li> Introduced constants for option requirements and advanced status.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7573/files#diff-7fd3f3a8eac3e23c45ecd072fd7e1d9d345b5799d3ff72f1a61bf7fcb5562341">+16/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>knime_package_support.cmake</strong><dd><code>Add MetaProSIP to CMake parameter removal list</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmake/knime_package_support.cmake

<li>Added MetaProSIP to the list of tools for parameter removal.<br> <li> Updated CMake configuration to handle R executable parameter.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7573/files#diff-983fbc97a96e1dda7bc982573ffeeceb8a2b16d8747f28ef95530385f4c39312">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

