### PR TITLE
Defining more enzymes in OpenMS Comet and SAGE adaptor

### DIFF
--- a/share/OpenMS/CHEMISTRY/Enzymes.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes.xml
@@ -150,7 +150,7 @@
       <ITEM name="XTandemID" value="[K]|[X]" type="string" />
       <ITEM name="OMSSAID" value="6" type="int" />
       <ITEM name="MSGFID" value="3" type="int" />
-      <ITEM name="CometID"   value="13" type="int" />
+      <ITEM name="CometID" value="13" type="int" />
     </NODE>
     <NODE name="PepsinA">
       <ITEM name="Name" value="PepsinA" type="string" />
@@ -211,7 +211,7 @@
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001915" type="string" />
       <ITEM name="XTandemID" value="[ALIV]|{P}" type="string" />
-      <ITEM name="CometID"   value="14" type="int" />
+      <ITEM name="CometID" value="14" type="int" />
     </NODE>
     <NODE name="proline endopeptidase">
       <ITEM name="Name" value="proline endopeptidase" type="string" />

--- a/share/OpenMS/CHEMISTRY/Enzymes.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes.xml
@@ -150,6 +150,7 @@
       <ITEM name="XTandemID" value="[K]|[X]" type="string" />
       <ITEM name="OMSSAID" value="6" type="int" />
       <ITEM name="MSGFID" value="3" type="int" />
+      <ITEM name="CometID"   value="13" type="int" />
     </NODE>
     <NODE name="PepsinA">
       <ITEM name="Name" value="PepsinA" type="string" />
@@ -210,6 +211,7 @@
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001915" type="string" />
       <ITEM name="XTandemID" value="[ALIV]|{P}" type="string" />
+      <ITEM name="CometID"   value="14" type="int" />
     </NODE>
     <NODE name="proline endopeptidase">
       <ITEM name="Name" value="proline endopeptidase" type="string" />

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -294,8 +294,8 @@ protected:
       {
         OPENMS_LOG_WARN << "Comet v2024.01.0 is known to have several bugs (see https://github.com/UWPR/Comet/issues/63). Please use a different version if possible." << std::endl;
       }
-      // Comet v2024.01.0 introduces “peptide_mass_tolerance_lower?and “peptide_mass_tolerance_upper?parameters
-      // and deprecates “peptide_mass_tolerance?(which is buggy in this version, see https://github.com/UWPR/Comet/issues/59)
+      // Comet v2024.01.0 introduces "peptide_mass_tolerance_lower" and "peptide_mass_tolerance_upper" parameters
+      // and deprecates "peptide_mass_tolerance" (which is buggy in this version, see https://github.com/UWPR/Comet/issues/59)
       // We need to use the new parameters from this version onwards
       double precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
       if (comet_year >= 2024)
@@ -610,8 +610,7 @@ protected:
     os << "11. No_cut                 1      @           @" << "\n";
     os << "12. Arg-C/P                1.     R           _" << "\n";
     os << "13. Lys-C/P                1      K           -" << "\n";
-    os << "14. Glutamyl_endopeptidase 1      E           E" << "\n";
-    os << "15. Leukocyte_elastase     1      ALIV        -" << "\n";
+    os << "14. Leukocyte_elastase     1      ALIV        -" << "\n";
 
     return ExitCodes::EXECUTION_OK;
   }

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -294,8 +294,8 @@ protected:
       {
         OPENMS_LOG_WARN << "Comet v2024.01.0 is known to have several bugs (see https://github.com/UWPR/Comet/issues/63). Please use a different version if possible." << std::endl;
       }
-      // Comet v2024.01.0 introduces “peptide_mass_tolerance_lower” and “peptide_mass_tolerance_upper” parameters
-      // and deprecates “peptide_mass_tolerance” (which is buggy in this version, see https://github.com/UWPR/Comet/issues/59)
+      // Comet v2024.01.0 introduces “peptide_mass_tolerance_lower?and “peptide_mass_tolerance_upper?parameters
+      // and deprecates “peptide_mass_tolerance?(which is buggy in this version, see https://github.com/UWPR/Comet/issues/59)
       // We need to use the new parameters from this version onwards
       double precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
       if (comet_year >= 2024)
@@ -609,6 +609,9 @@ protected:
     os << "10. Chymotrypsin           1      FWYL        P" << "\n";
     os << "11. No_cut                 1      @           @" << "\n";
     os << "12. Arg-C/P                1.     R           _" << "\n";
+    os << "13. Lys-C/P                1      K           -" << "\n";
+    os << "14. Glutamyl_endopeptidase 1      E           E" << "\n";
+    os << "15. Leukocyte_elastase     1      ALIV        -" << "\n";
 
     return ExitCodes::EXECUTION_OK;
   }

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -320,7 +320,21 @@ protected:
     {
       enzyme_details = 
    R"("cleave_at": "")";
-    }           
+    }
+    else if (enzyme == "glutamyl endopeptidase")
+    {
+      enzyme_details =
+   R"("cleave_at": "E",
+      "restrict": "E",
+      "c_terminal":true)";
+    }
+    else if (enzyme == "leukocyte elastase")
+    {
+      enzyme_details =
+   R"("cleave_at": "ALIV",
+      "restrict": null,
+      "c_terminal":true)";
+    }
 
     config_file.substitute("##enzyme_details##", enzyme_details);
 


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->
add definitions for several common enzymes in the Comet and SAGE adapters, glutamyl endopeptidase and leukocyte elastase.
## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Added definitions for new enzymes, Glutamyl endopeptidase and Leukocyte elastase, in both Comet and SAGE adapters.
- Updated enzyme lists and configuration logic to include these new enzymes.
- Improved comments for better understanding of parameter changes in CometAdapter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CometAdapter.cpp</strong><dd><code>Add new enzyme definitions to CometAdapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/topp/CometAdapter.cpp

<li>Added definitions for new enzymes: Glutamyl endopeptidase and <br>Leukocyte elastase.<br> <li> Updated enzyme list with new entries.<br> <li> Adjusted comments for clarity on parameter changes.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7584/files#diff-e1e99b4ea946a2cc81f22c595d19a1791202d46dccb4df3783971aa0c089e150">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SageAdapter.cpp</strong><dd><code>Define new enzymes in SageAdapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/topp/SageAdapter.cpp

<li>Added enzyme details for Glutamyl endopeptidase.<br> <li> Added enzyme details for Leukocyte elastase.<br> <li> Updated enzyme configuration logic.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7584/files#diff-e7a6640c1869e5ae5c09daa8f8cf1545eb7f920b62d8e829bbf5cf9aadff1b92">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

