### PR TITLE
feature: score switching to general score types - add option to perform protein inference on non-main scores

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h
@@ -12,6 +12,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 
 namespace OpenMS
 {
@@ -124,10 +125,17 @@ namespace OpenMS
     /// get the AggregationMethod enum from a @p method_string
     AggregationMethod aggFromString_(const std::string& method_string) const;
 
-    /// check if a @p score_type is compatible to the chosen @p aggregation_method
+    /// check if a @p score_name is compatible to the chosen @p aggregation_method
     /// I.e. only probabilities can be used for multiplication
     void checkCompat_(
         const String& score_type,
+        const AggregationMethod& aggregation_method
+        ) const;
+
+    /// check if a @p score_type is compatible to the chosen @p aggregation_method
+    /// I.e. only probabilities can be used for multiplication
+    void checkCompat_(
+        const IDScoreSwitcherAlgorithm::ScoreType& score_type,
         const AggregationMethod& aggregation_method
         ) const;
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -341,6 +341,7 @@ namespace OpenMS
    @param pep_ids The vector of PeptideIdentification objects to inspect.
    @param name Output parameter to store the determined overall score type.
    @param higher_better Output parameter to store whether a higher score is considered better.
+   @param score_type Output parameter to store the determined score type.
    @note This method assumes that all PeptideIdentification objects in the input vector have the same score type and orientation.
   */
   void determineScoreNameOrientationAndType(
@@ -380,6 +381,7 @@ namespace OpenMS
    @param cmap The ConsensusMap to inspect.
    @param name Output parameter to store the determined overall score type.
    @param higher_better Output parameter to store whether a higher score is considered better.
+   @param score_type Output parameter to store the determined score type.
    @param include_unassigned If true, unassigned peptide identifications are considered if no assigned ones are found. Default is true.
   */
   void determineScoreNameOrientationAndType(const ConsensusMap& cmap, 
@@ -558,42 +560,20 @@ namespace OpenMS
    * This structure contains both the original and requested score details, including
    * score names, their orientation (whether higher scores are better), and score types
    * before and after the switch. It also includes a flag to indicate if the main score
-   * has been switched. Used to switch back to the original score if needed.
-   *
-   * @var original_score_name
-   *     The name of the original score used before the switch.
-   *
-   * @var original_score_higher_better
-   *     Indicates if a higher original score is considered better. Defaults to true.
-   *
-   * @var original_score_type
-   *     The type of the original score before the switch. Defaults to IDScoreSwitcherAlgorithm::ScoreType::RAW.
-   *
-   * @var requested_score_higher_better
-   *     Indicates if a higher requested score is considered better. Initialized to original_score_higher_better.
-   *
-   * @var requested_score_type
-   *     The type of the requested score after the switch. Initialized to original_score_type.
-   *
-   * @var requested_score_name
-   *     The name of the requested score, which can be a search engine score name (e.g., "X!Tandem_score") 
-   *     or a score category (e.g., "PEP").
-   *
-   * @var score_switched
-   *     Flag indicating whether the main score has been switched. Defaults to false.
+   * has been switched. Used to switch back to the original score if needed.   
    */
   struct IDSwitchResult
   {
     // the score name, orientation and type used before the switch
-    String original_score_name;
-    bool original_score_higher_better = true;
-    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
+    String original_score_name; /// The name of the original score used before the switch.
+    bool original_score_higher_better = true; /// whether a higher original score is better
+    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW; /// the type of the original score
     // the score name, orientation and type used after the switch
-    bool requested_score_higher_better = original_score_higher_better;    
-    IDScoreSwitcherAlgorithm::ScoreType requested_score_type = original_score_type;      
+    bool requested_score_higher_better = original_score_higher_better; /// whether a higher requested score is better
+    IDScoreSwitcherAlgorithm::ScoreType requested_score_type = original_score_type; /// the type of the requested score
     String requested_score_name; // the search engine score name (e.g. "X!Tandem_score" or score category (e.g. "PEP")
     // wheter the main score was switched
-    bool score_switched = false;
+    bool score_switched = false; /// flag indicating whether the main score was switched
   };
 
   /**

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -638,8 +638,8 @@ namespace OpenMS
       result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
       IDScoreSwitcherAlgorithm idsa;
       auto param = idsa.getDefaults();
-      param.setValue("new_score", result.original_score_name);
-      param.setValue("new_score_orientation", result.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("new_score", result.requested_score_name);
+      param.setValue("new_score_orientation", result.requested_score_higher_better ? "higher_better" : "lower_better");
       param.setValue("proteins", "false");
       param.setValue("old_score", ""); // use default name generated for old score
       idsa.setParameters(param);            
@@ -703,8 +703,8 @@ namespace OpenMS
       result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
       IDScoreSwitcherAlgorithm idsa;
       auto param = idsa.getDefaults();
-      param.setValue("new_score", result.original_score_name);
-      param.setValue("new_score_orientation", result.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("new_score", result.requested_score_name);
+      param.setValue("new_score_orientation", result.requested_score_higher_better ? "higher_better" : "lower_better");
       param.setValue("proteins", "false");
       param.setValue("old_score", ""); // use default name generated for old score
       idsa.setParameters(param);            

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -429,6 +429,33 @@ namespace OpenMS
     }
     
     /**
+     * @brief Switches the scores of peptide identifications.
+     *
+     * This function iterates over all peptide identifications
+     * and switches their scores using the switchScores function. It also increments the
+     * provided counter for each peptide identification processed. Score names are
+     * taken from the algorithm's parameters. If the requested score is already set as the
+     * main score, the function returns without making any changes.
+     *
+     * @param pep_ids The peptide identifications whose scores need to be switched.
+     * @param counter A reference to a counter that will be incremented for each peptide identification processed.     
+     */
+    void switchScores(std::vector<PeptideIdentification>& pep_ids, Size& counter)
+    {
+      if (pep_ids.empty()) return;
+
+      if (new_score_ == pep_ids[0].getScoreType()) // correct score already set
+      {
+        return;
+      }
+      
+      for (auto& id : pep_ids)
+      {
+        switchScores(id, counter);
+      }
+    }
+
+    /**
      * @brief Searches for a specified score type within an identification object and its meta values.
      *
      * This method attempts to find a given score type in the main score type of an identification object (`id`)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -339,7 +339,7 @@ namespace OpenMS
    determination, assuming that all identifications in the vector have the same score type and orientation.
 
    @param pep_ids The vector of PeptideIdentification objects to inspect.
-   @param overall_score_type Output parameter to store the determined overall score type.
+   @param name Output parameter to store the determined overall score type.
    @param higher_better Output parameter to store whether a higher score is considered better.
    @note This method assumes that all PeptideIdentification objects in the input vector have the same score type and orientation.
   */
@@ -378,7 +378,7 @@ namespace OpenMS
    considers unassigned peptide identifications.
 
    @param cmap The ConsensusMap to inspect.
-   @param overall_score_type Output parameter to store the determined overall score type.
+   @param name Output parameter to store the determined overall score type.
    @param higher_better Output parameter to store whether a higher score is considered better.
    @param include_unassigned If true, unassigned peptide identifications are considered if no assigned ones are found. Default is true.
   */
@@ -552,7 +552,36 @@ namespace OpenMS
       }
     }
 
-
+  /**
+   * @brief Structure holding score switching information for IDScoreSwitcherAlgorithm.
+   *
+   * This structure contains both the original and requested score details, including
+   * score names, their orientation (whether higher scores are better), and score types
+   * before and after the switch. It also includes a flag to indicate if the main score
+   * has been switched. Used to switch back to the original score if needed.
+   *
+   * @var original_score_name
+   *     The name of the original score used before the switch.
+   *
+   * @var original_score_higher_better
+   *     Indicates if a higher original score is considered better. Defaults to true.
+   *
+   * @var original_score_type
+   *     The type of the original score before the switch. Defaults to IDScoreSwitcherAlgorithm::ScoreType::RAW.
+   *
+   * @var requested_score_higher_better
+   *     Indicates if a higher requested score is considered better. Initialized to original_score_higher_better.
+   *
+   * @var requested_score_type
+   *     The type of the requested score after the switch. Initialized to original_score_type.
+   *
+   * @var requested_score_name
+   *     The name of the requested score, which can be a search engine score name (e.g., "X!Tandem_score") 
+   *     or a score category (e.g., "PEP").
+   *
+   * @var score_switched
+   *     Flag indicating whether the main score has been switched. Defaults to false.
+   */
   struct IDSwitchResult
   {
     // the score name, orientation and type used before the switch
@@ -567,6 +596,19 @@ namespace OpenMS
     bool score_switched = false;
   };
 
+  /**
+   * @brief Switches the score type of a ConsensusMap to the requested score type.
+   *
+   * This static method updates the scores within the provided ConsensusMap to the specified
+   * score type. It determines the original score properties, checks if a switch is necessary
+   * based on the requested score type, and performs the switch if required.
+   *
+   * @param cmap The ConsensusMap object whose score types are to be switched.
+   * @param requested_score_type_as_string The desired score type as a string (e.g., "RAW", "PEP", "q-value").
+   * @param include_unassigned Optional flag indicating whether to include unassigned IDs in the score switch. Defaults to true.
+   *
+   * @return An IDSwitchResult structure containing information about the score switch operation, including the original and requested score names, types, and whether a switch was performed.
+   */
   static IDSwitchResult switchToScoreType(ConsensusMap& cmap, String requested_score_type_as_string, bool include_unassigned = true)
   {
     IDSwitchResult result;
@@ -611,6 +653,20 @@ namespace OpenMS
     return result;
   }
 
+  /**
+   * @brief Switches the score type of peptide identifications to the requested type.
+   *
+   * This static function modifies the provided vector of PeptideIdentification objects by switching
+   * their main score to the specified type. If no score type is requested, the original main score
+   * is retained. The function determines the original score's name, orientation, and type, and updates
+   * these attributes based on the requested score type. If a different score type is requested,
+   * it performs the switch and updates the relevant score information.
+   *
+   * @param pep_ids A vector of PeptideIdentification objects to be processed.
+   * @param requested_score_type_as_string The desired score type as a string (e.g., "RAW", "PEP", "q-value").
+   * @return IDSwitchResult A struct containing details about the original and requested score types,
+   *                        whether a switch was performed, and the number of IDs updated.
+   */
   static IDSwitchResult switchToScoreType(std::vector<PeptideIdentification>& pep_ids, String requested_score_type_as_string)
   {
     IDSwitchResult result;
@@ -655,6 +711,16 @@ namespace OpenMS
     return result;
   }
 
+  /**
+   * @brief Reverts the score type of a ConsensusMap to its original type based on the provided IDSwitchResult.
+   *
+   * This function checks if the scores have been switched and, if so, it switches them back to the original score type.
+   * It updates the ConsensusMap by switching the scores, optionally including unassigned PSMs.
+   *
+   * @param cmap The ConsensusMap object whose scores will be modified.
+   * @param isr The IDSwitchResult containing information about the score switch.
+   * @param include_unassigned A boolean flag indicating whether to include unassigned PSMs in the score switching process. Defaults to true.
+   */
   static void switchBackScoreType(ConsensusMap& cmap, IDSwitchResult isr, bool include_unassigned = true)
   {
     if (isr.score_switched)
@@ -673,6 +739,16 @@ namespace OpenMS
     }
   }
 
