### PR TITLE
Fix deb dependencies

### DIFF
--- a/cmake/package_deb.cmake
+++ b/cmake/package_deb.cmake
@@ -74,7 +74,7 @@ set(CPACK_COMPONENTS_ALL applications doc library share ${THIRDPARTY_COMPONENT_G
 ## Autogeneration with SHLIBDEPS will add to this variable. For now we include most things statically and require the standard Qt package and libc6 only.
 ## (only available in Ubuntu >=17.10). For older Ubuntu, dependencies can be installed from a thirdparty repo.
 set(CPACK_DEBIAN_PACKAGE_DEPENDS 
-  "qt6base-dev (>= 6.2.2), libqt6svg6 (>= 6.2.2), libc6 (>= 2.28), libqt6widgets6t64 (>= 6.2.2) | libqt6widget6 (>= 6.2.2), libqt6gui6t64 (>= 6.2.2) | libqt6gui6 (>= 6.2.2), libqt6core6t64 (>= 6.2.2) | libqt6core6 (>= 6.2.2)")
+  "libqt6svg6 (>= 6.2.2), libc6 (>= 2.28), libqt6widgets6t64 (>= 6.2.2) | libqt6widget6 (>= 6.2.2), libqt6gui6t64 (>= 6.2.2) | libqt6gui6 (>= 6.2.2), libqt6core6t64 (>= 6.2.2) | libqt6core6 (>= 6.2.2)")
 
 SET(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 SET(CPACK_DEBIAN_PACKAGE_SECTION "science")


### PR DESCRIPTION
qt6-base-dev not required for OpenMS usage. qt6base-dev (with no first dash) doesn't even exist. So remove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package dependency configuration to remove an obsolete entry while preserving all necessary version constraints for a more robust setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->