### PR TITLE
docs: update linux contrib requirements for qt-6

### DIFF
--- a/doc/doxygen/install/install-linux.doxygen
+++ b/doc/doxygen/install/install-linux.doxygen
@@ -103,13 +103,13 @@
       </pre></td>
   </tr>
   <tr>
-      <td><B>Ubuntu/Debian <br/>(>= 20.04)</B></td>
+      <td><B>Ubuntu/Debian <br/>(>= 22.04)</B></td>
       <td><pre>
     # Include the Ubuntu "universe" repository and update:
     sudo add-apt-repository universe
     sudo apt update
     sudo apt-get install build-essential cmake autoconf patch libtool git automake
-    sudo apt-get install qtbase6-dev libqt6svg6-dev libqt6opengl6-dev
+    sudo apt-get install qtbase6-dev libqt6svg6-dev
     sudo apt-get install libeigen3-dev libboost-random-dev libboost-regex-dev \
       libboost-iostreams-dev libboost-date-time-dev libboost-math-dev libxerces-c-dev \
       zlib1g-dev libsvm-dev libbz2-dev coinor-libcoinmp-dev libhdf5-dev


### PR DESCRIPTION


## Description
As per
https://askubuntu.com/questions/1404353/how-to-install-qt6-on-ubuntu-21-10 qtbase6-dev is not avaliable on ubuntu < 22.04. libqt6opengl6-dev does not seem to be installable however building still seems to work without it.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