+  /**
+   * @brief Reverts the scoring type of peptide identifications to their original scores.
+   *
+   * This function checks if the scores have been switched. If so, it restores the original scoring parameters
+   * using the provided IDSwitchResult. It updates the peptide identifications accordingly and logs the number
+   * of PSMs (Peptide-Spectrum Matches) that were reverted.
+   *
+   * @param pep_ids A vector of PeptideIdentification objects to be updated.
+   * @param isr An IDSwitchResult object containing information about the score switch state and original score details.
+   */
   static void switchBackScoreType(std::vector<PeptideIdentification>& pep_ids, IDSwitchResult isr)
   {
     if (isr.score_switched)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -260,9 +260,9 @@ namespace OpenMS
       }
       new_score_ = t;
 
-      if (type != ScoreType::RAW && higher_better_ != type_to_better_[type])
+      if (higher_better_ != type_to_better_[type])
       {
-        OPENMS_LOG_WARN << "Requested non-raw score type does not match the expected score direction. Correcting!\n";
+        OPENMS_LOG_WARN << "Requested score type does not match the expected score direction. Correcting!\n";
         higher_better_ = type_to_better_[type];
       }
       for (auto& i : id)
@@ -321,9 +321,9 @@ namespace OpenMS
       }
       new_score_ = new_type;
 
-      if (type != ScoreType::RAW && higher_better_ != type_to_better_[type])
+      if (higher_better_ != type_to_better_[type])
       {
-        OPENMS_LOG_WARN << "Requested non-raw score type does not match the expected score direction. Correcting!\n";
+        OPENMS_LOG_WARN << "Requested score type does not match the expected score direction. Correcting!\n";
         higher_better_ = type_to_better_[type];
       }
 
@@ -637,6 +637,13 @@ namespace OpenMS
     { // user requests a different score type than the main score
       result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
       IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", result.original_score_name);
+      param.setValue("new_score_orientation", result.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);            
+
       Size counter = 0; 
       idsa.switchToGeneralScoreType(cmap, result.requested_score_type, counter, include_unassigned);
       OPENMS_LOG_DEBUG << "Switched scores for " << counter << " IDs." << std::endl;
@@ -695,9 +702,16 @@ namespace OpenMS
     { // user requests a different score type than the main score
       result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
       IDScoreSwitcherAlgorithm idsa;
-      Size counter = 0; 
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", result.original_score_name);
+      param.setValue("new_score_orientation", result.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);            
+      Size counter = 0;       
       idsa.switchToGeneralScoreType(pep_ids, result.requested_score_type, counter);
       OPENMS_LOG_DEBUG << "Switched scores for " << counter << " IDs." << std::endl;
+
       result.score_switched = true;
     }
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -281,6 +281,86 @@ namespace OpenMS
       cmap.applyFunctionOnPeptideIDs(switchScoresSingle, unassigned_peptides_too);
     }
 
+  /// @brief determines the score type and orientation of the main score
+  /// @param pep_ids 
+  /// @param overall_score_type 
+  /// @param higher_better 
+  static void determineScoreTypeAndOrientation(const std::vector<PeptideIdentification>& pep_ids, String& overall_score_type, bool& higher_better)
+  {
+    //TODO check all pep IDs? this assumes equality
+    if (!pep_ids.empty())
+    {
+      overall_score_type = pep_ids[0].getScoreType();
+      higher_better = pep_ids[0].isHigherScoreBetter();
+    }
+  }
+
+  /// @brief determine score type and orientation of main score
+  /// @param cmap 
+  /// @param overall_score_type 
+  /// @param higher_better 
+  /// @param include_unassigned 
+  static void determineScoreTypeAndOrientation(const ConsensusMap& cmap, String& overall_score_type, bool& higher_better, bool include_unassigned = true)
+  {
+    overall_score_type = "";
+    higher_better = true;
+
+    // TODO: check all pep IDs? this assumes equality to first encountered
+    for (const auto& cf : cmap)
+    {
+      const auto& pep_ids = cf.getPeptideIdentifications();
+      if (!pep_ids.empty())
+      {
+        overall_score_type = pep_ids[0].getScoreType();
+        higher_better = pep_ids[0].isHigherScoreBetter();
+        return;
+      }
+    }
+
+    if (overall_score_type.empty() && include_unassigned)
+    {
+      for (const auto& id : cmap.getUnassignedPeptideIdentifications())
+      {
+        overall_score_type = id.getScoreType();
+        higher_better = id.isHigherScoreBetter();
+        return;
+      }
+    }    
+  }
+
+    /**
+     * @brief Switches the scores of peptide identifications in a ConsensusMap.
+     *
+     * This function iterates over all peptide identifications in the given ConsensusMap
+     * and switches their scores using the switchScores function. It also increments the
+     * provided counter for each peptide identification processed. Score names are
+     * taken from the algorithm's parameters. If the requested score is already set as the
+     * main score, the function returns without making any changes.
+     *
+     * @param cmap The ConsensusMap containing peptide identifications whose scores need to be switched.
+     * @param counter A reference to a counter that will be incremented for each peptide identification processed.
+     * @param unassigned_peptides_too A boolean flag indicating whether to include unassigned peptides in the score switching process. Default is true.
+     */
+    void switchScores(ConsensusMap& cmap, Size& counter, bool unassigned_peptides_too = true)
+    {
+      for (const auto& f : cmap)
+      {
+        const auto& ids = f.getPeptideIdentifications();
+        if (!ids.empty())
+        {
+          if (new_score_ == ids[0].getScoreType()) // correct score already set
+          {
+            return;
+          }
+          else
+          {
+            break;
+          }
+        }
+      }      
+      const auto switchScoresSingle = [&counter,this](PeptideIdentification& id){switchScores(id,counter);};
+      cmap.applyFunctionOnPeptideIDs(switchScoresSingle, unassigned_peptides_too);
+    }
     
     /**
      * @brief Searches for a specified score type within an identification object and its meta values.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -20,27 +20,56 @@
 namespace OpenMS
 {
 
-  class OPENMS_DLLAPI IDScoreSwitcherAlgorithm:
+  /**
+    @brief This class is used to switch identification scores within identification or consensus feature maps.
+
+    This class provides functionality to switch the main scoring type used in peptide or protein identification data.
+    It supports switching between different score types, such as raw scores, E-values, posterior probabilities,
+    posterior error probabilities, FDR, and q-values. The class also handles the direction of the score (whether a higher
+    score is better) and can store the original scores as meta values to prevent data loss.
+
+    The score switching process is configurable through parameters that specify the score types,
+    as well as the desired score direction and how old scores are annotated in the meta information.
+
+    The class can operate on individual identification objects or
+    ConsensusMaps, updating the main scores of all hits based on the specified criteria.
+
+  */
+  class OPENMS_DLLAPI IDScoreSwitcherAlgorithm :
     public DefaultParamHandler
   {
   public:
-    IDScoreSwitcherAlgorithm ();
+    /// Default constructor. Initializes the parameter handler with default values.
+    IDScoreSwitcherAlgorithm();
 
-    /// This is a rough hierarchy of possible score types in MS
-    /// In an ideal case this should be reimplemented to follow
-    /// ontology hierarchies as soon as e.g. MS-OBO is complete
-    /// and we switched the Metavalues to CV terms.
+    /**
+      @brief This is a rough hierarchy of possible score types in MS.
+
+      In an ideal case, this should be reimplemented to follow
+      ontology hierarchies as soon as e.g. MS-OBO is complete
+      and we switched the Metavalues to CV terms.
+    */
     enum class ScoreType
     {
-      RAW,
-      RAW_EVAL,
-      PP,
-      PEP,
-      FDR,
-      QVAL,
+      RAW,      ///< Raw score, e.g., search engine specific scores like hyperscore.
+      RAW_EVAL, ///< Raw score with E-value, e.g., search engine specific scores like expect score.
+      PP,       ///< Posterior probability.
+      PEP,      ///< Posterior error probability.
+      FDR,      ///< False discovery rate.
+      QVAL,     ///< Q-value.
     };
 
-    /// Checks if the given @p score_name is of ScoreType @p type
+    /**
+      @brief Checks if the given score name corresponds to a specific score type.
+
+      This method determines if a given score name, typically derived from an identification object or meta value,
+      matches a specified ScoreType. It performs a case-insensitive comparison and optionally removes the "_score"
+      suffix if present.
+
+      @param score_name The name of the score to check.
+      @param type The ScoreType to compare against.
+      @return True if the score name matches the given ScoreType, false otherwise.
+    */
     bool isScoreType(const String& score_name, const ScoreType& type)
     {
       String chopped = score_name;
@@ -52,7 +81,18 @@ namespace OpenMS
       return possible_types.find(chopped) != possible_types.end();
     }
 
-    /// Gets a @p ScoreType enum from a given score name @p score_name
+    /**
+      @brief Converts a string representation of a score type to a ScoreType enum.
+
+      This static method attempts to map a given string, representing a score type, to the corresponding
+      ScoreType enum value. It handles various common representations of score types, including those
+      with or without the "_score" suffix, and ignores case and special characters like '-', '_', and ' '.
+
+      @param score_type The string representation of the score type.
+      @return The corresponding ScoreType enum value.
+      @throws Exception::MissingInformation If the provided score_type string does not match any known
+                                            score type.
+    */
     static ScoreType getScoreType(String score_type)
     {
       if (score_type.hasSuffix("_score"))
@@ -89,20 +129,20 @@ namespace OpenMS
     }
 
     /**
-     * @brief Determines whether a higher score type is better given a ScoreType enum.
-     * 
-     * @param score_type The score type to check.
-     * @return True if a higher score type is better, false otherwise.
-     */
+      @brief Determines whether a higher score type is better given a ScoreType enum.
+
+      @param score_type The score type to check.
+      @return True if a higher score type is better, false otherwise.
+    */
     bool isScoreTypeHigherBetter(ScoreType score_type)
     {
       return type_to_better_[score_type];
     }
 
-    /*
-      * @brief Gets a vector of all score names that are used in OpenMS.
-      *
-      * @return A vector of all score names that are used in OpenMS (e.g., "q-value", "ln(hyperscore)").
+    /**
+      @brief Gets a vector of all score names that are used in OpenMS.
+
+      @return A vector of all score names that are used in OpenMS (e.g., "q-value", "ln(hyperscore)").
     */
     std::vector<String> getScoreTypeNames();
 
@@ -231,9 +271,19 @@ namespace OpenMS
       }
     }
 
-    /// Looks at the first Hit of the given @p id and according to the given @p type ,
-    /// deduces a fitting score and score direction to be switched to.
-    /// Then tries to switch all hits.
+    /**
+      @brief Switches the score type of a ConsensusMap to a general score type.
+
+      Looks at the first Hit of the given ConsensusMap and according to the given score type,
+      deduces a fitting score and score direction to be switched to.
+      Then tries to switch all hits.
+
+      @param cmap The ConsensusMap containing peptide identifications whose scores need to be switched.
+      @param type The desired general score type to switch to.
+      @param counter A reference to a counter that will be incremented for each peptide identification processed.
+      @param unassigned_peptides_too A boolean flag indicating whether to include unassigned peptides in the score switching process. Default is true.
+      @throws Exception::MissingInformation If the first encountered ID does not have the requested score type.
+    */
     void switchToGeneralScoreType(ConsensusMap& cmap, ScoreType type, Size& counter, bool unassigned_peptides_too = true)
     {
       String new_type = "";
@@ -281,10 +331,18 @@ namespace OpenMS
       cmap.applyFunctionOnPeptideIDs(switchScoresSingle, unassigned_peptides_too);
     }
 
