### PR TITLE
potential changes for cleaner pyopenms builds

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -241,25 +241,8 @@ jobs:
     - name: Build on macos arm
       run: |
         PYTHON_VERSIONS=$(cat OpenMS/.github/workflows/python_versions.json)
-        # export CC=clang
-        # export CXX=clang++
-        # export MACOSX_DEPLOYMENT_TARGET=12
-        # Unfortunately, on macOS due to the inofficial way of enabling OpenMP on AppleClang, passing the following
-        # options to setup.py extra_compile_args does not work. See also https://gist.github.com/andyfaff/084005bee32aee83d6b59e843278ab3e
-        export CFLAGS="-Xpreprocessor -fopenmp $CFLAGS"
-        export CXXFLAGS="-Xpreprocessor -fopenmp $CXXFLAGS"
-
-        # mkdir bld
-        # pushd bld
-        # Use -DCMAKE_FIND_DEBUG_MODE=ON for debug
-
-        # export OpenMP_ROOT="$(brew --prefix libomp)"
-        export CMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_DIR)/lib/cmake;${Qt6_DIR}"
-
-        #ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake
-
-        #cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_PREFIX_PATH="$(brew --prefix libomp);$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" -DCMAKE_OSX_DEPLOYMENT_TARGET=12 -DBOOST_USE_STATIC=OFF ../OpenMS
-        #make -j${{ steps.cpu-cores.outputs.count }} OpenMS
+        export OpenMP_ROOT=$(brew --prefix libomp)
+        export CMAKE_PREFIX_PATH="$(echo $Qt6_DIR)/lib/cmake;${Qt6_DIR}"
 
         mkdir pyopenms_whls
 

--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -69,10 +69,10 @@ def doCythonCompile(arg):
 if __name__ == '__main__':
 
   # import config
-  from env import (QT_QMAKE_VERSION_INFO, OPEN_MS_BUILD_TYPE, PYOPENMS_SRC_DIR,
-                   OPEN_MS_CONTRIB_BUILD_DIRS, OPEN_MS_LIB, OPEN_SWATH_ALGO_LIB,
-                   OPEN_MS_BUILD_DIR, MSVS_RTLIBS, OPEN_MS_VERSION,
-                   Boost_MAJOR_VERSION, Boost_MINOR_VERSION, PY_NUM_THREADS, PY_NUM_MODULES)
+  from env import (
+        QT_QMAKE_VERSION_INFO, OPEN_MS_BUILD_TYPE,
+        PYOPENMS_SRC_DIR, OPEN_MS_VERSION,
+        PY_NUM_THREADS, PY_NUM_MODULES)
 
   IS_DEBUG = OPEN_MS_BUILD_TYPE.upper() == "DEBUG"
 

--- a/src/pyOpenMS/env.py.in
+++ b/src/pyOpenMS/env.py.in
@@ -7,28 +7,6 @@ PYOPENMS_BUILD_DIR="@PROJECT_BINARY_DIR@"
 OPEN_MS_BUILD_DIR="@OPENMS_HOST_BINARY_DIRECTORY@"
 PYOPENMS_INCLUDE_DIRS="""@PYOPENMS_INCLUDE_DIRS@"""
 QT_QMAKE_VERSION_INFO="""@QT_QMAKE_VERSION_INFO@"""
-## CONTRIB_DIR uses paths typed by the user that are 
-## forwarded unchanged (just backslashes are converted 
-## to forward slashes for safety, i.e. a path must not 
-## end in '\', otherwise r"...\" is invalid python
-OPEN_MS_CONTRIB_BUILD_DIRS=r"@CONTRIB_DIR@"
-
-######################################################
-## The following should be a semicolon seperated list
-## of absolute paths to lib files to be linked
-## Can be ".a", ".so", ".dylib", ".lib"
-LIBRARIES_TO_BE_PARSED_EXTEND="@LIBRARIES_TO_BE_PARSED_EXTEND@"
-
-######################################################
-## The following allows for extra dynamic libraries
-## to be added (deprecated)
-INCLUDE_DIRS_EXTEND="@INCLUDE_DIRS_EXTEND@"
-LIBRARIES_EXTEND="@LIBRARIES_EXTEND@"
-LIBRARY_DIRS_EXTEND="@LIBRARY_DIRS_EXTEND@"
-
-QT_INSTALL_LIBS="@QT_INSTALL_LIBS@"
-QT_INSTALL_BINS="@QT_INSTALL_BINS@"
-MSVS_RTLIBS="@MSVS_RTLIBS@"
 
 ## TODO do we need these Boost vars?
 Boost_MAJOR_VERSION="@Boost_MAJOR_VERSION@"
