### PR TITLE
SequenceCoverageCalculator: write annotated proteins to idXML

### DIFF
--- a/src/topp/SequenceCoverageCalculator.cpp
+++ b/src/topp/SequenceCoverageCalculator.cpp
@@ -12,7 +12,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 
-#include <map>
+#include <unordered_map>
 #include <numeric>
 
 using namespace OpenMS;
@@ -104,9 +104,9 @@ protected:
     vector<PeptideHit> temp_hits;
     vector<Size> coverage;
     Size spectrum_count = 0;
-    map<String, Size> unique_peptides;
-    map<String, Size> temp_unique_peptides;
-    map<String, Size> temp_modified_unique_peptides;
+    unordered_map<String, Size> unique_peptides;
+    unordered_map<String, Size> temp_unique_peptides;
+    unordered_map<String, Size> temp_modified_unique_peptides;
 
     protein_identifications.push_back(ProteinIdentification());
     //-------------------------------------------------------------
@@ -129,7 +129,7 @@ protected:
     // calculations
     //-------------------------------------------------------------
 
-    map<String, CoverageInfo> prot2cov;
+    unordered_map<String, CoverageInfo> prot2cov;
     os << "proteinID\tcoverage (%)\tunique hits\n";
     for (Size j = 0; j < proteins.size(); ++j)
     {

--- a/src/topp/SequenceCoverageCalculator.cpp
+++ b/src/topp/SequenceCoverageCalculator.cpp
@@ -43,9 +43,8 @@ class TOPPSequenceCoverageCalculator :
 {
 public:
   TOPPSequenceCoverageCalculator() :
-    TOPPBase("SequenceCoverageCalculator", "Prints information about idXML files.")
+    TOPPBase("SequenceCoverageCalculator", "Annotates coverage information to idXML files.")
   {
-
   }
 
 protected:
@@ -56,7 +55,7 @@ protected:
     registerInputFile_("in_peptides", "<file>", "", "input file containing the identified peptides");
     setValidFormats_("in_peptides", ListUtils::create<String>("idXML"), true);
     registerOutputFile_("out", "<file>", "", "Optional text output file. If left out, the output is written to the command line.", false);
-    setValidFormats_("out", ListUtils::create<String>("txt"));
+    setValidFormats_("out", ListUtils::create<String>("idXML"), true);
   }
 
   void getStartAndEndIndex(const String& sequence, const String& substring, pair<Size, Size>& indices)
@@ -87,7 +86,14 @@ protected:
     }
   }
 
-  ExitCodes outputTo_(ostream& os)
+  struct CoverageInfo
+  {
+    double coverage{};  // fraction of sequence covered by peptides
+    Size count{};       // number of unique peptides
+    Size mod_count{};   // number of unique modified peptides
+  };
+
+  ExitCodes outputTo_(ostream& os, String out)
   {
     vector<ProteinIdentification> protein_identifications;
     vector<PeptideIdentification> identifications;
@@ -123,7 +129,7 @@ protected:
     // calculations
     //-------------------------------------------------------------
 
-
+    map<String, CoverageInfo> prot2cov;
     os << "proteinID\tcoverage (%)\tunique hits\n";
     for (Size j = 0; j < proteins.size(); ++j)
     {
@@ -191,6 +197,7 @@ protected:
       // details for this protein
       if (counts[j] > 0)
       {
+        prot2cov[proteins[j].identifier] = { statistics[j], counts[j], mod_counts[j] };
         os << proteins[j].identifier << "\t" << statistics[j] * 100 << "\t" << counts[j] << "\n";
       }
 
@@ -198,6 +205,22 @@ protected:
     }
 
 // os << "Sum of coverage is " << accumulate(statistics.begin(), statistics.end(), 0.) << endl;
+
+    // update meta values in protein_identifications
+    for (auto& prot_id : protein_identifications)
+    {
+      for (auto& prot_hit : prot_id.getHits())
+      {
+        if (prot2cov.find(prot_hit.getAccession()) != prot2cov.end())
+        {
+          prot_hit.setMetaValue("coverage", prot2cov[prot_hit.getAccession()].coverage);
+          prot_hit.setMetaValue("unique_peptides", prot2cov[prot_hit.getAccession()].count);
+          prot_hit.setMetaValue("unique_modified_peptides", prot2cov[prot_hit.getAccession()].mod_count);
+        }
+      }
+    }
+    FileHandler().storeIdentifications(out, protein_identifications, identifications, {FileTypes::IDXML});
+
     os << "Average coverage per protein is " << (accumulate(statistics.begin(), statistics.end(), 0.) / statistics.size()) << endl;
     os << "Average number of peptides per protein is " << (((double) accumulate(counts.begin(), counts.end(), 0.)) / counts.size()) << endl;
     os << "Average number of un/modified peptides per protein is " << (((double) accumulate(mod_counts.begin(), mod_counts.end(), 0.)) / mod_counts.size()) << endl;
@@ -232,21 +255,7 @@ protected:
   ExitCodes main_(int, const char**) override
   {
     String out = getStringOption_("out");
-
-    TOPPBase::ExitCodes ret;
-    if (!out.empty())
-    {
-      ofstream os(out.c_str());
-      ret = outputTo_(os);
-      os.close();
-    }
-    else
-    {
-      // directly use Log_info (no need for protecting output stream in non-parallel section)
-      ret = outputTo_(OpenMS_Log_info);
-    }
-
-    return ret;
+    return outputTo_(OpenMS_Log_info, out);
   }
 
 };


### PR DESCRIPTION
### **User description**
## Description

request by Dave.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the `SequenceCoverageCalculator` tool to annotate protein coverage information directly into `idXML` files.
- Introduced a new `CoverageInfo` structure to store detailed protein coverage metrics such as coverage percentage, unique peptides, and unique modified peptides.
- Updated the output format from `txt` to `idXML` for better compatibility with downstream tools.
- Modified the `main_` function to streamline output handling and ensure consistent writing of annotated data.
- Added logic to update protein hits with meta-values for coverage and peptide counts in the `idXML` output.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SequenceCoverageCalculator.cpp</strong><dd><code>Enhance SequenceCoverageCalculator to annotate proteins in idXML </code><br><code>format</code></dd></summary>
<hr>

src/topp/SequenceCoverageCalculator.cpp

<li>Updated the description of the <code>SequenceCoverageCalculator</code> tool to <br>reflect its new functionality.<br> <li> Changed the output format from <code>txt</code> to <code>idXML</code> for better integration.<br> <li> Introduced a new <code>CoverageInfo</code> structure to store protein coverage <br>details.<br> <li> Enhanced the logic to annotate protein hits with coverage and peptide <br>information in the output.<br> <li> Modified the <code>main_</code> function to handle output writing consistently.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7736/files#diff-ccf600cb8eeb5ae5264b8d11ca37e35259d175b6428d686f9c4033569bbc30be">+29/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information