### PR TITLE
Feature/im peakpicking

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/IonMobilityScoring.h
@@ -18,8 +18,9 @@
 #include <OpenMS/KERNEL/Mobilogram.h>
 
 // scoring
-#include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h>
 
+#include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
 #include <vector>
 namespace OpenMS
 {
@@ -65,6 +66,7 @@ namespace OpenMS
       @param dia_extraction_ppm_ Whether m/z extraction width is in ppm
       @param use_spline Whether to use spline for fitting
       @param drift_extra Extend the extraction window to gain a larger field of view beyond drift_upper - drift_lower (in percent)
+      @param apply_im_peak_picking Apply peak picking on the ion mobilogram
     */
     static void driftScoring(const SpectrumSequence& spectra,
                              const std::vector<TransitionType> & transitions,
@@ -74,7 +76,8 @@ namespace OpenMS
                              const double dia_extraction_window_,
                              const bool dia_extraction_ppm_,
                              const bool use_spline,
-                             const double drift_extra);
+                             const double drift_extra,
+                             const bool apply_im_peak_picking);
 
     /**
       @brief Performs scoring of the ion mobility dimension in MS1
@@ -186,6 +189,56 @@ namespace OpenMS
     static void extractIntensities(const std::vector< Mobilogram >& mobilograms,
                                    std::vector<std::vector<double>>& int_values);
 
-  };
-}
+    
 
+  };
+
+  /*
+  @brief Helper function to sum up aligned mobilograms
+
+  This function takes a vector of aligned mobilograms and sums them up to create a single Mobilogram object. The resulting Mobilogram object will contain the sum of the intensity values from all the input mobilograms.
+
+  @param[in] aligned_mobilograms A vector of aligned mobilograms
+  @return  A Mobilogram object that is the sum of the input mobilograms
+  */
+  OpenMS::Mobilogram sumAlignedMobilograms(const std::vector<OpenMS::Mobilogram>& aligned_mobilograms);
+
+  /*
+  @brief Helper function to find the highest peak in a mobilogram
+
+  This function takes a PeakPickerMobilogram object and returns the left position, apex position, and right position of the highest peak in the mobilogram.
+
+  @param[in] picker A PeakPickerMobilogram object
+  @return A tuple containing the left position, apex position, and right position of the highest peak in the mobilogram
+  */
+  std::tuple<size_t, size_t, size_t> findHighestPeak(const PeakPickerMobilogram& picker);
+
+  /*
+  @brief Helper function to filter peak intensities in a mobilogram
+
+  This function takes a mobilogram and filters the peak intensities based on the left and right indices provided.
+
+  @note This function modifies the input mobilogram in place.
+
+  @param[in,out] mobilogram A Mobilogram object
+  @param[in] left_index The left index of the peak range to filter
+  @param[in] right_index The right index of the peak range to filter
+  */
+
+  void filterPeakIntensities(OpenMS::Mobilogram& mobilogram, size_t left_index, size_t right_index);
+
+  /*
+  @brief Helper function to filter peak intensities for a vector of mobilograms
+
+  This function takes a vector of mobilograms and filters the peak intensities based on the left and right indices provided.
+
+  @note This function modifies the input mobilograms in place.
+
+  @param[in,out] mobilograms A vector of Mobilogram objects
+  @param[in] left_index The left index of the peak range to filter
+  @param[in] right_index The right index of the peak range to filter
+  */
+  void filterPeakIntensities(std::vector<OpenMS::Mobilogram>& mobilograms, size_t left_index, size_t right_index);
+
+
+  } // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -263,6 +263,7 @@ private:
     bool write_convex_hull_;
     bool strict_;
     bool use_ms1_ion_mobility_;
+    bool apply_im_peak_picking_;
     String scoring_model_;
 
     // scoring parameters

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScores.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScores.h
@@ -94,8 +94,11 @@ namespace OpenMS
     double im_delta_score = 0;
     double im_ms1_delta_score = 0;
     double im_drift = 0;
+    double im_drift_left = 0;
+    double im_drift_right = 0;
     double im_drift_weighted = 0;
     double im_delta = -1;
+    double im_log_intensity = 0;
     double im_ms1_contrast_coelution = 0;
     double im_ms1_contrast_shape = 0;
     double im_ms1_sum_contrast_coelution = 0;

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -54,6 +54,7 @@ namespace OpenMS
     double im_drift_extra_pcnt_;
     OpenSwath_Scores_Usage su_;
     bool use_ms1_ion_mobility_; ///< whether to use MS1 ion mobility extraction in DIA scores
+    bool apply_im_peak_picking_; ///< whether to apply peak picking on ion mobilograms
     const std::string ION_MOBILITY_DESCRIPTION = "Ion Mobility";
 
   public:
@@ -75,6 +76,7 @@ namespace OpenMS
      * @param su Which scores to actually compute
      * @param spectrum_addition_method Method to use for spectrum addition (valid: "simple", "resample")
      * @param use_ms1_ion_mobility Use MS1 ion mobility extraction in DIA scores
+     * @param apply_im_peak_picking Apply peak picking on ion mobilograms
      *
     */
     void initialize(double rt_normalization_factor,
@@ -83,7 +85,8 @@ namespace OpenMS
                     const double drift_extra,
                     const OpenSwath_Scores_Usage & su,
                     const std::string& spectrum_addition_method,
-                    bool use_ms1_ion_mobility);
+                    bool use_ms1_ion_mobility,
+                    bool apply_im_peak_picking);
 
     /** @brief Score a single peakgroup in a chromatogram using only chromatographic properties.
      *

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
@@ -1,0 +1,140 @@
+// Copyright (c) 2002-present, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/CONCEPT/ProgressLogger.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/ChromatogramPeak.h>
+#include <OpenMS/KERNEL/Mobilogram.h>
+#include <OpenMS/KERNEL/MobilityPeak1D.h>
+
+#include <OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h>
+#include <OpenMS/PROCESSING/SMOOTHING/SavitzkyGolayFilter.h>
+#include <OpenMS/PROCESSING/SMOOTHING/GaussFilter.h>
+
+#include <OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h>
+#include <vector>
+
+namespace OpenMS
+{
+    /**
+    @brief The PeakPickerChromatogram finds peaks a single mobilogram.
+
+    @htmlinclude OpenMS_PeakPickerChromatogram.parameters
+
+    It uses the PeakPickerHiRes internally to find interesting seed candidates.
+    These candidates are then expanded and a right/left border of the peak is
+    searched.
+    Additionally, overlapping peaks can be removed.
+
+    */
+
+    class OPENMS_DLLAPI PeakPickerMobilogram :
+            public DefaultParamHandler
+    {
+    public:
+        //@{
+        /// Constructor
+        PeakPickerMobilogram();
+
+        /// Destructor
+        ~PeakPickerMobilogram() override {}
+        //@}
+
+        /// indices into FloatDataArrays of resulting picked mobilogram
+        enum FLOATINDICES { IDX_FWHM = 0, IDX_ABUNDANCE = 1, IDX_LEFTBORDER = 2, IDX_RIGHTBORDER = 3, SIZE_OF_FLOATINDICES };
+
+        /**
+            @brief Finds peaks in a single mobilogram and annotates left/right borders
+
+            It uses a modified algorithm of the PeakPickerHiRes
+
+            This function will return a picked mobilogram
+        */
+        void pickMobilogram(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram);
+
+        /**
+            @brief Finds peaks in a single mobilogram and annotates left/right borders
+
+            It uses a modified algorithm of the PeakPickerHiRes
+
+            This function will return a picked mobilogram and a smoothed mobilogram
+        */
+        void pickMobilogram(Mobilogram mobilogram, Mobilogram& picked_mobilogram, Mobilogram& smoothed_mobilogram);
+
+        /// Temporary vector to hold the integrated intensities
+        std::vector<double> integrated_intensities_;
+
+        /// Temporary vector to hold the peak left widths
+        std::vector<Size> left_width_;
+
+        /// Temporary vector to hold the peak right widths
+        std::vector<Size> right_width_;
+
+      protected:
+        void pickMobilogram_(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram);
+
+        /**
+          @brief Compute peak area (peak integration)
+        */
+        void integratePeaks_(const Mobilogram& mobilogram);
+
+        /**
+          @brief Helper function to find the closest peak in a mobilogram to "target_im"
+
+          The search will start from the index current_peak, so the function is
+          assuming the closest peak is to the right of current_peak.
+
+          It will return the index of the closest peak in the mobilogram.
+        */
+        Size findClosestPeak_(const Mobilogram& mobilogram, double target_im, Size current_peak = 0);
+
+        /**
+          @brief Helper function to remove overlapping peaks in a single Chromatogram
+
+        */
+        void removeOverlappingPeaks_(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram);
+
+        /// Synchronize members with param class
+        void updateMembers_() override;
+
+        // Members
+        /// Frame length for the SGolay smoothing
+        UInt sgolay_frame_length_;
+        /// Polynomial order for the SGolay smoothing
+        UInt sgolay_polynomial_order_;
+        /// Width of the Gaussian smoothing
+        double gauss_width_;
+        /// Whether to use Gaussian smoothing
+        bool use_gauss_;
+        /// Whether to resolve overlapping peaks
+        bool remove_overlapping_;
+
+        /// Forced peak with
+        double peak_width_;
+        /// Signal to noise threshold
+        double signal_to_noise_;
+
+        /// Signal to noise window length
+        double sn_win_len_;
+        /// Signal to noise bin count
+        UInt sn_bin_count_;
+        /// Whether to write out log messages of the SN estimator
+        bool write_sn_log_messages_;
+        /// Peak picker method
+        String method_;
+
+        PeakPickerHiRes pp_;
+        SavitzkyGolayFilter sgolay_;
+        GaussFilter gauss_;
+        SignalToNoiseEstimatorMedian<Mobilogram > snt_;
+    };
+}

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/sources.cmake
@@ -31,6 +31,7 @@ set(sources_list_h
   OpenSwathWorkflow.h
   PeakIntegrator.h
   PeakPickerChromatogram.h
+  PeakPickerMobilogram.h
   SwathMapMassCorrection.h
   SwathWindowLoader.h
   SwathQC.h

--- a/src/openms/include/OpenMS/KERNEL/MobilityPeak1D.h
+++ b/src/openms/include/OpenMS/KERNEL/MobilityPeak1D.h
@@ -128,6 +128,18 @@ namespace OpenMS
       position_ = position;
     }
 
