### PR TITLE
Building up PeakPickerIM 

### DIFF
--- a/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
+++ b/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
@@ -48,7 +48,24 @@ namespace OpenMS
 
   private:
     /// determine sampling rate for linear resampler
-    double computeOptimalSamplingRate(const MSSpectrum& spectrum);
+    double computeOptimalSamplingRate(const std::vector<MSSpectrum>& spectra);
+
+    /// Sum up the intensity of data points with nearly identical float values
+    MSSpectrum SumFrame(const MSSpectrum& spectrum, double ppm_tolerance = 0.01);
+
+    /// Compute lower and upper m/z bounds based on ppm
+    std::pair<double, double> ppmBounds(double mz, double ppm);
+
+    /// Extract ion mobility traces as MSSpectra from the raw TimsTOF frame
+    /// Ion mobility is temporarily written in place of m/z inside Peak1D object.
+    /// raw m/z values are allocated to float data arrays with the label 'raw_mz'
+    std::vector<MSSpectrum> extractIonMobilityTraces(
+      const MSSpectrum& picked_spectrum,
+      const MSSpectrum& raw_spectrum);
+
+    /// compute m/z and ion mobility centers for picked traces. Returns centroided spectrum.
+    MSSpectrum ComputeCenters(const std::vector<MSSpectrum>& mobilogram_traces,
+                              const std::vector<MSSpectrum>& picked_traces);
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
+++ b/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
@@ -2,25 +2,49 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
-// $Author: Timo Sachsenberg $
+// $Author: Timo Sachsenberg, Mohammed Alhigaylan $
 // $Maintainer: Timo Sachsenberg $
 // -------------------------------------------------------------------------------------------------------------------------------------------
 
 #pragma once
 
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
 
 namespace OpenMS
 {
   /**
     @brief Peak picking algorithm for ion mobility data
-    
-    @ingroup PeakPicking
-  */
-  class OPENMS_DLLAPI PeakPickerIM
+
+  @ingroup PeakPicking
+      */
+    class OPENMS_DLLAPI PeakPickerIM
   {
-    public:
-        static void pickIMTraces(MSSpectrum& spectrum);
+  public:
+    /// Default constructor initializing parameters with default values.
+    PeakPickerIM();
+
+    /// Destructor.
+    virtual ~PeakPickerIM();
+
+    /// Picks ion mobility traces from the given spectrum.
+    void pickIMTraces(MSSpectrum& spectrum);
+
+    /// Sets the parameters for peak picking.
+    void setParameters(const Param& param);
+
+    /// Gets the current parameters.
+    Param getParameters() const;
+
+  protected:
+    /// Updates internal member variables when parameters are changed.
+    void updateMembers_();
+
+    /// Returns the default parameters.
+    Param getDefaultParameters() const;
+
+    /// Stores the parameters for peak picking.
+    Param parameters_;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
+++ b/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
@@ -18,7 +18,7 @@ namespace OpenMS
 
   @ingroup PeakPicking
       */
-    class OPENMS_DLLAPI PeakPickerIM
+  class OPENMS_DLLAPI PeakPickerIM
   {
   public:
     /// Default constructor initializing parameters with default values.
@@ -45,6 +45,10 @@ namespace OpenMS
 
     /// Stores the parameters for peak picking.
     Param parameters_;
+
+  private:
+    /// determine sampling rate for linear resampler
+    double computeOptimalSamplingRate(const MSSpectrum& spectrum);
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/PROCESSING/SMOOTHING/GaussFilterAlgorithm.h
+++ b/src/openms/include/OpenMS/PROCESSING/SMOOTHING/GaussFilterAlgorithm.h
@@ -16,6 +16,8 @@
 #include <cmath>
 #include <vector>
 
+#include <iostream>
+
 namespace OpenMS
 {
   /**

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -16,7 +16,70 @@
 
 namespace OpenMS
 {
-    // Constructor: initialize the parameters_ member with default parameters.
+    double PeakPickerIM::computeOptimalSamplingRate(const MSSpectrum& spectrum)
+    {
+      if (spectrum.size() < 2)
+      {
+        std::cerr << "Warning: Spectrum has too few points for resampling. Using fixed sampling rate of 0.001 1/k" << std::endl;
+        return 0.001; // Default fallback value
+      }
+
+      std::vector<double> mz_diffs;
+      mz_diffs.reserve(spectrum.size() - 1);
+
+      for (size_t i = 1; i < spectrum.size(); ++i)
+      {
+        mz_diffs.push_back(spectrum[i].getMZ() - spectrum[i - 1].getMZ());
+      }
+
+      // A mobilogram may have two peaks spaced far apart but in the 'm/z' array,
+      // the peaks are adjacent to each other and will result in a big mz_dff.
+      // Take the 75% percentile to remove large m/z gaps.
+      std::vector<double> filtered_mz_diffs = mz_diffs;
+      std::sort(filtered_mz_diffs.begin(), filtered_mz_diffs.end());
+      double threshold = filtered_mz_diffs[filtered_mz_diffs.size() * 0.75];
+      std::cerr << "75% percentile of ion mobility difference is determined to be... " << threshold << std::endl;
+
+      std::vector<double> small_mz_diffs;
+      for (double diff : mz_diffs)
+      {
+        if (diff <= threshold)
+        {
+          small_mz_diffs.push_back(diff);
+        }
+      }
+
+      if (small_mz_diffs.empty())
+      {
+        std::cerr << "Warning: No valid small m/z differences found. Using default sampling rate. Using fixed sampling rate of 0.001 1/k" << std::endl;
+        return 0.001; // Default fallback value
+      }
+
+      // Step 2: Compute mode (most common spacing)
+      std::map<double, int> freq_map;
+      for (double diff : small_mz_diffs)
+      {
+        freq_map[diff]++;
+      }
+
+      double mode_sampling_rate = small_mz_diffs.front(); // Default to first value
+      int max_count = 0;
+      for (const auto& [diff, count] : freq_map)
+      {
+        if (count > max_count)
+        {
+          mode_sampling_rate = diff;
+          max_count = count;
+        }
+      }
+
+      // Compute final sampling rate
+      double sampling_rate = mode_sampling_rate;
+      std::cout << "Computed sampling rate: " << sampling_rate << std::endl;
+
+      return sampling_rate;
+    }
+
     PeakPickerIM::PeakPickerIM() :
         parameters_(getDefaultParameters())
     {
@@ -59,8 +122,12 @@ namespace OpenMS
     }
 
     void PeakPickerIM::pickIMTraces(MSSpectrum& spectrum)
-    {        
-        // determine IM format of spectrum
+    {
+        // Debugging: Print the input spectrum size
+        std::cout << "Processing spectrum with " << spectrum.size() << " peaks." << std::endl;
+
+        /*
+        // IM format determination (Temporarily commented out)
         IMFormat format = IMTypes::determineIMFormat(spectrum);
         switch (format)
         {
@@ -68,50 +135,50 @@ namespace OpenMS
                 return; // no IM data
             case IMFormat::CENTROIDED:
                 return; // already centroided
-            case IMFormat::CONCATENATED: {
-                // TODO call peak picking algorithm for concatenated IM data
-                std::cout << "Processing concatenated IM data..." << std::endl;
-                std::cout << "Size of input spectrum..." << spectrum.size() << std::endl;
-
-                // initialize resampling
-                // Set up custom parameters for the resampler:
-                double sampling_rate = 0.05;
-                bool ppm = false;
-                Param resampler_param;
-                resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
-                resampler_param.setValue("ppm", ppm ? "true" : "false", "Whether spacing is in ppm or Th");
-
-                LinearResamplerAlign lin_resampler;
-                lin_resampler.setParameters(resampler_param);
-
-                lin_resampler.raster(spectrum);
-                std::cout << "Size of resampled spectrum: " << spectrum.size() << std::endl;
-                std::cout << "Resampled spectrum printing...: " << std::endl;
-                for (const auto& peak : spectrum)
-                {
-                  std::cout << "m/z: " << peak.getMZ()
-                            << ", intensity: " << peak.getIntensity() << std::endl;
-                }
-
-                PeakPickerHiRes picker;
-                // Forward the parameters from this object to the underlying picker
-                picker.setParameters(parameters_);
-                MSSpectrum picked_spectrum;
-
-                picker.pick(spectrum, picked_spectrum);
-                std::cout << "Size of picked_spectrum..." << picked_spectrum.size() << std::endl;
-
-                spectrum = picked_spectrum;
-
-                // set format to centroided
-                spectrum.setIMFormat(IMFormat::CENTROIDED);
-                break;
-            }
             case IMFormat::UNKNOWN:
-                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IMFormat set to UNKNOWN after determineIMFormat. This should never happen. Please contact the developers.", String(NamesOfIMFormat[(size_t)format]));
-            default:
-                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown IMFormat", String(NamesOfIMFormat[(size_t)format]));
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                    "IMFormat set to UNKNOWN after determineIMFormat. This should never happen.",
+                    String(NamesOfIMFormat[(size_t)format]));
         }
+        */
+
+        // Initialize resampling
+        double sampling_rate = computeOptimalSamplingRate(spectrum) * 4;
+        std::cout << "Using sampling rate: " << sampling_rate << std::endl;
+
+        // Set up custom parameters for the resampler
+        bool ppm = false;
+        Param resampler_param;
+        resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
+        resampler_param.setValue("ppm", ppm ? "true" : "false", "Whether spacing is in ppm or Th");
+
+        LinearResamplerAlign lin_resampler;
+        lin_resampler.setParameters(resampler_param);
+
+        lin_resampler.raster(spectrum);
+        std::cout << "Size of resampled spectrum: " << spectrum.size() << std::endl;
+
+        // Print resampled peaks for debugging
+        for (const auto& peak : spectrum)
+        {
+            std::cout << "m/z: " << peak.getMZ()
+                      << ", intensity: " << peak.getIntensity() << std::endl;
+        }
+
+        // Apply PeakPickerHiRes
+        PeakPickerHiRes picker;
+        picker.setParameters(parameters_);
+        MSSpectrum picked_spectrum;
+
+        picker.pick(spectrum, picked_spectrum);
+        std::cout << "Size of picked spectrum: " << picked_spectrum.size() << std::endl;
+
+        // Replace original spectrum with processed version
+        spectrum = picked_spectrum;
+
+        // Temporarily skipping IM format setting since we commented out the check
+        // spectrum.setIMFormat(IMFormat::CENTROIDED);
     }
+
 
 } // namespace OpenMS

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -2,14 +2,61 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
-// $Author: Timo Sachsenberg $
+// $Author: Timo Sachsenberg, Mohammed Alhigaylan $
 // $Maintainer: Timo Sachsenberg $
 // -------------------------------------------------------------------------------------------------------------------------------------------
 
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h>
+#include <OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>  // Updated include
+#include <iostream>
 
 namespace OpenMS
 {
+    // Constructor: initialize the parameters_ member with default parameters.
+    PeakPickerIM::PeakPickerIM() :
+        parameters_(getDefaultParameters())
+    {
+    }
+
+    // Destructor
+    PeakPickerIM::~PeakPickerIM()
+    {
+    }
+
+    // Returns a Param object with the default settings for peak picking.
+    Param PeakPickerIM::getDefaultParameters() const
+    {
+      Param p;
+      p.setValue("signal_to_noise", 0.0, "Signal to noise threshold for peak picking");
+      p.setValue("spacing_difference_gap", 0.0, "The extension of a peak is stopped if the spacing between two subsequent data points exceeds 'spacing_difference_gap * min_spacing'. 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points. '0' to disable the constraint. Not applicable to chromatograms.");
+      p.setValue("spacing_difference", 0.0, "Maximum allowed difference between points during peak extension, in multiples of the minimal difference between the peak apex and its two neighboring points. If this difference is exceeded a missing point is assumed (see parameter 'missing'). A higher value implies a less stringent peak definition, since individual signals within the peak are allowed to be further apart. '0' to disable the constraint. Not applicable to chromatograms.");
+      p.setValue("missing", 0, "Maximum number of missing points allowed when extending a peak to the left or to the right. A missing data point occurs if the spacing between two subsequent data points exceeds 'spacing_difference * min_spacing'. 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points. Not applicable to chromatograms.");
+      p.setValue("signal_to_noise", 0.0, "Signal to noise threshold for peak picking");
+      return p;
+    }
+    // Update internal members if any parameter changes require it.
+    void PeakPickerIM::updateMembers_()
+    {
+      // For this example, no extra member variables need updating.
+      // This function is a placeholder for potential future use.
+    }
+
+    // Sets the parameters and updates internal members accordingly.
+    void PeakPickerIM::setParameters(const Param& param)
+    {
+      parameters_ = param;
+      updateMembers_();
+    }
+
+    // Retrieves the current parameters.
+    Param PeakPickerIM::getParameters() const
+    {
+      return parameters_;
+    }
+
     void PeakPickerIM::pickIMTraces(MSSpectrum& spectrum)
     {        
         // determine IM format of spectrum
@@ -20,14 +67,27 @@ namespace OpenMS
                 return; // no IM data
             case IMFormat::CENTROIDED:
                 return; // already centroided
-            case IMFormat::CONCATENATED:
+            case IMFormat::CONCATENATED: {
                 // TODO call peak picking algorithm for concatenated IM data
+                std::cout << "Processing concatenated IM data..." << std::endl;
+                std::cout << "Size of input spectrum..." << spectrum.size() << std::endl;
+
+                PeakPickerHiRes picker;
+                // Forward the parameters from this object to the underlying picker
+                picker.setParameters(parameters_);
+                MSSpectrum picked_spectrum;
+
+                picker.pick(spectrum, picked_spectrum);
+                std::cout << "Size of picked_spectrum..." << picked_spectrum.size() << std::endl;
+
+                spectrum = picked_spectrum;
 
                 // set format to centroided
                 spectrum.setIMFormat(IMFormat::CENTROIDED);
                 break;
+            }
             case IMFormat::UNKNOWN:
-                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IMFormat set to UNKNOWN after deterineIMFormat. This should never happen. Please contact the developers.", String(NamesOfIMFormat[(size_t)format]));
+                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IMFormat set to UNKNOWN after determineIMFormat. This should never happen. Please contact the developers.", String(NamesOfIMFormat[(size_t)format]));
             default:
                 throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown IMFormat", String(NamesOfIMFormat[(size_t)format]));
         }

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -10,7 +10,8 @@
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/DATASTRUCTURES/Param.h>  // Updated include
+#include <OpenMS/DATASTRUCTURES/Param.h>
+#include <OpenMS/PROCESSING/RESAMPLING/LinearResamplerAlign.h>
 #include <iostream>
 
 namespace OpenMS
@@ -71,6 +72,26 @@ namespace OpenMS
                 // TODO call peak picking algorithm for concatenated IM data
                 std::cout << "Processing concatenated IM data..." << std::endl;
                 std::cout << "Size of input spectrum..." << spectrum.size() << std::endl;
+
+                // initialize resampling
+                // Set up custom parameters for the resampler:
+                double sampling_rate = 0.05;
+                bool ppm = false;
+                Param resampler_param;
+                resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
+                resampler_param.setValue("ppm", ppm ? "true" : "false", "Whether spacing is in ppm or Th");
+
+                LinearResamplerAlign lin_resampler;
+                lin_resampler.setParameters(resampler_param);
+
+                lin_resampler.raster(spectrum);
+                std::cout << "Size of resampled spectrum: " << spectrum.size() << std::endl;
+                std::cout << "Resampled spectrum printing...: " << std::endl;
+                for (const auto& peak : spectrum)
+                {
+                  std::cout << "m/z: " << peak.getMZ()
+                            << ", intensity: " << peak.getIntensity() << std::endl;
+                }
 
                 PeakPickerHiRes picker;
                 // Forward the parameters from this object to the underlying picker

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -8,38 +8,61 @@
 
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h>
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h>
+#include <OpenMS/PROCESSING/SMOOTHING/GaussFilter.h>
+#include <OpenMS/PROCESSING/SMOOTHING/SavitzkyGolayFilter.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/PROCESSING/RESAMPLING/LinearResamplerAlign.h>
+#include <OpenMS/MATH/MISC/CubicSpline2d.h>
+#include <OpenMS/MATH/MISC/SplineBisection.h>
 #include <iostream>
 
 namespace OpenMS
 {
-    double PeakPickerIM::computeOptimalSamplingRate(const MSSpectrum& spectrum)
+    double PeakPickerIM::computeOptimalSamplingRate(const std::vector<MSSpectrum>& spectra)
     {
-      if (spectrum.size() < 2)
-      {
-        std::cerr << "Warning: Spectrum has too few points for resampling. Using fixed sampling rate of 0.001 1/k" << std::endl;
-        return 0.001; // Default fallback value
-      }
-
       std::vector<double> mz_diffs;
-      mz_diffs.reserve(spectrum.size() - 1);
 
-      for (size_t i = 1; i < spectrum.size(); ++i)
+      for (size_t s = 0; s < spectra.size(); ++s)
       {
-        mz_diffs.push_back(spectrum[i].getMZ() - spectrum[i - 1].getMZ());
+        const MSSpectrum& spectrum = spectra[s];
+        // The spectrum could have multiple peaks at the same x position.
+        // Sum the peak intensity
+        MSSpectrum summed_trace = SumFrame(spectrum, 7000.0);
+
+        if (summed_trace.size() < 20)
+        {
+          std::cerr << "Skipping trace " << s << " because it has too few points ("
+                    << summed_trace.size() << ")." << std::endl;
+          continue; // skip this spectrum
+        }
+
+        for (size_t i = 1; i < summed_trace.size(); ++i)
+        {
+          double diff = summed_trace[i].getMZ() - summed_trace[i - 1].getMZ();
+          mz_diffs.push_back(diff);
+        }
       }
 
-      // A mobilogram may have two peaks spaced far apart but in the 'm/z' array,
-      // the peaks are adjacent to each other and will result in a big mz_dff.
-      // Take the 75% percentile to remove large m/z gaps.
-      std::vector<double> filtered_mz_diffs = mz_diffs;
-      std::sort(filtered_mz_diffs.begin(), filtered_mz_diffs.end());
-      double threshold = filtered_mz_diffs[filtered_mz_diffs.size() * 0.75];
-      std::cerr << "75% percentile of ion mobility difference is determined to be... " << threshold << std::endl;
+      // If we found no valid m/z differences
+      if (mz_diffs.empty())
+      {
+        std::cerr << "Warning: No valid m/z differences found in any spectra. Using default sampling rate of 0.01" << std::endl;
+        return 0.01; // Fallback value
+      }
 
+      // Sort the differences to compute the 75th percentile threshold
+      // This is needed in case there is a gap in the mobilogram. i+1 peak will skew the computed
+      // sampling rate.
+      std::sort(mz_diffs.begin(), mz_diffs.end());
+
+      size_t percentile_index = static_cast<size_t>(mz_diffs.size() * 0.75);
+      double threshold = mz_diffs[percentile_index];
+
+      std::cerr << "75th percentile of position differences is: " << threshold << std::endl;
+
+      // Filter out large differences (keep diffs <= threshold)
       std::vector<double> small_mz_diffs;
       for (double diff : mz_diffs)
       {
@@ -51,19 +74,20 @@ namespace OpenMS
 
       if (small_mz_diffs.empty())
       {
-        std::cerr << "Warning: No valid small m/z differences found. Using default sampling rate. Using fixed sampling rate of 0.001 1/k" << std::endl;
-        return 0.001; // Default fallback value
+        std::cerr << "Warning: No valid small m/z differences found after filtering. Using default sampling rate of 0.01" << std::endl;
+        return 0.01;
       }
 
-      // Step 2: Compute mode (most common spacing)
+      // Compute the mode
       std::map<double, int> freq_map;
       for (double diff : small_mz_diffs)
       {
         freq_map[diff]++;
       }
 
-      double mode_sampling_rate = small_mz_diffs.front(); // Default to first value
+      double mode_sampling_rate = small_mz_diffs.front();
       int max_count = 0;
+
       for (const auto& [diff, count] : freq_map)
       {
         if (count > max_count)
@@ -73,12 +97,475 @@ namespace OpenMS
         }
       }
 
-      // Compute final sampling rate
-      double sampling_rate = mode_sampling_rate;
-      std::cout << "Computed sampling rate: " << sampling_rate << std::endl;
+      std::cout << "Computed optimal sampling rate: " << mode_sampling_rate << std::endl;
 
-      return sampling_rate;
+      return mode_sampling_rate;
     }
+
+    // Function to compute the lower and upper m/z bounds based on ppm tolerance
+    std::pair<double, double> PeakPickerIM::ppmBounds(double mz, double ppm)
+    {
+      ppm = ppm / 1e6;
+      double delta_mz = (ppm * mz) / 2.0;
+
+      double low = mz - delta_mz;
+      double high = mz + delta_mz;
+
+      return std::make_pair(low, high);
+    }
+
+    // This function sums peaks if they are nearly identical
+    // OpenMS represents TimsTOF data in MSSpectrum() objects as one-array.
+    // There could be multiple 500.0 m/z peaks with different ion mobility values.
+    // Peak picking (such as HiRes) will not work properly if there are multiple y measurements at a given x m/z position.
+    MSSpectrum PeakPickerIM::SumFrame(const MSSpectrum& input_spectrum, double ppm_tolerance)
+    {
+      MSSpectrum export_spectrum;
+
+      if (input_spectrum.empty()) return export_spectrum;
+
+      MSSpectrum spectrum = input_spectrum;
+
+      if (!spectrum.isSorted())
+      {
+        std::cout << "Spectrum not sorted by m/z, sorting now..." << std::endl;
+        spectrum.sortByPosition();
+      }
+
+      double current_mz = spectrum[0].getMZ();
+      double current_intensity = spectrum[0].getIntensity();
+
+      for (Size i = 1; i < spectrum.size(); ++i)
+      {
+        double next_mz = spectrum[i].getMZ();
+        double next_intensity = spectrum[i].getIntensity();
+
+        double delta_mz = std::abs(next_mz - current_mz);
+        double ppm_diff = (delta_mz / current_mz) * 1e6;
+
+        if (ppm_diff <= ppm_tolerance)
+        {
+          current_intensity += next_intensity;
+        }
+        else
+        {
+          Peak1D peak;
+          peak.setMZ(current_mz);
+          peak.setIntensity(current_intensity);
+          export_spectrum.push_back(peak);
+
+          current_mz = next_mz;
+          current_intensity = next_intensity;
+        }
+      }
+      Peak1D last_peak;
+      last_peak.setMZ(current_mz);
+      last_peak.setIntensity(current_intensity);
+      export_spectrum.push_back(last_peak);
+
+      return export_spectrum;
+    }
+
+    // We use peak FWHM (from PeakPickerHiRes) to extract ion mobility traces.
+    // Given a picked m/z peak, we write a temporary MSSpectrum() object with ion mobility measurements
+    // in place of m/z in Peak1D object. This facilitates peak picking in the ion mobility dimension.
+    // To enable recomputing of m/z center after ion mobility peak picking, we tack raw m/z peak values
+    // in FloatDataArrays().
+
+    std::vector<MSSpectrum> PeakPickerIM::extractIonMobilityTraces(
+      const MSSpectrum& picked_spectrum,
+      const MSSpectrum& raw_spectrum)
+    {
+      const auto& float_data_arrays = picked_spectrum.getFloatDataArrays();
+
+      // Find FWHM array in picked_spectrum
+      const MSSpectrum::FloatDataArray* fwhm_array = nullptr;
+
+      for (const auto& array : float_data_arrays)
+      {
+        if (array.getName() == "FWHM_ppm")
+        {
+          fwhm_array = &array;
+          break;
+        }
+      }
+
+      if (!fwhm_array)
+      {
+        std::cerr << "FWHM data array not found!" << std::endl;
+        return {};
+      }
+
+      if (fwhm_array->size() != picked_spectrum.size())
+      {
+        std::cerr << "Size mismatch between FWHM array and picked peaks!" << std::endl;
+        return {};
+      }
+
+      // Get the Ion Mobility array from raw_spectrum
+      const auto& raw_float_data_arrays = raw_spectrum.getFloatDataArrays();
+      const MSSpectrum::FloatDataArray* ion_mobility_array = nullptr;
+
+      for (const auto& array : raw_float_data_arrays)
+      {
+        if (array.getName() == "Ion Mobility")
+        {
+          ion_mobility_array = &array;
+          break;
+        }
+      }
+
+      if (!ion_mobility_array)
+      {
+        std::cerr << "Ion Mobility data array not found in raw_spectrum!" << std::endl;
+        return {};
+      }
+
+      // Vector of MSSpectra for each picked m/z peak (each spectrum is a mobilogram trace)
+      std::vector<MSSpectrum> mobility_traces;
+
+      for (size_t i = 0; i < picked_spectrum.size(); ++i)
+      {
+        double picked_mz = picked_spectrum[i].getMZ();
+        double fwhm_ppm = (*fwhm_array)[i];
+
+        auto bounds = ppmBounds(picked_mz, fwhm_ppm);
+        double lower_bound = bounds.first;
+        double upper_bound = bounds.second;
+
+        SignedSize center_idx = raw_spectrum.findNearest(picked_mz);
+
+        if (center_idx == -1)
+        {
+          std::cerr << "No raw peaks found near picked m/z: " << picked_mz << std::endl;
+          mobility_traces.push_back(MSSpectrum());
+          continue;
+        }
+
+        MSSpectrum trace_spectrum; // A single mobilogram trace
+        // Prepare FloatDataArray to store raw m/z values
+        MSSpectrum::FloatDataArray raw_mz_array;
+        raw_mz_array.setName("raw_mz");
+
+        // Expand left
+        SignedSize left_idx = center_idx;
+        while (left_idx >= 0 && raw_spectrum[left_idx].getMZ() >= lower_bound)
+        {
+          Peak1D p;
+          p.setMZ((*ion_mobility_array)[left_idx]); // Ion Mobility as m/z
+          p.setIntensity(raw_spectrum[left_idx].getIntensity());
+
+          trace_spectrum.push_back(p);
+
+          // Store the raw m/z
+          raw_mz_array.push_back(raw_spectrum[left_idx].getMZ());
+
+          --left_idx;
+        }
+
+        // Expand right
+        SignedSize right_idx = center_idx + 1;
+        while (right_idx < static_cast<SignedSize>(raw_spectrum.size()) &&
+               raw_spectrum[right_idx].getMZ() <= upper_bound)
+        {
+          Peak1D p;
+          p.setMZ((*ion_mobility_array)[right_idx]); // Ion Mobility as m/z
+          p.setIntensity(raw_spectrum[right_idx].getIntensity());
+
+          trace_spectrum.push_back(p);
+
+          // Store the raw m/z data in floatDataArrays()
+          raw_mz_array.push_back(raw_spectrum[right_idx].getMZ());
+
+          ++right_idx;
+        }
+
+        // Attach the raw m/z array to trace_spectrum
+        auto& trace_float_arrays = trace_spectrum.getFloatDataArrays();
+        trace_float_arrays.push_back(std::move(raw_mz_array));
+
+        // Sort the trace_spectrum by ion mobility (m/z), while keeping raw m/z aligned
+        trace_spectrum.sortByPosition();
+
+        mobility_traces.push_back(std::move(trace_spectrum));
+      }
+
+      return mobility_traces;
+    }
+
+    // Function to compute m/z centers from mobilogram_traces and picked_traces
+    MSSpectrum PeakPickerIM::ComputeCenters(const std::vector<MSSpectrum>& mobilogram_traces,
+                              const std::vector<MSSpectrum>& picked_traces)
+    {
+      MSSpectrum centroided_frame;
+
+      // Create float data arrays to house ion mobility data and peaks FWHM
+      MSSpectrum::FloatDataArray ion_mobility_array;
+      ion_mobility_array.setName("Ion Mobility");
+
+      MSSpectrum::FloatDataArray ion_mobility_fwhm;
+      ion_mobility_fwhm.setName("IM FWHM");
+
+      MSSpectrum::FloatDataArray mz_fwhm_array;
+      mz_fwhm_array.setName("MZ FWHM");
+
+      // debug
+      std::cout << "picked_traces.size(): " << picked_traces.size() << std::endl;
+
+      // Loop over picked traces and their corresponding raw mobilogram traces
+      for (size_t i = 0; i < picked_traces.size(); ++i)
+      {
+        std::cout << "Looping through picked_trace that has .. " << picked_traces[i].size() << std::endl;
+        const MSSpectrum& picked_trace = picked_traces[i];
+        const MSSpectrum& raw_trace = mobilogram_traces[i];
+
+        const auto& picked_float_arrays = picked_trace.getFloatDataArrays();
+
+        if (picked_float_arrays.empty())
+        {
+          std::cerr << "No IM FWHM array found for picked_trace " << i << "!" << std::endl;
+          continue;
+        }
+
+        // Assuming the first FloatDataArray holds the ion mobility peak FWHM values
+        const auto& fwhm_array = picked_float_arrays[0];
+
+        if (fwhm_array.size() != picked_trace.size())
+        {
+          std::cerr << "FWHM array size mismatch with picked_trace size!" << std::endl;
+          continue;
+        }
+
+        // Get the FloatDataArrays from raw_trace (assumed to hold the raw m/z values)
+        const auto& raw_float_arrays = raw_trace.getFloatDataArrays();
+
+        if (raw_float_arrays.empty())
+        {
+          std::cerr << "No raw m/z peaks found for raw_trace " << i << "!" << std::endl;
+          continue;
+        }
+
+        // Assume the first array holds the raw m/z values
+        const auto& raw_mz_values = raw_float_arrays[0];
+
+        if (raw_mz_values.size() != raw_trace.size())
+        {
+          std::cerr << "raw_mz_values size mismatch with raw_trace size!" << std::endl;
+          continue;
+        }
+
+        std::cout << "\n--- Processing picked_trace " << i << " ---\n";
+
+        // Iterate through picked peaks in this trace
+        for (Size j = 0; j < picked_trace.size(); ++j)
+        {
+          double centroid_im = picked_trace[j].getMZ();   // Ion mobility centroid (stored as m/z)
+          double fwhm = fwhm_array[j];
+
+
+          double im_lower = centroid_im - (fwhm / 2.0);
+          double im_upper = centroid_im + (fwhm / 2.0);
+
+          std::cout << "Picked peak " << j << " IM centroid: " << centroid_im
+                    << " ion mobility FWHM: " << fwhm
+                    << " --> IM bounds: [" << im_lower << ", " << im_upper << "]" << std::endl;
+
+          // Use findNearest() to get the index of the closest peak in the raw mobilogram trace
+          SignedSize center_idx = raw_trace.findNearest(centroid_im);
+
+          if (center_idx == -1)
+          {
+            std::cerr << "Could not find nearest peak to centroid_im in raw_trace!" << std::endl;
+            continue;
+          }
+
+          MSSpectrum raw_peaks_within_bounds;
+
+          // --- Expand Left ---
+          SignedSize left_idx = center_idx;
+          while (left_idx >= 0 && raw_trace[left_idx].getMZ() >= im_lower)
+          {
+            Peak1D new_peak;
+            new_peak.setMZ(raw_mz_values[left_idx]);                      // m/z from FloatDataArray
+            new_peak.setIntensity(raw_trace[left_idx].getIntensity());    // intensity from raw_trace
+            raw_peaks_within_bounds.push_back(new_peak);
+
+            --left_idx;
+          }
+
+          // --- Expand Right ---
+          SignedSize right_idx = center_idx + 1;
+          while (right_idx < static_cast<SignedSize>(raw_trace.size()) &&
+                 raw_trace[right_idx].getMZ() <= im_upper)
+          {
+            Peak1D new_peak;
+            new_peak.setMZ(raw_mz_values[right_idx]);
+            new_peak.setIntensity(raw_trace[right_idx].getIntensity());
+            raw_peaks_within_bounds.push_back(new_peak);
+
+            ++right_idx;
+          }
+
+          std::cout << "Picked IM peak " << j << ": collected " << raw_peaks_within_bounds.size()
+                    << " raw m/z points between IM [" << im_lower << ", " << im_upper << "]" << std::endl;
+
+          // If we only retrieved one raw peak, pass it over to centroided_frame as is
+          // Resampling and smoothing the raw data distorts the intensity values.
+          // We recompute the m/z peak maxima and intensity using spline
+          if (raw_peaks_within_bounds.size() == 1)
+          {
+            const Peak1D& single_peak = raw_peaks_within_bounds.front();
+
+            // Add it directly to centroided_frame
+            centroided_frame.push_back(single_peak);
+
+            // Push corresponding ion mobility and FWHM arrays
+            ion_mobility_array.push_back(centroid_im);
+            ion_mobility_fwhm.push_back(fwhm);
+            mz_fwhm_array.push_back(0.0);
+
+            std::cout << "[INFO] Only one raw peak found. Added directly to centroided_frame. m/z: "
+                      << single_peak.getMZ() << " intensity: " << single_peak.getIntensity() << std::endl;
+
+            // Skip the rest of the loop and move on to the next picked_trace peak
+            continue;
+          }
+
+
+
+          raw_peaks_within_bounds.sortByPosition();
+
+          MSSpectrum raw_mz_peaks = SumFrame(raw_peaks_within_bounds, 0.1);
+          // Prepare data for spline
+          std::map<double, double> peak_raw_data;
+
+          for (const auto& peak : raw_mz_peaks)
+          {
+            peak_raw_data[peak.getMZ()] = peak.getIntensity();
+          }
+          if (peak_raw_data.empty())
+          {
+            std::cerr << "No data in raw_mz_peaks for picked IM peak " << j << "!" << std::endl;
+            continue;
+          }
+
+          // Initialize spline
+          CubicSpline2d spline(peak_raw_data);
+
+          // Define boundaries
+          const double left_bound = peak_raw_data.begin()->first;
+          const double right_bound = peak_raw_data.rbegin()->first;
+
+          // Find maximum via spline bisection
+          double apex_mz = (left_bound + right_bound) / 2.0;
+          double apex_intensity = 0.0;
+
+          const double max_search_threshold = 1e-6;
+
+          Math::spline_bisection(spline, left_bound, right_bound, apex_mz, apex_intensity, max_search_threshold);
+
+          std::cout << "Apex m/z: " << apex_mz << std::endl;
+          std::cout << "Apex intensity: " << apex_intensity << std::endl;
+
+          // FWHM calculation (same binary search as before)
+          double half_height = apex_intensity / 2.0;
+          const double fwhm_search_threshold = 0.01 * half_height;
+
+          // ---- Left side search ----
+          double mz_left = left_bound;
+          double mz_center = apex_mz;
+          double int_mid = 0.0;
+          double mz_mid = mz_left;
+
+          if (spline.eval(mz_left) > half_height)
+          {
+            mz_mid = mz_left;
+          }
+          else
+          {
+            do
+            {
+              mz_mid = (mz_left + mz_center) / 2.0;
+              int_mid = spline.eval(mz_mid);
+
+              if (int_mid < half_height)
+              {
+                mz_left = mz_mid;
+              }
+              else
+              {
+                mz_center = mz_mid;
+              }
+
+            } while (std::fabs(int_mid - half_height) > fwhm_search_threshold);
+          }
+          double fwhm_left_mz = mz_mid;
+
+          // ---- Right side search ----
+          double mz_right = right_bound;
+          mz_center = apex_mz;
+
+          if (spline.eval(mz_right) > half_height)
+          {
+            mz_mid = mz_right;
+          }
+          else
+          {
+            do
+            {
+              mz_mid = (mz_right + mz_center) / 2.0;
+              int_mid = spline.eval(mz_mid);
+
+              if (int_mid < half_height)
+              {
+                mz_right = mz_mid;
+              }
+              else
+              {
+                mz_center = mz_mid;
+              }
+
+            } while (std::fabs(int_mid - half_height) > fwhm_search_threshold);
+          }
+          double fwhm_right_mz = mz_mid;
+
+          // ---- FWHM result ----
+          double mz_fwhm = fwhm_right_mz - fwhm_left_mz;
+
+          std::cout << "Left m/z at half height: " << fwhm_left_mz << std::endl;
+          std::cout << "Right m/z at half height: " << fwhm_right_mz << std::endl;
+          std::cout << "m/z FWHM: " << mz_fwhm << std::endl;
+
+
+          Peak1D centroided_peak;
+          centroided_peak.setMZ(apex_mz);
+          centroided_peak.setIntensity(apex_intensity);
+
+          centroided_frame.push_back(centroided_peak);
+          ion_mobility_array.push_back(centroid_im);
+          ion_mobility_fwhm.push_back(fwhm);
+          mz_fwhm_array.push_back(mz_fwhm);
+        }
+
+        std::cout << "--- Finished processing picked_trace " << i << " ---\n\n";
+      }
+
+      auto& centroided_frame_fda = centroided_frame.getFloatDataArrays();
+      centroided_frame_fda.push_back(std::move(ion_mobility_array));
+      centroided_frame_fda.push_back(std::move(ion_mobility_fwhm));
+      centroided_frame_fda.push_back(std::move(mz_fwhm_array));
+
+      centroided_frame.sortByPosition();
+
+      std::cout << "Printing centroided_frame inside ComputerCenters function " << std::endl;
+      for (const auto& peak : centroided_frame)
+      {
+        std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+      }
+
+      return centroided_frame;
+    }
+
 
     PeakPickerIM::PeakPickerIM() :
         parameters_(getDefaultParameters())
@@ -90,7 +577,6 @@ namespace OpenMS
     {
     }
 
-    // Returns a Param object with the default settings for peak picking.
     Param PeakPickerIM::getDefaultParameters() const
     {
       Param p;
@@ -98,24 +584,21 @@ namespace OpenMS
       p.setValue("spacing_difference_gap", 0.0, "The extension of a peak is stopped if the spacing between two subsequent data points exceeds 'spacing_difference_gap * min_spacing'. 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points. '0' to disable the constraint. Not applicable to chromatograms.");
       p.setValue("spacing_difference", 0.0, "Maximum allowed difference between points during peak extension, in multiples of the minimal difference between the peak apex and its two neighboring points. If this difference is exceeded a missing point is assumed (see parameter 'missing'). A higher value implies a less stringent peak definition, since individual signals within the peak are allowed to be further apart. '0' to disable the constraint. Not applicable to chromatograms.");
       p.setValue("missing", 0, "Maximum number of missing points allowed when extending a peak to the left or to the right. A missing data point occurs if the spacing between two subsequent data points exceeds 'spacing_difference * min_spacing'. 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points. Not applicable to chromatograms.");
-      p.setValue("signal_to_noise", 0.0, "Signal to noise threshold for peak picking");
+      p.setValue("report_FWHM", "true");
+      p.setValue("report_FWHM_unit", "absolute");
       return p;
     }
-    // Update internal members if any parameter changes require it.
     void PeakPickerIM::updateMembers_()
     {
-      // For this example, no extra member variables need updating.
       // This function is a placeholder for potential future use.
     }
 
-    // Sets the parameters and updates internal members accordingly.
     void PeakPickerIM::setParameters(const Param& param)
     {
       parameters_ = param;
       updateMembers_();
     }
 
-    // Retrieves the current parameters.
     Param PeakPickerIM::getParameters() const
     {
       return parameters_;
@@ -123,62 +606,192 @@ namespace OpenMS
 
     void PeakPickerIM::pickIMTraces(MSSpectrum& spectrum)
     {
-        // Debugging: Print the input spectrum size
-        std::cout << "Processing spectrum with " << spectrum.size() << " peaks." << std::endl;
+      // Debugging: Print the input spectrum size
+      std::cout << "Processing spectrum with " << spectrum.size() << " peaks." << std::endl;
 
-        /*
-        // IM format determination (Temporarily commented out)
-        IMFormat format = IMTypes::determineIMFormat(spectrum);
-        switch (format)
-        {
-            case IMFormat::NONE:
-                return; // no IM data
-            case IMFormat::CENTROIDED:
-                return; // already centroided
-            case IMFormat::UNKNOWN:
-                throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                    "IMFormat set to UNKNOWN after determineIMFormat. This should never happen.",
-                    String(NamesOfIMFormat[(size_t)format]));
-        }
-        */
+      /*
+      // IM format determination (Temporarily commented out)
+      IMFormat format = IMTypes::determineIMFormat(spectrum);
+      switch (format)
+      {
+          case IMFormat::NONE:
+              return; // no IM data
+          case IMFormat::CENTROIDED:
+              return; // already centroided
+          case IMFormat::UNKNOWN:
+              throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                  "IMFormat set to UNKNOWN after determineIMFormat. This should never happen.",
+                  String(NamesOfIMFormat[(size_t)format]));
+      }
+      */
 
-        // Initialize resampling
-        double sampling_rate = computeOptimalSamplingRate(spectrum) * 4;
-        std::cout << "Using sampling rate: " << sampling_rate << std::endl;
 
-        // Set up custom parameters for the resampler
-        bool ppm = false;
-        Param resampler_param;
-        resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
-        resampler_param.setValue("ppm", ppm ? "true" : "false", "Whether spacing is in ppm or Th");
+      // --- Step 1a: Sum m/z peaks
+      // First, we project all timsTOF peaks into the m/z axis using SumFrame
+      // The ppm tolerance is a dynamic way of testing m/z floats being almost identical. Set it to 0.1 ppm
+      MSSpectrum summed_spectrum = SumFrame(spectrum, 0.1);
+      std::cout << "Spectrum after SumFrame has " << summed_spectrum.size() << " peaks." << std::endl;
 
+      // --- step 2a: smooth the data projected to the m/z axis.
+      std::cout << "Applying Gaussian smoothing..." << std::endl;
+      GaussFilter gauss_filter;
+
+      // Set Gaussian filter parameters. 5 ppm m/z is good approximation (make this a user parameter!)
+      Param gauss_params;
+      gauss_params.setValue("ppm_tolerance", 5.0);
+      gauss_params.setValue("use_ppm_tolerance", "true");
+
+      gauss_filter.setParameters(gauss_params);
+      gauss_filter.filter(summed_spectrum);
+      std::cout << "Spectrum after Gaussian smoothing has " << summed_spectrum.size() << " peaks." << std::endl;
+
+      for (const auto& peak : summed_spectrum)
+      {
+        std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+      }
+
+      // ---step 3a: Apply PeakPickerHiRes and make sure the peak FWHM is reported in ppm.
+      // (Maybe this should change to absolute FWHM value...?).
+      PeakPickerHiRes picker;
+      Param hirez_mz_p;
+      hirez_mz_p.setValue("signal_to_noise", 0.0);
+      hirez_mz_p.setValue("report_FWHM", "true");
+      hirez_mz_p.setValue("report_FWHM_unit", "relative");
+
+      picker.setParameters(hirez_mz_p);
+      MSSpectrum picked_spectrum;
+
+      picker.pick(summed_spectrum, picked_spectrum);
+      std::cout << "Size of picked spectrum: " << picked_spectrum.size() << std::endl;
+
+
+      // ---step 4a: Extract ion mobility traces for each picked m/z peak
+      auto mobilogram_traces = extractIonMobilityTraces(picked_spectrum, spectrum);
+
+      // --- compute optimal sampling rate from well-populated mobilograms in this frame.
+      // This is currently set to +20 peaks in a mobilogram. (Should this be a user parameter?)
+
+      // Add a parameter to allow user to control sampling). Here we simply multiply by 4.
+      double sampling_rate = computeOptimalSamplingRate(mobilogram_traces) * 4;
+      Param resampler_param;
+      resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
+      resampler_param.setValue("ppm", "false", "Whether spacing is in ppm or Th");
+
+      std::cout << "Using sampling rate... : " << sampling_rate << std::endl;
+
+
+
+      // *************** PART II ***************
+
+      // for each ion mobility trace, we process the raw signal, peak pick
+      // and recompute m/z and ion mobility centroid.
+      for (size_t i = 0; i < mobilogram_traces.size(); ++i)
+      {
+        std::cout << "Trace " << i << " contains " << mobilogram_traces[i].size() << " points in ion mobility space." << std::endl;
+      }
+
+      std::vector<MSSpectrum> picked_traces;
+
+      for (size_t i = 0; i < mobilogram_traces.size(); ++i)
+      {
+        MSSpectrum& trace = mobilogram_traces[i];
+
+        std::cout << "\n--- Processing Trace " << i << " ---\n";
+        std::cout << "Original trace has " << trace.size() << " peaks." << std::endl;
+
+        // --- Step 1b: Sum peaks that are too close ---
+        MSSpectrum summed_trace = SumFrame(trace, 7000.0); // 7000 ppm tolerance (temporary. Change function to accept absolute number)
+        std::cout << "Trace after SumFrame has " << summed_trace.size() << " peaks." << std::endl;
+
+        // Determine im boundaries of current mobilogram. Add 10 padding points (should this be a parameter?)
+        // If you do not pad the edges, peaks on the edge will have an odd shape and not be picked by PeakPickerHiRes!
+        double im_start = summed_trace.front().getMZ();
+        double im_end = summed_trace.back().getMZ();
+
+        std::cout << "Original summed trace ion mobility range: [" << im_start << ", " << im_end << "]" << std::endl;
+
+        Peak1D front_padding;
+        front_padding.setMZ(im_start - 10 * sampling_rate);
+        front_padding.setIntensity(0.0);
+        summed_trace.insert(summed_trace.begin(), front_padding);
+
+        Peak1D back_padding;
+        back_padding.setMZ(im_end + 10 * sampling_rate);
+        back_padding.setIntensity(0.0);
+        summed_trace.push_back(back_padding);
+
+        std::cout << "Padded summed trace im range: [" << summed_trace.front().getMZ() << ", " << summed_trace.back().getMZ() << "]" << std::endl;
+
+        // --- Step 2b: Resample the trace ---
         LinearResamplerAlign lin_resampler;
         lin_resampler.setParameters(resampler_param);
 
-        lin_resampler.raster(spectrum);
-        std::cout << "Size of resampled spectrum: " << spectrum.size() << std::endl;
+        lin_resampler.raster(summed_trace);
+        std::cout << "Size of resampled trace: " << summed_trace.size() << " peaks." << std::endl;
 
-        // Print resampled peaks for debugging
-        for (const auto& peak : spectrum)
+        // --- Step 3b: Apply Gaussian Smoothing ---
+        /*
+
+        std::cout << "Applying Gaussian smoothing..." << std::endl;
+
+        GaussFilter gauss_filter;
+        Param gauss_params;
+        gauss_params.setValue("gaussian_width", 0.005);
+        gauss_params.setValue("use_ppm_tolerance", "false"); // or "true" for ppm-based width
+
+        gauss_filter.setParameters(gauss_params);
+        gauss_filter.filter(summed_trace);
+
+        std::cout << "Trace after Gaussian smoothing has " << summed_trace.size() << " peaks." << std::endl;
+        */
+
+        // --- Step 3b: Apply SGolay Smoothing ---
+        SavitzkyGolayFilter sgolay_filter;
+        Param sgolay_params;
+
+        sgolay_params.setValue("frame_length", 15);
+        sgolay_params.setValue("polynomial_order", 3);
+        sgolay_filter.setParameters(sgolay_params);
+
+        sgolay_filter.filter(summed_trace);
+
+        std::cout << "Trace after Savitzky-Golay smoothing has " << summed_trace.size() << " peaks." << std::endl;
+
+        for (const auto& peak : summed_trace)
         {
-            std::cout << "m/z: " << peak.getMZ()
-                      << ", intensity: " << peak.getIntensity() << std::endl;
+          std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
         }
 
-        // Apply PeakPickerHiRes
+        // --- Step 4b: Apply PeakPickerHiRes ---
+        // We will use ion mobility peak FWHM to define min/max ion mobility boundaries.
+        // Revisit the raw traces and compute intensity weighted ion mobility centroids.
+        // The ion mobility traces also contains raw m/z peaks in FloatDataArrays.
+        // This makes it convenient  to re-compute m/z centroid.
         PeakPickerHiRes picker;
         picker.setParameters(parameters_);
-        MSSpectrum picked_spectrum;
 
-        picker.pick(spectrum, picked_spectrum);
-        std::cout << "Size of picked spectrum: " << picked_spectrum.size() << std::endl;
+        MSSpectrum picked_trace;
+        picker.pick(summed_trace, picked_trace);
+        // populated picked_traces vector
+        picked_traces.push_back(picked_trace);
 
-        // Replace original spectrum with processed version
-        spectrum = picked_spectrum;
+        std::cout << "Size of picked trace: " << picked_trace.size() << " peaks." << std::endl;
 
-        // Temporarily skipping IM format setting since we commented out the check
-        // spectrum.setIMFormat(IMFormat::CENTROIDED);
+        std::cout << "--- Finished Processing Trace " << i << " ---\n\n";
+      }
+
+      // Recompute m/z centers and output centroided frame
+      MSSpectrum centroided_frame = ComputeCenters(mobilogram_traces, picked_traces);
+      std::cout << "--- Centroided frame has been generated. It has  " << centroided_frame.size() << " --- peaks.";
+
+      // Replace the input spectrum with the centroided result
+      spectrum = centroided_frame;
+      std::cout << "--- Spectrum final output object has ..  " << spectrum.size() << " --- peaks.";
+      // Print peaks for debugging
+      for (const auto& peak : spectrum)
+      {
+        std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+      }
+
     }
-
-
 } // namespace OpenMS

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -431,11 +431,25 @@ namespace OpenMS
             continue;
           }
 
-
-
           raw_peaks_within_bounds.sortByPosition();
-
           MSSpectrum raw_mz_peaks = SumFrame(raw_peaks_within_bounds, 0.1);
+          // Summing peaks could result in spectrum.size() == 1 which causes error.
+          // in this case, simply sum the intensity values
+          if (raw_mz_peaks.size() == 1)
+          {
+            const Peak1D& single_peak = raw_mz_peaks.front();
+
+            centroided_frame.push_back(single_peak);
+            ion_mobility_array.push_back(centroid_im);
+            ion_mobility_fwhm.push_back(fwhm);
+            mz_fwhm_array.push_back(0.0);
+
+            std::cout << "[INFO] SumFrame reduced peaks to a single entry. Added directly to centroided_frame. m/z: " << single_peak.getMZ()
+                      << " intensity: " << single_peak.getIntensity() << std::endl;
+
+            continue;
+          }
+
           // Prepare data for spline
           std::map<double, double> peak_raw_data;
 
@@ -672,7 +686,7 @@ namespace OpenMS
       // This is currently set to +20 peaks in a mobilogram. (Should this be a user parameter?)
 
       // Add a parameter to allow user to control sampling). Here we simply multiply by 4.
-      double sampling_rate = computeOptimalSamplingRate(mobilogram_traces) * 4;
+      double sampling_rate = computeOptimalSamplingRate(mobilogram_traces) * 1;
       Param resampler_param;
       resampler_param.setValue("spacing", sampling_rate, "Spacing of the resampled output peaks.");
       resampler_param.setValue("ppm", "false", "Whether spacing is in ppm or Th");
@@ -710,13 +724,17 @@ namespace OpenMS
 
         std::cout << "Original summed trace ion mobility range: [" << im_start << ", " << im_end << "]" << std::endl;
 
+        // for SGolay smoothing -- pad the edges with the same number as SGolay window size.
+        // If the padded region is not matching, it will borrow the left points from the right
+        // aka window 15 --> 7 points to the right and 7 points to the left pushed to the right.
+        // This can create a fake peak in the padded edges.
         Peak1D front_padding;
-        front_padding.setMZ(im_start - 10 * sampling_rate);
+        front_padding.setMZ(im_start - 15 * sampling_rate);
         front_padding.setIntensity(0.0);
         summed_trace.insert(summed_trace.begin(), front_padding);
 
         Peak1D back_padding;
-        back_padding.setMZ(im_end + 10 * sampling_rate);
+        back_padding.setMZ(im_end + 15 * sampling_rate);
         back_padding.setIntensity(0.0);
         summed_trace.push_back(back_padding);
 
@@ -728,22 +746,31 @@ namespace OpenMS
 
         lin_resampler.raster(summed_trace);
         std::cout << "Size of resampled trace: " << summed_trace.size() << " peaks." << std::endl;
+        for (const auto& peak : summed_trace)
+        {
+          std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+        }
 
-        // --- Step 3b: Apply Gaussian Smoothing ---
         /*
-
+        // --- Step 3b: Apply Gaussian Smoothing ---
         std::cout << "Applying Gaussian smoothing..." << std::endl;
 
-        GaussFilter gauss_filter;
+        GaussFilter gauss_filter_2;
         Param gauss_params;
         gauss_params.setValue("gaussian_width", 0.005);
         gauss_params.setValue("use_ppm_tolerance", "false"); // or "true" for ppm-based width
 
-        gauss_filter.setParameters(gauss_params);
-        gauss_filter.filter(summed_trace);
+        gauss_filter_2.setParameters(gauss_params);
+        gauss_filter_2.filter(summed_trace);
 
         std::cout << "Trace after Gaussian smoothing has " << summed_trace.size() << " peaks." << std::endl;
+
+        for (const auto& peak : summed_trace)
+        {
+          std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+        }
         */
+
 
         // --- Step 3b: Apply SGolay Smoothing ---
         SavitzkyGolayFilter sgolay_filter;
@@ -761,6 +788,7 @@ namespace OpenMS
         {
           std::cout << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
         }
+
 
         // --- Step 4b: Apply PeakPickerHiRes ---
         // We will use ion mobility peak FWHM to define min/max ion mobility boundaries.

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -570,6 +570,7 @@ set(transformations_executables_list
   PeakPickerHiRes_test
   PeakPickerIterative_test
   PeakPickerIM_test
+  PeakPickerIM_test_2
   PeakWidthEstimator_test
   SeedListGenerator_test
   TraceFitter_test

--- a/src/tests/class_tests/openms/source/PeakPickerIM_test_2.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerIM_test_2.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2002-present, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Author: Timo Sachsenberg, Mohammed Alhigaylan $
+// $Maintainer: Timo Sachsenberg $
+// -------------------------------------------------------------------------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+
+///////////////////////////
+#include <OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h>
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(PeakPickerIM, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+PeakPickerIM* ptr = nullptr;
+PeakPickerIM* nullPointer = nullptr;
+
+START_SECTION((PeakPickerIM()))
+  ptr = new PeakPickerIM();
+  TEST_NOT_EQUAL(ptr, nullPointer)
+END_SECTION
+
+START_SECTION((virtual ~PeakPickerIM()))
+  delete ptr;
+END_SECTION
+
+
+// create dummy ion mobility spectrum
+MSSpectrum input;
+{
+  double start_mz = 0.8;
+  double end_mz = 1.2;
+  double step = 0.01;
+  double max_intensity = 1000.0; // Maximum intensity at m/z = 1.0
+
+  for (double mz = start_mz; mz <= end_mz; mz += step)
+  {
+    double intensity = 0.0;
+    if (mz <= 1.0)
+    {
+      // Linearly increase intensity from start_mz to 1.0
+      intensity = ((mz - start_mz) / (1.0 - start_mz)) * max_intensity;
+    }
+    else
+    {
+      // Linearly decrease intensity from 1.0 to end_mz
+      intensity = ((end_mz - mz) / (end_mz - 1.0)) * max_intensity;
+    }
+    input.emplace_back(mz, intensity);
+  }
+  // Set the IM format to CONCATENATED to force the peak picking branch
+  input.setIMFormat(IMFormat::CONCATENATED);
+//  input.getFloatDataArrays().resize(1);
+//  input.getFloatDataArrays()[0].setName("Ion Mobility");
+}
+
+
+START_SECTION(void pickIMTraces(MSSpectrum& spectrum))
+{
+    PeakPickerIM pp_im;
+    // print all peaks in our current input.
+    std::cout << "start printing dummy spectrum BEFORE picking! " << std::endl;
+    for (const auto& peak : input)
+    {
+        std::cout << "m/z: " << peak.getMZ()
+                  << ", intensity: " << peak.getIntensity() << std::endl;
+    }
+
+    pp_im.pickIMTraces(input);
+    std::cout << "start printing dummy spectrum AFTER picking! " << std::endl;
+    for (const auto& peak : input)
+    {
+        std::cout << "m/z: " << peak.getMZ()
+                  << ", intensity: " << peak.getIntensity() << std::endl;
+    }
+
+    // TODO adapt
+    TEST_EQUAL(input.size(), 10)
+    TEST_REAL_SIMILAR(input[0].getIntensity(), 450)
+    TEST_REAL_SIMILAR(input[0].getMZ(), 100.02)
+
+//    TEST_EQUAL(input.getFloatDataArrays().size(), 1)
+ //   TEST_EQUAL(input.getFloatDataArrays()[0].getName(), "Ion Mobility")
+ //   TEST_REAL_SIMILAR(input.getFloatDataArrays()[0][0], 150.0)
+}
+END_SECTION
+
+END_TEST

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2002-present, The OpenMS Team -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Author: Mohammed Alhigaylan $
+// $Maintainer: Timo Sachsenberg $
+// -------------------------------------------------------------------------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h>
+#include <OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h>
+
+using namespace OpenMS;
+using namespace std;
+
+class TOPPPeakPickerIM : public TOPPBase
+{
+public:
+  TOPPPeakPickerIM() : TOPPBase("PeakPickerIM", "Applies PeakPickerIM to an mzML file", false) {}
+
+protected:
+  void registerOptionsAndFlags_() override
+  {
+    registerInputFile_("in", "<file>", "", "Input mzML file");
+    setValidFormats_("in", ListUtils::create<String>("mzML"));
+
+    registerOutputFile_("out", "<file>", "", "Output mzML file");
+    setValidFormats_("out", ListUtils::create<String>("mzML"));
+  }
+
+  ExitCodes main_(int, const char**) override
+  {
+    // Get input and output file paths
+    String input_file = getStringOption_("in");
+    String output_file = getStringOption_("out");
+
+    // Load input mzML file
+    PeakMap exp;
+    MzMLFile mzml;
+    mzml.load(input_file, exp);
+
+    // Process each spectrum with PeakPickerIM
+    PeakPickerIM picker;
+    PeakMap processed_exp;
+    for (MSSpectrum& spectrum : exp)
+    {
+      std::cout << "Processing spectrum with " << spectrum.size() << " peaks." << std::endl;
+      picker.pickIMTraces(spectrum);
+      processed_exp.addSpectrum(spectrum);
+      std::cout << "Processed spectrum has " << spectrum.size() << " peaks." << std::endl;
+    }
+//    processed_exp.setExperimentalSettings(exp);
+    // Save output mzML file
+    mzml.store(output_file, processed_exp);
+
+    return EXECUTION_OK;
+  }
+};
+
+int main(int argc, const char** argv)
+{
+  TOPPPeakPickerIM tool;
+  return tool.main(argc, argv);
+}
+

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -26,10 +26,10 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input mzML file");
-    setValidFormats_("in", ListUtils::create<String>("mzML"));
+    setValidFormats_("in", { "mzML" });
 
     registerOutputFile_("out", "<file>", "", "Output mzML file");
-    setValidFormats_("out", ListUtils::create<String>("mzML"));
+    setValidFormats_("out", { "mzML" });
   }
 
   ExitCodes main_(int, const char**) override

--- a/src/topp/executables.cmake
+++ b/src/topp/executables.cmake
@@ -100,6 +100,7 @@ OpenSwathFeatureXMLToTSV
 OpenSwathRTNormalizer
 PeakPickerHiRes
 PeakPickerIterative
+PeakPickerIM
 PeptideIndexer
 PercolatorAdapter
 PhosphoScoring


### PR DESCRIPTION
### **User description**
## Description

Pushing my first PeakPickerIM draft for quick review. My print statements and file "PeakPickerIM_test_2" are temporary code debug. They will be removed later. 

The ideal behavior that I want here is to take in a mobilogram written in an MSSpectrum object, and then execute the following: 

 1. Apply linear resampling.
 2. Apply smoothing (gaussian / SGolay) 
 3. Apply PeakPickerHiRes with peaks FWHM reported. 

 With my current draft, I have two questions:

1. Linear resampler is needed here because ion mobility can have missing peaks. Linear resampler requires us to specify the step size and it is recommended to be above the instrument resolution. In my python implementation, I observed the raw mobilogram peaks are sampled at a rate of ~0.001 1/k. I resample the mobilogram at 0.001 x 4.0 (heuristics number, It seems to work for my purposes). 

 The question is, how do we determine the step size for resampling? I thought we could compute the ion mobility difference in a raw mobilogram and use that to automatically determine the linear resampler rate. We will introduce a 'resampling_factor' parameter that gets multiplied by the raw sampling rate and maybe set that to a default of 4.0. Do you have any thoughts here? Concerns?

2. For PeakPickerHiRes parameters, we need to enforce certain parameters so that PeakPickerHiRes is applicable to chromatograms and mobilograms. Those are mainly the spacing check parameters which only makes sense for m/z peak picking. Should we hide PeakPickerHiRes parameters from the user?


 
 


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `PeakPickerIM` class for ion mobility peak picking.
  - Added methods for parameter handling and peak picking logic.
  - Integrated linear resampling and high-resolution peak picking.

- Added unit tests for `PeakPickerIM` functionality.
  - Validated spectrum processing before and after peak picking.
  - Included dummy spectrum generation for testing.

- Updated build configuration to include new test file.

- Updated submodule reference in `contrib`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PeakPickerIM.cpp</strong><dd><code>Implement `PeakPickerIM` class with resampling and peak picking</code></dd></summary>
<hr>

src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp

<li>Implemented <code>PeakPickerIM</code> class with constructor, destructor, and <br>methods.<br> <li> Added linear resampling and high-resolution peak picking logic.<br> <li> Integrated parameter handling and spectrum format checks.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7848/files#diff-829d3dc7367e50508ab47e22fc940b6ee90bb333e55c06a44a10dc939dcdbea0">+84/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PeakPickerIM.h</strong><dd><code>Declare `PeakPickerIM` class and methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h

<li>Declared <code>PeakPickerIM</code> class and its methods.<br> <li> Added parameter handling and internal member updates.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7848/files#diff-048bf48fc1ff0f0b4eb13bed52a8c9a7fcf2c4c6c891a6a5327851a023fb4b9b">+31/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PeakPickerIM_test_2.cpp</strong><dd><code>Add unit tests for `PeakPickerIM` functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/class_tests/openms/source/PeakPickerIM_test_2.cpp

<li>Added unit tests for <code>PeakPickerIM</code> class.<br> <li> Validated spectrum processing before and after peak picking.<br> <li> Included dummy spectrum generation for testing.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7848/files#diff-5c422d1ef5e76a85147702a7ea803885ea7007d5c299a9dd03cf6f2188e909c2">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executables.cmake</strong><dd><code>Update build configuration for new test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/class_tests/openms/executables.cmake

- Added `PeakPickerIM_test_2` to the test executables list.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7848/files#diff-b383e931e63b075589578cc0e9114d5daf1f40ee10c7843561025466d44b39d0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contrib</strong><dd><code>Update submodule reference in `contrib`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contrib

- Updated submodule reference to a new commit.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7848/files#diff-fc1e87ada6cfa1335e3062451e7ac9d13f17482c4660989eeee7d5ec75a620d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>