### PR TITLE
fix: remove caching of number of peaks and ms levels in MSExperiment

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1071,7 +1071,6 @@ std::vector<MSChromatogram> extractXICs(
     /**
       @brief Updates the m/z, intensity, and retention time ranges of all spectra with a certain ms level
       
-      To update MS levels, use updateRanges() without parameters instead.
 
       @param ms_level MS level to consider for m/z range, RT range and intensity range (All MS levels if negative)
     */

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1071,7 +1071,6 @@ std::vector<MSChromatogram> extractXICs(
     /**
       @brief Updates the m/z, intensity, and retention time ranges of all spectra with a certain ms level
       
-      @note This method does not modify the set of MS levels (ms_levels_) stored in the experiment.
       To update MS levels, use updateRanges() without parameters instead.
 
       @param ms_level MS level to consider for m/z range, RT range and intensity range (All MS levels if negative)
@@ -1081,7 +1080,7 @@ std::vector<MSChromatogram> extractXICs(
     /// returns the total number of peaks (spectra and chromatograms included)
     UInt64 getSize() const;
 
-    /// returns an array of MS levels (calculated on demand)
+    /// returns a sorted array of MS levels (calculated on demand)
     std::vector<UInt> getMSLevels() const;
 
     ///@}

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1075,7 +1075,7 @@ std::vector<MSChromatogram> extractXICs(
     */
     void updateRanges(Int ms_level);
 
-    /// returns the total number of peaks
+    /// returns the total number of peaks (spectra and chromatograms included)
     UInt64 getSize() const;
 
     /// returns an array of MS levels
@@ -1281,8 +1281,6 @@ std::vector<MSChromatogram> extractXICs(
   protected:
     /// MS levels of the data
     std::vector<UInt> ms_levels_;
-    /// Number of all data points
-    UInt64 total_size_;
     /// chromatograms
     std::vector<MSChromatogram > chromatograms_;
     /// spectra

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1069,17 +1069,20 @@ std::vector<MSChromatogram> extractXICs(
     void updateRanges() override;
 
     /**
-      @brief Updates the m/z, intensity, retention time and MS level ranges of all spectra with a certain ms level
+      @brief Updates the m/z, intensity, and retention time ranges of all spectra with a certain ms level
+      
+      @note This method does not modify the set of MS levels (ms_levels_) stored in the experiment.
+      To update MS levels, use updateRanges() without parameters instead.
 
-      @param ms_level MS level to consider for m/z range , RT range and intensity range (All MS levels if negative)
+      @param ms_level MS level to consider for m/z range, RT range and intensity range (All MS levels if negative)
     */
     void updateRanges(Int ms_level);
 
     /// returns the total number of peaks (spectra and chromatograms included)
     UInt64 getSize() const;
 
-    /// returns an array of MS levels
-    const std::vector<UInt>& getMSLevels() const;
+    /// returns an array of MS levels (calculated on demand)
+    std::vector<UInt> getMSLevels() const;
 
     ///@}
 
@@ -1279,8 +1282,6 @@ std::vector<MSChromatogram> extractXICs(
     bool isIMFrame() const;
 
   protected:
-    /// MS levels of the data
-    std::vector<UInt> ms_levels_;
     /// chromatograms
     std::vector<MSChromatogram > chromatograms_;
     /// spectra

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -136,6 +136,7 @@ public:
     using ContainerType::erase;
     using ContainerType::swap;
     using ContainerType::data;
+    using ContainerType::shrink_to_fit;
 
     using typename ContainerType::iterator;
     using typename ContainerType::const_iterator;

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -17,14 +17,14 @@
 
 #include <algorithm>
 #include <limits>
+#include <unordered_set>
 
 namespace OpenMS
 {
   /// Constructor
   MSExperiment::MSExperiment() :
     RangeManagerContainerType(),
-    ExperimentalSettings(),
-    ms_levels_()
+    ExperimentalSettings()
   {}
 
   /// Copy constructor
@@ -40,7 +40,6 @@ namespace OpenMS
     RangeManagerContainerType::operator=(source);
     ExperimentalSettings::operator=(source);
 
-    ms_levels_ = source.ms_levels_;
     chromatograms_ = source.chromatograms_;
     spectra_ = source.spectra_;
 
@@ -230,9 +229,6 @@ namespace OpenMS
   */
   void MSExperiment::updateRanges(Int ms_level)
   {
-    // clear MS levels
-    ms_levels_.clear();
-
     // reset mz/rt/int range
     this->clearRanges();
 
@@ -247,12 +243,6 @@ namespace OpenMS
     {
       if (ms_level < Int(0) || Int(it->getMSLevel()) == ms_level)
       {
-        //ms levels
-        if (std::find(ms_levels_.begin(), ms_levels_.end(), it->getMSLevel()) == ms_levels_.end())
-        {
-          ms_levels_.push_back(it->getMSLevel());
-        }
-
         // ranges
         this->extendRT(it->getRT()); // RT
         // m/z, intensity and ion mobility from spectrum's range
@@ -268,9 +258,7 @@ namespace OpenMS
           this->extendMZ(it->getPrecursors()[0].getMZ());
         }
       }
-
     }
-    std::sort(ms_levels_.begin(), ms_levels_.end());
 
     if (this->chromatograms_.empty())
     {
@@ -305,10 +293,18 @@ namespace OpenMS
     return total_size;
   }
 
-  /// returns an array of MS levels
-  const std::vector<UInt>& MSExperiment::getMSLevels() const
+  /// returns an array of MS levels (calculated on demand)
+  std::vector<UInt> MSExperiment::getMSLevels() const
   {
-    return ms_levels_;
+    std::unordered_set<UInt> level_set;
+    for (const auto& spec : spectra_)
+    {
+      level_set.insert(spec.getMSLevel());
+    }
+    
+    std::vector<UInt> ms_levels(level_set.begin(), level_set.end());
+    std::sort(ms_levels.begin(), ms_levels.end());
+    return ms_levels;
   }
 
   const String sqMassRunID = "sqMassRunID";
@@ -614,8 +610,6 @@ namespace OpenMS
     //swap peaks
     spectra_.swap(from.getSpectra());
 
-    //swap remaining members
-    ms_levels_.swap(from.ms_levels_);
   }
 
   /// sets the spectrum list
@@ -805,7 +799,6 @@ namespace OpenMS
       clearRanges();
       this->ExperimentalSettings::operator=(ExperimentalSettings());             // no "clear" method
       chromatograms_.clear();
-      ms_levels_.clear();
     }
   }
 

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -24,8 +24,7 @@ namespace OpenMS
   MSExperiment::MSExperiment() :
     RangeManagerContainerType(),
     ExperimentalSettings(),
-    ms_levels_(),
-    total_size_(0)
+    ms_levels_()
   {}
 
   /// Copy constructor
@@ -42,7 +41,6 @@ namespace OpenMS
     ExperimentalSettings::operator=(source);
 
     ms_levels_ = source.ms_levels_;
-    total_size_ = source.total_size_;
     chromatograms_ = source.chromatograms_;
     spectra_ = source.spectra_;
 
@@ -237,8 +235,6 @@ namespace OpenMS
 
     // reset mz/rt/int range
     this->clearRanges();
-    // reset point count
-    total_size_ = 0;
 
     // empty
     if (spectra_.empty() && chromatograms_.empty())
@@ -256,9 +252,6 @@ namespace OpenMS
         {
           ms_levels_.push_back(it->getMSLevel());
         }
-
-        // calculate size
-        total_size_ += it->size();
 
         // ranges
         this->extendRT(it->getRT()); // RT
@@ -297,8 +290,6 @@ namespace OpenMS
         continue;
       }
 
-      total_size_ += cp.size();
-
       // ranges
       this->extendMZ(cp.getMZ());// MZ
       this->extend(cp);// RT and intensity from chroms's range
@@ -307,8 +298,11 @@ namespace OpenMS
 
   /// returns the total number of peaks
   UInt64 MSExperiment::getSize() const
-  {
-    return total_size_;
+  {    
+    Size total_size{};
+    for (const auto& spec : spectra_) total_size += spec.size(); // sum up all peaks in all spectra
+    for (const auto& chrom : chromatograms_) total_size += chrom.size(); // sum up all peaks in all chromatograms
+    return total_size;
   }
 
   /// returns an array of MS levels
@@ -622,7 +616,6 @@ namespace OpenMS
 
     //swap remaining members
     ms_levels_.swap(from.ms_levels_);
-    std::swap(total_size_, from.total_size_);
   }
 
   /// sets the spectrum list
@@ -813,7 +806,6 @@ namespace OpenMS
       this->ExperimentalSettings::operator=(ExperimentalSettings());             // no "clear" method
       chromatograms_.clear();
       ms_levels_.clear();
-      total_size_ = 0;
     }
   }
 

