### PR TITLE
TOPPView: open idXML in same layer as underlying data, if raw mzML is detected …

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -187,10 +187,10 @@ public:
       @param data_type Type of the data
       @param show_as_1d Force dataset to be opened in 1D mode (even if it contains several spectra)
       @param show_options If the options dialog should be shown (otherwise the defaults are used)
-      @param as_new_window Open the layer in a new window within TOPPView
+      @param as_new_window Open the layer in a new window within TOPPView (ignored if 'window_id' is set)
       @param filename source file name (if the data came from a file)
       @param caption Sets the layer name and window caption of the data. If unset the file name is used. If set, the file is not monitored for changes.
-      @param window_id in which window the file is opened if opened as a new layer (0 or default equals current
+      @param window_id in which window the file is opened if opened as a new layer (0 will open a new window).
       @param spectrum_id determines the spectrum to show in 1D view.
     */
     void addData(const FeatureMapSharedPtrType& feature_map,

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -742,7 +742,7 @@ namespace OpenMS
     glock.unlock();
 
     if (!annotate_path.empty())
-    {
+    { // this opens a new window with raw data + annotation; we want the actual idXML data on top
       auto load_res = addDataFile(annotate_path, false, false);
       if (load_res == LOAD_RESULT::OK)
       {
@@ -759,6 +759,7 @@ namespace OpenMS
             log_->appendNewHeader(LogWindow::LogState::NOTICE, "Error", "Annotation failed.");
           }
         }
+        window_id = getActivePlotWidget()->getWindowId(); // add ids on top of raw data
       }
     }
 


### PR DESCRIPTION
### **User description**
…in idXML meta data



## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the logic in TOPPView to open idXML data on top of the raw mzML data when detected in the metadata.
- Updated the `addData` method documentation to clarify the behavior of parameters related to window management.
- Improved layer management by retrieving the active plot window ID.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TOPPViewBase.cpp</strong><dd><code>Enhance idXML data handling in TOPPView</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp

<li>Modified logic to open idXML data on top of raw data.<br> <li> Added retrieval of active plot window ID for better layer management.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7585/files#diff-de3321ce3896ccc73240b41d43c08ec2d579b25b65b789281a585b8a8d9ed463">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TOPPViewBase.h</strong><dd><code>Update method documentation for data handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h

<li>Updated documentation for <code>addData</code> method parameters.<br> <li> Clarified behavior of <code>as_new_window</code> and <code>window_id</code> parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7585/files#diff-195e71d7b8238650f880dea7fd8bd48e5b94999c96c62b5cb62a879f3d05efeb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

