### PR TITLE
Multthreaded build on windows

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -105,6 +105,7 @@ jobs:
           echo "tp_folder=Linux" >> $GITHUB_OUTPUT
           echo "xvfb=xvfb-run -a" >> $GITHUB_OUTPUT
           echo "static_boost=OFF" >> $GITHUB_OUTPUT
+          echo "build_flags=-j${{ steps.cpu-cores.outputs.count }}" >> $GITHUB_OUTPUT
           # always run doxygen on Ubuntu (because its fast), to detect Doxygen errors
           echo "enable_docs=ON" >> $GITHUB_OUTPUT  
           if [ "$DO_PACKAGE" = true ]; then
@@ -122,6 +123,7 @@ jobs:
           echo "contrib_compiler=msvc-14.2/" >> $GITHUB_OUTPUT
           echo "xvfb=" >> $GITHUB_OUTPUT
           echo "static_boost=ON" >> $GITHUB_OUTPUT
+          echo "build_flags=-p:CL_MPCount=${{ steps.cpu-cores.outputs.count }}" >> $GITHUB_OUTPUT # For VS Generator and MSBuild
           if [ "$DO_PACKAGE" = true ]; then
             echo "pkg_type=nsis" >> $GITHUB_OUTPUT
             echo "enable_docs=ON" >> $GITHUB_OUTPUT
@@ -134,6 +136,7 @@ jobs:
 
         if [[ "${{ matrix.os }}" == macos-* ]]; then
           echo "tp_folder=MacOS" >> $GITHUB_OUTPUT
+          echo "build_flags=-j${{ steps.cpu-cores.outputs.count }}" >> $GITHUB_OUTPUT
           echo "contrib_os=macOS" >> $GITHUB_OUTPUT
           echo "contrib_os_ver=10.15.5/" >> $GITHUB_OUTPUT
           echo "contrib_compiler=appleclang-11.0.0/" >> $GITHUB_OUTPUT
@@ -380,7 +383,7 @@ jobs:
           OPENMP: "ON"
           BOOST_USE_STATIC: ${{ steps.set-vars.outputs.static_boost }}
           #  BUILD_FLAGS: "-p:CL_MPCount=2" # For VS Generator and MSBuild
-          BUILD_FLAGS: "-j${{ steps.cpu-cores.outputs.count }}" # Ninja will otherwise use all cores (doesn't go well in GHA).
+          BUILD_FLAGS: ${{ steps.set-vars.outputs.build_flags }}
           CMAKE_CCACHE_EXE: "ccache"
           CCACHE_BASEDIR: ${{ github.workspace }}
           CCACHE_DIR: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
### **User description**
Pass the proper flags for msbuild to use multiple processors

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Introduced multithreading capabilities in the build process for Windows, Ubuntu, and macOS by setting appropriate build flags.
- Configured the build system to utilize multiple CPU cores, enhancing build performance.
- Updated the GitHub Actions workflow to dynamically set `build_flags` based on the number of available CPU cores.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openms_ci_matrix_full.yml</strong><dd><code>Enable multithreaded builds across different operating systems</code></dd></summary>
<hr>

.github/workflows/openms_ci_matrix_full.yml

<li>Added build flags for multithreading on Ubuntu, Windows, and macOS.<br> <li> Configured <code>build_flags</code> to utilize multiple CPU cores.<br> <li> Updated <code>BUILD_FLAGS</code> to use the new <code>build_flags</code> variable.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7717/files#diff-0be71f2159fab4dd562ae195019726d8ef93f807d2e9b91b67494e57c1419f1c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information