### PR TITLE
refactor: Peptidehit - store special pepXML values in member variables (after 7983)

### DIFF
--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -19,10 +19,26 @@
 
 namespace OpenMS
 {
-  /**
-    @brief Representation of a peptide hit
+  class PeptideHit;
+  using SpectrumMatch = PeptideHit; // better name that might become the default in future version
 
-    It contains the fields score, score_type, rank, and sequence.
+  /**
+    @brief Represents a single spectrum match (candidate) for a specific tandem mass spectrum (MS/MS).
+
+    Stores the primary information about a potential match, including:
+    - The sequence (potentially with modifications) using AASequence.
+    - The primary score assigned by the identification algorithm (e.g., search engine).
+    - The rank of this hit compared to other hits for the same spectrum.
+    - The precursor charge state assumed for this match.
+    - Evidence linking the peptide sequence to specific protein sequences (PeptideEvidence).
+    - Optional annotations mapping fragment ions in the MS/MS spectrum to interpretations (PeakAnnotation).
+    - Optional secondary scores from post-processing tools (PepXMLAnalysisResult).
+
+    Objects are typically contained within a PeptideIdentification object, which represents
+    all hits found for a single spectrum. Inherits from MetaInfoInterface, allowing
+    arbitrary metadata (key-value pairs) to be attached.
+
+    @see PeptideIdentification, AASequence, PeptideEvidence, PeakAnnotation, PepXMLAnalysisResult, MetaInfoInterface
 
     @ingroup Metadata
   */

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -285,9 +285,6 @@ protected:
     /// the score of the peptide hit
     double score_{};
 
-    /// additional scores attached to the original, aggregated score
-    std::vector<PepXMLAnalysisResult>* analysis_results_;
-
     /// the position(rank) where the hit appeared in the hit list
     UInt rank_{};
 
@@ -299,6 +296,13 @@ protected:
 
     /// annotations of fragments in the corresponding spectrum
     std::vector<PeptideHit::PeakAnnotation> fragment_annotations_;
+
+private:
+    /// Get the number of analysis results stored as meta values
+    size_t getNumberOfAnalysisResultsFromMetaValues_() const;
+
+    /// Extract analysis results from meta values
+    std::vector<PepXMLAnalysisResult> extractAnalysisResultsFromMetaValues_() const;
   };
 
   /// Stream operator

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -253,14 +253,14 @@ public:
     /// sets the PSM score
     void setScore(double score);
 
-    /// set information on (search engine) sub scores associated with this PSM
-    void setAnalysisResults(std::vector<PepXMLAnalysisResult> aresult);
+    /// set information on (search engine) sub scores associated with this PSM (only used by pepXML)
+    void setAnalysisResults(const std::vector<PepXMLAnalysisResult>& aresult);
 
-    /// add information on (search engine) sub scores associated with this PSM
+    /// add information on (search engine) sub scores associated with this PSM (only used by pepXML)
     void addAnalysisResults(const PepXMLAnalysisResult& aresult);
 
-    /// returns information on (search engine) sub scores associated with this PSM
-    const std::vector<PepXMLAnalysisResult>& getAnalysisResults() const;
+    /// returns information on (search engine) sub scores associated with this PSM (only used by pepXML)
+    std::vector<PepXMLAnalysisResult> getAnalysisResults() const;
 
     /// returns the PSM rank
     UInt getRank() const;

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -19,20 +19,41 @@
 namespace OpenMS
 {
     class ConsensusMap;
-  /**
-    @brief Represents the peptide hits for a spectrum
+    class PeptideIdentification;
 
-      This class is closely related to ProteinIdentification, which stores the protein hits
-      and the general information about the identification run. More than one PeptideIdentification
-      can belong to one ProteinIdentification. The general information about a
-      PeptideIdentification has to be looked up in the corresponding ProteinIdentification, using
-      the unique <i>identifier</i> that links the two.
-      When loading PeptideHit instances from a File, the retention time and mass-to-charge ratio
-      of the precursor spectrum can be accessed using getRT() and getMZ().
-      This information can be used to map the peptide hits to an MSExperiment, a FeatureMap
-      or a ConsensusMap using the IDMapper class.
+    using SpectrumIdentification = PeptideIdentification; // better name that might become the default in future version
 
-        @ingroup Metadata
+    /**
+    @brief Represents the set of candidates (SpectrumMatches) identified for a single precursor spectrum.
+
+    Typically encapsulates the results of searching one specific MS/MS spectrum
+    against a sequence database or spectral library. It primarily holds a list of PeptideHit objects,
+    each representing a potential match to the spectrum.
+
+    Crucially, a PeptideIdentification is typically associated with a parent ProteinIdentification
+    object. This parent object contains global information about the entire identification run,
+    such as the search parameters, database used, and the overall set of identified proteins. The
+    link between a PeptideIdentification and its parent ProteinIdentification is established
+    via a shared identifier string (see getIdentifier() and setIdentifier()). Multiple
+    PeptideIdentification instances (one per spectrum analyzed) can belong to the same
+    ProteinIdentification run.
+
+    Each PeptideIdentification stores the precursor ion's retention time (RT) and mass-to-charge
+    ratio (m/z) corresponding to the spectrum that was identified. This information (retrieved via
+    getRT() and getMZ()) is essential for mapping these identifications back to experimental data,
+    such as peaks in an MSExperiment, features in a FeatureMap, or consensus features in a
+    ConsensusMap. The IDMapper class is often used for this purpose.
+
+    The class also stores information about the scoring system used (getScoreType(),
+    isHigherScoreBetter()) and an optional significance threshold (getSignificanceThreshold())
+    for the peptide hits.
+
+    PeptideIdentification inherits from MetaInfoInterface, allowing arbitrary metadata (key-value pairs)
+    to be attached.
+
+    @see PeptideHit, ProteinIdentification, IDMapper, MetaInfoInterface
+
+    @ingroup Metadata          
   */
   class OPENMS_DLLAPI PeptideIdentification :
     public MetaInfoInterface
@@ -186,16 +207,13 @@ public:
                                     const std::map<String, StringList>& identifier_to_msrunpath);
 
 protected:
-
     String id_; ///< Identifier by which ProteinIdentification and PeptideIdentification are matched
     std::vector<PeptideHit> hits_; ///< A list containing the peptide hits
     double significance_threshold_; ///< the peptide significance threshold
     String score_type_; ///< The score type (Mascot, Sequest, e-value, p-value)
     bool higher_score_better_; ///< The score orientation
-    // hint: here is an alignment gap of 7 bytes <-- here --> use it when introducing new members with sizeof(m)<=4
     double mz_;
     double rt_;
-
   };
 
 } //namespace OpenMS

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -363,25 +363,6 @@ namespace OpenMS
           writeFragmentAnnotations_("UserParam", os, p_hit.getPeakAnnotations(), 4);
           writeUserParam_("UserParam", os, p_hit, 4);
 
