### PR TITLE
MzTab: preallocate enough memory instead of allocating in the loops

### DIFF
--- a/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
@@ -85,7 +85,12 @@ namespace OpenMS
     double mz_max = exp.getMaxMZ();
     double rt_min = exp.getMinRT();
     double rt_max = exp.getMaxRT();
-    
+
+    if (mz_min < 0.0 || mz_max < mz_min || mz_max > 1.0e12)
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max));
+    }
+
     // extend the grid by a small absolute margin
     double mz_margin = 1e-2;
     double rt_margin = 1e-2;

--- a/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
@@ -86,9 +86,10 @@ namespace OpenMS
     double rt_min = exp.getMinRT();
     double rt_max = exp.getMaxRT();
 
-    if (mz_min < 0.0 || mz_max < mz_min || mz_max > 1.0e12)
+    if (mz_min < 0.0 || mz_max < mz_min || mz_max > 1.0e12 || 
+ rt_max < rt_min || rt_max > 1.0e12) // check ranges (but allow negative RTs which can happen because of chrom. alignment)
     {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max));
+throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ,MinRT,MaxRT values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max) + "/" + String(rt_min) + "/" + String(rt_max));
     }
 
     // extend the grid by a small absolute margin

--- a/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/FEATUREFINDER/MultiplexClustering.cpp
@@ -86,12 +86,12 @@ namespace OpenMS
     double rt_min = exp.getMinRT();
     double rt_max = exp.getMaxRT();
 
-    if (mz_min < 0.0 || mz_max < mz_min || mz_max > 1.0e12 || 
- rt_max < rt_min || rt_max > 1.0e12) // check ranges (but allow negative RTs which can happen because of chrom. alignment)
+    if (!RangeMZ(0.0, 1.0e12).containsMZ({mz_min, mz_max}) ||
+        !RangeRT(-1.0e12, 1.0e12).containsRT({rt_min, rt_max}) ) 
     {
-throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ,MinRT,MaxRT values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max) + "/" + String(rt_min) + "/" + String(rt_max));
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MinMZ,MaxMZ,MinRT,MaxRT values outside of sensible value ranges. Are they uninitialized? (" + String(mz_min) + "/" + String(mz_max) + "/" + String(rt_min) + "/" + String(rt_max));
     }
-
+    
     // extend the grid by a small absolute margin
     double mz_margin = 1e-2;
     double rt_margin = 1e-2;

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -2606,7 +2606,7 @@ state0:
     {
       new_size += consensus_map.getUnassignedPeptideIdentifications().size();
     }
-    peptide_ids_.reserve(peptide_ids_.size() + new_size);
+    peptide_ids_.reserve(new_size);
 
  
     // extract mapped IDs

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -2601,7 +2601,7 @@ state0:
 
     // pre-reserve to prevent reallocations
     size_t new_size = peptide_ids_.size();
-    for (Size i = 0; i < consensus_map.size(); ++i) new_size += consensus_map[i].getPeptideIdentifications().size();
+    for (const auto& elem : consensus_map) new_size += elem.getPeptideIdentifications().size();
     if (export_unassigned_ids)
     {
       new_size += consensus_map.getUnassignedPeptideIdentifications().size();

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -2598,13 +2598,22 @@ state0:
     {
       prot_ids_.push_back(&i);
     }
+
+    // pre-reserve to prevent reallocations
+    size_t new_size = peptide_ids_.size();
+    for (Size i = 0; i < consensus_map.size(); ++i) new_size += consensus_map[i].getPeptideIdentifications().size();
+    if (export_unassigned_ids)
+    {
+      new_size += consensus_map.getUnassignedPeptideIdentifications().size();
+    }
+    peptide_ids_.reserve(peptide_ids_.size() + new_size);
+
  
     // extract mapped IDs
     for (Size i = 0; i < consensus_map.size(); ++i)
     {
       const ConsensusFeature& c = consensus_map[i];
       const vector<PeptideIdentification>& p = c.getPeptideIdentifications();
-      peptide_ids_.reserve(peptide_ids_.size() + p.size());
       for (const PeptideIdentification& pi : p) { peptide_ids_.push_back(&pi); }
     }
 
@@ -2612,7 +2621,6 @@ state0:
     if (export_unassigned_ids)
     {
       const vector<PeptideIdentification>& up = consensus_map.getUnassignedPeptideIdentifications();
-      peptide_ids_.reserve(peptide_ids_.size() + up.size());
       for (const PeptideIdentification& pi : up) { peptide_ids_.push_back(&pi); }
     }
 


### PR DESCRIPTION
### **User description**
## Description

relevant for huge studies

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added boundary checks in `MultiplexClustering.cpp` to prevent out-of-range errors for MZ values, throwing an exception if values are not sensible.
- Improved memory management in `MzTab.cpp` by pre-reserving memory for `peptide_ids_`, reducing memory fragmentation and reallocations for large datasets.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MultiplexClustering.cpp</strong><dd><code>Add boundary checks for MZ values to prevent errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/FEATUREFINDER/MultiplexClustering.cpp

<li>Added boundary checks for <code>mz_min</code> and <code>mz_max</code> values.<br> <li> Throws an exception if values are outside sensible ranges.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7627/files#diff-eb82b3e5192739ed425c68e6f27032fa653d323d72b2a03671a3e00b62bbe269">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MzTab.cpp</strong><dd><code>Optimize memory allocation for peptide identifications</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/FORMAT/MzTab.cpp

<li>Pre-reserved memory for <code>peptide_ids_</code> to prevent reallocations.<br> <li> Improved memory management for large datasets.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7627/files#diff-1b56a88313b5baabf2f9e465bcfd887e065543d7cf5c84281fdf2652e19e2d3e">+10/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information