+    /// Alias for getIM()
+    inline CoordinateType getMZ() const
+    {
+      return position_[0];
+    }
+
+    /// Alias for setIM()
+    inline void setMZ(CoordinateType im)
+    {
+      position_[0] = im;
+    }
+
     ///@}
 
     /// Equality operator

--- a/src/openms/include/OpenMS/KERNEL/Mobilogram.h
+++ b/src/openms/include/OpenMS/KERNEL/Mobilogram.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <OpenMS/KERNEL/MobilityPeak1D.h>
+#include <OpenMS/METADATA/MetaInfoDescription.h>
+#include <OpenMS/KERNEL/RangeManager.h>
+#include <OpenMS/METADATA/DataArrays.h>
 
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/KERNEL/RangeManager.h>
@@ -45,6 +48,15 @@ namespace OpenMS
     /// RangeManager
     using RangeManagerContainerType = RangeManagerContainer<RangeMobility, RangeIntensity>;
     using RangeManagerType = RangeManager<RangeMobility, RangeIntensity>;
+    /// Float data array vector type
+    typedef OpenMS::DataArrays::FloatDataArray FloatDataArray ;
+    typedef std::vector<FloatDataArray> FloatDataArrays;
+    /// String data array vector type
+    typedef OpenMS::DataArrays::StringDataArray StringDataArray ;
+    typedef std::vector<StringDataArray> StringDataArrays;
+    /// Integer data array vector type
+    typedef OpenMS::DataArrays::IntegerDataArray IntegerDataArray ;
+    typedef std::vector<IntegerDataArray> IntegerDataArrays;
     //@}
 
     ///@name Peak container iterator type definitions
@@ -232,6 +244,12 @@ namespace OpenMS
 
     ///@name Accessors for meta information
     ///@{
+    /// Returns the name
+    const String& getName() const;
+
+    /// Sets the name
+    void setName(const String& name);
+
     /// Returns the retention time (in seconds)
     double getRT() const noexcept
     {
@@ -262,6 +280,56 @@ namespace OpenMS
 
     //@}
 
+    /**
+      @name Peak data array methods
+
+      These methods are used to annotate each peak in a chromatogram with meta information.
+      It is an intermediate way between storing the information in the peak's MetaInfoInterface
+      and deriving a new peak type with members for this information.
+
+      These statements should help you chose which approach to use
+        - Access to meta info arrays is slower than to a member variable
+        - Access to meta info arrays is faster than to a %MetaInfoInterface
+        - Meta info arrays are stored when using mzML format for storing
+    */
+    ///@{
+    /// Returns a const reference to the float meta data arrays
+    const FloatDataArrays& getFloatDataArrays() const;
+
+    /// Returns a mutable reference to the float meta data arrays
+    FloatDataArrays& getFloatDataArrays();
+
+    /// Sets the float meta data arrays
+    void setFloatDataArrays(const FloatDataArrays& fda)
+    {
+      float_data_arrays_ = fda;
+    }
+
+    /// Returns a const reference to the string meta data arrays
+    const StringDataArrays& getStringDataArrays() const;
+
+    /// Returns a mutable reference to the string meta data arrays
+    StringDataArrays& getStringDataArrays();
+
+    /// Sets the string meta data arrays
+    void setStringDataArrays(const StringDataArrays& sda)
+    {
+      string_data_arrays_ = sda;
+    }
+
+    /// Returns a const reference to the integer meta data arrays
+    const IntegerDataArrays& getIntegerDataArrays() const;
+
+    /// Returns a mutable reference to the integer meta data arrays
+    IntegerDataArrays& getIntegerDataArrays();
+
+    /// Sets the integer meta data arrays
+    void setIntegerDataArrays(const IntegerDataArrays& ida)
+    {
+      integer_data_arrays_ = ida;
+    }
+
+    ///@}
 
     ///@name Sorting peaks
     //@{
@@ -515,8 +583,20 @@ namespace OpenMS
     /// Retention time
     double retention_time_ = -1;
 
+    /// Name
+    String name_;
+
     /// Drift time unit
     DriftTimeUnit drift_time_unit_ = DriftTimeUnit::NONE;
+
+    /// Float data arrays
+    FloatDataArrays float_data_arrays_;
+
+    /// String data arrays
+    StringDataArrays string_data_arrays_;
+
+    /// Integer data arrays
+    IntegerDataArrays integer_data_arrays_;
   };
 
   OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const Mobilogram& mb);

--- a/src/openms/include/OpenMS/KERNEL/StandardTypes.h
+++ b/src/openms/include/OpenMS/KERNEL/StandardTypes.h
@@ -14,6 +14,7 @@ namespace OpenMS
 {
   class MSSpectrum;
   class MSChromatogram;
+  class Mobilogram;
   class MSExperiment;
 
   //@{
@@ -39,6 +40,13 @@ namespace OpenMS
       @ingroup Kernel
   */
   typedef MSChromatogram Chromatogram;
+
+  /**
+      @brief Mobilogram consisting of raw data points or peaks
+    
+      @ingroup Kernel
+  */
+  typedef Mobilogram Mobilogram;
   //@}
 
 }

