### PR TITLE
feature: add option to ouput only psms that reached some PSM-FDR threshold

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Misc:
 - pyOpenMS: improve developer experience (installation/compilation) (#7735)
 - TOPP tools and TOPPAS/ExecutePipeline return exit code 14 when external third-party tools (such as Comet or Sage) are not found (#7758)
 - ProteinInference tool: Algorithm:score_type allows switching the main score (e.g., "RAW", "PEP") for BasicProteinInference. (#7769)
+- PercolatorAdapter tool: reported_psm_or_peptide_qvalue_threshold allows to filter percolator results by PSM- or peptide-level qvalue
 
 Library:
 - IDScoreSwitcherAlgorithm: Added switchToScoreType and switchBackScoreType methods for score switching and reversion. (#7769)

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.idXML
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.idXML
@@ -1,0 +1,829 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="decoy.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unspecific cleavage" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+		<FixedModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+				<UserParam type="string" name="SE:Comet" value=""/>
+				<UserParam type="string" name="Comet:db" value="decoy.fasta"/>
+				<UserParam type="string" name="Comet:db_version" value=""/>
+				<UserParam type="string" name="Comet:taxonomy" value=""/>
+				<UserParam type="string" name="Comet:charges" value=""/>
+				<UserParam type="string" name="Comet:fixed_modifications" value="Carbamidomethyl (C)"/>
+				<UserParam type="string" name="Comet:variable_modifications" value="Oxidation (M)"/>
+				<UserParam type="int" name="Comet:missed_cleavages" value="1"/>
+				<UserParam type="float" name="Comet:fragment_mass_tolerance" value="0.01"/>
+				<UserParam type="string" name="Comet:fragment_mass_tolerance_unit" value="Da"/>
+				<UserParam type="float" name="Comet:precursor_mass_tolerance" value="5"/>
+				<UserParam type="string" name="Comet:precursor_mass_tolerance_unit" value="ppm"/>
+				<UserParam type="string" name="Comet:digestion_enzyme" value="unspecific cleavage"/>
+				<UserParam type="string" name="feature_extractor" value="TOPP_PSMFeatureExtractor"/>
+				<UserParam type="string" name="extra_features" value="COMET:deltCn,COMET:deltLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
+	</SearchParameters>
+	<IdentificationRun date="2017-09-11T11:20:57" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="sp|Q02952|AKA12_HUMAN" score="0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="sp|Q12774|ARHG5_HUMAN" score="0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="514.2804560319" RT="721.4" spectrum_reference="controllerType=0 controllerNumber=1 scan=3" >
+			<PeptideHit score="0.0342" sequence="EAVPAQKERRRRGAH" charge="2" aa_before="A" aa_after="P" start="1211" end="1219" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="9"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="11906"/>
+				<UserParam type="float" name="MS:1002252" value="1.622"/>
+				<UserParam type="float" name="MS:1002253" value="0.256"/>
+				<UserParam type="float" name="MS:1002255" value="256.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0342"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.37552963491358"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.38479775371334"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5625"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="499.6107780319" RT="721.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=4" >
+			<PeptideHit score="0.0272" sequence="TRILKHGAKDKDDLHKY" charge="3" aa_before="F F F" aa_after="] ] ]" start="159 158 159" end="171 170 171" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="10"/>
+				<UserParam type="string" name="MS:1002259" value="48"/>
+				<UserParam type="string" name="num_matched_peptides" value="13136"/>
+				<UserParam type="float" name="MS:1002252" value="1.162"/>
+				<UserParam type="float" name="MS:1002253" value="0.37"/>
+				<UserParam type="float" name="MS:1002255" value="106.5"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0272"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.60453830568019"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.48311183169221"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.208333333333333"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="545.7501825319" RT="721.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=5" >
+			<PeptideHit score="0.0421" sequence="AAGGEAEHQRAY" charge="2" aa_before="A" aa_after="L" start="171" end="179" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9348"/>
+				<UserParam type="float" name="MS:1002252" value="1.546"/>
+				<UserParam type="float" name="MS:1002253" value="0.344"/>
+				<UserParam type="float" name="MS:1002255" value="126.3"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0421"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.1677075382938"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.14291769565875"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.375"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="527.3117670319" RT="722.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=6" >
+			<PeptideHit score="1.01" sequence="TQVVVSHLLKL" charge="2" aa_before="Q" aa_after="S" start="327" end="335" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="4910"/>
+				<UserParam type="float" name="MS:1002252" value="0.951"/>
+				<UserParam type="float" name="MS:1002253" value="0.014"/>
+				<UserParam type="float" name="MS:1002255" value="44.5"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="1.01"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.951"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.00995033085316809"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.49902922078857"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="561.2817375319" RT="722.3" spectrum_reference="controllerType=0 controllerNumber=1 scan=7" >
+			<PeptideHit score="6.24" sequence="AGIYR" charge="2" aa_before="N" aa_after="C" start="82" end="91" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="16834"/>
+				<UserParam type="float" name="MS:1002252" value="0.397"/>
+				<UserParam type="float" name="MS:1002253" value="0.011"/>
+				<UserParam type="float" name="MS:1002255" value="4.4"/>
+				<UserParam type="float" name="MS:1002256" value="5"/>
+				<UserParam type="float" name="MS:1002257" value="6.24"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.397"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="1.83098018238134"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.73115592977152"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.6094379124341"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0555555555555556"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="514.7599480319" RT="722.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=9" >
+			<PeptideHit score="0.401" sequence="SVSSKRGHASSYRR" charge="2" aa_before="R" aa_after="M" start="4" end="12" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="8"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.41"/>
+				<UserParam type="float" name="MS:1002253" value="0.037"/>
+				<UserParam type="float" name="MS:1002255" value="159.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.401"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.0375886524822695"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0375886524822695"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.913793851675568"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.46141032593123"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5"/>
+			</PeptideHit>
+			<PeptideHit score="0.592" sequence="AGGDPAAKGERLHFY" charge="2" aa_before="G" aa_after="W" start="2239" end="2249" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.204"/>
+				<UserParam type="float" name="MS:1002255" value="99.6"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="0.592"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.524248644098131"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.46141032593123"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="570.8154900319" RT="723.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=11" >
+			<PeptideHit score="2.02" sequence="GKRGAAARGEPGGV" charge="2" aa_before="E" aa_after="G" start="488" end="499" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="22"/>
+				<UserParam type="string" name="num_matched_peptides" value="10184"/>
+				<UserParam type="float" name="MS:1002252" value="0.424"/>
+				<UserParam type="float" name="MS:1002253" value="0.006"/>
+				<UserParam type="float" name="MS:1002255" value="8.7"/>
+				<UserParam type="float" name="MS:1002256" value="2"/>
+				<UserParam type="float" name="MS:1002257" value="2.02"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.424"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.703097511413113"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.22857314023724"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.693147180559945"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0909090909090909"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="528.2542105319" RT="723.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=13" >
+			<PeptideHit score="0.409" sequence="EVFHSGHSFHLAY" charge="2" aa_before="E" aa_after="N" start="219" end="227" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12114"/>
+				<UserParam type="float" name="MS:1002252" value="0.645"/>
+				<UserParam type="float" name="MS:1002253" value="0.236"/>
+				<UserParam type="float" name="MS:1002255" value="51.4"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.409"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.645"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.894040122939335"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.40211708754089"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="514.2804560319" RT="721.4" spectrum_reference="controllerType=0 controllerNumber=1 scan=3" >
+			<PeptideHit score="0.0342" sequence="EAVPAACQKERRRRGAH" charge="2" aa_before="A" aa_after="P" start="1211" end="1219" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="9"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="11906"/>
+				<UserParam type="float" name="MS:1002252" value="1.622"/>
+				<UserParam type="float" name="MS:1002253" value="0.256"/>
+				<UserParam type="float" name="MS:1002255" value="256.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0342"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.37552963491358"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.38479775371334"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5625"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="499.6107780319" RT="721.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=4" >
+			<PeptideHit score="0.0272" sequence="TRILKHGGFAAKDKDDLHKY" charge="3" aa_before="F F F" aa_after="] ] ]" start="159 158 159" end="171 170 171" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="10"/>
+				<UserParam type="string" name="MS:1002259" value="48"/>
+				<UserParam type="string" name="num_matched_peptides" value="13136"/>
+				<UserParam type="float" name="MS:1002252" value="1.162"/>
+				<UserParam type="float" name="MS:1002253" value="0.37"/>
+				<UserParam type="float" name="MS:1002255" value="106.5"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0272"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.60453830568019"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.48311183169221"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.208333333333333"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="545.7501825319" RT="721.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=5" >
+			<PeptideHit score="0.0421" sequence="AAGGEAEHQASDRAY" charge="2" aa_before="A" aa_after="L" start="171" end="179" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9348"/>
+				<UserParam type="float" name="MS:1002252" value="1.546"/>
+				<UserParam type="float" name="MS:1002253" value="0.344"/>
+				<UserParam type="float" name="MS:1002255" value="126.3"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0421"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.1677075382938"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.14291769565875"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.375"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="527.3117670319" RT="722.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=6" >
+			<PeptideHit score="1.01" sequence="TQVASDVVSHLLKL" charge="2" aa_before="Q" aa_after="S" start="327" end="335" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="4910"/>
+				<UserParam type="float" name="MS:1002252" value="0.951"/>
+				<UserParam type="float" name="MS:1002253" value="0.014"/>
+				<UserParam type="float" name="MS:1002255" value="44.5"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="1.01"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.951"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.00995033085316809"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.49902922078857"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="561.2817375319" RT="722.3" spectrum_reference="controllerType=0 controllerNumber=1 scan=7" >
+			<PeptideHit score="6.24" sequence="AGIYGFR" charge="2" aa_before="N" aa_after="C" start="82" end="91" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="16834"/>
+				<UserParam type="float" name="MS:1002252" value="0.397"/>
+				<UserParam type="float" name="MS:1002253" value="0.011"/>
+				<UserParam type="float" name="MS:1002255" value="4.4"/>
+				<UserParam type="float" name="MS:1002256" value="5"/>
+				<UserParam type="float" name="MS:1002257" value="6.24"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.397"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="1.83098018238134"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.73115592977152"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.6094379124341"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0555555555555556"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="514.7599480319" RT="722.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=9" >
+			<PeptideHit score="0.401" sequence="SVSSAASDKRGHASSYRR" charge="2" aa_before="R" aa_after="M" start="4" end="12" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="8"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.41"/>
+				<UserParam type="float" name="MS:1002253" value="0.037"/>
+				<UserParam type="float" name="MS:1002255" value="159.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.401"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.0375886524822695"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0375886524822695"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.913793851675568"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.46141032593123"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5"/>
+			</PeptideHit>
+			<PeptideHit score="0.592" sequence="AGGDASDFPAAKGERLHFY" charge="2" aa_before="G" aa_after="W" start="2239" end="2249" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.204"/>
+				<UserParam type="float" name="MS:1002255" value="99.6"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="0.592"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.524248644098131"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.46141032593123"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="570.8154900319" RT="723.1" spectrum_reference="controllerType=0 controllerNumber=1 scan=11" >
+			<PeptideHit score="2.02" sequence="GKRGAAARGEPGASDFGV" charge="2" aa_before="E" aa_after="G" start="488" end="499" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="22"/>
+				<UserParam type="string" name="num_matched_peptides" value="10184"/>
+				<UserParam type="float" name="MS:1002252" value="0.424"/>
+				<UserParam type="float" name="MS:1002253" value="0.006"/>
+				<UserParam type="float" name="MS:1002255" value="8.7"/>
+				<UserParam type="float" name="MS:1002256" value="2"/>
+				<UserParam type="float" name="MS:1002257" value="2.02"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.424"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.703097511413113"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.22857314023724"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.693147180559945"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0909090909090909"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="528.2542105319" RT="723.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=13" >
+			<PeptideHit score="0.409" sequence="EVFASDFHSGHSFHLAY" charge="2" aa_before="E" aa_after="N" start="219" end="227" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12114"/>
+				<UserParam type="float" name="MS:1002252" value="0.645"/>
+				<UserParam type="float" name="MS:1002253" value="0.236"/>
+				<UserParam type="float" name="MS:1002255" value="51.4"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.409"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.645"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.894040122939335"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.40211708754089"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="556.3450920319" RT="724.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=17" >
+			<PeptideHit score="0.969" sequence="SAAGHLASDFKQQAL" charge="2" aa_before="K" aa_after="L" start="1099" end="1108" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="3320"/>
+				<UserParam type="float" name="MS:1002252" value="0.533"/>
+				<UserParam type="float" name="MS:1002253" value="0.164"/>
+				<UserParam type="float" name="MS:1002255" value="9"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.969"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.533"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.0314906670913708"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.10772006191053"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="563.7900995319" RT="726.3" spectrum_reference="controllerType=0 controllerNumber=1 scan=22" >
+			<PeptideHit score="6.1" sequence="GSYC(Carbamidomethyl)HSGAFALKPI" charge="2" aa_before="A" aa_after="F" start="187" end="197" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="0"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12282"/>
+				<UserParam type="float" name="MS:1002252" value="0.155"/>
+				<UserParam type="float" name="MS:1002253" value="0.121"/>
+				<UserParam type="float" name="MS:1002255" value="0"/>
+				<UserParam type="float" name="MS:1002256" value="11"/>
+				<UserParam type="float" name="MS:1002257" value="6.1"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.155"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="1.80828877117927"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.41589005488934"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="2.39789527279837"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="614.8654165319" RT="726.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=24" >
+			<PeptideHit score="0.0506" sequence="KGRVRRKKKRRKEEA" charge="2" aa_before="P" aa_after="K" start="504" end="513" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="6600"/>
+				<UserParam type="float" name="MS:1002252" value="0.453"/>
+				<UserParam type="float" name="MS:1002253" value="0.34"/>
+				<UserParam type="float" name="MS:1002255" value="11.9"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0506"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.453"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-2.98380370268872"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.79482492801452"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="584.8013300319" RT="727.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=26" >
+			<PeptideHit score="0.0246" sequence="QTKGTGASGSFKHHLAKY" charge="2" aa_before="V V V V V" aa_after="L L L L L" start="97 94 94 95 97" end="108 105 105 106 108" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="22"/>
+				<UserParam type="string" name="num_matched_peptides" value="17838"/>
+				<UserParam type="float" name="MS:1002252" value="1.073"/>
+				<UserParam type="float" name="MS:1002253" value="0.318"/>
+				<UserParam type="float" name="MS:1002255" value="57.4"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0246"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.70500883604382"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.78908629222615"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.227272727272727"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="455.7484125319" RT="727.6" spectrum_reference="controllerType=0 controllerNumber=1 scan=28" >
+			<PeptideHit score="1.48" sequence="VVGANRASHVVAAGGYY" charge="2" aa_before="F" aa_after="R" start="974" end="982" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9784"/>
+				<UserParam type="float" name="MS:1002252" value="1.196"/>
+				<UserParam type="float" name="MS:1002253" value="0.06"/>
+				<UserParam type="float" name="MS:1002255" value="113.4"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="1.48"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.392042087776024"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18850367736701"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="562.3155510319" RT="727.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=29" >
+			<PeptideHit score="2.2" sequence="FQSMKIILLFQSMH" charge="2" aa_before="D" aa_after="N" start="78" end="86" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9754"/>
+				<UserParam type="float" name="MS:1002252" value="0.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.134"/>
+				<UserParam type="float" name="MS:1002255" value="1.7"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="2.2"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.357"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.78845736036427"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18543273627"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0625"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="558.7988885319" RT="728.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=33" >
+			<PeptideHit score="0.635" sequence="QQKGRLHSYQQLLAG" charge="2" aa_before="W" aa_after="]" start="210" end="218" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="17366"/>
+				<UserParam type="float" name="MS:1002252" value="0.72"/>
+				<UserParam type="float" name="MS:1002253" value="0.252"/>
+				<UserParam type="float" name="MS:1002255" value="7.2"/>
+				<UserParam type="float" name="MS:1002256" value="5"/>
+				<UserParam type="float" name="MS:1002257" value="0.635"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.72"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.454130280089445"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.76226955062059"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.6094379124341"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="544.7874140319" RT="729.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=37" >
+			<PeptideHit score="10.7" sequence="KAAPGHSRQH" charge="2" aa_before="P" aa_after="T" start="72" end="81" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="16732"/>
+				<UserParam type="float" name="MS:1002252" value="0.163"/>
+				<UserParam type="float" name="MS:1002253" value="0.089"/>
+				<UserParam type="float" name="MS:1002255" value="2.4"/>
+				<UserParam type="float" name="MS:1002256" value="6"/>
+				<UserParam type="float" name="MS:1002257" value="10.7"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.163"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="2.37024374146786"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.72507833256209"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.79175946922805"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0555555555555556"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="624.2362055319" RT="730.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=39" >
+			<PeptideHit score="0.627" sequence="SDYNEDNLDYSTNGD" charge="2" aa_before="E" aa_after="Y" start="307" end="316" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="1012"/>
+				<UserParam type="float" name="MS:1002252" value="0.406"/>
+				<UserParam type="float" name="MS:1002253" value="0.168"/>
+				<UserParam type="float" name="MS:1002255" value="15.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.627"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.406"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.466808738349216"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="6.91968384984741"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="645.677123365233" RT="730.4" spectrum_reference="controllerType=0 controllerNumber=1 scan=40" >
+			<PeptideHit score="0.359" sequence="WIRITGDEYGVVAD" charge="3" aa_before="D" aa_after="P" start="192" end="208" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="64"/>
+				<UserParam type="string" name="num_matched_peptides" value="20414"/>
+				<UserParam type="float" name="MS:1002252" value="0.463"/>
+				<UserParam type="float" name="MS:1002253" value="0.297"/>
+				<UserParam type="float" name="MS:1002255" value="5.1"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.359"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.463"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-1.02443289049386"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.92397621896344"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.03125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="554.7780145319" RT="732.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=45" >
+			<PeptideHit score="0.0175" sequence="ALKAAHPTASDFNVQR" charge="2" aa_before="F" aa_after="L" start="114" end="123" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="18586"/>
+				<UserParam type="float" name="MS:1002252" value="1.141"/>
+				<UserParam type="float" name="MS:1002253" value="0.355"/>
+				<UserParam type="float" name="MS:1002255" value="60.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0175"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-4.04555439805267"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.83016388811729"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.277777777777778"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="556.3450920319" RT="724.9" spectrum_reference="controllerType=0 controllerNumber=1 scan=17" >
+			<PeptideHit score="0.969" sequence="SAAGHLASDFKQQASDFAL" charge="2" aa_before="K" aa_after="L" start="1099" end="1108" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="3320"/>
+				<UserParam type="float" name="MS:1002252" value="0.533"/>
+				<UserParam type="float" name="MS:1002253" value="0.164"/>
+				<UserParam type="float" name="MS:1002255" value="9"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.969"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.533"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.0314906670913708"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.10772006191053"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="563.7900995319" RT="726.3" spectrum_reference="controllerType=0 controllerNumber=1 scan=22" >
+			<PeptideHit score="6.1" sequence="GSYC(Carbamidomethyl)HSASDFGAFALKPI" charge="2" aa_before="A" aa_after="F" start="187" end="197" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="0"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12282"/>
+				<UserParam type="float" name="MS:1002252" value="0.155"/>
+				<UserParam type="float" name="MS:1002253" value="0.121"/>
+				<UserParam type="float" name="MS:1002255" value="0"/>
+				<UserParam type="float" name="MS:1002256" value="11"/>
+				<UserParam type="float" name="MS:1002257" value="6.1"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.155"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="1.80828877117927"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.41589005488934"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="2.39789527279837"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="614.8654165319" RT="726.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=24" >
+			<PeptideHit score="0.0506" sequence="KGRVRRASDFKKKRRKEEA" charge="2" aa_before="P" aa_after="K" start="504" end="513" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="6600"/>
+				<UserParam type="float" name="MS:1002252" value="0.453"/>
+				<UserParam type="float" name="MS:1002253" value="0.34"/>
+				<UserParam type="float" name="MS:1002255" value="11.9"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0506"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.453"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-2.98380370268872"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.79482492801452"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="584.8013300319" RT="727.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=26" >
+			<PeptideHit score="0.0246" sequence="QTKASDFGTGASGSFKHHLAKY" charge="2" aa_before="V V V V V" aa_after="L L L L L" start="97 94 94 95 97" end="108 105 105 106 108" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="22"/>
+				<UserParam type="string" name="num_matched_peptides" value="17838"/>
+				<UserParam type="float" name="MS:1002252" value="1.073"/>
+				<UserParam type="float" name="MS:1002253" value="0.318"/>
+				<UserParam type="float" name="MS:1002255" value="57.4"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0246"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.70500883604382"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.78908629222615"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.227272727272727"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="455.7484125319" RT="727.6" spectrum_reference="controllerType=0 controllerNumber=1 scan=28" >
+			<PeptideHit score="1.48" sequence="VVGANRASASDFHVVAAGGYY" charge="2" aa_before="F" aa_after="R" start="974" end="982" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9784"/>
+				<UserParam type="float" name="MS:1002252" value="1.196"/>
+				<UserParam type="float" name="MS:1002253" value="0.06"/>
+				<UserParam type="float" name="MS:1002255" value="113.4"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="1.48"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.392042087776024"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18850367736701"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="562.3155510319" RT="727.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=29" >
+			<PeptideHit score="2.2" sequence="FQSMKIILASDFLFQSMH" charge="2" aa_before="D" aa_after="N" start="78" end="86" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9754"/>
+				<UserParam type="float" name="MS:1002252" value="0.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.134"/>
+				<UserParam type="float" name="MS:1002255" value="1.7"/>
+				<UserParam type="float" name="MS:1002256" value="3"/>
+				<UserParam type="float" name="MS:1002257" value="2.2"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.357"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.78845736036427"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18543273627"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0625"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="558.7988885319" RT="728.7" spectrum_reference="controllerType=0 controllerNumber=1 scan=33" >
+			<PeptideHit score="0.635" sequence="QQKGRLHSASDFYQQLLAG" charge="2" aa_before="W" aa_after="]" start="210" end="218" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="17366"/>
+				<UserParam type="float" name="MS:1002252" value="0.72"/>
+				<UserParam type="float" name="MS:1002253" value="0.252"/>
+				<UserParam type="float" name="MS:1002255" value="7.2"/>
+				<UserParam type="float" name="MS:1002256" value="5"/>
+				<UserParam type="float" name="MS:1002257" value="0.635"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.72"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.454130280089445"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.76226955062059"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.6094379124341"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="544.7874140319" RT="729.8" spectrum_reference="controllerType=0 controllerNumber=1 scan=37" >
+			<PeptideHit score="10.7" sequence="KAAPGHSRQASDFH" charge="2" aa_before="P" aa_after="T" start="72" end="81" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="16732"/>
+				<UserParam type="float" name="MS:1002252" value="0.163"/>
+				<UserParam type="float" name="MS:1002253" value="0.089"/>
+				<UserParam type="float" name="MS:1002255" value="2.4"/>
+				<UserParam type="float" name="MS:1002256" value="6"/>
+				<UserParam type="float" name="MS:1002257" value="10.7"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.163"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="2.37024374146786"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.72507833256209"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.79175946922805"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0555555555555556"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="624.2362055319" RT="730.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=39" >
+			<PeptideHit score="0.627" sequence="SDYNEDASDFNLDYSTNGD" charge="2" aa_before="E" aa_after="Y" start="307" end="316" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="1012"/>
+				<UserParam type="float" name="MS:1002252" value="0.406"/>
+				<UserParam type="float" name="MS:1002253" value="0.168"/>
+				<UserParam type="float" name="MS:1002255" value="15.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.627"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.406"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.466808738349216"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="6.91968384984741"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.111111111111111"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="645.677123365233" RT="730.4" spectrum_reference="controllerType=0 controllerNumber=1 scan=40" >
+			<PeptideHit score="0.359" sequence="WIRITGASDFDEYGVVAD" charge="3" aa_before="D" aa_after="P" start="192" end="208" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="2"/>
+				<UserParam type="string" name="MS:1002259" value="64"/>
+				<UserParam type="string" name="num_matched_peptides" value="20414"/>
+				<UserParam type="float" name="MS:1002252" value="0.463"/>
+				<UserParam type="float" name="MS:1002253" value="0.297"/>
+				<UserParam type="float" name="MS:1002255" value="5.1"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.359"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.463"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-1.02443289049386"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.92397621896344"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.03125"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0" MZ="554.7780145319" RT="732.2" spectrum_reference="controllerType=0 controllerNumber=1 scan=45" >
+			<PeptideHit score="0.0175" sequence="ALKAAASDFHPTNVQR" charge="2" aa_before="F" aa_after="L" start="114" end="123" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="18586"/>
+				<UserParam type="float" name="MS:1002252" value="1.141"/>
+				<UserParam type="float" name="MS:1002253" value="0.355"/>
+				<UserParam type="float" name="MS:1002255" value="60.6"/>
+				<UserParam type="float" name="MS:1002256" value="1"/>
+				<UserParam type="float" name="MS:1002257" value="0.0175"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-4.04555439805267"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.83016388811729"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.277777777777778"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.ini
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.ini
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NODE name="PercolatorAdapter" description="Facilitate input to Percolator and reintegrate.">
+    <ITEM name="version" value="3.4.0" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
+    <NODE name="1" description="Instance &apos;1&apos; section for &apos;PercolatorAdapter&apos;">
+      <ITEMLIST name="in" type="input-file" description="Input file(s)" required="false" advanced="false" supported_formats="*.mzid,*.idXML">
+      </ITEMLIST>
+      <ITEMLIST name="in_decoy" type="input-file" description="Input decoy file(s) in case of separate searches" required="false" advanced="false" supported_formats="*.mzid,*.idXML">
+      </ITEMLIST>
+      <ITEM name="in_osw" value="" type="input-file" description="Input file in OSW format" required="false" advanced="false" supported_formats="*.OSW" />
+      <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.mzid,*.idXML,*.osw" />
+      <ITEM name="out_pin" value="" type="output-file" description="Write pin file (e.g., for debugging)" required="false" advanced="true" supported_formats="*.tab" />
+      <ITEM name="out_type" value="" type="string" description="Output file type -- default: determined from file extension or content." required="false" advanced="false" restrictions="mzid,idXML,osw" />
+      <ITEM name="enzyme" value="trypsin" type="string" description="Type of enzyme: no_enzyme,elastase,pepsin,proteinasek,thermolysin,chymotrypsin,lys-n,lys-c,arg-c,asp-n,glu-c,trypsin" required="false" advanced="false" restrictions="no_enzyme,elastase,pepsin,proteinasek,thermolysin,chymotrypsin,lys-n,lys-c,arg-c,asp-n,glu-c,trypsin" />
+      <ITEM name="percolator_executable" value="percolator" type="input-file" description="Percolator executable of the installation e.g. &apos;percolator.exe&apos;" required="true" advanced="false" />
+      <ITEM name="peptide_level_fdrs" value="false" type="string" description="Calculate peptide-level FDRs instead of PSM-level FDRs." required="false" advanced="false" restrictions="true,false" />
+      <ITEM name="protein_level_fdrs" value="false" type="string" description="Use the picked protein-level FDR to infer protein probabilities. Use the -fasta option and -decoy_pattern to set the Fasta file and decoy pattern." required="false" advanced="false" restrictions="true,false" />
+      <ITEM name="generic_feature_set" value="false" type="string" description="Use only generic (i.e. not search engine specific) features. Generating search engine specific features for common search engines by PSMFeatureExtractor will typically boost the identification rate significantly." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="subset_max_train" value="0" type="int" description="Only train an SVM on a subset of &lt;x&gt; PSMs, and use the resulting score vector to evaluate the other PSMs. Recommended when analyzing huge numbers (&gt;1 million) of PSMs. When set to 0, all PSMs are used for training as normal." required="false" advanced="true" />
+      <ITEM name="cpos" value="0" type="double" description="Cpos, penalty for mistakes made on positive examples. Set by cross validation if not specified." required="false" advanced="true" />
+      <ITEM name="cneg" value="0" type="double" description="Cneg, penalty for mistakes made on negative examples. Set by cross validation if not specified." required="false" advanced="true" />
+      <ITEM name="testFDR" value="0.5" type="double" description="False discovery rate threshold for evaluating best cross validation result and the reported end result." required="false" advanced="true" />
+      <ITEM name="trainFDR" value="0.5" type="double" description="False discovery rate threshold to define positive examples in training. Set to testFDR if 0." required="false" advanced="true" />
+      <ITEM name="maxiter" value="10" type="int" description="Maximal number of iterations" required="false" advanced="true" />
+      <ITEM name="quick_validation" value="false" type="string" description="Quicker execution by reduced internal cross-validation." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="weights" value="" type="output-file" description="Output final weights to the given file" required="false" advanced="true" />
+      <ITEM name="init_weights" value="" type="input-file" description="Read initial weights to the given file" required="false" advanced="true" />
+      <ITEM name="default_direction" value="" type="string" description="The most informative feature given as the feature name, can be negated to indicate that a lower value is better." required="false" advanced="true" />
+      <ITEM name="verbose" value="2" type="int" description="Set verbosity of output: 0=no processing info, 5=all." required="false" advanced="true" />
+      <ITEM name="unitnorm" value="false" type="string" description="Use unit normalization [0-1] instead of standard deviation normalization" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="test_each_iteration" value="false" type="string" description="Measure performance on test set each iteration" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="override" value="false" type="string" description="Override error check and do not fall back on default score vector in case of suspect score vector" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="seed" value="1" type="int" description="Setting seed of the random number generator." required="false" advanced="true" />
+      <ITEM name="doc" value="0" type="int" description="Include description of correct features" required="false" advanced="true" />
+      <ITEM name="klammer" value="false" type="string" description="Retention time features calculated as in Klammer et al. Only available if -doc is set" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="fasta" value="" type="input-file" description="Provide the fasta file as the argument to this flag, which will be used for protein grouping based on an in-silico digest (only valid if option -protein_level_fdrs is active)." required="false" advanced="true" supported_formats="*.FASTA" />
+      <ITEM name="decoy_pattern" value="random" type="string" description="Define the text pattern to identify the decoy proteins and/or PSMs, set this up if the label that identifies the decoys in the database is not the default (Only valid if option -protein_level_fdrs is active)." required="false" advanced="true" />
+      <ITEM name="post_processing_tdc" value="false" type="string" description="Use target-decoy competition to assign q-values and PEPs." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
+      <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="reported_psm_qvalue_threshold" value="0.5" type="double" description="Only include PSMs with q-value less than or equal to this threshold in the output. This only affects what is reported in the output file, not Percolator&apos;s operation." required="false" advanced="true" restrictions="0.0:1.0" />
+    </NODE>
+  </NODE>
+</PARAMETERS>

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.ini
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_6.ini
@@ -42,7 +42,7 @@
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
-      <ITEM name="reported_psm_qvalue_threshold" value="0.5" type="double" description="Only include PSMs with q-value less than or equal to this threshold in the output. This only affects what is reported in the output file, not Percolator&apos;s operation." required="false" advanced="true" restrictions="0.0:1.0" />
+      <ITEM name="reported_psm_or_peptide_qvalue_threshold" value="0.5" type="double" description="Only include PSMs with q-value less than or equal to this threshold in the output. This only affects what is reported in the output file, not Percolator&apos;s operation." required="false" advanced="true" restrictions="0.0:1.0" />
     </NODE>
   </NODE>
 </PARAMETERS>

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_6_out.idXML
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_6_out.idXML
@@ -1,0 +1,534 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="decoy.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unspecific cleavage" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+		<FixedModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+				<UserParam type="string" name="SE:Comet" value=""/>
+				<UserParam type="string" name="Comet:db" value="decoy.fasta"/>
+				<UserParam type="string" name="Comet:db_version" value=""/>
+				<UserParam type="string" name="Comet:taxonomy" value=""/>
+				<UserParam type="string" name="Comet:charges" value=""/>
+				<UserParam type="string" name="Comet:fixed_modifications" value="Carbamidomethyl (C)"/>
+				<UserParam type="string" name="Comet:variable_modifications" value="Oxidation (M)"/>
+				<UserParam type="int" name="Comet:missed_cleavages" value="1"/>
+				<UserParam type="float" name="Comet:fragment_mass_tolerance" value="0.01"/>
+				<UserParam type="string" name="Comet:fragment_mass_tolerance_unit" value="Da"/>
+				<UserParam type="float" name="Comet:precursor_mass_tolerance" value="5.0"/>
+				<UserParam type="string" name="Comet:precursor_mass_tolerance_unit" value="ppm"/>
+				<UserParam type="string" name="Comet:digestion_enzyme" value="unspecific cleavage"/>
+				<UserParam type="string" name="feature_extractor" value="TOPP_PSMFeatureExtractor"/>
+				<UserParam type="string" name="extra_features" value="COMET:deltCn,COMET:deltLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
+				<UserParam type="int" name="Percolator:peptide_level_fdrs" value="0"/>
+				<UserParam type="int" name="Percolator:protein_level_fdrs" value="0"/>
+				<UserParam type="int" name="Percolator:generic_feature_set" value="0"/>
+				<UserParam type="float" name="Percolator:testFDR" value="0.5"/>
+				<UserParam type="float" name="Percolator:trainFDR" value="0.5"/>
+				<UserParam type="int" name="Percolator:maxiter" value="10"/>
+				<UserParam type="int" name="Percolator:subset_max_train" value="0"/>
+				<UserParam type="int" name="Percolator:quick_validation" value="0"/>
+				<UserParam type="int" name="Percolator:static" value="0"/>
+				<UserParam type="string" name="Percolator:weights" value=""/>
+				<UserParam type="string" name="Percolator:init_weights" value=""/>
+				<UserParam type="string" name="Percolator:default_direction" value=""/>
+				<UserParam type="float" name="Percolator:cpos" value="0.0"/>
+				<UserParam type="float" name="Percolator:cneg" value="0.0"/>
+				<UserParam type="int" name="Percolator:unitnorm" value="0"/>
+				<UserParam type="int" name="Percolator:override" value="0"/>
+				<UserParam type="int" name="Percolator:seed" value="1"/>
+				<UserParam type="int" name="Percolator:doc" value="0"/>
+				<UserParam type="int" name="Percolator:klammer" value="0"/>
+				<UserParam type="string" name="Percolator:fasta" value=""/>
+				<UserParam type="string" name="Percolator:decoy_pattern" value="random"/>
+				<UserParam type="int" name="Percolator:post_processing_tdc" value="0"/>
+				<UserParam type="int" name="Percolator:train_best_positive" value="0"/>
+	</SearchParameters>
+	<IdentificationRun date="2024-12-18T13:04:48" search_engine="Percolator" search_engine_version="3.05" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="sp|Q02952|AKA12_HUMAN" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="sp|Q12774|ARHG5_HUMAN" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[]"/>
+			<UserParam type="string" name="percolator" value="PercolatorAdapter"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="514.28045603190003" RT="721.399999999999977" spectrum_reference="controllerType=0 controllerNumber=1 scan=3" >
+			<PeptideHit score="0.357143" sequence="EAVPAQKERRRRGAH" charge="2" aa_before="A" aa_after="P" start="1211" end="1219" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="9"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="11906"/>
+				<UserParam type="float" name="MS:1002252" value="1.622"/>
+				<UserParam type="float" name="MS:1002253" value="0.256"/>
+				<UserParam type="float" name="MS:1002255" value="256.600000000000023"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0342"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.37552963491358"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.38479775371334"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5625"/>
+				<UserParam type="float" name="expect" value="0.0342"/>
+				<UserParam type="float" name="MS:1001492" value="-0.657375"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.868362"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="499.610778031899997" RT="721.700000000000046" spectrum_reference="controllerType=0 controllerNumber=1 scan=4" >
+			<PeptideHit score="0.357143" sequence="TRILKHGAKDKDDLHKY" charge="3" aa_before="F F F" aa_after="] ] ]" start="159 158 159" end="171 170 171" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="10"/>
+				<UserParam type="string" name="MS:1002259" value="48"/>
+				<UserParam type="string" name="num_matched_peptides" value="13136"/>
+				<UserParam type="float" name="MS:1002252" value="1.162"/>
+				<UserParam type="float" name="MS:1002253" value="0.37"/>
+				<UserParam type="float" name="MS:1002255" value="106.5"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0272"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.60453830568019"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.483111831692209"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.208333333333333"/>
+				<UserParam type="float" name="expect" value="0.0272"/>
+				<UserParam type="float" name="MS:1001492" value="0.343995"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.157704"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="545.750182531900009" RT="721.899999999999977" spectrum_reference="controllerType=0 controllerNumber=1 scan=5" >
+			<PeptideHit score="0.357143" sequence="AAGGEAEHQRAY" charge="2" aa_before="A" aa_after="L" start="171" end="179" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9348"/>
+				<UserParam type="float" name="MS:1002252" value="1.546"/>
+				<UserParam type="float" name="MS:1002253" value="0.344"/>
+				<UserParam type="float" name="MS:1002255" value="126.299999999999997"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0421"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.1677075382938"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.142917695658751"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.375"/>
+				<UserParam type="float" name="expect" value="0.0421"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="527.31176703189999" RT="722.100000000000023" spectrum_reference="controllerType=0 controllerNumber=1 scan=6" >
+			<PeptideHit score="0.357143" sequence="TQVVVSHLLKL" charge="2" aa_before="Q" aa_after="S" start="327" end="335" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="4910"/>
+				<UserParam type="float" name="MS:1002252" value="0.951"/>
+				<UserParam type="float" name="MS:1002253" value="0.014"/>
+				<UserParam type="float" name="MS:1002255" value="44.5"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="1.01"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.951"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="9.95033085316809e-03"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.49902922078857"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+				<UserParam type="float" name="expect" value="1.01"/>
+				<UserParam type="float" name="MS:1001492" value="-0.80373"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="514.759948031899967" RT="722.700000000000046" spectrum_reference="controllerType=0 controllerNumber=1 scan=9" >
+			<PeptideHit score="0.357143" sequence="SVSSKRGHASSYRR" charge="2" aa_before="R" aa_after="M" start="4" end="12" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="8"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.41"/>
+				<UserParam type="float" name="MS:1002253" value="0.037"/>
+				<UserParam type="float" name="MS:1002255" value="159.599999999999994"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.401"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.03758865248227"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.03758865248227"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.913793851675568"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.461410325931229"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5"/>
+				<UserParam type="float" name="expect" value="0.401"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+			<PeptideHit score="0.357143" sequence="AGGDPAAKGERLHFY" charge="2" aa_before="G" aa_after="W" start="2239" end="2249" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.204"/>
+				<UserParam type="float" name="MS:1002255" value="99.599999999999994"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.592"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.524248644098131"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.461410325931229"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3"/>
+				<UserParam type="float" name="expect" value="0.592"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="528.254210531899957" RT="723.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=13" >
+			<PeptideHit score="0.357143" sequence="EVFHSGHSFHLAY" charge="2" aa_before="E" aa_after="N" start="219" end="227" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12114"/>
+				<UserParam type="float" name="MS:1002252" value="0.645"/>
+				<UserParam type="float" name="MS:1002253" value="0.236"/>
+				<UserParam type="float" name="MS:1002255" value="51.399999999999999"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.409"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.645"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.894040122939335"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.402117087540891"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+				<UserParam type="float" name="expect" value="0.409"/>
+				<UserParam type="float" name="MS:1001492" value="-0.814315"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="514.28045603190003" RT="721.399999999999977" spectrum_reference="controllerType=0 controllerNumber=1 scan=3" >
+			<PeptideHit score="0.357143" sequence="EAVPAACQKERRRRGAH" charge="2" aa_before="A" aa_after="P" start="1211" end="1219" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="9"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="11906"/>
+				<UserParam type="float" name="MS:1002252" value="1.622"/>
+				<UserParam type="float" name="MS:1002253" value="0.256"/>
+				<UserParam type="float" name="MS:1002255" value="256.600000000000023"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0342"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.37552963491358"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.38479775371334"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5625"/>
+				<UserParam type="float" name="expect" value="0.0342"/>
+				<UserParam type="float" name="MS:1001492" value="-0.657375"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.868362"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="499.610778031899997" RT="721.700000000000046" spectrum_reference="controllerType=0 controllerNumber=1 scan=4" >
+			<PeptideHit score="0.357143" sequence="TRILKHGGFAAKDKDDLHKY" charge="3" aa_before="F F F" aa_after="] ] ]" start="159 158 159" end="171 170 171" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="10"/>
+				<UserParam type="string" name="MS:1002259" value="48"/>
+				<UserParam type="string" name="num_matched_peptides" value="13136"/>
+				<UserParam type="float" name="MS:1002252" value="1.162"/>
+				<UserParam type="float" name="MS:1002253" value="0.37"/>
+				<UserParam type="float" name="MS:1002255" value="106.5"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0272"/>
+				<UserParam type="string" name="protein_references" value="non-unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.60453830568019"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.483111831692209"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.208333333333333"/>
+				<UserParam type="float" name="expect" value="0.0272"/>
+				<UserParam type="float" name="MS:1001492" value="0.343995"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.157704"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="545.750182531900009" RT="721.899999999999977" spectrum_reference="controllerType=0 controllerNumber=1 scan=5" >
+			<PeptideHit score="0.357143" sequence="AAGGEAEHQASDRAY" charge="2" aa_before="A" aa_after="L" start="171" end="179" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9348"/>
+				<UserParam type="float" name="MS:1002252" value="1.546"/>
+				<UserParam type="float" name="MS:1002253" value="0.344"/>
+				<UserParam type="float" name="MS:1002255" value="126.299999999999997"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0421"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-3.1677075382938"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.142917695658751"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.375"/>
+				<UserParam type="float" name="expect" value="0.0421"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="527.31176703189999" RT="722.100000000000023" spectrum_reference="controllerType=0 controllerNumber=1 scan=6" >
+			<PeptideHit score="0.357143" sequence="TQVASDVVSHLLKL" charge="2" aa_before="Q" aa_after="S" start="327" end="335" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="4910"/>
+				<UserParam type="float" name="MS:1002252" value="0.951"/>
+				<UserParam type="float" name="MS:1002253" value="0.014"/>
+				<UserParam type="float" name="MS:1002255" value="44.5"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="1.01"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.951"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="9.95033085316809e-03"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="8.49902922078857"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+				<UserParam type="float" name="expect" value="1.01"/>
+				<UserParam type="float" name="MS:1001492" value="-0.80373"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="514.759948031899967" RT="722.700000000000046" spectrum_reference="controllerType=0 controllerNumber=1 scan=9" >
+			<PeptideHit score="0.357143" sequence="SVSSAASDKRGHASSYRR" charge="2" aa_before="R" aa_after="M" start="4" end="12" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="8"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.41"/>
+				<UserParam type="float" name="MS:1002253" value="0.037"/>
+				<UserParam type="float" name="MS:1002255" value="159.599999999999994"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.401"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.03758865248227"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.03758865248227"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.913793851675568"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.461410325931229"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.5"/>
+				<UserParam type="float" name="expect" value="0.401"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+			<PeptideHit score="0.357143" sequence="AGGDASDFPAAKGERLHFY" charge="2" aa_before="G" aa_after="W" start="2239" end="2249" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="6"/>
+				<UserParam type="string" name="MS:1002259" value="20"/>
+				<UserParam type="string" name="num_matched_peptides" value="12854"/>
+				<UserParam type="float" name="MS:1002252" value="1.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.204"/>
+				<UserParam type="float" name="MS:1002255" value="99.599999999999994"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.592"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.524248644098131"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.461410325931229"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3"/>
+				<UserParam type="float" name="expect" value="0.592"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="528.254210531899957" RT="723.5" spectrum_reference="controllerType=0 controllerNumber=1 scan=13" >
+			<PeptideHit score="0.357143" sequence="EVFASDFHSGHSFHLAY" charge="2" aa_before="E" aa_after="N" start="219" end="227" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="MS:1002258" value="4"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="12114"/>
+				<UserParam type="float" name="MS:1002252" value="0.645"/>
+				<UserParam type="float" name="MS:1002253" value="0.236"/>
+				<UserParam type="float" name="MS:1002255" value="51.399999999999999"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.409"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.645"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-0.894040122939335"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.402117087540891"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.25"/>
+				<UserParam type="float" name="expect" value="0.409"/>
+				<UserParam type="float" name="MS:1001492" value="-0.814315"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="455.748412531899987" RT="727.600000000000023" spectrum_reference="controllerType=0 controllerNumber=1 scan=28" >
+			<PeptideHit score="0.357143" sequence="VVGANRASHVVAAGGYY" charge="2" aa_before="F" aa_after="R" start="974" end="982" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9784"/>
+				<UserParam type="float" name="MS:1002252" value="1.196"/>
+				<UserParam type="float" name="MS:1002253" value="0.06"/>
+				<UserParam type="float" name="MS:1002255" value="113.400000000000006"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="1.48"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.392042087776024"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.188503677367009"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3125"/>
+				<UserParam type="float" name="expect" value="1.48"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="562.315551031899986" RT="727.799999999999955" spectrum_reference="controllerType=0 controllerNumber=1 scan=29" >
+			<PeptideHit score="0.5" sequence="FQSMKIILLFQSMH" charge="2" aa_before="D" aa_after="N" start="78" end="86" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9754"/>
+				<UserParam type="float" name="MS:1002252" value="0.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.134"/>
+				<UserParam type="float" name="MS:1002255" value="1.7"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="2.2"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.357"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.78845736036427"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18543273627"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0625"/>
+				<UserParam type="float" name="expect" value="2.2"/>
+				<UserParam type="float" name="MS:1001492" value="-0.918262"/>
+				<UserParam type="float" name="MS:1001491" value="0.5"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="554.778014531899999" RT="732.200000000000045" spectrum_reference="controllerType=0 controllerNumber=1 scan=45" >
+			<PeptideHit score="0.357143" sequence="ALKAAHPTASDFNVQR" charge="2" aa_before="F" aa_after="L" start="114" end="123" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="18586"/>
+				<UserParam type="float" name="MS:1002252" value="1.141"/>
+				<UserParam type="float" name="MS:1002253" value="0.355"/>
+				<UserParam type="float" name="MS:1002255" value="60.600000000000001"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0175"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-4.04555439805267"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.830163888117291"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.277777777777778"/>
+				<UserParam type="float" name="expect" value="0.0175"/>
+				<UserParam type="float" name="MS:1001492" value="-0.500436"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.669637"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="455.748412531899987" RT="727.600000000000023" spectrum_reference="controllerType=0 controllerNumber=1 scan=28" >
+			<PeptideHit score="0.357143" sequence="VVGANRASASDFHVVAAGGYY" charge="2" aa_before="F" aa_after="R" start="974" end="982" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9784"/>
+				<UserParam type="float" name="MS:1002252" value="1.196"/>
+				<UserParam type="float" name="MS:1002253" value="0.06"/>
+				<UserParam type="float" name="MS:1002255" value="113.400000000000006"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="1.48"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.392042087776024"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.188503677367009"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.3125"/>
+				<UserParam type="float" name="expect" value="1.48"/>
+				<UserParam type="float" name="MS:1001492" value="0.0"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.286744"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="562.315551031899986" RT="727.799999999999955" spectrum_reference="controllerType=0 controllerNumber=1 scan=29" >
+			<PeptideHit score="0.5" sequence="FQSMKIILASDFLFQSMH" charge="2" aa_before="D" aa_after="N" start="78" end="86" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="1"/>
+				<UserParam type="string" name="MS:1002259" value="16"/>
+				<UserParam type="string" name="num_matched_peptides" value="9754"/>
+				<UserParam type="float" name="MS:1002252" value="0.357"/>
+				<UserParam type="float" name="MS:1002253" value="0.134"/>
+				<UserParam type="float" name="MS:1002255" value="1.7"/>
+				<UserParam type="float" name="MS:1002256" value="3.0"/>
+				<UserParam type="float" name="MS:1002257" value="2.2"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="0.357"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="0.78845736036427"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.18543273627"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="1.09861228866811"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0625"/>
+				<UserParam type="float" name="expect" value="2.2"/>
+				<UserParam type="float" name="MS:1001492" value="-0.918262"/>
+				<UserParam type="float" name="MS:1001491" value="0.5"/>
+				<UserParam type="float" name="MS:1001493" value="1.0"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0.0" MZ="554.778014531899999" RT="732.200000000000045" spectrum_reference="controllerType=0 controllerNumber=1 scan=45" >
+			<PeptideHit score="0.357143" sequence="ALKAAASDFHPTNVQR" charge="2" aa_before="F" aa_after="L" start="114" end="123" protein_refs="PH_1" >
+				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="MS:1002258" value="5"/>
+				<UserParam type="string" name="MS:1002259" value="18"/>
+				<UserParam type="string" name="num_matched_peptides" value="18586"/>
+				<UserParam type="float" name="MS:1002252" value="1.141"/>
+				<UserParam type="float" name="MS:1002253" value="0.355"/>
+				<UserParam type="float" name="MS:1002255" value="60.600000000000001"/>
+				<UserParam type="float" name="MS:1002256" value="1.0"/>
+				<UserParam type="float" name="MS:1002257" value="0.0175"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+				<UserParam type="float" name="COMET:deltCn" value="1.0"/>
+				<UserParam type="float" name="COMET:deltLCn" value="0.0"/>
+				<UserParam type="float" name="COMET:lnExpect" value="-4.04555439805267"/>
+				<UserParam type="float" name="COMET:lnNumSP" value="9.830163888117291"/>
+				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.277777777777778"/>
+				<UserParam type="float" name="expect" value="0.0175"/>
+				<UserParam type="float" name="MS:1001492" value="-0.500436"/>
+				<UserParam type="float" name="MS:1001491" value="0.357143"/>
+				<UserParam type="float" name="MS:1001493" value="0.669637"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -218,6 +218,10 @@ if (NOT (${PERCOLATOR_BINARY} STREQUAL "PERCOLATOR_BINARY-NOTFOUND"))
   set_tests_properties("TOPP_PercolatorAdapter_4" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_3")
   add_test("TOPP_PercolatorAdapter_5" ${TOPP_BIN_PATH}/PercolatorAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.ini -in ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_1.idXML -out PercolatorAdapter_1_out1.tmp.idXML -out_type idXML -percolator_executable "${PERCOLATOR_BINARY}" -out_pin PercolatorAdapter_1_out1.tsv )
   set_tests_properties("TOPP_PercolatorAdapter_5" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_4")
+  add_test("TOPP_PercolatorAdapter_6" ${TOPP_BIN_PATH}/PercolatorAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_6.ini -in ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_6.idXML -out PercolatorAdapter_6_out1.tmp.idXML -out_type idXML -percolator_executable "${PERCOLATOR_BINARY}")
+  add_test("TOPP_PercolatorAdapter_6_out1" ${DIFF} -in1 PercolatorAdapter_6_out1.tmp.idXML -in2 ${DATA_DIR_TOPP}/THIRDPARTY/PercolatorAdapter_6_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"spectra_data\" value=")
+  set_tests_properties("TOPP_PercolatorAdapter_6_out1" PROPERTIES DEPENDS "TOPP_PercolatorAdapter_6")
+
   ### TOPP_PercolatorAdapter_2-4 do not validate output, but checks whether OSW files can be read and written to.
   ### same for TOPP_PercolatorAdapter_5 which tests if pin file can be written
 endif()

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -1058,7 +1058,7 @@ protected:
             const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_or_peptide_qvalue_threshold;
 
             if (!report_psm_threshold_passed) continue;
-            writeDebug_("Theshold passed:" + String(pr->second.qvalue), 10);
+            writeDebug_("Threshold passed:" + String(pr->second.qvalue), 10);
 
             hit.setMetaValue(old_score_type, hit.getScore());  // old search engine "main" score as metavalue
             hit.setMetaValue("MS:1001492", pr->second.score);  // svm score

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -283,11 +283,11 @@ protected:
     registerDoubleOption_("ipf_max_transition_isotope_overlap", "<value>", 0.5, "OSW/IPF: Maximum isotope overlap to consider transitions in IPF.", !is_required, is_advanced_option);
     registerDoubleOption_("ipf_min_transition_sn", "<value>", 0, "OSW/IPF: Minimum log signal-to-noise level to consider transitions in IPF. Set -1 to disable this filter.", !is_required, is_advanced_option);
 
-    registerDoubleOption_("reported_psm_qvalue_threshold", "<value>", 1.0, 
+    registerDoubleOption_("reported_psm_or_peptide_qvalue_threshold", "<value>", 1.0, 
     "Only include PSMs with q-value less than or equal to this threshold in the output. This only affects what is reported in the output file, not Percolator's operation.", 
     false, true);
-    setMinFloat_("reported_psm_qvalue_threshold", 0.0);
-    setMaxFloat_("reported_psm_qvalue_threshold", 1.0);
+    setMinFloat_("reported_psm_or_peptide_qvalue_threshold", 0.0);
+    setMaxFloat_("reported_psm_or_peptide_qvalue_threshold", 1.0);
   }
   
 
@@ -578,7 +578,7 @@ protected:
     OPENMS_LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << " & " << ListUtils::concatenate(in_decoy, ",") << " (decoy)" << endl;
     const String in_osw = getStringOption_("in_osw");
     const OSWFile::OSWLevel osw_level = (OSWFile::OSWLevel)Helpers::indexOf(OSWFile::names_of_oswlevel, getStringOption_("osw_level"));
-    const double reported_psm_qvalue_threshold = getDoubleOption_("reported_psm_qvalue_threshold");
+    const double reported_psm_or_peptide_qvalue_threshold = getDoubleOption_("reported_psm_or_peptide_qvalue_threshold");
 
     //output file names and types
     String out = getStringOption_("out");
@@ -1050,12 +1050,12 @@ protected:
 
           // if q-value filtering is enabled skip hit without identifiers
           // (if filtering is disabled also report unidentified identifer) for backwards compatibility
-          if (!identifier_found && (reported_psm_qvalue_threshold < 1.0)) continue;
+          if (!identifier_found && (reported_psm_or_peptide_qvalue_threshold < 1.0)) continue;
 
           if (identifier_found)
           {
             // skip reporting of identified peptide hit if PSM q-value threshold not reached
-            const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_qvalue_threshold;
+            const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_or_peptide_qvalue_threshold;
 
             if (!report_psm_threshold_passed) continue;
             writeDebug_("Theshold passed:" + String(pr->second.qvalue), 10);

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -1050,13 +1050,15 @@ protected:
 
           // if q-value filtering is enabled skip hit without identifiers
           // (if filtering is disabled also report unidentified identifer) for backwards compatibility
-          if (!identifier_found && reported_psm_qvalue_threshold < 1.0) continue;
+          if (!identifier_found && (reported_psm_qvalue_threshold < 1.0)) continue;
 
           if (identifier_found)
           {
             // skip reporting of identified peptide hit if PSM q-value threshold not reached
             const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_qvalue_threshold;
+
             if (!report_psm_threshold_passed) continue;
+            writeDebug_("Theshold passed:" + String(pr->second.qvalue), 10);
 
             hit.setMetaValue(old_score_type, hit.getScore());  // old search engine "main" score as metavalue
             hit.setMetaValue("MS:1001492", pr->second.score);  // svm score
@@ -1104,8 +1106,8 @@ protected:
             }
             filtered_hits.push_back(hit);
           }
-          pep_id.setHits(filtered_hits);
         }
+        pep_id.setHits(filtered_hits);
       }
 
       if (!peptide_level_fdrs)

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -1032,6 +1032,9 @@ protected:
         String file_identifier = pep_id.getMetaValue("file_origin", String());
         file_identifier += (String)pep_id.getMetaValue("id_merge_index", String());
 
+        vector<PeptideHit> filtered_hits;
+        filtered_hits.reserve(pep_id.getHits().size());
+
         //check each PeptideHit for compliance with one of the PercolatorResults (by sequence)
         for (PeptideHit& hit : pep_id.getHits())
         {
@@ -1043,8 +1046,12 @@ protected:
  
           map<String, PercolatorResult>::iterator pr = pep_map.find(psm_identifier);
 
-          // skip reporting a peptide hit if PSM q-value threshold not reached
-          if (reported_psm_qvalue_threshold < 1.0 && pr != pep_map.end() pr->second.qvalue > reported_psm_qvalue_threshold) continue;
+          // if q-value filtering is enabled skip unidentified hits
+          if (reported_psm_qvalue_threshold < 1.0 && 
+            pr == pep_map.end()) continue;
+
+          // skip reporting of identified peptide hit if PSM q-value threshold not reached            
+          if (pr->second.qvalue > reported_psm_qvalue_threshold) continue;
 
           if (pr != pep_map.end())
           {
@@ -1064,6 +1071,12 @@ protected:
             else if (scoreType == "svm")
             {
               hit.setScore(pr->second.score);
+            }
+
+            // Only keep hits that pass q-value threshold
+            if (pr->second.qvalue <= reported_psm_qvalue_threshold)
+            {
+              filtered_hits.push_back(hit);
             }
 
             ++cnt;
@@ -1091,6 +1104,7 @@ protected:
               hit.setScore(-100.0); // set SVM score to -100.0 if hit not found in results
             }
           }
+          pep_id.setHits(filtered_hits);
         }
       }
 
@@ -1184,7 +1198,6 @@ protected:
         search_parameters.setMetaValue("Percolator:decoy_pattern", getStringOption_("decoy_pattern"));
         search_parameters.setMetaValue("Percolator:post_processing_tdc", getFlag_("post_processing_tdc"));
         search_parameters.setMetaValue("Percolator:train_best_positive", getFlag_("train_best_positive"));
-        
         prot_id_run.setSearchParameters(search_parameters);
       }
       // Storing the PeptideHits with calculated q-value, pep and svm score

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -282,6 +282,12 @@ protected:
     registerDoubleOption_("ipf_max_peakgroup_pep", "<value>", 0.7, "OSW/IPF: Assess transitions only for candidate peak groups until maximum posterior error probability.", !is_required, is_advanced_option);
     registerDoubleOption_("ipf_max_transition_isotope_overlap", "<value>", 0.5, "OSW/IPF: Maximum isotope overlap to consider transitions in IPF.", !is_required, is_advanced_option);
     registerDoubleOption_("ipf_min_transition_sn", "<value>", 0, "OSW/IPF: Minimum log signal-to-noise level to consider transitions in IPF. Set -1 to disable this filter.", !is_required, is_advanced_option);
+
+    registerDoubleOption_("reported_psm_qvalue_threshold", "<value>", 1.0, 
+    "Only include PSMs with q-value less than or equal to this threshold in the output. This only affects what is reported in the output file, not Percolator's operation.", 
+    false, true);
+    setMinFloat_("reported_psm_qvalue_threshold", 0.0);
+    setMaxFloat_("reported_psm_qvalue_threshold", 1.0);
   }
   
 
