### PR TITLE
refactor: move basename member out of PeptideIdentification into MetaValues

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -558,6 +558,11 @@ namespace OpenMS
               String
       */
       inline const std::string   MSM_SUM_FORMULA = "Sum_Formula";
+
+      /** User parameter name for the base name which links to underlying peak map
+              String
+      */
+      inline const std::string   BASE_NAME = "base_name";
     }
 
     //@}

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -110,7 +110,7 @@ public:
     void setIdentifier(const String& id);
 
     /// returns the base name which links to underlying peak map
-    const String& getBaseName() const;
+    String getBaseName() const;
     /// sets the base name which links to underlying peak map
     void setBaseName(const String& base_name);
 
@@ -193,7 +193,6 @@ protected:
     String score_type_; ///< The score type (Mascot, Sequest, e-value, p-value)
     bool higher_score_better_; ///< The score orientation
     // hint: here is an alignment gap of 7 bytes <-- here --> use it when introducing new members with sizeof(m)<=4
-    String base_name_;
     double mz_;
     double rt_;
 

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -5,9 +5,10 @@
 // $Maintainer: Timo Sachsenberg $
 // $Authors: $
 // --------------------------------------------------------------------------
-
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/CONCEPT/Constants.h>
+
 
 
 using namespace std;
@@ -22,7 +23,6 @@ namespace OpenMS
     significance_threshold_(0.0),
     score_type_(),
     higher_score_better_(true),
-    base_name_(),
     mz_(std::numeric_limits<double>::quiet_NaN()),
     rt_(std::numeric_limits<double>::quiet_NaN())
   {
@@ -40,7 +40,7 @@ namespace OpenMS
            && score_type_ == rhs.score_type_
            && higher_score_better_ == rhs.higher_score_better_
            && getExperimentLabel() == rhs.getExperimentLabel()
-           && base_name_ == rhs.base_name_
+           && getBaseName() == rhs.getBaseName()
            && (mz_ == rhs.mz_ || (!this->hasMZ() && !rhs.hasMZ())) // might be NaN, so comparing == will always be false
            && (rt_ == rhs.rt_ || (!this->hasRT() && !rhs.hasRT()));// might be NaN, so comparing == will always be false
   }
@@ -161,14 +161,22 @@ namespace OpenMS
     this->setMetaValue(Constants::UserParam::SPECTRUM_REFERENCE, id);
   }
 
-  const String& PeptideIdentification::getBaseName() const
+  String PeptideIdentification::getBaseName() const
   {
-    return base_name_;
+    return this->getMetaValue(Constants::UserParam::BASE_NAME, "");
   }
 
   void PeptideIdentification::setBaseName(const String& base_name)
   {
-    base_name_ = base_name;
+    // do not store empty base_name (default value)
+    if (!base_name.empty())
+    {
+      setMetaValue(Constants::UserParam::BASE_NAME, base_name);
+    }
+    else
+    {
+      removeMetaValue(Constants::UserParam::BASE_NAME);
+    }
   }
 
   const String PeptideIdentification::getExperimentLabel() const
@@ -239,7 +247,7 @@ namespace OpenMS
            && significance_threshold_ == 0.0
            && score_type_.empty()
            && higher_score_better_ == true
-           && base_name_.empty();
+           && !metaValueExists(Constants::UserParam::BASE_NAME);
   }
 
   std::vector<PeptideHit> PeptideIdentification::getReferencingHits(const std::vector<PeptideHit>& hits, const std::set<String>& accession)

--- a/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
@@ -10,7 +10,6 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <string>
 
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
@@ -20,6 +19,8 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 
 ///////////////////////////
@@ -560,5 +561,38 @@ END_SECTION
 */
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
+
+START_SECTION((const String& getBaseName() const))
+  PeptideIdentification id;
+  TEST_EQUAL(id.getBaseName(), "")
+  
+  id.setBaseName("test_base_name");
+  TEST_EQUAL(id.getBaseName(), "test_base_name")
+  
+  // Test that it's stored as a MetaValue
+  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), true)
+  TEST_EQUAL(id.getMetaValue(Constants::UserParam::BASE_NAME), "test_base_name")
+END_SECTION
+
+START_SECTION((void setBaseName(const String& base_name)))
+  PeptideIdentification id;
+  
+  // Test setting a non-empty base name
+  id.setBaseName("test_base_name");
+  TEST_EQUAL(id.getBaseName(), "test_base_name")
+  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), true)
+  
+  // Test setting an empty base name (should remove the meta value)
+  id.setBaseName("");
+  TEST_EQUAL(id.getBaseName(), "")
+  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), false)
+  
+  // Test that empty() method works correctly with base name as meta value
+  TEST_EQUAL(id.empty(), true)
+  id.setBaseName("test_base_name");
+  TEST_EQUAL(id.empty(), false)
+  id.setBaseName("");
+  TEST_EQUAL(id.empty(), true)
+END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
@@ -70,12 +70,12 @@ START_SECTION((PeptideIdentification(const PeptideIdentification& source)))
   PeptideIdentification hits2(hits);
 
   TEST_EQUAL(hits.getSignificanceThreshold(), hits2.getSignificanceThreshold())
