### PR TITLE
fix pyopenms

### DIFF
--- a/src/pyOpenMS/pxds/Precursor.pxd
+++ b/src/pyOpenMS/pxds/Precursor.pxd
@@ -62,6 +62,8 @@ cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
 
 cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS::Precursor":
     cdef enum ActivationMethod:
+      # wrap-attach:
+      #  Precursor
       # wrap-doc:
       #  Enum for activation/fragmentation methods of mass spectra
       #  

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2581,8 +2581,6 @@ def testSample():
      Sample.getConcentration
      Sample.getSubsamples
      Sample.setSubsamples
-     Sample.removeTreatment
-     Sample.countTreatments
      """
     ins = pyopenms.Sample()
 
@@ -2614,7 +2612,6 @@ def testSample():
     except Exception:
         has_exception = True
     assert has_exception
-    assert ins.countTreatments() == 0
 
 @report
 def testLogType():
@@ -4459,8 +4456,8 @@ def testPrecursor():
     assert not prec != prec2
 
     # Test activation methods
-    methods = set([pyopenms.Precursor.ActivationMethod.CID, 
-                  pyopenms.Precursor.ActivationMethod.HCD])
+    methods = set([pyopenms.ActivationMethod.CID, 
+                  pyopenms.ActivationMethod.HCD])
     methods_short = ["CID", "HCD"]
     methods_long = ["Collision-induced dissociation", "beam-type collision-induced dissociation"]
     prec.setActivationMethods(methods)
@@ -4478,12 +4475,12 @@ def testPrecursor():
 
     # Test static methods for all activation methods
     all_names = pyopenms.Precursor.getAllNamesOfActivationMethods()
-    assert len(all_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
-    assert all_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "Collision-induced dissociation"
+    assert len(all_names) == pyopenms.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_names[pyopenms.ActivationMethod.CID].decode() == "Collision-induced dissociation"
     
     all_short_names = pyopenms.Precursor.getAllShortNamesOfActivationMethods()
-    assert len(all_short_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
-    assert all_short_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "CID"
+    assert len(all_short_names) == pyopenms.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_short_names[pyopenms.ActivationMethod.CID].decode() == "CID"
 
     # Test isolation window
     prec.setIsolationWindowLowerOffset(0.5)

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4456,8 +4456,8 @@ def testPrecursor():
     assert not prec != prec2
 
     # Test activation methods
-    methods = set([pyopenms.ActivationMethod.CID, 
-                  pyopenms.ActivationMethod.HCD])
+    methods = set([pyopenms.Precursor.ActivationMethod.CID, 
+                  pyopenms.Precursor.ActivationMethod.HCD])
     methods_short = ["CID", "HCD"]
     methods_long = ["Collision-induced dissociation", "beam-type collision-induced dissociation"]
     prec.setActivationMethods(methods)
@@ -4475,12 +4475,12 @@ def testPrecursor():
 
     # Test static methods for all activation methods
     all_names = pyopenms.Precursor.getAllNamesOfActivationMethods()
-    assert len(all_names) == pyopenms.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
-    assert all_names[pyopenms.ActivationMethod.CID].decode() == "Collision-induced dissociation"
+    assert len(all_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "Collision-induced dissociation"
     
     all_short_names = pyopenms.Precursor.getAllShortNamesOfActivationMethods()
-    assert len(all_short_names) == pyopenms.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
-    assert all_short_names[pyopenms.ActivationMethod.CID].decode() == "CID"
+    assert len(all_short_names) == pyopenms.Precursor.ActivationMethod.SIZE_OF_ACTIVATIONMETHOD
+    assert all_short_names[pyopenms.Precursor.ActivationMethod.CID].decode() == "CID"
 
     # Test isolation window
     prec.setIsolationWindowLowerOffset(0.5)


### PR DESCRIPTION
## Description



## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced documentation for activation methods within the Precursor class.
  
- **Tests**
  - Removed outdated verifications related to sample treatments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->