--- a/src/openms/source/PROCESSING/FILTERING/ThresholdMower.cpp
+++ b/src/openms/source/PROCESSING/FILTERING/ThresholdMower.cpp
@@ -42,10 +42,7 @@ namespace OpenMS
 
   void ThresholdMower::filterPeakMap(PeakMap & exp)
   {
-    for (PeakMap::Iterator it = exp.begin(); it != exp.end(); ++it)
-    {
-      filterSpectrum(*it);
-    }
+    for (auto& s : exp) filterSpectrum(s);
   }
 
 }

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -530,8 +530,11 @@ START_SECTION((virtual void updateRanges()))
 
   //Update for MS level 1
 
+  // Store initial MS levels
+  std::vector<UInt> initial_ms_levels = tmp.getMSLevels();
+
   tmp.updateRanges(1);
-  tmp.updateRanges(1);
+  tmp.updateRanges(1); // Call twice to verify consistent behavior
   for (int l = 0; l < 2; ++l)
   {
     TEST_REAL_SIMILAR(tmp.getMinMZ(),5.0)
@@ -542,8 +545,8 @@ START_SECTION((virtual void updateRanges()))
     TEST_REAL_SIMILAR(tmp.getMaxRT(),40.0)
     TEST_REAL_SIMILAR(tmp.getRange().getMinMobility(), 99)
     TEST_REAL_SIMILAR(tmp.getRange().getMaxMobility(), 99)
-    TEST_EQUAL(tmp.getMSLevels().size(),1)
-    TEST_EQUAL(tmp.getMSLevels()[0],1)
+    // Verify MS levels remain unchanged
+    TEST_EQUAL(tmp.getMSLevels() == initial_ms_levels, true)
     TEST_EQUAL(tmp.getSize(),4)
     tmp.updateRanges(1);
   }

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -544,7 +544,7 @@ START_SECTION((virtual void updateRanges()))
     TEST_REAL_SIMILAR(tmp.getRange().getMaxMobility(), 99)
     TEST_EQUAL(tmp.getMSLevels().size(),1)
     TEST_EQUAL(tmp.getMSLevels()[0],1)
-    TEST_EQUAL(tmp.getSize(),2)
+    TEST_EQUAL(tmp.getSize(),4)
     tmp.updateRanges(1);
   }
 

--- a/src/topp/IonMobilityBinning.cpp
+++ b/src/topp/IonMobilityBinning.cpp
@@ -80,7 +80,7 @@ protected:
     auto [mzML_bins, im_ranges] = IMDataConverter::splitExperimentByIonMobility(std::move(experiment), bins, bin_extension_abs, mz_binning_width, mz_binning_width_unit);
     
     const Size width = String(bins).size();
-    for (Size counter = 0; counter < bins; ++counter)
+    for (Size counter = 0; counter < (Size)bins; ++counter)
     {
       ostringstream out_name;
       out_name << out_prefix << "_part" << setw(width) << setfill('0') << (1+counter) << "of" << bins << "_" << im_ranges[counter].getMin() << "-"


### PR DESCRIPTION
## Description

Remove caching of total number of peaks and ms levels. 
Make results always reflect the current content of MSExperiment and not depend on previous calls to updateRanges.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.openms.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
