### PR TITLE
improve file list comparison

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -304,8 +304,6 @@ public:
       - ORDER_MISMATCH (1): Same set of files but in different order
       - SET_MISMATCH (2): Different sets of files (including different counts)
 
-      Note: Because workflow systems may assign file names randomly, this function 
-      focuses on detecting order mismatches rather than exact content differences.
 
       @param sl1 First StringList with filenames
       @param sl2 Second StringList with filenames

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -288,7 +288,7 @@ public:
     static String getTemporaryFile(const String& alternative_file = "");
 
 
-    enum MatchingFileListsStatus 
+    enum class MatchingFileListsStatus 
     {
         MATCH = 0,           // Everything matches perfectly
         ORDER_MISMATCH = 1,  // Same set of files but in wrong order
@@ -303,9 +303,6 @@ public:
       - MATCH (0): Files match perfectly (considering basename/extension settings)
       - ORDER_MISMATCH (1): Same set of files but in different order
       - SET_MISMATCH (2): Different sets of files (including different counts)
-
-      Note: Because workflow systems may assign file names randomly, this function 
-      focuses on detecting order mismatches rather than exact content differences.
 
       @param sl1 First StringList with filenames
       @param sl2 Second StringList with filenames

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -287,27 +287,36 @@ public:
     */
     static String getTemporaryFile(const String& alternative_file = "");
 
+
+    enum MatchingFileListsStatus 
+    {
+        MATCH = 0,           // Everything matches perfectly
+        ORDER_MISMATCH = 1,  // Same set of files but in wrong order
+        SET_MISMATCH = 2     // Different sets of files (including size mismatch)
+    };
+
     /**
       @brief Helper function to test if filenames provided in two StringLists match.
 
       Passing several InputFilesLists is error-prone as users may provide files in a different order.
-      To check for common mistakes this helper function checks:
-      - if both file lists have the same length (returns false otherwise)
-      - if the content is the same and provided in exactly the same order (returns false otherwise)
+      This helper function performs validation and returns one of three states:
+      - MATCH (0): Files match perfectly (considering basename/extension settings)
+      - ORDER_MISMATCH (1): Same set of files but in different order
+      - SET_MISMATCH (2): Different sets of files (including different counts)
 
-      Note: Because workflow systems may assign file names randomly a non-strict comparison mode is enabled by default.      
-      Instead of the strict comparison (which returns false if there is a single mismatch), the non-strict comparison mode 
-      only returns false if the unique set of filenames match but some positions differ, i.e., only the order has been mixed up.
+      Note: Because workflow systems may assign file names randomly, this function 
+      focuses on detecting order mismatches rather than exact content differences.
 
       @param sl1 First StringList with filenames
       @param sl2 Second StringList with filenames
       @param basename If set to true, only basenames are compared
       @param ignore_extension If set to true, extensions are ignored (e.g., useful to compare spectra filenames to ID filenames)
-      @param strict If set to true, no mismatches (respecting basename and ignore_extension parameter) are allowed. 
-                    If set to false, only the order is compared if both share the same filenames.
-      @return False, if both StringLists are different (respecting the parameters)
+      @return MatchingFileListsStatus indicating the validation result
     */
-    static bool validateMatchingFileNames(const StringList& sl1, const StringList& sl2, bool basename = true, bool ignore_extension = true, bool strict = false);
+    static MatchingFileListsStatus validateMatchingFileNames(const StringList& sl1, 
+                                                       const StringList& sl2, 
+                                                       bool basename = true, 
+                                                       bool ignore_extension = true);
 
     /**
       @brief Download file from given URL into a download folder. Returns when done.

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -350,6 +350,79 @@ START_SECTION(File::download(std::string url, std::string filename))
 }
 END_SECTION
 
+START_SECTION(static File::MatchingFileListsStatus validateMatchingFileNames(const StringList& sl1, const StringList& sl2, bool basename, bool ignore_extension))
+{
+  // Test exact match
+  {
+    StringList list1 = {"file1.txt", "file2.txt"};
+    StringList list2 = {"file1.txt", "file2.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::MATCH)
+  }
+
+  // Test order mismatch
+  {
+    StringList list1 = {"file1.txt", "file2.txt"};
+    StringList list2 = {"file2.txt", "file1.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::ORDER_MISMATCH)
+  }
+
+  // Test different sets
+  {
+    StringList list1 = {"file1.txt", "file2.txt"};
+    StringList list2 = {"file1.txt", "file3.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::SET_MISMATCH)
+  }
+
+  // Test different counts
+  {
+    StringList list1 = {"file1.txt", "file2.txt"};
+    StringList list2 = {"file1.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::SET_MISMATCH)
+  }
+
+  // Test basename comparison
+  {
+    StringList list1 = {"/path/to/file1.txt", "/different/path/file2.txt"};
+    StringList list2 = {"/other/path/file1.txt", "/somewhere/file2.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, false), File::MatchingFileListsStatus::MATCH)
+  }
+
+  // Test basename with order mismatch
+  {
+    StringList list1 = {"/path/to/file1.txt", "/different/path/file2.txt"};
+    StringList list2 = {"/somewhere/file2.txt", "/other/path/file1.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, false), File::MatchingFileListsStatus::ORDER_MISMATCH)
+  }
+
+  // Test ignore extension
+  {
+    StringList list1 = {"file1.txt", "file2.mzML"};
+    StringList list2 = {"file1.mzML", "file2.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, false, true), File::MatchingFileListsStatus::ORDER_MISMATCH)
+  }
+
+  // Test ignore extension with different basenames
+  {
+    StringList list1 = {"file1.txt", "file2.mzML"};
+    StringList list2 = {"file1.mzML", "file3.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, false, true), File::MatchingFileListsStatus::SET_MISMATCH)
+  }
+
+  // Test with both basename and ignore extension
+  {
+    StringList list1 = {"/path/to/file1.txt", "/different/path/file2.mzML"};
+    StringList list2 = {"/other/path/file1.mzML", "/somewhere/file2.txt"};
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, true), File::MatchingFileListsStatus::MATCH)
+  }
+
+  // Test with empty lists
+  {
+    StringList list1, list2;
+    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::MATCH)
+  }
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -398,7 +398,7 @@ START_SECTION(static File::MatchingFileListsStatus validateMatchingFileNames(con
   {
     StringList list1 = {"file1.txt", "file2.mzML"};
     StringList list2 = {"file1.mzML", "file2.txt"};
-    TEST_TRUE(File::validateMatchingFileNames(list1, list2, false, true) == File::MatchingFileListsStatus::ORDER_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, false, true) == File::MatchingFileListsStatus::MATCH)
   }
 
   // Test ignore extension with different basenames

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -356,69 +356,69 @@ START_SECTION(static File::MatchingFileListsStatus validateMatchingFileNames(con
   {
     StringList list1 = {"file1.txt", "file2.txt"};
     StringList list2 = {"file1.txt", "file2.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::MATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2) ==  File::MatchingFileListsStatus::MATCH)
   }
 
   // Test order mismatch
   {
     StringList list1 = {"file1.txt", "file2.txt"};
     StringList list2 = {"file2.txt", "file1.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::ORDER_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2) == File::MatchingFileListsStatus::ORDER_MISMATCH)
   }
 
   // Test different sets
   {
     StringList list1 = {"file1.txt", "file2.txt"};
     StringList list2 = {"file1.txt", "file3.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::SET_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2) == File::MatchingFileListsStatus::SET_MISMATCH)
   }
 
   // Test different counts
   {
     StringList list1 = {"file1.txt", "file2.txt"};
     StringList list2 = {"file1.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::SET_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2) ==  File::MatchingFileListsStatus::SET_MISMATCH)
   }
 
   // Test basename comparison
   {
     StringList list1 = {"/path/to/file1.txt", "/different/path/file2.txt"};
     StringList list2 = {"/other/path/file1.txt", "/somewhere/file2.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, false), File::MatchingFileListsStatus::MATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, true, false) ==  File::MatchingFileListsStatus::MATCH)
   }
 
   // Test basename with order mismatch
   {
     StringList list1 = {"/path/to/file1.txt", "/different/path/file2.txt"};
     StringList list2 = {"/somewhere/file2.txt", "/other/path/file1.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, false), File::MatchingFileListsStatus::ORDER_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, true, false) ==  File::MatchingFileListsStatus::ORDER_MISMATCH)
   }
 
   // Test ignore extension
   {
     StringList list1 = {"file1.txt", "file2.mzML"};
     StringList list2 = {"file1.mzML", "file2.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, false, true), File::MatchingFileListsStatus::ORDER_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, false, true) == File::MatchingFileListsStatus::ORDER_MISMATCH)
   }
 
   // Test ignore extension with different basenames
   {
     StringList list1 = {"file1.txt", "file2.mzML"};
     StringList list2 = {"file1.mzML", "file3.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, false, true), File::MatchingFileListsStatus::SET_MISMATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, false, true) ==  File::MatchingFileListsStatus::SET_MISMATCH)
   }
 
   // Test with both basename and ignore extension
   {
     StringList list1 = {"/path/to/file1.txt", "/different/path/file2.mzML"};
     StringList list2 = {"/other/path/file1.mzML", "/somewhere/file2.txt"};
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2, true, true), File::MatchingFileListsStatus::MATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2, true, true) == File::MatchingFileListsStatus::MATCH)
   }
 
   // Test with empty lists
   {
     StringList list1, list2;
-    TEST_EQUAL(File::validateMatchingFileNames(list1, list2), File::MatchingFileListsStatus::MATCH)
+    TEST_TRUE(File::validateMatchingFileNames(list1, list2) == File::MatchingFileListsStatus::MATCH)
   }
 }
 END_SECTION

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -280,34 +280,48 @@ protected:
   {
     // validate file lists (use only basename and ignore extension)
     auto validation_result = File::validateMatchingFileNames(in, in_ids, true, true);
-    switch(validation_result)
+    // we try to fail early (without parsing files) if the input is obviously wrong
+    // check for two major mistakes:
+    //  1. different number of files (-> certainly wrong)
+    //  2. same number of files but different order (-> certainly wrong)
+    // If some files differ in names, we can't be sure at this point and skip this test for now.
+    // We need to look into the ID files to infer the spectra filenames later to be sure a mistake was made.
+    switch (validation_result)
     {
       case File::MatchingFileListsStatus::SET_MISMATCH:
-        OPENMS_LOG_ERROR << "ID and spectra file lists differ. Please provide the same files in the same order."
-          "File in spectra file list: " << endl;
-        for (const auto& f : in)
+        if (in.size() != in_ids.size())
         {
-          OPENMS_LOG_ERROR << f << endl;
+          OPENMS_LOG_FATAL_ERROR << "ID and spectra file lists differ in size. Please provide the same number of files for spectra and ID." << endl;
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+            "ID and spectra file lists differ in size. Please provide the same number of files for spectra and ID.");          
         }
-        OPENMS_LOG_ERROR << "File in ID file list: " << endl;
-        for (const auto& f : in_ids)
-        {
-          OPENMS_LOG_ERROR << f << endl;
+        else
+        { // same number of files but filenames differ (we will try to read the spectra filenames from the id files later)
+          writeDebug_("ID and spectra file lists differ. Please provide the same files in the same order.", 1);
+          writeDebug_("File in spectra file list:", 1);
+          for (const auto& f : in)
+          {
+            writeDebug_(f + '\n', 1);
+          }
+          writeDebug_("File in ID file list:", 1);
+          for (const auto& f : in_ids)
+          {
+            writeDebug_(f, 1);
+          }
+          writeDebug_("Will try to infere spectra filenames from id files later.", 1);
         }
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Set of ID and spectra file lists differ.");
         break;
       case File::MatchingFileListsStatus::ORDER_MISMATCH:
-        OPENMS_LOG_ERROR << "ID and spectra file match but order of file names seem to differ. Please provide the same files in the same order." << std::endl;
-        OPENMS_LOG_ERROR << "File in spectra file list: " << endl;
+        writeDebug_("ID and spectra file match but order of file names seem to differ. Please provide the same files in the same order.", 1);
+        writeDebug_("File in spectra file list:", 1);
         for (const auto& f : in)
         {
-          OPENMS_LOG_ERROR << f << endl;
+          writeDebug_(f, 1);
         }
-        OPENMS_LOG_ERROR << "File in ID file list: " << endl;
+        OPENMS_LOG_WARN << "File in ID file list: " << endl;
         for (const auto& f : in_ids)
         {
-          OPENMS_LOG_ERROR << f << endl;
+          writeDebug_(f, 1);
         }
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "ID and spectra file match but order of file names seem to differ. They need to be provided in the same order.");

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -283,10 +283,32 @@ protected:
     switch(validation_result)
     {
       case File::MatchingFileListsStatus::SET_MISMATCH:
+        OPENMS_LOG_ERROR << "ID and spectra file lists differ. Please provide the same files in the same order."
+          "File in spectra file list: " << endl;
+        for (const auto& f : in)
+        {
+          OPENMS_LOG_ERROR << f << endl;
+        }
+        OPENMS_LOG_ERROR << "File in ID file list: " << endl;
+        for (const auto& f : in_ids)
+        {
+          OPENMS_LOG_ERROR << f << endl;
+        }
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "Set of ID and spectra file lists differ.");
         break;
       case File::MatchingFileListsStatus::ORDER_MISMATCH:
+        OPENMS_LOG_ERROR << "ID and spectra file match but order of file names seem to differ. Please provide the same files in the same order." << std::endl;
+        OPENMS_LOG_ERROR << "File in spectra file list: " << endl;
+        for (const auto& f : in)
+        {
+          OPENMS_LOG_ERROR << f << endl;
+        }
+        OPENMS_LOG_ERROR << "File in ID file list: " << endl;
+        for (const auto& f : in_ids)
+        {
+          OPENMS_LOG_ERROR << f << endl;
+        }
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "ID and spectra file match but order of file names seem to differ. They need to be provided in the same order.");
         break;

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -278,12 +278,21 @@ protected:
   // Warn if the primaryMSRun indicates that files were provided in the wrong order.
   map<String, String> mapMzML2Ids_(StringList & in, StringList & in_ids)
   {
-    // Detect the common case that ID files have same names as spectra files
-    if (!File::validateMatchingFileNames(in, in_ids, true, true, false)) // only basenames, without extension, only order
+    // validate file lists (use only basename and ignore extension)
+    auto validation_result = File::validateMatchingFileNames(in, in_ids, true, true);
+    switch(validation_result)
     {
-      // Spectra and id files have the same set of basenames but appear in different order. -> this is most likely an error
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "ID and spectra file match but order of file names seem to differ. They need to be provided in the same order.");
+      case MatchingFileListsStatus::SET_MISMATCH:
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Set of ID and spectra file lists differ.");
+        break;
+      case MatchingFileListsStatus::ORDER_MISMATCH:
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "ID and spectra file match but order of file names seem to differ. They need to be provided in the same order.");
+        break;
+      default MatchingFileListsStatus::MATCH:
+        writeLog_("Info: ID files have the same names as spectra files.");
+        break;
     }
 
     map<String, String> mzfile2idfile;
@@ -1277,7 +1286,8 @@ protected:
 
     // Check for common mistake that order of input files have been switched.
     // This is the case if basenames are identical but the order does not match.
-    if (!File::validateMatchingFileNames(in_MS_run, id_MS_run_ref, true, true, false)) // only basenames, without extension, only order
+    if (File::validateMatchingFileNames(in_MS_run, id_MS_run_ref, true, true) ==
+          == MatchingFileListsStatus::ORDER_MISMATCH) // only basenames, without extension, only order
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__,
         OPENMS_PRETTY_FUNCTION, "MS run path reference in ID files and spectra filenames match but order differs.");

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -282,17 +282,17 @@ protected:
     auto validation_result = File::validateMatchingFileNames(in, in_ids, true, true);
     switch(validation_result)
     {
-      case MatchingFileListsStatus::SET_MISMATCH:
+      case File::MatchingFileListsStatus::SET_MISMATCH:
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "Set of ID and spectra file lists differ.");
         break;
-      case MatchingFileListsStatus::ORDER_MISMATCH:
+      case File::MatchingFileListsStatus::ORDER_MISMATCH:
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "ID and spectra file match but order of file names seem to differ. They need to be provided in the same order.");
         break;
-      default MatchingFileListsStatus::MATCH:
-        writeLog_("Info: ID files have the same names as spectra files.");
-        break;
+      case File::MatchingFileListsStatus::MATCH:
+        writeLogInfo_("Info: ID files have the same names as spectra files.");
+        break;      
     }
 
     map<String, String> mzfile2idfile;
@@ -1284,14 +1284,22 @@ protected:
       ++fraction_group;
     }
 
-    // Check for common mistake that order of input files have been switched.
-    // This is the case if basenames are identical but the order does not match.
-    if (File::validateMatchingFileNames(in_MS_run, id_MS_run_ref, true, true) ==
-          == MatchingFileListsStatus::ORDER_MISMATCH) // only basenames, without extension, only order
+    // validate file lists (use only basename and ignore extension)
+    auto validation_result = File::validateMatchingFileNames(in_MS_run, id_MS_run_ref, true, true);
+    switch(validation_result)
     {
-      throw Exception::IllegalArgument(__FILE__, __LINE__,
-        OPENMS_PRETTY_FUNCTION, "MS run path reference in ID files and spectra filenames match but order differs.");
-    }
+      case File::MatchingFileListsStatus::SET_MISMATCH:
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "MS run path reference in ID files and spectra filenames differ.");
+        break;
+      case File::MatchingFileListsStatus::ORDER_MISMATCH:
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "MS run path reference in ID files and spectra filenames match but order differs.");
+        break;
+      case File::MatchingFileListsStatus::MATCH:
+        writeLogInfo_("ID files reference same names as spectra files.");
+        break;
+    }    
 
     //-------------------------------------------------------------
     // Align all features of this fraction (if not already aligned)


### PR DESCRIPTION
### **User description**
## Description

as requested by @jpfeuffer 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored the `validateMatchingFileNames` function to return a `MatchingFileListsStatus` enum instead of a boolean, improving clarity and error handling.
- Introduced new status codes: `MATCH`, `ORDER_MISMATCH`, and `SET_MISMATCH` to represent different validation outcomes.
- Added comprehensive tests for the `validateMatchingFileNames` function to cover various scenarios, ensuring robustness.
- Updated the `ProteomicsLFQ` class to utilize the new validation logic, enhancing error reporting and handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>File.cpp</strong><dd><code>Refactor file list validation to use status codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/SYSTEM/File.cpp

<li>Changed return type of <code>validateMatchingFileNames</code> to <br><code>MatchingFileListsStatus</code>.<br> <li> Removed <code>strict</code> parameter and adjusted logic for file list validation.<br> <li> Introduced new status codes for file list validation: <code>MATCH</code>, <br><code>ORDER_MISMATCH</code>, and <code>SET_MISMATCH</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7645/files#diff-e7d2d98e6bc31e659d7a9ed853b63d69a365b252c78fa83f0f51c8be4732cbec">+42/-39</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ProteomicsLFQ.cpp</strong><dd><code>Update file validation logic in ProteomicsLFQ</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/topp/ProteomicsLFQ.cpp

<li>Updated calls to <code>validateMatchingFileNames</code> to handle new status codes.<br> <li> Improved error handling based on validation results.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7645/files#diff-1a8349c94e787728b67eeb8af8476400a6fcfb06d8f845940ccf32b81c73f1f9">+16/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>File.h</strong><dd><code>Define status codes for file list validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/include/OpenMS/SYSTEM/File.h

<li>Defined <code>MatchingFileListsStatus</code> enum for file list validation results.<br> <li> Updated <code>validateMatchingFileNames</code> function signature and <br>documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7645/files#diff-db9442289ec1f9a58a5dad7411cc13c2d928509b63c5ad43c8b30eed8357f3d1">+19/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>File_test.cpp</strong><dd><code>Add comprehensive tests for file list validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/class_tests/openms/source/File_test.cpp

<li>Added new tests for <code>validateMatchingFileNames</code> covering different <br>scenarios.<br> <li> Tested scenarios include exact match, order mismatch, set mismatch, <br>and basename comparison.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7645/files#diff-a747f5274b83bc8b6410d27f1121915e6553d8835a41997f8bbaebc142c08d54">+73/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information