### PR TITLE
Revert "conda: try to add windows builds"

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -1,4 +1,5 @@
 name: Deploy to Bioconda
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,33 +13,26 @@ on:
 
 jobs:
   bioconda-deploy:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            platform: linux-64
-          - os: windows-latest
-            platform: win-64
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -le {0}  # Use login shell for conda initialization
-
+        shell: bash -le {0}  # Important! Use login shell for proper conda initialization
+        
     steps:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: bioconda_env
           auto-update-conda: true
+          #environment-file: environment.yml # Replace with your Conda environment file if necessary
           python-version: 3.9
           channels: conda-forge,bioconda,defaults
           channel-priority: true
 
       - name: Prepare output directory
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/output/${{ matrix.platform }}
-          touch $GITHUB_WORKSPACE/output/${{ matrix.platform }}/repodata.json
+        run: |       
+          mkdir -p $GITHUB_WORKSPACE/output/noarch
+          touch $GITHUB_WORKSPACE/output/noarch/repodata.json
           conda install bioconda-utils -y
           conda index $GITHUB_WORKSPACE/output
           ls -l
@@ -48,44 +42,38 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-
-      - name: Clone Bioconda recipes repository
+          
+      - name: Clone Bioconda recipes repository and add our changes (e.g., version with 'dev') on top of it
         run: |
           git clone https://github.com/OpenMS/bioconda-recipes.git bioconda-recipes
           cd bioconda-recipes
           git checkout -b nightly origin/nightly
           git remote add bioconda https://github.com/bioconda/bioconda-recipes.git
           git fetch bioconda master
-          git rebase bioconda/master
+          git rebase bioconda/master         
 
       - name: Lint and build OpenMS Bioconda packages
         run: |
           cd bioconda-recipes
           bioconda-utils lint --packages pyopenms openms-meta
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            # Windows-specific build command (may need adjustments)
-            bioconda-utils build --pkg_dir $GITHUB_WORKSPACE/output --packages openms-meta || true
-          else
-            # Linux build command with Docker
-            bioconda-utils build --docker --pkg_dir $GITHUB_WORKSPACE/output --packages openms-meta || true
-          fi
+          bioconda-utils build --docker --pkg_dir $GITHUB_WORKSPACE/output --packages openms-meta || true
           conda index $GITHUB_WORKSPACE/output
-
+          
       - name: Build pyopenms package
         run: |
           cd bioconda-recipes
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            # Windows-specific build command
-            bioconda-utils build --pkg_dir $GITHUB_WORKSPACE/output --packages pyopenms || true
-          else
-            # Linux build command with Docker and mulled-test
-            bioconda-utils build --docker --mulled-test --pkg_dir $GITHUB_WORKSPACE/output --packages pyopenms || true
-          fi
+          bioconda-utils build --docker --mulled-test --pkg_dir $GITHUB_WORKSPACE/output --packages pyopenms || true
           conda index $GITHUB_WORKSPACE/output
 
       - name: Upload Conda packages
         run: |
           cd bioconda-recipes
           ls -l $GITHUB_WORKSPACE/output
-          # Upload packages for the specific platform
-          anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force $GITHUB_WORKSPACE/output/${{ matrix.platform }}/*.tar.bz2
+          anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2
+
+      - name: Check upload status
+        run: |
+          if [[ $? -ne 0 ]]; then
+            echo "Upload failed!"
+            exit 1
+          fi


### PR DESCRIPTION
### **User description**
Reverts OpenMS/OpenMS#7692

seems only conda-forge provides full support


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Reverted the addition of Windows build support in the Bioconda deployment workflow, focusing solely on Ubuntu builds.
- Simplified the workflow by removing the matrix strategy and platform-specific build commands.
- Adjusted the package upload process to handle only Linux platform outputs, ensuring streamlined deployment.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bioconda_deploy.yaml</strong><dd><code>Revert Windows build support in Bioconda deployment workflow</code></dd></summary>
<hr>

.github/workflows/bioconda_deploy.yaml

<li>Removed Windows build support from the Bioconda deployment workflow.<br> <li> Reverted to using only Ubuntu for the deployment process.<br> <li> Simplified build commands by removing platform-specific logic.<br> <li> Adjusted upload process to handle only Linux outputs.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7693/files#diff-a06a03d5eefe1916bd07aa7f4dc581ff84ddd1c23e537a1de946d6a5dc0312c4">+22/-34</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information