-  /// @brief determines the score type and orientation of the main score
-  /// @param pep_ids 
-  /// @param overall_score_type 
-  /// @param higher_better 
+  /**
+   @brief Determines the score type and orientation of the main score for a set of peptide identifications.
+
+   This static method inspects a vector of PeptideIdentification objects to determine the overall score type and
+   whether a higher score is considered better. It uses the first PeptideIdentification in the vector to make this
+   determination, assuming that all identifications in the vector have the same score type and orientation.
+
+   @param pep_ids The vector of PeptideIdentification objects to inspect.
+   @param overall_score_type Output parameter to store the determined overall score type.
+   @param higher_better Output parameter to store whether a higher score is considered better.
+   @note This method assumes that all PeptideIdentification objects in the input vector have the same score type and orientation.
+  */
   static void determineScoreTypeAndOrientation(const std::vector<PeptideIdentification>& pep_ids, String& overall_score_type, bool& higher_better)
   {
     //TODO check all pep IDs? this assumes equality
@@ -295,11 +353,19 @@ namespace OpenMS
     }
   }
 
-  /// @brief determine score type and orientation of main score
-  /// @param cmap 
-  /// @param overall_score_type 
-  /// @param higher_better 
-  /// @param include_unassigned 
+  /**
+   @brief Determines the score type and orientation of the main score in a ConsensusMap.
+
+   This static method inspects a ConsensusMap to determine the overall score type and whether a higher score is
+   considered better. It iterates through the ConsensusMap's features and uses the first PeptideIdentification found
+   to determine the score type and orientation. If no assigned peptide identifications are found, it optionally
+   considers unassigned peptide identifications.
+
+   @param cmap The ConsensusMap to inspect.
+   @param overall_score_type Output parameter to store the determined overall score type.
+   @param higher_better Output parameter to store whether a higher score is considered better.
+   @param include_unassigned If true, unassigned peptide identifications are considered if no assigned ones are found. Default is true.
+  */
   static void determineScoreTypeAndOrientation(const ConsensusMap& cmap, String& overall_score_type, bool& higher_better, bool include_unassigned = true)
   {
     overall_score_type = "";
@@ -421,7 +487,8 @@ namespace OpenMS
     }
 
   private:
-    void updateMembers_() override;
+
+    void updateMembers_() override; ///< documented in base class
 
     /// relative tolerance for score comparisons:
     const double tolerance_ = 1e-6;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -552,6 +552,145 @@ namespace OpenMS
       }
     }
 
+
+  struct IDSwitchResult
+  {
+    // the score name, orientation and type used before the switch
+    String original_score_name;
+    bool original_score_higher_better = true;
+    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
+    // the score name, orientation and type used after the switch
+    bool requested_score_higher_better = original_score_higher_better;    
+    IDScoreSwitcherAlgorithm::ScoreType requested_score_type = original_score_type;      
+    String requested_score_name; // the search engine score name (e.g. "X!Tandem_score" or score category (e.g. "PEP")
+    // wheter the main score was switched
+    bool score_switched = false;
+  };
+
+  static IDSwitchResult switchToScoreType(ConsensusMap& cmap, String requested_score_type_as_string, bool include_unassigned = true)
+  {
+    IDSwitchResult result;
+    // fill in the original score name, orientation and type
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
+      result.original_score_name, 
+      result.original_score_higher_better, 
+      result.original_score_type,
+      include_unassigned);
+
+    // initalize with the assumption that the main score is the requested score
+    result.requested_score_name = result.original_score_name; // the search engine score name (e.g. "X!Tandem_score" or score category (e.g. "PEP")
+    result.requested_score_type = result.original_score_type;
+    result.requested_score_higher_better = result.original_score_higher_better;          
+
+    // no score type specified -> use main score
+    if (requested_score_type_as_string.empty())
+    {
+      OPENMS_LOG_DEBUG << "No score type specified. Using main score." << std::endl;
+      return result;
+    }
+
+    // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
+    result.requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
+    if (result.requested_score_type != result.original_score_type) // switch needed because we change type?
+    { // user requests a different score type than the main score
+      result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
+      IDScoreSwitcherAlgorithm idsa;
+      Size counter = 0; 
+      idsa.switchToGeneralScoreType(cmap, result.requested_score_type, counter, include_unassigned);
+      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " IDs." << std::endl;
+      result.score_switched = true;
+    }
+
+    // update after potential switch and read out actual score name
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
+      result.requested_score_name, 
+      result.requested_score_higher_better, 
+      result.requested_score_type,
+      include_unassigned);
+
+    return result;
+  }
+
+  static IDSwitchResult switchToScoreType(std::vector<PeptideIdentification>& pep_ids, String requested_score_type_as_string)
+  {
+    IDSwitchResult result;
+    // fill in the original score name, orientation and type
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
+      result.original_score_name, 
+      result.original_score_higher_better, 
+      result.original_score_type
+      );
+
+    // initalize with the assumption that the main score is the requested score
+    result.requested_score_name = result.original_score_name; // the search engine score name (e.g. "X!Tandem_score" or score category (e.g. "PEP")
+    result.requested_score_type = result.original_score_type;
+    result.requested_score_higher_better = result.original_score_higher_better;
+
+    // no score type specified -> use main score
+    if (requested_score_type_as_string.empty())
+    {
+      OPENMS_LOG_DEBUG << "No score type specified. Using main score." << std::endl;
+      return result;
+    }
+
+    // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
+    result.requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
+    if (result.requested_score_type != result.original_score_type) // switch needed because we change type?
+    { // user requests a different score type than the main score
+      result.requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(result.requested_score_type);
+      IDScoreSwitcherAlgorithm idsa;
+      Size counter = 0; 
+      idsa.switchToGeneralScoreType(pep_ids, result.requested_score_type, counter);
+      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " IDs." << std::endl;
+      result.score_switched = true;
+    }
+
+    // update after potential switch and read out actual score name
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
+      result.requested_score_name, 
+      result.requested_score_higher_better, 
+      result.requested_score_type
+      );
+
+    return result;
+  }
+
+  static void switchBackScoreType(ConsensusMap& cmap, IDSwitchResult isr, bool include_unassigned = true)
+  {
+    if (isr.score_switched)
+    {
+      // switch back to original score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", isr.original_score_name);
+      param.setValue("new_score_orientation", isr.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0;
+      idsa.switchScores(cmap, counter, include_unassigned);
+      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
+    }
+  }
+
+  static void switchBackScoreType(std::vector<PeptideIdentification>& pep_ids, IDSwitchResult isr)
+  {
+    if (isr.score_switched)
+    {
+      // switch back to original score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", isr.original_score_name);
+      param.setValue("new_score_orientation", isr.original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0;
+      idsa.switchScores(pep_ids, counter);
+      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
+    }
+  }
+
   private:
 
     void updateMembers_() override; ///< documented in base class

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h
@@ -93,7 +93,7 @@ namespace OpenMS
       @throws Exception::MissingInformation If the provided score_type string does not match any known
                                             score type.
     */
-    static ScoreType getScoreType(String score_type)
+    static ScoreType toScoreTypeEnum(String score_type)
     {
       if (score_type.hasSuffix("_score"))
       {
@@ -124,7 +124,7 @@ namespace OpenMS
       else
       {
         throw Exception::MissingInformation(__FILE__, __LINE__,
-                                            OPENMS_PRETTY_FUNCTION, String("Unknown score type ") + score_type);
+                                            OPENMS_PRETTY_FUNCTION, String("Unknown score type '") + score_type + "'.");
       }
     }
 
@@ -144,7 +144,7 @@ namespace OpenMS
 
       @return A vector of all score names that are used in OpenMS (e.g., "q-value", "ln(hyperscore)").
     */
-    std::vector<String> getScoreTypeNames();
+    std::vector<String> getScoreNames();
 
     /**
      * @brief Switches the main scores of all hits in an identification object based on the new scoring settings.
@@ -343,13 +343,29 @@ namespace OpenMS
    @param higher_better Output parameter to store whether a higher score is considered better.
    @note This method assumes that all PeptideIdentification objects in the input vector have the same score type and orientation.
   */
-  static void determineScoreTypeAndOrientation(const std::vector<PeptideIdentification>& pep_ids, String& overall_score_type, bool& higher_better)
+  void determineScoreNameOrientationAndType(
+    const std::vector<PeptideIdentification>& pep_ids, 
+    String& name, 
+    bool& higher_better,
+    ScoreType& score_type)
   {
     //TODO check all pep IDs? this assumes equality
     if (!pep_ids.empty())
     {
-      overall_score_type = pep_ids[0].getScoreType();
+      name = pep_ids[0].getScoreType(); // The name of the score. Typically a name like "XTandem" or "Percolator_qvalue"
       higher_better = pep_ids[0].isHigherScoreBetter();
+      
+      // look up the score category ("RAW", "PEP", "q-value", etc.) for the given score name
+      for (auto& [scoretype, names] : type_to_str_)
+      {
+        if (names.find(name) != names.end())
+        {
+          score_type = scoretype;
+          OPENMS_LOG_INFO << "Found score type " << name << " to be of type " 
+            << static_cast<std::underlying_type<ScoreType>::type>(scoretype) << std::endl;
+          return;
+        }
+      }
     }
   }
 
@@ -366,9 +382,13 @@ namespace OpenMS
    @param higher_better Output parameter to store whether a higher score is considered better.
    @param include_unassigned If true, unassigned peptide identifications are considered if no assigned ones are found. Default is true.
   */
-  static void determineScoreTypeAndOrientation(const ConsensusMap& cmap, String& overall_score_type, bool& higher_better, bool include_unassigned = true)
+  void determineScoreNameOrientationAndType(const ConsensusMap& cmap, 
+    String& name,
+    bool& higher_better,
+    ScoreType& score_type,
+    bool include_unassigned = true)
   {
-    overall_score_type = "";
+    name = "";
     higher_better = true;
 
     // TODO: check all pep IDs? this assumes equality to first encountered
@@ -377,18 +397,37 @@ namespace OpenMS
       const auto& pep_ids = cf.getPeptideIdentifications();
       if (!pep_ids.empty())
       {
-        overall_score_type = pep_ids[0].getScoreType();
+        name = pep_ids[0].getScoreType();
         higher_better = pep_ids[0].isHigherScoreBetter();
-        return;
+
+        // look up the score category ("RAW", "PEP", "q-value", etc.) for the given score name
+        for (auto& [scoretype, names] : type_to_str_)
+        {
+          if (names.find(name) != names.end())
+          {
+            score_type = scoretype;
+            return;
+          }
+        }
       }
     }
 
-    if (overall_score_type.empty() && include_unassigned)
+    if (name.empty() && include_unassigned)
     {
       for (const auto& id : cmap.getUnassignedPeptideIdentifications())
       {
-        overall_score_type = id.getScoreType();
+        name = id.getScoreType();
         higher_better = id.isHigherScoreBetter();
+
+         // look up the score category ("RAW", "PEP", "q-value", etc.) for the given score name
+        for (auto& [scoretype, names] : type_to_str_)
+        {
+          if (names.find(name) != names.end())
+          {
+            score_type = scoretype;
+            return;
+          }
+        }        
         return;
       }
     }    
@@ -414,7 +453,7 @@ namespace OpenMS
         const auto& ids = f.getPeptideIdentifications();
         if (!ids.empty())
         {
-          if (new_score_ == ids[0].getScoreType()) // correct score already set
+          if (new_score_ == ids[0].getScoreType()) // correct score or category already set
           {
             return;
           }

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -123,7 +123,7 @@ namespace OpenMS
 
     // determine current main score and orientation
     String original_score_name;
-    bool original_score_higher_better;
+    bool original_score_higher_better = true;
     IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(cmap, original_score_name, original_score_higher_better, include_unassigned);
 
     // switch to requested score if provided by user and if it is different from current main score
@@ -277,6 +277,38 @@ namespace OpenMS
     std::unordered_map<std::string, std::map<Int, PeptideHit*>> best_pep;
     std::unordered_map<std::string, std::pair<ProteinHit*, Size>> acc_to_protein_hitP_and_count;
 
+   // determine current main score and orientation
+    String original_score_name;
+    bool original_score_higher_better = true;
+    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(pep_ids, original_score_name, original_score_higher_better);
+
+    // switch to requested score if provided by user and if it is different from current main score
+    String requested_score_name = param_.getValue("score").toString();
+    bool requested_score_higher_better = param_.getValue("score_orientation").toString() == "higher_better" ? true : false;
+
+    bool switched_main_score = false;
+
+    if (requested_score_name.empty() || requested_score_name == original_score_name)
+    { // user requests the main score
+      requested_score_name = original_score_name;
+      requested_score_higher_better = original_score_higher_better;
+    }
+    else
+    { // user requests a different score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", requested_score_name);
+      param.setValue("new_score_orientation", requested_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0;
+      idsa.switchScores(pep_ids, counter);
+      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " PSMs." << std::endl;
+      switched_main_score = true;
+    } 
+
+
     for (auto &prot_run : prot_ids)
     {
       processRun_(
@@ -291,6 +323,21 @@ namespace OpenMS
     {
       IDFilter::updateProteinReferences(pep_ids, prot_ids, true); //TODO allow keeping PSMs without evidence?
     }
+
+    if (switched_main_score)
+    {
+      // switch back to original score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", original_score_name);
+      param.setValue("new_score_orientation", original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0;
+      idsa.switchScores(pep_ids, counter);
+      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
+    }    
   }
 
   void BasicProteinInferenceAlgorithm::aggregatePeptideScores_(

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -74,6 +74,9 @@ namespace OpenMS
     std::unordered_map<std::string, std::map<Int, PeptideHit*>> best_pep;
     std::unordered_map<std::string, std::pair<ProteinHit*, Size>> acc_to_protein_hitP_and_count;
 
+    String requested_score_type_as_string = param_.getValue("score_type").toString();
+    auto isr = IDScoreSwitcherAlgorithm::switchToScoreType(pep_ids, requested_score_type_as_string);
+
     processRun_(
         acc_to_protein_hitP_and_count,
         best_pep,
@@ -88,6 +91,8 @@ namespace OpenMS
       IDFilter::updateProteinReferences(pep_ids, tmp, true); //TODO allow keeping PSMs without evidence?
       std::swap(tmp[0], prot_id);
     }
+
+    IDScoreSwitcherAlgorithm::switchBackScoreType(pep_ids, isr);
   }
 
   void BasicProteinInferenceAlgorithm::run(ConsensusMap& cmap, ProteinIdentification& prot_run, bool include_unassigned) const
@@ -121,57 +126,18 @@ namespace OpenMS
 
     IDFilter::keepNBestPeptideHits(cmap, 1); // we should filter for best psm per spec only, since those will be the psms used, also filterUnreferencedProteins depends on it (e.g. after resolution)
 
-    // determine current main score, orientation and type
-    String original_score_name;
-    bool original_score_higher_better = true;
-    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
-
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
-      original_score_name, 
-      original_score_higher_better, 
-      original_score_type,
-      include_unassigned);
-
     // determine requested score type. This can be a search engine score name or a broader score category (e.g. PEP)
     String requested_score_type_as_string = param_.getValue("score_type").toString();
-    
-    // determine if we need to switch scores
 
-    // initalize with the assumption that the main score is the requested score
-
-    bool switched_main_score = false;
-    bool requested_score_higher_better = original_score_higher_better;    
-    IDScoreSwitcherAlgorithm::ScoreType requested_score_type = original_score_type;
-
-    if (!requested_score_type_as_string.empty())
-    {       
-      // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
-      requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
-      if (requested_score_type != original_score_type)
-      { // user requests a different score type than the main score
-        requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(requested_score_type);
-
-        IDScoreSwitcherAlgorithm idsa;
-        Size counter = 0; 
-        idsa.switchToGeneralScoreType(cmap, requested_score_type, counter, include_unassigned);
-        // OPENMS_LOG_INFO << "Switched scores for " << counter << " IDs." << std::endl;
-        switched_main_score = true;
-      }
-    }
-
-    // update after potential switch and read out actual score name
-    String requested_score_name;
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
-      requested_score_name, 
-      requested_score_higher_better, 
-      requested_score_type,
-      include_unassigned);
-
-    // Here: we can be sure that we have the requested score type that as the main score now
+    // switch scores to requested score type (e.g., "RAW" = a search engine score, "PEP", "q-value")
+    // for convenience, the results als contain name, score orientation and type before and after switching
+    // as well as a flag that indicates if a swtich was performed (or e.g., score was already the main score)
+    auto isr = IDScoreSwitcherAlgorithm::switchToScoreType(cmap, requested_score_type_as_string, include_unassigned);
+    // Here: we can be sure that we have the requested score type that as the main score now    
  
     // determine inital values for protein scores based on score type
-    bool pep_scores = (requested_score_type == IDScoreSwitcherAlgorithm::ScoreType::PEP);
-    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || requested_score_higher_better); // if we have pep scores, we will complement to pp during aggregation
+    bool pep_scores = (isr.requested_score_type == IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || isr.requested_score_higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     for (auto& prothit : prot_hits)
     {
@@ -179,14 +145,14 @@ namespace OpenMS
       acc_to_protein_hitP_and_count[prothit.getAccession()] = std::make_pair<ProteinHit*, Size>(&prothit, 0);
     }
 
-    checkCompat_(requested_score_name, aggregation_method);
+    checkCompat_(isr.requested_score_name, aggregation_method);
 
     for (auto& cf : cmap)
     {
       aggregatePeptideScores_(best_pep, 
         cf.getPeptideIdentifications(), 
-        requested_score_name, 
-        requested_score_higher_better, 
+        isr.requested_score_name, 
+        isr.requested_score_higher_better, 
         "");
     }
 
@@ -194,8 +160,8 @@ namespace OpenMS
     {
       aggregatePeptideScores_(best_pep, 
         cmap.getUnassignedPeptideIdentifications(),
-        requested_score_name,
-        requested_score_higher_better,
+        isr.requested_score_name,
+        isr.requested_score_higher_better,
         "");
     }
 
@@ -203,7 +169,7 @@ namespace OpenMS
         acc_to_protein_hitP_and_count,
         best_pep,
         pep_scores,
-        requested_score_higher_better
+        isr.requested_score_higher_better
     );
 
     if (pep_scores)
@@ -213,8 +179,8 @@ namespace OpenMS
     }
     else
     {
-      prot_run.setScoreType(requested_score_name);
-      prot_run.setHigherScoreBetter(requested_score_higher_better);
+      prot_run.setScoreType(isr.requested_score_name); // score name after switch (e.g. "PEP", "q-value")
+      prot_run.setHigherScoreBetter(isr.requested_score_higher_better);
     }
 
     if (min_peptides_per_protein > 0)
@@ -267,21 +233,8 @@ namespace OpenMS
     }
 
     prot_run.sort();
-
-    if (switched_main_score)
-    {
-      // switch back to original score
-      IDScoreSwitcherAlgorithm idsa;
-      auto param = idsa.getDefaults();
-      param.setValue("new_score", original_score_name);
-      param.setValue("new_score_orientation", original_score_higher_better ? "higher_better" : "lower_better");
-      param.setValue("proteins", "false");
-      param.setValue("old_score", ""); // use default name generated for old score
-      idsa.setParameters(param);
-      Size counter = 0;
-      idsa.switchScores(cmap, counter);
-      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
-    }
+    
+    IDScoreSwitcherAlgorithm::switchBackScoreType(cmap, isr, include_unassigned); // NOP if no switch was performed
   }
 
   void BasicProteinInferenceAlgorithm::run(std::vector<PeptideIdentification> &pep_ids,
@@ -292,46 +245,9 @@ namespace OpenMS
     std::unordered_map<std::string, std::map<Int, PeptideHit*>> best_pep;
     std::unordered_map<std::string, std::pair<ProteinHit*, Size>> acc_to_protein_hitP_and_count;
 
-   // determine current main score and orientation
-    String original_score_name;
-    bool original_score_higher_better = true;
-    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
-
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
-      original_score_name, 
-      original_score_higher_better,
-      original_score_type
-      );
-
     // determine requested score type. This can be a search engine score name or a broader score category (e.g. PEP)
     String requested_score_type_as_string = param_.getValue("score_type").toString();