@@ -41,7 +19,6 @@ OPEN_SWATH_ALGO_LIB="@OPEN_SWATH_ALGO_LIB@"
 OPEN_MS_LIB="@OPEN_MS_LIB@"
 PY_NUM_THREADS="@PY_NUM_THREADS@"
 PY_NUM_MODULES="@PY_NUM_MODULES@"
-SYSROOT_OSX_PATH="@SYSROOT_OSX_PATH@"
 
 OPENMS_GIT_LC_DATE_FORMAT="@OPENMS_GIT_LC_DATE_FORMAT@"
 OPENMP_FOUND="@OpenMP_FOUND@"

--- a/src/pyOpenMS/pyproject.toml.test
+++ b/src/pyOpenMS/pyproject.toml.test
@@ -30,7 +30,9 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]
@@ -46,6 +48,7 @@ include_package_data = true
 
 [tool.setuptools.package-data]
 pyopenms = ["*.pxd", "*.pyx", "*.h", "*.cpp"]
+# add py.typed? Or maybe it's included by default by now.
 
 [tool.setuptools.packages.find]
 include = ["pyopenms"]

--- a/src/pyOpenMS/pyproject.toml.test
+++ b/src/pyOpenMS/pyproject.toml.test
@@ -1,0 +1,68 @@
+[build-system]
+requires = [
+    "cython >= 3",
+    # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
+    # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
+    # define).  For older Python versions (where NumPy 1.25 is not yet available)
+    # continue using oldest-support-numpy.
+    "oldest-supported-numpy>=0.14; python_version<'3.9'",
+    "numpy>=1.25; python_version>='3.9'",
+    # configuring setuptools_scm in pyproject.toml requires
+    # versions released after 2022
+    "setuptools_scm[toml]>=8",
+    "setuptools>=64",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyopenms"
+dynamic = ["version"]
+description = "Python bindings for OpenMS"
+authors = [{name = "OpenMS Team", email = "openms-support@lists.sourceforge.net"}]
+license = {text = "BSD-3-Clause"}
+maintainers = [
+    {name = "OpenMS Team", email = "openms-support@lists.sourceforge.net"}
+]
+classifiers = [
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
+]
+
+[project.urls]
+Homepage = "https://www.openms.de/"
+Documentation = "https://pyopenms.readthedocs.io/"
+Repository = "https://github.com/OpenMS/OpenMS"
+Issues = "https://github.com/OpenMS/OpenMS/issues"
+
+[tool.setuptools]
+packages = ["pyopenms"]
+zip-safe = false
+include_package_data = true
+
+[tool.setuptools.package-data]
+pyopenms = ["*.pxd", "*.pyx", "*.h", "*.cpp"]
+
+[tool.setuptools.packages.find]
+include = ["pyopenms"]
+namespaces = false
+
+#[project.optional-dependencies]
+#test = [
+#    'pytest',
+#    'hypothesis',
+#    'cffi',
+#    'pytz',
+#    'pandas'
+#]
+
+#[tool.setuptools_scm]
+#root = '..'
+#version_file = 'pyarrow/_generated_version.py'
+#version_scheme = 'guess-next-dev'
+#git_describe_command = 'git describe --dirty --tags --long --match "apache-arrow-[0-9]*.*"'
+#fallback_version = '20.0.0a0'

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -19,12 +19,9 @@ if "--no-optimization" in sys.argv:
     sys.argv.remove("--no-optimization")
 
 # import config
-from env import  (OPEN_MS_COMPILER, PYOPENMS_SRC_DIR, OPEN_MS_GIT_BRANCH, OPEN_MS_BUILD_DIR, OPEN_MS_CONTRIB_BUILD_DIRS,
-                  QT_INSTALL_LIBS, QT_INSTALL_BINS, MSVS_RTLIBS,
-                  OPEN_MS_BUILD_TYPE, OPEN_MS_VERSION, INCLUDE_DIRS_EXTEND, LIBRARIES_EXTEND,
-                  LIBRARY_DIRS_EXTEND, OPEN_MS_LIB, OPEN_SWATH_ALGO_LIB, PYOPENMS_INCLUDE_DIRS,
-                  PY_NUM_MODULES, PY_NUM_THREADS, SYSROOT_OSX_PATH, LIBRARIES_TO_BE_PARSED_EXTEND,
-                  OPENMS_GIT_LC_DATE_FORMAT, OPENMP_FOUND, OPENMP_CXX_FLAGS)
+from env import  (OPEN_MS_COMPILER, PYOPENMS_SRC_DIR, OPEN_MS_GIT_BRANCH, OPEN_MS_BUILD_DIR,
+                  OPEN_MS_BUILD_TYPE, OPEN_MS_VERSION, PYOPENMS_INCLUDE_DIRS,
+                  PY_NUM_MODULES, OPENMS_GIT_LC_DATE_FORMAT, OPENMP_FOUND, OPENMP_CXX_FLAGS)
 
 IS_DEBUG = OPEN_MS_BUILD_TYPE.upper() == "DEBUG"
 OMP = (OPENMP_FOUND.upper() == "ON" or OPENMP_FOUND.upper() == "TRUE" or OPENMP_FOUND == "1")
@@ -38,7 +35,6 @@ import os
 import glob
 import re
 import shutil
-import time
 
 if OPEN_MS_GIT_BRANCH == "nightly":
     package_name = "pyopenms"
@@ -68,15 +64,6 @@ from setuptools import setup, Extension
 with open("pyopenms/version.py", "w") as fp:
     print("version=%r" % package_version, file=fp)
 
-# parse config
-
-if OPEN_MS_CONTRIB_BUILD_DIRS.endswith(";"):
-    OPEN_MS_CONTRIB_BUILD_DIRS = OPEN_MS_CONTRIB_BUILD_DIRS[:-1]
-
-for OPEN_MS_CONTRIB_BUILD_DIR in OPEN_MS_CONTRIB_BUILD_DIRS.split(";"):
-    if os.path.exists(os.path.join(OPEN_MS_CONTRIB_BUILD_DIR, "lib")):
-        break
-
 
 # Package data expected to be installed. On Linux the debian package
 # contains share/ data and must be installed to get access to the OpenMS shared
@@ -102,62 +89,23 @@ if (iswin):
                     j(OPEN_MS_BUILD_DIR, "lib", "Release"),
                     j(OPEN_MS_BUILD_DIR, "bin", "Release"),
                     j(OPEN_MS_BUILD_DIR, "Release"),
-                    QT_INSTALL_BINS,
-                    QT_INSTALL_LIBS,
                     ]
 else:
     library_dirs = [OPEN_MS_BUILD_DIR,
                 j(OPEN_MS_BUILD_DIR, "lib"),
                 j(OPEN_MS_BUILD_DIR, "bin"),
-                QT_INSTALL_BINS,
-                QT_INSTALL_LIBS,
                 ]
