### PR TITLE
Choco's CMake 3.31.2 is bugged. Force use of 3.31.1

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -246,7 +246,7 @@ jobs:
         if [[ "${{ matrix.os }}" == windows-* ]]; then
           # QT_ROOT_DIR set by Install Qt step
           echo "cmake_prefix=$QT_ROOT_DIR/lib/cmake;$QT_ROOT_DIR" >> $GITHUB_OUTPUT
-          choco install ccache ninja cmake -y --no-progress
+          choco install ccache ninja cmake -y -v -d
           ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
           # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
           echo "C:\Program Files (x86)\GitHub CLI" >> $GITHUB_PATH

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -246,7 +246,8 @@ jobs:
         if [[ "${{ matrix.os }}" == windows-* ]]; then
           # QT_ROOT_DIR set by Install Qt step
           echo "cmake_prefix=$QT_ROOT_DIR/lib/cmake;$QT_ROOT_DIR" >> $GITHUB_OUTPUT
-          choco install ccache ninja cmake -y -v -d
+          choco install ccache ninja -y
+          choco install cmake --version=3.31.1 -y -v -d
           ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
           # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
           echo "C:\Program Files (x86)\GitHub CLI" >> $GITHUB_PATH

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -246,8 +246,8 @@ jobs:
         if [[ "${{ matrix.os }}" == windows-* ]]; then
           # QT_ROOT_DIR set by Install Qt step
           echo "cmake_prefix=$QT_ROOT_DIR/lib/cmake;$QT_ROOT_DIR" >> $GITHUB_OUTPUT
-          choco install ccache ninja -y
-          choco install cmake --version=3.31.1 -y -v -d
+          choco install ccache ninja -y --no-progress
+          choco install cmake --version=3.31.1 -y --no-progress
           ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
           # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
           echo "C:\Program Files (x86)\GitHub CLI" >> $GITHUB_PATH


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `choco install` command in the CI workflow to include verbose (`-v`) and debug (`-d`) flags for better debugging and output visibility.
- This change aims to improve the debugging process for the installation of tools like `ccache`, `ninja`, and `cmake` on Windows environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openms_ci_matrix_full.yml</strong><dd><code>Enhance `choco install` command with verbose and debug flags</code></dd></summary>
<hr>

.github/workflows/openms_ci_matrix_full.yml

<li>Modified the <code>choco install</code> command to include verbose (<code>-v</code>) and debug <br>(<code>-d</code>) flags.<br> <li> Adjusted the installation process for better debugging and output <br>visibility.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7752/files#diff-0be71f2159fab4dd562ae195019726d8ef93f807d2e9b91b67494e57c1419f1c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information