### PR TITLE
Fix RPATH creation in deb package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ cmake-*-build
 *.code-workspace
 .vs
 .clion.*
+_CPack_Packages
+_deps
+Modules
+src/openms_gui/OpenMS_GUI_autogen
+src/openms/OpenMS_autogen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,8 @@ if(UNIX)
       else()
         SET(CMAKE_INSTALL_RPATH "@executable_path/${INSTALL_LIB_PATH_REL_TO_BIN}/")
       endif()
+    if(NOT "${PACKAGE_TYPE}" STREQUAL "deb")
+      SET(CMAKE_SKIP_INSTALL_RPATH FALSE)
     else() # linux and variants
       SET(CMAKE_INSTALL_RPATH "$ORIGIN/${INSTALL_LIB_PATH_REL_TO_BIN}/")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ if(UNIX)
       else()
         SET(CMAKE_INSTALL_RPATH "@executable_path/${INSTALL_LIB_PATH_REL_TO_BIN}/")
       endif()
-    if(NOT "${PACKAGE_TYPE}" STREQUAL "deb")
+    elseif(NOT "${PACKAGE_TYPE}" STREQUAL "deb")
       SET(CMAKE_SKIP_INSTALL_RPATH FALSE)
     else() # linux and variants
       SET(CMAKE_INSTALL_RPATH "$ORIGIN/${INSTALL_LIB_PATH_REL_TO_BIN}/")

--- a/cmake/package_deb.cmake
+++ b/cmake/package_deb.cmake
@@ -68,9 +68,10 @@ set(CPACK_COMPONENTS_ALL applications doc library share ${THIRDPARTY_COMPONENT_G
 ## We should probably use a full system-shared-libs-only machine for building. Then the deps should look similar to below.
 #set(CPACK_DEBIAN_PACKAGE_DEPENDS "libxerces-c-dev (>= 3.1.1), libeigen3-dev, libboost-dev (>= 1.54.0), libboost-iostreams-dev (>= 1.54.0), libboost-date-time-dev (>= 1.54.0), libboost-math-dev (>= 1.54.0), libsvm-dev (>= 3.12), libglpk-dev (>= 4.52.1), zlib1g-dev (>= 1.2.7), libbz2-dev (>= 1.0.6), libqt4-dev (>= 4.8.2), libqt4-opengl-dev (>= 4.8.2), libqtwebkit-dev (>= 2.2.1), coinor-libcoinutils-dev (>= 2.6.4)")
 
-## Autogeneration with SHLIBDEPS will add to this variable. For now we include most things statically and require the standard Qt package only.
+## Autogeneration with SHLIBDEPS will add to this variable. For now we include most things statically and require the standard Qt package and libc6 only.
 ## (only available in Ubuntu >=17.10). For older Ubuntu, dependencies can be installed from a thirdparty repo.
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "qtbase5-dev (>= 5.7.0) | qt57base | qt58base | qt59base | qt510base | qt511base, libqt5svg5 (>= 5.7.0) | qt57svg | qt58svg | qt59svg | qt510svg | qt511svg")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS 
+  "qtbase5-dev (>= 5.7.0) | qt57base | qt58base | qt59base | qt510base | qt511base, libqt5svg5 (>= 5.7.0) | qt57svg | qt58svg | qt59svg | qt510svg | qt511svg, libc6 (>= 2.28)")
 
 SET(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 SET(CPACK_DEBIAN_PACKAGE_SECTION "science")

--- a/cmake/package_general.cmake
+++ b/cmake/package_general.cmake
@@ -75,8 +75,8 @@ elseif(APPLE)
   set(EXCLUDE "/usr/lib" "/System/")
   set(POST_EXCLUDE "")
 else()
-  set(EXCLUDE ".*/ld-linux-.*" ".*/linux-vdso.*" ".*/libm\\..*" ".*/libc\\..*" ".*/libpthread\\..*" ".*/libdl\\..*")
-  set(POST_EXCLUDE "")
+  set(EXCLUDE "")
+  set(POST_EXCLUDE ".*/ld-linux-.*" ".*/linux-vdso.*" ".*/libm\\..*" ".*/libc\\..*" ".*/libpthread\\..*" ".*/libdl\\..*")
 endif()
 
 # TODO check if we can reduce the permissions


### PR DESCRIPTION
### **User description**
## Description

Debian discourages the use of RPATH (https://wiki.debian.org/RpathIssue). Our current inclusion of it breaks any deb packages we create:
`GLIBC_2.32' not found (required by /lib/x86_64-linux-gnu/libsystemd.so.0)
TOPPView: /usr/bin/../lib/libc.so.6: version GLIBC_2.34' not found (required by /lib/x86_64-linux-gnu/libsystemd.so.0)
...`
due to our use of our own version of things like libc:
` libc.so.6 => /usr/bin/../lib/libc.so.6 (0x00007cdd89200000)`
but the system version of other libraries that we don't specify as NEEDED in the binaries:
`    libgssapi_krb5.so.2 => /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 (0x00007cdd90594000)
    libssl.so.1.1 => /lib/libssl.so.1.1 (0x00007cdd88000000)`

This patch resolves that issue by not adding the RPATH to any executables that we package in a deb.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
bug_fix, configuration changes


___

### **Description**
- Fixed the issue with RPATH creation in Debian packages by adding a condition to skip RPATH installation when the package type is 'deb'.
- This change prevents the inclusion of RPATH in executables, resolving compatibility issues with system libraries.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Conditional RPATH exclusion for Debian package builds</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CMakeLists.txt

<li>Added condition to skip RPATH installation for Debian packages.<br> <li> Ensured RPATH is not set for executables in Debian packages.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7671/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information