### PR TITLE
fix scan number extraction for merged spectra

### DIFF
--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -318,7 +318,7 @@ namespace OpenMS
       boost::sregex_token_iterator current_begin(native_id.begin(), native_id.end(), regexp, subgroups);
       boost::sregex_token_iterator current_end(native_id.end(), native_id.end(), regexp, subgroups);
       matches.insert(matches.end(), current_begin, current_end);
-      if (matches.size() == 1) // default case: one native identifier
+      if (subgroups.size() == 1) // default case: one native identifier
       {
         try
         {
@@ -338,7 +338,7 @@ namespace OpenMS
           return -1;
         }
       }
-      else if (matches.size() == 2) // special case: wiff file with two native identifiers
+      else if (subgroups.size() == 2) // special case: wiff file with two native identifiers
       {
         try
         {


### PR DESCRIPTION
## Description

For spectra created with `SpectraMerger` the native ids of scans get appended as comma separated values. In `SpectrumLookup::extractScanNumber()` this causes multiple subgroups to be matched even if only one is expected, resulting in misinterpretation of the second scan number as experiment number if the merged spectrum contains two scans or the return of `-1` if >2 scans were merged.

This PR ensures that the scan number of the first scan in the list of merged spectra is returned.

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
