### PR TITLE
Update openms_ci_matrix_full.yml

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -327,16 +327,21 @@ jobs:
           cd ..
           # add third-party binaries to PATH
           # use flat THIRDPARTY structure
+          $THIRDPARTY_DIR = "OpenMS/THIRDPARTY"
           mkdir -p _thirdparty
           # Copy the correct architecture
-          cp -R OpenMS/THIRDPARTY/${{ steps.set-vars.outputs.tp_folder }}/`uname -m`/* _thirdparty/
-          # For MacOS 14 we also want to copy over any tools that we only have in x86_64 flavor. cp -n avoids overwriting the arm specific executables that we've already copied above
+          cp -R $THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/`uname -m`/* _thirdparty/
+          
+          # For MacOS 14 we also want to copy over any tools that we only have in x86_64 flavor.
           if [[ "${{ matrix.os }}" == macos-14 ]]; then
             echo "Copying x86_64 tools for MacOS 14"
-            cp -R OpenMS/THIRDPARTY/MacOS/x86_64/MaRaCluster/* _thirdparty/
-            cp -R OpenMS/THIRDPARTY/MacOS/x86_64/SpectraST/* _thirdparty/
-            cp -R OpenMS/THIRDPARTY/MacOS/x86_64/XTandem/* _thirdparty/
-          fi
+            for tool in $THIRDPARTY_DIR/MacOS/x86_64/*; do
+              toolname=$(basename "$tool")
+              if [[ ! -e "_thirdparty/$toolname" ]]; then
+                echo "Copying missing tool from x86_64: $toolname"
+                cp -R "$tool" "_thirdparty/"
+              fi
+            done
           cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
           # add third-party binaries to PATH
           for thirdpartytool in '${{ github.workspace }}/_thirdparty'/*

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -330,8 +330,7 @@ jobs:
           THIRDPARTY_DIR="OpenMS/THIRDPARTY"
           mkdir -p _thirdparty
           # Copy the correct architecture
-          cp -R $THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/`uname -m`/* _thirdparty/
-          
+          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/          
           # For MacOS 14 we also want to copy over any tools that we only have in x86_64 flavor.
           if [[ "${{ matrix.os }}" == macos-14 ]]; then
             echo "Copying x86_64 tools for MacOS 14"

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -342,6 +342,7 @@ jobs:
                 cp -R "$tool" "_thirdparty/"
               fi
             done
+          fi
           cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
           # add third-party binaries to PATH
           for thirdpartytool in '${{ github.workspace }}/_thirdparty'/*

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -327,7 +327,7 @@ jobs:
           cd ..
           # add third-party binaries to PATH
           # use flat THIRDPARTY structure
-          $THIRDPARTY_DIR = "OpenMS/THIRDPARTY"
+          THIRDPARTY_DIR="OpenMS/THIRDPARTY"
           mkdir -p _thirdparty
           # Copy the correct architecture
           cp -R $THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/`uname -m`/* _thirdparty/


### PR DESCRIPTION
## Description
Should fix the Nightlies.
## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized the third-party directory path using a variable for easier maintenance.
  - Updated the macOS 14 workflow to copy only missing x86_64 third-party tools, preventing overwriting of existing arm64 binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->