--- a/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h
@@ -19,6 +19,7 @@
 namespace OpenMS
 {
   class MSChromatogram;
+  class Mobilogram;
   class OnDiscMSExperiment;
 
   /**
@@ -90,6 +91,11 @@ public:
     void pick(const MSChromatogram& input, MSChromatogram& output) const;
 
     /**
+      @brief Applies the peak-picking algorithm to a map (Mobilogram). The resulting picked peaks are written to the output mobilogram.
+    */
+    void pick(const Mobilogram& input, Mobilogram& output) const;
+
+    /**
       @brief Applies the peak-picking algorithm to a single spectrum
       (MSSpectrum). The resulting picked peaks are written to the output
       spectrum. Peak boundaries are written to a separate structure.
@@ -111,6 +117,17 @@ public:
       @param check_spacings  check spacing constraints? (yes for spectra, no for chromatograms)
      */
     void pick(const MSChromatogram& input, MSChromatogram& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = false) const;
+
+    /**
+      @brief Applies the peak-picking algorithm to a single mobilogram
+      (Mobilogram). The resulting picked peaks are written to the output mobilogram.
+     
+      @param input  input mobilogram in profile mode
+      @param output  output mobilogram with picked peaks
+      @param boundaries  boundaries of the picked peaks
+      @param check_spacings  check spacing constraints? (yes for spectra, no for chromatogram and mobilogram)
+     */
+    void pick(const Mobilogram& input, Mobilogram& output, std::vector<PeakBoundary>& boundaries, bool check_spacings = false) const;
 
     /**
       @brief Applies the peak-picking algorithm to a map (MSExperiment). This

--- a/src/openms/include/OpenMS/PROCESSING/SMOOTHING/GaussFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/SMOOTHING/GaussFilter.h
@@ -63,6 +63,8 @@ public:
 
     void filter(MSChromatogram & chromatogram);
 
+    void filter(Mobilogram & mobilogram);
+
     /**
       @brief Smoothes an MSExperiment containing profile data.
 

--- a/src/openms/include/OpenMS/PROCESSING/SMOOTHING/SavitzkyGolayFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/SMOOTHING/SavitzkyGolayFilter.h
@@ -11,6 +11,7 @@
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/Mobilogram.h> 
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 namespace OpenMS
@@ -180,6 +181,19 @@ public:
       filter(chromatogram.begin(), chromatogram.end(), output.begin());
       // swap back
       std::swap(chromatogram, output);
+    }
+
+    /**
+      @brief Removed the noise from an Mobilogram
+    */
+    void filter(Mobilogram & mobilogram)
+    {
+      // copy the data AND META DATA to the output container
+      Mobilogram output = mobilogram;
+      // filter
+      filter(mobilogram.begin(), mobilogram.end(), output.begin());
+      // swap back
+      std::swap(mobilogram, output);
     }
 
     /**

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -903,7 +903,10 @@ namespace OpenMS
           mrmfeature.addScore("var_im_delta_score", scores.im_delta_score);
           mrmfeature.addScore("var_im_ms1_delta_score", scores.im_ms1_delta_score);
           mrmfeature.addScore("im_drift", scores.im_drift); // MS2 level
+          mrmfeature.addScore("im_drift_left", scores.im_drift_left); // MS2 level
+          mrmfeature.addScore("im_drift_right", scores.im_drift_right); // MS2 level
           mrmfeature.addScore("im_drift_weighted", scores.im_drift_weighted); // MS2 level
+          mrmfeature.addScore("im_log_intensity", scores.im_log_intensity); // MS2 level
           mrmfeature.addScore("im_ms1_drift", scores.im_ms1_drift); // MS1 level
           mrmfeature.addScore("im_ms1_delta", scores.im_ms1_delta); // MS1 level
           mrmfeature.addScore("im_delta", scores.im_delta); // MS2 level

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -85,6 +85,8 @@ namespace OpenMS
     defaults_.setValue("strict", "true", "Whether to error (true) or skip (false) if a transition in a transition group does not have a corresponding chromatogram.", {"advanced"});
     defaults_.setValidStrings("strict", {"true","false"});
     defaults_.setValue("use_ms1_ion_mobility", "true", "Performs ion mobility extraction in MS1. Set to false if MS1 spectra do not contain ion mobility", {"advanced"});
+    defaults_.setValue("apply_im_peak_picking", "true", "Whether to apply peaking picking on the ion mobilograms.", {"advanced"});
+    defaults_.setValidStrings("apply_im_peak_picking", {"true","false"});
 
     defaults_.insert("TransitionGroupPicker:", MRMTransitionGroupPicker().getDefaults());
 
@@ -549,7 +551,8 @@ namespace OpenMS
                       im_extra_drift_,
                       su_,
                       spectrum_addition_method_,
-                      use_ms1_ion_mobility_);
+                      use_ms1_ion_mobility_,
+                      apply_im_peak_picking_);
 
     ProteaseDigestion pd;
     pd.setEnzyme("Trypsin");
@@ -1030,6 +1033,7 @@ namespace OpenMS
     emgscoring_.setFitterParam(param_.copy("EMGScoring:", true));
     strict_ = (bool)param_.getValue("strict").toBool();
     use_ms1_ion_mobility_ = (bool)param_.getValue("use_ms1_ion_mobility").toBool();
+    apply_im_peak_picking_ = (bool)param_.getValue("apply_im_peak_picking").toBool();
 
     su_.use_coelution_score_     = param_.getValue("Scores:use_coelution_score").toBool();
     su_.use_shape_score_         = param_.getValue("Scores:use_shape_score").toBool();

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -47,7 +47,9 @@ namespace OpenMS
       "NORM_RT REAL NOT NULL," \
       "DELTA_RT REAL NOT NULL," \
       "LEFT_WIDTH REAL NOT NULL," \
-      "RIGHT_WIDTH REAL NOT NULL); " \
+      "RIGHT_WIDTH REAL NOT NULL," \
+      "EXP_IM_LEFTWIDTH REAL," \
+      "EXP_IM_RIGHTWIDTH REAL); " \
 
       // MS1-level scores
       "CREATE TABLE FEATURE_MS1(" \
@@ -77,6 +79,8 @@ namespace OpenMS
       "TOTAL_AREA_INTENSITY REAL NOT NULL," \
       "APEX_INTENSITY REAL NOT NULL," \
       "EXP_IM REAL," \
+      "EXP_IM_LEFTWIDTH REAL," \
+      "EXP_IM_RIGHTWIDTH REAL," \
       "DELTA_IM REAL," \
       "TOTAL_MI REAL NULL," \
       "VAR_BSERIES_SCORE REAL NULL," \
@@ -107,7 +111,8 @@ namespace OpenMS
 
       "VAR_IM_XCORR_SHAPE REAL NULL," \
       "VAR_IM_XCORR_COELUTION REAL NULL," \
-      "VAR_IM_DELTA_SCORE REAL NULL);" \
+      "VAR_IM_DELTA_SCORE REAL NULL," \
+      "VAR_IM_LOG_INTENSITY REAL NULL);" \
 
       "CREATE TABLE FEATURE_PRECURSOR(" \
       "FEATURE_ID INT NOT NULL," \
@@ -294,7 +299,7 @@ namespace OpenMS
       if (feature_it.metaValueExists("norm_RT") ) norm_rt = feature_it.getMetaValue("norm_RT");
       if (feature_it.metaValueExists("delta_rt") ) delta_rt = feature_it.getMetaValue("delta_rt");
 
-      sql_feature << "INSERT INTO FEATURE (ID, RUN_ID, PRECURSOR_ID, EXP_RT, EXP_IM, NORM_RT, DELTA_RT, LEFT_WIDTH, RIGHT_WIDTH) VALUES ("
+      sql_feature << "INSERT INTO FEATURE (ID, RUN_ID, PRECURSOR_ID, EXP_RT, EXP_IM, NORM_RT, DELTA_RT, LEFT_WIDTH, RIGHT_WIDTH, EXP_IM_LEFTWIDTH, EXP_IM_RIGHTWIDTH) VALUES ("
                   << feature_id << ", "
                   << run_id_ << ", "
                   << id << ", "
@@ -303,10 +308,12 @@ namespace OpenMS
                   << norm_rt << ", "
                   << delta_rt << ", "
                   << feature_it.getMetaValue("leftWidth") << ", "
-                  << feature_it.getMetaValue("rightWidth") << "); ";
+                  << feature_it.getMetaValue("rightWidth") << ", "
+                  << getScore(feature_it, "im_drift_left") << ", "
+                  << getScore(feature_it, "im_drift_right") << "); ";
 
       sql_feature_ms2 << "INSERT INTO FEATURE_MS2 " \
-        "(FEATURE_ID, AREA_INTENSITY, TOTAL_AREA_INTENSITY, APEX_INTENSITY, EXP_IM, DELTA_IM, TOTAL_MI, "\
+        "(FEATURE_ID, AREA_INTENSITY, TOTAL_AREA_INTENSITY, APEX_INTENSITY, EXP_IM, EXP_IM_LEFTWIDTH, EXP_IM_RIGHTWIDTH, DELTA_IM, TOTAL_MI, "\
         "VAR_BSERIES_SCORE, VAR_DOTPROD_SCORE, VAR_INTENSITY_SCORE, " \
         "VAR_ISOTOPE_CORRELATION_SCORE, VAR_ISOTOPE_OVERLAP_SCORE, VAR_LIBRARY_CORR,  "\
         "VAR_LIBRARY_DOTPROD, VAR_LIBRARY_MANHATTAN, VAR_LIBRARY_RMSD, VAR_LIBRARY_ROOTMEANSQUARE, "\
@@ -314,13 +321,15 @@ namespace OpenMS
         "VAR_MI_SCORE, VAR_MI_WEIGHTED_SCORE, VAR_MI_RATIO_SCORE, VAR_NORM_RT_SCORE, "\
         "VAR_XCORR_COELUTION,VAR_XCORR_COELUTION_WEIGHTED, VAR_XCORR_SHAPE, "\
         "VAR_XCORR_SHAPE_WEIGHTED, VAR_YSERIES_SCORE, VAR_ELUTION_MODEL_FIT_SCORE, "\
-        "VAR_IM_XCORR_SHAPE, VAR_IM_XCORR_COELUTION, VAR_IM_DELTA_SCORE"
+        "VAR_IM_XCORR_SHAPE, VAR_IM_XCORR_COELUTION, VAR_IM_DELTA_SCORE, VAR_IM_LOG_INTENSITY"
         << ") VALUES ("
                       << feature_id << ", "
                       << feature_it.getIntensity() << ", "
                       << getScore(feature_it, "total_xic") << ", "
                       << getScore(feature_it, "peak_apices_sum") << ", "
                       << getScore(feature_it, "im_drift") << ", "
+                      << getScore(feature_it, "im_drift_left") << ", "
+                      << getScore(feature_it, "im_drift_right") << ", "
                       << getScore(feature_it, "im_delta") << ", "
                       << getScore(feature_it, "total_mi") << ", "
                       << getScore(feature_it, "var_bseries_score") << ", "
@@ -350,7 +359,8 @@ namespace OpenMS
                       << getScore(feature_it, "var_elution_model_fit_score") << ", "
                       << getScore(feature_it, "var_im_xcorr_shape") << ", "
                       << getScore(feature_it, "var_im_xcorr_coelution") << ", "
-                      << getScore(feature_it, "var_im_delta_score");
+                      << getScore(feature_it, "var_im_delta_score") << ", "
+                      << getScore(feature_it, "im_log_intensity");
       sql_feature_ms2 << "); ";
 
       bool enable_ms1 = feature_it.metaValueExists("var_ms1_ppm_diff");

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
@@ -45,7 +45,8 @@ namespace OpenMS
                                     const double drift_extra,
                                     const OpenSwath_Scores_Usage & su,
                                     const std::string& spectrum_addition_method,
-                                    bool use_ms1_ion_mobility)
+                                    bool use_ms1_ion_mobility,
+                                    bool apply_im_peak_picking)
   {
     this->rt_normalization_factor_ = rt_normalization_factor;
     this->add_up_spectra_ = add_up_spectra;
@@ -66,6 +67,7 @@ namespace OpenMS
     this->spacing_for_spectra_resampling_ = spacing_for_spectra_resampling;
     this->su_ = su;
     this->use_ms1_ion_mobility_ = use_ms1_ion_mobility;
+    this->apply_im_peak_picking_ = apply_im_peak_picking;
   }
 
   void OpenSwathScoring::calculateDIAScores(OpenSwath::IMRMFeature* imrmfeature,
@@ -100,7 +102,7 @@ namespace OpenMS
       IonMobilityScoring::driftScoring(spectra, transitions, scores,
                                        drift_target, im_range,
                                        dia_extract_window_, dia_extraction_ppm_,
-                                       false, im_drift_extra_pcnt_);
+                                       false, im_drift_extra_pcnt_, apply_im_peak_picking_);
     }
 
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
@@ -1,0 +1,510 @@
+// Copyright (c) 2002-present, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h>
+#include <iostream>
+#include <iomanip>    // For std::setw
+#include <vector>
+#include <algorithm>  // For std::min_element and std::max_element
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+
+namespace OpenMS
+{
+    PeakPickerMobilogram::PeakPickerMobilogram() :
+            DefaultParamHandler("PeakPickerMobilogram")
+//            ProgressLogger()
+    {
+        defaults_.setValue("sgolay_frame_length", 9, "The number of subsequent data points used for smoothing.\nThis number has to be uneven. If it is not, 1 will be added.");
+        defaults_.setValue("sgolay_polynomial_order", 3, "Order of the polynomial that is fitted.");
+        defaults_.setValue("gauss_width", 0.002, "Gaussian width in seconds, estimated peak size.");
+        defaults_.setValue("use_gauss", "true", "Use Gaussian filter for smoothing (alternative is Savitzky-Golay filter)");
+        defaults_.setValidStrings("use_gauss", {"false","true"});
+
+        defaults_.setValue("peak_width", -1.0, "Force a certain minimal peak_width on the data (e.g. extend the peak at least by this amount on both sides) in seconds. -1 turns this feature off.");
+        defaults_.setValue("signal_to_noise", 1.0, "Signal-to-noise threshold at which a peak will not be extended any more. Note that setting this too high (e.g. 1.0) can lead to peaks whose flanks are not fully captured.");
+        defaults_.setMinFloat("signal_to_noise", 0.0);
+
+        defaults_.setValue("sn_win_len", 1, "Signal to noise window length.");
+        defaults_.setValue("sn_bin_count", 4, "Signal to noise bin count.");
+        defaults_.setValue("write_sn_log_messages", "false", "Write out log messages of the signal-to-noise estimator in case of sparse windows or median in rightmost histogram bin");
+        defaults_.setValidStrings("write_sn_log_messages", {"true","false"});
+
+        defaults_.setValue("remove_overlapping_peaks", "false", "Try to remove overlapping peaks during peak picking");
+        defaults_.setValidStrings("remove_overlapping_peaks", {"false","true"});
+
+        defaults_.setValue("method", "corrected", "Which method to choose for mobilogram peak-picking (OpenSWATH legacy on raw data, corrected picking on smoothed mobilogram).");
+        defaults_.setValidStrings("method", {"legacy","corrected","crawdad"});
+
+        // write defaults into Param object param_
+        defaultsToParam_();
+        updateMembers_();
+
+        // PeakPickerHiRes pp_;
+        Param pepi_param = pp_.getDefaults();
+        pepi_param.setValue("signal_to_noise", signal_to_noise_);
+        // disable spacing constraints, since we're dealing with chromatograms
+        pepi_param.setValue("spacing_difference", 0.0);
+        pepi_param.setValue("spacing_difference_gap", 0.0);
+        pepi_param.setValue("report_FWHM", "true");
+        pepi_param.setValue("report_FWHM_unit", "absolute");
+        pp_.setParameters(pepi_param);
+    }
+
+#include <iostream>
+#include <iomanip>  // For std::setw
+#include <vector>
+#include <algorithm>  // For std::min_element and std::max_element
+
+    void plotMobilogram(const OpenMS::Mobilogram& mobilogram, int height = 10, int width = 50) {
+      if (mobilogram.empty()) {
+        std::cout << "Mobilogram is empty.\n";
+        return;
+      }
+
+      std::vector<double> intensities;
+      std::vector<double> positions;
+
+      for (const auto& peak : mobilogram) {
+        intensities.push_back(peak.getIntensity());
+        positions.push_back(peak.getPosition()[0]);
+      }
+
+      if (intensities.empty() || positions.empty()) {
+        std::cout << "No valid data in mobilogram.\n";
+        return;
+      }
+
+      double min_intensity = *std::min_element(intensities.begin(), intensities.end());
+      double max_intensity = *std::max_element(intensities.begin(), intensities.end());
+      double min_position = *std::min_element(positions.begin(), positions.end());
+      double max_position = *std::max_element(positions.begin(), positions.end());
+
+      if (min_intensity == max_intensity) {
+        std::cout << "All intensities are the same: " << min_intensity << "\n";
+        return;
+      }
+
+      if (min_position == max_position) {
+        std::cout << "All positions are the same: " << min_position << "\n";
+        return;
+      }
+
+      std::vector<std::vector<char>> plot(height, std::vector<char>(width, ' '));
+      std::vector<int> index_map(width, -1);
+
+      for (size_t i = 0; i < intensities.size(); ++i) {
+        double normalized_intensity = (intensities[i] - min_intensity) / (max_intensity - min_intensity);
+        double normalized_position = (positions[i] - min_position) / (max_position - min_position);
+
+        int y = static_cast<int>(std::floor(normalized_intensity * (height - 1)));
+        int x = static_cast<int>(std::floor(normalized_position * (width - 1)));
+
+        if (y >= 0 && y < height && x >= 0 && x < width) {
+          plot[height - 1 - y][x] = '*';
+          index_map[x] = i;
+        }
+      }
+
+      // Plot mobilogram with fixed-width formatting for alignment
+      std::cout << "Mobilogram (max intensity: " << max_intensity << ")\n";
+      for (const auto& row : plot) {
+        for (char c : row) {
+          std::cout << std::setw(2) << c;  // Ensure consistent width for each character
+        }
+        std::cout << '\n';
+      }
+
+      // Print indices below the intensity plot with a separator
+      for (int idx : index_map) {
+        if (idx != -1) {
+          std::cout << std::setw(2) << idx << "-";  // Use "-" as separator between numbers
+        } else {
+          std::cout << "-";  // Ensure spacing and separator when no index is available
+        }
+      }
+      std::cout << '\n';
+
+      // Add a line to separate the plot and the index
+      std::cout << std::string(width * 2, '-') << '\n';  // Adjust width of separator line
+      std::cout << "Position range: " << min_position << " - " << max_position << "\n";
+    }
+
+    void writeMobilogramToCSV(const OpenMS::Mobilogram& mobilogram, const std::string& filename) {
+      std::ofstream outFile(filename, std::ios::app);  // Open file in append mode
+
+      if (!outFile.is_open()) {
+        std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
+        return;
+      }
+
+      // Write header if the file is empty
+      outFile.seekp(0, std::ios::end);
+      if (outFile.tellp() == 0) {
+        outFile << "Name,Mobility,Intensity" << std::endl;
+      }
+
+      // Write data
+      for (size_t i = 0; i < mobilogram.size(); ++i) {
+        const auto& peak = mobilogram[i];
+        outFile << mobilogram.getName() << ","
+                << peak.getMobility() << ","
+                << peak.getIntensity() << std::endl;
+      }
+
+      outFile.close();
+
+//      std::cout << "Mobilogram data appended to " << filename << std::endl;
+    }
+
+    void writeIntegratedDataToCSV(const OpenMS::Mobilogram& mobilogram,
+                                  const std::vector<double>& integrated_intensities,
+                                  const std::vector<Size>& left_width,
+                                  const std::vector<Size>& right_width,
+                                  const std::string& filename)
+    {
+      std::ofstream outFile(filename, std::ios::app);  // Open file in append mode
+
+      if (!outFile.is_open())
+      {
+        std::cerr << "Error: Could not open file " << filename << " for writing." << std::endl;
+        return;
+      }
+
+      // Write header if the file is empty
+      outFile.seekp(0, std::ios::end);
+      if (outFile.tellp() == 0) {
+        outFile << "Name,Index,Integrated_Intensity,Left_Width,Right_Width,Left_Mobility,Right_Mobility" << std::endl;
+      }
+
+      // Write data
+      for (Size i = 0; i < integrated_intensities.size(); i++)
+      {
+        outFile << mobilogram.getName() << ","
+                << i << ","
+                << std::fixed << std::setprecision(4) << integrated_intensities[i] << ","
+                << left_width[i] << ","
+                << right_width[i] << ","
+                << std::fixed << std::setprecision(6) << mobilogram[left_width[i]].getMobility() << ","
+                << std::fixed << std::setprecision(6) << mobilogram[right_width[i]].getMobility()
+                << std::endl;
+      }
+
+      outFile.close();
+
+//      std::cout << "Integrated data appended to " << filename << std::endl;
+    }
+
+    std::string generateRandomID(size_t length) {
+      const char charset[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+      std::random_device rd;  // Obtain a random number from hardware
+      std::mt19937 generator(rd());  // Seed the generator
+      std::uniform_int_distribution<> distribution(0, sizeof(charset) - 2); // Exclude the null terminator
+
+      std::string randomID;
+      for (size_t i = 0; i < length; ++i) {
+        randomID += charset[distribution(generator)];
+      }
+      return randomID;
+    }
+
+
+    void PeakPickerMobilogram::pickMobilogram(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram)
+    {
+      Mobilogram s;
+      pickMobilogram(mobilogram, picked_mobilogram, s);
+    }
+
+    void PeakPickerMobilogram::pickMobilogram(Mobilogram mobilogram, Mobilogram& picked_mobilogram, Mobilogram& smoothed_mobilogram)
+    {
+      if (!mobilogram.isSorted())
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Mobilogram needs to be sorted by position.");
+      }
+
+      if (mobilogram.empty())
+      {
+          OPENMS_LOG_DEBUG << " ====  Mobilogram empty. Skip picking.";
+          return;
+      }
+      else
+      {
+        OPENMS_LOG_DEBUG << " ====  Picking mobilogram for " << mobilogram.getName() << " at RT " << mobilogram.getRT() <<
+        " with " << mobilogram.size() << " peaks (start at IM " << mobilogram[0].getMobility() << " to IM " << mobilogram.back().getMobility() << ") "
+        "using method \'" << method_ << "\'" << std::endl;
+      }
+      picked_mobilogram.clear();
+
+      // Generate a random ID and concatenate it with the names
+      std::string concatenated_name;
+      concatenated_name += mobilogram.getName();
+      // Append a random unique ID
+      std::string randomID = generateRandomID(8); // Generate an 8-character ID
+      concatenated_name += ";" + randomID;
+
+      // Set the concatenated name for the summed mobilogram
+      mobilogram.setName(concatenated_name);
+
+      // Smooth the mobilogram
+      smoothed_mobilogram = mobilogram;
+//      Mobilogram smoothed_mobilogram_gauss;
+//      smoothed_mobilogram_gauss = mobilogram;
+      if (!use_gauss_)
+      {
+          sgolay_.filter(smoothed_mobilogram);
+//          gauss_.filter(smoothed_mobilogram);
+      }
+      else
+      {
+          gauss_.filter(smoothed_mobilogram);
+      }
+
+//      plotMobilogram(mobilogram);
+//      writeMobilogramToCSV(mobilogram, "mobilogram_raw_data.csv");
+//      plotMobilogram(smoothed_mobilogram);
+//      writeMobilogramToCSV(smoothed_mobilogram_gauss, "mobilogram_sgolay_smooth_data.csv");
+//      writeMobilogramToCSV(smoothed_mobilogram, "mobilogram_gauss_smooth_data.csv");
+      // Find initial seeds (peak picking)
+      pp_.pick(smoothed_mobilogram, picked_mobilogram);
+//      std::cout << "Picked " << picked_mobilogram.size() << " mobilogram peaks." << std::endl;
+
+      if (method_ == "legacy")
+      {
+        // Legacy is to use the original chromatogram for peak-detection
+        pickMobilogram_(mobilogram, picked_mobilogram);
+        if (remove_overlapping_)
+          removeOverlappingPeaks_(mobilogram, picked_mobilogram);
+
+        // for peak integration, we want to use the raw data
+        integratePeaks_(mobilogram);
+      }
+      else if (method_ == "corrected")
+      {
+        // use the smoothed chromatogram to derive the peak boundaries
+        pickMobilogram_(smoothed_mobilogram, picked_mobilogram);
+        if (remove_overlapping_)
+          removeOverlappingPeaks_(smoothed_mobilogram, picked_mobilogram);
+
+        // for peak integration, we want to use the raw data
+        integratePeaks_(mobilogram);
+      }
+
+//      // Store the result in the picked_chromatogram
+//      OPENMS_POSTCONDITION(picked_mobilogram.getFloatDataArrays().size() == 1 &&
+//                             picked_mobilogram.getFloatDataArrays()[IDX_FWHM].getName() == "FWHM", "Swath: PeakPicking did not deliver FWHM attributes.")
+
+      picked_mobilogram.getFloatDataArrays().resize(SIZE_OF_FLOATINDICES);
+      picked_mobilogram.getFloatDataArrays()[IDX_ABUNDANCE].setName("IntegratedIntensity");
+      picked_mobilogram.getFloatDataArrays()[IDX_LEFTBORDER].setName("leftWidth");
+      picked_mobilogram.getFloatDataArrays()[IDX_RIGHTBORDER].setName("rightWidth");
+      // just copy FWHM from initial peak picking
+//      std::cout << "Size of picked_mobilogram: " << picked_mobilogram.size() << std::endl;
+      picked_mobilogram.getFloatDataArrays()[IDX_ABUNDANCE].reserve(picked_mobilogram.size());
+      picked_mobilogram.getFloatDataArrays()[IDX_LEFTBORDER].reserve(picked_mobilogram.size());
+      picked_mobilogram.getFloatDataArrays()[IDX_RIGHTBORDER].reserve(picked_mobilogram.size());
+      for (Size i = 0; i < picked_mobilogram.size(); i++)
+      {
+//        std::cout << "Size of picked_mobilogram: " << picked_mobilogram.size() << " integrated_intensitie: " << integrated_intensities_[i] << " left_width: " << left_width_[i] << " right_width: " << right_width_[i] << std::endl;
+        picked_mobilogram.getFloatDataArrays()[IDX_ABUNDANCE].push_back(integrated_intensities_[i]);
+        picked_mobilogram.getFloatDataArrays()[IDX_LEFTBORDER].push_back((float)mobilogram[left_width_[i]].getMobility());
+        picked_mobilogram.getFloatDataArrays()[IDX_RIGHTBORDER].push_back((float)mobilogram[right_width_[i]].getMobility());
+      }
+//      writeIntegratedDataToCSV(mobilogram, integrated_intensities_, left_width_, right_width_, "peak_picking_data.csv");
+
+    }
+
+    void PeakPickerMobilogram::pickMobilogram_(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram)
+    {
+
+        integrated_intensities_.clear();
+        left_width_.clear();
+        right_width_.clear();
+        integrated_intensities_.reserve(picked_mobilogram.size());
+        left_width_.reserve(picked_mobilogram.size());
+        right_width_.reserve(picked_mobilogram.size());
+
+//        if (signal_to_noise_ > 0.0)
+//        {
+//          snt_.init(mobilogram);
+//        }
+        Size current_peak = 0;
+        for (Size i = 0; i < picked_mobilogram.size(); i++)
+        {
+          const double central_peak_rt = picked_mobilogram[i].getMobility();
+          current_peak = findClosestPeak_(mobilogram, central_peak_rt, current_peak);
+          const Size min_i = current_peak;
+
+          // peak core found, now extend it to the left
+          Size k = 2;
+          while ((min_i - k + 1) > 0
+                 //&& std::fabs(chromatogram[min_i-k].getMZ() - peak_raw_data.begin()->first) < spacing_difference*min_spacing
+                 && (mobilogram[min_i - k].getIntensity() < mobilogram[min_i - k + 1].getIntensity()
+                     || (peak_width_ > 0.0 && std::fabs(mobilogram[min_i - k].getMobility() - central_peak_rt) < peak_width_)))
+//                 && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(min_i - k) >= signal_to_noise_))
+          {
+            ++k;
+          }
+          int left_idx = min_i - k + 1;
+
+          // to the right
+          k = 2;
+          while ((min_i + k) < mobilogram.size()
+                 //&& std::fabs(chromatogram[min_i+k].getMZ() - peak_raw_data.rbegin()->first) < spacing_difference*min_spacing
+                 && (mobilogram[min_i + k].getIntensity() < mobilogram[min_i + k - 1].getIntensity()
+                     || (peak_width_ > 0.0 && std::fabs(mobilogram[min_i + k].getMobility() - central_peak_rt) < peak_width_)))
+//                 && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(min_i + k) >= signal_to_noise_) )
+          {
+            ++k;
+          }
+          int right_idx = min_i + k - 1;
+
+          left_width_.push_back(left_idx);
+          right_width_.push_back(right_idx);
+          integrated_intensities_.push_back(0);
+
+          OPENMS_LOG_DEBUG << "Found peak at " << central_peak_rt << " with intensity "  << picked_mobilogram[i].getIntensity()
+                           << " and borders " << mobilogram[left_width_[i]].getMobility() << " " << mobilogram[right_width_[i]].getMobility() <<
+            " (" << mobilogram[right_width_[i]].getMobility() - mobilogram[left_width_[i]].getMobility() << ") "
+                           << 0 << " weighted IM " << /* weighted_mz << */ std::endl;
+        }
+
+    }
+
+    void PeakPickerMobilogram::integratePeaks_(const Mobilogram& mobilogram)
+    {
+      for (Size i = 0; i < left_width_.size(); i++)
+      {
+        const int current_left_idx = left_width_[i];
+        const int current_right_idx = right_width_[i];
+
+        // Also integrate the intensities
+        integrated_intensities_[i] = 0;
+        for (int k = current_left_idx; k <= current_right_idx; k++)
+        {
+          integrated_intensities_[i] += mobilogram[k].getIntensity();
+        }
+      }
+    }
+
+    Size PeakPickerMobilogram::findClosestPeak_(const Mobilogram& mobilogram, double target_im, Size current_peak)
+    {
+      while (current_peak < mobilogram.size())
+      {
+        // check if we have walked past the RT of the peak
+        if (target_im < mobilogram[current_peak].getMobility())
+        {
+          // see which one is closer, the current one or the one before
+          if (current_peak > 0 &&
+              std::fabs(target_im - mobilogram[current_peak - 1].getMobility()) <
+                std::fabs(target_im - mobilogram[current_peak].getMobility()))
+          {
+            current_peak--;
+          }
+
+          return current_peak;
+        }
+        current_peak++;
+      }
+      return current_peak;
+    }
+
+    void PeakPickerMobilogram::removeOverlappingPeaks_(const Mobilogram& mobilogram, Mobilogram& picked_mobilogram)
+    {
+      if (picked_mobilogram.empty()) {return; }
+      OPENMS_LOG_DEBUG << "Remove overlapping peaks now (size " << picked_mobilogram.size() << ")" << std::endl;
+      Size current_peak = 0;
+      // Find overlapping peaks
+      for (Size i = 0; i < picked_mobilogram.size() - 1; i++)
+      {
+        // Check whether the current right overlaps with the next left
+        // See whether we can correct this and find some border between the two
+        // features ...
+        if (right_width_[i] > left_width_[i + 1])
+        {
+          const int current_left_idx = left_width_[i];
+          const int current_right_idx = right_width_[i];
+          const int next_left_idx = left_width_[i + 1];
+          const int next_right_idx = right_width_[i + 1];
+          OPENMS_LOG_DEBUG << " Found overlapping " << i << " : " << current_left_idx << " " << current_right_idx << std::endl;
+          OPENMS_LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << std::endl;
+
+          // Find the peak width and best RT
+          double central_peak_mz = picked_mobilogram[i].getMobility();
+          double next_peak_mz = picked_mobilogram[i + 1].getMobility();
+          current_peak = findClosestPeak_(mobilogram, central_peak_mz, current_peak);
+          Size next_peak = findClosestPeak_(mobilogram, next_peak_mz, current_peak);
+
+          // adjust the right border of the current and left border of next
+          Size k = 1;
+          while ((current_peak + k) < mobilogram.size()
+                 && (mobilogram[current_peak + k].getIntensity() < mobilogram[current_peak + k - 1].getIntensity()))
+          {
+            ++k;
+          }
+          Size new_right_border = current_peak + k - 1;
+          k = 1;
+          while ((next_peak - k + 1) > 0
+                 && (mobilogram[next_peak - k].getIntensity() < mobilogram[next_peak - k + 1].getIntensity()))
+          {
+            ++k;
+          }
+          Size new_left_border = next_peak - k + 1;
+
+          // assert that the peaks are now not overlapping any more ...
+          if (new_left_border < new_right_border)
+          {
+            std::cerr << "Something went wrong, peaks are still overlapping!" << " - new left border " << new_left_border << " vs " << new_right_border << " -- will take the mean" << std::endl;
+            new_left_border = (new_left_border + new_right_border) / 2;
+            new_right_border = (new_left_border + new_right_border) / 2;
+
+          }
+
+          OPENMS_LOG_DEBUG << "New peak l: " << mobilogram[current_left_idx].getMobility() << " " << mobilogram[new_right_border].getMobility() << " int " << integrated_intensities_[i] << std::endl;
+          OPENMS_LOG_DEBUG << "New peak r: " << mobilogram[new_left_border].getMobility() << " " << mobilogram[next_right_idx].getMobility() << " int " << integrated_intensities_[i + 1] << std::endl;
+
+
+          right_width_[i] = new_right_border;
+          left_width_[i + 1] = new_left_border;
+
+        }
+      }
+    }
+
+    void PeakPickerMobilogram::updateMembers_()
+    {
+        sgolay_frame_length_ = (UInt)param_.getValue("sgolay_frame_length");
+        sgolay_polynomial_order_ = (UInt)param_.getValue("sgolay_polynomial_order");
+        gauss_width_ = (double)param_.getValue("gauss_width");
+        peak_width_ = (double)param_.getValue("peak_width");
+        signal_to_noise_ = (double)param_.getValue("signal_to_noise");
+        sn_win_len_ = (double)param_.getValue("sn_win_len");
+        sn_bin_count_ = (UInt)param_.getValue("sn_bin_count");
+        // TODO make list, not boolean
+        use_gauss_ = (bool)param_.getValue("use_gauss").toBool();
+        write_sn_log_messages_ = (bool)param_.getValue("write_sn_log_messages").toBool();
+        method_ = (String)param_.getValue("method").toString();
+
+        Param sg_filter_parameters = sgolay_.getParameters();
+        sg_filter_parameters.setValue("frame_length", sgolay_frame_length_);
+        sg_filter_parameters.setValue("polynomial_order", sgolay_polynomial_order_);
+        sgolay_.setParameters(sg_filter_parameters);
+
+        Param gfilter_parameters = gauss_.getParameters();
+        gfilter_parameters.setValue("gaussian_width", gauss_width_);
+        gauss_.setParameters(gfilter_parameters);
+
+        Param snt_parameters = snt_.getParameters();
+        snt_parameters.setValue("win_len", sn_win_len_);
+        snt_parameters.setValue("bin_count", sn_bin_count_);
+        snt_parameters.setValue("write_log_messages", param_.getValue("write_sn_log_messages"));
+        snt_.setParameters(snt_parameters);
+    }
+}

