### PR TITLE
discussion: Add IMFrameView class for spectrum handling

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/IMFrameView.h
+++ b/src/openms/include/OpenMS/KERNEL/IMFrameView.h
@@ -221,6 +221,3 @@ namespace OpenMS
   }; // class IMFrameView
 
 } // namespace OpenMS
-
-// Free function to create an IMFrameView from an MSSpectrum reference
-OpenMS::IMFrameView make_imframe(OpenMS::MSSpectrum& spectrum);

--- a/src/openms/include/OpenMS/KERNEL/IMFrameView.h
+++ b/src/openms/include/OpenMS/KERNEL/IMFrameView.h
@@ -1,0 +1,226 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------
+// $Maintainer: OpenMS Team $
+// $Authors: OpenMS Team $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/DATASTRUCTURES/DataValue.h>
+#include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/CONCEPT/Exception.h> // Include for exceptions
+
+#include <vector>
+#include <string>
+#include <numeric>
+#include <algorithm>
+
+namespace OpenMS
+{
+  /**
+    @brief Provides a non-owning view/adapter for an MSSpectrum containing centroided Ion Mobility data.
+
+    This class wraps a pointer to an MSSpectrum (MSSpectrum*) that is assumed to be
+    centroided and MUST contain a FloatDataArray with ion mobility data
+    (as determined by MSSpectrum::containsIMData()) with drift time values
+    corresponding to each peak.
+
+    It provides convenient accessors for m/z, intensity, and drift time. Sorting
+    operations modify the underlying MSSpectrum object directly.
+
+    @warning This class stores a raw pointer (MSSpectrum*). The user is responsible
+             for ensuring that the pointed-to MSSpectrum object remains valid for
+             the lifetime of the IMFrameView object. Using a dangling pointer will
+             lead to undefined behavior (likely crashes).
+
+    @ingroup Kernel
+  */
+  class OPENMS_DLLAPI IMFrameView
+  {
+  public:
+    /// Struct to hold peak data (m/z, intensity, drift time) for convenience
+    /// (Identical to the previous version)
+    struct IMPeak
+    {
+        double mz = 0.0;
+        float intensity = 0.0f;
+        double drift_time = 0.0; // Use double for external interface consistency
+
+        IMPeak() = default;
+        IMPeak(double mz, float intensity, double dt) :
+          mz(mz), intensity(intensity), drift_time(dt) {}
+
+        bool operator==(const IMPeak& other) const {
+            return mz == other.mz && intensity == other.intensity && drift_time == other.drift_time;
+        }
+        bool operator!=(const IMPeak& other) const {
+            return !(*this == other);
+        }
+    };
+
+    ///@name Constructors and Destructor
+    ///@{
+
+    /// Constructor requires a pointer to an existing MSSpectrum.
+    /// Performs validation checks on the pointed-to spectrum:
+    /// - Pointer must not be null.
+    /// - Spectrum must be centroided.
+    /// - Spectrum must contain a FloatDataArray with ion mobility data (IMFormat::CONCATENATED).
+    /// - The drift time array must have the same size as the number of peaks.
+    /// Throws Exception::NullPointer, Exception::InvalidValue, or Exception::MissingInformation if validation fails.
+    explicit IMFrameView(MSSpectrum* spectrum_ptr);
+
+    // Default copy/move constructors/assignments are okay as they just copy/move the pointer.
+    // The user remains responsible for the lifetime of the pointed-to object.
+    IMFrameView(const IMFrameView& source) = default;
+    IMFrameView(IMFrameView&& source) noexcept = default;
+    IMFrameView& operator=(const IMFrameView& source) = default;
+    IMFrameView& operator=(IMFrameView&& source) noexcept = default;
+
+
+    /// Destructor (does not delete the pointed-to spectrum)
+    virtual ~IMFrameView();
+    ///@}
+
+    ///@name Accessors (Const methods provide read-only access)
+    ///@{
+    /// Returns a const pointer to the underlying MSSpectrum.
+    const MSSpectrum* getSpectrum() const;
+
+    /// Returns a pointer to the underlying MSSpectrum.
+    /// @warning Use caution when modifying the spectrum directly, as it might
+    /// invalidate the assumptions of the IMFrameView (e.g., drift time consistency)
+    /// if not done carefully. Prefer IMFrameView methods where possible.
+    MSSpectrum* getSpectrum();
+
+    /// Read-only access to the peaks as IMPeak structs. Constructs these on the fly. (const)
+    std::vector<IMPeak> getPeaks() const;
+
+    /// Read-only access to m/z values (const)
+    std::vector<double> getMZArray() const;
+
+    /// Read-only access to intensity values (const)
+    std::vector<float> getIntensityArray() const;
+
+    /// Read-only access to drift time values (converted to double) (const)
+    std::vector<double> getDriftTimeArray() const;
+
+    /// Returns the number of peaks in the frame (const)
+    Size size() const;
+
+    /// Returns true if the frame is empty (no peaks) (const)
+    bool empty() const;
+
+    /// Returns true if the object is valid (const)
+    /// Note: The constructor already validates the spectrum, so this will always return true
+    /// for a successfully constructed object.
+    bool isValid() const; 
+
+    /// Gets a const pointer to the FloatDataArray containing drift times. (const)
+    /// Returns nullptr if not found or if name mismatch. Size check is separate.
+    const MSSpectrum::FloatDataArray* getDriftTimeDataArrayPtr() const;
+
+    /// Returns the retention time (const)
+    double getRT() const;
+
+    /// Sets the retention time on the underlying spectrum (non-const)
+    void setRT(double rt);
+
+    /// Returns the MS level (const)
+    UInt getMSLevel() const;
+
+    /// Sets the MS level on the underlying spectrum (non-const)
+    void setMSLevel(UInt level);
+
+    /// Gets the native ID string (const)
+    const std::string& getNativeID() const;
+
+    /// Sets the native ID string on the underlying spectrum (non-const)
+    void setNativeID(const std::string& id);
+
+    // Add other relevant getters (const) / setters (non-const) as needed
+    ///@}
+
+    ///@name Operations (Modify the underlying spectrum)
+    ///@{
+
+    /// Sorts peaks by m/z value (ascending). Also sorts drift times accordingly. (non-const)
+    /// Modifies the underlying MSSpectrum and its FloatDataArray.
+    void sortByMZ();
+
+    /// Sorts peaks by intensity. Also sorts drift times accordingly. (non-const)
+    /// Modifies the underlying MSSpectrum and its FloatDataArray.
+    void sortByIntensity(bool reverse = true);
+
+    /// Sorts peaks by drift time (ascending). Also sorts drift times accordingly. (non-const)
+    /// Modifies the underlying MSSpectrum and its FloatDataArray.
+    void sortByDriftTime();
+
+    ///@}
+
+    ///@name Comparison operators (Compare pointers for identity, or underlying spectra for equality)
+    ///@{
+    /// Equality operator: Compares the underlying spectra for value equality.
+    bool operator==(const IMFrameView& rhs) const;
+
+    /// Inequality operator
+    bool operator!=(const IMFrameView& rhs) const;
+    ///@}
+
+  private:
+    /// Pointer to the non-owned MSSpectrum object.
+    MSSpectrum* spectrum_ptr_;
+
+    /// Helper to find the drift time array (const version)
+    const MSSpectrum::FloatDataArray* findDriftTimeArray_() const;
+
+    /// Helper to find the drift time array (non-const version for sorting)
+    MSSpectrum::FloatDataArray* findDriftTimeArray_();
+
+    /// Performs validation checks on the pointed-to spectrum. Called by constructor. (const)
+    void validateSpectrum_(const std::string& context_message = "") const;
+
+    /// Internal sorting helper (operates on *spectrum_ptr_ and its drift time array) (non-const)
+    template <typename Compare> 
+    void sortPeaksAndDriftTime_(Compare comp)
+    {
+        checkPointer_();
+        
+        MSSpectrum* spec = spectrum_ptr_;
+        
+        // Create a vector of indices
+        std::vector<Size> indices(spec->size());
+        std::iota(indices.begin(), indices.end(), 0);
+        
+        // Sort the indices based on the comparison function
+        std::stable_sort(indices.begin(), indices.end(), 
+                        [&](Size i, Size j) { return comp(i, j); });
+        
+        // Use MSSpectrum::select to reorder the peaks and all data arrays
+        spec->select(indices);
+    }
+
+    /// Internal helper to check pointer validity
+    inline void checkPointer_() const
+    {
+        // This check should ideally only fail if the object was moved from
+        // or if constructed with nullptr (which constructor prevents).
+        // It doesn't protect against the underlying object being deleted elsewhere.
+        if (!spectrum_ptr_) {
+             throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Internal spectrum pointer is null. View is invalid (e.g., moved from?).");
+        }
+    }
+
+
+  }; // class IMFrameView
+
+} // namespace OpenMS
+
+// Free function to create an IMFrameView from an MSSpectrum reference
+OpenMS::IMFrameView make_imframe(OpenMS::MSSpectrum& spectrum);

