### PR TITLE
fix Dockerfile

### DIFF
--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -65,8 +65,8 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
       - name: Build and push library image
         uses: docker/build-push-action@v5
         with:
@@ -79,8 +79,8 @@ jobs:
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library:${{ steps.tag_name.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
       - name: Build and push tools image
         uses: docker/build-push-action@v6
         with:
@@ -94,8 +94,8 @@ jobs:
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables:${{ steps.tag_name.outputs.tag }}
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools:${{ steps.tag_name.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
       - name: Build and push tools + thirdparty image
         uses: docker/build-push-action@v5
         with:
@@ -108,8 +108,8 @@ jobs:
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools-thirdparty:${{ steps.tag_name.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
   deploy-singularity:
     runs-on: ubuntu-latest
     needs: deploy-docker

--- a/.github/workflows/containerdeploy.yml
+++ b/.github/workflows/containerdeploy.yml
@@ -40,18 +40,6 @@ jobs:
             ## Remove release/ from release branch name (or keep the non-release name)
             echo "tag=${BRANCH#release/}" >> $GITHUB_OUTPUT
         id: tag_name
-      - name: Define contrib image tag
-        id: contrib_tag
-        shell: bash
-        run: |
-            # the contrib image tag is the same as the main image tag for release branches
-            # for non-release branches, we use the latest contrib image
-            if [[ "${{ steps.extract_branch.outputs.branch }}" == "release/"* ]]
-            then
-              echo "contrib_tag=${{ steps.tag_name.outputs.tag }}" >> $GITHUB_OUTPUT
-            else
-              echo "contrib_tag=latest" >> $GITHUB_OUTPUT
-            fi
       - name: Downcase REPO
         run: echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
         id: downcase_repo
@@ -67,22 +55,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Checkout contrib submodule repository
-        run: git submodule update --init contrib
-        # we only need the contrib submodule if we're on a release branch
-        # otherwise, we use the latest contrib image built in the OpenMS/contrib
-        if: startsWith(steps.extract_branch.outputs.branch, 'release/')
-      - name: Build contrib container using the correct submodule hash
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          context: contrib
-          file: contrib/dockerfiles/Dockerfile
-          tags: |
-            ghcr.io/openms/contrib:${{ steps.tag_name.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-        if: startsWith(steps.extract_branch.outputs.branch, 'release/')
       - name: Test docker build in runtime base
         uses: docker/build-push-action@v5
         with:
@@ -93,7 +65,6 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-            CONTRIB_IMAGE_TAG=${{ steps.contrib_tag.outputs.contrib_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push library image
@@ -106,7 +77,6 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-            CONTRIB_IMAGE_TAG=${{ steps.contrib_tag.outputs.contrib_tag }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-library:${{ steps.tag_name.outputs.tag }}
           cache-from: type=gha
@@ -121,7 +91,6 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-            CONTRIB_IMAGE_TAG=${{ steps.contrib_tag.outputs.contrib_tag }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-executables:${{ steps.tag_name.outputs.tag }}
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools:${{ steps.tag_name.outputs.tag }}
@@ -137,7 +106,6 @@ jobs:
             NUM_BUILD_CORES=4
             BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
             OPENMS_VERSION_TAG=${{ steps.tag_name.outputs.tag }}
-            CONTRIB_IMAGE_TAG=${{ steps.contrib_tag.outputs.contrib_tag }}
           tags: |
             ghcr.io/${{ steps.downcase_repo.outputs.repo }}-tools-thirdparty:${{ steps.tag_name.outputs.tag }}
           cache-from: type=gha

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     libgomp1 \
     libqt6svg6-dev \
     libxerces-c3.2 \
+    libxerces-c-dev \
     coinor-libcoinmp1v5 \
     libboost-date-time1.74-dev  \
     libboost-iostreams1.74-dev \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
     libgl1-mesa-dev \
     libqt6opengl6-dev \
     libqt6svg6-dev \   
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
   && update-ca-certificates
 
 # installing cmake

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -45,8 +45,10 @@ RUN apt-get update \
     libboost-math1.74-dev \
     libboost-random1.74-dev \
     qt6-base-dev \
+    libglx-dev \
+    libgl1-mesa-dev \
     libqt6opengl6-dev \
-    libqt6svg6-dev \
+    libqt6svg6-dev \   
   && rm -rf /var/lib/apt/lists/*
 
 # The main reason we're pulling this in is to make sure that the metadata

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -116,6 +116,7 @@ ARG INSTALL_DIR
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
+    qt6-base \
     libqt6opengl6 \
     libsvm3 \
     libzip4 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,7 +8,7 @@ ARG INSTALL_DIR="/opt/OpenMS"
 ARG THIRDPARTY_DIR="/opt/OpenMS/thirdparty"
 ARG NUM_BUILD_CORES=8
 ARG MAKEFLAGS="-j${NUM_BUILD_CORES}"
-ARG CMAKE_VERSION="3.28.1"
+ARG CMAKE_VERSION=3.28.1
 
 
 ### OpenMS base ###
@@ -49,6 +49,7 @@ RUN apt-get update \
     libqt6opengl6-dev \
     libqt6svg6-dev \   
   && rm -rf /var/lib/apt/lists/*
+  && update-ca-certificates
 
 # installing cmake
 WORKDIR /tmp
@@ -163,8 +164,8 @@ LABEL software="OpenMS (tools + thirdparty)"
 FROM tools-thirdparty AS test
 ARG SOURCE_DIR
 ARG BUILD_DIR
-ARG CMAKE_VERSION
-ARG NUM_BUILD_CORES
+ARG NUM_BUILD_CORES=8
+ARG CMAKE_VERSION=3.28.1
 
 RUN apt-get update \ 
     && apt-get install -y --no-install-recommends --no-install-suggests \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -116,7 +116,7 @@ ARG INSTALL_DIR
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
-    qt6-base \
+    qt6-base-dev \
     libqt6opengl6 \
     libsvm3 \
     libzip4 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
     libomp-dev \
     libhdf5-dev\
     coinor-libcoinmp-dev \
+    libeigen3-dev \
     libboost-date-time1.74-dev \
     libboost-iostreams1.74-dev \
     libboost-regex1.74-dev \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -28,19 +28,16 @@ RUN apt-get update \
     build-essential \
     # OpenMS build dependencies
     libsvm-dev \
-    libsvm3 \
     libglpk-dev \
     libzip-dev \
     zlib1g-dev \
     libzip4 \
     zlib1g \
     libxerces-c-dev \
-    libxerces-c3.2 \
     libbz2-dev \
-    libbz2-1.0 \
     libomp-dev \
-    libgomp1 \
     libhdf5-dev\
+    coinor-libcoinmp-dev \
     libboost-date-time1.74-dev \
     libboost-iostreams1.74-dev \
     libboost-regex1.74-dev \
@@ -49,7 +46,6 @@ RUN apt-get update \
     qt6-base-dev \
     libqt6opengl6-dev \
     libqt6svg6-dev \
-    coinor-libcoinmp1v5 \
   && rm -rf /var/lib/apt/lists/*
 
 # The main reason we're pulling this in is to make sure that the metadata

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update \
     g++ \
     make \
     git \
-    cmake \
     ca-certificates \
     build-essential \
     # OpenMS build dependencies
@@ -50,6 +49,18 @@ RUN apt-get update \
     libqt6opengl6-dev \
     libqt6svg6-dev \   
   && rm -rf /var/lib/apt/lists/*
+
+# installing cmake
+WORKDIR /tmp
+ADD https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh cmake.sh
+RUN <<-EOF
+    set -eux
+    mkdir -p /opt/cmake
+    sh cmake.sh --skip-license --prefix=/opt/cmake
+    ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+    ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest
+    rm -rf /tmp/*
+EOF
 
 # The main reason we're pulling this in is to make sure that the metadata
 # below is consistently formatted for releases irrespective of the base image

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -20,30 +20,36 @@ RUN apt-get update \
     && add-apt-repository universe \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
-    build-essential \
-    cmake \
-    autoconf \
-    patch \
-    libtool \
+    g++ \
+    make \
     git \
-    automake \
-    qt6-base-dev \
-    libqt6opengl6-dev \
-    libsvm3 \
+    cmake \
+    ca-certificates \
+    build-essential \
+    # OpenMS build dependencies
     libsvm-dev \
+    libsvm3 \
+    libglpk-dev \
+    libzip-dev \
+    zlib1g-dev \
     libzip4 \
     zlib1g \
-    libbz2-1.0 \
-    libgomp1 \
-    libqt6svg6-dev \
-    libxerces-c3.2 \
     libxerces-c-dev \
-    coinor-libcoinmp1v5 \
-    libboost-date-time1.74-dev  \
+    libxerces-c3.2 \
+    libbz2-dev \
+    libbz2-1.0 \
+    libomp-dev \
+    libgomp1 \
+    libhdf5-dev\
+    libboost-date-time1.74-dev \
     libboost-iostreams1.74-dev \
     libboost-regex1.74-dev \
     libboost-math1.74-dev \
     libboost-random1.74-dev \
+    qt6-base-dev \
+    libqt6opengl6-dev \
+    libqt6svg6-dev \
+    coinor-libcoinmp1v5 \
   && rm -rf /var/lib/apt/lists/*
 
 # The main reason we're pulling this in is to make sure that the metadata

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     qt6-base-dev \
     libqt6opengl6-dev \
     libsvm3 \
+    libsvm-dev \
     libzip4 \
     zlib1g \
     libbz2-1.0 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -5,11 +5,6 @@ ARG OPENMS_VERSION_TAG=latest
 ARG SOURCE_DIR="/tmp/OpenMS"
 ARG BUILD_DIR="${SOURCE_DIR}/bld"
 ARG INSTALL_DIR="/opt/OpenMS"
-# the contrib image is the collection of dependencies needed to build OpenMS
-ARG CONTRIB_IMAGE_TAG=latest
-ARG CONTRIB_BASE_IMAGE=ghcr.io/openms/contrib:${CONTRIB_IMAGE_TAG}
-# this directory is where any dependencies that are built from source go
-ARG CONTRIB_BUILD_DIR="/contrib-build"
 ARG THIRDPARTY_DIR="/opt/OpenMS/thirdparty"
 ARG NUM_BUILD_CORES=8
 ARG MAKEFLAGS="-j${NUM_BUILD_CORES}"
@@ -17,15 +12,21 @@ ARG CMAKE_VERSION="3.28.1"
 
 
 ### OpenMS base ###
-FROM ${CONTRIB_BASE_IMAGE} AS base
+FROM ubuntu:22.04 AS base
 ARG OPENMS_VERSION_TAG
-ARG CONTRIB_BUILD_DIR
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \
     && add-apt-repository universe \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
+    build-essential \
+    cmake \
+    autoconf \
+    patch \
+    libtool \
+    git \
+    automake \
     qt6-base-dev \
     libqt6opengl6-dev \
     libsvm3 \
@@ -43,13 +44,7 @@ RUN apt-get update \
     libboost-random1.74-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# if the contrib image builds anything from source it will place the binaries
-# in the CONTRIB_BUILD_DIR. If it doesn't (ie. because they are installed from
-# the package manager) then we need to create the directory anyway since other
-# stages attempt to copy from it
-RUN mkdir -p ${CONTRIB_BUILD_DIR}/bin
-
-# the main reason we're pulling this in is to make sure that the metadata
+# The main reason we're pulling this in is to make sure that the metadata
 # below is consistently formatted for releases irrespective of the base image
 LABEL version="${OPENMS_VERSION_TAG}"
 LABEL software.version="${OPENMS_VERSION_TAG}-Ubuntu22.04"
@@ -61,7 +56,6 @@ FROM base AS build
 ARG SOURCE_DIR
 ARG BUILD_DIR
 ARG INSTALL_DIR
-ARG CONTRIB_BUILD_DIR
 ARG THIRDPARTY_DIR
 ARG MAKEFLAGS
 ENV MAKEFLAGS="${MAKEFLAGS}"
@@ -86,7 +80,7 @@ ENV PATH="${THIRDPARTY_DIR}/LuciPHOr2:${THIRDPARTY_DIR}/MSGFPlus:${THIRDPARTY_DI
 RUN cmake \
     -DQt6_DIR="/usr/lib/x86_64-linux-gnu/cmake/Qt6" \
     -DCMAKE_BUILD_TYPE='Release' \
-    -DCMAKE_PREFIX_PATH="${CONTRIB_BUILD_DIR}/;/usr/;/usr/local" \
+    -DCMAKE_PREFIX_PATH="/usr/;/usr/local" \
     -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
     -DBOOST_USE_STATIC=OFF \
     -S ${SOURCE_DIR} \
@@ -100,9 +94,7 @@ RUN make install/strip
 ### OpenMS library ###
 FROM ubuntu:22.04 AS library
 ARG INSTALL_DIR
-ARG CONTRIB_BUILD_DIR
 
-COPY --from=build ${CONTRIB_BUILD_DIR}/bin ${CONTRIB_BUILD_DIR}/bin
 COPY --from=build ${INSTALL_DIR}/lib ${INSTALL_DIR}/lib
 COPY --from=build ${INSTALL_DIR}/include ${INSTALL_DIR}/include
 COPY --from=build ${INSTALL_DIR}/share ${INSTALL_DIR}/share

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -114,6 +114,24 @@ RUN make install/strip
 FROM ubuntu:22.04 AS library
 ARG INSTALL_DIR
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends --no-install-suggests \
+    libqt6opengl6 \
+    libsvm3 \
+    libzip4 \
+    zlib1g \
+    libbz2-1.0 \
+    libgomp1 \
+    libqt6svg6 \
+    libxerces-c3.2 \
+    coinor-libcoinmp1v5 \
+    libboost-date-time1.74-dev  \
+    libboost-iostreams1.74-dev \
+    libboost-regex1.74-dev \
+    libboost-math1.74-dev \
+    libboost-random1.74-dev \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build ${INSTALL_DIR}/lib ${INSTALL_DIR}/lib
 COPY --from=build ${INSTALL_DIR}/include ${INSTALL_DIR}/include
 COPY --from=build ${INSTALL_DIR}/share ${INSTALL_DIR}/share

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,12 +8,12 @@ ARG INSTALL_DIR="/opt/OpenMS"
 ARG THIRDPARTY_DIR="/opt/OpenMS/thirdparty"
 ARG NUM_BUILD_CORES=8
 ARG MAKEFLAGS="-j${NUM_BUILD_CORES}"
-ARG CMAKE_VERSION=3.28.1
 
 
 ### OpenMS base ###
 FROM ubuntu:22.04 AS base
 ARG OPENMS_VERSION_TAG
+ARG CMAKE_VERSION=3.28.1
 
 RUN apt-get update \
     && apt-get install -y software-properties-common \


### PR DESCRIPTION
### **User description**
## Description

some of the dependencies were not right

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Updated the Dockerfile to use `ubuntu:22.04` as the base image instead of `ghcr.io/openms/contrib`.
- Removed the `CONTRIB_BUILD_DIR` argument and related commands, simplifying the build process.
- Added essential build dependencies such as `build-essential`, `cmake`, `autoconf`, `patch`, `libtool`, `git`, and `automake` to ensure compatibility with the new base image.
- Adjusted the `CMAKE_PREFIX_PATH` to remove references to the removed `CONTRIB_BUILD_DIR`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile to use Ubuntu 22.04 and streamline dependencies</code></dd></summary>
<hr>

dockerfiles/Dockerfile

<li>Replaced the base image from <code>ghcr.io/openms/contrib</code> to <code>ubuntu:22.04</code>.<br> <li> Removed unused <code>CONTRIB_BUILD_DIR</code> argument and related commands.<br> <li> Added new dependencies like <code>build-essential</code>, <code>cmake</code>, <code>autoconf</code>, <code>patch</code>, <br><code>libtool</code>, <code>git</code>, and <code>automake</code>.<br> <li> Updated <code>CMAKE_PREFIX_PATH</code> to remove references to <code>CONTRIB_BUILD_DIR</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7739/files#diff-7e7761f8246553fb5d6f4a5b1688554ad98b104abde757b174889dfdd8eec8f6">+10/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information