--- a/src/openms/source/ANALYSIS/OPENSWATH/sources.cmake
+++ b/src/openms/source/ANALYSIS/OPENSWATH/sources.cmake
@@ -31,6 +31,7 @@ set(sources_list
   OpenSwathWorkflow.cpp
   PeakIntegrator.cpp
   PeakPickerChromatogram.cpp
+  PeakPickerMobilogram.cpp
   SwathMapMassCorrection.cpp
   SwathWindowLoader.cpp
   SwathQC.cpp

--- a/src/openms/source/KERNEL/Mobilogram.cpp
+++ b/src/openms/source/KERNEL/Mobilogram.cpp
@@ -34,6 +34,46 @@ namespace OpenMS
     }
   }
 
+  const String &Mobilogram::getName() const
+  {
+    return name_;
+  }
+
+  void Mobilogram::setName(const String &name)
+  {
+    name_ = name;
+  }
+
+  const Mobilogram::FloatDataArrays &Mobilogram::getFloatDataArrays() const
+  {
+    return float_data_arrays_;
+  }
+
+  Mobilogram::FloatDataArrays &Mobilogram::getFloatDataArrays()
+  {
+    return float_data_arrays_;
+  }
+
+  const Mobilogram::StringDataArrays &Mobilogram::getStringDataArrays() const
+  {
+    return string_data_arrays_;
+  }
+
+  Mobilogram::StringDataArrays &Mobilogram::getStringDataArrays()
+  {
+    return string_data_arrays_;
+  }
+
+  const Mobilogram::IntegerDataArrays &Mobilogram::getIntegerDataArrays() const
+  {
+    return integer_data_arrays_;
+  }
+
+  Mobilogram::IntegerDataArrays &Mobilogram::getIntegerDataArrays()
+  {
+    return integer_data_arrays_;
+  }
+
   String Mobilogram::getDriftTimeUnitAsString() const
   {
     return NamesOfDriftTimeUnit[(size_t)drift_time_unit_];

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerHiRes.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerHiRes.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h>
 #include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/Mobilogram.h>
 #include <OpenMS/MATH/MISC/SplineBisection.h>
 #include <OpenMS/MATH/MISC/CubicSpline2d.h>
 #include <OpenMS/KERNEL/SpectrumHelper.h>
@@ -68,6 +69,12 @@ namespace OpenMS
     pick(input, output, boundaries);
   }
 