-          // write out the (optional) peptide prophet / interprophet results as UserParams
-          {
-            int k = 0;
-            auto analysis_results = p_hit.getAnalysisResults();
-            for (auto ar_it = analysis_results.begin(); ar_it != analysis_results.end(); ++ar_it, ++k)
-            {
-              os << "\t\t\t\t<UserParam type=\"string\" name=\"_ar_" << String(k) << "_score_type\" value=\"" << ar_it->score_type << "\"/>" << "\n";
-              os << "\t\t\t\t<UserParam type=\"float\" name=\"_ar_" << String(k) << "_score\" value=\"" << String(ar_it->main_score) << "\"/>" << "\n";
-              if (!ar_it->sub_scores.empty())
-              {
-                for (std::map<String, double>::const_iterator subscore_it = ar_it->sub_scores.begin();
-                    subscore_it != ar_it->sub_scores.end(); ++subscore_it)
-                {
-                  os << "\t\t\t\t<UserParam type=\"float\" name=\"_ar_" << String(k) << "_subscore_" << subscore_it->first <<"\" value=\"" << String(subscore_it->second) << "\"/>" << "\n";
-                }
-              }
-            }
-
-          }
           os << "\t\t\t</PeptideHit>\n";
         }
 

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -366,8 +366,8 @@ namespace OpenMS
           // write out the (optional) peptide prophet / interprophet results as UserParams
           {
             int k = 0;
-            for (std::vector<PeptideHit::PepXMLAnalysisResult>::const_iterator ar_it = p_hit.getAnalysisResults().begin();
-                ar_it != p_hit.getAnalysisResults().end(); ++ar_it, ++k)
+            auto analysis_results = p_hit.getAnalysisResults();
+            for (auto ar_it = analysis_results.begin(); ar_it != analysis_results.end(); ++ar_it, ++k)
             {
               os << "\t\t\t\t<UserParam type=\"string\" name=\"_ar_" << String(k) << "_score_type\" value=\"" << ar_it->score_type << "\"/>" << "\n";
               os << "\t\t\t\t<UserParam type=\"float\" name=\"_ar_" << String(k) << "_score\" value=\"" << String(ar_it->main_score) << "\"/>" << "\n";

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/PeptideHit.h>
+#include <iostream>
 #include <ostream>
 #include <utility>
 
@@ -281,6 +282,7 @@ namespace OpenMS
           key.hasSuffix(suffix))
       {
         String index_str = key.substr(prefix.size(), key.size() - prefix.size() - suffix.size()); // Extract index from _ar_<index>_score_type"
+        std::cout << "Index: " << index_str << std::endl;
         indices.insert(index_str.toInt());
       }
     }

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -199,14 +199,14 @@ namespace OpenMS
     score_ = score;
   }
 
-  void PeptideHit::setAnalysisResults(std::vector<PeptideHit::PepXMLAnalysisResult> aresult)
+  void PeptideHit::setAnalysisResults(const std::vector<PeptideHit::PepXMLAnalysisResult>& aresult)
   {
     // Remove all existing analysis result meta values
     std::vector<String> keys;
     getKeys(keys);
     for (const auto& key : keys)
     {
-      if (key.hasPrefix("OpenMS:AnalysisResult:"))
+      if (key.hasPrefix("_ar_"))
       {
         removeMetaValue(key);
       }
@@ -216,13 +216,13 @@ namespace OpenMS
     for (size_t i = 0; i < aresult.size(); ++i)
     {
       const auto& ar = aresult[i];
-      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":ScoreType", ar.score_type);
-      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":Score", ar.main_score);
-      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":HigherIsBetter", ar.higher_is_better == true ? "true" : "false");
+      setMetaValue("_ar_" + String(i) + "_score_type", ar.score_type);
+      setMetaValue("_ar_" + String(i) + "_score", ar.main_score);
+      setMetaValue("_ar_" + String(i) + "_higher_is_better", ar.higher_is_better == true ? "true" : "false");
       
       for (const auto& subscore : ar.sub_scores)
       {
-        setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":SubScore:" + subscore.first, subscore.second);
+        setMetaValue("_ar_" + String(i) + "_subscore_" + subscore.first, subscore.second);
       }
     }
   }
@@ -231,22 +231,19 @@ namespace OpenMS
   {
     size_t index = getNumberOfAnalysisResultsFromMetaValues_();
     
-    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":ScoreType", aresult.score_type);
-    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":Score", aresult.main_score);
-    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":HigherIsBetter", aresult.higher_is_better == true ? "true" : "false");
+    setMetaValue("_ar_" + String(index) + "_score_type", aresult.score_type);
+    setMetaValue("_ar_" + String(index) + "_score", aresult.main_score);
+    setMetaValue("_ar_" + String(index) + "_higher_is_better", aresult.higher_is_better == true ? "true" : "false");
     
     for (const auto& subscore : aresult.sub_scores)
     {
-      setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":SubScore:" + subscore.first, subscore.second);
+      setMetaValue("_ar_" + String(index) + "_subscore_" + subscore.first, subscore.second);
     }
   }
   
-  const std::vector<PeptideHit::PepXMLAnalysisResult>& PeptideHit::getAnalysisResults() const
+  std::vector<PeptideHit::PepXMLAnalysisResult> PeptideHit::getAnalysisResults() const
   {
-    // Use a thread_local static variable to avoid allocations on each call
-    static thread_local std::vector<PeptideHit::PepXMLAnalysisResult> result;
-    result = extractAnalysisResultsFromMetaValues_();
-    return result;
+    return extractAnalysisResultsFromMetaValues_();
   }
 
   size_t PeptideHit::getNumberOfAnalysisResultsFromMetaValues_() const
