### PR TITLE
add quick check for almost certain out of memory error

### DIFF
--- a/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
@@ -85,7 +85,12 @@ namespace OpenMS
     double mz_max = exp.getMaxMZ();
     double rt_min = exp.getMinRT();
     double rt_max = exp.getMaxRT();
-    
+
+    if (mz_min < 0.0 || mz_max < mz_min || mz_max > 1.0e12)
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max));
+    }
+
     // extend the grid by a small absolute margin
     double mz_margin = 1e-2;
     double rt_margin = 1e-2;


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
bug_fix


___

### **Description**
- Added boundary checks in `MultiplexClustering.cpp` to prevent potential out of memory errors by ensuring `mz_min` and `mz_max` values are within sensible ranges.
- Throws an exception if `mz_min` is negative, `mz_max` is less than `mz_min`, or `mz_max` exceeds a large threshold, indicating possible uninitialized values.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MultiplexClustering.cpp</strong><dd><code>Add boundary checks to prevent out of memory errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/FEATUREFINDER/MultiplexClustering.cpp

<li>Added boundary checks for <code>mz_min</code> and <code>mz_max</code> values.<br> <li> Throws an exception if <code>mz_min</code> is negative, <code>mz_max</code> is less than <code>mz_min</code>, <br>or <code>mz_max</code> exceeds a large threshold.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7624/files#diff-eb82b3e5192739ed425c68e6f27032fa653d323d72b2a03671a3e00b62bbe269">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information