-
-# extend with contrib lib dirs
-for OPEN_MS_CONTRIB_BUILD_DIR in OPEN_MS_CONTRIB_BUILD_DIRS.split(";"):
-  library_dirs.append(j(OPEN_MS_CONTRIB_BUILD_DIR, "lib"))
-
-import numpy
-
 
 include_dirs = [
     "extra_includes",
-    j(numpy.core.__path__[0], "include")
 ]
 
 # append all include and library dirs exported by CMake
 include_dirs.extend(PYOPENMS_INCLUDE_DIRS.split(";"))
 
-if INCLUDE_DIRS_EXTEND: # only add if not empty
-    include_dirs.extend(INCLUDE_DIRS_EXTEND.split(";"))
-if LIBRARY_DIRS_EXTEND: # only add if not empty
-    library_dirs.extend(LIBRARY_DIRS_EXTEND.split(";"))
-if LIBRARIES_EXTEND: # only add if not empty
-    libraries.extend(LIBRARIES_EXTEND.split(";"))
-
 
 # libraries of any type to be parsed and added
 objects = []
-add_libs = LIBRARIES_TO_BE_PARSED_EXTEND.split(";")
-for lib in add_libs:
-  if not iswin:
-    if lib.endswith(".a"):
-      objects.append(lib)
-      name_search = re.search('.*/lib(.*)\.a$', lib)
-      if name_search:
-        libraries.append(name_search.group(1))
-        library_dirs.append(os.path.dirname(lib))
-    if lib.endswith(".so") or lib.endswith(".dylib"):
-      name_search = re.search('.*/lib(.*)\.(so|dylib)$', lib)
-      if name_search:
-        libraries.append(name_search.group(1))
-        library_dirs.append(os.path.dirname(lib))
-  else:
-    if lib.endswith(".lib"):
-      name_search = re.search('.*/(.*)\.lib$', lib)
-      if name_search:
-        libraries.append(name_search.group(1))
-        library_dirs.append(os.path.dirname(lib))
 
 
 extra_link_args = []
