### PR TITLE
revert small change in MSstatsFile.cpp

### DIFF
--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -108,6 +108,8 @@ void MSstatsFile::constructFile_(const String& retention_time_summarization_meth
                                          LineType& peptideseq_to_prefix_to_intensities) const
 
 {
+  // sanity check that the triples (peptide_sequence, precursor_charge, run) only appears once
+  set<tuple<String, String, String> > peptideseq_precursor_charge_run;
 
   for (const auto &peptideseq : peptideseq_quantifyable)
   {
@@ -131,8 +133,7 @@ void MSstatsFile::constructFile_(const String& retention_time_summarization_meth
           intensities.insert(get<0>(p));
         }
       }
-      tuple<String, String, String> tpl = make_tuple(
-          line.first.sequence(), line.first.precursor_charge(), line.first.run());
+      peptideseq_precursor_charge_run.emplace(line.first.sequence(), line.first.precursor_charge(), line.first.run());
 
       // If the rt summarization method is set to manual, we simply output all it,rt pairs
       if (rt_summarization_manual)


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Added a sanity check in the `constructFile_` method to ensure that each triple of peptide sequence, precursor charge, and run appears only once.
- Replaced the creation of a tuple with the `emplace` method for inserting into the set `peptideseq_precursor_charge_run`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MSstatsFile.cpp</strong><dd><code>Add sanity check for unique peptide sequence triples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/FORMAT/MSstatsFile.cpp

<li>Added a sanity check to ensure unique triples of peptide sequence, <br>precursor charge, and run.<br> <li> Replaced tuple creation with <code>emplace</code> method for set insertion.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7657/files#diff-84c58d52d8f0b0f1d9e495d1237c14b81d12927ba9606e3a54a18a90ad989172">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information