### PR TITLE
Fix/openswathscoring pxd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,9 @@ OpenSwath:
 	- Deprecate -out_osw, -out_tsv. -out_features is used for outputting .osw or .featureXML files and file format is autodetected.
 	- Enable outputting any feature file (.osw or .featureXML) from a .tsv library 
 - Add warning message if irt_im_extraction_window not set and im_window is set (#7813)
+- Add auto add up spectra across the peak width in retention time for ion mobility extraction (#7742)
+- Add peak-picking for extracted ion mobilogram (#7759)
+- Add ion mobility scoring for identifying transitions for IPF (#7760)
 
 Misc:
 - pyOpenMS: improve developer experience (installation/compilation) (#7735)

--- a/src/pyOpenMS/pxds/OpenSwathScoring.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathScoring.pxd
@@ -14,10 +14,13 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
         void initialize(double rt_normalization_factor,
                         int add_up_spectra,
                         double spacing_for_spectra_resampling,
+                        double merge_spectra_by_peak_width_fraction,
                         double drift_extra,
                         OpenSwath_Scores_Usage su,
                         libcpp_string spectrum_addition_method,
-                        bool use_ms1_ion_mobility) except + nogil
+                        libcpp_string spectrum_merge_method_type,
+                        bool use_ms1_ion_mobility,
+                        bool apply_im_peak_picking) except + nogil
             # wrap-doc:
                 #  Initialize the scoring object\n
                 #  Sets the parameters for the scoring

--- a/src/pyOpenMS/pxds/OpenSwathScoring.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathScoring.pxd
@@ -29,8 +29,13 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h>" namespace "Ope
                 #  :param rt_normalization_factor: Specifies the range of the normalized retention time space
                 #  :param add_up_spectra: How many spectra to add up (default 1)
                 #  :param spacing_for_spectra_resampling: Spacing factor for spectra addition
+                #  :param merge_spectra_by_peak_width_fraction: Fraction of peak width to construct the number of spectra to add
+                #  :param drift_extra: Extend the extraction window to gain a larger field of view beyond drift_upper - drift_lower (in percent)
                 #  :param su: Which scores to actually compute
                 #  :param spectrum_addition_method: Method to use for spectrum addition (valid: "simple", "resample")
+                #  :param spectrum_merge_method_type: Type of method to use for spectrum addition. (valid: "fixed", "dynamic")
+                #  :param use_ms1_ion_mobility: Use MS1 ion mobility extraction in DIA scores
+                #  :param apply_im_peak_picking: Apply peak picking to the  extracted ion mobilograms
 
         # void calculateChromatographicScores(
         #      OpenSwath::IMRMFeature* imrmfeature,


### PR DESCRIPTION
## Description

This fixes #7862. Also update the CHANGELOG with the recent PRs for OpenSwath Ion mobility enhanced IPF scoring.

I tested building pyopenms locally, and it builds successfully. 

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automatic aggregation of spectra across the peak width in retention time for enhanced ion mobility extraction.
  - Added peak-picking functionality for ion mobilograms to improve peak identification.
  - Implemented refined scoring to enhance the identification of key transitions in ion mobility profiles.
  - Expanded configuration options for spectrum merging and peak selection, offering improved data processing flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->