-  TEST_EQUAL(hits.getHits().size() == 1, true)
-  TEST_EQUAL(*(hits.getHits().begin()) == peptide_hit, true)
+  TEST_TRUE(hits.getHits().size() == 1)
+  TEST_TRUE(*(hits.getHits().begin()) == peptide_hit)
   TEST_EQUAL((UInt)hits.getMetaValue("label"),17)
   TEST_EQUAL(hits.getIdentifier(),"id")
   TEST_EQUAL(hits.getScoreType(),"score_type")
-  TEST_EQUAL(hits.isHigherScoreBetter(),false)
+  TEST_FALSE(hits.isHigherScoreBetter())
 }
 END_SECTION
 
@@ -84,7 +84,7 @@ START_SECTION((PeptideIdentification(PeptideIdentification&& source) noexcept))
 {
   // Ensure that PeptideIdentification has a no-except move constructor (otherwise
   // std::vector is inefficient and will copy instead of move).
-  TEST_EQUAL(noexcept(PeptideIdentification(std::declval<PeptideIdentification&&>())), true)
+  TEST_TRUE(noexcept(PeptideIdentification(std::declval<PeptideIdentification&&>())))
 
   PeptideIdentification hits;
   hits.setSignificanceThreshold(peptide_significance_threshold);
@@ -99,18 +99,18 @@ START_SECTION((PeptideIdentification(PeptideIdentification&& source) noexcept))
   PeptideIdentification hits2(std::move(example));
 
   TEST_EQUAL(hits.getSignificanceThreshold(), hits2.getSignificanceThreshold())
-  TEST_EQUAL(hits.getHits().size() == 1, true)
-  TEST_EQUAL(*(hits.getHits().begin()) == peptide_hit, true)
+  TEST_TRUE(hits.getHits().size() == 1)
+  TEST_TRUE(*(hits.getHits().begin()) == peptide_hit)
   TEST_EQUAL((UInt)hits.getMetaValue("label"),17)
   TEST_EQUAL(hits.getIdentifier(),"id")
   TEST_EQUAL(hits.getScoreType(),"score_type")
-  TEST_EQUAL(hits.isHigherScoreBetter(),false)
+  TEST_FALSE(hits.isHigherScoreBetter())
 
   // the move source should be empty
-  TEST_EQUAL(example.getHits().empty(), true)
-  TEST_EQUAL(example.isMetaEmpty(), true)
-  TEST_EQUAL(example.getIdentifier().empty(), true)
-  TEST_EQUAL(example.getScoreType().empty(), true)
+  TEST_TRUE(example.getHits().empty())
+  TEST_TRUE(example.isMetaEmpty())
+  TEST_TRUE(example.getIdentifier().empty())
+  TEST_TRUE(example.getScoreType().empty())
 }
 END_SECTION
 