@@ -257,8 +254,8 @@ namespace OpenMS
     
     for (const auto& key : keys)
     {
-      if (key.hasPrefix("OpenMS:AnalysisResult:") &&
-          key.hasSuffix(":ScoreType"))
+      if (key.hasPrefix("_ar_") &&
+          key.hasSuffix("_score_type"))
       {
         ++count;
       }
@@ -278,10 +275,12 @@ namespace OpenMS
     
     for (const auto& key : keys)
     {
-      if (key.hasPrefix("OpenMS:AnalysisResult:") &&
-          key.hasSuffix(":ScoreType"))
+      const String prefix = "_ar_";
+      const String suffix = "_score_type";
+      if (key.hasPrefix(prefix) &&
+          key.hasSuffix(suffix))
       {
-        String index_str = key.substr(22, key.size() - 32); // Extract index from "OpenMS:AnalysisResult:<index>:ScoreType"
+        String index_str = key.substr(prefix.size(), key.size() - prefix.size() - suffix.size()); // Extract index from _ar_<index>_score_type"
         indices.insert(index_str.toInt());
       }
     }
@@ -290,28 +289,28 @@ namespace OpenMS
     for (size_t index : indices)
     {
       PeptideHit::PepXMLAnalysisResult ar;
-      String prefix = "OpenMS:AnalysisResult:" + String(index) + ":";
+      String prefix = "_ar_" + String(index) + "_";
       
       // Get score type
-      if (metaValueExists(prefix + "ScoreType"))
+      if (metaValueExists(prefix + "score_type"))
       {
-        ar.score_type = getMetaValue(prefix + "ScoreType").toString();
+        ar.score_type = getMetaValue(prefix + "score_type").toString();
       }
       
       // Get main score
-      if (metaValueExists(prefix + "Score"))
+      if (metaValueExists(prefix + "score"))
       {
-        ar.main_score = getMetaValue(prefix + "Score");
+        ar.main_score = getMetaValue(prefix + "score");
       }
       
       // Get higher_is_better flag
-      if (metaValueExists(prefix + "HigherIsBetter"))
+      if (metaValueExists(prefix + "higher_is_better"))
       {
-        ar.higher_is_better = getMetaValue(prefix + "HigherIsBetter").toBool();
+        ar.higher_is_better = getMetaValue(prefix + "higher_is_better").toBool();
       }
       
       // Get sub-scores
-      String subscore_prefix = prefix + "SubScore:";
+      String subscore_prefix = prefix + "subscore_";
       for (const auto& key : keys)
       {
         if (key.hasPrefix(subscore_prefix))

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -19,7 +19,6 @@ namespace OpenMS
     MetaInfoInterface(),
     sequence_(),
     score_(0),
-    analysis_results_(nullptr),
     rank_(0),
     charge_(0),
     peptide_evidences_(),
@@ -32,7 +31,6 @@ namespace OpenMS
       MetaInfoInterface(),
       sequence_(sequence),
       score_(score),
-      analysis_results_(nullptr),
       rank_(rank),
       charge_(charge),
       peptide_evidences_(),
@@ -45,7 +43,6 @@ namespace OpenMS
     MetaInfoInterface(),
     sequence_(sequence),
     score_(score),
-    analysis_results_(nullptr),
     rank_(rank),
     charge_(charge),
     peptide_evidences_(),
@@ -58,16 +55,11 @@ namespace OpenMS
     MetaInfoInterface(source),
     sequence_(source.sequence_),
     score_(source.score_),
-    analysis_results_(nullptr),
     rank_(source.rank_),
     charge_(source.charge_),
     peptide_evidences_(source.peptide_evidences_),
     fragment_annotations_(source.fragment_annotations_)
   {
-    if (source.analysis_results_ != nullptr)
-    {
-      analysis_results_ = new std::vector<PepXMLAnalysisResult>(*source.analysis_results_);
-    }
   }
 
   /// Move constructor
@@ -75,20 +67,16 @@ namespace OpenMS
     MetaInfoInterface(std::move(source)), // NOTE: rhs itself is an lvalue
     sequence_(std::move(source.sequence_)),
     score_(source.score_),
-    analysis_results_(std::move(source.analysis_results_)),
     rank_(source.rank_),
     charge_(source.charge_),
     peptide_evidences_(std::move(source.peptide_evidences_)),
     fragment_annotations_(std::move(source.fragment_annotations_))
   {
-    // see http://thbecker.net/articles/rvalue_references/section_05.html
-    source.analysis_results_ = nullptr;
   }
 
   // destructor
   PeptideHit::~PeptideHit()
   {
-    delete analysis_results_;
   }
 
   PeptideHit& PeptideHit::operator=(const PeptideHit& source)
@@ -101,11 +89,6 @@ namespace OpenMS
     MetaInfoInterface::operator=(source);
     sequence_ = source.sequence_;
     score_ = source.score_;
-    delete analysis_results_;
-    if (source.analysis_results_ != nullptr)
-    {
-      analysis_results_ = new std::vector<PepXMLAnalysisResult>(*source.analysis_results_);
-    }
     rank_ = source.rank_;
     charge_ = source.charge_;
     peptide_evidences_ = source.peptide_evidences_;
@@ -124,12 +107,6 @@ namespace OpenMS
     //clang-tidy overly strict, should be fine to move the rest here
     sequence_ = source.sequence_;
     score_ = source.score_;
-
-    // free memory and assign rhs memory
-    delete analysis_results_;
-    analysis_results_ = source.analysis_results_;
-    source.analysis_results_ = nullptr;
-
     rank_ = source.rank_;
     charge_ = source.charge_;
     peptide_evidences_ = source.peptide_evidences_;
@@ -140,23 +117,9 @@ namespace OpenMS
 
   bool PeptideHit::operator==(const PeptideHit& rhs) const
   {
-    bool ar_equal = false;
-    if (analysis_results_ == nullptr && rhs.analysis_results_ == nullptr)
-    {
-      ar_equal = true;
-    }
-    else if (analysis_results_ != nullptr && rhs.analysis_results_ != nullptr)
-    {
-      ar_equal = (*analysis_results_ == *rhs.analysis_results_);
-    }
-    else
-    {
-      return false; // one is null the other isn't
-    }
     return MetaInfoInterface::operator==(rhs)
            && sequence_ == rhs.sequence_
            && score_ == rhs.score_
-           && ar_equal
            && rank_ == rhs.rank_
            && charge_ == rhs.charge_
            && peptide_evidences_ == rhs.peptide_evidences_
@@ -238,28 +201,129 @@ namespace OpenMS
 
   void PeptideHit::setAnalysisResults(std::vector<PeptideHit::PepXMLAnalysisResult> aresult)
   {
-    // delete old results first
-    if (analysis_results_ != nullptr) delete analysis_results_;
-    analysis_results_ = new std::vector< PeptideHit::PepXMLAnalysisResult> (std::move(aresult));
+    // Remove all existing analysis result meta values
+    std::vector<String> keys;
+    getKeys(keys);
+    for (const auto& key : keys)
+    {
+      if (key.hasPrefix("OpenMS:AnalysisResult:"))
+      {
+        removeMetaValue(key);
+      }
+    }
+    
+    // Add new analysis results as meta values
+    for (size_t i = 0; i < aresult.size(); ++i)
+    {
+      const auto& ar = aresult[i];
+      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":ScoreType", ar.score_type);
+      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":Score", ar.main_score);
+      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":HigherIsBetter", ar.higher_is_better);
+      
+      for (const auto& subscore : ar.sub_scores)
+      {
+        setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":SubScore:" + subscore.first, subscore.second);
+      }
+    }
   }
 
   void PeptideHit::addAnalysisResults(const PeptideHit::PepXMLAnalysisResult& aresult)
   {
-    if (analysis_results_ == nullptr)
+    size_t index = getNumberOfAnalysisResultsFromMetaValues_();
+    
+    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":ScoreType", aresult.score_type);
+    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":Score", aresult.main_score);
+    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":HigherIsBetter", aresult.higher_is_better);
+    
+    for (const auto& subscore : aresult.sub_scores)
     {
-      analysis_results_ = new std::vector< PeptideHit::PepXMLAnalysisResult>();
+      setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":SubScore:" + subscore.first, subscore.second);
     }
