### PR TITLE
more convenient constructor for AASequence in Python

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -350,7 +350,7 @@ protected:
     AASequence& operator=(const AASequence&) = default;
 
     /// Move assignment operator
-    AASequence& operator=(AASequence&&) = default; // TODO: add noexcept (gcc 4.8 bug)
+    AASequence& operator=(AASequence&&) noexcept = default;
 
     /// check if sequence is empty
     bool empty() const;
@@ -596,6 +596,12 @@ protected:
     */
     static AASequence fromString(const char* s,
                                  bool permissive = true);
+
+    /// constructor from String
+    explicit AASequence(const String& s);
+
+    /// constructor from C string
+    explicit AASequence(const char* s);
 
   protected:
 

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -604,6 +604,17 @@ protected:
     /// @brief constructor from C string
     /// @param s A C-style string representing the amino acid sequence
     explicit AASequence(const char* s);
+
+    /// @brief constructor from String
+    /// @param s A String representing the amino acid sequence
+    /// @param permissive If set, skip spaces and replace stop codon symbols ("*", "#", "+") by "X" (unknown amino acid) during parsing
+    explicit AASequence(const String& s, bool permissive);
+
+    /// @brief constructor from C string
+    /// @param s A C-style string representing the amino acid sequence
+    /// @param permissive If set, skip spaces and replace stop codon symbols ("*", "#", "+") by "X" (unknown amino acid) during parsing
+    explicit AASequence(const char* s, bool permissive);
+
   protected:
 
     std::vector<const Residue*> peptide_;

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -82,7 +82,7 @@ namespace OpenMS
 
       @ingroup Chemistry
   */
