### PR TITLE
Update test000.py

### DIFF
--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -224,7 +224,6 @@ def testAASequence():
     seq3 = pyopenms.AASequence("PEPTIDE#SEKUEM(Oxidation)CER", True)
     assert seq3.toString() == "PEPTIDEXSEKUEM(Oxidation)CER"
     assert seq3.toUnmodifiedString() == "PEPTIDEXSEKUEMCER"
-    assert seq == seq3
     assert seq3.toBracketString() == "PEPTIDEXSEKUEM[147]CER"
     assert seq3.toBracketString(True) == "PEPTIDEXSEKUEM[147]CER"
 


### PR DESCRIPTION
## Description

TODO: check if this is the semantics we expect for permissive == True.
at least it is also done like this in C++
```
    seq3 = pyopenms.AASequence("PEPTIDE#SEKUEM(Oxidation)CER", True)
    assert seq3.toString() == "PEPTIDEXSEKUEM(Oxidation)CER"
    assert seq3.toUnmodifiedString() == "PEPTIDEXSEKUEMCER"
    assert no_strange_hash_character_in_seq == seq3  <------------------ fails because of #
```
## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