-    analysis_results_->push_back(aresult);
   }
   
   const std::vector<PeptideHit::PepXMLAnalysisResult>& PeptideHit::getAnalysisResults() const
   {
-    static std::vector<PeptideHit::PepXMLAnalysisResult> empty;
-    if (analysis_results_ == nullptr)
+    // Use a thread_local static variable to avoid allocations on each call
+    static thread_local std::vector<PeptideHit::PepXMLAnalysisResult> result;
+    result = extractAnalysisResultsFromMetaValues_();
+    return result;
+  }
+
+  size_t PeptideHit::getNumberOfAnalysisResultsFromMetaValues_() const
+  {
+    size_t count = 0;
+    std::vector<String> keys;
+    getKeys(keys);
+    
+    for (const auto& key : keys)
     {
-      return empty;
+      if (key.hasPrefix("OpenMS:AnalysisResult:") &&
+          key.hasSuffix(":ScoreType"))
+      {
+        ++count;
+      }
     }
-    return (*analysis_results_);
+    
+    return count;
+  }
+
+  std::vector<PeptideHit::PepXMLAnalysisResult> PeptideHit::extractAnalysisResultsFromMetaValues_() const
+  {
+    std::vector<PeptideHit::PepXMLAnalysisResult> results;
+    std::vector<String> keys;
+    getKeys(keys);
+    
+    // First, find all indices that have analysis results
+    std::set<size_t> indices;
+    for (const auto& key : keys)
+    {
+      if (key.hasPrefix("OpenMS:AnalysisResult:") &&
+          key.hasSuffix(":ScoreType"))
+      {
+        String index_str = key.substr(19, key.size() - 29); // Extract index from "OpenMS:AnalysisResult:<index>:ScoreType"
+        indices.insert(index_str.toInt());
+      }
+    }
+    
+    // For each index, extract the analysis result
+    for (size_t index : indices)
+    {
+      PeptideHit::PepXMLAnalysisResult ar;
+      String prefix = "OpenMS:AnalysisResult:" + String(index) + ":";
+      
+      // Get score type
+      if (metaValueExists(prefix + "ScoreType"))
+      {
+        ar.score_type = getMetaValue(prefix + "ScoreType").toString();
+      }
+      
+      // Get main score
+      if (metaValueExists(prefix + "Score"))
+      {
+        ar.main_score = getMetaValue(prefix + "Score");
+      }
+      
+      // Get higher_is_better flag
+      if (metaValueExists(prefix + "HigherIsBetter"))
+      {
+        ar.higher_is_better = getMetaValue(prefix + "HigherIsBetter").toBool();
+      }
+      
+      // Get sub-scores
+      String subscore_prefix = prefix + "SubScore:";
+      for (const auto& key : keys)
+      {
+        if (key.hasPrefix(subscore_prefix))
+        {
+          String subscore_name = key.substr(subscore_prefix.size());
+          ar.sub_scores[subscore_name] = getMetaValue(key);
+        }
+      }
+      
+      results.push_back(ar);
+    }
+    
+    return results;
   }
 
   // sets the rank

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -218,7 +218,7 @@ namespace OpenMS
       const auto& ar = aresult[i];
       setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":ScoreType", ar.score_type);
       setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":Score", ar.main_score);
-      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":HigherIsBetter", ar.higher_is_better);
+      setMetaValue("OpenMS:AnalysisResult:" + String(i) + ":HigherIsBetter", ar.higher_is_better == true ? "true" : "false");
       
       for (const auto& subscore : ar.sub_scores)
       {
@@ -233,7 +233,7 @@ namespace OpenMS
     
     setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":ScoreType", aresult.score_type);
     setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":Score", aresult.main_score);
