### PR TITLE
Use adhoc mac signing identity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,8 @@ is_valid_package(${PACKAGE_TYPE})
 if("${PACKAGE_TYPE}" STREQUAL "dmg" OR "${PACKAGE_TYPE}" STREQUAL "pkg")
   if (NOT DEFINED SIGNING_IDENTITY OR "${SIGNING_IDENTITY}" STREQUAL "" OR NOT DEFINED SIGNING_EMAIL OR "${SIGNING_EMAIL}" STREQUAL "")
     message(WARNING "Trying to create macOS package/image without SIGNING_IDENTITY and SIGNING_EMAIL being set. "
-                    "This disables notarization and might lead to problems with macOS' Gatekeeper on target machines.")
+                    "Using ad hoc (https://developer.apple.com/documentation/security/seccodesignatureflags/adhoc) identity.")
+    set(CPACK_BUNDLE_APPLE_CERT_APP "-")
   else()
     ## CPack has a special variable for the identity
     set(CPACK_BUNDLE_APPLE_CERT_APP "${SIGNING_IDENTITY}")


### PR DESCRIPTION
### **User description**
Treats the lack of SIGNING_IDENTITY or SIGNING_EMAIL as choosing to use the adhoc identity.

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Enhanced macOS package signing process by treating the absence of `SIGNING_IDENTITY` or `SIGNING_EMAIL` as opting for an ad hoc signing identity.
- Updated the warning message to inform users about the use of an ad hoc identity and its implications.
- Introduced a configuration change to set `CPACK_BUNDLE_APPLE_CERT_APP` to `"-"` when no signing identity or email is provided.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Enhance macOS package signing with ad hoc identity fallback</code></dd></summary>
<hr>

CMakeLists.txt

<li>Updated warning message to include information about using an ad hoc <br>signing identity.<br> <li> Added configuration to set <code>CPACK_BUNDLE_APPLE_CERT_APP</code> to <code>"-"</code> when <br>signing identity or email is not defined.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7740/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information