### PR TITLE
Now that we aren't passing the package type during the build just set…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,8 +421,6 @@ if(UNIX)
       else()
         SET(CMAKE_INSTALL_RPATH "@executable_path/${INSTALL_LIB_PATH_REL_TO_BIN}/")
       endif()
-    elseif(NOT "${PACKAGE_TYPE}" STREQUAL "deb")
-      SET(CMAKE_SKIP_INSTALL_RPATH FALSE)
     else() # linux and variants
       SET(CMAKE_INSTALL_RPATH "$ORIGIN/${INSTALL_LIB_PATH_REL_TO_BIN}/")
     endif()

--- a/cmake/package_deb.cmake
+++ b/cmake/package_deb.cmake
@@ -53,6 +53,9 @@ set(CPACK_DEBIAN_ARCHIVE_TYPE "gnutar")
 ## We usually do not want to ship things like stdlib or glibc. Could mess up a system slighlty, when installed system wide
 #include(InstallRequiredSystemLibraries)
 
+# Don't add RPATH
+SET(CMAKE_SKIP_INSTALL_RPATH TRUE)
+
 ## Try autogeneration of dependencies:
 ## This may result in non-standard package names in the dependencies (e.g. when using Qt from a Thirdparty repo)
 ## It also will add system dependencies like a minimum glibc or gomp version (not necessarily bad)


### PR DESCRIPTION
### **User description**
Update the fix from https://github.com/OpenMS/OpenMS/pull/7671 now that we know we can't pass the PACKAGE_TYPE.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Added a configuration in the CMake file to skip adding RPATH during the installation process, which helps in avoiding potential issues with system libraries.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package_deb.cmake</strong><dd><code>Set CMAKE_SKIP_INSTALL_RPATH to TRUE in CMake configuration</code></dd></summary>
<hr>

cmake/package_deb.cmake

<li>Added a setting to skip adding RPATH during the installation process.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7685/files#diff-e1ab9f54a264ed2639a56781454247b865566873543fb034d3a1f20b9c2d3650">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information