@@ -572,6 +578,7 @@ protected:
     OPENMS_LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << " & " << ListUtils::concatenate(in_decoy, ",") << " (decoy)" << endl;
     const String in_osw = getStringOption_("in_osw");
     const OSWFile::OSWLevel osw_level = (OSWFile::OSWLevel)Helpers::indexOf(OSWFile::names_of_oswlevel, getStringOption_("osw_level"));
+    const double reported_psm_qvalue_threshold = getDoubleOption_("reported_psm_qvalue_threshold");
 
     //output file names and types
     String out = getStringOption_("out");
@@ -1035,6 +1042,10 @@ protected:
           writeDebug_("PSM identifier in PeptideHit: " + psm_identifier, 10);
  
           map<String, PercolatorResult>::iterator pr = pep_map.find(psm_identifier);
+
+          // skip reporting a peptide hit if PSM q-value threshold not reached
+          if (reported_psm_qvalue_threshold < 1.0 && pr != pep_map.end() pr->second.qvalue > reported_psm_qvalue_threshold) continue;
+
           if (pr != pep_map.end())
           {
             hit.setMetaValue(old_score_type, hit.getScore());  // old search engine "main" score as metavalue

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -1046,14 +1046,17 @@ protected:
  
           map<String, PercolatorResult>::iterator pr = pep_map.find(psm_identifier);
 
-          // if q-value filtering is enabled skip unidentified hits
-          if (reported_psm_qvalue_threshold < 1.0 && 
-            pr == pep_map.end()) continue;
+          const bool identifier_found = (pr != pep_map.end());
 
-          // skip reporting of identified peptide hit if PSM q-value threshold not reached            
-          if (pr->second.qvalue > reported_psm_qvalue_threshold) continue;
+          // if q-value filtering is enabled skip hit without identifiers
+          // (if filtering is disabled also report unidentified identifer) for backwards compatibility
+          if (!identifier_found && reported_psm_qvalue_threshold < 1.0) continue;
 
-          if (pr != pep_map.end())
+          // skip reporting of identified peptide hit if PSM q-value threshold not reached
+          const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_qvalue_threshold;
+          if (identifier_found && !report_psm_threshold_passed) continue;
+
+          if (identifier_found)
           {
             hit.setMetaValue(old_score_type, hit.getScore());  // old search engine "main" score as metavalue
             hit.setMetaValue("MS:1001492", pr->second.score);  // svm score
@@ -1074,7 +1077,7 @@ protected:
             }
 
             // Only keep hits that pass q-value threshold
-            if (pr->second.qvalue <= reported_psm_qvalue_threshold)
+            if (report_psm_threshold_passed)
             {
               filtered_hits.push_back(hit);
             }

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -1052,12 +1052,12 @@ protected:
           // (if filtering is disabled also report unidentified identifer) for backwards compatibility
           if (!identifier_found && reported_psm_qvalue_threshold < 1.0) continue;
 
-          // skip reporting of identified peptide hit if PSM q-value threshold not reached
-          const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_qvalue_threshold;
-          if (identifier_found && !report_psm_threshold_passed) continue;
-
           if (identifier_found)
           {
+            // skip reporting of identified peptide hit if PSM q-value threshold not reached
+            const bool report_psm_threshold_passed = pr->second.qvalue <= reported_psm_qvalue_threshold;
+            if (!report_psm_threshold_passed) continue;
+
             hit.setMetaValue(old_score_type, hit.getScore());  // old search engine "main" score as metavalue
             hit.setMetaValue("MS:1001492", pr->second.score);  // svm score
             hit.setMetaValue("MS:1001491", pr->second.qvalue);  // percolator q value
@@ -1076,11 +1076,7 @@ protected:
               hit.setScore(pr->second.score);
             }
 
-            // Only keep hits that pass q-value threshold
-            if (report_psm_threshold_passed)
-            {
-              filtered_hits.push_back(hit);
-            }
+            filtered_hits.push_back(hit);
 
             ++cnt;
           }
@@ -1106,6 +1102,7 @@ protected:
             {
               hit.setScore(-100.0); // set SVM score to -100.0 if hit not found in results
             }
+            filtered_hits.push_back(hit);
           }
           pep_id.setHits(filtered_hits);
         }


### PR DESCRIPTION
## Description

Allows to already filter percolator output by PSM-level FDR.
Could potentially already be done during reading the percolator output file, but I guess this will not be the 
memory / performance bottleneck.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
