### PR TITLE
Update update_ini_files_OpenMS_version.sh

### DIFF
--- a/tools/update_ini_files_OpenMS_version.sh
+++ b/tools/update_ini_files_OpenMS_version.sh
@@ -1,2 +1,5 @@
 TOOL_DIR_PATH="./src/tests/topp/"
-find $TOOL_DIR_PATH -type f -iname '*.ini' -exec grep -q '<ITEM name="version".*Version of the tool' {} \; -exec sed -i '' -e 's/name="version" value=".*" type="string"/name="version" value="3.2.0" type="string"/g' {} \;
+OPENMS_VERSION="3.2.0"
+find $TOOL_DIR_PATH -type f -iname '*.ini' \
+  -exec grep -q '<ITEM name="version".*Version of the tool' {} \; \
+  -exec sed -i -e "s/name=\"version\" value=\".*\" type=\"string\"/name=\"version\" value=\"$OPENMS_VERSION\" type=\"string\"/g" {} \;


### PR DESCRIPTION
### **User description**
## Description

Make script work on linux, use variable for version, move to multiple lines

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a variable `OPENMS_VERSION` to store the version number, enhancing maintainability.
- Modified the `sed` command to use the `OPENMS_VERSION` variable, allowing easier updates to the version number.
- Adjusted the `sed` command to be compatible with Linux by removing the empty string argument for the `-i` option.
- Reformatted the `find` command for improved readability and maintainability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update_ini_files_OpenMS_version.sh</strong><dd><code>Enhance script with version variable and Linux compatibility</code></dd></summary>
<hr>

tools/update_ini_files_OpenMS_version.sh

<li>Introduced a variable <code>OPENMS_VERSION</code> to store the version number.<br> <li> Modified the <code>sed</code> command to use the <code>OPENMS_VERSION</code> variable.<br> <li> Adjusted the <code>sed</code> command to be compatible with Linux by removing the <br>empty string argument for the <code>-i</code> option.<br> <li> Reformatted the <code>find</code> command for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7677/files#diff-3f0b3de627174a7f224c89f2d455794c36061e695160110b8c950c58765829ab">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information