### PR TITLE
Fix broken filterable list boxes

### DIFF
--- a/src/openms_gui/source/VISUAL/MISC/FilterableList.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/FilterableList.cpp
@@ -107,8 +107,7 @@ namespace OpenMS
 
     void FilterableList::updateVisibleList_()
     {
-      QRegularExpression regex(QRegularExpression::wildcardToRegularExpression(ui_->filter_text->text()),
-                               QRegularExpression::CaseInsensitiveOption);
+      QRegularExpression regex(ui_->filter_text->text(), QRegularExpression::CaseInsensitiveOption);
       ui_->list_items->clear();
       ui_->list_items->addItems(items_wo_bl_.filter(regex));
     }


### PR DESCRIPTION
Don't use wildcardToRegularExpression. Fixes https://github.com/OpenMS/OpenMS/issues/7941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced list filtering to provide a more consistent and responsive search experience while maintaining case-insensitivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->