### PR TITLE
fix: Handle Visual C++ runtime library configuration for static build…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,19 @@ if (MINGW OR MSYS)
   message(FATAL_ERROR "MSYS and/or MinGW are not supported! Please use a Visual Studio environment! See Windows build instructions for further information!")
 endif()
 
+# Configure Visual C++ runtime library for MSVC builds
+if(MSVC)
+  if(BOOST_USE_STATIC)
+    foreach(flag_var
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif()
+    endforeach()
+  endif()
+endif()
+
 #------------------------------------------------------------------------------
 # Setup CMAKE_PREFIX_PATH for finding external libs (contrib or system)
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Description
This pull request addresses issue #7926 by ensuring proper handling of Visual C++ runtime library settings when building OpenMS with MSVC and static libraries.

Changes Made
Updated CMake configuration to switch from the default dynamic runtime (/MD) to static runtime (/MT) when BOOST_USE_STATIC is enabled.
Applied these changes across all relevant build configurations:
Debug
Release
MinSizeRel
RelWithDebInfo
Ensures consistent linking behavior for Visual C++ runtime libraries in static builds, preventing common issues with mismatched runtime configurations when using Boost or other static libraries on Windows.
Issue Fixed
Resolves incorrect runtime library linkage when building OpenMS with MSVC and static libraries (BOOST_USE_STATIC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the Visual C++ build configuration to automatically apply static runtime linking when the static linking option is enabled, ensuring consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->