-
-    // switch scores if requested
-    bool switched_main_score = false;    
-    if (!requested_score_type_as_string.empty())
-    { 
-      // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
-      auto requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
-      if (requested_score_type != original_score_type)
-      { // user requests a different score type than the main score   
-        IDScoreSwitcherAlgorithm idsa;
-        Size counter = 0; 
-        idsa.switchToGeneralScoreType(pep_ids, requested_score_type, counter);
-        OPENMS_LOG_INFO << "Switched scores for " << counter << " IDs." << std::endl;
-        switched_main_score = true;
-      }
-    }
-
-    // update after potential switch and read out actual score name
-    String requested_score_name;
-    bool requested_score_higher_better{};
-    IDScoreSwitcherAlgorithm::ScoreType requested_score_type{};
-
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
-      requested_score_name, 
-      requested_score_higher_better,
-      requested_score_type
-      );
+    auto isr = IDScoreSwitcherAlgorithm::switchToScoreType(pep_ids, requested_score_type_as_string);
 
     for (auto &prot_run : prot_ids)
     {
@@ -348,20 +264,7 @@ namespace OpenMS
       IDFilter::updateProteinReferences(pep_ids, prot_ids, true); //TODO allow keeping PSMs without evidence?
     }
 
-    if (switched_main_score)
-    {
-      // switch back to original score
-      IDScoreSwitcherAlgorithm idsa;
-      auto param = idsa.getDefaults();
-      param.setValue("new_score", original_score_name);
-      param.setValue("new_score_orientation", original_score_higher_better ? "higher_better" : "lower_better");
-      param.setValue("proteins", "false");
-      param.setValue("old_score", ""); // use default name generated for old score
-      idsa.setParameters(param);
-      Size counter = 0;
-      idsa.switchScores(pep_ids, counter);
-      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
-    }    
+    IDScoreSwitcherAlgorithm::switchBackScoreType(pep_ids, isr); // NOP if no switch was performed
   }
 
   void BasicProteinInferenceAlgorithm::aggregatePeptideScores_(

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -59,6 +59,10 @@ namespace OpenMS
     defaults_.setValue("greedy_group_resolution", "false", "If this is true, shared peptides will be associated to best proteins only (i.e. become potentially quantifiable razor peptides).");
     defaults_.setValidStrings("greedy_group_resolution", {"true","false"});
 
+    defaults_.setValue("score", "", "PSM score to use (default: empty string will select main score)");
+    defaults_.setValue("score_orientation", "higher_better", "Orientation of the new score (are higher or lower values better?)");
+    defaults_.setValidStrings("score_orientation", {"lower_better", "higher_better"});
+
     defaultsToParam_();
   }
 
@@ -117,33 +121,42 @@ namespace OpenMS
 
     IDFilter::keepNBestPeptideHits(cmap, 1); // we should filter for best psm per spec only, since those will be the psms used, also filterUnreferencedProteins depends on it (e.g. after resolution)
 
