### PR TITLE
[refactor] remove getMZ alias from chromatograms

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
@@ -171,13 +171,13 @@ public:
         iter--;
       }
 
-      typename ContainerT::const_iterator prev = iter;
-      if (prev != chromatogram_.begin() ) 
+      auto prev = iter;
+      if (prev != chromatogram_.begin()) 
       {
         prev--;
       }
 
-      if (std::fabs(prev->getMZ() - RT) < std::fabs(iter->getMZ() - RT) )
+      if (std::fabs(prev->getPos() - RT) < std::fabs(iter->getPos() - RT) )
       {
         // prev is closer to the apex
         return sn_.getSignalToNoise((Size) distance(chromatogram_.begin(),prev));

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
@@ -163,7 +163,7 @@ public:
 
       // Note that MZBegin does not seem to return the same iterator on
       // different setups, see https://github.com/OpenMS/OpenMS/issues/1163
-      typename ContainerT::const_iterator iter = chromatogram_.MZEnd(RT);
+      auto iter = chromatogram_.PosEnd(RT);
 
       // ensure that iter is valid
       if (iter == chromatogram_.end()) 

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
@@ -109,18 +109,6 @@ public:
       position_[0] = pos;
     }
 
-    /// Alias for getRT()
-    inline CoordinateType getMZ() const
-    {
-      return position_[0];
-    }
-
-    /// Alias for setRT()
-    inline void setMZ(CoordinateType rt)
-    {
-      position_[0] = rt;
-    }
-
     /// Non-mutable access to the position
     inline PositionType const & getPosition() const
     {

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
@@ -86,10 +86,7 @@ public:
           }
 
           // new spec contains one peak, with product m/z and intensity
-          typename ExperimentType::PeakType peak;
-          peak.setMZ(it->getMZ());
-          peak.setIntensity(pit->getIntensity());
-          spec.push_back(peak);
+          spec.emplace_back(it->getMZ(), pit->getIntensity());
           exp.addSpectrum(spec);
         }
       }

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -295,8 +295,6 @@ public:
     */
     ConstIterator RTEnd(CoordinateType rt) const;
 
