### PR TITLE
try forcing disabling of library validation

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -419,7 +419,7 @@ jobs:
       run: |
           # do not fail immediately
           set +e
-          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cipackage.cmake
+          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -VV -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cipackage.cmake
           retVal=$?
           if [ $retVal -ne 0 ]; then
               echo -e "\033[0;31m Errors in packaging:"

--- a/cmake/MacOSX/entitlements.plist
+++ b/cmake/MacOSX/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/src/openms_gui/add_mac_bundle.cmake
+++ b/src/openms_gui/add_mac_bundle.cmake
@@ -155,7 +155,7 @@ macro(add_mac_app_bundle _name)
 				## Note: Signing identity has to be unique, and present in any of the keychains in search list
 				## which needs to be unlocked. Play around with keychain argument otherwise.
 				 install(CODE "
-execute_process(COMMAND codesign --deep --force --options runtime --entitlements com.apple.security.cs.disable-library-validation --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
+execute_process(COMMAND codesign --deep --force --options runtime --entitlements ${OPENMS_HOST_DIRECTORY}/cmake/MacOSX/entitlements.plist --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
 message('\${sign_out}')" COMPONENT Applications)
 
 				 install(CODE "

--- a/src/openms_gui/add_mac_bundle.cmake
+++ b/src/openms_gui/add_mac_bundle.cmake
@@ -155,7 +155,7 @@ macro(add_mac_app_bundle _name)
 				## Note: Signing identity has to be unique, and present in any of the keychains in search list
 				## which needs to be unlocked. Play around with keychain argument otherwise.
 				 install(CODE "
-execute_process(COMMAND codesign --deep --force --options runtime --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
+execute_process(COMMAND codesign --deep --force --options runtime --entitlements com.apple.security.cs.disable-library-validation --sign \"${CPACK_BUNDLE_APPLE_CERT_APP}\" -i de.openms.${_name} \${CMAKE_INSTALL_PREFIX}/${_name}.app OUTPUT_VARIABLE sign_out ERROR_VARIABLE sign_out)
 message('\${sign_out}')" COMPONENT Applications)
 
 				 install(CODE "


### PR DESCRIPTION
### **User description**
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed an issue with macOS app bundle signing by adding the `--entitlements com.apple.security.cs.disable-library-validation` option to the `codesign` command.
- Ensures compatibility by disabling library validation during the signing process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add_mac_bundle.cmake</strong><dd><code>Adjusted macOS app bundle signing to disable library validation</code></dd></summary>
<hr>

src/openms_gui/add_mac_bundle.cmake

<li>Modified the <code>codesign</code> command to include the <code>--entitlements </code><br><code>com.apple.security.cs.disable-library-validation</code> option.<br> <li> Adjusted the signing process to disable library validation for macOS <br>app bundles.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7762/files#diff-73ac884d6fd1b4a7dece1ac47f8e69c2258c56c610f8c582b7e8e051d8820547">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information