### PR TITLE
Cmake fix

### DIFF
--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -62,7 +62,7 @@ macro(find_boost)
     "1.75.1" "1.75.0" "1.75"
     "1.74.1" "1.74.0" "1.74")
 
-  find_package(Boost 1.74.0 COMPONENTS ${ARGN} REQUIRED)
+  find_package(Boost 1.74.0 COMPONENTS ${ARGN} REQUIRED CONFIG)
 
 endmacro(find_boost)
 

--- a/src/openms/configh.cmake
+++ b/src/openms/configh.cmake
@@ -127,7 +127,6 @@ file (GENERATE
 add_custom_command (
 		COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CONFIGURED_BUILD_CONFIG_H}" "${CONFIGURED_BUILD_CONFIG_CURRENT_H}"
 		VERBATIM
-		PRE_BUILD
 		DEPENDS  "${CONFIGURED_BUILD_CONFIG_H}"
 		OUTPUT   "${CONFIGURED_BUILD_CONFIG_CURRENT_H}"
 		COMMENT  "creating build_config.h file ({event: PRE_BUILD}, {filename: build_config.h})"

--- a/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/Users/johannes/openms-development/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0" peak_mass_tolerance_ppm="true" >
+	<SearchParameters id="SP_0" db="C:/dev/omsq6/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0" peak_mass_tolerance_ppm="true" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
 				<UserParam type="string" name="extra_features" value="score,SAGE:ln(-poisson),SAGE:ln(delta_best),SAGE:ln(delta_next),SAGE:ln(matched_intensity_pct),SAGE:longest_b,SAGE:longest_y,SAGE:longest_y_pct,SAGE:matched_peaks,SAGE:scored_candidates"/>
-				<UserParam type="stringList" name="SageAdapter:1:in" value="[/Users/johannes/openms-development/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.mzML]"/>
+				<UserParam type="stringList" name="SageAdapter:1:in" value="[C:/dev/omsq6/src/tests/topp/THIRDPARTY/SageAdapter_1.mzML]"/>
 				<UserParam type="string" name="SageAdapter:1:out" value="SageAdapter_1_out.tmp.idXML"/>
-				<UserParam type="string" name="SageAdapter:1:database" value="/Users/johannes/openms-development/OpenMS/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta"/>
-				<UserParam type="string" name="SageAdapter:1:sage_executable" value="sage"/>
+				<UserParam type="string" name="SageAdapter:1:database" value="C:/dev/omsq6/src/tests/topp/THIRDPARTY/SageAdapter_1.fasta"/>
+				<UserParam type="string" name="SageAdapter:1:sage_executable" value="C:/dev/omsq6/THIRDPARTY/Windows/64bit/Sage/sage.exe"/>
 				<UserParam type="string" name="SageAdapter:1:decoy_prefix" value="DECOY_"/>
 				<UserParam type="int" name="SageAdapter:1:batch_size" value="0"/>
 				<UserParam type="float" name="SageAdapter:1:precursor_tol_left" value="-6.0"/>
@@ -65,7 +65,7 @@
 				<UserParam type="string" name="SageAdapter:1:specificity" value="auto"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2024-09-28T11:51:54" search_engine="Sage" search_engine_version="0.15.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2024-10-24T09:46:46" search_engine="Sage" search_engine_version="0.14.6" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q99536|VAT1_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -73,18 +73,18 @@
 			<UserParam type="stringList" name="spectra_data" value="[SageAdapter_1.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="hyperscore" higher_score_better="true" significance_threshold="0.0" MZ="643.034443133437662" RT="6497.123999999999796" spectrum_reference="controllerType=0 controllerNumber=1 scan=30069" >
-			<PeptideHit score="4.480576737759205" sequence="LQSRPAAPPAPGPGQLTLR" charge="3" aa_before="K" aa_after="L" start="63" end="81" protein_refs="PH_0" >
-				<UserParam type="string" name="fragment_annotation" value="175.119030000000009,6.7576475e05,1,&quot;y1&quot;|242.149889999999999,5.408394e05,1,&quot;b2&quot;|288.202729999999974,2.1372394e05,1,&quot;y2&quot;|362.708340000000021,2.404841e05,2,&quot;b7&quot;|389.250999999999976,7.1299375e05,1,&quot;y3&quot;|392.737459999999999,9.837225999999999e05,2,&quot;y7&quot;|411.235000000000014,1.0779025e06,2,&quot;b8&quot;|421.247860000000003,2.5909306e05,2,&quot;y8&quot;|459.761320000000012,2.5751027e05,2,&quot;b9&quot;|469.774659999999983,2.4631088e06,2,&quot;y9&quot;|485.282750000000021,5.52907e05,1,&quot;b4&quot;|495.278470000000027,3.1598797e05,2,&quot;b10&quot;|502.334839999999986,1.0549086e06,1,&quot;y4&quot;|582.334169999999972,2.4971842e05,1,&quot;b5&quot;|602.346700000000055,6.912584399999999e05,2,&quot;y12&quot;|630.393500000000017,6.033776e05,1,&quot;y5&quot;|653.372299999999996,4.4862062e05,1,&quot;b6&quot;|687.414300000000026,1.6463646e06,1,&quot;y6&quot;|724.409700000000044,7.8130335e06,1,&quot;b7&quot;|784.46735000000001,3.6912602e06,1,&quot;y7&quot;|821.462200000000053,3.489648e05,1,&quot;b8&quot;|841.488600000000019,4.294338e06,1,&quot;y8&quot;|843.491300000000024,6.370896999999999e05,2,&quot;y17&quot;|938.541699999999992,9.045038999999999e06,1,&quot;y9&quot;|989.552369999999996,7.521718e06,1,&quot;b10&quot;|1009.57854999999995,1.0414806e06,1,&quot;y10&quot;|1106.630499999999984,1.7313295e06,1,&quot;y11&quot;|1143.62259999999992,4.4309975e05,1,&quot;b12&quot;"/>
+			<PeptideHit score="4.478099542157132" sequence="LQSRPAAPPAPGPGQLTLR" charge="3" aa_before="K" aa_after="L" start="63" end="81" protein_refs="PH_0" >
+				<UserParam type="string" name="fragment_annotation" value="242.149889999999999,5.408394e05,1,&quot;b2&quot;|288.202729999999974,2.1372394e05,1,&quot;y2&quot;|362.708340000000021,2.404841e05,2,&quot;b7&quot;|389.250999999999976,7.1299375e05,1,&quot;y3&quot;|392.737459999999999,9.837225999999999e05,2,&quot;y7&quot;|411.235000000000014,1.0779025e06,2,&quot;b8&quot;|421.247860000000003,2.5909306e05,2,&quot;y8&quot;|459.761320000000012,2.5751027e05,2,&quot;b9&quot;|469.774659999999983,2.4631088e06,2,&quot;y9&quot;|485.282750000000021,5.52907e05,1,&quot;b4&quot;|495.278470000000027,3.1598797e05,2,&quot;b10&quot;|502.334839999999986,1.0549086e06,1,&quot;y4&quot;|582.334169999999972,2.4971842e05,1,&quot;b5&quot;|602.346700000000055,6.912584399999999e05,2,&quot;y12&quot;|630.393500000000017,6.033776e05,1,&quot;y5&quot;|653.372299999999996,4.4862062e05,1,&quot;b6&quot;|687.414300000000026,1.6463646e06,1,&quot;y6&quot;|724.409700000000044,7.8130335e06,1,&quot;b7&quot;|784.46735000000001,3.6912602e06,1,&quot;y7&quot;|821.462200000000053,3.489648e05,1,&quot;b8&quot;|841.488600000000019,4.294338e06,1,&quot;y8&quot;|843.491300000000024,6.370896999999999e05,2,&quot;y17&quot;|918.518500000000017,8.440116999999999e04,1,&quot;b9&quot;|938.541699999999992,9.045038999999999e06,1,&quot;y9&quot;|989.552369999999996,7.521718e06,1,&quot;b10&quot;|1009.57854999999995,1.0414806e06,1,&quot;y10&quot;|1106.630499999999984,1.7313295e06,1,&quot;y11&quot;|1143.62259999999992,4.4309975e05,1,&quot;b12&quot;"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="spectrum_q" value="1.0"/>
 				<UserParam type="float" name="DeltaMass" value="1.500000000078217e-03"/>
-				<UserParam type="string" name="SAGE:ln(-poisson)" value="1.0931239712241543"/>
+				<UserParam type="string" name="SAGE:ln(-poisson)" value="1.0573840088869841"/>
 				<UserParam type="string" name="SAGE:ln(delta_best)" value="0.0"/>
-				<UserParam type="string" name="SAGE:ln(delta_next)" value="4.480576737759205"/>
-				<UserParam type="string" name="SAGE:ln(matched_intensity_pct)" value="3.8391638"/>
+				<UserParam type="string" name="SAGE:ln(delta_next)" value="4.478099542157132"/>
+				<UserParam type="string" name="SAGE:ln(matched_intensity_pct)" value="3.8601763"/>
 				<UserParam type="string" name="SAGE:longest_b" value="7"/>
-				<UserParam type="string" name="SAGE:longest_y" value="12"/>
-				<UserParam type="string" name="SAGE:longest_y_pct" value="0.6315789"/>
+				<UserParam type="string" name="SAGE:longest_y" value="11"/>
+				<UserParam type="string" name="SAGE:longest_y_pct" value="0.57894737"/>
 				<UserParam type="string" name="SAGE:matched_peaks" value="28"/>
 				<UserParam type="string" name="SAGE:scored_candidates" value="1"/>
 				<UserParam type="string" name="PTM" value=""/>

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -127,7 +127,12 @@ endif()
 if (NOT (${SAGE_BINARY} STREQUAL "SAGE_BINARY-NOTFOUND"))
   ### NOT needs to be added after the binarys have been included
   add_test("TOPP_SageAdapter_1" ${TOPP_BIN_PATH}/SageAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.ini -database  ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.fasta -in  ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.mzML -out SageAdapter_1_out.tmp.idXML -sage_executable "${SAGE_BINARY}")
-  add_test("TOPP_SageAdapter_1_out1" ${DIFF} -in1 SageAdapter_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1_out.idXML -whitelist "search_engine_version" "IdentificationRun date" "spectra_data" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"SageAdapter:1:in\" value=" "UserParam type=\"string\" name=\"SageAdapter:1:database\" value=" "UserParam type=\"string\" name=\"SageAdapter:1:sage_executable\" value=" "fragment_annotation")
+  add_test("TOPP_SageAdapter_1_out1" ${DIFF} -in1 SageAdapter_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1_out.idXML -whitelist 
+      "SearchParameters id=" 
+      "IdentificationRun date="
+      "SageAdapter:1:in"
+      "SageAdapter:1:database" 
+      "SageAdapter:1:sage_executable")
   set_tests_properties("TOPP_SageAdapter_1_out1" PROPERTIES DEPENDS "TOPP_SageAdapter_1")
 endif()
 

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -127,7 +127,7 @@ endif()
 if (NOT (${SAGE_BINARY} STREQUAL "SAGE_BINARY-NOTFOUND"))
   ### NOT needs to be added after the binarys have been included
   add_test("TOPP_SageAdapter_1" ${TOPP_BIN_PATH}/SageAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.ini -database  ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.fasta -in  ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1.mzML -out SageAdapter_1_out.tmp.idXML -sage_executable "${SAGE_BINARY}")
-  add_test("TOPP_SageAdapter_1_out1" ${DIFF} -in1 SageAdapter_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1_out.idXML -whitelist "search_engine_version" "IdentificationRun date" "spectra_data" "SearchParameters id="SP_0" db=" "UserParam type="stringList" name="SageAdapter:1:in" value=" "UserParam type="string" name="SageAdapter:1:database" value=" "UserParam type="string" name="SageAdapter:1:sage_executable" value=" "fragment_annotation")
+  add_test("TOPP_SageAdapter_1_out1" ${DIFF} -in1 SageAdapter_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SageAdapter_1_out.idXML -whitelist "search_engine_version" "IdentificationRun date" "spectra_data" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"SageAdapter:1:in\" value=" "UserParam type=\"string\" name=\"SageAdapter:1:database\" value=" "UserParam type=\"string\" name=\"SageAdapter:1:sage_executable\" value=" "fragment_annotation")
   set_tests_properties("TOPP_SageAdapter_1_out1" PROPERTIES DEPENDS "TOPP_SageAdapter_1")
 endif()
 


### PR DESCRIPTION
### **User description**
## Description

address CMake warnings when using the latest CMake 3.31

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Updated CMake configuration to use Boost's `CONFIG` option, aligning with the new policy of CMake.
- Removed an invalid `PRE_BUILD` option in `add_custom_command` to fix a bug.
- Escaped quotes in strings for test commands to prevent syntax errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_system_macros.cmake</strong><dd><code>Use Boost config instead of find module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmake/build_system_macros.cmake

- Added `CONFIG` option to `find_package` for Boost.



</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7625/files#diff-07646c13914ab7f649e4db7ead97c0d53686f9b2ddc56be197104f7dc78f4675">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>third_party_tests.cmake</strong><dd><code>Escape quotes in test command whitelist strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/topp/THIRDPARTY/third_party_tests.cmake

- Escaped quotes in whitelist strings for test command.



</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7625/files#diff-4218a92bde2dbd1b648bf9149653c715ae656af87c7c256b38ed243d866ab687">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configh.cmake</strong><dd><code>Remove invalid PRE_BUILD option in custom command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/configh.cmake

- Removed invalid `PRE_BUILD` option from `add_custom_command`.



</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7625/files#diff-5ef991606b5974e531e0602c3d44252df0b5ed423f8a1278ac7e0e24e6cd392a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information