@@ -198,9 +146,6 @@ if not iswin:
         extra_link_args.append("-mmacosx-version-min=10.9") # due to libc++
         extra_compile_args.append("-Wno-deprecated")
         extra_compile_args.append("-Wno-nullability-completeness")
-        if (osx_ver >= "10.14.0" and SYSROOT_OSX_PATH): # since macOS Mojave
-            extra_link_args.append("-isysroot" + SYSROOT_OSX_PATH)
-            extra_compile_args.append("-isysroot" + SYSROOT_OSX_PATH)
     else:
         extra_compile_args.append("-Wno-deprecated-copy")
     extra_compile_args.append("-Wno-redeclared-class-member")

--- a/src/pyOpenMS/setup_new_approach.py
+++ b/src/pyOpenMS/setup_new_approach.py
@@ -1,0 +1,310 @@
+
+#!/usr/bin/env python
+
+# THIS IS ADAPTED FROM PYARROW
+# https://github.com/apache/arrow/blob/main/python/setup.py
+
+
+# All the package metadata and build+run dependencies goes to
+# pyproject.toml. This setup.py is only for building/registering
+# the C++ extensions.
+
+# Idea is:
+#  - if run outside of the general OpenMS CMake script,
+#  the setup.py just calls cmake --build pyopenms, collects the
+#  extension modules and declares them as output
+#  - if run inside the general OpenMS CMake script, the setup.py
+#  reads the generated env.py and uses that to add the
+#  modules to be expected from the build to ext_modules
+
+
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import os
+import os.path
+from os.path import join as pjoin
+import re
+import shlex
+import sys
+import warnings
+try:
+    import env
+except ImportError:
+    print("Info: env.py not found. Which means running outside of a CMake process.")
+
+if sys.version_info >= (3, 10):
+    import sysconfig
+else:
+    # Get correct EXT_SUFFIX on Windows (https://bugs.python.org/issue39825)
+    from distutils import sysconfig
+
+from setuptools import setup, Extension, Distribution
+
+from Cython.Distutils import build_ext as _build_ext
+import Cython
+
+# Check if we're running 64-bit Python
+is_64_bit = sys.maxsize > 2**32
+
+
+if Cython.__version__ < '3':
+    raise Exception(
+        'Please update your Cython version. Supported Cython >= 3')
+
+setup_dir = os.path.abspath(os.path.dirname(__file__))
+
+ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+
+
+@contextlib.contextmanager
+def changed_dir(dirname):
+    oldcwd = os.getcwd()
+    os.chdir(dirname)
+    try:
+        yield
+    finally:
+        os.chdir(oldcwd)
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    # Copied from distutils
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
+class build_ext(_build_ext):
+    _found_names = ()
+
+    def build_extensions(self):
+        import numpy
+        numpy_incl = numpy.get_include()
+
+        self.extensions = [ext for ext in self.extensions
+                           if ext.name != '__dummy__']
+
+        for ext in self.extensions:
+            if (hasattr(ext, 'include_dirs') and
+                    numpy_incl not in ext.include_dirs):
+                ext.include_dirs.append(numpy_incl)
+        _build_ext.build_extensions(self)
+
+    def run(self):
+        self._run_cmake()
+        _build_ext.run(self)
+
+    # adapted from cmake_build_ext in dynd-python
+    # github.com/libdynd/dynd-python
+
+    description = "Build the C-extensions for arrow"
+    user_options = ([('cmake-generator=', None, 'CMake generator'),
+                     ('extra-cmake-args=', None, 'extra arguments for CMake'),
+                     ('num_modules=', None, 'number of modules to split cython cpps into'),
+                     ('num_threads=', None, 'number of threads to use for building, i.e. how many modules to build in parallel'),
+                     ('build-type=', None, 'build type (debug or release), default release'),] +
+                    _build_ext.user_options)
+
+    def initialize_options(self):
+        _build_ext.initialize_options(self)
+        self.cmake_generator = os.environ.get('OPENMS_CMAKE_GENERATOR')
+        if not self.cmake_generator and sys.platform == 'win32':
+            self.cmake_generator = 'Visual Studio 15 2017 Win64'
+        self.extra_cmake_args = os.environ.get('OPENMS_CMAKE_OPTIONS', '')
+        self.build_type = os.environ.get('OPENMS_BUILD_TYPE',
+                                         'release').lower()
+
+        self.cmake_cxxflags = os.environ.get('OPENMS_CXXFLAGS', '')
+
+        if sys.platform == 'win32':
+            # Cannot do debug builds in Windows unless Python itself is a debug
+            # build
+            if not hasattr(sys, 'gettotalrefcount'):
+                self.build_type = 'release'
+
+
+    def _run_cmake(self):
+        # check if build_type is correctly passed / set
+        if self.build_type.lower() not in ('release', 'debug',
+                                           'relwithdebinfo'):
+            raise ValueError("--build-type (or OPENMS_BUILD_TYPE) needs to "
+                             "be 'release', 'debug' or 'relwithdebinfo'")
+
+        # The directory containing this setup.py
+        source = os.path.dirname(os.path.abspath(__file__))
+
+        # The staging directory for the module being built
+        build_cmd = self.get_finalized_command('build')
+        saved_cwd = os.getcwd()
+        build_temp = pjoin(saved_cwd, build_cmd.build_temp)
+        build_lib = pjoin(saved_cwd, build_cmd.build_lib)
+
+        if not os.path.isdir(build_temp):
+            self.mkpath(build_temp)
+
+        if self.inplace:
+            # a bit hacky
+            build_lib = saved_cwd
+
+        install_prefix = pjoin(build_lib, "OPENMS")
+
+        # Change to the build directory
+        with changed_dir(build_temp):
+            # Detect if we built elsewhere
+            if os.path.isfile('CMakeCache.txt'):
+                cachefile = open('CMakeCache.txt', 'r')
+                cachedir = re.search('CMAKE_CACHEFILE_DIR:INTERNAL=(.*)',
+                                     cachefile.read()).group(1)
+                cachefile.close()
+                if (cachedir != build_temp):
+                    build_base = pjoin(saved_cwd, build_cmd.build_base)
+                    print(f"-- Skipping build. Temp build {build_temp} does "
+                          f"not match cached dir {cachedir}")
+                    print("---- For a clean build you might want to delete "
+                          f"{build_base}.")
+                    return
+
+            cmake_options = [
+                f'-DCMAKE_INSTALL_PREFIX={install_prefix}',
+                f'-DPYTHON_EXECUTABLE={sys.executable}',
+                f'-DPython3_EXECUTABLE={sys.executable}',
+                f'-DOPENMS_CXXFLAGS={self.cmake_cxxflags}',
+            ]
+
+            def append_cmake_bool(value, varname):
+                cmake_options.append('-D{0}={1}'.format(
+                    varname, 'on' if value else 'off'))
+
+            def append_cmake_component(flag, varname):
+                # only pass this to cmake if the user pass the --with-component
+                # flag to setup.py build_ext
+                if flag is not None:
+                    flag_name = (
+                        "--with-"
+                        + varname.removeprefix("OPENMS_").lower().replace("_", "-"))
+                    warnings.warn(
+                        MSG_DEPR_SETUP_BUILD_FLAGS.format(flag_name),
+                        UserWarning, stacklevel=2
+                    )
+                    append_cmake_bool(flag, varname)
+
+            if self.cmake_generator:
+                cmake_options += ['-G', self.cmake_generator]
+
+            append_cmake_bool(self.bundle_cython_cpp,
+                              'OPENMS_BUNDLE_CYTHON_CPP')
+            append_cmake_bool(self.generate_coverage,
+                              'OPENMS_GENERATE_COVERAGE')
+
+            cmake_options.append(
+                f'-DCMAKE_BUILD_TYPE={self.build_type.lower()}')
+
+            extra_cmake_args = shlex.split(self.extra_cmake_args)
+
+            build_tool_args = []
+            if sys.platform == 'win32':
+                if not is_64_bit:
+                    raise RuntimeError('Not supported on 32-bit Windows')
+            else:
+                build_tool_args.append('--')
+                if os.environ.get('OPENMS_BUILD_VERBOSE', '0') == '1':
+                    cmake_options.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
+                parallel = os.environ.get('OPENMS_PARALLEL')
+                if parallel:
+                    build_tool_args.append(f'-j{parallel}')
+
+            # Generate the build files
+            print("-- Running cmake for OPENMS")
+            self.spawn(['cmake'] + extra_cmake_args + cmake_options + [source])
+
+            print("-- Finished cmake for OPENMS")
+
+            print("-- Running cmake --build for OPENMS")
+            self.spawn(['cmake', '--build', '.', '--config', self.build_type] +
+                       build_tool_args)
+            print("-- Finished cmake --build for OPENMS")
+
+            print("-- Running cmake --build --target install for OPENMS")
+            self.spawn(['cmake', '--build', '.', '--config', self.build_type] +
+                       ['--target', 'install'] + build_tool_args)
+            print("-- Finished cmake --build --target install for OPENMS")
+
+            self._found_names = []
+            for name in self.CYTHON_MODULE_NAMES:
+                built_path = pjoin(install_prefix, name + ext_suffix)
+                if os.path.exists(built_path):
+                    self._found_names.append(name)
+
+    def _get_build_dir(self):
+        # Get the package directory from build_py
+        build_py = self.get_finalized_command('build_py')
+        return build_py.get_package_dir('OPENMS')
+
+    def _get_cmake_ext_path(self, name):
+        # This is the name of the arrow C-extension
+        filename = name + ext_suffix
+        return pjoin(self._get_build_dir(), filename)
+
+    def get_ext_generated_cpp_source(self, name):
+        if sys.platform == 'win32':
+            head, tail = os.path.split(name)
+            return pjoin(head, tail + ".cpp")
+        else:
+            return pjoin(name + ".cpp")
+
+    def get_ext_built_api_header(self, name):
+        if sys.platform == 'win32':
+            head, tail = os.path.split(name)
+            return pjoin(head, tail + "_api.h")
+        else:
+            return pjoin(name + "_api.h")
+
+    def get_names(self):
+        return self._found_names
+
+    def get_outputs(self):
+        # Just the C extensions
+        # regular_exts = _build_ext.get_outputs(self)
+        return [self._get_cmake_ext_path(name)
+                for name in self.get_names()]
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(foo):
+        return True
+
+
+setup(
+    distclass=BinaryDistribution,
+    # Dummy extension to trigger build_ext
+    ext_modules=[Extension('__dummy__', sources=[])],
+    cmdclass={
+        'build_ext': build_ext
+    },
+)