+  void PeakPickerHiRes::pick(const Mobilogram& input, Mobilogram& output) const
+  {
+    std::vector<PeakBoundary> boundaries;
+    pick(input, output, boundaries);
+  }
+
   void PeakPickerHiRes::pick(const MSSpectrum& input, MSSpectrum& output, std::vector<PeakBoundary>& boundaries, bool check_spacings) const
   {
     // copy meta data of the input spectrum
@@ -92,6 +99,16 @@ namespace OpenMS
     output.ChromatogramSettings::operator=(input);
     output.MetaInfoInterface::operator=(input);
     output.setName(input.getName());
+
+    pick_(input, output, boundaries, check_spacings);
+  }
+
+  void PeakPickerHiRes::pick(const Mobilogram& input, Mobilogram& output, std::vector<PeakBoundary>& boundaries, bool check_spacings) const
+  {
+    // copy meta data of the input mobilogram
+    output.clear();
+    output.setRT(input.getRT());
+    output.setDriftTimeUnit(input.getDriftTimeUnit());
 
     pick_(input, output, boundaries, check_spacings);
   }

--- a/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
+++ b/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/PROCESSING/SMOOTHING/GaussFilter.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/KERNEL/Mobilogram.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <cmath>
@@ -136,6 +137,57 @@ namespace OpenMS
       {
         chromatogram[p].setIntensity(*int_it);
         chromatogram[p].setMZ(*mz_it);
+      }
+    }
+  }
+
+  void GaussFilter::filter(Mobilogram & mobilogram)
+  {
+    if (param_.getValue("use_ppm_tolerance").toBool())
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
+        "GaussFilter: Cannot use ppm tolerance on mobilogram");
+    }
+
+    bool found_signal = false;
+    const Size data_size = mobilogram.size();
+    std::vector<double> im_in(data_size), int_in(data_size), im_out(data_size), int_out(data_size);
+
+    // copy spectrum to container
+    for (Size p = 0; p < mobilogram.size(); ++p)
+    {
+      im_in[p] = mobilogram[p].getMobility();
+      int_in[p] = mobilogram[p].getIntensity();
+    }
+
+    // apply filter
+    auto im_out_it = im_out.begin();
+    auto int_out_it = int_out.begin();
+    found_signal = gauss_algo_.filter(im_in.begin(), im_in.end(), int_in.begin(), im_out_it, int_out_it);
+
+    // If all intensities are zero in the scan and the scan has a reasonable size, throw an exception.
+    // This is the case if the Gaussian filter is smaller than the spacing of raw data
+    if (!found_signal && mobilogram.size() >= 3)
+    {
+      if (write_log_messages_)
+      {
+        String error_message = "Found no signal. The Gaussian width is probably smaller than the spacing in your mobilogram data. Try to use a bigger width.";
+        if (mobilogram.getRT() > 0.0)
+        {
+          error_message += String(" The error occurred in the mobilogram with RT ") + mobilogram.getRT() + ".";
+        }
+        OPENMS_LOG_ERROR << error_message << std::endl;
+      }
+    }
+    else
+    {
+      // copy the new data into the spectrum
+      auto im_it = im_out.begin();
+      auto int_it = int_out.begin();
+      for (Size p = 0; im_it != im_out.end(); im_it++, int_it++, p++)
+      {
+        mobilogram[p].setIntensity(*int_it);
+        mobilogram[p].setMobility(*im_it);
       }
     }
   }

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -602,6 +602,7 @@ if(NOT DISABLE_OPENSWATH)
     OpenSwathScores_test
     PeakIntegrator_test
     PeakPickerChromatogram_test