-    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":HigherIsBetter", aresult.higher_is_better);
+    setMetaValue("OpenMS:AnalysisResult:" + String(index) + ":HigherIsBetter", aresult.higher_is_better == true ? "true" : "false");
     
     for (const auto& subscore : aresult.sub_scores)
     {

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -265,6 +265,319 @@ START_SECTION((void setPeakAnnotations(const vector<PeptideHit::PeakAnnotation> 
   TEST_EQUAL(hit.getPeakAnnotations()[1].annotation == "second test string", true)
   TEST_EQUAL(hit.getPeakAnnotations()[1].mz == 89.1, true)
 END_SECTION
+
+START_SECTION((void setAnalysisResults(std::vector<PepXMLAnalysisResult> aresult)))
+{
+  PeptideHit hit;
+  
+  // Create some analysis results
+  std::vector<PeptideHit::PepXMLAnalysisResult> results;
+  
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  ar1.sub_scores["ntt"] = 2.0;
+  
+  PeptideHit::PepXMLAnalysisResult ar2;
+  ar2.score_type = "interprophet";
+  ar2.higher_is_better = true;
+  ar2.main_score = 0.98;
+  ar2.sub_scores["nss"] = 0.0;
+  ar2.sub_scores["nrs"] = 10.2137;
+  
+  results.push_back(ar1);
+  results.push_back(ar2);
+  
+  // Set the analysis results
+  hit.setAnalysisResults(results);
+  
+  // Check that the analysis results were set correctly
+  TEST_EQUAL(hit.getAnalysisResults().size(), 2);
+  
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_EQUAL(hit.getAnalysisResults()[0].higher_is_better, true);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("ntt"), 2.0);
+  
+  TEST_EQUAL(hit.getAnalysisResults()[1].score_type, "interprophet");
+  TEST_EQUAL(hit.getAnalysisResults()[1].higher_is_better, true);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].main_score, 0.98);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].sub_scores.at("nss"), 0.0);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].sub_scores.at("nrs"), 10.2137);
+  
+  // Check that the analysis results are stored as meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:Score"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:HigherIsBetter"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:SubScore:fval"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:SubScore:ntt"), true);
+  
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:Score"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:HigherIsBetter"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:SubScore:nss"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:SubScore:nrs"), true);
+  
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:Score"), 0.95);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:HigherIsBetter").toBool(), true);
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:SubScore:fval"), 0.7114);
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:SubScore:ntt"), 2.0);
+  
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:ScoreType").toString(), "interprophet");
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:Score"), 0.98);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:HigherIsBetter").toBool(), true);
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:SubScore:nss"), 0.0);
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:SubScore:nrs"), 10.2137);
+  
+  // Test overwriting existing analysis results
+  PeptideHit::PepXMLAnalysisResult ar3;
+  ar3.score_type = "mascot";
+  ar3.higher_is_better = true;
+  ar3.main_score = 100.0;
+  
+  std::vector<PeptideHit::PepXMLAnalysisResult> new_results;
+  new_results.push_back(ar3);
+  
+  hit.setAnalysisResults(new_results);
+  
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "mascot");
+  TEST_EQUAL(hit.getAnalysisResults()[0].higher_is_better, true);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 100.0);
+  
+  // Check that the old meta values are gone
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), false);
+  
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "mascot");
+  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:Score"), 100.0);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:HigherIsBetter").toBool(), true);
+}
+END_SECTION
+
+START_SECTION((void addAnalysisResults(const PepXMLAnalysisResult& aresult)))
+{
+  PeptideHit hit;
+  
+  // Add first analysis result
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  
+  hit.addAnalysisResults(ar1);
+  
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  
+  // Add second analysis result
+  PeptideHit::PepXMLAnalysisResult ar2;
+  ar2.score_type = "interprophet";
+  ar2.higher_is_better = true;
+  ar2.main_score = 0.98;
+  ar2.sub_scores["nrs"] = 10.2137;
+  
+  hit.addAnalysisResults(ar2);
+  
+  TEST_EQUAL(hit.getAnalysisResults().size(), 2);
+  TEST_EQUAL(hit.getAnalysisResults()[1].score_type, "interprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].main_score, 0.98);
+  
+  // Check meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), true);
+  
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:ScoreType").toString(), "interprophet");
+}
+END_SECTION
+
+START_SECTION((const std::vector<PepXMLAnalysisResult>& getAnalysisResults() const))
+{
+  PeptideHit hit;
+  
+  // Test empty analysis results
+  TEST_EQUAL(hit.getAnalysisResults().size(), 0);
+  
+  // Add analysis results
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  
+  hit.addAnalysisResults(ar1);
+  
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+}
+END_SECTION
+
+START_SECTION((PeptideHit(const PeptideHit& source) - with analysis results))
+{
+  PeptideHit source;
+  
+  // Add analysis results to source
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  
+  source.addAnalysisResults(ar1);
+  
+  // Copy construct
+  PeptideHit hit(source);
+  
+  // Check that analysis results were copied
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
+  
+  // Check meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+}
+END_SECTION
+
+START_SECTION((PeptideHit& operator=(const PeptideHit& source) - with analysis results))
+{
+  PeptideHit source;
+  
+  // Add analysis results to source
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  
+  source.addAnalysisResults(ar1);
+  
+  // Assignment
+  PeptideHit hit;
+  hit = source;
+  
+  // Check that analysis results were copied
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
+  
+  // Check meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+}
+END_SECTION
+
+START_SECTION((bool operator==(const PeptideHit& rhs) const - with analysis results))
+{
+  PeptideHit hit1, hit2;
+  
+  // Empty hits should be equal
+  TEST_EQUAL(hit1 == hit2, true);
+  
+  // Add analysis results to hit1
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  
+  hit1.addAnalysisResults(ar1);
+  
+  // Now they should be different
+  TEST_EQUAL(hit1 == hit2, false);
+  
+  // Add same analysis results to hit2
+  hit2.addAnalysisResults(ar1);
+  
+  // Now they should be equal again
+  TEST_EQUAL(hit1 == hit2, true);
+  
+  // Add different analysis results to hit2
+  PeptideHit::PepXMLAnalysisResult ar2;
+  ar2.score_type = "interprophet";
+  ar2.higher_is_better = true;
+  ar2.main_score = 0.98;
+  
+  hit2.addAnalysisResults(ar2);
+  
+  // Now they should be different again
+  TEST_EQUAL(hit1 == hit2, false);
+}
+END_SECTION
+
+START_SECTION((PeptideHit(PeptideHit&& source) noexcept - with analysis results))
+{
+  PeptideHit source;
+  
+  // Add analysis results to source
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  
+  source.addAnalysisResults(ar1);
+  
+  // Move construct
+  PeptideHit hit(std::move(source));
+  
+  // Check that analysis results were moved
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
+  
+  // Check meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  
+  // Source should have no meta values after move
+  TEST_EQUAL(source.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), false);
+  TEST_EQUAL(source.getAnalysisResults().size(), 0);
+}
+END_SECTION
+
+START_SECTION((PeptideHit& operator=(PeptideHit&& source) noexcept - with analysis results))
+{
+  PeptideHit source;
+  
+  // Add analysis results to source
+  PeptideHit::PepXMLAnalysisResult ar1;
+  ar1.score_type = "peptideprophet";
+  ar1.higher_is_better = true;
+  ar1.main_score = 0.95;
+  ar1.sub_scores["fval"] = 0.7114;
+  
+  source.addAnalysisResults(ar1);
+  
+  // Move assignment
+  PeptideHit hit;
+  hit = std::move(source);
+  
+  // Check that analysis results were moved
+  TEST_EQUAL(hit.getAnalysisResults().size(), 1);
+  TEST_EQUAL(hit.getAnalysisResults()[0].score_type, "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 0.95);
+  TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
+  
+  // Check meta values
+  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
+  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  
+  // Source should have no meta values after move
+  TEST_EQUAL(source.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), false);
+  TEST_EQUAL(source.getAnalysisResults().size(), 0);
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -312,26 +312,26 @@ START_SECTION((void setAnalysisResults(std::vector<PepXMLAnalysisResult> aresult
   TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
   TEST_EQUAL(hit.metaValueExists("_ar_0_score"), true);
   TEST_EQUAL(hit.metaValueExists("_ar_0_higher_is_better"), true);
-  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore:fval"), true);
-  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore:ntt"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore_fval"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore_ntt"), true);
   
   TEST_EQUAL(hit.metaValueExists("_ar_1_score_type"), true);
   TEST_EQUAL(hit.metaValueExists("_ar_1_score"), true);
   TEST_EQUAL(hit.metaValueExists("_ar_1_higher_is_better"), true);
-  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore:nss"), true);
-  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore:nrs"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore_nss"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore_nrs"), true);
   
   TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
   TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_score"), 0.95);
   TEST_EQUAL(hit.getMetaValue("_ar_0_higher_is_better").toBool(), true);
-  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore:fval"), 0.7114);
-  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore:ntt"), 2.0);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore_fval"), 0.7114);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore_ntt"), 2.0);
   
   TEST_EQUAL(hit.getMetaValue("_ar_1_score_type").toString(), "interprophet");
   TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_score"), 0.98);
   TEST_EQUAL(hit.getMetaValue("_ar_1_higher_is_better").toBool(), true);
-  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore:nss"), 0.0);
-  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore:nrs"), 10.2137);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore_nss"), 0.0);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore_nrs"), 10.2137);
   
   // Test overwriting existing analysis results
   PeptideHit::PepXMLAnalysisResult ar3;

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -309,29 +309,29 @@ START_SECTION((void setAnalysisResults(std::vector<PepXMLAnalysisResult> aresult
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].sub_scores.at("nrs"), 10.2137);
   
   // Check that the analysis results are stored as meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:Score"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:HigherIsBetter"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:SubScore:fval"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:SubScore:ntt"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_higher_is_better"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore:fval"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_subscore:ntt"), true);
   
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:Score"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:HigherIsBetter"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:SubScore:nss"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:SubScore:nrs"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_score_type"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_score"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_higher_is_better"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore:nss"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_subscore:nrs"), true);
   
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:Score"), 0.95);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:HigherIsBetter").toBool(), true);
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:SubScore:fval"), 0.7114);
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:SubScore:ntt"), 2.0);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_score"), 0.95);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_higher_is_better").toBool(), true);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore:fval"), 0.7114);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_subscore:ntt"), 2.0);
   
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:ScoreType").toString(), "interprophet");
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:Score"), 0.98);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:HigherIsBetter").toBool(), true);
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:SubScore:nss"), 0.0);
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:1:SubScore:nrs"), 10.2137);
+  TEST_EQUAL(hit.getMetaValue("_ar_1_score_type").toString(), "interprophet");
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_score"), 0.98);
+  TEST_EQUAL(hit.getMetaValue("_ar_1_higher_is_better").toBool(), true);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore:nss"), 0.0);
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_1_subscore:nrs"), 10.2137);
   
   // Test overwriting existing analysis results
   PeptideHit::PepXMLAnalysisResult ar3;
