### PR TITLE
Fix residue heisenbug

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/Residue.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Residue.h
@@ -468,10 +468,6 @@ protected:
 
     std::vector<EmpiricalFormula> NTerm_loss_formulas_;
 
-    double loss_average_weight_;
-
-    double loss_mono_weight_;
-
     /// low mass markers like immonium ions
     std::vector<EmpiricalFormula> low_mass_ions_;
 

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -542,6 +542,9 @@ namespace OpenMS
 
   bool Residue::operator==(const Residue& residue) const
   {
+    // usually, its the same address (from ResidueDB)
+    if (this == &residue) return true;
+    // otherwise compare members
     return name_ == residue.name_ &&
            synonyms_ == residue.synonyms_ &&
            three_letter_code_ == residue.three_letter_code_ &&

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -554,8 +554,6 @@ namespace OpenMS
            loss_formulas_ == residue.loss_formulas_ &&
            NTerm_loss_names_ == residue.NTerm_loss_names_ &&
            NTerm_loss_formulas_ == residue.NTerm_loss_formulas_ &&
-           loss_average_weight_ == residue.loss_average_weight_ &&
-           loss_mono_weight_ == residue.loss_mono_weight_ &&
            low_mass_ions_ == residue.low_mass_ions_ &&
            pka_ == residue.pka_ &&
            pkb_ == residue.pkb_ &&


### PR DESCRIPTION
## Description

fixes #7723

interesting Heisenbug:
our Residue class had unused members of type `double` which were also uninitialized!
Thus, they receive a "random" value upon instantiation.
When comparing an object to itself in `operator==` with code like `return member_a == rhs.member_a && ...`
then this can fail if the member has a `nan` value, since `nan == nan` is always `false`!

Even though the initialization with `nan` seems compiler specific (latest VS does this sporadically), this should go into 3.3 just to make sure.
@poshul 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