+    PeakPickerMobilogram_test
     MRMTransitionGroupPicker_test
     DIAHelper_test
     DIAScoring_test
@@ -641,6 +642,7 @@ set(Boost_dependent_tests
   OpenSwathMRMFeatureAccessOpenMS_test
   OpenSwathSpectrumAccessOpenMS_test
   PeakPickerChromatogram_test
+  PeakPickerMobilogram_test
   SpectrumLookup_test
   SpectrumMetaDataLookup_test
   StatisticFunctions_test

--- a/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2002-present, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+// 
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+#include <boost/assign/std/vector.hpp>
+
+#include <OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h>
+
+using namespace OpenMS;
+using namespace std;
+
+typedef Mobilogram RichPeakMobilogram;
+
+RichPeakMobilogram get_mobilogram(int i)
+{
+  static const double im_data1[]
+    = {0.93734956, 0.93835497, 0.9393905,  0.9404265,  0.9414631, 0.9425003,  0.9435083,  0.9445466,  0.9455854,  0.94662476, 0.947635,
+       0.94867545, 0.9496867,  0.95072824, 0.95177037, 0.9527832, 0.9538264,  0.95484036, 0.9558847,  0.9568997,  0.9579451,  0.9589612,
+       0.96000767, 0.9610248,  0.96207243, 0.96309066, 0.9641094, 0.96515864, 0.9661785,  0.96719885, 0.96824974, 0.9692712,  0.9702931,
+       0.97131556, 0.9723687,  0.97339225, 0.9744164,  0.975441,  0.9764661,  0.977522,   0.9785482,  0.979575,   0.98060226, 0.98163015,
+       0.9826585,  0.9836874,  0.98471683, 0.9857468,  0.9867773, 0.98780835, 0.98883986, 0.989872,   0.9909046,  0.9919378,  0.99297154,
+       0.99397534, 0.99501014, 0.9960454,  0.9970813,  0.9981177, 1.0125301};
+
+  static const double int_data1[] = {341.995757, 200.000741, 325.0076900000001, 79.002655, 227.00538, 487.00108, 576.0032550000001, 526.996605, 715.9864020000001, 778.010235, 686.003534, 548.0023570000001, 481.00395999999995, 547.00563, 950.006949, 1453.9987189999997, 831.026847, 1839.009966, 2306.021277, 2588.9953999999993, 2126.0273610000004, 3254.0281579999996, 3961.0108749999995, 4708.020719000002, 4991.072095, 5230.084562000001, 6559.103413000001, 6486.9137040000005, 9512.035332, 14461.755780000001, 16570.804681, 19887.687351000004, 22368.220470000004, 31683.985819, 37679.199531000006, 46487.67955, 48958.673168000016, 52820.41709300001, 58070.474128999995, 57655.34146700001, 58849.449743000005, 56964.34470800001, 56100.919934, 48964.276839, 43019.251419, 39263.106511000005, 28199.275315000003, 25018.205981999996, 20248.883416, 14727.949587000001, 10372.823519, 6309.068338999999, 5370.119231000001, 2253.037892, 2025.998686, 868.9924269999999, 209.0077, 44.99693, 317.999914, 57.00195, 78.0025};
+
+  RichPeakMobilogram mobilogram;
+  for (int k = 0; k < 60; k++)
+  {
+    MobilityPeak1D peak;
+    if (i == 0)
+    {
+      peak.setMZ(im_data1[k]);
+      peak.setIntensity(int_data1[k]);
+    }
+    mobilogram.push_back(peak);
+  }
+  return mobilogram;
+}
+
+START_TEST(PeakPickerMobilogram, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+PeakPickerMobilogram* ptr = nullptr;
+PeakPickerMobilogram* nullPointer = nullptr;
+
+START_SECTION(PeakPickerMobilogram())
+{
+	ptr = new PeakPickerMobilogram();
+	TEST_NOT_EQUAL(ptr, nullPointer)
+}
+END_SECTION
+
+START_SECTION(~PeakPickerMobilogram())
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION(void pickMobilogram(const RichPeakMobilogram& mobilogram, RichPeakMobilogram& picked_mobilogram))
+{
+  RichPeakMobilogram mobilogram, picked_mobilogram, smoothed_mobilogram;
+  
+  mobilogram = get_mobilogram(0);
+  PeakPickerMobilogram picker;
+  Param picker_param = picker.getParameters();
+  picker_param.setValue("method", "corrected");
+  picker_param.setValue("use_gauss", "false");
+  picker.setParameters(picker_param);
+  picker.pickMobilogram(mobilogram, picked_mobilogram, smoothed_mobilogram);
+  
+  TEST_REAL_SIMILAR(picked_mobilogram[0].getIntensity(), 58956.1);
+  TEST_REAL_SIMILAR(picked_mobilogram[0].getMZ(), 0.978364);
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_ABUNDANCE][0], 884145); // IntegratedIntensity
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_LEFTBORDER][0], 0.948675); // leftWidth
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_RIGHTBORDER][0], 0.997081); // rightWidth
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Hannes Roest $
-// $Authors: Hannes Roest $
+// $Maintainer: Justin Sing $
+// $Authors: Justin Sing $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -20,8 +20,7 @@ typedef Mobilogram RichPeakMobilogram;
 
 RichPeakMobilogram get_mobilogram(int i)
 {
-  static const double im_data1[]
-    = {0.93734956, 0.93835497, 0.9393905,  0.9404265,  0.9414631, 0.9425003,  0.9435083,  0.9445466,  0.9455854,  0.94662476, 0.947635,
+  static const double im_data1[] = {0.93734956, 0.93835497, 0.9393905,  0.9404265,  0.9414631, 0.9425003,  0.9435083,  0.9445466,  0.9455854,  0.94662476, 0.947635,
        0.94867545, 0.9496867,  0.95072824, 0.95177037, 0.9527832, 0.9538264,  0.95484036, 0.9558847,  0.9568997,  0.9579451,  0.9589612,
        0.96000767, 0.9610248,  0.96207243, 0.96309066, 0.9641094, 0.96515864, 0.9661785,  0.96719885, 0.96824974, 0.9692712,  0.9702931,
        0.97131556, 0.9723687,  0.97339225, 0.9744164,  0.975441,  0.9764661,  0.977522,   0.9785482,  0.979575,   0.98060226, 0.98163015,
@@ -76,7 +75,7 @@ START_SECTION(void pickMobilogram(const RichPeakMobilogram& mobilogram, RichPeak
   picker_param.setValue("use_gauss", "false");
   picker.setParameters(picker_param);
   picker.pickMobilogram(mobilogram, picked_mobilogram, smoothed_mobilogram);
-  
+
   TEST_REAL_SIMILAR(picked_mobilogram[0].getIntensity(), 58956.1);
   TEST_REAL_SIMILAR(picked_mobilogram[0].getMZ(), 0.978364);
   TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_ABUNDANCE][0], 884145); // IntegratedIntensity


### PR DESCRIPTION
## Description

This is 2 of 3 (probably) PRs related to improvements for ion mobility IPF scoring. 

This PR implements peak picking on the extracted ion mobilograms (XIMs) during IM scoring. This implementation is basically a copy and paste of PeakPickerChromatogram, except peak picking is done on a summed aggregation of the XIMs for the fragment ions. Based on my experience, I don't think it makes too much difference to do individual level peak picking on the fragment XIMs, so I opted to perform an aggregation peak picking to save computation time. 

![image](https://github.com/user-attachments/assets/c01af289-527d-4809-bd7b-32729ead3729)

**Note:** This does use the same hacky methods for using the `getMZ` as an IM alias, which is also used in `PeakPickerChromatogram` as a RT alias, due to using the `PeakPickerHiRez` implementation under the hood. 

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