@@ -127,12 +127,12 @@ START_SECTION((PeptideIdentification& operator=(const PeptideIdentification& sou
   hits2 = hits;
 
   TEST_EQUAL(hits.getSignificanceThreshold(), hits2.getSignificanceThreshold())
-  TEST_EQUAL(hits.getHits().size() == 1, true)
-  TEST_EQUAL(*(hits.getHits().begin()) == peptide_hit, true)
+  TEST_TRUE(hits.getHits().size() == 1)
+  TEST_TRUE(*(hits.getHits().begin()) == peptide_hit)
   TEST_EQUAL((UInt)hits.getMetaValue("label"),17)
   TEST_EQUAL(hits.getIdentifier(),"id")
   TEST_EQUAL(hits.getScoreType(),"score_type")
-  TEST_EQUAL(hits.isHigherScoreBetter(),false)
+  TEST_FALSE(hits.isHigherScoreBetter())
 END_SECTION
 
 START_SECTION((bool operator == (const PeptideIdentification& rhs) const))
@@ -140,30 +140,30 @@ START_SECTION((bool operator == (const PeptideIdentification& rhs) const))
   TEST_TRUE(search1 == search2)
 
   search1.setSignificanceThreshold(peptide_significance_threshold);
-  TEST_EQUAL(search1 == search2, false)
+  TEST_FALSE(search1 == search2)
   search1 = search2;
 
   search2.setMetaValue("label",17);
-  TEST_EQUAL(search1 == search2, false)
+  TEST_FALSE(search1 == search2)
   search1 = search2;
 
   search2.setIdentifier("id");
-  TEST_EQUAL(search1 == search2, false)
+  TEST_FALSE(search1 == search2)
   search1 = search2;
 
   search2.setScoreType("score_type");
-  TEST_EQUAL(search1 == search2, false)
+  TEST_FALSE(search1 == search2)
   search1 = search2;
 
   search2.setHigherScoreBetter(false);
-  TEST_EQUAL(search1 == search2, false)
+  TEST_FALSE(search1 == search2)
   search1 = search2;
 END_SECTION
 
 
 START_SECTION((bool operator != (const PeptideIdentification& rhs) const))
   PeptideIdentification search1, search2;
-  TEST_EQUAL(search1 != search2, false)
+  TEST_FALSE(search1 != search2)
 
   search1.setSignificanceThreshold(peptide_significance_threshold);
   TEST_FALSE(search1 == search2)
@@ -175,7 +175,7 @@ END_SECTION
 
 START_SECTION((double getRT() const))
 	PeptideIdentification pi;
-	TEST_EQUAL(pi.hasRT(), false);
+	TEST_FALSE(pi.hasRT());
 	pi.setRT(1024.0);
 	TEST_EQUAL(pi.getRT(), 1024.0);
 END_SECTION
@@ -190,7 +190,7 @@ END_SECTION
 
 START_SECTION((double getMZ() const))
 	PeptideIdentification pi;
-	TEST_EQUAL(pi.hasMZ(), false);
+	TEST_FALSE(pi.hasMZ());
 	pi.setMZ(1024.0);
 	TEST_EQUAL(pi.getMZ(), 1024.0);
 END_SECTION
@@ -210,21 +210,21 @@ END_SECTION
 START_SECTION((const std::vector<PeptideHit>& getHits() const))
   PeptideIdentification hits;
   hits.insertHit(peptide_hit);
-  TEST_EQUAL(hits.getHits().size() == 1, true)
-  TEST_EQUAL(hits.getHits()[0] == peptide_hit, true)
+  TEST_TRUE(hits.getHits().size() == 1)
+  TEST_TRUE(hits.getHits()[0] == peptide_hit)
 END_SECTION
 
 START_SECTION((void insertHit(const PeptideHit &hit)))
   PeptideIdentification hits;
   hits.insertHit(peptide_hit);
-  TEST_EQUAL(hits.getHits().size() == 1, true)
-  TEST_EQUAL(*(hits.getHits().begin()) == peptide_hit, true)
+  TEST_TRUE(hits.getHits().size() == 1)
+  TEST_TRUE(*(hits.getHits().begin()) == peptide_hit)
 END_SECTION
 
 START_SECTION((void setHits(const std::vector< PeptideHit > &hits)))
   PeptideIdentification hits;
   hits.setHits(peptide_hits);
-  TEST_EQUAL(hits.getHits() == peptide_hits, true)
+  TEST_TRUE(hits.getHits() == peptide_hits)
 END_SECTION
 
 START_SECTION((void setSignificanceThreshold(double value)))
@@ -246,13 +246,13 @@ END_SECTION
 
 START_SECTION((bool isHigherScoreBetter() const))
 	PeptideIdentification hits;
-	TEST_EQUAL(hits.isHigherScoreBetter(), true)
+	TEST_TRUE(hits.isHigherScoreBetter())
 END_SECTION
 
 START_SECTION((void setHigherScoreBetter(bool value)))
   PeptideIdentification hits;
   hits.setHigherScoreBetter(false);
-  TEST_EQUAL(hits.isHigherScoreBetter(),false)
+  TEST_FALSE(hits.isHigherScoreBetter())
 END_SECTION
 
 START_SECTION((const String& getIdentifier() const))
@@ -268,22 +268,22 @@ END_SECTION
 
 START_SECTION((bool empty() const))
   PeptideIdentification hits;
-  TEST_EQUAL(hits.empty(), true)
+  TEST_TRUE(hits.empty())
+hits.setSignificanceThreshold(1);
+TEST_FALSE(hits.empty())
 
-  hits.setSignificanceThreshold(1);
-  TEST_EQUAL(hits.empty(), false)
+hits.setSignificanceThreshold(0);
+TEST_TRUE(hits.empty())
 
-  hits.setSignificanceThreshold(0);
-  TEST_EQUAL(hits.empty(), true)
+hits.setBaseName("basename");
+TEST_FALSE(hits.empty())
 
-  hits.setBaseName("basename");
-  TEST_EQUAL(hits.empty(), false)
+hits.setBaseName("");
+TEST_TRUE(hits.empty())
 
-  hits.setBaseName("");
-  TEST_EQUAL(hits.empty(), true)
 
   hits.insertHit(peptide_hit);
-  TEST_EQUAL(hits.empty(), false)
+  TEST_FALSE(hits.empty())
 END_SECTION
 
 START_SECTION((void sort()))
@@ -570,7 +570,7 @@ START_SECTION((const String& getBaseName() const))
   TEST_EQUAL(id.getBaseName(), "test_base_name")
   
   // Test that it's stored as a MetaValue
-  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), true)
+  TEST_TRUE(id.metaValueExists(Constants::UserParam::BASE_NAME))
   TEST_EQUAL(id.getMetaValue(Constants::UserParam::BASE_NAME), "test_base_name")
 END_SECTION
 
@@ -580,19 +580,19 @@ START_SECTION((void setBaseName(const String& base_name)))
   // Test setting a non-empty base name
   id.setBaseName("test_base_name");
   TEST_EQUAL(id.getBaseName(), "test_base_name")
-  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), true)
+  TEST_TRUE(id.metaValueExists(Constants::UserParam::BASE_NAME))
   
   // Test setting an empty base name (should remove the meta value)
   id.setBaseName("");
   TEST_EQUAL(id.getBaseName(), "")
