### PR TITLE
Revert "add some debug output"

### DIFF
--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -395,15 +395,10 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
   param.setValue("add_abundant_immonium_ions", "true");
   ptr->setParameters(param);
   spec.clear(true);
-  AASequence aas = AASequence::fromString("HFYLWCP");
-  for (const auto& aa : aas)
-  {
-    std::cout << aa << std::endl;
-  }
-  ptr->getSpectrum(spec, aas, 1, 1);
+  ptr->getSpectrum(spec, AASequence::fromString("HFYLWCP"), 1, 1);
   TEST_EQUAL(spec.size(), 7)
-  TEST_REAL_SIMILAR(spec[0].getPosition()[0], 70.0656) // ImP
-  TEST_REAL_SIMILAR(spec[1].getPosition()[0], 76.0221) // ImC
+  TEST_REAL_SIMILAR(spec[0].getPosition()[0], 70.0656)
+  TEST_REAL_SIMILAR(spec[1].getPosition()[0], 76.0221)
   TEST_REAL_SIMILAR(spec[2].getPosition()[0], 86.09698)
   TEST_REAL_SIMILAR(spec[3].getPosition()[0], 110.0718)
   TEST_REAL_SIMILAR(spec[4].getPosition()[0], 120.0813)


### PR DESCRIPTION
### **User description**
Reverts OpenMS/OpenMS#7728


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted the addition of debug output in `TheoreticalSpectrumGenerator_test.cpp` that printed each amino acid in the sequence.
- Simplified the test by directly passing the amino acid sequence to the `getSpectrum` function instead of using a variable.
- Removed comments that described specific spectrum positions, streamlining the test code.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TheoreticalSpectrumGenerator_test.cpp</strong><dd><code>Revert debug output and simplify test in </code><br><code>TheoreticalSpectrumGenerator_test.cpp</code></dd></summary>
<hr>

src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp

<li>Removed debug output that printed each amino acid in the sequence.<br> <li> Simplified the test by directly using the amino acid sequence in the <br>function call.<br> <li> Removed comments describing specific spectrum positions.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7730/files#diff-1a1d232ae13613a9d26a64490e0eb4173afae738296bfcb474430361d4f6c352">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information