@@ -350,12 +350,12 @@ START_SECTION((void setAnalysisResults(std::vector<PepXMLAnalysisResult> aresult
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].main_score, 100.0);
   
   // Check that the old meta values are gone
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), false);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_score_type"), false);
   
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "mascot");
-  TEST_REAL_SIMILAR(hit.getMetaValue("OpenMS:AnalysisResult:0:Score"), 100.0);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:HigherIsBetter").toBool(), true);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "mascot");
+  TEST_REAL_SIMILAR(hit.getMetaValue("_ar_0_score"), 100.0);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_higher_is_better").toBool(), true);
 }
 END_SECTION
 
@@ -390,11 +390,11 @@ START_SECTION((void addAnalysisResults(const PepXMLAnalysisResult& aresult)))
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[1].main_score, 0.98);
   
   // Check meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:1:ScoreType"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.metaValueExists("_ar_1_score_type"), true);
   
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:1:ScoreType").toString(), "interprophet");
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
+  TEST_EQUAL(hit.getMetaValue("_ar_1_score_type").toString(), "interprophet");
 }
 END_SECTION
 
@@ -442,8 +442,8 @@ START_SECTION((PeptideHit(const PeptideHit& source) - with analysis results))
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
   
   // Check meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
 }
 END_SECTION
 
@@ -471,8 +471,8 @@ START_SECTION((PeptideHit& operator=(const PeptideHit& source) - with analysis r
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
   
   // Check meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
 }
 END_SECTION
 
@@ -536,11 +536,11 @@ START_SECTION((PeptideHit(PeptideHit&& source) noexcept - with analysis results)
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
   
   // Check meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
   
   // Source should have no meta values after move
-  TEST_EQUAL(source.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), false);
+  TEST_EQUAL(source.metaValueExists("_ar_0_score_type"), false);
   TEST_EQUAL(source.getAnalysisResults().size(), 0);
 }
 END_SECTION
@@ -569,11 +569,11 @@ START_SECTION((PeptideHit& operator=(PeptideHit&& source) noexcept - with analys
   TEST_REAL_SIMILAR(hit.getAnalysisResults()[0].sub_scores.at("fval"), 0.7114);
   
   // Check meta values
-  TEST_EQUAL(hit.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), true);
-  TEST_EQUAL(hit.getMetaValue("OpenMS:AnalysisResult:0:ScoreType").toString(), "peptideprophet");
+  TEST_EQUAL(hit.metaValueExists("_ar_0_score_type"), true);
+  TEST_EQUAL(hit.getMetaValue("_ar_0_score_type").toString(), "peptideprophet");
   
   // Source should have no meta values after move
-  TEST_EQUAL(source.metaValueExists("OpenMS:AnalysisResult:0:ScoreType"), false);
+  TEST_EQUAL(source.metaValueExists("_ar_0_score_type"), false);
   TEST_EQUAL(source.getAnalysisResults().size(), 0);
 }
 END_SECTION

--- a/src/tests/topp/IDFileConverter_10_output.idXML
+++ b/src/tests/topp/IDFileConverter_10_output.idXML
@@ -36,6 +36,7 @@
 				<UserParam type="float" name="MS:1001330" value="0.033"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.7911"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_RT" value="72.480000000000004"/>
 				<UserParam type="float" name="_ar_0_subscore_RT_score" value="1.36"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="2.8985"/>
@@ -45,6 +46,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="false"/>
 			</PeptideHit>
 			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/H_LN1"/>
 		</PeptideIdentification>
@@ -56,6 +58,7 @@
 				<UserParam type="float" name="MS:1001330" value="2.0e-04"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.9938"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_RT" value="3464.929999999999836"/>
 				<UserParam type="float" name="_ar_0_subscore_RT_score" value="-0.73"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="6.9022"/>
@@ -65,6 +68,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="false"/>
 			</PeptideHit>
 			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/H_LN1"/>
 		</PeptideIdentification>
@@ -84,6 +88,7 @@
 				<UserParam type="float" name="MS:1001330" value="1.0e-04"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="1.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_RT" value="-407.370000000000005"/>
 				<UserParam type="float" name="_ar_0_subscore_RT_score" value="2.18"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="7.941"/>
@@ -93,6 +98,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="false"/>
 			</PeptideHit>
 			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/L_LN1"/>
 		</PeptideIdentification>
@@ -104,6 +110,7 @@
 				<UserParam type="float" name="MS:1001330" value="1.3e-07"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="1.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_RT" value="3644.050000000000182"/>
 				<UserParam type="float" name="_ar_0_subscore_RT_score" value="-1.04"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="9.966200000000001"/>
@@ -113,6 +120,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="xpress"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="false"/>
 			</PeptideHit>
 			<UserParam type="string" name="base_name" value="c:/Inetpub/wwwroot/ISB/data/user-data/Lars/20141217_tMS2_tests/TPP/LN1/L_LN1"/>
 		</PeptideIdentification>