-  TEST_EQUAL(id.metaValueExists(Constants::UserParam::BASE_NAME), false)
+  TEST_FALSE(id.metaValueExists(Constants::UserParam::BASE_NAME))
   
   // Test that empty() method works correctly with base name as meta value
-  TEST_EQUAL(id.empty(), true)
+  TEST_TRUE(id.empty())
   id.setBaseName("test_base_name");
-  TEST_EQUAL(id.empty(), false)
+  TEST_FALSE(id.empty())
   id.setBaseName("");
-  TEST_EQUAL(id.empty(), true)
+  TEST_TRUE(id.empty())
 END_SECTION
 
 END_TEST

--- a/src/tests/topp/IDFileConverter_10_output.idXML
+++ b/src/tests/topp/IDFileConverter_10_output.idXML
@@ -46,6 +46,7 @@
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/H_LN1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="863.492925031899972" RT="4120.789999999999964" spectrum_reference="scan=30513" >
 			<PeptideHit score="0.9938" sequence=".(Dimethyl:2H(4)13C(2))DLADELALVDVIEDK(Dimethyl:2H(4)13C(2)).(MOD:00266)" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
@@ -65,6 +66,7 @@
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/H_LN1"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 	<IdentificationRun date="2015-01-06T13:43:07" search_engine="X! Tandem" search_engine_version="" search_parameters_ref="SP_1" >
@@ -92,6 +94,7 @@
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/L_LN1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="853.11645836523337" RT="4131.050000000000182" spectrum_reference="scan=30586" >
 			<PeptideHit score="1.0" sequence=".(Dimethyl)TLVLSNLSYSATEETLQEVFEK(Dimethyl).(MOD:00266)" charge="3" aa_before="K" aa_after="A" protein_refs="PH_3" >
@@ -111,6 +114,7 @@
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/L_LN1"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDFileConverter_16_output.idXML
+++ b/src/tests/topp/IDFileConverter_16_output.idXML
@@ -45,6 +45,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="4.1724"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="360.700329914712484" RT="0.0" spectrum_reference="scan=2770" >
 			<PeptideHit score="0.0" sequence="GLVC(Carbamidomethyl)GSK" charge="2" aa_before="A" aa_after="F" protein_refs="PH_2" >
@@ -64,6 +65,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="6.9737"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="350.530489419920002" RT="0.0" spectrum_reference="scan=2999" >
 			<PeptideHit score="0.0223989" sequence="LIWTM(Oxidation)IGIS" charge="3" aa_before="R" aa_after="F" protein_refs="PH_3" >
@@ -83,6 +85,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="4.0003"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="566.770337238929983" RT="0.0" spectrum_reference="scan=3084" >
 			<PeptideHit score="0.0505509" sequence=".(Glu-&gt;pyro-Glu)EAGIVDELAYA" charge="2" aa_before="K" aa_after="V" protein_refs="PH_4" >
@@ -102,6 +105,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="20.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="608.957491373046651" RT="0.0" spectrum_reference="scan=3905" >
 			<PeptideHit score="0.999999" sequence=".(Acetyl)SASAQHSQAQQQQQQK" charge="3" aa_before="M" aa_after="S" protein_refs="PH_5" >
