### PR TITLE
feature: Add intensity sum function to MassTrace

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MassTrace.h
+++ b/src/openms/include/OpenMS/KERNEL/MassTrace.h
@@ -228,8 +228,11 @@ public:
     /// Sum all non-negative (smoothed!) intensities in the mass trace
     double computeSmoothedPeakArea() const;
 
-    /// Sum intensities of all peaks in the mass trace
+    /// Compute area of peaks in the mass trace
     double computePeakArea() const;
+
+    /// Sum all peak intensities in the mass trace
+    double computeIntensitySum() const;
 
     /// Return the index of the mass trace's highest peak within the MassTrace container (based either on raw or smoothed intensities).
     Size findMaxByIntPeak(bool use_smoothed_ints = false) const;

--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -96,6 +96,13 @@ namespace OpenMS
       return peak_area;
     }
 
+
+    double MassTrace::computeIntensitySum() const
+    {
+      return std::accumulate(trace_peaks_.begin(), trace_peaks_.end(), 0.0, 
+        [](double sum, const Peak2D& peak) { return sum + peak.getIntensity(); });
+    }    
+
     Size MassTrace::findMaxByIntPeak(bool use_smoothed_ints) const
     {
       if (use_smoothed_ints && smoothed_intensities_.empty())

--- a/src/pyOpenMS/pxds/MassTrace.pxd
+++ b/src/pyOpenMS/pxds/MassTrace.pxd
@@ -32,6 +32,7 @@ cdef extern from "<OpenMS/KERNEL/MassTrace.h>" namespace "OpenMS":
 
         double computeSmoothedPeakArea() except + nogil  # wrap-doc:Sums all non-negative (smoothed!) intensities in the mass trace
         double computePeakArea() except + nogil  # wrap-doc:Sums intensities of all peaks in the mass trace
+        double computeIntensitySum() except + nogil  # wrap-doc:Sum all peak intensities in the mass trace
         Size findMaxByIntPeak(bool) except + nogil  # wrap-doc:Returns the index of the mass trace's highest peak within the MassTrace container (based either on raw or smoothed intensities)
         Size estimateFWHM(bool) except + nogil  # wrap-doc:Estimates FWHM of chromatographic peak in seconds (based on either raw or smoothed intensities)
         double computeFwhmArea() except + nogil # TODO

--- a/src/tests/class_tests/openms/source/MassTrace_test.cpp
+++ b/src/tests/class_tests/openms/source/MassTrace_test.cpp
@@ -801,6 +801,20 @@ START_SECTION((void updateSmoothedWeightedMeanRT()))
 END_SECTION
 
 /////
+
+START_SECTION((double computeIntensitySum() const))
+{
+    // Test empty trace
+    MassTrace empty_trace;
+    TEST_REAL_SIMILAR(empty_trace.computeIntensitySum(), 0.0);
+
+    // Test with known data
+    // Sum should be: 542.0 + 542293.0 + 18282393.0 + 33329535.0 + 17342933.0 + 333291.0 + 339.0
+    TEST_REAL_SIMILAR(test_mt.computeIntensitySum(), 69831326.0);
+}
+END_SECTION
+
+/////
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST


### PR DESCRIPTION
## Description

Introduce a new function to compute the sum of all peak intensities in the mass trace, along with corresponding tests to validate its functionality.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

Introduce a new function to compute the sum of all peak intensities in the mass trace, along with corresponding tests to validate its functionality.