### PR TITLE
Handled Single-Peak Mass Traces

### DIFF
--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -650,6 +650,7 @@ namespace OpenMS
       if (trace_peaks_.size() == 1)
       {
         centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
+        centroid_sd_ = 0.0; // For a single peak, standard deviation is 0
         return;
       }
 

--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -96,7 +96,6 @@ namespace OpenMS
       return peak_area;
     }
 
-
     double MassTrace::computeIntensitySum() const
     {
       return std::accumulate(trace_peaks_.begin(), trace_peaks_.end(), 0.0, 
@@ -404,6 +403,12 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid RT undefined!", String(trace_peaks_.size()));
       }
 
+      // support single peak traces
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_rt_ = (*(trace_peaks_.begin())).getRT();
+        return;
+      }
 
 
 
@@ -441,6 +446,13 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace was not smoothed before! Aborting...", String(smoothed_intensities_.size()));
       }
 
+      // support single peak traces
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_rt_ = (*(trace_peaks_.begin())).getRT();
+        return;
+      }
+
       double trace_area(0.0), wmean_rt(0.0);
 
       for (Size i = 0; i < smoothed_intensities_.size(); ++i)
@@ -465,6 +477,11 @@ namespace OpenMS
       if (smoothed_intensities_.empty())
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace was not smoothed before! Aborting...", String(smoothed_intensities_.size()));
+      }
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_rt_ = (*(trace_peaks_.begin())).getRT();
+        return;
       }
 
       double tmp_max(-1.0);
@@ -522,7 +539,6 @@ namespace OpenMS
         centroid_rt_ = temp_rt[mid];
       }
 
-
       return;
     }
 
@@ -570,6 +586,11 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid MZ undefined!", String(trace_peaks_.size()));
       }
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
+        return;
+      }
 
       Size trace_size = trace_peaks_.size();
 
@@ -590,6 +611,11 @@ namespace OpenMS
       if (trace_peaks_.empty())
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid MZ undefined!", String(trace_peaks_.size()));
+      }
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
+        return;
       }
 
       double weighted_sum(0.0);
@@ -616,6 +642,11 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... std of MZ undefined!", String(trace_peaks_.size()));
       }
+      if (trace_peaks_.size() == 1)
+      {
+        centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
+        return;
+      }
 
       double weighted_sum(0.0);
       double total_weight(0.0);
@@ -637,3 +668,5 @@ namespace OpenMS
     }
 
 } // end of MassTrace.cpp
+
+

--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -403,7 +403,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid RT undefined!", String(trace_peaks_.size()));
       }
 
-      // support single peak traces
+      // Handle single-peak traces: set centroid RT directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_rt_ = (*(trace_peaks_.begin())).getRT();
@@ -446,7 +446,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace was not smoothed before! Aborting...", String(smoothed_intensities_.size()));
       }
 
-      // support single peak traces
+      // Handle single-peak traces: set centroid RT directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_rt_ = (*(trace_peaks_.begin())).getRT();
@@ -478,6 +478,7 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace was not smoothed before! Aborting...", String(smoothed_intensities_.size()));
       }
+      // Handle single-peak traces: set centroid RT directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_rt_ = (*(trace_peaks_.begin())).getRT();
@@ -549,6 +550,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid MZ undefined!", String(trace_peaks_.size()));
       }
 
+      // Handle single-peak traces: set centroid MZ directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
@@ -586,6 +588,7 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid MZ undefined!", String(trace_peaks_.size()));
       }
+      // Handle single-peak traces: set centroid MZ directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
@@ -612,6 +615,7 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... centroid MZ undefined!", String(trace_peaks_.size()));
       }
+      // Handle single-peak traces: set centroid MZ directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_mz_ = (*(trace_peaks_.begin())).getMZ();
@@ -642,6 +646,7 @@ namespace OpenMS
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MassTrace is empty... std of MZ undefined!", String(trace_peaks_.size()));
       }
+      // Handle single-peak traces: set centroid MZ directly from the only peak
       if (trace_peaks_.size() == 1)
       {
         centroid_mz_ = (*(trace_peaks_.begin())).getMZ();


### PR DESCRIPTION
This PR applies the provided patch to robustly handle single-peak mass traces robustly, ensuring correct centroid assignment and preventing -NaN values, as requested in the related issue. No unrelated code was changed.

Resolves #8006 

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of MassTraces containing a single peak to prevent errors in centroid calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->