--- a/src/tests/topp/IDFileConverter_16_output.idXML
+++ b/src/tests/topp/IDFileConverter_16_output.idXML
@@ -32,6 +32,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.9208"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.434"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-5.0e-03"/>
@@ -39,6 +40,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="0.806668"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="8.728"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>
@@ -52,6 +54,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-3.5466"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="0.023"/>
@@ -59,6 +62,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>
@@ -72,6 +76,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.217"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="0.801"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="6.0e-03"/>
@@ -79,6 +84,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0223989"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>
@@ -92,6 +98,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.07"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3114"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-0.02"/>
@@ -99,6 +106,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="0.0505509"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>
@@ -112,6 +120,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="1.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="4.795"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-6.0e-03"/>
@@ -119,6 +128,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="2.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="0.999999"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.999999"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>
@@ -132,6 +142,7 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="7.0e-04"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3658"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-0.063"/>
@@ -139,6 +150,7 @@
 				<UserParam type="float" name="_ar_0_subscore_ntt" value="1.0"/>
 				<UserParam type="string" name="_ar_1_score_type" value="interprophet"/>
 				<UserParam type="float" name="_ar_1_score" value="2.01282e-05"/>
+				<UserParam type="string" name="_ar_1_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_1_subscore_nrs" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsi" value="0.0"/>
 				<UserParam type="float" name="_ar_1_subscore_nsm" value="0.0"/>

--- a/src/tests/topp/IDFileConverter_24_output.idXML
+++ b/src/tests/topp/IDFileConverter_24_output.idXML
@@ -65,6 +65,7 @@
 				<UserParam type="float" name="MS:1002257" value="27.899999999999999"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-2.3431"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="-0.087"/>
@@ -111,6 +112,7 @@
 				<UserParam type="float" name="MS:1002257" value="3.44"/>
 				<UserParam type="string" name="_ar_0_score_type" value="peptideprophet"/>
 				<UserParam type="float" name="_ar_0_score" value="0.0"/>
+				<UserParam type="string" name="_ar_0_higher_is_better" value="true"/>
 				<UserParam type="float" name="_ar_0_subscore_fval" value="-1.3443"/>
 				<UserParam type="float" name="_ar_0_subscore_isomassd" value="0.0"/>
 				<UserParam type="float" name="_ar_0_subscore_massd" value="0.129"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1_out.idXML
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-17T08:17:57" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_2_out.idXML
@@ -72,7 +72,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:22" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-17T08:17:58" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="prot1" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3_out.idXML
@@ -78,7 +78,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:23" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2  (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-17T08:17:59" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="DECOY_tr|Q5QTS3|Q5QTS3_HUMAN" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_4_out.idXML
@@ -74,7 +74,7 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-16T12:04:25" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2 (7c9150d)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-17T08:18:01" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|A9ESU7|ALR_SORC5" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/THIRDPARTY/CometAdapter_5_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_5_out.idXML
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="unspecific cleavage" missed_cleavages="1" precursor_peak_tolerance="20" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="0:0" enzyme="chymotrypsin/p" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.01" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML"/>
-				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_6_out1.tmp.idXML"/>
-				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_3.fasta"/>
+				<UserParam type="string" name="CometAdapter:1:in" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test_in.mzML"/>
+				<UserParam type="string" name="CometAdapter:1:out" value="CometAdapter_5_out1.tmp.idXML"/>
+				<UserParam type="string" name="CometAdapter:1:database" value="/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test.fasta"/>
 				<UserParam type="string" name="CometAdapter:1:comet_executable" value="/mnt/c/Program Files/OpenMS-3.1.0-pre-nightly-2024-02-02/share/OpenMS/THIRDPARTY/Comet/comet.exe"/>
 				<UserParam type="string" name="CometAdapter:1:pin_out" value=""/>
 				<UserParam type="string" name="CometAdapter:1:default_params_file" value=""/>
-				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="20.0"/>
+				<UserParam type="float" name="CometAdapter:1:precursor_mass_tolerance" value="10.0"/>
 				<UserParam type="string" name="CometAdapter:1:precursor_error_units" value="ppm"/>
 				<UserParam type="string" name="CometAdapter:1:isotope_error" value="off"/>
 				<UserParam type="float" name="CometAdapter:1:fragment_mass_tolerance" value="0.01"/>
@@ -24,7 +24,7 @@
 				<UserParam type="string" name="CometAdapter:1:use_Y_ions" value="true"/>
 				<UserParam type="string" name="CometAdapter:1:use_Z_ions" value="false"/>
 				<UserParam type="string" name="CometAdapter:1:use_NL_ions" value="false"/>
-				<UserParam type="string" name="CometAdapter:1:enzyme" value="unspecific cleavage"/>
+				<UserParam type="string" name="CometAdapter:1:enzyme" value="Chymotrypsin/P"/>
 				<UserParam type="string" name="CometAdapter:1:second_enzyme" value=""/>
 				<UserParam type="string" name="CometAdapter:1:num_enzyme_termini" value="fully"/>
 				<UserParam type="int" name="CometAdapter:1:missed_cleavages" value="1"/>
@@ -74,67 +74,39 @@
 				<UserParam type="string" name="extra_features" value="isotope_error,COMET:deltaCn,COMET:deltaLCn,COMET:lnExpect,MS:1002252,MS:1002255,COMET:lnNumSP,COMET:lnRankSP,COMET:IonFrac"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-04-17T08:18:07" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2025-04-17T08:18:06" search_engine="Comet" search_engine_version="# comet_version 2023.01 rev. 2" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