-    String overall_score_type = "";
-    bool higher_better = true;
+    // determine current main score and orientation
+    String original_score_name;
+    bool original_score_higher_better;
+    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(cmap, original_score_name, original_score_higher_better, include_unassigned);
 
-    //TODO check all pep IDs? this assumes equality to first encountered
-    // will throw a well-formed exception in aggregatePeptideScores though.
-    for (const auto& cf : cmap)
-    {
-      const auto& pep_ids = cf.getPeptideIdentifications();
-      if (!pep_ids.empty())
-      {
-        overall_score_type = pep_ids[0].getScoreType();
-        higher_better = pep_ids[0].isHigherScoreBetter();
-        break;
-      }
-    }
-    if (overall_score_type.empty())
-    {
-      for (const auto& id : cmap.getUnassignedPeptideIdentifications())
-      {
-        overall_score_type = id.getScoreType();
-        higher_better = id.isHigherScoreBetter();
-        break;
-      }
-    }
+    // switch to requested score if provided by user and if it is different from current main score
+    String requested_score_name = param_.getValue("score").toString();
+    bool requested_score_higher_better = param_.getValue("score_orientation").toString() == "higher_better" ? true : false;
 
-    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(overall_score_type,IDScoreSwitcherAlgorithm::ScoreType::PEP);
-    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || higher_better); // if we have pep scores, we will complement to pp during aggregation
+    bool switched_main_score = false;
+
+    if (requested_score_name.empty() || requested_score_name == original_score_name)
+    { // user requests the main score
+      requested_score_name = original_score_name;
+      requested_score_higher_better = original_score_higher_better;
+    }
+    else
+    { // user requests a different score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", requested_score_name);
+      param.setValue("new_score_orientation", requested_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0; 
+      idsa.switchScores(cmap, counter);
+      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " PSMs." << std::endl;
+      switched_main_score = true;
+    } 
+
+    // Here: requested_score_name and orientation are  set according to the main score (potentially after a switch)
+ 
+    // determine inital values for protein scores based on score type
+    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(requested_score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || requested_score_higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     for (auto& prothit : prot_hits)
     {
@@ -151,23 +164,31 @@ namespace OpenMS
       acc_to_protein_hitP_and_count[prothit.getAccession()] = std::make_pair<ProteinHit*, Size>(&prothit, 0);
     }
 
-    checkCompat_(overall_score_type, aggregation_method);
+    checkCompat_(requested_score_name, aggregation_method);
 
     for (auto& cf : cmap)
     {
-      aggregatePeptideScores_(best_pep, cf.getPeptideIdentifications(), overall_score_type, higher_better, "");
+      aggregatePeptideScores_(best_pep, 
+        cf.getPeptideIdentifications(), 
+        requested_score_name, 
+        requested_score_higher_better, 
+        "");
     }
 
     if (include_unassigned)
     {
-      aggregatePeptideScores_(best_pep, cmap.getUnassignedPeptideIdentifications(), overall_score_type, higher_better, "");
+      aggregatePeptideScores_(best_pep, 
+        cmap.getUnassignedPeptideIdentifications(),
+        requested_score_name,
+        requested_score_higher_better,
+        "");
     }
 
     updateProteinScores_(
         acc_to_protein_hitP_and_count,
         best_pep,
         pep_scores,
-        higher_better
+        requested_score_higher_better
     );
 
     if (pep_scores)
@@ -177,8 +198,8 @@ namespace OpenMS
     }
     else
     {
-      prot_run.setScoreType(overall_score_type);
-      prot_run.setHigherScoreBetter(higher_better);
+      prot_run.setScoreType(requested_score_name);
+      prot_run.setHigherScoreBetter(requested_score_higher_better);
     }
 
     if (min_peptides_per_protein > 0)
@@ -231,6 +252,21 @@ namespace OpenMS
     }
 
     prot_run.sort();
+
+    if (switched_main_score)
+    {
+      // switch back to original score
+      IDScoreSwitcherAlgorithm idsa;
+      auto param = idsa.getDefaults();
+      param.setValue("new_score", original_score_name);
+      param.setValue("new_score_orientation", original_score_higher_better ? "higher_better" : "lower_better");
+      param.setValue("proteins", "false");
+      param.setValue("old_score", ""); // use default name generated for old score
+      idsa.setParameters(param);
+      Size counter = 0;
+      idsa.switchScores(cmap, counter);
+      OPENMS_LOG_DEBUG << "Switched scores back for " << counter << " PSMs." << std::endl;
+    }
   }
 
   void BasicProteinInferenceAlgorithm::run(std::vector<PeptideIdentification> &pep_ids,
@@ -413,14 +449,14 @@ namespace OpenMS
   }
 
   void BasicProteinInferenceAlgorithm::checkCompat_(
-        const String& overall_score_type,
+        const String& score_name,
         const AggregationMethod& aggregation_method
   ) const
   {
     //TODO do something smart about the scores, e.g. let the user specify a general score type
     // he wants to use and then switch all of them
-    if (!IDScoreSwitcherAlgorithm().isScoreType(overall_score_type, IDScoreSwitcherAlgorithm::ScoreType::PEP) &&
-        !IDScoreSwitcherAlgorithm().isScoreType(overall_score_type, IDScoreSwitcherAlgorithm::ScoreType::PP) &&
+    if (!IDScoreSwitcherAlgorithm().isScoreType(score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP) &&
+        !IDScoreSwitcherAlgorithm().isScoreType(score_name, IDScoreSwitcherAlgorithm::ScoreType::PP) &&
         aggregation_method == AggregationMethod::PROD)
     {
       OPENMS_LOG_WARN << "ProteinInference with multiplicative aggregation "
@@ -500,7 +536,6 @@ namespace OpenMS
     }
   }
 
-
   void BasicProteinInferenceAlgorithm::processRun_(
       std::unordered_map<std::string, std::pair<ProteinHit*, Size>>& acc_to_protein_hitP_and_count,
       std::unordered_map<std::string, std::map<Int, PeptideHit*>>& best_pep,
@@ -534,15 +569,9 @@ namespace OpenMS
     sp.setMetaValue("TOPPProteinInference:treat_modification_variants_separately", treat_modification_variants_separately);
     prot_run.setSearchParameters(sp);
 
-    String overall_score_type = "";
+    String overall_score_type;
     bool higher_better = true;
-
-    //TODO check all pep IDs? this assumes equality
-    if (!pep_ids.empty())
-    {
-      overall_score_type = pep_ids[0].getScoreType();
-      higher_better = pep_ids[0].isHigherScoreBetter();
-    }
+    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(pep_ids, overall_score_type, higher_better);
 
     bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(overall_score_type,IDScoreSwitcherAlgorithm::ScoreType::PEP);
     double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || higher_better); // if we have pep scores, we will complement to pp during aggregation

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -558,12 +558,12 @@ namespace OpenMS
     sp.setMetaValue("TOPPProteinInference:treat_modification_variants_separately", treat_modification_variants_separately);
     prot_run.setSearchParameters(sp);
 
-    String score_name;
+    String main_score_name;
     bool higher_better = true;
-    IDScoreSwitcherAlgorithm::ScoreType overall_score_type_enum = IDScoreSwitcherAlgorithm::ScoreType::RAW;
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, score_name, higher_better, overall_score_type_enum);
+    IDScoreSwitcherAlgorithm::ScoreType main_score_type;
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, main_score_name, higher_better, main_score_type);
 
-    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(main_score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
     double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     //create Accession to ProteinHit and peptide count map. To have quick access later.
@@ -574,9 +574,9 @@ namespace OpenMS
       phit.setScore(initScore);
     }
 
-    checkCompat_(score_name, aggregation_method);
+    checkCompat_(main_score_name, aggregation_method);
 
-    aggregatePeptideScores_(best_pep, pep_ids, score_name, higher_better, prot_run.getIdentifier());
+    aggregatePeptideScores_(best_pep, pep_ids, main_score_name, higher_better, prot_run.getIdentifier());
 
     updateProteinScores_(acc_to_protein_hitP_and_count, best_pep, pep_scores, higher_better);
 
@@ -587,7 +587,7 @@ namespace OpenMS
     }
     else
     {
-      prot_run.setScoreType(score_name);
+      prot_run.setScoreType(main_score_name);
       prot_run.setHigherScoreBetter(higher_better);
     }
 

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -61,8 +61,6 @@ namespace OpenMS
     defaults_.setValue("score_type", "", "PSM score type to use for inference. (default: empty = main score)");
     defaults_.setValidStrings("score_type", {"", "PEP", "q-value", "RAW"});
 
-    defaults_.setValidStrings("greedy_group_resolution", {"true","false"});
-
     defaultsToParam_();
   }
 

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -7,7 +7,6 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h>
-#include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/IDBoostGraph.h>
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
@@ -59,9 +58,10 @@ namespace OpenMS
     defaults_.setValue("greedy_group_resolution", "false", "If this is true, shared peptides will be associated to best proteins only (i.e. become potentially quantifiable razor peptides).");
     defaults_.setValidStrings("greedy_group_resolution", {"true","false"});
 
-    defaults_.setValue("score", "", "PSM score to use (default: empty string will select main score)");
-    defaults_.setValue("score_orientation", "higher_better", "Orientation of the new score (are higher or lower values better?)");
-    defaults_.setValidStrings("score_orientation", {"lower_better", "higher_better"});
+    defaults_.setValue("score_type", "", "PSM score type to use for inference. (default: empty = main score)");
+    defaults_.setValidStrings("score_type", {"", "PEP", "q-value", "RAW"});
+
+    defaults_.setValidStrings("greedy_group_resolution", {"true","false"});
 
     defaultsToParam_();
   }
@@ -121,41 +121,56 @@ namespace OpenMS
 
     IDFilter::keepNBestPeptideHits(cmap, 1); // we should filter for best psm per spec only, since those will be the psms used, also filterUnreferencedProteins depends on it (e.g. after resolution)
 
-    // determine current main score and orientation
+    // determine current main score, orientation and type
     String original_score_name;
     bool original_score_higher_better = true;
-    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(cmap, original_score_name, original_score_higher_better, include_unassigned);
+    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
 
-    // switch to requested score if provided by user and if it is different from current main score
-    String requested_score_name = param_.getValue("score").toString();
-    bool requested_score_higher_better = param_.getValue("score_orientation").toString() == "higher_better" ? true : false;
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
+      original_score_name, 
+      original_score_higher_better, 
+      original_score_type,
+      include_unassigned);
+
+    // determine requested score type. This can be a search engine score name or a broader score category (e.g. PEP)
+    String requested_score_type_as_string = param_.getValue("score_type").toString();
+    
+    // determine if we need to switch scores
+
+    // initalize with the assumption that the main score is the requested score
 
     bool switched_main_score = false;
+    bool requested_score_higher_better = original_score_higher_better;    
+    IDScoreSwitcherAlgorithm::ScoreType requested_score_type = original_score_type;
 
