### PR TITLE
pyopenms: add string accessors for activationmethods

### DIFF
--- a/src/openms/include/OpenMS/METADATA/Precursor.h
+++ b/src/openms/include/OpenMS/METADATA/Precursor.h
@@ -82,6 +82,11 @@ public:
     static const std::string NamesOfActivationMethod[SIZE_OF_ACTIVATIONMETHOD];
     static const std::string NamesOfActivationMethodShort[SIZE_OF_ACTIVATIONMETHOD];
 
+    /// returns all activation method full names (e.g., "Collision-induced dissociation") known to OpenMS
+    static StringList getAllNamesOfActivationMethods();
+    /// returns all activation method abbreviations (e.g., "CID") known to OpenMS
+    static StringList getAllShortNamesOfActivationMethods();
+
     /// Equality operator
     bool operator==(const Precursor & rhs) const;
     /// Equality operator
@@ -91,14 +96,12 @@ public:
     const std::set<ActivationMethod>& getActivationMethods() const;
     /// returns a mutable reference to the activation methods
     std::set<ActivationMethod>& getActivationMethods();
-    /// convenience function, returning string representation of getActivationMethods()
+    
+    /// Returns the full names (e.g., "Collision-induced dissociation") of the activation methods set on this instance
     StringList getActivationMethodsAsString() const;    
-    /// convenience function, returning short string representation of getActivationMethods()
+    /// Returns the abbreviations (e.g., "CID") of the activation methods set on this instance
     StringList getActivationMethodsAsShortString() const;
-    /// returns all available activation method names
-    static StringList getNamesOfAllActivationMethods();
-    /// returns all available activation method short names
-    static StringList getShortNamesOfAllActivationMethods();
+
     /// sets the activation methods
     void setActivationMethods(const std::set<ActivationMethod> & activation_methods);
 

--- a/src/openms/include/OpenMS/METADATA/Precursor.h
+++ b/src/openms/include/OpenMS/METADATA/Precursor.h
@@ -93,6 +93,12 @@ public:
     std::set<ActivationMethod>& getActivationMethods();
     /// convenience function, returning string representation of getActivationMethods()
     StringList getActivationMethodsAsString() const;    
+    /// convenience function, returning short string representation of getActivationMethods()
+    StringList getActivationMethodsAsShortString() const;
+    /// returns all available activation method names
+    static StringList getNamesOfAllActivationMethods();
+    /// returns all available activation method short names
+    static StringList getShortNamesOfAllActivationMethods();
     /// sets the activation methods
     void setActivationMethods(const std::set<ActivationMethod> & activation_methods);
 

--- a/src/openms/source/METADATA/Precursor.cpp
+++ b/src/openms/source/METADATA/Precursor.cpp
@@ -115,6 +115,41 @@ namespace OpenMS
     return am;
   }
 
+  StringList Precursor::getActivationMethodsAsShortString() const
+  {
+    StringList am;
+    am.reserve(activation_methods_.size());
+    for (const auto& m : activation_methods_)
+    {
+      am.push_back(NamesOfActivationMethodShort[m]);
+    }
+    return am;
+  }
+
+  StringList Precursor::getNamesOfAllActivationMethods()
+  {
+    StringList am;
+    am.reserve(SIZE_OF_ACTIVATIONMETHOD);
+    for (size_t i = 0; i < SIZE_OF_ACTIVATIONMETHOD; ++i)
+    {
+      am.push_back(NamesOfActivationMethod[i]);
+    }
+    return am;
+  }
+
+  StringList Precursor::getShortNamesOfAllActivationMethods()
+  {
+    StringList am;
+    am.reserve(SIZE_OF_ACTIVATIONMETHOD);
+    for (size_t i = 0; i < SIZE_OF_ACTIVATIONMETHOD; ++i)
+    {
+      am.push_back(NamesOfActivationMethodShort[i]);
+    }
+    return am;
+  }
+
+
+
   void Precursor::setActivationMethods(const set<Precursor::ActivationMethod> & activation_methods)
   {
     activation_methods_ = activation_methods;

--- a/src/openms/source/METADATA/Precursor.cpp
+++ b/src/openms/source/METADATA/Precursor.cpp
@@ -126,7 +126,7 @@ namespace OpenMS
     return am;
   }
 
-  StringList Precursor::getNamesOfAllActivationMethods()
+  StringList Precursor::getAllNamesOfActivationMethods()
   {
     StringList am;
     am.reserve(SIZE_OF_ACTIVATIONMETHOD);
@@ -137,7 +137,7 @@ namespace OpenMS
     return am;
   }
 
