### PR TITLE
fix: use GITHUB_TOKEN instead of non-existent secret in update_nightly workflow

### DIFF
--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -45,7 +45,7 @@ jobs:
         git merge develop --ff-only
         git push origin nightly
       env:
-        GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Forcibly reset nightly 
       if: inputs.force
@@ -54,7 +54,7 @@ jobs:
         git reset --hard develop
         git push origin nightly -f
       env:
-        GITHUB_TOKEN: ${{ secrets.OPENMS_GITHUB_APP_PRIVATE_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Call CI
       if: steps.compare_branches.outputs.behind == 'true' || inputs.force


### PR DESCRIPTION
### **User description**
## Pull Request description

### fix: use GITHUB_TOKEN instead of non-existent secret in update_nightly workflow

- This commit message follows conventional commit format and clearly states:
  - The type of change (fix)
  - What was fixed (replacing incorrect secret)
  - Where it was fixed (update_nightly workflow)

### Which issue this PR aims to resolve or fix?
Solve #7920 

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Replaced non-existent secret with `GITHUB_TOKEN` in `update_nightly.yml`.

- Ensured proper authentication for nightly branch operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update_nightly.yml</strong><dd><code>Replace incorrect secret with `GITHUB_TOKEN` in workflow</code>&nbsp; </dd></summary>
<hr>

.github/workflows/update_nightly.yml

<li>Updated <code>env</code> to use <code>GITHUB_TOKEN</code> instead of <br><code>OPENMS_GITHUB_APP_PRIVATE_KEY</code>.<br> <li> Fixed authentication issues in nightly branch operations.


</details>


  </td>
  <td><a href="https://github.com/OpenMS/OpenMS/pull/7921/files#diff-3ace9f2af1911f6a5c26a30d82287229912ccb00be7e378adadb15a09527a5d9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**  
  - Enhanced the automated workflow responsible for synchronizing release branches, ensuring more reliable nightly updates without altering visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->