@@ -121,6 +125,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="9.90429"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.4998"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="681.293347492839985" RT="0.0" spectrum_reference="scan=7319" >
 			<PeptideHit score="2.01282e-05" sequence=".(Ammonia-loss)C(Carbamidomethyl)LPGPATASIYQT" charge="2" aa_before="K" aa_after="L" protein_refs="PH_6" >
@@ -140,6 +145,7 @@
 				<UserParam type="float" name="_ar_1_subscore_nsp" value="2.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nss" value="0.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDFileConverter_24_output.idXML
+++ b/src/tests/topp/IDFileConverter_24_output.idXML
@@ -89,6 +89,7 @@
 				<UserParam type="float" name="COMET:sprank" value="84.0"/>
 				<UserParam type="float" name="MS:1002257" value="27.899999999999999"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/home/rostlab/annieha/ConvertedRaw_Nina/LakeTroutChromiumsearched/ctl/rep1/1"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0.0" MZ="669.061888531899967" RT="78.0" spectrum_reference="scan=9" >
 			<PeptideHit score="0.0" sequence="LPVLYSSPAALLALRVC(Carbamidomethyl)QGVVKVSAGVSRRGC(Carbamidomethyl)AGAVPVM" charge="6" aa_before="D" aa_after="-" protein_refs="PH_11" >
@@ -116,6 +117,7 @@
 				<UserParam type="float" name="_ar_0_subscore_nmc" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="/home/rostlab/annieha/ConvertedRaw_Nina/LakeTroutChromiumsearched/ctl/rep1/1"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDFileConverter_2_output.idXML
+++ b/src/tests/topp/IDFileConverter_2_output.idXML
@@ -62,6 +62,7 @@
 				<UserParam type="float" name="hyperscore" value="329.0"/>
 				<UserParam type="float" name="nextscore" value="323.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="637.885175031899962" RT="1.719" spectrum_reference="scan=3" >
 			<PeptideHit score="7.7" sequence=".(Gln-&gt;pyro-Glu)QLPGVNIKPVVK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_3" >
@@ -69,6 +70,7 @@
 				<UserParam type="float" name="hyperscore" value="173.0"/>
 				<UserParam type="float" name="nextscore" value="167.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="678.384725031899961" RT="2.0436" spectrum_reference="scan=4" >
 			<PeptideHit score="4.9" sequence="IFQAALYAAPYK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_4" >
@@ -76,6 +78,7 @@
 				<UserParam type="float" name="hyperscore" value="274.0"/>
 				<UserParam type="float" name="nextscore" value="250.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="762.728391698566725" RT="2.7843" spectrum_reference="scan=6" >
 			<PeptideHit score="9.1e-04" sequence="EISPDTTLLDLQNNDISELR" charge="3" aa_before="K X X X" aa_after="K X X X" protein_refs="PH_5 PH_6 PH_7 PH_8" >
@@ -83,6 +86,7 @@
 				<UserParam type="float" name="hyperscore" value="807.0"/>
 				<UserParam type="float" name="nextscore" value="446.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="1143.595525031900024" RT="3.085" spectrum_reference="scan=7" >
 			<PeptideHit score="7.9e-05" sequence="EISPDTTLLDLQNNDISELR" charge="2" aa_before="K X X X" aa_after="K X X X" protein_refs="PH_5 PH_6 PH_7 PH_8" >
@@ -90,6 +94,7 @@
 				<UserParam type="float" name="hyperscore" value="705.0"/>
 				<UserParam type="float" name="nextscore" value="309.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="770.055225031900022" RT="3.4018" spectrum_reference="scan=8" >
 			<PeptideHit score="14.0" sequence="RSHTILNSSQSFAKGC(Carbamidomethyl)VQC(Carbamidomethyl)K" charge="3" aa_before="K X X" aa_after="H X X" protein_refs="PH_9 PH_10 PH_11" >
@@ -97,6 +102,7 @@
 				<UserParam type="float" name="hyperscore" value="350.0"/>
 				<UserParam type="float" name="nextscore" value="349.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="757.412291698566719" RT="4.4573" spectrum_reference="scan=10" >
 			<PeptideHit score="0.65" sequence="VSLPNYPAIPSDATLEVQSLR" charge="3" aa_before="K X X" aa_after="S X X" protein_refs="PH_12 PH_13 PH_14" >