-    if (requested_score_name.empty() || requested_score_name == original_score_name)
-    { // user requests the main score
-      requested_score_name = original_score_name;
-      requested_score_higher_better = original_score_higher_better;
+    if (!requested_score_type_as_string.empty())
+    {       
+      // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
+      requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
+      if (requested_score_type != original_score_type)
+      { // user requests a different score type than the main score
+        requested_score_higher_better = IDScoreSwitcherAlgorithm().isScoreTypeHigherBetter(requested_score_type);
+
+        IDScoreSwitcherAlgorithm idsa;
+        Size counter = 0; 
+        idsa.switchToGeneralScoreType(cmap, requested_score_type, counter, include_unassigned);
+        // OPENMS_LOG_INFO << "Switched scores for " << counter << " IDs." << std::endl;
+        switched_main_score = true;
+      }
     }
-    else
-    { // user requests a different score
-      IDScoreSwitcherAlgorithm idsa;
-      auto param = idsa.getDefaults();
-      param.setValue("new_score", requested_score_name);
-      param.setValue("new_score_orientation", requested_score_higher_better ? "higher_better" : "lower_better");
-      param.setValue("proteins", "false");
-      param.setValue("old_score", ""); // use default name generated for old score
-      idsa.setParameters(param);
-      Size counter = 0; 
-      idsa.switchScores(cmap, counter);
-      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " PSMs." << std::endl;
-      switched_main_score = true;
-    } 
 
-    // Here: requested_score_name and orientation are  set according to the main score (potentially after a switch)
+    // update after potential switch and read out actual score name
+    String requested_score_name;
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(cmap, 
+      requested_score_name, 
+      requested_score_higher_better, 
+      requested_score_type,
+      include_unassigned);
+
+    // Here: we can be sure that we have the requested score type that as the main score now
  
     // determine inital values for protein scores based on score type
-    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(requested_score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    bool pep_scores = (requested_score_type == IDScoreSwitcherAlgorithm::ScoreType::PEP);
     double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || requested_score_higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     for (auto& prothit : prot_hits)
@@ -280,34 +295,43 @@ namespace OpenMS
    // determine current main score and orientation
     String original_score_name;
     bool original_score_higher_better = true;
-    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(pep_ids, original_score_name, original_score_higher_better);
+    IDScoreSwitcherAlgorithm::ScoreType original_score_type = IDScoreSwitcherAlgorithm::ScoreType::RAW;
 
-    // switch to requested score if provided by user and if it is different from current main score
-    String requested_score_name = param_.getValue("score").toString();
-    bool requested_score_higher_better = param_.getValue("score_orientation").toString() == "higher_better" ? true : false;
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
+      original_score_name, 
+      original_score_higher_better,
+      original_score_type
+      );
 
-    bool switched_main_score = false;
+    // determine requested score type. This can be a search engine score name or a broader score category (e.g. PEP)
+    String requested_score_type_as_string = param_.getValue("score_type").toString();
 
-    if (requested_score_name.empty() || requested_score_name == original_score_name)
-    { // user requests the main score
-      requested_score_name = original_score_name;
-      requested_score_higher_better = original_score_higher_better;
+    // switch scores if requested
+    bool switched_main_score = false;    
+    if (!requested_score_type_as_string.empty())
+    { 
+      // ENUM for requested score type (e.g. "RAW", "PEP", "q-value")
+      auto requested_score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(requested_score_type_as_string);
+      if (requested_score_type != original_score_type)
+      { // user requests a different score type than the main score   
+        IDScoreSwitcherAlgorithm idsa;
+        Size counter = 0; 
+        idsa.switchToGeneralScoreType(pep_ids, requested_score_type, counter);
+        OPENMS_LOG_INFO << "Switched scores for " << counter << " IDs." << std::endl;
+        switched_main_score = true;
+      }
     }
-    else
-    { // user requests a different score
-      IDScoreSwitcherAlgorithm idsa;
-      auto param = idsa.getDefaults();
-      param.setValue("new_score", requested_score_name);
-      param.setValue("new_score_orientation", requested_score_higher_better ? "higher_better" : "lower_better");
-      param.setValue("proteins", "false");
-      param.setValue("old_score", ""); // use default name generated for old score
-      idsa.setParameters(param);
-      Size counter = 0;
-      idsa.switchScores(pep_ids, counter);
-      OPENMS_LOG_DEBUG << "Switched scores for " << counter << " PSMs." << std::endl;
-      switched_main_score = true;
-    } 
 
+    // update after potential switch and read out actual score name
+    String requested_score_name;
+    bool requested_score_higher_better{};
+    IDScoreSwitcherAlgorithm::ScoreType requested_score_type{};
+
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, 
+      requested_score_name, 
+      requested_score_higher_better,
+      requested_score_type
+      );
 
     for (auto &prot_run : prot_ids)
     {
@@ -512,6 +536,23 @@ namespace OpenMS
     }
   }
 
+  void BasicProteinInferenceAlgorithm::checkCompat_(
+        const IDScoreSwitcherAlgorithm::ScoreType& score_type,
+        const AggregationMethod& aggregation_method
+  ) const
+  {
+    //TODO do something smart about the scores, e.g. let the user specify a general score type
+    // he wants to use and then switch all of them
+    if ((score_type != IDScoreSwitcherAlgorithm::ScoreType::PEP) &&
+        (score_type != IDScoreSwitcherAlgorithm::ScoreType::PP) &&
+        aggregation_method == AggregationMethod::PROD)
+    {
+      OPENMS_LOG_WARN << "ProteinInference with multiplicative aggregation "
+                         " should probably use Posterior (Error) Probabilities in the Peptide Hits."
+                         " Use Percolator with PEP score or run IDPosteriorErrorProbability first.\n";
+    }
+  }  
+
   BasicProteinInferenceAlgorithm::AggregationMethod BasicProteinInferenceAlgorithm::aggFromString_(const std::string& agg_method_string) const
   {
     if (agg_method_string == "best")
@@ -616,11 +657,12 @@ namespace OpenMS
     sp.setMetaValue("TOPPProteinInference:treat_modification_variants_separately", treat_modification_variants_separately);
     prot_run.setSearchParameters(sp);
 
-    String overall_score_type;
+    String score_name;
     bool higher_better = true;
-    IDScoreSwitcherAlgorithm::determineScoreTypeAndOrientation(pep_ids, overall_score_type, higher_better);
+    IDScoreSwitcherAlgorithm::ScoreType overall_score_type_enum = IDScoreSwitcherAlgorithm::ScoreType::RAW;
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, score_name, higher_better, overall_score_type_enum);
 
-    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(overall_score_type,IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
     double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     //create Accession to ProteinHit and peptide count map. To have quick access later.
@@ -631,9 +673,9 @@ namespace OpenMS
       phit.setScore(initScore);
     }
 
-    checkCompat_(overall_score_type, aggregation_method);
+    checkCompat_(score_name, aggregation_method);
 
-    aggregatePeptideScores_(best_pep, pep_ids, overall_score_type, higher_better, prot_run.getIdentifier());
+    aggregatePeptideScores_(best_pep, pep_ids, score_name, higher_better, prot_run.getIdentifier());
 
     updateProteinScores_(acc_to_protein_hitP_and_count, best_pep, pep_scores, higher_better);
 
@@ -644,7 +686,7 @@ namespace OpenMS
     }
     else
     {
-      prot_run.setScoreType(overall_score_type);
+      prot_run.setScoreType(score_name);
       prot_run.setHigherScoreBetter(higher_better);
     }
 

--- a/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BasicProteinInferenceAlgorithm.cpp
@@ -559,12 +559,12 @@ namespace OpenMS
     prot_run.setSearchParameters(sp);
 
     String main_score_name;
-    bool higher_better = true;
+    bool main_higher_better = true;
     IDScoreSwitcherAlgorithm::ScoreType main_score_type;
-    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, main_score_name, higher_better, main_score_type);
+    IDScoreSwitcherAlgorithm().determineScoreNameOrientationAndType(pep_ids, main_score_name, main_higher_better, main_score_type);
 
-    bool pep_scores = IDScoreSwitcherAlgorithm().isScoreType(main_score_name, IDScoreSwitcherAlgorithm::ScoreType::PEP);
-    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || higher_better); // if we have pep scores, we will complement to pp during aggregation
+    bool pep_scores = (main_score_type == IDScoreSwitcherAlgorithm::ScoreType::PEP);
+    double initScore = getInitScoreForAggMethod_(aggregation_method, pep_scores || main_higher_better); // if we have pep scores, we will complement to pp during aggregation
 
     //create Accession to ProteinHit and peptide count map. To have quick access later.
     //If a protein occurs in multiple runs, it picks the last
@@ -576,9 +576,9 @@ namespace OpenMS
 
     checkCompat_(main_score_name, aggregation_method);
 
-    aggregatePeptideScores_(best_pep, pep_ids, main_score_name, higher_better, prot_run.getIdentifier());
+    aggregatePeptideScores_(best_pep, pep_ids, main_score_name, main_higher_better, prot_run.getIdentifier());
 
-    updateProteinScores_(acc_to_protein_hitP_and_count, best_pep, pep_scores, higher_better);
+    updateProteinScores_(acc_to_protein_hitP_and_count, best_pep, pep_scores, main_higher_better);
 
     if (pep_scores) // we converted/ will convert
     {
@@ -588,7 +588,7 @@ namespace OpenMS
     else
     {
       prot_run.setScoreType(main_score_name);
-      prot_run.setHigherScoreBetter(higher_better);
+      prot_run.setHigherScoreBetter(main_higher_better);
     }
 
     if (min_peptides_per_protein > 0)

--- a/src/openms/source/ANALYSIS/ID/IDScoreSwitcherAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDScoreSwitcherAlgorithm.cpp
@@ -39,7 +39,7 @@ namespace OpenMS
     if (new_score_type_.empty()) new_score_type_ = new_score_;
   }
 
