### PR TITLE
Add check for pandas in cmake

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -291,10 +291,24 @@ if(WHEEL_MISSING)
 endif()
 
 #------------------------------------------------------------------------------
+# Check for pandas which is required to run pyopenms tests
+execute_process(
+     COMMAND
+     ${Python_EXECUTABLE} -c "import pandas"
+     RESULT_VARIABLE PANDAS_MISSING
+     ERROR_QUIET
+     OUTPUT_QUIET
+)
+
+if(PANDAS_MISSING)
+  message(FATAL_ERROR "Looking for pandas - not found")
+endif()
+
+#------------------------------------------------------------------------------
 # Handle missing libraries (this should never be reached, as the individual
 #  parts should fire FATAL_ERRORs if something is missing)
 if(NUMPY_MISSING OR CYTHON_MODULE_NOTFOUND OR NOT CYTHON_MODULE_VERSION_CHECK_OK OR NOT AUTOWRAP_VERSION_OK
-   OR SETUPTOOLS_MISSING OR WHEEL_MISSING)
+   OR SETUPTOOLS_MISSING OR WHEEL_MISSING OR PANDAS_MISSING)
   message(FATAL_ERROR "Required Python modules not found or out of date")
 endif()
     


### PR DESCRIPTION
### **User description**
## Description

Running the ctests for pyopenms now needs pandas to be installed, check to make sure that is the case.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a check in the CMake configuration to ensure that the `pandas` library is installed, which is required for running pyOpenMS tests.
- The build process will now trigger a fatal error if `pandas` is not found, preventing further execution.
- Updated the condition that handles missing libraries to include `pandas`, ensuring comprehensive dependency management.



___



PRDescriptionHeader.CHANGES_WALKTHROUGH
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add check for pandas library in CMake configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pyOpenMS/CMakeLists.txt

<li>Added a check for the presence of the <code>pandas</code> library.<br> <li> Trigger a fatal error if <code>pandas</code> is not found.<br> <li> Updated the condition for handling missing libraries to include <br><code>pandas</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7638/files#diff-6a0bad726a336d563ba385e0b83975f1a2dd69d50ea694c0a93e495d7e50f97a">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information