--- a/src/openms/include/OpenMS/KERNEL/sources.cmake
+++ b/src/openms/include/OpenMS/KERNEL/sources.cmake
@@ -17,6 +17,7 @@ DPeak.h
 Feature.h
 FeatureHandle.h
 FeatureMap.h
+IMFrameView.h
 MassTrace.h
 MobilityPeak1D.h
 MobilityPeak2D.h

--- a/src/openms/source/KERNEL/IMFrameView.cpp
+++ b/src/openms/source/KERNEL/IMFrameView.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------
+// $Maintainer: OpenMS Team $
+// $Authors: OpenMS Team $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/KERNEL/IMFrameView.h>
+
+namespace OpenMS
+{
+  IMFrameView::IMFrameView(MSSpectrum* spectrum_ptr) : spectrum_ptr_(spectrum_ptr)
+  {
+    validateSpectrum_("Constructor");
+  }
+
+  IMFrameView::~IMFrameView() = default;
+
+  const MSSpectrum* IMFrameView::getSpectrum() const
+  {
+    checkPointer_();
+    return spectrum_ptr_;
+  }
+
+  MSSpectrum* IMFrameView::getSpectrum()
+  {
+    checkPointer_();
+    return spectrum_ptr_;
+  }
+
+  std::vector<IMFrameView::IMPeak> IMFrameView::getPeaks() const
+  {
+    checkPointer_();
+    
+    const MSSpectrum* spec = spectrum_ptr_;
+    const MSSpectrum::FloatDataArray* drift_times = findDriftTimeArray_();
+    
+    std::vector<IMPeak> result;
+    result.reserve(spec->size());
+    
+    for (Size i = 0; i < spec->size(); ++i)
+    {
+      const Peak1D& peak = (*spec)[i];
+      result.emplace_back(peak.getMZ(), peak.getIntensity(), static_cast<double>((*drift_times)[i]));
+    }
+    
+    return result;
+  }
+
+  std::vector<double> IMFrameView::getMZArray() const
+  {
+    checkPointer_();
+    
+    const MSSpectrum* spec = spectrum_ptr_;
+    std::vector<double> result;
+    result.reserve(spec->size());
+    
+    for (Size i = 0; i < spec->size(); ++i)
+    {
+      result.push_back((*spec)[i].getMZ());
+    }
+    
+    return result;
+  }
+
+  std::vector<float> IMFrameView::getIntensityArray() const
+  {
+    checkPointer_();
+    
+    const MSSpectrum* spec = spectrum_ptr_;
+    std::vector<float> result;
+    result.reserve(spec->size());
+    
+    for (Size i = 0; i < spec->size(); ++i)
+    {
+      result.push_back((*spec)[i].getIntensity());
+    }
+    
+    return result;
+  }
+
+  std::vector<double> IMFrameView::getDriftTimeArray() const
+  {
+    checkPointer_();
+    
+    const MSSpectrum::FloatDataArray* drift_times = findDriftTimeArray_();
+    std::vector<double> result;
+    result.reserve(drift_times->size());
+    
+    for (Size i = 0; i < drift_times->size(); ++i)
+    {
+      result.push_back(static_cast<double>((*drift_times)[i]));
+    }
+    
+    return result;
+  }
+
+  Size IMFrameView::size() const
+  {
+    checkPointer_();
+    return spectrum_ptr_->size();
+  }
+
+  bool IMFrameView::empty() const
+  {
+    checkPointer_();
+    return spectrum_ptr_->empty();
+  }
+
+  bool IMFrameView::isValid() const
+  {
+    try
+    {
+      validateSpectrum_("isValid");
+      return true;
+    }
+    catch (...)
+    {
+      return false;
+    }
+  }
+
+  const MSSpectrum::FloatDataArray* IMFrameView::getDriftTimeDataArrayPtr() const
+  {
+    checkPointer_();
+    return findDriftTimeArray_();
+  }
+
+  double IMFrameView::getRT() const
+  {
+    checkPointer_();
+    return spectrum_ptr_->getRT();
+  }
+
+  void IMFrameView::setRT(double rt)
+  {
+    checkPointer_();
+    spectrum_ptr_->setRT(rt);
+  }
+
+  UInt IMFrameView::getMSLevel() const
+  {
+    checkPointer_();
+    return spectrum_ptr_->getMSLevel();
+  }
+
+  void IMFrameView::setMSLevel(UInt level)
+  {
+    checkPointer_();
+    spectrum_ptr_->setMSLevel(level);
+  }
+
+  const std::string& IMFrameView::getNativeID() const
+  {
+    checkPointer_();
+    return spectrum_ptr_->getNativeID();
+  }
+
+  void IMFrameView::setNativeID(const std::string& id)
+  {
+    checkPointer_();
+    spectrum_ptr_->setNativeID(id);
+  }
+
+  void IMFrameView::sortByMZ()
+  {
+    checkPointer_();
+    
+    // Use the template method with a comparator for m/z
+    sortPeaksAndDriftTime_([spec = spectrum_ptr_](Size i, Size j) {
+      return (*spec)[i].getMZ() < (*spec)[j].getMZ();
+    });
+  }
+
+  void IMFrameView::sortByIntensity(bool reverse)
+  {
+    checkPointer_();
+    
+    // Use the template method with a comparator for intensity
+    if (reverse)
+    {
+      sortPeaksAndDriftTime_([spec = spectrum_ptr_](Size i, Size j) {
+        return (*spec)[i].getIntensity() > (*spec)[j].getIntensity();
+      });
+    }
+    else
+    {
+      sortPeaksAndDriftTime_([spec = spectrum_ptr_](Size i, Size j) {
+        return (*spec)[i].getIntensity() < (*spec)[j].getIntensity();
+      });
+    }
+  }
+
+  void IMFrameView::sortByDriftTime()
+  {
+    checkPointer_();
+    
+    // Use the template method with a comparator for drift time
+    MSSpectrum::FloatDataArray* dt_array = findDriftTimeArray_();
+    sortPeaksAndDriftTime_([dt_array](Size i, Size j) {
+      return (*dt_array)[i] < (*dt_array)[j];
+    });
+  }
+
+  bool IMFrameView::operator==(const IMFrameView& rhs) const
+  {
+    // First check if they point to the same spectrum
+    if (spectrum_ptr_ == rhs.spectrum_ptr_)
+    {
+      return true;
+    }
+    
+    // If either pointer is null, they can't be equal (since they're not the same pointer)
+    if (!spectrum_ptr_ || !rhs.spectrum_ptr_)
+    {
+      return false;
+    }
+    
+    // Check if the spectra have the same number of peaks
+    if (spectrum_ptr_->size() != rhs.spectrum_ptr_->size())
+    {
+      return false;
+    }
+    
+    // Get the drift time arrays
+    const MSSpectrum::FloatDataArray* dt_array1 = findDriftTimeArray_();
+    const MSSpectrum::FloatDataArray* dt_array2 = rhs.findDriftTimeArray_();
+    
+    // Check if both have valid drift time arrays of the same size
+    if (!dt_array1 || !dt_array2 || dt_array1->size() != dt_array2->size())
+    {
+      return false;
+    }
+    
+    // Compare each peak and its drift time
+    for (Size i = 0; i < spectrum_ptr_->size(); ++i)
+    {
+      const Peak1D& peak1 = (*spectrum_ptr_)[i];
+      const Peak1D& peak2 = (*rhs.spectrum_ptr_)[i];
+      
+      // Compare m/z, intensity, and drift time
+      if (peak1.getMZ() != peak2.getMZ() ||
+          peak1.getIntensity() != peak2.getIntensity() ||
+          (*dt_array1)[i] != (*dt_array2)[i])
+      {
+        return false;
+      }
+    }
+    
+    // All peaks and drift times are equal
+    return true;
+  }
+
+  bool IMFrameView::operator!=(const IMFrameView& rhs) const
+  {
+    return !(*this == rhs);
+  }
+
+  const MSSpectrum::FloatDataArray* IMFrameView::findDriftTimeArray_() const
+  {
+    checkPointer_();
+    
+    const MSSpectrum* spec = spectrum_ptr_;
+    try
+    {
+      // Get the ion mobility data array index
+      Size im_index = spec->getIMData().first;
+      return &(spec->getFloatDataArrays()[im_index]);
+    }
+    catch (Exception::MissingInformation&)
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Could not find ion mobility data array");
+    }
+  }
+
+  MSSpectrum::FloatDataArray* IMFrameView::findDriftTimeArray_()
+  {
+    checkPointer_();
+    
+    MSSpectrum* spec = spectrum_ptr_;
+    try
+    {
+      // Get the ion mobility data array index
+      Size im_index = spec->getIMData().first;
+      return &(spec->getFloatDataArrays()[im_index]);
+    }
+    catch (Exception::MissingInformation&)
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Could not find ion mobility data array");
+    }
+  }
+
+  void IMFrameView::validateSpectrum_(const std::string& context_message) const
+  {
+    // Check if the pointer is null
+    if (!spectrum_ptr_)
+    {
+      throw Exception::NullPointer(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+    }
+    
+    // Check if the spectrum is centroided
+    if (spectrum_ptr_->getType() != SpectrumSettings::CENTROID)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
+                                  "Spectrum must be centroided. " + context_message,
+                                  "non-centroided");
+    }
+    
+    // Check if the spectrum has the correct ion mobility format (CONCATENATED)
+    if (IMTypes::determineIMFormat(*spectrum_ptr_) != IMFormat::CONCATENATED)
+    {
+      IMFormat format = IMTypes::determineIMFormat(*spectrum_ptr_);
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  "Spectrum must have ion mobility data in CONCATENATED format (with drift time array). " + context_message,
+                                  toString(format));
+    }
+    
+    // Find the drift time array
+    try
+    {
+      // Get the ion mobility data array
+      Size im_index = spectrum_ptr_->getIMData().first;
+      const MSSpectrum::FloatDataArray* dt_array = &(spectrum_ptr_->getFloatDataArrays()[im_index]);
+      
+      // Check if the drift time array has the same size as the number of peaks
+      if (dt_array->size() != spectrum_ptr_->size())
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "Drift time array size (" + std::to_string(dt_array->size()) + 
+                                     ") must match the number of peaks (" + std::to_string(spectrum_ptr_->size()) + 
+                                     "). " + context_message,
+                                     std::to_string(dt_array->size()));
+      }
+    }
+    catch (Exception::MissingInformation&)
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Spectrum must contain an ion mobility data array. " + context_message);
+    }
+  }
+
+
+} // namespace OpenMS

