### PR TITLE
qt6: Update pyopenms-wheels.yml

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -39,9 +39,9 @@ jobs:
       id: cpu-cores
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
-        version: '5.12.6' # 5.12.7 is broken https://bugreports.qt.io/browse/QTBUG-81715
+        version: '6.*'
         host: 'windows' # default: win64_msvc2017_64
         target: 'desktop'
         install-deps: 'true'
@@ -85,12 +85,12 @@ jobs:
       shell: bash
       run: |
         PYTHON_VERSIONS=$(cat OpenMS/.github/workflows/python_versions.json)
-        CMAKE_PREFIX_PATH="$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}"
+        CMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}"
         #mkdir bld
         #pushd bld
         # TODO: set generator via variable, then we can share this step
         # cmake --version
-        # cmake -G "Visual Studio 17 2022" -A x64 -DOPENMS_CONTRIB_LIBS="$GITHUB_WORKSPACE/OpenMS/contrib" -DCMAKE_PREFIX_PATH="$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" ../OpenMS
+        # cmake -G "Visual Studio 17 2022" -A x64 -DOPENMS_CONTRIB_LIBS="$GITHUB_WORKSPACE/OpenMS/contrib" -DCMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" ../OpenMS
         # Note: multiple --targets only supported by CMake 3.15+
         # cmake --build . --config Release --target OpenMS
         
@@ -148,7 +148,7 @@ jobs:
           CMAKE_GENERATOR: "Visual Studio 17 2022"
           CMAKE_GENERATOR_PLATFORM: "x64"
           OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/OpenMS/contrib"
-          #CMAKE_PREFIX_PATH: "$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" #TODO move this to env
+          #CMAKE_PREFIX_PATH: "$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" #TODO move this to env
           BUILD_TYPE: "Release"
           CI_PROVIDER: "GitHub-Actions"
           CMAKE_CCACHE_EXE: "ccache"
@@ -227,7 +227,7 @@ jobs:
         brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
         brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5 libomp
         echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
-        echo "Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5" >> $GITHUB_ENV
+        echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
           brew install --quiet doxygen ghostscript graphviz
         fi
@@ -248,11 +248,11 @@ jobs:
         # Use -DCMAKE_FIND_DEBUG_MODE=ON for debug
 
         # export OpenMP_ROOT="$(brew --prefix libomp)"
-        export CMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_DIR)/lib/cmake;${Qt5_DIR}"
+        export CMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_DIR)/lib/cmake;${Qt6_DIR}"
 
         #ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake
 
-        #cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
+        #cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
         #make -j${{ steps.cpu-cores.outputs.count }} OpenMS
 
         mkdir pyopenms_whls
@@ -396,7 +396,7 @@ jobs:
         brew install --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
         brew install libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@5 libomp
         echo "cmake_prefix=$(brew --prefix qt@5)/lib/cmake;$(brew --prefix qt@5)" >> $GITHUB_OUTPUT
-        echo "Qt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5" >> $GITHUB_ENV
+        echo "Qt6_DIR=$(brew --prefix qt@5)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
           brew install --quiet doxygen ghostscript graphviz
         fi
@@ -412,12 +412,12 @@ jobs:
         export CFLAGS="-Xpreprocessor -fopenmp $CFLAGS"
         export CXXFLAGS="-Xpreprocessor -fopenmp $CXXFLAGS"
         # export OpenMP_ROOT="$(brew --prefix libomp)"
-        export CMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}"
+        export CMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}"
 
         #mkdir bld
         #pushd bld
         # Use -DCMAKE_FIND_DEBUG_MODE=ON for debug
-        #cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt5_Dir)/lib/cmake;${Qt5_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
+        #cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
         #make -j${{ steps.cpu-cores.outputs.count }} OpenMS
 
         mkdir pyopenms_whls


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Updated the GitHub Actions workflow in `pyopenms-wheels.yml` to use Qt6 instead of Qt5.
- Upgraded the `install-qt-action` to version 4 to support the new Qt version.
- Replaced all references to `Qt5_Dir` with `Qt6_Dir` to ensure compatibility with Qt6.
- Adjusted CMake configurations and environment variables to align with the new Qt version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyopenms-wheels.yml</strong><dd><code>Update GitHub Actions workflow to use Qt6</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pyopenms-wheels.yml

<li>Updated the <code>install-qt-action</code> GitHub Action to version 4.<br> <li> Changed Qt version from 5.12.6 to 6.* in the workflow.<br> <li> Replaced references to <code>Qt5_Dir</code> with <code>Qt6_Dir</code> throughout the file.<br> <li> Adjusted environment variables and CMake configurations to align with <br>Qt6.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7746/files#diff-084f20ae9727db0905c5fbbc32ef797e048c87887ccfc57b0f89b2bf82f45979">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information