### PR TITLE
https://bugreports.qt.io/browse/QTBUG-110118 marked as fixed in qt6 r…

### DIFF
--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -235,6 +235,18 @@ function(openms_add_library)
     set(has_dll_dep
             $<BOOL:$<TARGET_RUNTIME_DLLS:${openms_add_library_TARGET_NAME}>>
             )
+ ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
+  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
+
+  # TODO only works if WebEngineWidgets is the only optional component
+  set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)
+  if(Qt6WebEngineWidgets_FOUND)
+    list(APPEND OpenMS_GUI_QT_FOUND_COMPONENTS_OPT "WebEngineWidgets")
+  else()
+    message(WARNING "Qt6WebEngineWidgets not found or disabled, disabling JS Views in TOPPView!")
+  endif()
+
+
     set(none_command
             ${CMAKE_COMMAND} -E echo
             )

--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -235,18 +235,6 @@ function(openms_add_library)
     set(has_dll_dep
             $<BOOL:$<TARGET_RUNTIME_DLLS:${openms_add_library_TARGET_NAME}>>
             )
- ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
-  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
-
-  # TODO only works if WebEngineWidgets is the only optional component
-  set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)
-  if(Qt6WebEngineWidgets_FOUND)
-    list(APPEND OpenMS_GUI_QT_FOUND_COMPONENTS_OPT "WebEngineWidgets")
-  else()
-    message(WARNING "Qt6WebEngineWidgets not found or disabled, disabling JS Views in TOPPView!")
-  endif()
-
-
     set(none_command
             ${CMAKE_COMMAND} -E echo
             )

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -234,8 +234,6 @@ if (WITH_GUI)
     message(STATUS "Qt6Widgets not found!")
     message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt6Libs>' <src-dir>")
   ENDIF()
-  ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
-  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
 
   # TODO only works if WebEngineWidgets is the only optional component
   set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -234,6 +234,16 @@ if (WITH_GUI)
     message(STATUS "Qt6Widgets not found!")
     message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt6Libs>' <src-dir>")
   ENDIF()
+  ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
+  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
+
+  # TODO only works if WebEngineWidgets is the only optional component
+  set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)
+  if(Qt6WebEngineWidgets_FOUND)
+    list(APPEND OpenMS_GUI_QT_FOUND_COMPONENTS_OPT "WebEngineWidgets")
+  else()
+    message(WARNING "Qt6WebEngineWidgets not found or disabled, disabling JS Views in TOPPView!")
+  endif()
 
   set(OpenMS_GUI_DEP_LIBRARIES "OpenMS")
 

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -234,6 +234,7 @@ if (WITH_GUI)
     message(STATUS "Qt6Widgets not found!")
     message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt6Libs>' <src-dir>")
   ENDIF()
+  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT})
 
   # TODO only works if WebEngineWidgets is the only optional component
   set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -235,25 +235,6 @@ if (WITH_GUI)
     message(FATAL_ERROR "To find a custom Qt installation use: cmake <..more options..> -DCMAKE_PREFIX_PATH='<path_to_parent_folder_of_lib_folder_withAllQt6Libs>' <src-dir>")
   ENDIF()
 
-  ## QuickWidgets is a runtime-only dependency that we need to copy and install when WebEngine is found.
-  # https://gitlab.kitware.com/cmake/cmake/-/issues/16462
-  # https://bugreports.qt.io/browse/QTBUG-110118
-  find_package(Qt6 QUIET COMPONENTS ${OpenMS_GUI_QT_COMPONENTS_OPT} QuickWidgets)
-
-  # TODO only works if WebEngineWidgets is the only optional component
-  set(OpenMS_GUI_QT_FOUND_COMPONENTS_OPT)
-  if(Qt6WebEngineWidgets_FOUND)
-    list(APPEND OpenMS_GUI_QT_FOUND_COMPONENTS_OPT "WebEngineWidgets")
-    # we assume that it is available for now. They should have dependencies when installing Qt.
-    install(IMPORTED_RUNTIME_ARTIFACTS "Qt6::QuickWidgets"
-            DESTINATION "${INSTALL_LIB_DIR}"
-            RUNTIME_DEPENDENCY_SET OPENMS_GUI_DEPS
-            COMPONENT Dependencies)
-  else()
-    message(WARNING "Qt6WebEngineWidgets not found or disabled, disabling JS Views in TOPPView!")
-  endif()
-
-
   set(OpenMS_GUI_DEP_LIBRARIES "OpenMS")
 
   foreach(COMP IN LISTS OpenMS_GUI_QT_COMPONENTS)


### PR DESCRIPTION
### **User description**
Remove quickwidgets install call since the bug it resolves is reportedly closed.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the manual installation of `Qt6::QuickWidgets` as the bug it addressed (`QTBUG-110118`) is reportedly fixed in Qt6.
- Deleted conditional logic for `Qt6WebEngineWidgets` and associated warnings, simplifying the dependency management.
- Improved maintainability by removing unnecessary runtime dependency handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmake_findExternalLibs.cmake</strong><dd><code>Remove manual installation of QuickWidgets and related logic</code></dd></summary>
<hr>

cmake/cmake_findExternalLibs.cmake

<li>Removed the manual installation of <code>Qt6::QuickWidgets</code> as a runtime <br>dependency.<br> <li> Deleted the conditional logic for handling <code>Qt6WebEngineWidgets</code> and <br>associated warnings.<br> <li> Simplified the dependency management by removing unnecessary <br>components.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7751/files#diff-d93d6eef7cb6d735ad09c4de827e1cdcedbd9c701da39b72cdd9bb52f6a315d2">+0/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information