### PR TITLE
expose eigen downstream

### DIFF
--- a/cmake/OpenMSConfig.cmake.in
+++ b/cmake/OpenMSConfig.cmake.in
@@ -50,6 +50,7 @@ endif()
 #TODO somehow add the same/compatible versions that were found by OpenMS? And what about static vs dynamic? E.g. if we link to static zlib in OpenMS(.dll) what (if at all) can/should the consumer link against?
 find_dependency(Qt5 @QT_MIN_VERSION@ COMPONENTS @OpenMS_QT_COMPONENTS@)
 find_dependency(XercesC)
+find_dependency(Eigen3 3.3.4)
 find_dependency(LIBSVM 2.91)
 
 # Rest are private linked libraries
@@ -58,7 +59,6 @@ find_dependency(LIBSVM 2.91)
 #find_dependency(GLPK)
 #find_dependency(ZLIB)
 #find_dependency(BZip2)
-#find_dependency(Eigen3 3.3.4)
 #find_dependency(SQLite3 3.15.0)
 #find_dependency(HDF5)
 


### PR DESCRIPTION
### **User description**
## Description

hopefully fixes #7614 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Added `Eigen3` version 3.3.4 as a required dependency in the CMake configuration file, making it available for downstream projects.
- This change addresses the need to expose `Eigen3` for projects that depend on OpenMS, potentially fixing issues related to missing dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OpenMSConfig.cmake.in</strong><dd><code>Expose Eigen3 as a required dependency in CMake configuration</code></dd></summary>
<hr>

cmake/OpenMSConfig.cmake.in

<li>Added <code>Eigen3</code> as a required dependency with version 3.3.4.<br> <li> Moved <code>Eigen3</code> from commented private dependencies to active <br>find_dependency.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7618/files#diff-ef44723ccf2496b7f0f091f1844d8d35cbe59db110f26e4ea1384e8281aefcd0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information