### PR TITLE
Added Support for Python 3.13.0 version

### DIFF
--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -253,6 +253,7 @@ setup(
     package_data= {
         'pyopenms': ['py.typed', '*.pyi']
     },
+    python_requires=">=3.8, <3.13",
 	install_requires=[
           'numpy>=1.25.0',
           'pandas',

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -253,7 +253,7 @@ setup(
     package_data= {
         'pyopenms': ['py.typed', '*.pyi']
     },
-    python_requires=">=3.8, <3.13",
+    python_requires=">=3.8, <=3.13",
 	install_requires=[
           'numpy>=1.25.0',
           'pandas',


### PR DESCRIPTION
### **User description**
## Description

This PR ensures that pyOpenMS supports the latest Python version 3.13.0.

## Checklist
- [x] Ensure compatibility with Python 3.13.0
- [x] Update the setup.py file for versions up to 3.13.0

Fixes #7874


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for Python 3.13 in `pyOpenMS`.

- Updated `python_requires` in `setup.py` to include Python 3.13.

- Ensured compatibility with Python 3.13 dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Update `setup.py` to support Python 3.13</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pyOpenMS/setup.py

<li>Updated <code>python_requires</code> to include Python 3.13.<br> <li> Ensured compatibility with Python 3.13 dependencies.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7875/files#diff-1343deca77d77a5eb66c3fddd2f25c883ba408f22d13c33b760b691b5ea82d75">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the package’s installation criteria to support only Python versions 3.8 up to 3.13, ensuring a smoother installation experience for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->