-  std::vector<String> IDScoreSwitcherAlgorithm::getScoreTypeNames()
+  std::vector<String> IDScoreSwitcherAlgorithm::getScoreNames()
   {
     std::vector<String> names;
     for (auto i : type_to_str_)

--- a/src/tests/class_tests/openms/data/PeptideProteinResolution_out2_ibg.idXML
+++ b/src/tests/class_tests/openms/data/PeptideProteinResolution_out2_ibg.idXML
@@ -36,8 +36,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="703.351318359375" RT="2377.154599999979837" >
 			<PeptideHit score="0.01" sequence="AAA" charge="2" aa_before="[" aa_after="R" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
-				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="float" name="E-Value" value="2.2"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 			</PeptideHit>
@@ -45,8 +45,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="783.913208007812955" RT="2398.082299999980023" >
 			<PeptideHit score="0.66" sequence="CCC" charge="2" aa_before="R X" aa_after="C X" protein_refs="PH_1 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="float" name="E-Value" value="20.0"/>
 				<UserParam type="float" name="nextscore" value="8.6"/>
 			</PeptideHit>
@@ -54,8 +54,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="784.913208007812955" RT="2399.082299999980023" >
 			<PeptideHit score="0.1" sequence="DDD" charge="2" aa_before="R X" aa_after="C X" protein_refs="PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="float" name="E-Value" value="20.0"/>
 				<UserParam type="float" name="nextscore" value="8.6"/>
 			</PeptideHit>
@@ -63,8 +63,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="785.913208007812955" RT="2499.082299999980023" >
 			<PeptideHit score="0.99" sequence="EEE" charge="2" protein_refs="PH_6" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.9"/>
 				<UserParam type="float" name="E-Value" value="20.0"/>
 				<UserParam type="float" name="nextscore" value="8.6"/>
 			</PeptideHit>
@@ -72,8 +72,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="703.351318359375" RT="2377.154599999979837" >
 			<PeptideHit score="0.7" sequence="FFF" charge="2" aa_before="[" aa_after="R" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="float" name="E-Value" value="2.2"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 			</PeptideHit>
@@ -81,8 +81,8 @@
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0.0" MZ="703.351318359375" RT="2377.154599999979837" >
 			<PeptideHit score="0.75" sequence="GGG" charge="2" aa_before="[" aa_after="R" protein_refs="PH_6" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="8.0"/>
 				<UserParam type="float" name="E-Value" value="2.2"/>
 				<UserParam type="float" name="nextscore" value="8.0"/>
 			</PeptideHit>

--- a/src/tests/class_tests/openms/data/newMergerTest_out.idXML
+++ b/src/tests/class_tests/openms/data/newMergerTest_out.idXML
@@ -33,17 +33,17 @@
 			<PeptideHit score="0.4" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_before="K [" aa_after="G ]" start="227 4" end="248 25" protein_refs="PH_0 PH_1" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
-				<UserParam type="float" name="XTandem_score" value="2"/>
+				<UserParam type="float" name="XTandem_score" value="2.5"/>
 			</PeptideHit>
 			<PeptideHit score="0.5" sequence="EDQSCPSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0" end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
-				<UserParam type="float" name="XTandem_score" value="4"/>
+				<UserParam type="float" name="XTandem_score" value="2"/>
 			</PeptideHit>
 			<PeptideHit score="0.6" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[" aa_after="]" start="0" end="17" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
-				<UserParam type="float" name="XTandem_score" value="6"/>
+				<UserParam type="float" name="XTandem_score" value="1.666"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="0"/>
 		</PeptideIdentification>
@@ -51,11 +51,11 @@
 			<PeptideHit score="0.2" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[" aa_after="]" start="0" end="17" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
-				<UserParam type="float" name="XTandem_score" value="3"/>
+				<UserParam type="float" name="XTandem_score" value="5"/>
 			</PeptideHit>
 			<PeptideHit score="0.3" sequence="NIEMATCHED" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
-				<UserParam type="float" name="XTandem_score" value="1"/>
+				<UserParam type="float" name="XTandem_score" value="3.333"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="0"/>
 		</PeptideIdentification>
@@ -63,12 +63,12 @@
 			<PeptideHit score="0.4" sequence="LVTLAESPRAPSP" charge="2" aa_before="K [" aa_after="G ]" start="227 4" end="248 25" protein_refs="PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
-				<UserParam type="float" name="XTandem_score" value="5"/>
+				<UserParam type="float" name="XTandem_score" value="2.5"/>
 			</PeptideHit>
 			<PeptideHit score="0.5" sequence="EDQRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0" end="20" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
-				<UserParam type="float" name="XTandem_score" value="10"/>
+				<UserParam type="float" name="XTandem_score" value="2"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="1"/>
 		</PeptideIdentification>
@@ -76,7 +76,7 @@
 			<PeptideHit score="0.1" sequence="FIANGE" charge="2" aa_before="D" aa_after="R" start="1" end="6" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
-				<UserParam type="float" name="XTandem_score" value="20"/>				
+				<UserParam type="float" name="XTandem_score" value="10"/>				
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="1"/>
 		</PeptideIdentification>

--- a/src/tests/class_tests/openms/data/newMergerTest_out.idXML
+++ b/src/tests/class_tests/openms/data/newMergerTest_out.idXML
@@ -11,19 +11,15 @@
 		<ProteinIdentification score_type="" higher_score_better="false" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="A" score="0.258519381284714" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="0"/>
 			</ProteinHit>
 			<ProteinHit id="PH_1" accession="D" score="0.258519381284714" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="0"/>
 			</ProteinHit>
 			<ProteinHit id="PH_2" accession="B" score="0.258519381284714" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="0"/>
 			</ProteinHit>
 			<ProteinHit id="PH_3" accession="C" score="0.258519381284714" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="float" name="XTandem_score" value="0"/>
 			</ProteinHit>
 			<ProteinHit id="PH_4" accession="Thyroglo" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -37,14 +33,17 @@
 			<PeptideHit score="0.4" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_before="K [" aa_after="G ]" start="227 4" end="248 25" protein_refs="PH_0 PH_1" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="XTandem_score" value="2"/>
 			</PeptideHit>
 			<PeptideHit score="0.5" sequence="EDQSCPSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0" end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="4"/>
 			</PeptideHit>
 			<PeptideHit score="0.6" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[" aa_after="]" start="0" end="17" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="6"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="0"/>
 		</PeptideIdentification>
@@ -52,9 +51,11 @@
 			<PeptideHit score="0.2" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[" aa_after="]" start="0" end="17" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="3"/>
 			</PeptideHit>
 			<PeptideHit score="0.3" sequence="NIEMATCHED" charge="2" >
 				<UserParam type="string" name="protein_references" value="unmatched"/>
+				<UserParam type="float" name="XTandem_score" value="1"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="0"/>
 		</PeptideIdentification>
@@ -62,10 +63,12 @@
 			<PeptideHit score="0.4" sequence="LVTLAESPRAPSP" charge="2" aa_before="K [" aa_after="G ]" start="227 4" end="248 25" protein_refs="PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="XTandem_score" value="5"/>
 			</PeptideHit>
 			<PeptideHit score="0.5" sequence="EDQRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0" end="20" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="10"/>
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="1"/>
 		</PeptideIdentification>
@@ -73,6 +76,7 @@
 			<PeptideHit score="0.1" sequence="FIANGE" charge="2" aa_before="D" aa_after="R" start="1" end="6" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="XTandem_score" value="20"/>				
 			</PeptideHit>
 			<UserParam type="int" name="id_merge_index" value="1"/>
 		</PeptideIdentification>

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -140,4 +140,42 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
     }
     END_SECTION
 
+    START_SECTION(BasicProteinInferenceAlgorithm on Protein Peptide ID with grouping plus resolution and user set score type)
+    {
+      vector<ProteinIdentification> prots;
+      vector<PeptideIdentification> peps;
+      IdXMLFile idf;
+      idf.load(OPENMS_GET_TEST_DATA_PATH("newMergerTest_out.idXML"),prots,peps);
+      BasicProteinInferenceAlgorithm bpia;
+      Param p = bpia.getParameters();
+      p.setValue("min_peptides_per_protein", 0);
+      p.setValue("annotate_indistinguishable_groups", "true");
+      p.setValue("greedy_group_resolution", "true");
+      p.setValue("score", "XTandem_score");  // run on XTandem score meta value
+      p.setValue("score_orientation", "higher_better");
+      p.setValue("old_score", "");
+      bpia.setParameters(p);
+
+      TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score is PEP
+      bpia.run(peps, prots);
+      TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score has been reset again to PEP
+
+      TEST_EQUAL(prots[0].getHits().size(), 4)
+      TEST_EQUAL(prots[0].getHits()[0].getScore(), 2)  // 2 is the highest XTandem score
+      TEST_EQUAL(prots[0].getHits()[1].getScore(), 2)  // 2 is the highest XTandem score
+      TEST_EQUAL(prots[0].getHits()[2].getScore(), 5)  // 5 is the highest XTandem score
+      TEST_EQUAL(prots[0].getHits()[3].getScore(), 20) // 20 is the highest XTandem score
+
+      TEST_EQUAL(prots[0].getHits()[0].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[1].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[2].getMetaValue("nr_found_peptides"), 2)
+      TEST_EQUAL(prots[0].getHits()[3].getMetaValue("nr_found_peptides"), 1)
+
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 3);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 20);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 5);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 2);
+    }
+    END_SECTION
+
 END_TEST

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -157,18 +157,18 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       bpia.run(peps, prots);
       TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score has been reset again to PEP
       
-      TEST_EQUAL(prots[0].getHits()[0].getScore(), 0.6)
-      TEST_EQUAL(prots[0].getHits()[1].getScore(), 0.6)
-      TEST_EQUAL(prots[0].getHits()[2].getScore(), -std::numeric_limits<double>::infinity())  // TODO: +inf?
-      TEST_EQUAL(prots[0].getHits()[3].getScore(), 0.8)
-      TEST_EQUAL(prots[0].getHits()[4].getScore(), 0.6)
-      TEST_EQUAL(prots[0].getHits()[5].getScore(), 0.9)
+      TEST_EQUAL(prots[0].getHits()[0].getScore(), 2.5)
+      TEST_EQUAL(prots[0].getHits()[1].getScore(), 2.5)
+      TEST_EQUAL(prots[0].getHits()[2].getScore(), -std::numeric_limits<double>::infinity())
+      TEST_EQUAL(prots[0].getHits()[3].getScore(), 5.0)
+      TEST_EQUAL(prots[0].getHits()[4].getScore(), 2.5)
+      TEST_EQUAL(prots[0].getHits()[5].getScore(), 10.0)
 
       TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 4);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 0.9);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 0.8);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 0.6);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 0.6);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 10.9);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 5.0);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 2.5);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 2.5);
 
       TEST_EQUAL(prots[0].getHits()[0].getMetaValue("nr_found_peptides"), 1)
       TEST_EQUAL(prots[0].getHits()[1].getMetaValue("nr_found_peptides"), 1)
@@ -200,7 +200,7 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       TEST_EQUAL(prots[0].getHits().size(), 4)
       TEST_EQUAL(prots[0].getHits().at(0).getScore(), 2.5)
       TEST_EQUAL(prots[0].getHits().at(1).getScore(), 2.5)
-      TEST_EQUAL(prots[0].getHits().at(2).getScore(), 2.5) 
+      TEST_EQUAL(prots[0].getHits().at(2).getScore(), 5.0) 
       TEST_EQUAL(prots[0].getHits().at(3).getScore(), 10.0)
 
       TEST_EQUAL(prots[0].getHits().at(0).getMetaValue("nr_found_peptides"), 1)
@@ -211,7 +211,7 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 3);
       TEST_EQUAL(prots[0].getIndistinguishableProteins().at(0).probability, 10);
       TEST_EQUAL(prots[0].getIndistinguishableProteins().at(1).probability, 2.5);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(2).probability, 2.5);      
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(2).probability, 5.0);      
     }
     END_SECTION
 

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -140,6 +140,45 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
     }
     END_SECTION
 
+    START_SECTION(BasicProteinInferenceAlgorithm on Protein Peptide ID with grouping and user score)
+    {
+      vector<ProteinIdentification> prots;
+      vector<PeptideIdentification> peps;
+      IdXMLFile idf;
+      idf.load(OPENMS_GET_TEST_DATA_PATH("newMergerTest_out.idXML"),prots,peps);
+      BasicProteinInferenceAlgorithm bpia;
+      Param p = bpia.getParameters();
+      p.setValue("min_peptides_per_protein", 0);
+      p.setValue("annotate_indistinguishable_groups", "true");
+      p.setValue("score_type", "RAW");  // should use the XTandem score meta value      
+      bpia.setParameters(p);
+
+      TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score is PEP
+      bpia.run(peps, prots);
+      TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score has been reset again to PEP
+      
+      TEST_EQUAL(prots[0].getHits()[0].getScore(), 0.6)
+      TEST_EQUAL(prots[0].getHits()[1].getScore(), 0.6)
+      TEST_EQUAL(prots[0].getHits()[2].getScore(), -std::numeric_limits<double>::infinity())  // TODO: +inf?
+      TEST_EQUAL(prots[0].getHits()[3].getScore(), 0.8)
+      TEST_EQUAL(prots[0].getHits()[4].getScore(), 0.6)
+      TEST_EQUAL(prots[0].getHits()[5].getScore(), 0.9)
+
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 4);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 0.9);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 0.8);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 0.6);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 0.6);
+
+      TEST_EQUAL(prots[0].getHits()[0].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[1].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[2].getMetaValue("nr_found_peptides"), 0)
+      TEST_EQUAL(prots[0].getHits()[3].getMetaValue("nr_found_peptides"), 2)
+      TEST_EQUAL(prots[0].getHits()[4].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[5].getMetaValue("nr_found_peptides"), 1)
+    }
+    END_SECTION
+
     START_SECTION(BasicProteinInferenceAlgorithm on Protein Peptide ID with grouping plus resolution and user set score type)
     {
       vector<ProteinIdentification> prots;

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -165,7 +165,7 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       TEST_EQUAL(prots[0].getHits()[5].getScore(), 10.0)
 
       TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 4);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 10.9);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 10.0);
       TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 5.0);
       TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 2.5);
       TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 2.5);
