### PR TITLE
make setup.py check for AVX support

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -269,7 +269,7 @@ jobs:
           ## Update the package lists for Brew
           brew update
           ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
-          brew install python3@3.12 --force --overwrite
+          brew install python@3.12 --force --overwrite
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -269,8 +269,7 @@ jobs:
           ## Update the package lists for Brew
           brew update
           ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
-          brew install python3 --force --overwrite
-          brew link --overwrite python@3.12 ## the runner has 3.12 installed by default, the line above worked to fix overwriting when 3.12 was the default brew version now we do it manually.
+          brew install python3@3.12 --force --overwrite
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -270,6 +270,7 @@ jobs:
           brew update
           ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
           brew install python3 --force --overwrite
+          brew link --overwrite python@3.12 ## the runner has 3.12 installed by default, the line above worked to fix overwriting when 3.12 was the default brew version now we do it manually.
           brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
           brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5
           echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -120,6 +120,7 @@ jobs:
           pip install -U pytest
           pip install 'numpy<=1.26.4'
           pip install -U wheel
+          pip install -U py-cpuinfo
 
           echo $CURRENT_PYTHON_EXECUTABLE
 
@@ -229,6 +230,8 @@ jobs:
           pip install 'numpy<=1.26.4'
           pip install -U wheel
           pip install -U pandas
+          pip install -U py-cpuinfo
+
 
           # build pyopenms distribution (macOS)
           cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} .
@@ -345,6 +348,7 @@ jobs:
           pip install 'numpy<=1.26.4'
           pip install -U wheel
           pip install -U pandas
+          pip install -U py-cpuinfo
 
           # build pyopenms distribution (macOS)
           cmake -DPYTHON_EXECUTABLE:FILEPATH=$CURRENT_PYTHON_EXECUTABLE -DPYOPENMS=ON -DPY_NUM_THREADS=${{ steps.cpu-cores.outputs.count }} .

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -21,12 +21,12 @@ def check_avx_support():
         info = get_cpu_info()
 
         # Check for AVX support
-        if 'avx' not in info['flags']:
-            sys.stderr.write("ERROR: The CPU (or virtualization environment) does not support AVX. AVX support is necessary for pyOpenMS.\n")
-            sys.exit(1)
+    if 'flags' not in info:
+        raise RuntimeError("ERROR: Cannot determine if AVX is supported. Something is wrong with get_cpu_info.\n")
+    elif 'avx' not in info['flags']:
+        raise RuntimeError("ERROR: The CPU (or virtualization environment) does not support AVX. AVX support is necessary for pyOpenMS.\n")
     except ImportError:
-        sys.stderr.write("ERROR: 'py-cpuinfo' is required to check AVX support.\n")
-        sys.exit(1)
+        raise RuntimeError("ERROR: 'py-cpuinfo' is required to check AVX support.\n")
 
 if "--no-optimization" in sys.argv:
     no_optimization = True

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -14,6 +14,20 @@ if isosx:
 import sys
 no_optimization = False
 
+def check_avx_support():
+    """Check if the CPU supports AVX instruction set."""
+    try:
+        from cpuinfo import get_cpu_info()
+        info = get_cpu_info()
+
+        # Check for AVX support
+        if 'avx' not in info['flags']:
+            sys.stderr.write("ERROR: The CPU (or virtualization environment) does not support AVX. AVX support is necessary for pyOpenMS.\n")
+            sys.exit(1)
+    except ImportError:
+        sys.stderr.write("ERROR: 'py-cpuinfo' is required to check AVX support.\n")
+        sys.exit(1)
+
 if "--no-optimization" in sys.argv:
     no_optimization = True
     sys.argv.remove("--no-optimization")
@@ -221,6 +235,9 @@ if not iswin:
 mnames = ["_pyopenms_%s" % (k+1) for k in range(int(PY_NUM_MODULES))]
 ext = []
 
+## Check if the CPU support AVX and throw an error if it doesn't
+check_avx_support()
+
 ##WARNING debug
 libraries.extend("boost_regex-mt-x64")
 
@@ -256,7 +273,8 @@ setup(
 	install_requires=[
           'numpy<=1.26.4',
           'pandas',
-          'matplotlib>=3.5'
+          'matplotlib>=3.5',
+          'py-cpuinfo' ## Needed to check if our CPU supports AVX
     ],
 
     version=package_version,

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -17,7 +17,7 @@ no_optimization = False
 def check_avx_support():
     """Check if the CPU supports AVX instruction set."""
     try:
-        from cpuinfo import get_cpu_info()
+        from cpuinfo import get_cpu_info
         info = get_cpu_info()
 
         # Check for AVX support

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -21,10 +21,10 @@ def check_avx_support():
         info = get_cpu_info()
 
         # Check for AVX support
-    if 'flags' not in info:
-        raise RuntimeError("ERROR: Cannot determine if AVX is supported. Something is wrong with get_cpu_info.\n")
-    elif 'avx' not in info['flags']:
-        raise RuntimeError("ERROR: The CPU (or virtualization environment) does not support AVX. AVX support is necessary for pyOpenMS.\n")
+        if 'flags' not in info:
+            raise RuntimeError("ERROR: Cannot determine if AVX is supported. Something is wrong with get_cpu_info.\n")
+        elif 'avx' not in info['flags']:
+            raise RuntimeError("ERROR: The CPU (or virtualization environment) does not support AVX. AVX support is necessary for pyOpenMS.\n")
     except ImportError:
         raise RuntimeError("ERROR: 'py-cpuinfo' is required to check AVX support.\n")
 


### PR DESCRIPTION
### **User description**
Check before installing pyopenms that the processor has AVX support rather than throwing eldritch error messages at runtime.

## Description

Address https://github.com/OpenMS/OpenMS/issues/7333 by failing at install time if the CPU doesn't support AVX. AVX has been standard for (physical) processors since the early 2010's so this is most likely to affect virtualization envs where changing the VM options solves the issue.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, dependencies


___

### **Description**
- Introduced a function `check_avx_support` to verify if the CPU supports the AVX instruction set, preventing runtime errors.
- Integrated the AVX support check into the setup process to fail early if the CPU does not support AVX.
- Added 'py-cpuinfo' as a required dependency to facilitate the AVX support check.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Add AVX support check and update dependencies in setup.py</code></dd></summary>
<hr>

src/pyOpenMS/setup.py

<li>Added a function to check for AVX support in the CPU.<br> <li> Integrated AVX support check into the setup process.<br> <li> Added 'py-cpuinfo' to the list of installation requirements.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7617/files#diff-1343deca77d77a5eb66c3fddd2f25c883ba408f22d13c33b760b691b5ea82d75">+19/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information