### PR TITLE
doc: PeptideHit and PeptideIdentification

### DIFF
--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -19,10 +19,26 @@
 
 namespace OpenMS
 {
-  /**
-    @brief Representation of a peptide hit
+  class PeptideHit;
+  using SpectrumMatch = PeptideHit; // better name that might become the default in future version
 
-    It contains the fields score, score_type, rank, and sequence.
+  /**
+    @brief Represents a single spectrum match (candidate) for a specific tandem mass spectrum (MS/MS).
+
+    Stores the primary information about a potential match, including:
+    - The sequence (potentially with modifications) using AASequence.
+    - The primary score assigned by the identification algorithm (e.g., search engine).
+    - The rank of this hit compared to other hits for the same spectrum.
+    - The precursor charge state assumed for this match.
+    - Evidence linking the peptide sequence to specific protein sequences (PeptideEvidence).
+    - Optional annotations mapping fragment ions in the MS/MS spectrum to interpretations (PeakAnnotation).
+    - Optional secondary scores from post-processing tools (PepXMLAnalysisResult).
+
+    Objects are typically contained within a PeptideIdentification object, which represents
+    all hits found for a single spectrum. Inherits from MetaInfoInterface, allowing
+    arbitrary metadata (key-value pairs) to be attached.
+
+    @see PeptideIdentification, AASequence, PeptideEvidence, PeakAnnotation, PepXMLAnalysisResult, MetaInfoInterface
 
     @ingroup Metadata
   */

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -38,6 +38,8 @@ namespace OpenMS
     all hits found for a single spectrum. Inherits from MetaInfoInterface, allowing
     arbitrary metadata (key-value pairs) to be attached.
 
+    @deprecated Use SpectrumMatch instead. PeptideHit may be removed in a future OpenMS version.
+
     @see PeptideIdentification, AASequence, PeptideEvidence, PeakAnnotation, PepXMLAnalysisResult, MetaInfoInterface
 
     @ingroup Metadata

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -19,20 +19,41 @@
 namespace OpenMS
 {
     class ConsensusMap;
-  /**
-    @brief Represents the peptide hits for a spectrum
+    class PeptideIdentification;
 
-      This class is closely related to ProteinIdentification, which stores the protein hits
-      and the general information about the identification run. More than one PeptideIdentification
-      can belong to one ProteinIdentification. The general information about a
-      PeptideIdentification has to be looked up in the corresponding ProteinIdentification, using
-      the unique <i>identifier</i> that links the two.
-      When loading PeptideHit instances from a File, the retention time and mass-to-charge ratio
-      of the precursor spectrum can be accessed using getRT() and getMZ().
-      This information can be used to map the peptide hits to an MSExperiment, a FeatureMap
-      or a ConsensusMap using the IDMapper class.
+    using SpectrumIdentification = PeptideIdentification; // better name that might become the default in future version
 
-        @ingroup Metadata
+    /**
+    @brief Represents the set of candidates (SpectrumMatches) identified for a single precursor spectrum.
+
+    Typically encapsulates the results of searching one specific MS/MS spectrum
+    against a sequence database or spectral library. It primarily holds a list of PeptideHit objects,
+    each representing a potential match to the spectrum.
+
+    Crucially, a PeptideIdentification is typically associated with a parent ProteinIdentification
+    object. This parent object contains global information about the entire identification run,
+    such as the search parameters, database used, and the overall set of identified proteins. The
+    link between a PeptideIdentification and its parent ProteinIdentification is established
+    via a shared identifier string (see getIdentifier() and setIdentifier()). Multiple
+    PeptideIdentification instances (one per spectrum analyzed) can belong to the same
+    ProteinIdentification run.
+
+    Each PeptideIdentification stores the precursor ion's retention time (RT) and mass-to-charge
+    ratio (m/z) corresponding to the spectrum that was identified. This information (retrieved via
+    getRT() and getMZ()) is essential for mapping these identifications back to experimental data,
+    such as peaks in an MSExperiment, features in a FeatureMap, or consensus features in a
+    ConsensusMap. The IDMapper class is often used for this purpose.
+
+    The class also stores information about the scoring system used (getScoreType(),
+    isHigherScoreBetter()) and an optional significance threshold (getSignificanceThreshold())
+    for the peptide hits.
+
+    PeptideIdentification inherits from MetaInfoInterface, allowing arbitrary metadata (key-value pairs)
+    to be attached.
+
+    @see PeptideHit, ProteinIdentification, IDMapper, MetaInfoInterface
+
+    @ingroup Metadata          
   */
   class OPENMS_DLLAPI PeptideIdentification :
     public MetaInfoInterface
@@ -186,16 +207,13 @@ public:
                                     const std::map<String, StringList>& identifier_to_msrunpath);
 
 protected:
-
     String id_; ///< Identifier by which ProteinIdentification and PeptideIdentification are matched
     std::vector<PeptideHit> hits_; ///< A list containing the peptide hits
     double significance_threshold_; ///< the peptide significance threshold
     String score_type_; ///< The score type (Mascot, Sequest, e-value, p-value)
     bool higher_score_better_; ///< The score orientation
-    // hint: here is an alignment gap of 7 bytes <-- here --> use it when introducing new members with sizeof(m)<=4
     double mz_;
     double rt_;
-
   };
 
 } //namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -51,6 +51,8 @@ namespace OpenMS
     PeptideIdentification inherits from MetaInfoInterface, allowing arbitrary metadata (key-value pairs)
     to be attached.
 
+    @deprecated Use SpectrumIdentification instead. PeptideIdentification may be removed in a future OpenMS version.
+
     @see PeptideHit, ProteinIdentification, IDMapper, MetaInfoInterface
 
     @ingroup Metadata          


### PR DESCRIPTION
## Description

This pull request includes significant updates to the `PeptideHit` and `PeptideIdentification` classes in the OpenMS library. The changes involve renaming and enhancing the documentation to provide better clarity and future-proofing.

### Enhancements to class documentation and renaming:

* [`src/openms/include/OpenMS/METADATA/PeptideHit.h`](diffhunk://#diff-f57d0fe81ff42dba982fa9f9f2d4d83db5845f66fff737b3a0902e845f285e56L22-R41): Updated the `PeptideHit` class documentation to provide more detailed information about the fields and their usage. Introduced `SpectrumMatch` as a new alias for `PeptideHit`, which may become the default name in future versions.

* [`src/openms/include/OpenMS/METADATA/PeptideIdentification.h`](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aR22-R54): Enhanced the `PeptideIdentification` class documentation to better describe its relationship with `ProteinIdentification` and its role in the identification process. Introduced `SpectrumIdentification` as a new alias for `PeptideIdentification`, which may become the default name in future versions.

### Codebase simplification:

* [`src/openms/include/OpenMS/METADATA/PeptideIdentification.h`](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aL189-L198): Removed outdated comments and added more detailed explanations for the member variables and their significance. This includes the identifier string, list of peptide hits, significance threshold, score type, score orientation, and precursor ion's retention time and mass-to-charge ratio.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified documentation for peptide hit and peptide identification classes, providing detailed descriptions of their roles, data members, and usage context.
  - Introduced alternative names for these classes to improve clarity in future usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->