@@ -104,6 +110,7 @@
 				<UserParam type="float" name="hyperscore" value="463.0"/>
 				<UserParam type="float" name="nextscore" value="431.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="807.394125031899989" RT="4.8288" spectrum_reference="scan=11" >
 			<PeptideHit score="4.6e-03" sequence="NALWHTGDTESQVR" charge="2" aa_before="R X X" aa_after="L X X" protein_refs="PH_15 PH_16 PH_17" >
@@ -111,6 +118,7 @@
 				<UserParam type="float" name="hyperscore" value="478.0"/>
 				<UserParam type="float" name="nextscore" value="278.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="512.784525031899989" RT="5.1785" spectrum_reference="scan=12" >
 			<PeptideHit score="1.1" sequence="SSLKNYANK" charge="2" aa_before="R X" aa_after="I X" protein_refs="PH_18 PH_19" >
@@ -118,6 +126,7 @@
 				<UserParam type="float" name="hyperscore" value="266.0"/>
 				<UserParam type="float" name="nextscore" value="228.0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="PepXMLFile_test"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 	<IdentificationRun date="2009-05-25T12:33:23" search_engine="SEQUEST" search_engine_version="" search_parameters_ref="SP_1" >
@@ -144,54 +153,63 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="5.136"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="637.885525031899988" RT="1.7" spectrum_reference="scan=3" >
 			<PeptideHit score="1.024" sequence="LLTAQEQPVYI" charge="2" aa_before="R" aa_after="-" protein_refs="PH_21" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.024"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="538.605558365233378" RT="1.4" spectrum_reference="scan=2" >
 			<PeptideHit score="1.641" sequence="HEVVIWLGDLNYR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_22" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.641"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="770.055558365233424" RT="3.4" spectrum_reference="scan=8" >
 			<PeptideHit score="1.606" sequence="LDGNYLKPPIPLDLM(Oxidation)MC(Carbamidomethyl)FR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="int" name="isotope_error" value="-1"/>
 				<UserParam type="float" name="MS:1001155" value="1.606"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="512.784525031899989" RT="5.2" spectrum_reference="scan=12" >
 			<PeptideHit score="1.288" sequence="EHVQLRDK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_24" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="1.288"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="678.384525031900012" RT="2.0" spectrum_reference="scan=4" >
 			<PeptideHit score="3.986" sequence="FSDGAFLGVTTLK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_25" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="3.986"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="807.394525031900002" RT="4.8" spectrum_reference="scan=11" >
 			<PeptideHit score="2.831" sequence="NALWHTGDTESQVR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_26" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="2.831"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="757.412558365233394" RT="4.5" spectrum_reference="scan=10" >
 			<PeptideHit score="2.197" sequence="VSLPNYPAIPSDATLEVQSLR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_27" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="2.197"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="xcorr" higher_score_better="true" significance_threshold="0.0" MZ="762.728558365233425" RT="2.8" spectrum_reference="scan=6" >
 			<PeptideHit score="5.638" sequence="EISPDTTLLDLQNNDISELR" charge="3" aa_before="K" aa_after="K" protein_refs="PH_20" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="MS:1001155" value="5.638"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="./PepXMLFile_test"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/IDFileConverter_6_output.idXML
+++ b/src/tests/topp/IDFileConverter_6_output.idXML
@@ -44,11 +44,13 @@
 			<PeptideHit score="0.89" sequence="VPIGVANVAK" charge="2" aa_before="K X X" aa_after="K X X" protein_refs="PH_1 PH_2 PH_3" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="../cgi/master_results.pl?file=../data/20130606/F025589.dat"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="403.554869031899955" RT="679.558800000000019" >
 			<PeptideHit score="6.9e-03" sequence="SATPAQAQAVHK" charge="3" aa_before="K X X" aa_after="F X X" protein_refs="PH_4 PH_5 PH_6" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="../cgi/master_results.pl?file=../data/20130606/F025589.dat"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="516.267699031899951" RT="687.714600000000019" >
 			<PeptideHit score="0.013" sequence="AVQAVVHHNETADR" charge="3" aa_before="K X X" aa_after="A X X" protein_refs="PH_7 PH_8 PH_9" >
@@ -57,6 +59,7 @@
 			<PeptideHit score="1.4" sequence="GKGVVTISVAEC(Carbamidomethyl)GNR" charge="3" aa_before="K X X" aa_after="V X X" protein_refs="PH_10 PH_11 PH_12" >
 				<UserParam type="int" name="isotope_error" value="0"/>
 			</PeptideHit>