-  class OPENMS_DLLAPI AASequence
+  class OPENMS_DLLAPI AASequence final
   {
 public:
 
@@ -334,7 +334,7 @@ protected:
     //@{
 
     /// Default constructor
-    AASequence();
+    AASequence() = default;
 
     /// Copy constructor
     AASequence(const AASequence&) = default;
@@ -343,7 +343,7 @@ protected:
     AASequence(AASequence&&) noexcept = default;
 
     /// Destructor
-    virtual ~AASequence();
+    virtual ~AASequence() = default;
     //@}
 
     /// Assignment operator

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -597,12 +597,13 @@ protected:
     static AASequence fromString(const char* s,
                                  bool permissive = true);
 
-    /// constructor from String
+    /// @brief constructor from String
+    /// @param s A String representing the amino acid sequence
     explicit AASequence(const String& s);
 
-    /// constructor from C string
+    /// @brief constructor from C string
+    /// @param s A C-style string representing the amino acid sequence
     explicit AASequence(const char* s);
-
   protected:
 
     std::vector<const Residue*> peptide_;

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -607,9 +607,9 @@ protected:
 
     std::vector<const Residue*> peptide_;
 
-    const ResidueModification* n_term_mod_;
+    const ResidueModification* n_term_mod_ = nullptr;
 
-    const ResidueModification* c_term_mod_;
+    const ResidueModification* c_term_mod_ = nullptr;
 
     /**
       @brief Parses modifications in round brackets (an identifier)

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1691,12 +1691,16 @@ namespace OpenMS
     return aas;
   }
 
-  AASequence::AASequence(const String& s)
+  AASequence::AASequence(const String& s) :  
+    n_term_mod_(nullptr),
+    c_term_mod_(nullptr)
   {
     parseString_(s, *this, true);
   }
 
-  AASequence::AASequence(const char* s)
+  AASequence::AASequence(const char* s) :
+    n_term_mod_(nullptr),
+    c_term_mod_(nullptr)
   {
     parseString_(s, *this, true);
   }

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1691,4 +1691,15 @@ namespace OpenMS
     return aas;
   }
 
+  AASequence::AASequence(const String& s)
+  {
+    parseString_(s, *this, true);
+  }
+
+  AASequence::AASequence(const char* s)
+  {
+    parseString_(s, *this, true);
+  }
+
+
 }

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -117,6 +117,16 @@ namespace OpenMS
     parseString_(s, *this, true);
   }
 
+  AASequence::AASequence(const String& s, bool permissive)
+  {
+    parseString_(s, *this, permissive);
+  }
+
+  AASequence::AASequence(const char* s, bool permissive)
+  {
+    parseString_(s, *this, permissive);
+  }
+
   const Residue& AASequence::getResidue(Size index) const
   {
     if (index >= peptide_.size())

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -107,14 +107,15 @@ namespace OpenMS
     return m;
   }
 
-
-  AASequence::AASequence() :
-    n_term_mod_(nullptr),
-    c_term_mod_(nullptr)
+  AASequence::AASequence(const String& s)
   {
+    parseString_(s, *this, true);
   }
 
-  AASequence::~AASequence() = default;
+  AASequence::AASequence(const char* s)
+  {
+    parseString_(s, *this, true);
+  }
 
   const Residue& AASequence::getResidue(Size index) const
   {
@@ -1690,20 +1691,5 @@ namespace OpenMS
     parseString_(String(s), aas, permissive);
     return aas;
   }
-
-  AASequence::AASequence(const String& s) :  
-    n_term_mod_(nullptr),
-    c_term_mod_(nullptr)
-  {
-    parseString_(s, *this, true);
-  }
-
-  AASequence::AASequence(const char* s) :
-    n_term_mod_(nullptr),
-    c_term_mod_(nullptr)
-  {
-    parseString_(s, *this, true);
-  }
-
 
 }

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -139,4 +139,4 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS::AASequence
         AASequence fromString(String s, bool permissive) except + nogil   # wrap-attach:AASequence wrap-as:fromStringPermissive
         
         # static members
-        AASequence fromString(String s) except + nogil   # wrap-attach:AASequence
+        AASequence fromString(String s) except + nogil   # wrap-attach:AASequence wrap-doc: deprecated. Use AASequence(String) instead.

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -25,8 +25,8 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         AASequence operator+(AASequence) except + nogil 
         AASequence iadd(AASequence) except + nogil  # wrap-as:operator+=
 
-		bool operator==(AASequence &rhs) except + nogil 
-		bool operator!=(AASequence &rhs) except + nogil 
+        bool operator==(AASequence &rhs) except + nogil
+        bool operator!=(AASequence &rhs) except + nogil
 
         # Note that this is a const-ref, so we cannot easily set residues
         Residue operator[](size_t) except + nogil  # wrap-upper-limit:size()

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -21,7 +21,7 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         AASequence(AASequence &) except + nogil
     
         AASequence(const String&) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE")
-        AASequence(const String&, bool permissive) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE")
+        AASequence(const String&, bool permissive) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE"), permissive allows for '+', '*', and '#' in the sequence
 
         AASequence operator+(AASequence) except + nogil 
         AASequence iadd(AASequence) except + nogil  # wrap-as:operator+=

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -18,7 +18,9 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         #  instance primarily contains a sequence of residues. 
 
         AASequence() except + nogil 
-        AASequence(AASequence &) except + nogil 
+        AASequence(AASequence &) except + nogil
+    
+        AASequence(const String&) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE")
 
         AASequence operator+(AASequence) except + nogil 
         AASequence iadd(AASequence) except + nogil  # wrap-as:operator+=

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -21,6 +21,7 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         AASequence(AASequence &) except + nogil
     
         AASequence(const String&) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE")
+        AASequence(const String&, bool permissive) except + nogil # wrap-doc:Constructor from amino acid sequence (e.g. "PEPTM(Oxidatio)IDE")
 
         AASequence operator+(AASequence) except + nogil 
         AASequence iadd(AASequence) except + nogil  # wrap-as:operator+=
@@ -136,7 +137,7 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
 cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS::AASequence":
         
         # static members
-        AASequence fromString(String s, bool permissive) except + nogil   # wrap-attach:AASequence wrap-as:fromStringPermissive
+        AASequence fromString(String s, bool permissive) except + nogil   # wrap-attach:AASequence wrap-as:fromStringPermissive wrap-doc:deprecated. Use AASequence(String) instead.
         
         # static members
-        AASequence fromString(String s) except + nogil   # wrap-attach:AASequence wrap-doc: deprecated. Use AASequence(String) instead.
+        AASequence fromString(String s) except + nogil   # wrap-attach:AASequence wrap-doc:deprecated. Use AASequence(String) instead.

--- a/src/pyOpenMS/pxds/AASequence.pxd
+++ b/src/pyOpenMS/pxds/AASequence.pxd
@@ -25,6 +25,9 @@ cdef extern from "<OpenMS/CHEMISTRY/AASequence.h>" namespace "OpenMS":
         AASequence operator+(AASequence) except + nogil 
         AASequence iadd(AASequence) except + nogil  # wrap-as:operator+=
 
+		bool operator==(AASequence &rhs) except + nogil 
+		bool operator!=(AASequence &rhs) except + nogil 
+
         # Note that this is a const-ref, so we cannot easily set residues
         Residue operator[](size_t) except + nogil  # wrap-upper-limit:size()
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -205,11 +205,21 @@ def testAASequence():
     assert aas.toString() == "DFPIANGER"
     assert aas.toUnmodifiedString() == "DFPIANGER"
 
+    # constructor from C string using the static method
     seq = pyopenms.AASequence.fromString("PEPTIDESEKUEM(Oxidation)CER")
     assert seq.toString() == "PEPTIDESEKUEM(Oxidation)CER"
     assert seq.toUnmodifiedString() == "PEPTIDESEKUEMCER"
     assert seq.toBracketString() == "PEPTIDESEKUEM[147]CER"
     assert seq.toBracketString(True) == "PEPTIDESEKUEM[147]CER"
+
+    # constructor from String
+    seq2 = pyopenms.AASequence("PEPTIDESEKUEM(Oxidation)CER")
+    assert seq == seq2
+    assert seq2.toString() == "PEPTIDESEKUEM(Oxidation)CER"
+    assert seq2.toUnmodifiedString() == "PEPTIDESEKUEMCER"
+    assert seq2.toBracketString() == "PEPTIDESEKUEM[147]CER"
+    assert seq2.toBracketString(True) == "PEPTIDESEKUEM[147]CER"
+
 
     assert seq.toBracketString(False) == "PEPTIDESEKUEM[147.03540001709996]CER" or \
            seq.toBracketString(False) == "PEPTIDESEKUEM[147.035400017100017]CER"

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -214,9 +214,9 @@ def testAASequence():
 
     # constructor from String
     seq2 = pyopenms.AASequence("PEPTIDESEKUEM(Oxidation)CER")
-    assert seq == seq2
     assert seq2.toString() == "PEPTIDESEKUEM(Oxidation)CER"
     assert seq2.toUnmodifiedString() == "PEPTIDESEKUEMCER"
+    assert seq == seq2
     assert seq2.toBracketString() == "PEPTIDESEKUEM[147]CER"
     assert seq2.toBracketString(True) == "PEPTIDESEKUEM[147]CER"
 


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced new constructors for the `AASequence` class to allow initialization from `String` and `char*`.
- Updated the `AASequence` header to include explicit constructors and made the move assignment operator `noexcept`.
- Added equality operators to the `AASequence` Cython wrapper.
- Implemented unit tests to verify the functionality of the new constructors and operators.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AASequence.cpp</strong><dd><code>Add new constructors for AASequence class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/CHEMISTRY/AASequence.cpp

<li>Added new constructors for <code>AASequence</code> from <code>String</code> and <code>char*</code>.<br> <li> Initialized <code>n_term_mod_</code> and <code>c_term_mod_</code> to <code>nullptr</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7650/files#diff-0040f2beba30f4f40b8bdbf21c98b822e01a3b334a13e7a5e80b72d7d99bf3e7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AASequence.pxd</strong><dd><code>Extend AASequence with new constructor and operators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pyOpenMS/pxds/AASequence.pxd

<li>Added new constructor for <code>AASequence</code> from <code>String</code>.<br> <li> Added equality operators for <code>AASequence</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7650/files#diff-1f4229a559cf1ba0460b73d7c7cd52d3b56f7bf230d1237aac897eda16b7c3af">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AASequence.h</strong><dd><code>Update AASequence interface with new constructors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/include/OpenMS/CHEMISTRY/AASequence.h

<li>Added explicit constructors for <code>AASequence</code> from <code>String</code> and <code>char*</code>.<br> <li> Made move assignment operator <code>noexcept</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7650/files#diff-df09f7e70ffbe48753a3299ef6fea8154ee65547bb05d52852b7d467a6798f88">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test000.py</strong><dd><code>Add unit tests for new AASequence constructors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pyOpenMS/tests/unittests/test000.py

<li>Added unit tests for new <code>AASequence</code> constructors.<br> <li> Verified equality and string conversion methods.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7650/files#diff-9b64f80ffadfaff913d4cd4a67264c1b950fc47ad83ebf98bcaf1431d6479354">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information