### PR TITLE
add final to iterators and remove unneeded virtual

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -92,7 +92,7 @@ public:
 
         AASequence constant iterator
     */
-    class OPENMS_DLLAPI ConstIterator
+    class OPENMS_DLLAPI ConstIterator final
     {
     public:
       // TODO Iterator constructor for ConstIterator
@@ -129,7 +129,7 @@ public:
       }
 
       /// destructor
-      virtual ~ConstIterator() = default;
+      ~ConstIterator() = default;
 
       //@}
 
@@ -210,7 +210,7 @@ protected:
 
         Mutable iterator for AASequence
     */
-    class OPENMS_DLLAPI Iterator
+    class OPENMS_DLLAPI Iterator final
     {
 public:
 
@@ -239,7 +239,7 @@ public:
       Iterator(const Iterator& rhs) = default;
 
       /// destructor
-      virtual ~Iterator() = default;
+      ~Iterator() = default;
 
       //@}
 
@@ -343,7 +343,7 @@ protected:
     AASequence(AASequence&&) noexcept = default;
 
     /// Destructor
-    virtual ~AASequence() = default;
+    ~AASequence() = default;
     //@}
 
     /// Assignment operator

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -340,7 +340,7 @@ protected:
     AASequence(const AASequence&) = default;
 
     /// Move constructor
-    AASequence(AASequence&&) noexcept = default;
+    AASequence(AASequence&&) = default;
 
     /// Destructor
     ~AASequence() = default;


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Marked the `ConstIterator` and `Iterator` classes in the `AASequence` header file as `final`, ensuring they cannot be inherited.
- Removed the `virtual` keyword from destructors in `ConstIterator`, `Iterator`, and `AASequence` classes, as they are not intended to be overridden.
- These changes improve code clarity and potentially optimize performance by preventing unnecessary virtual table lookups.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AASequence.h</strong><dd><code>Mark iterators and AASequence destructors as final and non-virtual</code></dd></summary>
<hr>

src/openms/include/OpenMS/CHEMISTRY/AASequence.h

<li>Marked <code>ConstIterator</code> and <code>Iterator</code> classes as <code>final</code> to prevent further <br>inheritance.<br> <li> Removed unnecessary <code>virtual</code> keyword from destructors in <code>ConstIterator</code>, <br><code>Iterator</code>, and <code>AASequence</code> classes.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7724/files#diff-df09f7e70ffbe48753a3299ef6fea8154ee65547bb05d52852b7d467a6798f88">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information