+			<UserParam type="string" name="base_name" value="../cgi/master_results.pl?file=../data/20130606/F025589.dat"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/THIRDPARTY/Chy_test.tmp.idXML
+++ b/src/tests/topp/THIRDPARTY/Chy_test.tmp.idXML
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="Chy_test.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="chymotrypsin/p" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="chymotrypsin/p" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="CometAdapter:1:in" value="Chy_test_in.mzML"/>
-				<UserParam type="string" name="CometAdapter:1:out" value="final.idXML"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="Chy_test.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test_in.mzML"/>
+				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_5_out1.tmp.idXML"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value=""/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="10.0"/>
@@ -74,13 +74,13 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-01-02T14:50:23" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:05:21" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q5PT55|NTCP5_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
 			<UserParam type="stringList" name="spectra_data_raw" value="[file:///F:/CONFETTI_NEW_HELA/Hela_Chy_Try_pH3_CID_3xload_1_20140729.raw]"/>
-			<UserParam type="stringList" name="spectra_data" value="[Chy_test_in.mzML]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test_in.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="705.973693031899984" RT="2850.0" spectrum_reference="controllerType=0 controllerNumber=1 scan=7904" >
 			<PeptideHit score="940.0" sequence="PEAQAFGVVMTC(Carbamidomethyl)TC(Carbamidomethyl)PGGGGGY" charge="3" aa_before="L" aa_after="L" start="201" end="221" protein_refs="PH_0" >