-			<ProteinHit id="PH_0" accession="DECOY_sp|P61313|RL15_HUMAN" score="0.0" sequence="" >
-				<UserParam type="string" name="target_decoy" value="decoy"/>
+			<ProteinHit id="PH_0" accession="sp|Q5PT55|NTCP5_HUMAN" score="0.0" sequence="" >
+				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/CometAdapter_6_in.mzML]"/>
-			<UserParam type="string" name="IM" value="1/K0"/>
+			<UserParam type="stringList" name="spectra_data_raw" value="[file:///F:/CONFETTI_NEW_HELA/Hela_Chy_Try_pH3_CID_3xload_1_20140729.raw]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/home/sachsenb/Development/OpenMS/src/tests/topp/THIRDPARTY/Chy_test_in.mzML]"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="577.819547531899957" RT="0.9" spectrum_reference="index=7" >
-			<PeptideHit score="999.0" sequence="HVPKGYTAGKP" charge="2" aa_before="H" aa_after="V" start="118" end="128" protein_refs="PH_0" >
-				<UserParam type="string" name="MS:1002258" value="0"/>
-				<UserParam type="string" name="MS:1002259" value="20"/>
-				<UserParam type="string" name="num_matched_peptides" value="2"/>
-				<UserParam type="int" name="isotope_error" value="0"/>
-				<UserParam type="float" name="MS:1002252" value="0.1106"/>
-				<UserParam type="float" name="COMET:xcorr" value="0.1106"/>
-				<UserParam type="float" name="MS:1002253" value="1.0"/>
-				<UserParam type="float" name="COMET:deltaCn" value="1.0"/>
-				<UserParam type="float" name="MS:1002255" value="0.0"/>
-				<UserParam type="float" name="COMET:spscore" value="0.0"/>
-				<UserParam type="float" name="MS:1002256" value="1.0"/>
-				<UserParam type="float" name="COMET:sprank" value="1.0"/>
-				<UserParam type="float" name="MS:1002257" value="999.0"/>
-				<UserParam type="float" name="Comet:lnrSp" value="0.0"/>
-				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
-				<UserParam type="float" name="COMET:deltaLCn" value="0.0"/>
-				<UserParam type="float" name="COMET:lnExpect" value="6.906754778648554"/>
-				<UserParam type="float" name="Comet:IonFrac" value="0.0"/>
-				<UserParam type="float" name="COMET:IonFrac" value="0.0"/>
-				<UserParam type="float" name="COMET:lnNumSP" value="0.6931"/>
-				<UserParam type="string" name="target_decoy" value="decoy"/>
-				<UserParam type="string" name="protein_references" value="unique"/>
-			</PeptideHit>
-			<UserParam type="float" name="IM" value="0.784869800680812"/>
-		</PeptideIdentification>
-		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="537.842461531899971" RT="10.199999999999999" spectrum_reference="index=57" >
-			<PeptideHit score="999.0" sequence="RVRIRYIV" charge="2" aa_before="R" aa_after="Y" start="137" end="144" protein_refs="PH_0" >
+		<PeptideIdentification score_type="expect" higher_score_better="false" significance_threshold="0.0" MZ="705.973693031899984" RT="2850.0" spectrum_reference="controllerType=0 controllerNumber=1 scan=7904" >
+			<PeptideHit score="940.0" sequence="PEAQAFGVVMTC(Carbamidomethyl)TC(Carbamidomethyl)PGGGGGY" charge="3" aa_before="L" aa_after="L" start="201" end="221" protein_refs="PH_0" >
 				<UserParam type="string" name="MS:1002258" value="1"/>
-				<UserParam type="string" name="MS:1002259" value="14"/>
+				<UserParam type="string" name="MS:1002259" value="80"/>
 				<UserParam type="string" name="num_matched_peptides" value="1"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
-				<UserParam type="float" name="MS:1002252" value="0.2442"/>
-				<UserParam type="float" name="COMET:xcorr" value="0.2442"/>
+				<UserParam type="float" name="MS:1002252" value="0.1621"/>
+				<UserParam type="float" name="COMET:xcorr" value="0.1621"/>
 				<UserParam type="float" name="MS:1002253" value="1.0"/>
 				<UserParam type="float" name="COMET:deltaCn" value="1.0"/>
-				<UserParam type="float" name="MS:1002255" value="1.8"/>
-				<UserParam type="float" name="COMET:spscore" value="1.8"/>
+				<UserParam type="float" name="MS:1002255" value="0.1"/>
+				<UserParam type="float" name="COMET:spscore" value="0.1"/>
 				<UserParam type="float" name="MS:1002256" value="1.0"/>
 				<UserParam type="float" name="COMET:sprank" value="1.0"/>
-				<UserParam type="float" name="MS:1002257" value="999.0"/>
+				<UserParam type="float" name="MS:1002257" value="940.0"/>
 				<UserParam type="float" name="Comet:lnrSp" value="0.0"/>
 				<UserParam type="float" name="COMET:lnRankSP" value="0.0"/>
 				<UserParam type="float" name="COMET:deltaLCn" value="0.0"/>
-				<UserParam type="float" name="COMET:lnExpect" value="6.906754778648554"/>
-				<UserParam type="float" name="Comet:IonFrac" value="0.0714"/>
-				<UserParam type="float" name="COMET:IonFrac" value="0.0714"/>
+				<UserParam type="float" name="COMET:lnExpect" value="6.84587987526405"/>
+				<UserParam type="float" name="Comet:IonFrac" value="0.0125"/>
+				<UserParam type="float" name="COMET:IonFrac" value="0.0125"/>
 				<UserParam type="float" name="COMET:lnNumSP" value="0.0"/>
-				<UserParam type="string" name="target_decoy" value="decoy"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<UserParam type="float" name="IM" value="0.770198702491127"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>


### PR DESCRIPTION
This pull request includes significant updates to the `PeptideHit` and `PeptideIdentification` classes in the OpenMS library. The primary changes involve renaming classes for clarity, enhancing documentation, and refactoring how analysis results are stored and managed.

### Class Renaming and Documentation Improvements:
* [`src/openms/include/OpenMS/METADATA/PeptideHit.h`](diffhunk://#diff-f57d0fe81ff42dba982fa9f9f2d4d83db5845f66fff737b3a0902e845f285e56R22-R41): Introduced `SpectrumMatch` as an alias for `PeptideHit` and updated the class documentation to provide a detailed description of the information stored in `PeptideHit`.
* [`src/openms/include/OpenMS/METADATA/PeptideIdentification.h`](diffhunk://#diff-8b61fff3c786837e11442bfad275f016bf96e54a39c0981e416c762408fd420aR22-R54): Introduced `SpectrumIdentification` as an alias for `PeptideIdentification` and enhanced the class documentation to describe the relationship between `PeptideIdentification` and `ProteinIdentification`.

### Refactoring Analysis Results Storage:
* [`src/openms/include/OpenMS/METADATA/PeptideHit.h`](diffhunk://#diff-f57d0fe81ff42dba982fa9f9f2d4d83db5845f66fff737b3a0902e845f285e56R299-R305): Removed the `analysis_results_` member and added private methods `getNumberOfAnalysisResultsFromMetaValues_` and `extractAnalysisResultsFromMetaValues_` to manage analysis results using meta values.
* [`src/openms/source/METADATA/PeptideHit.cpp`](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L241-R326): Refactored methods to store analysis results as meta values instead of using a dedicated member. This includes changes to `setAnalysisResults`, `addAnalysisResults`, and `getAnalysisResults`.

### Code Cleanup:
* [`src/openms/source/METADATA/PeptideHit.cpp`](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L22): Removed the `analysis_results_` member initialization and cleanup from constructors, destructor, and assignment operators. [[1]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L22) [[2]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L35) [[3]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L48) [[4]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L61-L91) [[5]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L104-L108) [[6]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L127-L132) [[7]](diffhunk://#diff-70fb8b85bc442403ca3eae6bc8b2623f975050af018cf10e96323927c24c5ff6L143-L159)

These changes aim to improve code clarity, documentation, and the handling of analysis results in the OpenMS library.## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of secondary scores in peptide hits by storing analysis results within meta values for more reliable management.
  - Removed legacy output of analysis results in IdXML files to streamline serialization.

- **Tests**
  - Added comprehensive tests to verify correct management, copying, moving, and comparison of analysis results within peptide hits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->