-  StringList Precursor::getShortNamesOfAllActivationMethods()
+  StringList Precursor::getAllShortNamesOfActivationMethods()
   {
     StringList am;
     am.reserve(SIZE_OF_ACTIVATIONMETHOD);

--- a/src/pyOpenMS/pxds/Precursor.pxd
+++ b/src/pyOpenMS/pxds/Precursor.pxd
@@ -23,7 +23,14 @@ cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
         Precursor(Precursor &) except + nogil 
 
         libcpp_set[ActivationMethod] getActivationMethods() except + nogil  # wrap-doc:Returns the activation methods
+        libcpp_vector[String] getActivationMethodsAsString() except + nogil  # wrap-doc:Returns the activation methods as strings
+        libcpp_vector[String] getActivationMethodsAsShortString() except + nogil  # wrap-doc:Returns the activation methods as short strings
         void setActivationMethods(libcpp_set[ActivationMethod] activation_methods) except + nogil  # wrap-doc:Sets the activation methods
+
+        @staticmethod
+        libcpp_vector[String] getNamesOfAllActivationMethods() except + nogil  # wrap-doc:Returns all available activation method names
+        @staticmethod
+        libcpp_vector[String] getShortNamesOfAllActivationMethods() except + nogil  # wrap-doc:Returns all available activation method short names
 
         double getActivationEnergy() except + nogil  # wrap-doc:Returns the activation energy (in electronvolt)
         void setActivationEnergy(double activation_energy) except + nogil  # wrap-doc:Sets the activation energy (in electronvolt)

--- a/src/pyOpenMS/pxds/Precursor.pxd
+++ b/src/pyOpenMS/pxds/Precursor.pxd
@@ -23,14 +23,14 @@ cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
         Precursor(Precursor &) except + nogil 
 
         libcpp_set[ActivationMethod] getActivationMethods() except + nogil  # wrap-doc:Returns the activation methods
-        libcpp_vector[String] getActivationMethodsAsString() except + nogil  # wrap-doc:Returns the activation methods as strings
-        libcpp_vector[String] getActivationMethodsAsShortString() except + nogil  # wrap-doc:Returns the activation methods as short strings
+        libcpp_vector[String] getActivationMethodsAsString() except + nogil  # wrap-doc:Returns the full names (e.g., "Collision-induced dissociation") of the activation methods set on this instance
+        libcpp_vector[String] getActivationMethodsAsShortString() except + nogil  # wrap-doc:Returns the abbreviations (e.g., "CID") of the activation methods set on this instance
         void setActivationMethods(libcpp_set[ActivationMethod] activation_methods) except + nogil  # wrap-doc:Sets the activation methods
 
         @staticmethod
-        libcpp_vector[String] getNamesOfAllActivationMethods() except + nogil  # wrap-doc:Returns all available activation method names
+        libcpp_vector[String] getAllNamesOfActivationMethods() except + nogil  # wrap-doc:Returns the full names (e.g., "Collision-induced dissociation") of ALL possible activation methods, not just those set on this instance
         @staticmethod
-        libcpp_vector[String] getShortNamesOfAllActivationMethods() except + nogil  # wrap-doc:Returns all available activation method short names
+        libcpp_vector[String] getAllShortNamesOfActivationMethods() except + nogil  # wrap-doc:Returns the abbreviations (e.g., "CID") of ALL possible activation methods, not just those set on this instance
 
         double getActivationEnergy() except + nogil  # wrap-doc:Returns the activation energy (in electronvolt)
         void setActivationEnergy(double activation_energy) except + nogil  # wrap-doc:Sets the activation energy (in electronvolt)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4477,11 +4477,11 @@ def testPrecursor():
     assert sorted([s.decode() for s in long_strings]) == sorted(methods_long)
 
     # Test static methods for all activation methods
-    all_names = pyopenms.Precursor.getNamesOfAllActivationMethods()
+    all_names = pyopenms.Precursor.getAllNamesOfActivationMethods()
     assert len(all_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
     assert all_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "Collision-induced dissociation"
     
-    all_short_names = pyopenms.Precursor.getShortNamesOfAllActivationMethods()
+    all_short_names = pyopenms.Precursor.getAllShortNamesOfActivationMethods()
     assert len(all_short_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
     assert all_short_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "CID"
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4461,12 +4461,29 @@ def testPrecursor():
     # Test activation methods
     methods = set([pyopenms.Precursor.ActivationMethod.CID, 
                   pyopenms.Precursor.ActivationMethod.HCD])
+    methods_short = ["CID", "HCD"]
+    methods_long = ["Collision-induced dissociation", "beam-type collision-induced dissociation"]
     prec.setActivationMethods(methods)
     assert prec.getActivationMethods() == methods
 
     # Test activation energy  
     prec.setActivationEnergy(25.0)
     assert abs(prec.getActivationEnergy() - 25.0) < 1e-5
+
+    # Test activation methods as strings
+    short_strings = prec.getActivationMethodsAsShortString()
+    assert sorted([s.decode() for s in short_strings]) == sorted(methods_short)
+    long_strings = prec.getActivationMethodsAsString()
+    assert sorted([s.decode() for s in long_strings]) == sorted(methods_long)
+
+    # Test static methods for all activation methods
+    all_names = pyopenms.Precursor.getNamesOfAllActivationMethods()
+    assert len(all_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "Collision-induced dissociation"
+    
+    all_short_names = pyopenms.Precursor.getShortNamesOfAllActivationMethods()
+    assert len(all_short_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_short_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "CID"
 
     # Test isolation window
     prec.setIsolationWindowLowerOffset(0.5)

--- a/src/tests/class_tests/openms/source/Precursor_test.cpp
+++ b/src/tests/class_tests/openms/source/Precursor_test.cpp
@@ -84,6 +84,36 @@ START_SECTION((void setActivationMethods(const set<ActivationMethod>& activation
   TEST_EQUAL(tmp.getActivationMethods().size(),1);
 END_SECTION
 
+START_SECTION((StringList getActivationMethodsAsString() const))
+  Precursor tmp;
+  set<Precursor::ActivationMethod> methods;
+  methods.insert(Precursor::CID);
+  tmp.setActivationMethods(methods);
+  StringList result = tmp.getActivationMethodsAsString();
+  TEST_EQUAL(result.size(), 1);
+  TEST_EQUAL(result[0], "Collision-induced dissociation");
+END_SECTION
+
+START_SECTION((StringList getActivationMethodsAsShortString() const))
+  Precursor tmp;
+  set<Precursor::ActivationMethod> methods;
+  methods.insert(Precursor::CID);
+  tmp.setActivationMethods(methods);
+  StringList result = tmp.getActivationMethodsAsShortString();
+  TEST_EQUAL(result.size(), 1);
+  TEST_EQUAL(result[0], "CID");
+END_SECTION
+
+START_SECTION((static StringList getNamesOfAllActivationMethods()))
+  StringList result = Precursor::getNamesOfAllActivationMethods();
+  TEST_EQUAL(result.size(), Precursor::SIZE_OF_ACTIVATIONMETHOD);
+END_SECTION
+
+START_SECTION((static StringList getShortNamesOfAllActivationMethods()))
+  StringList result = Precursor::getShortNamesOfAllActivationMethods();
+  TEST_EQUAL(result.size(), Precursor::SIZE_OF_ACTIVATIONMETHOD);
+END_SECTION
+
 START_SECTION((double getIsolationWindowUpperOffset() const))
   Precursor tmp;
   TEST_REAL_SIMILAR(tmp.getIsolationWindowUpperOffset(), 0);

--- a/src/tests/class_tests/openms/source/Precursor_test.cpp
+++ b/src/tests/class_tests/openms/source/Precursor_test.cpp
@@ -104,13 +104,13 @@ START_SECTION((StringList getActivationMethodsAsShortString() const))
   TEST_EQUAL(result[0], "CID");
 END_SECTION
 
-START_SECTION((static StringList getNamesOfAllActivationMethods()))
-  StringList result = Precursor::getNamesOfAllActivationMethods();
+START_SECTION((static StringList getAllNamesOfActivationMethods()))
+  StringList result = Precursor::getAllNamesOfActivationMethods();
   TEST_EQUAL(result.size(), Precursor::SIZE_OF_ACTIVATIONMETHOD);
 END_SECTION
 
-START_SECTION((static StringList getShortNamesOfAllActivationMethods()))
-  StringList result = Precursor::getShortNamesOfAllActivationMethods();
+START_SECTION((static StringList getAllShortNamesOfActivationMethods()))
+  StringList result = Precursor::getAllShortNamesOfActivationMethods();
   TEST_EQUAL(result.size(), Precursor::SIZE_OF_ACTIVATIONMETHOD);
 END_SECTION
 


### PR DESCRIPTION
## Description

Provides stable string identifier for pyopenms. requested by @ypriverol 

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced functionality to retrieve activation method details in both complete and abbreviated formats, offering more descriptive options to users.

- **Tests**
  - Expanded test coverage to ensure reliable and accurate behavior of the new activation method retrieval features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->