### PR TITLE
DOC: Minor update to OSW TOPP doc

### DIFF
--- a/share/OpenMS/examples/CHROMATOGRAMS/Spyogenes.chrom.mzML
+++ b/share/OpenMS/examples/CHROMATOGRAMS/Spyogenes.chrom.mzML
@@ -59,7 +59,7 @@
 				<userParam name="parameter: rt_norm" type="xsd:string" value=""/>
 				<userParam name="parameter: swath_windows_file" type="xsd:string" value="strep_win.txt"/>
 				<userParam name="parameter: sort_swath_maps" type="xsd:string" value="true"/>
-				<userParam name="parameter: use_ms1_traces" type="xsd:string" value="true"/>
+				<userParam name="parameter: enable_ms1" type="xsd:string" value="true"/>
 				<userParam name="parameter: enable_uis_scoring" type="xsd:string" value="false"/>
 				<userParam name="parameter: out_features" type="xsd:string" value=""/>
 				<userParam name="parameter: out_tsv" type="xsd:string" value="/localscratch/hroest.4041515.0/output.tsv"/>

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -130,7 +130,7 @@ window for the retention time. In m/z domain, consider adjusting
 @p -mz_extraction_window to your instrument resolution, which can be in Th or
 ppm.
 
-Furthermore, if you wish to use MS1 information, use the @p -use_ms1_traces flag
+Furthermore, if you wish to use MS1 information, use the @p -enable_ms1 flag
 and provide an MS1 map in addition to the SWATH data.
 
 If you encounter issues with peak picking, try to disable peak filtering by


### PR DESCRIPTION
## Description

The main TOPP doc for OpenSwathWorkflow still had a reference to `use_ms1_traces`, so I just updated it to the changed `enable_ms1` name that is used now. Also updated the example output chrom mzML file param to use `enable_ms1`.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming for the MS1 option in both configuration examples and the command-line interface to "enable_ms1" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->