### PR TITLE
Residue names, attempt 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,9 +37,11 @@ Misc:
 - Improve file list comparison (#7645)
 - pyOpenMS: Add more convenient constructor for AASequence (#7650)
 - Add annotate_features param in Deisotoper.cpp (#7643)
+- internal enhancements (#7652)
 
 Fixes:
 - OpenMS does not compile when using GLPK (instead of COINOR) (#7626)
+- fix MassCalculator error ('residue type has no name') (#7698)
 - pyOpenMS
   - get_feature_df() in MRMTransitionGroupCP, output is now as expected (#7646)
 - Fix scan number extraction for merged spectra (#7599)

--- a/src/openms/include/OpenMS/CHEMISTRY/Residue.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Residue.h
@@ -13,6 +13,9 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 
+
+
+#include <array>
 #include <iosfwd>
 #include <set>
 #include <vector>
@@ -169,6 +172,29 @@ public:
       SizeOfResidueType
     };
     //@}
+    
+    /// Names corresponding to the ResidueType enum
+    static inline std::array<std::string_view, Residue::ResidueType::SizeOfResidueType> names_of_residuetype {
+      "full",
+      "internal",
+      "N-terminal",
+      "C-terminal",
+      "a-ion",
+      "b-ion",
+      "c-ion",
+      "x-ion",
+      "y-ion",
+      "z-ion",
+      "z+1-ion",
+      "z+2-ion",
+      "precursor-ion",
+      "b-H2O-ion",
+      "y-H2O-ion",
+      "b-NH3-ion",
+      "y-NH3-ion",
+      "Non-identified ion",
+      "unannotated"
+    };
 
     /// returns the ion name given as a residue type
     static String getResidueTypeName(const ResidueType res_type);
@@ -414,7 +440,7 @@ public:
 protected:
 
     /// the name of the residue
-    String name_;
+    String name_ = "unknown";
 
     std::set<String> synonyms_;
 
@@ -426,12 +452,12 @@ protected:
 
     EmpiricalFormula internal_formula_;
 
-    double average_weight_;
+    double average_weight_ = 0;
 
-    double mono_weight_;
+    double mono_weight_ = 0;
 
     /// pointer to the modification 
-    const ResidueModification* modification_;
+    const ResidueModification* modification_ = nullptr;
 
     // loss
     std::vector<String> loss_names_;
@@ -450,22 +476,22 @@ protected:
     std::vector<EmpiricalFormula> low_mass_ions_;
 
     // pka values
-    double pka_;
+    double pka_ = 0;
 
     // pkb values
-    double pkb_;
+    double pkb_ = 0;
 
     // pkc values
-    double pkc_;
+    double pkc_ = -1.0;
 
     /// SideChainBasicity
-    double gb_sc_;
+    double gb_sc_ = 0;
 
     /// BackboneBasicityLeft
-    double gb_bb_l_;
+    double gb_bb_l_ = 0;
 
     /// BackboneBasicityRight
-    double gb_bb_r_;
+    double gb_bb_r_ = 0;
 
     /// residue sets this amino acid is contained in
     std::set<String> residue_sets_;

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -20,18 +20,7 @@ using namespace std;
 namespace OpenMS
 {
 
-  Residue::Residue() :
-    name_("unknown"),
-    average_weight_(0.0f),
-    mono_weight_(0.0f),
-    modification_(nullptr),
-    loss_average_weight_(0.0f),
-    loss_mono_weight_(0.0f),
-    pka_(0.0),
-    pkb_(0.0),
-    pkc_(-1.0)
-  {
-  }
+  Residue::Residue() = default;
 
   Residue::Residue(const String& name,
             const String& three_letter_code,
@@ -44,7 +33,6 @@ namespace OpenMS
             double gb_bb_l,
             double gb_bb_r,
             const set<String>& synonyms):
-                
     name_(name),
     synonyms_(synonyms),
     three_letter_code_(three_letter_code),
@@ -52,9 +40,6 @@ namespace OpenMS
     formula_(formula),
     average_weight_(formula.getAverageWeight()),
     mono_weight_(formula.getMonoWeight()),
-    modification_(nullptr),
-    loss_average_weight_(0.0f),
-    loss_mono_weight_(0.0f),
     pka_(pka),
     pkb_(pkb),
     pkc_(pkc),
@@ -82,69 +67,7 @@ namespace OpenMS
 
   String Residue::getResidueTypeName(const Residue::ResidueType res_type)
   {
-    switch (res_type)
-    {
-    case Residue::Full:
-      return "full";
-
-    case Residue::Internal:
-      return "internal";
-
-    case Residue::NTerminal:
-      return "N-terminal";
-
-    case Residue::CTerminal:
-      return "C-terminal";
-
-    case Residue::AIon:
-      return "a-ion";
-
-    case Residue::BIon:
-      return "b-ion";
-
-    case Residue::CIon:
-      return "c-ion";
-
-    case Residue::XIon:
-      return "x-ion";
-
-    case Residue::YIon:
-      return "y-ion";
-
-    case Residue::ZIon:
-      return "z-ion";
-
-    case Residue::Precursor:
-      return "precursor-ion";
-
-    case Residue::BIonMinusH20:
-      return "b-H2O-ion";
-
-    case Residue::YIonMinusH20:
-      return "y-H2O-ion";
-
-    case Residue::BIonMinusNH3:
-      return "B-NH3-ion";
-
-    case Residue::YIonMinusNH3:
-      return "y-NH3-ion";
-
-    case Residue::Zp1Ion:
-      return "z+1-ion";
-      
-    case Residue::Zp2Ion:
-      return "z+2-ion";      
-
-    case Residue::NonIdentified:
-      return "Non-identified ion";
-
-    case Residue::Unannotated:
-      return "unannotated";
-
-    default:
-      cerr << "Error: Residue::getResidueTypeName - residue type has no name. The developer should add a residue name to Residue.cpp" << endl;
-    }
-    return "";
+    return names_of_residuetype[res_type];
   }
 
   void Residue::setSynonyms(const set<String>& synonyms)
@@ -699,10 +622,10 @@ namespace OpenMS
 
   ostream& operator<<(ostream& os, const Residue& residue)
   {
-    os << residue.name_ << " "
-    << residue.three_letter_code_ << " "
-    << residue.one_letter_code_ << " "
-    << residue.formula_;
+    os << residue.name_ << ' '
+       << residue.three_letter_code_ << ' '
+       << residue.one_letter_code_ << ' '
+       << residue.formula_;
     return os;
   }
 

--- a/src/tests/class_tests/openms/source/Residue_test.cpp
+++ b/src/tests/class_tests/openms/source/Residue_test.cpp
@@ -726,6 +726,23 @@ START_SECTION((static String getResidueTypeName(const ResidueType res_type)))
   TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::XIon), "x-ion")
   TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::YIon), "y-ion")
   TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::ZIon), "z-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::Zp1Ion), "z+1-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::Zp2Ion), "z+2-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::Precursor), "precursor-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::BIonMinusH20), "b-H2O-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::YIonMinusH20), "y-H2O-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::BIonMinusNH3), "b-NH3-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::YIonMinusNH3), "y-NH3-ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::NonIdentified), "Non-identified ion")
+  TEST_STRING_EQUAL(Residue::getResidueTypeName(Residue::Unannotated), "unannotated")
+
+
+  TEST_EQUAL(Residue::SizeOfResidueType, Residue::names_of_residuetype.size());
+  // test that no entries in array are empty (the initializer of std::array<> can have less values than the std::array<>)
+  for (int i = 0; i < Residue::names_of_residuetype.size(); ++i)
+  {
+    TEST_FALSE(Residue::getResidueTypeName(static_cast<Residue::ResidueType>(i)).empty());
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

amends #7697

Convert from switch statement to array for enum lookup.
It's not really safer, but a bit more readable.

Also:
 * rename "B-NH3-ion" to "b-NH3-ion"
 * minor optimizations
 * initialize all members of Residue (gb_sc_ etc)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