@@ -210,8 +210,8 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
 
       TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 3);
       TEST_EQUAL(prots[0].getIndistinguishableProteins().at(0).probability, 10);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(1).probability, 2.5);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(2).probability, 5.0);      
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(1).probability, 5.0);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(2).probability, 2.5);      
     }
     END_SECTION
 

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -151,30 +151,31 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       p.setValue("min_peptides_per_protein", 0);
       p.setValue("annotate_indistinguishable_groups", "true");
       p.setValue("greedy_group_resolution", "true");
-      p.setValue("score", "XTandem_score");  // run on XTandem score meta value
-      p.setValue("score_orientation", "higher_better");
-      p.setValue("old_score", "");
+      p.setValue("score_type", "RAW");  // should use the XTandem score meta value
       bpia.setParameters(p);
 
       TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score is PEP
       bpia.run(peps, prots);
       TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score has been reset again to PEP
 
-      TEST_EQUAL(prots[0].getHits().size(), 4)
-      TEST_EQUAL(prots[0].getHits()[0].getScore(), 2)  // 2 is the highest XTandem score
-      TEST_EQUAL(prots[0].getHits()[1].getScore(), 2)  // 2 is the highest XTandem score
-      TEST_EQUAL(prots[0].getHits()[2].getScore(), 5)  // 5 is the highest XTandem score
-      TEST_EQUAL(prots[0].getHits()[3].getScore(), 20) // 20 is the highest XTandem score
+      TEST_EQUAL(prots[0].getHits().size(), 5)
+      TEST_EQUAL(prots[0].getHits()[0].getScore(), 2)
+      TEST_EQUAL(prots[0].getHits()[1].getScore(), 2)
+      TEST_EQUAL(prots[0].getHits()[2].getScore(), 3) 
+      TEST_EQUAL(prots[0].getHits()[3].getScore(), 5)
+      TEST_EQUAL(prots[0].getHits()[4].getScore(), 20)
 
       TEST_EQUAL(prots[0].getHits()[0].getMetaValue("nr_found_peptides"), 1)
       TEST_EQUAL(prots[0].getHits()[1].getMetaValue("nr_found_peptides"), 1)
       TEST_EQUAL(prots[0].getHits()[2].getMetaValue("nr_found_peptides"), 2)
       TEST_EQUAL(prots[0].getHits()[3].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits()[4].getMetaValue("nr_found_peptides"), 1)
 
-      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 3);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 4);
       TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 20);
       TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 5);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 2);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 3);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 2);
     }
     END_SECTION
 

--- a/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/BasicProteinInferenceAlgorithm_test.cpp
@@ -158,24 +158,21 @@ START_TEST(BasicProteinInferenceAlgorithm, "$Id$")
       bpia.run(peps, prots);
       TEST_EQUAL(peps[0].getScoreType(), "Posterior Error Probability"); // check if main score has been reset again to PEP
 
-      TEST_EQUAL(prots[0].getHits().size(), 5)
-      TEST_EQUAL(prots[0].getHits()[0].getScore(), 2)
-      TEST_EQUAL(prots[0].getHits()[1].getScore(), 2)
-      TEST_EQUAL(prots[0].getHits()[2].getScore(), 3) 
-      TEST_EQUAL(prots[0].getHits()[3].getScore(), 5)
-      TEST_EQUAL(prots[0].getHits()[4].getScore(), 20)
+      TEST_EQUAL(prots[0].getHits().size(), 4)
+      TEST_EQUAL(prots[0].getHits().at(0).getScore(), 2.5)
+      TEST_EQUAL(prots[0].getHits().at(1).getScore(), 2.5)
+      TEST_EQUAL(prots[0].getHits().at(2).getScore(), 2.5) 
+      TEST_EQUAL(prots[0].getHits().at(3).getScore(), 10.0)
 
-      TEST_EQUAL(prots[0].getHits()[0].getMetaValue("nr_found_peptides"), 1)
-      TEST_EQUAL(prots[0].getHits()[1].getMetaValue("nr_found_peptides"), 1)
-      TEST_EQUAL(prots[0].getHits()[2].getMetaValue("nr_found_peptides"), 2)
-      TEST_EQUAL(prots[0].getHits()[3].getMetaValue("nr_found_peptides"), 1)
-      TEST_EQUAL(prots[0].getHits()[4].getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits().at(0).getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits().at(1).getMetaValue("nr_found_peptides"), 1)
+      TEST_EQUAL(prots[0].getHits().at(2).getMetaValue("nr_found_peptides"), 2)
+      TEST_EQUAL(prots[0].getHits().at(3).getMetaValue("nr_found_peptides"), 1)    
 
-      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 4);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[0].probability, 20);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[1].probability, 5);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[2].probability, 3);
-      TEST_EQUAL(prots[0].getIndistinguishableProteins()[3].probability, 2);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().size(), 3);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(0).probability, 10);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(1).probability, 2.5);
+      TEST_EQUAL(prots[0].getIndistinguishableProteins().at(2).probability, 2.5);      
     }
     END_SECTION
 

--- a/src/topp/FalseDiscoveryRate.cpp
+++ b/src/topp/FalseDiscoveryRate.cpp
@@ -99,7 +99,7 @@ protected:
 
     registerStringOption_("protein_score", "<type>", "", "The protein score used to calculate the protein FDR. If empty, the main score is used.", false, true);
     auto ids = IDScoreSwitcherAlgorithm();
-    setValidStrings_("protein_score", ids.getScoreTypeNames()); // lists all scores (including PSM only scores)
+    setValidStrings_("protein_score", ids.getScoreNames()); // lists all scores (including PSM only scores)
 
     registerStringOption_("protein_base_score", "<score name or type>", "", "Set if you want to choose a different score than the last calculated main score for protein (group) level.", false);
     registerStringOption_("protein_base_score_orientation", "<higher/lower>", "", "Set if you want to choose a different score than the last calculated main score for protein (group) level.", false, true);
@@ -173,7 +173,7 @@ protected:
         {
           try 
           {
-            IDScoreSwitcherAlgorithm::ScoreType score_type = IDScoreSwitcherAlgorithm::getScoreType(protein_score);
+            IDScoreSwitcherAlgorithm::ScoreType score_type = IDScoreSwitcherAlgorithm::toScoreTypeEnum(protein_score);
             IDScoreSwitcherAlgorithm switcher;
             Size c = 0;
             switcher.switchToGeneralScoreType(prot_ids, score_type, c);

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -132,11 +132,11 @@ protected:
     registerDoubleOption_("score:psm", "<score>", NAN, "The score which should be reached by a peptide hit to be kept. (use 'NAN' to disable this filter)", false);
     registerDoubleOption_("score:peptide", "<score>", NAN, "The score which should be reached by a peptide hit to be kept.  (use 'NAN' to disable this filter)", false);
     registerStringOption_("score:type_peptide", "<type>", "", "Score used for filtering. If empty, the main score is used.", false, true);
-    setValidStrings_("score:type_peptide", ids.getScoreTypeNames());
+    setValidStrings_("score:type_peptide", ids.getScoreNames());
 
     registerDoubleOption_("score:protein", "<score>", NAN, "The score which should be reached by a protein hit to be kept. All proteins are filtered based on their singleton scores irrespective of grouping. Use in combination with 'delete_unreferenced_peptide_hits' to remove affected peptides. (use 'NAN' to disable this filter)", false);
     registerStringOption_("score:type_protein", "<type>", "", "The type of the score which should be reached by a protein hit to be kept. If empty, the most recently set score is used.", false, true);
-    setValidStrings_("score:type_protein", ids.getScoreTypeNames());
+    setValidStrings_("score:type_protein", ids.getScoreNames());
 
     registerDoubleOption_("score:proteingroup", "<score>", NAN, "The score which should be reached by a protein group to be kept. Performs group level score filtering (including groups of single proteins). Use in combination with 'delete_unreferenced_peptide_hits' to remove affected peptides. (use 'NAN' to disable this filter)", false);
 
@@ -579,7 +579,7 @@ protected:
 
       if (!score_type.empty())
       {
-        IDScoreSwitcherAlgorithm::ScoreType score_type_enum = IDScoreSwitcherAlgorithm::getScoreType(score_type);
+        IDScoreSwitcherAlgorithm::ScoreType score_type_enum = IDScoreSwitcherAlgorithm::toScoreTypeEnum(score_type);
         IDFilter::filterHitsByScore(proteins, pep_score, score_type_enum);
       }
       else
@@ -665,7 +665,7 @@ protected:
       OPENMS_LOG_INFO << "Filtering by protein score  (better than " << prot_score << ") ..." << endl;
       if (!score_type_prot.empty())
       {
-        IDScoreSwitcherAlgorithm::ScoreType score_type_prot_enum = IDScoreSwitcherAlgorithm::getScoreType(score_type_prot);
+        IDScoreSwitcherAlgorithm::ScoreType score_type_prot_enum = IDScoreSwitcherAlgorithm::toScoreTypeEnum(score_type_prot);
         IDFilter::filterHitsByScore(proteins, prot_score, score_type_prot_enum);
       }
       else


### PR DESCRIPTION
**Motivation**
ID results often contain either:
- A search engine-specific score as the main score (e.g., "X!Tandem" scores), or
- A broader score category, such as posterior error probabilities (PEP) or q-values.

In practice, many algorithms require specific types of scores, such as probabilities, for compatibility (e.g., PEP or PP). To address this, the IDScoreSwitcherAlgorithm has been extended to allow dynamic switching of the main score to a requested score type. This ensures compatibility across algorithms while providing the ability to revert back to the original main score when the process is complete.

**Algorithm:**
New Parameter for BasicProteinInference: score_type. 
Previously, the BPI always relied on the main PSM score for inference. This update introduces a parameter that enables the selection of a score from the meta values annotated to the PSMs (PeptideHit), rather than being restricted to the main score.
If the requested score is already the main score, no action is needed.
Otherwise, the IDScoreSwitcherAlgorithm is used to find and switch the score of the requested type/category to the main score.
After processing, the main score is reverted to its original value.
Enhancements to IDScoreSwitcherAlgorithm: To generalize and simplify this functionality for wider use, the logic has been moved into the IDScoreSwitcherAlgorithm. The algorithm now supports two new static methods:

switchToScoreType: Accepts a string representing the score type (e.g., "RAW", "PEP", "q-value") and switches the main score accordingly.
switchBackScoreType: Reverts the main score to its previous state using the result object from the initial switch.
Benefits

**ProteinInference Tool:**
By adding the score switching logic to the BasicProteinInference algorithm the TOPP tool ProteinInference gained a new parameter.
```
ProteinInference \
    -in ID_mapper_merge.consensusXML \
    -threads 16 \
    -picked_fdr true \
    -picked_decoy_string DECOY_ \
    -protein_fdr true \
    -Algorithm:use_shared_peptides true \
    -Algorithm:annotate_indistinguishable_groups true \
    -Algorithm:score_aggregation_method best \
    -Algorithm:min_peptides_per_protein 1 \
    -out ID_mapper_merge_epi_new.consensusXML \
    -Algorithm:score_type "PEP"     <-------------------------------- this is new
```

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
