### PR TITLE
INI/CTD files: double NAN's as 'NaN'

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ParamXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ParamXMLFile.h
@@ -15,7 +15,7 @@ namespace OpenMS
 {
   /**
     @brief The file pendant of the Param class used to load and store the param
-           datastructure as paramXML.
+           datastructure as paramXML (i.e. INI files).
 
     A documented schema for this format can be found at https://github.com/OpenMS/OpenMS/tree/develop/share/OpenMS/SCHEMAS
 

--- a/src/openms/include/OpenMS/FORMAT/TextFile.h
+++ b/src/openms/include/OpenMS/FORMAT/TextFile.h
@@ -54,7 +54,9 @@ public:
     TextFile(const String& filename, bool trim_lines = false, Int first_n = -1, bool skip_empty_lines = false, const String& comment_symbol = "");
 
     /**
-      @brief Loads data from a text file.
+      @brief Loads data from a text file into the internal buffer.
+
+      Retrieve the data using begin() and end().
 
       @param filename The input file name
       @param trim_lines Whether or not the lines are trimmed when reading them from file

--- a/src/openms/source/DATASTRUCTURES/ParamValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/ParamValue.cpp
@@ -7,7 +7,8 @@
 
 #include <OpenMS/DATASTRUCTURES/ParamValue.h>
 
-//#include <ostream>
+#include <OpenMS/DATASTRUCTURES/String.h>
+
 #include <OpenMS/CONCEPT/Exception.h>
 #include <sstream>
 #include <cmath>
@@ -814,53 +815,7 @@ namespace OpenMS
 
   std::string ParamValue::doubleToString(double value, bool full_precision)
   {
-    std::ostringstream os;
-    std::string s;
-    if (full_precision)
-    {
-      os.precision(15);
-    }
-    else
-    {
-      os.precision(3);
-    }
-    if (value != 0 &&
-        (std::abs(value) >= 10000.0 ||
-         std::abs(value) < 0.001 ||
-         (full_precision && std::abs(value) < 0.01)))
-    {
-      os << std::scientific << value;
-      s = os.str();
-      size_t cutoff_end = s.find_last_of('e');
-      size_t cutoff_start = s.substr(0, cutoff_end).find_last_not_of('0');
-      if (s.at(cutoff_end + 1) == '+')
-      {
-        s.erase(cutoff_end + 1, 1);
-      }
-      if (cutoff_start != cutoff_end)
-      {
-        if (s.find_first_of('.') == cutoff_start)
-        {
-          ++cutoff_start;
-        }
-        s.erase(cutoff_start + 1, cutoff_end - cutoff_start - 1);
-      }
-    }
-    else
-    {
-      os << std::fixed << value;
-      s = os.str();
-      size_t cutoff = s.find_last_not_of('0');
-      if (cutoff != std::string::npos)
-      {
-        if (s.find_first_of('.') == cutoff)
-        {
-          ++cutoff;
-        }
-        s.erase(cutoff + 1);
-      }
-    }
-    return s;
+    return String(value, full_precision);
   }
 
 } //namespace

--- a/src/openms/source/DATASTRUCTURES/String.cpp
+++ b/src/openms/source/DATASTRUCTURES/String.cpp
@@ -111,8 +111,6 @@ namespace OpenMS
   String::String(float f, bool full_precision) :
     string()
   {
-    if (std::fabs(f) < std::numeric_limits<float>::min()) { *this = "0.0"; return; } // workaroud for issue https://github.com/OpenMS/OpenMS/issues/6507
-
     full_precision ? StringConversions::append(f, *this)
                    : StringConversions::appendLowP(f, *this);
   }
@@ -120,8 +118,6 @@ namespace OpenMS
   String::String(double d, bool full_precision) :
     string()
   {
-    if (std::fabs(d) < std::numeric_limits<double>::min()) { *this = "0.0"; return; } // workaroud for issue https://github.com/OpenMS/OpenMS/issues/6507
-
     full_precision ? StringConversions::append(d, *this)
                    : StringConversions::appendLowP(d, *this);
   }
@@ -129,8 +125,6 @@ namespace OpenMS
   String::String(long double ld, bool full_precision) :
     string()
   {
-    if (std::fabs(ld) < std::numeric_limits<long double>::min()) { *this = "0.0"; return; } // workaroud for issue https://github.com/OpenMS/OpenMS/issues/6507
-
     full_precision ? StringConversions::append(ld, *this)
                    : StringConversions::appendLowP(ld, *this);
   }

--- a/src/tests/class_tests/openms/source/ParamCTDFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamCTDFile_test.cpp
@@ -15,6 +15,7 @@
 
 #include <OpenMS/FORMAT/ParamCTDFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
+#include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
@@ -207,6 +208,22 @@ START_SECTION((void store(const String& filename, const Param& param) const))
 	TEST_REAL_SIMILAR(p6.getEntry("doublelist3").max_float, 4.45)
 	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").min_float, 0.1)
 	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").max_float, 5.8)
+
+  // NaN for float/double
+  Param p_nan;
+  p_nan.setValue("float_nan", std::numeric_limits<float>::quiet_NaN());
+  p_nan.setValue("double_nan", std::numeric_limits<double>::quiet_NaN());
+  NEW_TMP_FILE(filename);
+  paramFile.store(filename, p_nan, info);
+  Param p_nan2;
+  paramXML.load(filename, p_nan2);
+  TEST_TRUE(std::isnan((double)p_nan2.getValue("float_nan")))
+  TEST_TRUE(std::isnan((double)p_nan2.getValue("double_nan")))
+  // ... test the actual values written to INI (should be 'NaN', not 'nan', for compatibility with downstream tools, like Java's double)
+  TextFile tf;
+  tf.load(filename);
+  TEST_TRUE((tf.begin() + 7)->hasSubstring("value=\"NaN\""))
+  TEST_TRUE((tf.begin() + 8)->hasSubstring("value=\"NaN\""))
 
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ParamXMLFile_test.cpp
@@ -15,6 +15,8 @@
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
+#include <OpenMS/FORMAT/TextFile.h>
+
 ///////////////////////////
 
 #include <fstream>
@@ -93,7 +95,7 @@ START_SECTION((void store(const String& filename, const Param& param) const))
 	TEST_EQUAL(p3.hasTag("test2:a:a1","advanced"),false)
 	TEST_EQUAL(ParamXMLFile().isValid(filename, std::cerr),true)
 
-	//advanced
+	// advanced
 	NEW_TMP_FILE(filename);
 	Param p7;
 	p7.setValue("true",5,"",{"advanced"});
@@ -168,52 +170,68 @@ START_SECTION((void store(const String& filename, const Param& param) const))
 
 
 	TEST_EQUAL(p6.getEntry("int").min_int, -numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("int").max_int, numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("int_min").min_int, 4)
-	TEST_EQUAL(p6.getEntry("int_min").max_int, numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("int_max").min_int, -numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("int_max").max_int, 6)
-	TEST_EQUAL(p6.getEntry("int_min_max").min_int, 0)
-	TEST_EQUAL(p6.getEntry("int_min_max").max_int, 10)
+  TEST_EQUAL(p6.getEntry("int").max_int, numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("int_min").min_int, 4)
+  TEST_EQUAL(p6.getEntry("int_min").max_int, numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("int_max").min_int, -numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("int_max").max_int, 6)
+  TEST_EQUAL(p6.getEntry("int_min_max").min_int, 0)
+  TEST_EQUAL(p6.getEntry("int_min_max").max_int, 10)
 
-	TEST_REAL_SIMILAR(p6.getEntry("float").min_float, -numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("float").max_float, numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("float_min").min_float, 4.1)
-	TEST_REAL_SIMILAR(p6.getEntry("float_min").max_float, numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("float_max").min_float, -numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("float_max").max_float, 6.1)
-	TEST_REAL_SIMILAR(p6.getEntry("float_min_max").min_float, 0.1)
-	TEST_REAL_SIMILAR(p6.getEntry("float_min_max").max_float, 10.1)
+  TEST_REAL_SIMILAR(p6.getEntry("float").min_float, -numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("float").max_float, numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("float_min").min_float, 4.1)
+  TEST_REAL_SIMILAR(p6.getEntry("float_min").max_float, numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("float_max").min_float, -numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("float_max").max_float, 6.1)
+  TEST_REAL_SIMILAR(p6.getEntry("float_min_max").min_float, 0.1)
+  TEST_REAL_SIMILAR(p6.getEntry("float_min_max").max_float, 10.1)
 
-	TEST_EQUAL(p6.getEntry("string").valid_strings.size(),0)
-	TEST_EQUAL(p6.getEntry("string_2").valid_strings.size(),2)
-	TEST_EQUAL(p6.getEntry("string_2").valid_strings[0],"bla")
-	TEST_EQUAL(p6.getEntry("string_2").valid_strings[1],"bluff")
+  TEST_EQUAL(p6.getEntry("string").valid_strings.size(), 0)
+  TEST_EQUAL(p6.getEntry("string_2").valid_strings.size(), 2)
+  TEST_EQUAL(p6.getEntry("string_2").valid_strings[0], "bla")
+  TEST_EQUAL(p6.getEntry("string_2").valid_strings[1], "bluff")
 
 
+  TEST_EQUAL(p6.getEntry("stringlist").valid_strings.size(), 0)
+  TEST_EQUAL(p6.getEntry("stringlist2").valid_strings.size(), 2)
+  TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[0], "xml")
+  TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[1], "txt")
 
-	TEST_EQUAL(p6.getEntry("stringlist").valid_strings.size(),0)
-	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings.size(),2)
-	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[0],"xml")
-	TEST_EQUAL(p6.getEntry("stringlist2").valid_strings[1],"txt")
+  TEST_EQUAL(p6.getEntry("intlist").min_int, -numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("intlist").max_int, numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("intlist2").min_int, 1)
+  TEST_EQUAL(p6.getEntry("intlist2").max_int, numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("intlist3").min_int, -numeric_limits<Int>::max())
+  TEST_EQUAL(p6.getEntry("intlist3").max_int, 11)
+  TEST_EQUAL(p6.getEntry("intlist4").min_int, 0)
+  TEST_EQUAL(p6.getEntry("intlist4").max_int, 15)
 
-	TEST_EQUAL(p6.getEntry("intlist").min_int, -numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("intlist").max_int, numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("intlist2").min_int, 1)
-	TEST_EQUAL(p6.getEntry("intlist2").max_int, numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("intlist3").min_int, -numeric_limits<Int>::max())
-	TEST_EQUAL(p6.getEntry("intlist3").max_int, 11)
-	TEST_EQUAL(p6.getEntry("intlist4").min_int, 0)
-	TEST_EQUAL(p6.getEntry("intlist4").max_int, 15)
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist").min_float, -numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist").max_float, numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist2").min_float, 1.1)
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist2").max_float, numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist3").min_float, -numeric_limits<double>::max())
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist3").max_float, 4.45)
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist4").min_float, 0.1)
+  TEST_REAL_SIMILAR(p6.getEntry("doublelist4").max_float, 5.8)
 
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist").min_float, -numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist").max_float, numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist2").min_float, 1.1)
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist2").max_float, numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist3").min_float, -numeric_limits<double>::max())
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist3").max_float, 4.45)
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").min_float, 0.1)
-	TEST_REAL_SIMILAR(p6.getEntry("doublelist4").max_float, 5.8)
+  // NaN for float/double
+  Param p_nan;
+  p_nan.setValue("float_nan", std::numeric_limits<float>::quiet_NaN());
+  p_nan.setValue("double_nan", std::numeric_limits<double>::quiet_NaN());
+  NEW_TMP_FILE(filename);
+  paramFile.store(filename, p_nan);
+  Param p_nan2;
+  paramFile.load(filename, p_nan2);
+  TEST_TRUE(std::isnan((double)p_nan2.getValue("float_nan")))
+  TEST_TRUE(std::isnan((double)p_nan2.getValue("double_nan")))
+  // ... test the actual values written to INI (should be 'NaN', not 'nan', for compatibility with downstream tools, like Java's double)
+  TextFile tf;
+  tf.load(filename);
+  TEST_TRUE((tf.begin() + 2)->hasSubstring("value=\"NaN\""))
+  TEST_TRUE((tf.begin() + 3)->hasSubstring("value=\"NaN\""))
+
 	//Test if an empty Param written to a file validates against the schema
 	NEW_TMP_FILE(filename);
 	Param p4;

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -242,10 +242,11 @@ START_SECTION((String(long double ld, bool full_precision = true)))
   String s2(17.012345L, false); // suffix L indicates long double
   TEST_EQUAL(s2, "17.012")
   // test denormals
-  long double denorm = 1.0e-320;
+  long double denorm = std::numeric_limits<long double>::min() / 10;
   assert(std::fpclassify(denorm) == FP_SUBNORMAL);
-  TEST_EQUAL(String(denorm, true), "9.999888671826829e-321")
-  TEST_EQUAL(String(denorm, false), "1.0e-320")
+  // we cannot test `long double` since it's size is very platform dependent
+  // TEST_EQUAL(String(denorm, true), "9.999888671826829e-321")
+  //TEST_EQUAL(String(denorm, false), "1.0e-320")
   
   // we need this special 'NaN' since the default 'nan' is not recognized by downstream tools
   // such as any Java-based tool (e.g. KNIME) trying to parse our output files

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -620,9 +620,9 @@ START_SECTION((double toDouble() const))
   s = "47218.890000001";
   TEST_EQUAL(String(s.toDouble()),"4.7218890000001e04");
   s = "nan";
-  TEST_EQUAL(std::isnan(s.toDouble()),true);
-  s = "NaN";
-  TEST_EQUAL(std::isnan(s.toDouble()),true);
+  TEST_TRUE(std::isnan(s.toDouble()));
+  s = "NaN"; // used in INI files, for Java compatibility
+  TEST_TRUE(std::isnan(s.toDouble()));
   s = "not a number";
   TEST_EXCEPTION_WITH_MESSAGE(Exception::ConversionError, s.toDouble(), String("Could not convert string '") + s + "' to a double value")
 END_SECTION

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -15,6 +15,9 @@
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 
 #include <algorithm>
+#include <cmath>
+
+#include <limits>
 #include <iostream>
 #include <iomanip>
 #include <random>
@@ -184,9 +187,9 @@ START_SECTION((String(short unsigned int i)))
 END_SECTION
 
 START_SECTION((String(float f, bool full_precision = true)))
-  String s(float(17.0123));
-  TEST_EQUAL(s,"17.0123")
-  String s2(float(17.0123), false);
+  String s(17.0123456f);
+  TEST_EQUAL(s,"17.012346")
+  String s2(17.0123f, false);
   TEST_EQUAL(s2, "17.012")
 END_SECTION
 
@@ -197,6 +200,20 @@ START_SECTION((String(float f)))
   TEST_EQUAL(s,"5.02542e04")
   String s2(d);
   TEST_EQUAL(s2, "5.025419921875e04")
+
+  // test denormals
+  constexpr float denorm = std::numeric_limits<float>::min() / 10;
+  //assert(std::fpclassify(denorm) == FP_SUBNORMAL);
+  TEST_EQUAL(String(denorm, true), "1.175495e-39")
+  TEST_EQUAL(String(denorm, false), "1.175e-39")
+
+  // we need this special 'NaN' since the default 'nan' is not recognized by downstream tools
+  // such as any Java-based tool (e.g. KNIME) trying to parse our output files
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  assert(std::isnan(nan));
+  TEST_EQUAL(String(nan, true), "NaN")
+  TEST_EQUAL(String(nan, false), "NaN")
+
 END_SECTION
 
 START_SECTION((String(double d, bool full_precision = true)))
@@ -204,6 +221,19 @@ START_SECTION((String(double d, bool full_precision = true)))
   TEST_EQUAL(s,"17.012345")
   String s2(double(17.012345), false);
   TEST_EQUAL(s2, "17.012")
+  // test denormals
+  constexpr double denorm = std::numeric_limits<double>::min() / 10;
+  assert(std::fpclassify(denorm) == FP_SUBNORMAL);
+  TEST_EQUAL(String(denorm, true), "2.225073858507203e-309")
+  TEST_EQUAL(String(denorm, false), "2.225e-309")
+
+  // we need this special 'NaN' since the default 'nan' is not recognized by downstream tools 
+  // such as any Java-based tool (e.g. KNIME) trying to parse our output files
+  constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+  assert(std::isnan(nan));
+  TEST_EQUAL(String(nan, true), "NaN")
+  TEST_EQUAL(String(nan, false), "NaN")
+
 END_SECTION
 
 START_SECTION((String(long double ld, bool full_precision = true)))
@@ -211,6 +241,18 @@ START_SECTION((String(long double ld, bool full_precision = true)))
   TEST_EQUAL(s,"17.012345")
   String s2(17.012345L, false); // suffix L indicates long double
   TEST_EQUAL(s2, "17.012")
+  // test denormals
+  long double denorm = 1.0e-320;
+  assert(std::fpclassify(denorm) == FP_SUBNORMAL);
+  TEST_EQUAL(String(denorm, true), "9.999888671826829e-321")
+  TEST_EQUAL(String(denorm, false), "1.0e-320")
+  
+  // we need this special 'NaN' since the default 'nan' is not recognized by downstream tools
+  // such as any Java-based tool (e.g. KNIME) trying to parse our output files
+  constexpr long double nan = std::numeric_limits<long double>::quiet_NaN();
+  assert(std::isnan(nan));
+  TEST_EQUAL(String(nan, true), "NaN")
+  TEST_EQUAL(String(nan, false), "NaN")
 END_SECTION
 
 START_SECTION((String(const DataValue& d, bool full_precision = true)))


### PR DESCRIPTION
## Description

modify our handling of not-a-number for doubles in INI and CTD files to ensure compatibility with downstream tools, such as Java (KNIME) which only understand 'NaN', but not 'nan'.
Fixes: #7623

Also:
removed workaround from #6507 (minimal Boost we require fixed the issue).


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
