### PR TITLE
Fix #7839: Skip initial empty lines in FASTAFile::load without breaki…

### DIFF
--- a/src/openms/source/FORMAT/FASTAFile.cpp
+++ b/src/openms/source/FORMAT/FASTAFile.cpp
@@ -222,19 +222,51 @@ namespace OpenMS
     return (infile_.peek() == std::streambuf::traits_type::eof());
   }
 
-  void FASTAFile::load(const String &filename, vector<FASTAEntry> &data) const
-  {
-    startProgress(0, 1, "Loading FASTA file");
+  void FASTAFile::load(const String& filename, std::vector<FASTAEntry>& data)
+ {
     data.clear();
-    FASTAEntry p;
-    FASTAFile f;
-    f.readStart(filename);
-    while (f.readNext(p))
+    TextFile file(filename, true); // Trim lines automatically
+    
+    // Skip initial empty lines
+    String line;
+    while (file.readLine(line) && line.empty())
     {
-      data.push_back(std::move(p));
+        // Continue until a non-empty line is found
     }
-    endProgress();
-  }
+    
+    // Process the first non-empty line
+    if (!file.eof() && !line.empty())
+    {
+        if (line[0] != '>')
+        {
+            throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "First non-empty line must start with '>'");
+        }
+        FASTAEntry entry;
+        entry.identifier = line.substr(1);
+        
+        // Continue parsing the rest of the file
+        while (file.readLine(line))
+        {
+            if (line.empty()) continue; // Skip mid-file empty lines
+            if (line[0] == '>')
+            {
+                data.push_back(entry);
+                entry = FASTAEntry();
+                entry.identifier = line.substr(1);
+            }
+            else
+            {
+                entry.sequence += line;
+            }
+        }
+        if (!entry.sequence.empty()) data.push_back(entry);
+    }
+    
+    if (data.empty())
+    {
+        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "No valid FASTA entries found!");
+    }
+}
 
   void FASTAFile::writeStart(const String &filename)
   {


### PR DESCRIPTION
### **User description**
…ng parsing

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `FASTAFile::load` to skip initial empty lines.

- Added validation for the first non-empty line in FASTA files.

- Improved parsing logic to handle mid-file empty lines.

- Ensured proper error handling for invalid or empty FASTA files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FASTAFile.cpp</strong><dd><code>Improved `FASTAFile::load` parsing and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/openms/source/FORMAT/FASTAFile.cpp

<li>Updated <code>FASTAFile::load</code> to skip initial empty lines.<br> <li> Added validation for the first non-empty line to start with '>'.<br> <li> Enhanced parsing logic to handle mid-file empty lines.<br> <li> Added error handling for invalid or empty FASTA files.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7899/files#diff-1634a9be9835164c03030f4b3ef003f252f7380f73fb220b1c859f87b7b10252">+42/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error detection during FASTA file imports, ensuring that invalid or improperly formatted files are promptly flagged.
  
- **Refactor**
  - Streamlined the FASTA file import process for more consistent and reliable handling of file content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->