--- a/src/tests/topp/THIRDPARTY/Chy_test.tmp.idXML
+++ b/src/tests/topp/THIRDPARTY/Chy_test.tmp.idXML
@@ -74,7 +74,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:05:21" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:05:21" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q5PT55|NTCP5_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
@@ -5,7 +5,7 @@
 				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/spectra_comet.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_1_out1.tmp.idXML"/>
 				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/proteins.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/home/sachsenb/Development/OpenMS/THIRDPARTY/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_1_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="3.0"/>
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2024-01-31T00:34:20" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
@@ -5,7 +5,7 @@
 				<UserParam type="string" name="CometAdapter:1:in" value="CometAdapter_2_prepared.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_2_out1.tmp.idXML"/>
 				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_2_in.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/home/sachsenb/Development/OpenMS/THIRDPARTY/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_2_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="3.0"/>
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2024-01-31T00:34:20" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="prot1" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="prot1" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
@@ -78,7 +78,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:23" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:23" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2  (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_tr|Q5QTS3|Q5QTS3_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
@@ -11,7 +11,7 @@
 				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_3_out1.tmp.idXML"/>
 				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/home/sachsenb/Development/OpenMS/THIRDPARTY/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value="CometAdapter_3_out2.tmp.tsv"/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="5.0"/>
@@ -78,7 +78,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2024-01-31T00:34:21" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:23" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_tr|Q5QTS3|Q5QTS3_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
@@ -7,7 +7,7 @@
 				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/share/OpenMS/examples/FRACTIONS/BSA1_F1.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_4_out1.tmp.idXML"/>
 				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/share/OpenMS/examples/TOPPAS/data/BSA_Identification/18Protein_SoCe_Tr_detergents_trace_target_decoy.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/home/sachsenb/Development/OpenMS/THIRDPARTY/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value=""/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="5.0"/>
@@ -74,7 +74,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2024-01-31T00:34:21" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:25" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|A9ESU7|ALR_SORC5" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -14926,7 +14926,7 @@
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="476.302215031900005" RT="1939.900000000000091" spectrum_reference="spectrum=2823" >
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="476.302215031900005" RT="1940.0" spectrum_reference="spectrum=2823" >
 			<PeptideHit score="999.0" sequence="LRRHRLT" charge="2" aa_before="R" aa_after="]" start="813" end="819" protein_refs="PH_59" >
 				<UserParam type="string" name="MS:1002258" value="0"/>
 				<UserParam type="string" name="MS:1002259" value="12"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
@@ -74,7 +74,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:25" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:25" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|A9ESU7|ALR_SORC5" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_6_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_6_out.idXML
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/mnt/volume/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="unspecific cleavage" missed_cleavages="1" precursor_peak_tolerance="20" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="unspecific cleavage" missed_cleavages="1" precursor_peak_tolerance="20" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="CometAdapter:1:in" value="/mnt/volume/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML"/>
+				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML"/>
 				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_6_out1.tmp.idXML"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="/mnt/volume/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
-				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/volume/OpenMS/THIRDPARTY/Linux/64bit/Comet/comet.exe"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value=""/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
 				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="20.0"/>
@@ -74,12 +74,12 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-01-13T18:51:46" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:31" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_sp|P61313|RL15_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[/mnt/volume/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML]"/>
 			<UserParam type="string" name="IM" value="1/K0"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="577.819547531899957" RT="0.9" spectrum_reference="index=7" >
@@ -107,7 +107,7 @@
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<UserParam type="float" name="IM" value="0.78486979007721"/>
+			<UserParam type="float" name="IM" value="0.784869800680812"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="537.842461531899971" RT="10.199999999999999" spectrum_reference="index=57" >
 			<PeptideHit score="999.0" sequence="RVRIRYIV" charge="2" aa_before="R" aa_after="Y" start="137" end="144" protein_refs="PH_0" >
@@ -134,7 +134,7 @@
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<UserParam type="float" name="IM" value="0.770198702812195"/>
+			<UserParam type="float" name="IM" value="0.770198702491127"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_6_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_6_out.idXML
@@ -74,7 +74,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:31" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-16T12:04:31" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_sp|P61313|RL15_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -760,11 +760,18 @@ protected:
     // if "reindex" parameter is set to true will perform reindexing
     if (auto ret = reindex_(protein_identifications, peptide_identifications); ret != EXECUTION_OK) return ret;
 
-	// Parse ion mobility information if present
-	bool all_ids_have_im = SpectrumMetaDataLookup::addMissingIMToPeptideIDs(peptide_identifications, exp);
-	if (all_ids_have_im) {
-		protein_identifications[0].setMetaValue(Constants::UserParam::IM, exp.getSpectrum(0).getDriftTimeUnitAsString());
-	}
+    // Parse ion mobility information if present
+    bool all_ids_have_im = SpectrumMetaDataLookup::addMissingIMToPeptideIDs(peptide_identifications, exp);
+    if (all_ids_have_im) 
+    {
+      protein_identifications[0].setMetaValue(Constants::UserParam::IM, exp.getSpectrum(0).getDriftTimeUnitAsString());
+    }
+
+    // remove base_name meta value from peptide identifications
+    for (auto& peptide_identification : peptide_identifications)
+    {      
+      peptide_identification.removeMetaValue("base_name");
+    }
 
     // add percolator features
     StringList feature_set;


### PR DESCRIPTION
## Description


This pull request includes several changes to the `PeptideIdentification` class in the OpenMS project. The main focus is on modifying how the base name, which links to the underlying peak map, is handled. The most important changes include adding a new constant for the base name, updating the getter and setter methods for the base name, and modifying the relevant tests to ensure proper functionality.

This value is mainly set from code that parses pepXML files.

Modifications to `PeptideIdentification` class:

* [`src/openms/include/OpenMS/METADATA/PeptideIdentification.h`](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aL113-R113): Changed the return type of `getBaseName` from `const String&` to `String`. Removed the `base_name_` member variable. [[1]](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aL113-R113) [[2]](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aL196)
* [`src/openms/source/METADATA/PeptideIdentification.cpp`](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L164-R179): Updated the `getBaseName` method to retrieve the base name from meta values and the `setBaseName` method to store the base name as a meta value. [[1]](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L164-R179) [[2]](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L43-R43) [[3]](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L25) [[4]](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L242-R250)

Addition of new constant:

* [`src/openms/include/OpenMS/CONCEPT/Constants.h`](diffhunk://#diff-3da0f7da14951308957e047a5ccc6bebb8a11e49a080e2fe884685d2d2da4056R561-R565): Added a new constant `BASE_NAME` for the base name user parameter.

Test updates:

* [`src/tests/class_tests/openms/source/PeptideIdentification_test.cpp`](diffhunk://#diff-2696ecc7dca647abea0491fbbcb5b4ba4cc1c4411609fbc2614507bcb4af114fR565-R597): Added new test sections for `getBaseName` and `setBaseName` to ensure the base name is correctly handled as a meta value.

Additional includes:

* `src/openms/source/METADATA/PeptideIdentification.cpp` and `src/tests/class_tests/openms/source/PeptideIdentification_test.cpp`: Included `Constants.h` to access the new `BASE_NAME` constant. [[1]](diffhunk://#diff-af17d269746f3345a0e6b0c78d4a7449ac020136524b29a8ed8e6efd2a24fc00L8-R11) [[2]](diffhunk://#diff-2696ecc7dca647abea0491fbbcb5b4ba4cc1c4411609fbc2614507bcb4af114fR23-R24)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new user parameter for storing the base name associated with underlying peak maps.

- **Refactor**
	- Updated the storage of base name in peptide identifications to use meta values instead of a dedicated member variable.
	- Modified the method for retrieving the base name to return a value instead of a reference.
	- Removed base name meta values from peptide identifications in cleanup routines.

- **Tests**
	- Added tests to verify correct storage, retrieval, and removal of the base name, as well as the updated empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->