### PR TITLE
Feature/build pyopenms workflow

### DIFF
--- a/.github/workflows/build_pyopenms.yml
+++ b/.github/workflows/build_pyopenms.yml
@@ -1,0 +1,140 @@
+name: Build pyOpenMS Packages for Testing
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: OpenMS
+      
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.25.x'
+
+    - name: Reduce PATH
+      run: echo "DISTUTILS_USE_SDK=1"
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.*'
+        host: 'windows'
+        target: 'desktop'
+        install-deps: 'true'
+        archives: 'qtsvg qtbase'
+        cache: 'false'
+
+    - name: Install Miniconda
+      shell: bash
+      run: |
+        MINICONDA_FILENAME=Miniconda3-latest-Windows-x86_64.exe
+        curl -o $MINICONDA_FILENAME "https://repo.anaconda.com/miniconda/$MINICONDA_FILENAME"
+        ./Miniconda3-latest-Windows-x86_64.exe //InstallationType=JustMe //RegisterPython=0 //S //D=$HOME/miniconda3
+
+    - name: Download contrib build from archive (Windows)
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd OpenMS/contrib
+        gh release download -R OpenMS/contrib --pattern 'contrib_build-Windows.tar.gz'
+        7z x -so contrib_build-Windows.tar.gz | 7z x -si -ttar
+        rm contrib_build-Windows.tar.gz
+        ls -la
+
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+
+    - name: Setup conda paths
+      shell: bash
+      run: |
+        echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+        echo "$HOME/miniconda3/Scripts" >> $GITHUB_PATH
+
+    - name: Build pyOpenMS
+      shell: bash
+      run: |
+        PYTHON_VERSIONS=$(cat OpenMS/.github/workflows/python_versions.json)
+        CMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}"
+        export CXXFLAGS="-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR $CXXFLAGS"
+        mkdir pyopenms_whls
+        RESET_PATH=$PATH
+
+        for py in $(echo "${PYTHON_VERSIONS}" | jq -r '.[]'); do
+          find . -name "_pyopenms*.pyd" -exec rm -rf {} \;
+          PATH=$RESET_PATH
+
+          py=$(echo "$py" | tr -d " \r\n")
+          pynodot=$(echo "$py" | tr -d ".")
+          conda create -n pyoms-bld-"${pynodot}" python="${py}"
+          source activate pyoms-bld-"${pynodot}"
+
+          CURRENT_PYTHON_EXECUTABLE=$(which python)
+          ${CURRENT_PYTHON_EXECUTABLE} -m pip install --upgrade pip
+          ${CURRENT_PYTHON_EXECUTABLE} -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
+          
+          export Python_ROOT_DIR=$(conda info --json | jq -r '.sys.prefix')
+          echo "Python root directory: $Python_ROOT_DIR"
+
+          export BUILD_NAME="pyopenms-wheels-${{ runner.arch }}-class-pyopenms-$py-${{ github.run_number }}"
+
+          ctest --output-on-failure -VV -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake --config Release
+
+          echo "Current dir is `pwd`"
+          echo "wheels are in `find . | grep whl`"
+          echo "current ls is `ls -la`"
+          cp OpenMS/bld/pyOpenMS/dist/*.whl pyopenms_whls/
+        done
+
+      env: 
+        SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+        CMAKE_GENERATOR: "Visual Studio 17 2022"
+        CMAKE_GENERATOR_PLATFORM: "x64"
+        OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/OpenMS/contrib"
+        BUILD_TYPE: "Release"
+        CI_PROVIDER: "GitHub-Actions"
+        CMAKE_CCACHE_EXE: "ccache"
+        CCACHE_BASEDIR: ${{ github.workspace }}
+        CCACHE_DIR: ${{ github.workspace }}/.ccache
+        CCACHE_COMPRESS: true
+        CCACHE_COMPRESSLEVEL: 12
+        CCACHE_MAXSIZE: 400M
+        PYOPENMS: "ON"
+        PY_NUM_THREADS: ${{ steps.cpu-cores.outputs.count }}
+        ENABLE_TUTORIALS: "OFF"
+        ENABLE_DOCS: "OFF"
+        ENABLE_PIPELINE_TESTING: "OFF"
+        ENABLE_STYLE_TESTING: "OFF"
+        ENABLE_TOPP_TESTING: "OFF"
+        ENABLE_CLASS_TESTING: "OFF"
+        USE_STATIC_RUNTIME: "ON"
+
+    - name: Run Unit Tests
+      shell: bash
+      run: |
+        ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/citest.cmake -C Release
+      env:
+        SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+        CI_PROVIDER: "GitHub-Actions"
+        BUILD_NAME: "${{ runner.arch }}-class-pyopenms-${{ github.run_number }}"
+        BUILD_TYPE: "Release"
+
+    - uses: actions/upload-artifact@v4
+      name: Upload pyOpenMS wheels for testing
+      with:
+        name: pyopenms-wheels-${{ github.run_number }}
+        path: pyopenms_whls
+        retention-days: 7 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,24 @@ endif()
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
 
 #------------------------------------------------------------------------------
+# Visual C++ Runtime Library Configuration
+#------------------------------------------------------------------------------
+option(USE_STATIC_RUNTIME "Use static runtime (/MT) for MSVC builds. Only enable for pyOpenMS on GitHub Actions." OFF)
+
+if(MSVC)
+  # Use modern CMake approach with MSVC_RUNTIME_LIBRARY
+  cmake_policy(SET CMP0091 NEW)
+  
+  if(USE_STATIC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "Using static runtime library (/MT) for MSVC builds")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    message(STATUS "Using dynamic runtime library (/MD) for MSVC builds")
+  endif()
+endif()
+
+#------------------------------------------------------------------------------
 # Project specific compiler flags
 #------------------------------------------------------------------------------
 # Fill this with compile flags that external projects should use as well

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -71,6 +71,13 @@ if(WIN32)
         message(FATAL_ERROR "Either reconfigure with the correct Visual Studio generator, select a different Python version with -DPython_EXECUTABLE:FILEPATH=/path/to/python or disable pyOpenMS.")
     endif()
 
+    # Configure runtime library for pyOpenMS
+    if(DEFINED ENV{GITHUB_ACTIONS})
+        # On GitHub Actions, use static runtime for better compatibility
+        set(USE_STATIC_RUNTIME ON CACHE BOOL "Use static runtime (/MT) for MSVC builds" FORCE)
+        message(STATUS "GitHub Actions detected - Using static runtime for pyOpenMS")
+    endif()
+
     # Try to find MSVS runtime libs
     include(InstallRequiredSystemLibraries)
 
@@ -81,7 +88,7 @@ if(WIN32)
     if("${MSVS_RTLIBS}" STREQUAL "")
         message(FATAL_ERROR "Did not find MSVS runtime, either provide with -DMSVS_RTLIBS='lib1;lib2' or disable pyOpenMS.")
     else()
-    message(STATUS "Found MSVS runtime: ${MSVS_RTLIBS}")
+        message(STATUS "Found MSVS runtime: ${MSVS_RTLIBS}")
     endif()
 
 endif(WIN32)


### PR DESCRIPTION
# Add workflow for building pyOpenMS packages for testing

## Description
This PR adds a new GitHub Actions workflow to build pyOpenMS packages with the modernized Visual C++ runtime configuration. The workflow is designed to facilitate testing of the packages by automatically building and providing them as downloadable artifacts.

## Changes
- Added new workflow file `.github/workflows/build_pyopenms.yml`
- Workflow builds pyOpenMS with static runtime configuration
- Runs unit tests to ensure package quality
- Uploads built wheels as artifacts for easy testing
- Sets 7-day retention period for artifacts

## Testing
The workflow will run automatically on this PR, and you can find the built packages in the "Artifacts" section of the workflow run. To test:
1. Download the wheels from the workflow artifacts
2. Install using pip: `pip install <downloaded-wheel-file>`
3. Test the installed package

## Related Issues
Addresses #7932 - Modernize Visual C++ runtime library configuration using CMake

## Notes
- The workflow is configured to run on Windows since we're dealing with MSVC runtime configuration
- Builds are performed with `USE_STATIC_RUNTIME=ON` for better compatibility
- No PyPI upload is included as this is for testing purposes only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow that builds and tests Windows packages, supporting multiple Python versions and preparing artifacts for distribution.
  
- **Chores**
  - Added a configurable option for Windows builds to select between different runtime libraries, ensuring improved consistency and performance in continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->