--- a/src/pyOpenMS/setup_new_approach.py
+++ b/src/pyOpenMS/setup_new_approach.py
@@ -123,7 +123,7 @@ class build_ext(_build_ext):
     # adapted from cmake_build_ext in dynd-python
     # github.com/libdynd/dynd-python
 
-    description = "Build the C-extensions for arrow"
+    description = "Build the Cpp-extensions for OpenMS"
     user_options = ([('cmake-generator=', None, 'CMake generator'),
                      ('extra-cmake-args=', None, 'extra arguments for CMake'),
                      ('num_modules=', None, 'number of modules to split cython cpps into'),


### PR DESCRIPTION
- Simplifies pyopenms GHA for openmp
- Removes old and unused setup.py features that are done in CMake these days (not complete, can be removed further when switching completely to new setup_new.py, we should not have any library/compile definition passing in setup.py anymore since this is done in CMake)
- Suggests a potential way of running CMake from setup.py for standalone builds and builds from global OpenMS CMake based on pyarrow's approach
- moves package metadata into modern pyproject.toml. We could specify build and runtime dependencies there and install them with more powerful packaging tools like uv.

Note: Most things are untested but are suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**  
  - Introduced an updated project metadata file and enhanced build tooling for smoother extension management.
  - Added a new setup script for building and registering C++ extensions.

- **Chores**  
  - Removed deprecated environment settings and redundant configuration to simplify the build process.

- **Refactor**  
  - Streamlined setup and dependency management for more efficient and maintainable operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->