--- a/src/openms/source/KERNEL/IMFrameView.cpp
+++ b/src/openms/source/KERNEL/IMFrameView.cpp
@@ -110,15 +110,8 @@ namespace OpenMS
 
   bool IMFrameView::isValid() const
   {
-    try
-    {
-      validateSpectrum_("isValid");
-      return true;
-    }
-    catch (...)
-    {
-      return false;
-    }
+    // If the constructor succeeded, the spectrum is valid
+    return true;
   }
 
   const MSSpectrum::FloatDataArray* IMFrameView::getDriftTimeDataArrayPtr() const

--- a/src/openms/source/KERNEL/sources.cmake
+++ b/src/openms/source/KERNEL/sources.cmake
@@ -17,6 +17,7 @@ Feature.cpp
 FeatureHandle.cpp
 FeatureMap.cpp
 MassTrace.cpp
+IMFrameView.cpp
 MobilityPeak1D.cpp
 MobilityPeak2D.cpp
 Mobilogram.cpp

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -141,6 +141,7 @@ set(kernel_executables_list
   FeatureMap_test
   Feature_test
   MassTrace_test
+  IMFrameView_test
   Mobilogram_test
   MobilityPeak1D_test
   MobilityPeak2D_test

--- a/src/tests/class_tests/openms/source/IMFrameView_test.cpp
+++ b/src/tests/class_tests/openms/source/IMFrameView_test.cpp
@@ -1,0 +1,606 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: OpenMS Team $
+// $Authors: OpenMS Team $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+#include <OpenMS/KERNEL/IMFrameView.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
+#include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/METADATA/DataArrays.h>
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(IMFrameView, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+// Helper function to create a test spectrum with drift time array
+MSSpectrum createTestSpectrum()
+{
+  MSSpectrum spectrum;
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  Peak1D peak2;
+  peak2.setMZ(200.0);
+  peak2.setIntensity(2000.0f);
+  spectrum.push_back(peak2);
+  
+  Peak1D peak3;
+  peak3.setMZ(300.0);
+  peak3.setIntensity(3000.0f);
+  spectrum.push_back(peak3);
+  
+  // Set spectrum as centroided
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Add drift time array using controlled vocabulary
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(10.0f);
+  drift_times.push_back(20.0f);
+  drift_times.push_back(30.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Set other metadata
+  spectrum.setRT(42.0);
+  spectrum.setMSLevel(1);
+  spectrum.setNativeID("test_spectrum");
+  
+  // Verify that the spectrum has the correct IMFormat
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::CONCATENATED);
+  
+  return spectrum;
+}
+
+// Helper function to create a test spectrum without drift time array
+MSSpectrum createInvalidSpectrum()
+{
+  MSSpectrum spectrum;
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  // Verify that the spectrum has the correct IMFormat
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::NONE);
+  
+  // Set spectrum as centroided
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  return spectrum;
+}
+
+// Helper function to create a test spectrum with mismatched drift time array size
+MSSpectrum createMismatchedSpectrum()
+{
+  MSSpectrum spectrum;
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  Peak1D peak2;
+  peak2.setMZ(200.0);
+  peak2.setIntensity(2000.0f);
+  spectrum.push_back(peak2);
+  
+  // Set spectrum as centroided
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Add drift time array with wrong size
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(10.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Verify that the spectrum has the correct IMFormat
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::CONCATENATED);
+  
+  return spectrum;
+}
+
+// Helper function to create a test spectrum that is not centroided
+MSSpectrum createNonCentroidedSpectrum()
+{
+  MSSpectrum spectrum;
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  // Set spectrum as profile
+  spectrum.setType(SpectrumSettings::PROFILE);
+  
+  // Add drift time array
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(10.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Verify that the spectrum has the correct IMFormat
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::CONCATENATED);
+  
+  return spectrum;
+}
+
+// Helper function to create a test spectrum with MULTIPLE_SPECTRA format
+MSSpectrum createMultipleSpectraFormatSpectrum()
+{
+  MSSpectrum spectrum;
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  // Set spectrum as centroided
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Set drift time directly on the spectrum (MULTIPLE_SPECTRA format)
+  spectrum.setDriftTime(15.0);
+  spectrum.setDriftTimeUnit(DriftTimeUnit::MILLISECOND);
+  
+  // Verify that the spectrum has the correct IMFormat
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::MULTIPLE_SPECTRA);
+  
+  return spectrum;
+}
+
+IMFrameView* imframe_ptr = nullptr;
+IMFrameView* nullPointer = nullptr;
+
+START_SECTION((explicit IMFrameView(MSSpectrum* spectrum_ptr)))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  imframe_ptr = new IMFrameView(&spectrum);
+  TEST_NOT_EQUAL(imframe_ptr, nullPointer)
+}
+END_SECTION
+
+START_SECTION((virtual ~IMFrameView()))
+{
+  delete imframe_ptr;
+}
+END_SECTION
+
+START_SECTION((const MSSpectrum* getSpectrum() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  TEST_EQUAL(imframe.getSpectrum(), &spectrum)
+}
+END_SECTION
+
+START_SECTION((MSSpectrum* getSpectrum()))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  TEST_EQUAL(imframe.getSpectrum(), &spectrum)
+}
+END_SECTION
+
+START_SECTION((std::vector<IMPeak> getPeaks() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  std::vector<IMFrameView::IMPeak> peaks = imframe.getPeaks();
+  
+  TEST_EQUAL(peaks.size(), 3)
+  TEST_REAL_SIMILAR(peaks[0].mz, 100.0)
+  TEST_REAL_SIMILAR(peaks[0].intensity, 1000.0)
+  TEST_REAL_SIMILAR(peaks[0].drift_time, 10.0)
+  
+  TEST_REAL_SIMILAR(peaks[1].mz, 200.0)
+  TEST_REAL_SIMILAR(peaks[1].intensity, 2000.0)
+  TEST_REAL_SIMILAR(peaks[1].drift_time, 20.0)
+  
+  TEST_REAL_SIMILAR(peaks[2].mz, 300.0)
+  TEST_REAL_SIMILAR(peaks[2].intensity, 3000.0)
+  TEST_REAL_SIMILAR(peaks[2].drift_time, 30.0)
+}
+END_SECTION
+
+START_SECTION((std::vector<double> getMZArray() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  std::vector<double> mzs = imframe.getMZArray();
+  
+  TEST_EQUAL(mzs.size(), 3)
+  TEST_REAL_SIMILAR(mzs[0], 100.0)
+  TEST_REAL_SIMILAR(mzs[1], 200.0)
+  TEST_REAL_SIMILAR(mzs[2], 300.0)
+}
+END_SECTION
+
+START_SECTION((std::vector<float> getIntensityArray() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  std::vector<float> intensities = imframe.getIntensityArray();
+  
+  TEST_EQUAL(intensities.size(), 3)
+  TEST_REAL_SIMILAR(intensities[0], 1000.0)
+  TEST_REAL_SIMILAR(intensities[1], 2000.0)
+  TEST_REAL_SIMILAR(intensities[2], 3000.0)
+}
+END_SECTION
+
+START_SECTION((std::vector<double> getDriftTimeArray() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  std::vector<double> drift_times = imframe.getDriftTimeArray();
+  
+  TEST_EQUAL(drift_times.size(), 3)
+  TEST_REAL_SIMILAR(drift_times[0], 10.0)
+  TEST_REAL_SIMILAR(drift_times[1], 20.0)
+  TEST_REAL_SIMILAR(drift_times[2], 30.0)
+}
+END_SECTION
+
+START_SECTION((Size size() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  TEST_EQUAL(imframe.size(), 3)
+}
+END_SECTION
+
+START_SECTION((bool empty() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  TEST_EQUAL(imframe.empty(), false)
+  
+  MSSpectrum empty_spectrum;
+  empty_spectrum.setType(SpectrumSettings::CENTROID);
+  DataArrays::FloatDataArray empty_drift_times;
+  IMDataConverter::setIMUnit(empty_drift_times, DriftTimeUnit::MILLISECOND);
+  empty_spectrum.getFloatDataArrays().push_back(empty_drift_times);
+  
+  IMFrameView empty_imframe(&empty_spectrum);
+  TEST_EQUAL(empty_imframe.empty(), true)
+}
+END_SECTION
+
+START_SECTION((bool isValid() const))
+{
+  MSSpectrum valid_spectrum = createTestSpectrum();
+  IMFrameView valid_imframe(&valid_spectrum);
+  TEST_EQUAL(valid_imframe.isValid(), true)
+  
+  MSSpectrum invalid_spectrum = createInvalidSpectrum();
+  IMFrameView invalid_imframe(&invalid_spectrum);
+  TEST_EQUAL(invalid_imframe.isValid(), false)
+  
+  MSSpectrum mismatched_spectrum = createMismatchedSpectrum();
+  IMFrameView mismatched_imframe(&mismatched_spectrum);
+  TEST_EQUAL(mismatched_imframe.isValid(), false)
+  
+  MSSpectrum non_centroided_spectrum = createNonCentroidedSpectrum();
+  IMFrameView non_centroided_imframe(&non_centroided_spectrum);
+  TEST_EQUAL(non_centroided_imframe.isValid(), false)
+  
+  // Test with a spectrum that has MULTIPLE_SPECTRA format
+  MSSpectrum multiple_spectra_spectrum = createMultipleSpectraFormatSpectrum();
+  
+  // This should be invalid for IMFrameView since it requires CONCATENATED format
+  IMFrameView multiple_spectra_imframe(&multiple_spectra_spectrum);
+  TEST_EQUAL(multiple_spectra_imframe.isValid(), false)
+}
+END_SECTION
+
+START_SECTION((const MSSpectrum::FloatDataArray* getDriftTimeDataArrayPtr() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  const MSSpectrum::FloatDataArray* dt_array = imframe.getDriftTimeDataArrayPtr();
+  
+  TEST_NOT_EQUAL(dt_array, nullPointer)
+  TEST_EQUAL(IMTypes::determineIMFormat(spectrum), IMFormat::CONCATENATED)
+  TEST_EQUAL(dt_array->size(), 3)
+  TEST_REAL_SIMILAR((*dt_array)[0], 10.0)
+  TEST_REAL_SIMILAR((*dt_array)[1], 20.0)
+  TEST_REAL_SIMILAR((*dt_array)[2], 30.0)
+}
+END_SECTION
+
+START_SECTION((double getRT() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  TEST_REAL_SIMILAR(imframe.getRT(), 42.0)
+}
+END_SECTION
+
+START_SECTION((void setRT(double rt)))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  imframe.setRT(99.9);
+  TEST_REAL_SIMILAR(imframe.getRT(), 99.9)
+  TEST_REAL_SIMILAR(spectrum.getRT(), 99.9)
+}
+END_SECTION
+
+START_SECTION((UInt getMSLevel() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  TEST_EQUAL(imframe.getMSLevel(), 1)
+}
+END_SECTION
+
+START_SECTION((void setMSLevel(UInt level)))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  imframe.setMSLevel(2);
+  TEST_EQUAL(imframe.getMSLevel(), 2)
+  TEST_EQUAL(spectrum.getMSLevel(), 2)
+}
+END_SECTION
+
+START_SECTION((const std::string& getNativeID() const))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  TEST_EQUAL(imframe.getNativeID(), "test_spectrum")
+}
+END_SECTION
+
+START_SECTION((void setNativeID(const std::string& id)))
+{
+  MSSpectrum spectrum = createTestSpectrum();
+  IMFrameView imframe(&spectrum);
+  
+  imframe.setNativeID("new_id");
+  TEST_EQUAL(imframe.getNativeID(), "new_id")
+  TEST_EQUAL(spectrum.getNativeID(), "new_id")
+}
+END_SECTION
+
+START_SECTION((void sortByMZ()))
+{
+  MSSpectrum spectrum;
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Add peaks in unsorted order
+  Peak1D peak1;
+  peak1.setMZ(300.0);
+  peak1.setIntensity(3000.0f);
+  spectrum.push_back(peak1);
+  
+  Peak1D peak2;
+  peak2.setMZ(100.0);
+  peak2.setIntensity(1000.0f);
+  spectrum.push_back(peak2);
+  
+  Peak1D peak3;
+  peak3.setMZ(200.0);
+  peak3.setIntensity(2000.0f);
+  spectrum.push_back(peak3);
+  
+  // Add drift time array in corresponding order
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(30.0f);
+  drift_times.push_back(10.0f);
+  drift_times.push_back(20.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Create IMFrameView and sort
+  IMFrameView imframe(&spectrum);
+  imframe.sortByMZ();
+  
+  // Check if peaks are sorted by m/z
+  TEST_EQUAL(spectrum.size(), 3)
+  TEST_REAL_SIMILAR(spectrum[0].getMZ(), 100.0)
+  TEST_REAL_SIMILAR(spectrum[1].getMZ(), 200.0)
+  TEST_REAL_SIMILAR(spectrum[2].getMZ(), 300.0)
+  
+  // Check if drift times are sorted accordingly
+  const MSSpectrum::FloatDataArray* dt_array = imframe.getDriftTimeDataArrayPtr();
+  TEST_EQUAL(dt_array->size(), 3)
+  TEST_REAL_SIMILAR((*dt_array)[0], 10.0)
+  TEST_REAL_SIMILAR((*dt_array)[1], 20.0)
+  TEST_REAL_SIMILAR((*dt_array)[2], 30.0)
+}
+END_SECTION
+
+START_SECTION((void sortByIntensity(bool reverse = true)))
+{
+  MSSpectrum spectrum;
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  Peak1D peak2;
+  peak2.setMZ(200.0);
+  peak2.setIntensity(3000.0f);
+  spectrum.push_back(peak2);
+  
+  Peak1D peak3;
+  peak3.setMZ(300.0);
+  peak3.setIntensity(2000.0f);
+  spectrum.push_back(peak3);
+  
+  // Add drift time array
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(10.0f);
+  drift_times.push_back(30.0f);
+  drift_times.push_back(20.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Create IMFrameView and sort by intensity (descending by default)
+  IMFrameView imframe(&spectrum);
+  imframe.sortByIntensity();
+  
+  // Check if peaks are sorted by intensity (descending)
+  TEST_EQUAL(spectrum.size(), 3)
+  TEST_REAL_SIMILAR(spectrum[0].getIntensity(), 3000.0)
+  TEST_REAL_SIMILAR(spectrum[1].getIntensity(), 2000.0)
+  TEST_REAL_SIMILAR(spectrum[2].getIntensity(), 1000.0)
+  
+  // Check if drift times are sorted accordingly
+  const MSSpectrum::FloatDataArray* dt_array = imframe.getDriftTimeDataArrayPtr();
+  TEST_EQUAL(dt_array->size(), 3)
+  TEST_REAL_SIMILAR((*dt_array)[0], 30.0)
+  TEST_REAL_SIMILAR((*dt_array)[1], 20.0)
+  TEST_REAL_SIMILAR((*dt_array)[2], 10.0)
+  
+  // Sort by intensity ascending
+  imframe.sortByIntensity(false);
+  
+  // Check if peaks are sorted by intensity (ascending)
+  TEST_EQUAL(spectrum.size(), 3)
+  TEST_REAL_SIMILAR(spectrum[0].getIntensity(), 1000.0)
+  TEST_REAL_SIMILAR(spectrum[1].getIntensity(), 2000.0)
+  TEST_REAL_SIMILAR(spectrum[2].getIntensity(), 3000.0)
+  
+  // Check if drift times are sorted accordingly
+  dt_array = imframe.getDriftTimeDataArrayPtr();
+  TEST_EQUAL(dt_array->size(), 3)
+  TEST_REAL_SIMILAR((*dt_array)[0], 10.0)
+  TEST_REAL_SIMILAR((*dt_array)[1], 20.0)
+  TEST_REAL_SIMILAR((*dt_array)[2], 30.0)
+}
+END_SECTION
+
+START_SECTION((void sortByDriftTime()))
+{
+  MSSpectrum spectrum;
+  spectrum.setType(SpectrumSettings::CENTROID);
+  
+  // Add peaks
+  Peak1D peak1;
+  peak1.setMZ(100.0);
+  peak1.setIntensity(1000.0f);
+  spectrum.push_back(peak1);
+  
+  Peak1D peak2;
+  peak2.setMZ(200.0);
+  peak2.setIntensity(2000.0f);
+  spectrum.push_back(peak2);
+  
+  Peak1D peak3;
+  peak3.setMZ(300.0);
+  peak3.setIntensity(3000.0f);
+  spectrum.push_back(peak3);
+  
+  // Add drift time array in unsorted order
+  DataArrays::FloatDataArray drift_times;
+  IMDataConverter::setIMUnit(drift_times, DriftTimeUnit::MILLISECOND);
+  drift_times.push_back(30.0f);
+  drift_times.push_back(10.0f);
+  drift_times.push_back(20.0f);
+  
+  spectrum.getFloatDataArrays().push_back(drift_times);
+  
+  // Create IMFrameView and sort by drift time
+  IMFrameView imframe(&spectrum);
+  imframe.sortByDriftTime();
+  
+  // Check if drift times are sorted
+  const MSSpectrum::FloatDataArray* dt_array = imframe.getDriftTimeDataArrayPtr();
+  TEST_EQUAL(dt_array->size(), 3)
+  TEST_REAL_SIMILAR((*dt_array)[0], 10.0)
+  TEST_REAL_SIMILAR((*dt_array)[1], 20.0)
+  TEST_REAL_SIMILAR((*dt_array)[2], 30.0)
+  
+  // Check if peaks are sorted accordingly
+  TEST_EQUAL(spectrum.size(), 3)
+  TEST_REAL_SIMILAR(spectrum[0].getMZ(), 200.0)
+  TEST_REAL_SIMILAR(spectrum[1].getMZ(), 300.0)
+  TEST_REAL_SIMILAR(spectrum[2].getMZ(), 100.0)
+}
+END_SECTION
+
+START_SECTION((bool operator==(const IMFrameView& rhs) const))
+{
+  MSSpectrum spectrum1 = createTestSpectrum();
+  IMFrameView imframe1(&spectrum1);
+  
+  MSSpectrum spectrum2 = createTestSpectrum();
+  IMFrameView imframe2(&spectrum2);
+  
+  // Different objects but same content
+  TEST_EQUAL(imframe1 == imframe2, true)
+  
+  // Same object
+  TEST_EQUAL(imframe1 == imframe1, true)
+  
+  // Different content
+  spectrum2[0].setIntensity(999.0f);
+  TEST_EQUAL(imframe1 == imframe2, false)
+}
+END_SECTION
+
+START_SECTION((bool operator!=(const IMFrameView& rhs) const))
+{
+  MSSpectrum spectrum1 = createTestSpectrum();
+  IMFrameView imframe1(&spectrum1);
+  
+  MSSpectrum spectrum2 = createTestSpectrum();
+  IMFrameView imframe2(&spectrum2);
+  
+  // Different objects but same content
+  TEST_EQUAL(imframe1 != imframe2, false)
+  
+  // Same object
+  TEST_EQUAL(imframe1 != imframe1, false)
+  
+  // Different content
+  spectrum2[0].setIntensity(999.0f);
+  TEST_EQUAL(imframe1 != imframe2, true)
+}
+END_SECTION
+
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST

--- a/src/tests/class_tests/openms/source/IMFrameView_test.cpp
+++ b/src/tests/class_tests/openms/source/IMFrameView_test.cpp
@@ -18,12 +18,6 @@
 using namespace OpenMS;
 using namespace std;
 
-START_TEST(IMFrameView, "$Id$")
-
-/////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////
-
-// Helper function to create a test spectrum with drift time array
 MSSpectrum createTestSpectrum()
 {
   MSSpectrum spectrum;
@@ -170,6 +164,11 @@ MSSpectrum createMultipleSpectraFormatSpectrum()
   return spectrum;
 }
 
+START_TEST(IMFrameView, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
 IMFrameView* imframe_ptr = nullptr;
 IMFrameView* nullPointer = nullptr;
 
@@ -297,27 +296,27 @@ END_SECTION
 START_SECTION((bool isValid() const))
 {
   MSSpectrum valid_spectrum = createTestSpectrum();
-  IMFrameView valid_imframe(&valid_spectrum);
+  IMFrameView valid_imframe(&valid_spectrum); // Constructor succeeds
   TEST_EQUAL(valid_imframe.isValid(), true)
   
   MSSpectrum invalid_spectrum = createInvalidSpectrum();
-  IMFrameView invalid_imframe(&invalid_spectrum);
-  TEST_EQUAL(invalid_imframe.isValid(), false)
+  // For spectra with IMFormat::NONE, the constructor should throw an exception
+  TEST_EXCEPTION(Exception::InvalidValue, IMFrameView invalid_imframe(&invalid_spectrum))
   
-  MSSpectrum mismatched_spectrum = createMismatchedSpectrum();
-  IMFrameView mismatched_imframe(&mismatched_spectrum);
-  TEST_EQUAL(mismatched_imframe.isValid(), false)
-  
-  MSSpectrum non_centroided_spectrum = createNonCentroidedSpectrum();
-  IMFrameView non_centroided_imframe(&non_centroided_spectrum);
-  TEST_EQUAL(non_centroided_imframe.isValid(), false)
-  
-  // Test with a spectrum that has MULTIPLE_SPECTRA format
+  // For spectra with IMFormat::MULTIPLE_SPECTRA, the constructor should throw an exception
   MSSpectrum multiple_spectra_spectrum = createMultipleSpectraFormatSpectrum();
+  TEST_EXCEPTION(Exception::InvalidValue, IMFrameView multiple_spectra_imframe(&multiple_spectra_spectrum))
   
-  // This should be invalid for IMFrameView since it requires CONCATENATED format
-  IMFrameView multiple_spectra_imframe(&multiple_spectra_spectrum);
-  TEST_EQUAL(multiple_spectra_imframe.isValid(), false)
+  // For non-centroided spectra, the constructor should throw an exception
+  MSSpectrum non_centroided_spectrum = createNonCentroidedSpectrum();
+  TEST_EXCEPTION(Exception::InvalidValue, IMFrameView non_centroided_imframe(&non_centroided_spectrum))
+  
+  // For spectra with mismatched drift time array size, the constructor should throw an exception
+  MSSpectrum mismatched_spectrum = createMismatchedSpectrum();
+  TEST_EXCEPTION(Exception::InvalidValue, IMFrameView mismatched_imframe(&mismatched_spectrum))
+  
+  // Note: isValid() always returns true if the constructor succeeds
+  // If the spectrum is invalid, the constructor will throw an exception
 }
 END_SECTION
 


### PR DESCRIPTION
Introduce the IMFrameView class to manage and manipulate ion mobility spectra, along with corresponding tests to ensure functionality.
The main idea is that we have a dedicated a "wrapper" if we have IMFrames stored in MSSpectrum.
Open for discussion if this is a good design etc..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an advanced interface for ion mobility spectra analysis, enhancing the ability to retrieve, validate, and sort spectral data such as m/z values, intensities, and drift times.
  - Added a new header file and source file for the `IMFrameView` class, which encapsulates functionalities related to ion mobility spectra.
  - Included a new test case for the `IMFrameView` functionality to validate its performance and accuracy.

- **Tests**
  - Added a comprehensive suite of unit tests to ensure the robustness and accuracy of the new ion mobility features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->