-    ConstIterator MZEnd(CoordinateType rt) const;
-
     /**
       @brief Binary search for peak range end (returns the past-the-end iterator)
 

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -31,7 +31,7 @@ namespace OpenMS
 
 public:
 
-    /// Comparator for the retention time.
+    /// Comparator for the precursor m/z time.
     struct OPENMS_DLLAPI MZLess
     {
       bool operator()(const MSChromatogram& a, const MSChromatogram& b) const;
@@ -82,6 +82,7 @@ public:
     using ContainerType::resize;
     using ContainerType::size;
     using ContainerType::push_back;
+    using ContainerType::emplace_back;
     using ContainerType::pop_back;
     using ContainerType::empty;
     using ContainerType::front;

--- a/src/openms/include/OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
+++ b/src/openms/include/OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
@@ -286,7 +286,7 @@ protected:
       {
 
         // erase all elements from histogram that will leave the window on the LEFT side
-        while ((*window_pos_borderleft).getMZ() <  (*window_pos_center).getMZ() - window_half_size)
+        while ((*window_pos_borderleft).getPos() < (*window_pos_center).getPos() - window_half_size)
         {
           to_bin = std::max(std::min<int>((int)((*window_pos_borderleft).getIntensity() / bin_size), bin_count_minus_1), 0);
           --histogram[to_bin];
@@ -296,7 +296,7 @@ protected:
 
         // add all elements to histogram that will enter the window on the RIGHT side
         while ((window_pos_borderright != scan_last_)
-              && ((*window_pos_borderright).getMZ() <= (*window_pos_center).getMZ() + window_half_size))
+              && ((*window_pos_borderright).getPos() <= (*window_pos_center).getPos() + window_half_size))
         {
           //std::cerr << (*window_pos_borderright).getIntensity() << " " << bin_size << " " << bin_count_minus_1 << std::endl;
           to_bin = std::max(std::min<int>((int)((*window_pos_borderright).getIntensity() / bin_size), bin_count_minus_1), 0);

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerChromatogram.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerChromatogram.cpp
@@ -277,10 +277,10 @@ namespace OpenMS
         OPENMS_LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << std::endl;
 
         // Find the peak width and best RT
-        double central_peak_mz = picked_chrom[i].getMZ();
-        double next_peak_mz = picked_chrom[i + 1].getMZ();
-        current_peak = findClosestPeak_(chromatogram, central_peak_mz, current_peak);
-        Size next_peak = findClosestPeak_(chromatogram, next_peak_mz, current_peak);
+        double central_peak_rt = picked_chrom[i].getPos();
+        double next_peak_rt = picked_chrom[i + 1].getPos();
+        current_peak = findClosestPeak_(chromatogram, central_peak_rt, current_peak);
+        Size next_peak = findClosestPeak_(chromatogram, next_peak_rt, current_peak);
 
         // adjust the right border of the current and left border of next
         Size k = 1;
@@ -307,8 +307,12 @@ namespace OpenMS
 
         }
 
-        OPENMS_LOG_DEBUG << "New peak l: " << chromatogram[current_left_idx].getMZ() << " " << chromatogram[new_right_border].getMZ() << " int " << integrated_intensities_[i] << std::endl;
-        OPENMS_LOG_DEBUG << "New peak r: " << chromatogram[new_left_border].getMZ() << " " << chromatogram[next_right_idx].getMZ() << " int " << integrated_intensities_[i + 1] << std::endl;
+        OPENMS_LOG_DEBUG << "New peak l: " << chromatogram[current_left_idx].getPos() 
+          << " " << chromatogram[new_right_border].getPos() 
+          << " int " << integrated_intensities_[i] << std::endl;
+        OPENMS_LOG_DEBUG << "New peak r: " << chromatogram[new_left_border].getPos() 
+          << " " << chromatogram[next_right_idx].getPos() 
+          << " int " << integrated_intensities_[i + 1] << std::endl;
 
 
         right_width_[i] = new_right_border;

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -5296,7 +5296,7 @@ namespace OpenMS::Internal
         {
           for (Size p = 0; p < container.size(); ++p)
           {
-            data_to_encode[p] = container[p].getMZ();
+            data_to_encode[p] = container[p].getPos();
           }
         }
         writeBinaryDataArray_(os, pf_options_, data_to_encode, false, array_type);
@@ -5316,7 +5316,7 @@ namespace OpenMS::Internal
         {
           for (Size p = 0; p < container.size(); ++p)
           {
-            data_to_encode[p] = container[p].getMZ();
+            data_to_encode[p] = container[p].getPos();
           }
         }
         writeBinaryDataArray_(os, pf_options_, data_to_encode, true, array_type);

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -184,7 +184,7 @@ namespace OpenMS
 
   template<class T>
   inline void fillDataArray(const std::vector<Internal::MzMLHandlerHelper::BinaryData>& data,
-                            T& spectrum,
+                            T& peak_container,
                             const bool x_precision_64,
                             const bool int_precision_64,
                             const SignedSize x_index,
@@ -200,10 +200,10 @@ namespace OpenMS
       {
         //add peak
         tmp.setIntensity(*int_it);
-        tmp.setMZ(*mz_it);
+        tmp.setPos(*mz_it);
         ++mz_it;
         ++int_it;
-        spectrum.push_back(tmp);
+        peak_container.push_back(tmp);
       }
     }
     else if (x_precision_64 && int_precision_64)
@@ -214,10 +214,10 @@ namespace OpenMS
       {
         //add peak
         tmp.setIntensity(*int_it);
-        tmp.setMZ(*mz_it);
+        tmp.setPos(*mz_it);
         ++mz_it;
         ++int_it;
-        spectrum.push_back(tmp);
+        peak_container.push_back(tmp);
       }
     }
     else if (!x_precision_64 && int_precision_64)
@@ -228,10 +228,10 @@ namespace OpenMS
       {
         //add peak
         tmp.setIntensity(*int_it);
-        tmp.setMZ(*mz_it);
+        tmp.setPos(*mz_it);
         ++mz_it;
         ++int_it;
-        spectrum.push_back(tmp);
+        peak_container.push_back(tmp);
       }
     }
     else if (!x_precision_64 && !int_precision_64)
@@ -242,10 +242,10 @@ namespace OpenMS
       {
         //add peak
         tmp.setIntensity(*int_it);
-        tmp.setMZ(*mz_it);
+        tmp.setPos(*mz_it);
         ++mz_it;
         ++int_it;
-        spectrum.push_back(tmp);
+        peak_container.push_back(tmp);
       }
     }
   }

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -181,7 +181,7 @@ namespace OpenMS::Internal
           std::vector< double >::iterator data_it = data.begin();
           for (auto it = containers[curr_id].begin(); it != containers[curr_id].end(); ++it, ++data_it)
           {
-            it->setMZ(*data_it);
+            it->setPos(*data_it);
           }
           cont_data[curr_id] += 1;
         }
@@ -197,7 +197,7 @@ namespace OpenMS::Internal
           std::vector< double >::iterator data_it = data.begin();
           for (auto it = containers[curr_id].begin(); it != containers[curr_id].end(); ++it, ++data_it)
           {
-            it->setMZ(*data_it);
+            it->setPos(*data_it);
           }
           cont_data[curr_id] += 1;
         }

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -352,10 +352,6 @@ MSChromatogram::PosBegin(MSChromatogram::Iterator begin, MSChromatogram::Coordin
   return RTBegin(begin, rt, end);
 }
 
-MSChromatogram::Iterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt)
-{
-  return RTEnd(rt);
-}
 
 MSChromatogram::Iterator
 MSChromatogram::PosEnd(MSChromatogram::Iterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::Iterator end)
@@ -374,18 +370,21 @@ MSChromatogram::PosBegin(MSChromatogram::ConstIterator begin, MSChromatogram::Co
   return RTBegin(begin, rt, end);
 }
 
-MSChromatogram::ConstIterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt) const
-{
-  return RTEnd(rt);
-}
-
 MSChromatogram::ConstIterator
 MSChromatogram::PosEnd(MSChromatogram::ConstIterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::ConstIterator end) const
 {
   return RTEnd(begin, rt, end);
 }
 
-MSChromatogram::ConstIterator MSChromatogram::MZEnd(MSChromatogram::CoordinateType rt) const {return RTEnd(rt);}
+MSChromatogram::Iterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt)
+{
+  return RTEnd(rt);
+}
+
+MSChromatogram::ConstIterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt) const 
+{
+  return RTEnd(rt);
+}
 
 void MSChromatogram::clear(bool clear_meta_data)
 {

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerHiRes.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerHiRes.cpp
@@ -147,9 +147,9 @@ namespace OpenMS
     // find local maxima in profile data
     for (Size i = 2; i < input.size() - 2; ++i)
     {
-      double central_peak_mz = input[i].getMZ(), central_peak_int = input[i].getIntensity();
-      double left_neighbor_mz = input[i - 1].getMZ(), left_neighbor_int = input[i - 1].getIntensity();
-      double right_neighbor_mz = input[i + 1].getMZ(), right_neighbor_int = input[i + 1].getIntensity();
+      double central_peak_mz = input[i].getPos(), central_peak_int = input[i].getIntensity();
+      double left_neighbor_mz = input[i - 1].getPos(), left_neighbor_int = input[i - 1].getIntensity();
+      double right_neighbor_mz = input[i + 1].getPos(), right_neighbor_int = input[i + 1].getIntensity();
 
       // do not interpolate when the left or right support is a zero-data-point
       if (std::fabs(left_neighbor_int) < std::numeric_limits<double>::epsilon())
@@ -207,8 +207,8 @@ namespace OpenMS
           (act_snt_l2 >= signal_to_noise_) &&
           (act_snt_r2 >= signal_to_noise_) &&
           (!check_spacings ||
-          ((left_neighbor_mz - input[i - 2].getMZ() < spacing_difference_ * min_spacing) && 
-            (input[i + 2].getMZ() - right_neighbor_mz < spacing_difference_ * min_spacing))))
+          ((left_neighbor_mz - input[i - 2].getPos() < spacing_difference_ * min_spacing) && 
+            (input[i + 2].getPos() - right_neighbor_mz < spacing_difference_ * min_spacing))))
         {
           ++i;
           continue;
@@ -242,7 +242,7 @@ namespace OpenMS
           (missing_left <= missing_) && 
           (input[i - k].getIntensity() <= peak_raw_data.begin()->second) &&
           (!check_spacings || 
-          (peak_raw_data.begin()->first - input[i - k].getMZ() < spacing_difference_gap_ * min_spacing)))
+          (peak_raw_data.begin()->first - input[i - k].getPos() < spacing_difference_gap_ * min_spacing)))
         {
           double act_snt_lk = 0.0;
 
@@ -253,9 +253,9 @@ namespace OpenMS
 
           if ((act_snt_lk >= signal_to_noise_) && 
             (!check_spacings ||
-            (peak_raw_data.begin()->first - input[i - k].getMZ() < spacing_difference_ * min_spacing)))
+            (peak_raw_data.begin()->first - input[i - k].getPos() < spacing_difference_ * min_spacing)))
           {
-            peak_raw_data[input[i - k].getMZ()] = input[i - k].getIntensity();
+            peak_raw_data[input[i - k].getPos()] = input[i - k].getIntensity();
             if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i - k] * input[i - k].getIntensity();
           }
           else
@@ -263,7 +263,7 @@ namespace OpenMS
             ++missing_left;
             if (missing_left <= missing_)
             {
-              peak_raw_data[input[i - k].getMZ()] = input[i - k].getIntensity();
+              peak_raw_data[input[i - k].getPos()] = input[i - k].getIntensity();
               if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i - k] * input[i - k].getIntensity();
             }
           }
@@ -285,7 +285,7 @@ namespace OpenMS
           (missing_right <= missing_) && 
           (input[i + k].getIntensity() <= peak_raw_data.rbegin()->second) &&
           (!check_spacings ||
-          (input[i + k].getMZ() - peak_raw_data.rbegin()->first < spacing_difference_gap_ * min_spacing)))
+          (input[i + k].getPos() - peak_raw_data.rbegin()->first < spacing_difference_gap_ * min_spacing)))
         {
           double act_snt_rk = 0.0;
 
@@ -296,9 +296,9 @@ namespace OpenMS
 
           if ((act_snt_rk >= signal_to_noise_) && 
             (!check_spacings ||
-            (input[i + k].getMZ() - peak_raw_data.rbegin()->first < spacing_difference_ * min_spacing)))
+            (input[i + k].getPos() - peak_raw_data.rbegin()->first < spacing_difference_ * min_spacing)))
           {
-            peak_raw_data[input[i + k].getMZ()] = input[i + k].getIntensity();
+            peak_raw_data[input[i + k].getPos()] = input[i + k].getIntensity();
             if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i + k] * input[i + k].getIntensity();
           }
           else
@@ -306,7 +306,7 @@ namespace OpenMS
             ++missing_right;
             if (missing_right <= missing_)
             {
-              peak_raw_data[input[i + k].getMZ()] = input[i + k].getIntensity();
+              peak_raw_data[input[i + k].getPos()] = input[i + k].getIntensity();
               if (has_im) weighted_im += input.getFloatDataArrays()[im_data_index][i + k] * input[i + k].getIntensity();
             }
           }
@@ -403,10 +403,10 @@ namespace OpenMS
         // save picked peak into output spectrum
         typename ContainerType::PeakType peak;
         PeakBoundary peak_boundary;
-        peak.setMZ(max_peak_mz);
+        peak.setPos(max_peak_mz);
         peak.setIntensity(max_peak_int);
-        peak_boundary.mz_min = input[left_boundary].getMZ();
-        peak_boundary.mz_max = input[right_boundary].getMZ();
+        peak_boundary.mz_min = input[left_boundary].getPos();
+        peak_boundary.mz_max = input[right_boundary].getPos();
         output.push_back(peak);
 
         boundaries.push_back(peak_boundary);

--- a/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
+++ b/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
@@ -79,12 +79,10 @@ namespace OpenMS
     else
     {
       // copy the new data into the spectrum
-      auto mz_it = mz_out.begin();
-      auto int_it = int_out.begin();
-      for (Size p = 0; mz_it != mz_out.end(); mz_it++, int_it++, p++)
+      for (Size p = 0; p < spectrum.size(); ++p)
       {
-        spectrum[p].setIntensity(*int_it);
-        spectrum[p].setMZ(*mz_it);
+        spectrum[p].setIntensity(int_out[p]);
+        spectrum[p].setMZ(mz_out[p]);
       }
     }
   }
@@ -129,13 +127,11 @@ namespace OpenMS
     }
     else
     {
-      // copy the new data into the spectrum
-      auto pos_it = rt_out.begin();
-      auto int_it = int_out.begin();
-      for (Size p = 0; pos_it != rt_out.end(); pos_it++, int_it++, p++)
+      // copy the new data into the chromatogram
+      for (Size p = 0; p < chromatogram.size(); ++p)
       {
-        chromatogram[p].setIntensity(*int_it);
-        chromatogram[p].setRT(*pos_it);
+        chromatogram[p].setIntensity(int_out[p]);
+        chromatogram[p].setRT(rt_out[p]);
       }
     }
   }

--- a/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
+++ b/src/openms/source/PROCESSING/SMOOTHING/GaussFilter.cpp
@@ -130,12 +130,12 @@ namespace OpenMS
     else
     {
       // copy the new data into the spectrum
-      auto mz_it = rt_out.begin();
+      auto pos_it = rt_out.begin();
       auto int_it = int_out.begin();
-      for (Size p = 0; mz_it != rt_out.end(); mz_it++, int_it++, p++)
+      for (Size p = 0; pos_it != rt_out.end(); pos_it++, int_it++, p++)
       {
         chromatogram[p].setIntensity(*int_it);
-        chromatogram[p].setMZ(*mz_it);
+        chromatogram[p].setRT(*pos_it);
       }
     }
   }

--- a/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
@@ -147,7 +147,7 @@ namespace OpenMS
     i = 1;
     for (auto it = rt.cbegin(); it != rt.cend(); ++it)
     {
-      projection_rt[i].setMZ(it->first);
+      projection_rt[i].setRT(it->first);
       projection_rt[i].setIntensity(it->second);
       ++i;
     }

--- a/src/tests/class_tests/openms/source/GaussFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/GaussFilter_test.cpp
@@ -76,10 +76,10 @@ START_SECTION((template <typename PeakType> void filter(MSChromatogram<PeakType>
   chromatogram.resize(5);
 
   MSChromatogram::Iterator it = chromatogram.begin();
-  for (Size i=0; i<5; ++i, ++it)
+  for (Size i = 0; i < 5; ++i, ++it)
   {
     it->setIntensity(1.0f);
-    it->setMZ(500.0+0.2*i);
+    it->setRT(500.0 + 0.2*i);
   }
 
   GaussFilter gauss;

--- a/src/tests/class_tests/openms/source/LinearResamplerAlign_test.cpp
+++ b/src/tests/class_tests/openms/source/LinearResamplerAlign_test.cpp
@@ -89,26 +89,26 @@ END_SECTION
 // it should also work with chromatograms
 START_SECTION([EXTRA] test_linear_res_chromat)
 {
-  MSChromatogram spec;
-  spec.resize(5);
-  spec[0].setMZ(0);
-  spec[0].setIntensity(3.0f);
-  spec[1].setMZ(0.5);
-  spec[1].setIntensity(6.0f);
-  spec[2].setMZ(1.);
-  spec[2].setIntensity(8.0f);
-  spec[3].setMZ(1.6);
-  spec[3].setIntensity(2.0f);
-  spec[4].setMZ(1.8);
-  spec[4].setIntensity(1.0f);
+  MSChromatogram chrom;
+  chrom.resize(5);
+  chrom[0].setRT(0);
+  chrom[0].setIntensity(3.0f);
+  chrom[1].setRT(0.5);
+  chrom[1].setIntensity(6.0f);
+  chrom[2].setRT(1.);
+  chrom[2].setIntensity(8.0f);
+  chrom[3].setRT(1.6);
+  chrom[3].setIntensity(2.0f);
+  chrom[4].setRT(1.8);
+  chrom[4].setIntensity(1.0f);
 
   LinearResamplerAlign lr;
   Param param;
-  param.setValue("spacing",default_spacing);
+  param.setValue("spacing", default_spacing);
   lr.setParameters(param);
-  lr.raster(spec);
+  lr.raster(chrom);
 
-  check_results(spec);
+  check_results(chrom);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -71,7 +71,7 @@ sum(datapoints[3:10])
   for (int k = 0; k < 18; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_1[k]);
+    peak.setRT(rtdata_1[k]);
     peak.setIntensity(intdata_1[k]);
     chromatogram.push_back(peak);
   } 
@@ -89,7 +89,7 @@ sum(datapoints[3:10])
   for (int k = 0; k < 18; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_2[k]);
+    peak.setRT(rtdata_2[k]);
     peak.setIntensity(intdata_2[k]);
     chromatogram.push_back(peak);
   } 
@@ -105,7 +105,7 @@ sum(datapoints[3:10])
   for (int k = 0; k < 18; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_2[k] + 0.5); // shift the "MS1" retention time as well 
+    peak.setRT(rtdata_2[k] + 0.5); // shift the "MS1" retention time as well 
     peak.setIntensity(ms1_intdata[k]);
     chromatogram.push_back(peak);
   } 
@@ -136,7 +136,7 @@ void setup_transition_group2(MRMTransitionGroupType & transition_group)
   for (int k = 0; k < 30; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_1[k]);
+    peak.setRT(rtdata_1[k]);
     peak.setIntensity(intdata_1[k]);
     chromatogram.push_back(peak);
   } 
@@ -154,7 +154,7 @@ void setup_transition_group2(MRMTransitionGroupType & transition_group)
   for (int k = 0; k < 30; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_2[k]);
+    peak.setRT(rtdata_2[k]);
     peak.setIntensity(intdata_2[k]);
     chromatogram.push_back(peak);
   } 
@@ -172,7 +172,7 @@ void setup_transition_group2(MRMTransitionGroupType & transition_group)
   for (int k = 0; k < 30; k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(rtdata_3[k]);
+    peak.setRT(rtdata_3[k]);
     peak.setIntensity(intdata_3[k]);
     chromatogram.push_back(peak);
   } 
@@ -215,7 +215,7 @@ void setup_toy_chromatogram(RichPeakChromatogram & chromatogram)
   for (size_t k = 0; k < time.size(); k++)
   {   
     ChromatogramPeak peak;
-    peak.setMZ(time[k]);
+    peak.setRT(time[k]);
     peak.setIntensity(intensity[k]);
     chromatogram.push_back(peak);
   } 
@@ -486,7 +486,7 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
   {
     RichPeakChromatogram picked_chrom;
     ChromatogramPeak peak;
-    peak.setMZ(1490);
+    peak.setRT(1490);
     peak.setIntensity(170);
     picked_chrom.push_back(peak);
 
@@ -618,10 +618,10 @@ START_SECTION(( void findLargestPeak(std::vector<RichPeakChromatogram> & picked_
   {
     RichPeakChromatogram picked_chrom;
     ChromatogramPeak peak;
-    peak.setMZ(3120);
+    peak.setRT(3120);
     peak.setIntensity(100+k);
     picked_chrom.push_back(peak);
-    peak.setMZ(4120);
+    peak.setRT(4120);
     peak.setIntensity(200+k);
     picked_chrom.push_back(peak);
 
@@ -714,7 +714,7 @@ START_SECTION((template < typename SpectrumT > void remove_overlapping_features(
 
     {
     ChromatogramPeak peak;
-    peak.setMZ(3120);
+    peak.setRT(3120);
     peak.setIntensity(default_intensity);
     picked_chrom.push_back(peak);
     picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER].push_back(3100.0);
@@ -723,7 +723,7 @@ START_SECTION((template < typename SpectrumT > void remove_overlapping_features(
 
     {
     ChromatogramPeak peak;
-    peak.setMZ(3090);
+    peak.setRT(3090);
     peak.setIntensity(default_intensity);
     picked_chrom.push_back(peak);
     picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER].push_back(3070.0);
@@ -732,7 +732,7 @@ START_SECTION((template < typename SpectrumT > void remove_overlapping_features(
 
     {
     ChromatogramPeak peak;
-    peak.setMZ(3060);
+    peak.setRT(3060);
     peak.setIntensity(default_intensity);
     picked_chrom.push_back(peak);
     picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER].push_back(3050.0);
@@ -752,7 +752,7 @@ START_SECTION((template < typename SpectrumT > void remove_overlapping_features(
 
     {
     ChromatogramPeak peak;
-    peak.setMZ(3120);
+    peak.setRT(3120);
     peak.setIntensity(default_intensity);
     picked_chrom.push_back(peak);
     picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER].push_back(3100.0);
@@ -761,7 +761,7 @@ START_SECTION((template < typename SpectrumT > void remove_overlapping_features(
 
     {
     ChromatogramPeak peak;
-    peak.setMZ(3060);
+    peak.setRT(3060);
     peak.setIntensity(default_intensity);
     picked_chrom.push_back(peak);
     picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER].push_back(3050.0);

--- a/src/tests/class_tests/openms/source/OpenSwathSpectrumAccessOpenMS_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathSpectrumAccessOpenMS_test.cpp
@@ -264,7 +264,7 @@ START_SECTION(OpenSwath::ChromatogramPtr getChromatogramById(int id))
     MSChromatogram chrom;
 
     ChromatogramPeak p;
-    p.setMZ(20.0);
+    p.setRT(20.0);
     p.setIntensity(22.0);
     chrom.push_back(p);
 

--- a/src/tests/class_tests/openms/source/PeakPickerChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerChromatogram_test.cpp
@@ -37,12 +37,12 @@ RichPeakChromatogram get_chrom(int i)
     ChromatogramPeak peak;
     if (i == 0)
     {
-      peak.setMZ(rtdata_1[k]);
+      peak.setRT(rtdata_1[k]);
       peak.setIntensity(intdata_1[k]);
     }
     else if (i == 1)
     {
-      peak.setMZ(rtdata_2[k]);
+      peak.setRT(rtdata_2[k]);
       peak.setIntensity(intdata_2[k]);
     }
     chromatogram.push_back(peak);
@@ -91,7 +91,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   // Peak picking is done by cubic spline interpolation and searching for the
   // point with zero derivative.
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 9981.93933103869);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1495.11321013749);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1495.11321013749);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 60124.9); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1490.95); // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1502.03); // rightWidth
@@ -106,7 +106,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   // Peak picking is done by cubic spline interpolation and searching for the
   // point with zero derivative.
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 78719.134569503);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1492.830608593);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1492.830608593);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 523378); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1481.84); // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1501.23); // rightWidth
@@ -120,7 +120,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   picker.setParameters(picker_param);
   picker.pickChromatogram(chrom, picked_chrom);
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 9981.93933103869);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1495.11368082583);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1495.11368082583);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 60605.7); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1482.64); // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1504.8);  // rightWidth
@@ -131,7 +131,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   TEST_EQUAL( picked_chrom.getFloatDataArrays().size(), PeakPickerChromatogram::SIZE_OF_FLOATINDICES);
 
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 78719.1346);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1492.8305);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1492.8305);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 525672.0); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1481.84);  // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1504.0);   // rightWidth
@@ -143,7 +143,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   picker.setParameters(picker_param);
   picker.pickChromatogram(chrom, picked_chrom);
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 61366.56640625);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1496.48);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1496.48);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 61366.6); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1479.88); // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1510.33); // rightWidth
@@ -154,7 +154,7 @@ START_SECTION(void pickChromatogram(const RichPeakChromatogram &chromatogram, Ri
   TEST_EQUAL( picked_chrom.getFloatDataArrays().size(), 3);
 
   TEST_REAL_SIMILAR( picked_chrom[0].getIntensity(), 533936.875);
-  TEST_REAL_SIMILAR( picked_chrom[0].getMZ(), 1490.15);
+  TEST_REAL_SIMILAR( picked_chrom[0].getRT(), 1490.15);
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_ABUNDANCE][0], 533936.875); // IntegratedIntensity
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_LEFTBORDER][0], 1479.08); // leftWidth
   TEST_REAL_SIMILAR( picked_chrom.getFloatDataArrays()[PeakPickerChromatogram::IDX_RIGHTBORDER][0], 1509.53); // rightWidth

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -175,15 +175,12 @@ public:
     setValidFormats_("out", ListUtils::create<String>("csv"));
   }
 
-  MSChromatogram toChromatogram(const MSSpectrum& in)
+  MSChromatogram toChromatogram(const MSSpectrum& in) // for debugging
   {
     MSChromatogram out;
-    for (Size ic = 0; ic < in.size(); ++ic)
+    for (const auto& peak : in)
     {
-      ChromatogramPeak peak;
-      peak.setMZ(in[ic].getMZ());
-      peak.setIntensity(in[ic].getIntensity());
-      out.push_back(peak);
+      out.emplace_back(peak.getMZ(), peak.getIntensity());
     }
     out.setChromatogramType(ChromatogramSettings::SELECTED_ION_CURRENT_CHROMATOGRAM);
 
@@ -324,7 +321,7 @@ public:
           for (Size is = 0; is < tics.size(); ++is)
           {
             Peak1D peak;
-            peak.setMZ(tic[is].getMZ());
+            peak.setMZ(tic[is].getPos());
             peak.setIntensity(snt.getSignalToNoise(is));
             tics_sn.push_back(peak);
           }


### PR DESCRIPTION
## Description

Remove the ugly getMZ alias from MSChromatogram.
getMZ was introduced at some point to make algorithms designed for spectra also work on chromatograms.

But as both Peak1D and ChromatogramPeak already contain a getPos() member that can be used in templates to access the position value (m/z or RT depending on type) this alias was not necessary. 
Code was changed to use getPos instead.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
