### PR TITLE
add missing ion names to Residue.cpp

### DIFF
--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -129,6 +129,12 @@ namespace OpenMS
     case Residue::YIonMinusNH3:
       return "y-NH3-ion";
 
+    case Residue::Zp1Ion:
+      return "z+1-ion";
+      
+    case Residue::Zp2Ion:
+      return "z+2-ion";      
+
     case Residue::NonIdentified:
       return "Non-identified ion";
 


### PR DESCRIPTION
### **User description**
## Description

Should fix: 
https://github.com/OpenMS/OpenMS/issues/7696 and https://github.com/OpenMS/OpenMS/issues/4678

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix


___

### **Description**
- Added missing ion names `z+1-ion` and `z+2-ion` to the `Residue.cpp` file to address error messages related to unnamed residue types.
- This change aims to fix issues where the `MassCalculator` was reporting errors due to missing residue type names.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Residue.cpp</strong><dd><code>Add missing ion names to Residue.cpp for Zp1Ion and Zp2Ion</code></dd></summary>
<hr>

src/openms/source/CHEMISTRY/Residue.cpp

<li>Added missing ion names for <code>Zp1Ion</code> and <code>Zp2Ion</code>.<br> <li> Ensured proper naming for new residue types.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7697/files#diff-11be5715633a0e04aa066f79aa957d602ed73dc63e9d9fb2239d270356ede638">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information