### PR TITLE
Range exception

### DIFF
--- a/doc/code_examples/Tutorial_MSExperiment.cpp
+++ b/doc/code_examples/Tutorial_MSExperiment.cpp
@@ -56,7 +56,7 @@ int main()
   exp.updateRanges();
   std::cout << "Data ranges:\n";
   exp.printRange(std::cout);
-  std::cout << "\nGet maximum intensity on its own: " << exp.getMinMobility() << '\n';
+  std::cout << "\nGet maximum intensity on its own: " << exp.getMaxIntensity() << '\n';
   exp.getMinRT();
 
   // Store the spectra to a mzML file with:

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -130,15 +130,7 @@ public:
     }
 
     // Docu in base class (RangeManager)
-    void updateRanges() override
-    {
-      clearRanges();
-      for (const auto& peak : (ContainerType&) *this)
-      {
-        extendRT(peak.getRT());
-        extendIntensity(peak.getIntensity());
-      }
-    }
+    void updateRanges() override;
 
     ///@name Accessors for meta information
     ///@{

--- a/src/openms/include/OpenMS/KERNEL/RangeManager.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeManager.h
@@ -126,9 +126,9 @@ public:
   /// only useful if isEmpty() returns false
   double getMin() const
   {
-    if (!isInitialized())
+    if (isEmpty())
     {
-      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is not initialized. Did you forget to call updateRanges()?");
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is empty. Did you forget to call updateRanges()?");
     }
     return min_;
   }
@@ -136,9 +136,9 @@ public:
   /// only useful if isEmpty() returns false
   double getMax() const
   {
-    if (!isInitialized())
+    if (isEmpty())
     {
-      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is not initialized. Did you forget to call updateRanges()?");
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is empty. Did you forget to call updateRanges()?");
     }
     return max_;
   }
@@ -269,13 +269,6 @@ public:
     return min_ == rhs.min_ && max_ == rhs.max_;
   }
 
-  /// @brief   Check if the range is initialized
-  /// @note    A range is initialized if min_ and max_ are not set to their default values (=uninitialized).
-  /// @return  True if the range is initialized, false otherwise
-  bool isInitialized() const
-  {
-    return min_ != std::numeric_limits<double>::max() && max_ != std::numeric_limits<double>::lowest();
-  }
   /**
    * \brief Return the current range, or (if empty) a full range (-1e308, 1e308).
    * \return A range where always: min <= max

--- a/src/openms/include/OpenMS/KERNEL/RangeManager.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeManager.h
@@ -123,22 +123,24 @@ public:
     if (min_ > max) min_ = max;
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the minimum value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMin() const
   {
     if (isEmpty())
     {
-      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is empty. Did you forget to call updateRanges()?");
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Empty or uninitalized range object. Did you forget to call updateRanges()?");
     }
     return min_;
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the maximum value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMax() const
   {
     if (isEmpty())
     {
-      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is empty. Did you forget to call updateRanges()?");
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Empty or uninitialized range object. Did you forget to call updateRanges()?");
     }
     return max_;
   }
@@ -316,13 +318,15 @@ struct OPENMS_DLLAPI RangeRT : public RangeBase
     setMax(max);
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the minimum RT value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMinRT() const
   {
     return getMin();
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the maximum RT value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMaxRT() const
   {
     return getMax();
@@ -377,13 +381,15 @@ struct OPENMS_DLLAPI RangeMZ : public RangeBase
     setMax(max);
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the minimum MZ value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMinMZ() const
   {
     return getMin();
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the maximum MZ value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMaxMZ() const
   {
     return getMax();
@@ -437,13 +443,15 @@ struct OPENMS_DLLAPI RangeIntensity : public RangeBase
     setMax(max);
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the minimum intensity value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMinIntensity() const
   {
     return getMin();
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the maximum intensity value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMaxIntensity() const
   {
     return getMax();
@@ -496,13 +504,15 @@ struct OPENMS_DLLAPI RangeMobility : public RangeBase
     setMax(max);
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the minimum mobility value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMinMobility() const
   {
     return getMin();
   }
 
-  /// only useful if isEmpty() returns false
+  /// Get the maximum mobility value of the range
+  /// @throws Exception::InvalidRange if the range is empty
   double getMaxMobility() const
   {
     return getMax();

--- a/src/openms/include/OpenMS/KERNEL/RangeManager.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeManager.h
@@ -126,12 +126,20 @@ public:
   /// only useful if isEmpty() returns false
   double getMin() const
   {
+    if (!isInitialized())
+    {
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is not initialized. Did you forget to call updateRanges()?");
+    }
     return min_;
   }
 
   /// only useful if isEmpty() returns false
   double getMax() const
   {
+    if (!isInitialized())
+    {
+      throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Range is not initialized. Did you forget to call updateRanges()?");
+    }
     return max_;
   }
   ///@}
@@ -261,6 +269,13 @@ public:
     return min_ == rhs.min_ && max_ == rhs.max_;
   }
 
+  /// @brief   Check if the range is initialized
+  /// @note    A range is initialized if min_ and max_ are not set to their default values (=uninitialized).
+  /// @return  True if the range is initialized, false otherwise
+  bool isInitialized() const
+  {
+    return min_ != std::numeric_limits<double>::max() && max_ != std::numeric_limits<double>::lowest();
+  }
   /**
    * \brief Return the current range, or (if empty) a full range (-1e308, 1e308).
    * \return A range where always: min <= max
@@ -432,13 +447,13 @@ struct OPENMS_DLLAPI RangeIntensity : public RangeBase
   /// only useful if isEmpty() returns false
   double getMinIntensity() const
   {
-    return min_;
+    return getMin();
   }
 
   /// only useful if isEmpty() returns false
   double getMaxIntensity() const
   {
-    return max_;
+    return getMax();
   }
   ///@}
 
@@ -491,13 +506,13 @@ struct OPENMS_DLLAPI RangeMobility : public RangeBase
   /// only useful if isEmpty() returns false
   double getMinMobility() const
   {
-    return min_;
+    return getMin();
   }
 
   /// only useful if isEmpty() returns false
   double getMaxMobility() const
   {
-    return max_;
+    return getMax();
   }
   ///@}
 

--- a/src/openms/include/OpenMS/KERNEL/RangeManager.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeManager.h
@@ -319,13 +319,13 @@ struct OPENMS_DLLAPI RangeRT : public RangeBase
   /// only useful if isEmpty() returns false
   double getMinRT() const
   {
-    return min_;
+    return getMin();
   }
 
   /// only useful if isEmpty() returns false
   double getMaxRT() const
   {
-    return max_;
+    return getMax();
   }
   ///@}
 
@@ -380,13 +380,13 @@ struct OPENMS_DLLAPI RangeMZ : public RangeBase
   /// only useful if isEmpty() returns false
   double getMinMZ() const
   {
-    return min_;
+    return getMin();
   }
 
   /// only useful if isEmpty() returns false
   double getMaxMZ() const
   {
-    return max_;
+    return getMax();
   }
   ///@}
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
@@ -352,16 +352,23 @@ namespace OpenMS
                                        "At least two input maps required");
     }
 
-    // set up the distance functor (and set other parameters)
-    // for the current partition
-    double max_intensity = 0.0;
-    double max_mz = 0.0;
-    for (typename vector<MapType>::const_iterator map_it = input_maps.begin(); 
-         map_it != input_maps.end(); ++map_it)
+    // set up the distance functor (and set other parameters) for the current partition
+    double max_intensity = std::numeric_limits<double>::lowest();
+    double max_mz = std::numeric_limits<double>::lowest();
+
+    for (auto it = input_maps.begin(); it != input_maps.end(); ++it)
     {
-      max_intensity = max(max_intensity, map_it->getMaxIntensity());
-      max_mz = max(max_mz, map_it->getMaxMZ());
+      if (!it->RangeIntensity::isEmpty())
+      {
+        max_intensity = max(max_intensity, it->getMaxIntensity());
+      }
+
+      if (!it->RangeMZ::isEmpty())
+      {
+        max_mz = max(max_mz, it->getMaxMZ());
+      }      
     }
+
     setParameters_(max_intensity, max_mz);
 
     // create the hash grid and fill it with features:

--- a/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
@@ -53,13 +53,31 @@ namespace OpenMS
   {
     // empty output destination:
     result_map.clear(false);
-
+    
     // sanity checks:
     if (input_maps.size() != 2)
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                        "exactly two input maps required");
     }
+
+    if (input_maps[0].empty() || input_maps[1].empty())
+    {
+      // at least one map is empty? write out unmatched consensus features
+      for (UInt input = 0; input <= 1; ++input)
+      {
+        for (UInt index = 0; index < input_maps[input].size(); ++index)
+        {
+          result_map.push_back(input_maps[input][index]);
+          if (result_map.back().size() <= 1) // singleton consensus feature
+          {
+            result_map.back().setQuality(0.0);
+          }
+        }
+      }
+      return;
+    }
+
     checkIds_(input_maps);
 
     // set up the distance functor:

--- a/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
@@ -61,28 +61,21 @@ namespace OpenMS
                                        "exactly two input maps required");
     }
 
-    if (input_maps[0].empty() || input_maps[1].empty())
-    {
-      // at least one map is empty? write out unmatched consensus features
-      for (UInt input = 0; input <= 1; ++input)
-      {
-        for (UInt index = 0; index < input_maps[input].size(); ++index)
-        {
-          result_map.push_back(input_maps[input][index]);
-          if (result_map.back().size() <= 1) // singleton consensus feature
-          {
-            result_map.back().setQuality(0.0);
-          }
-        }
-      }
-      return;
-    }
-
     checkIds_(input_maps);
 
     // set up the distance functor:
-    double max_intensity = max(input_maps[0].getMaxIntensity(),
-                               input_maps[1].getMaxIntensity());
+    double max_intensity = std::numeric_limits<double>::lowest();;
+    
+    if (!input_maps[0].RangeIntensity::isEmpty())
+    {
+      max_intensity = input_maps[0].getMaxIntensity();
+    }
+
+    if (!input_maps[1].RangeIntensity::isEmpty())
+    {
+      max_intensity = max(max_intensity, input_maps[1].getMaxIntensity());
+    }
+
     Param distance_params = param_.copy("");
     distance_params.remove("use_identifications");
     distance_params.remove("second_nearest_gap");

--- a/src/openms/source/FORMAT/ConsensusXMLFile.cpp
+++ b/src/openms/source/FORMAT/ConsensusXMLFile.cpp
@@ -97,6 +97,7 @@ namespace OpenMS
       // throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The ConsensusXML file contains invalid maps or references thereof. Please fix the file!");
 
     }
+    consensus_map.updateRanges();
 
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
@@ -247,6 +247,7 @@ namespace OpenMS::Internal
   {
     OpenMS::MSSpectrum s;
     getMSSpectrumById(id, s);
+    s.updateRanges();
     return s;
   }
 
@@ -264,6 +265,7 @@ namespace OpenMS::Internal
   {
     std::string text = IndexedMzMLHandler::getSpectrumById_helper_(id);
     MzMLSpectrumDecoder(skip_xml_checks_).domParseSpectrum(text, s);
+    s.updateRanges();
   }
 
   OpenMS::Interfaces::ChromatogramPtr IndexedMzMLHandler::getChromatogramById(int id)
@@ -278,6 +280,7 @@ namespace OpenMS::Internal
   {
     OpenMS::MSChromatogram c;
     getMSChromatogramById(id, c);
+    c.updateRanges();
     return c;
   }
 
@@ -296,6 +299,7 @@ namespace OpenMS::Internal
   {
     std::string text = IndexedMzMLHandler::getChromatogramById_helper_(id);
     MzMLSpectrumDecoder(skip_xml_checks_).domParseChromatogram(text, c);
+    c.updateRanges();
   }
 
 } //namespace OpenMS  //namespace Internal

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -126,6 +126,7 @@ namespace OpenMS
       expr += e.getFunction();
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, expr, String("- due to that error of type ") + e.getName());
     }
+
   }
 
   void MzMLFile::loadBuffer(const std::string& buffer, PeakMap& map)
@@ -135,6 +136,7 @@ namespace OpenMS
     Internal::MzMLHandler handler(map, "memory", getVersion(), *this);
     handler.setOptions(options_);
     parseBuffer_(buffer, &handler);
+    map.updateRanges();
   }
 
   void MzMLFile::load(const String& filename, PeakMap& map)
@@ -148,6 +150,7 @@ namespace OpenMS
     Internal::MzMLHandler handler(map, filename, getVersion(), *this);
     handler.setOptions(options_);
     safeParse_(filename, &handler);
+    map.updateRanges();
   }
 
   void MzMLFile::store(const String& filename, const PeakMap& map) const

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -126,7 +126,6 @@ namespace OpenMS
       expr += e.getFunction();
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, expr, String("- due to that error of type ") + e.getName());
     }
-
   }
 
   void MzMLFile::loadBuffer(const std::string& buffer, PeakMap& map)

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -7,7 +7,6 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/config.h>
-#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/FeatureMap.h>

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -6,6 +6,9 @@
 // $Authors: $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 
@@ -571,6 +574,14 @@ namespace OpenMS
 
   void ConsensusMap::updateRanges()
   {
+    #ifdef OPENMS_ASSERTIONS
+      double rt_min = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+    #endif
     clearRanges();
     // enlarge the range by the internal points of each feature
     for (const auto& cf : data_)
@@ -585,6 +596,24 @@ namespace OpenMS
         extendIntensity(handle.getIntensity());
       }
     }
+
+    #ifdef OPENMS_ASSERTIONS
+      // check if updateRanges() was necessary and find places where it was not
+      double rt_min_new = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max_new = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min_new = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max_new = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min_new = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max_new = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+
+      // check if all are equal and no update range was necessary
+      if (rt_min_new == rt_min && rt_max_new == rt_max
+        && int_min_new == int_min && int_max_new == int_max
+        && mz_min_new == mz_min && mz_max_new == mz_max)
+      {
+        OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+      }
+    #endif
   }
 
   bool ConsensusMap::isMapConsistent(Logger::LogStream* stream) const

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -6,6 +6,9 @@
 // $Authors: Marc Sturm, Chris Bielow, Clemens Groepl $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/KERNEL/FeatureMap.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -253,6 +256,15 @@ namespace OpenMS
 
   void FeatureMap::updateRanges()
   {
+    #ifdef OPENMS_ASSERTIONS
+      double rt_min = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+    #endif
+
     clearRanges();
     for (const auto& f : *this)
     {
@@ -273,8 +285,27 @@ namespace OpenMS
         extendMZ(box.maxPosition()[Peak2D::MZ]);
       }
     }
+
+    #ifdef OPENMS_ASSERTIONS
+      // check if updateRanges() was necessary and find places where it was not
+      double rt_min_new = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max_new = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min_new = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max_new = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min_new = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max_new = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+
+      // check if all are equal and no update range was necessary
+      if (rt_min_new == rt_min && rt_max_new == rt_max
+        && int_min_new == int_min && int_max_new == int_max
+        && mz_min_new == mz_min && mz_max_new == mz_max)
+      {
+        OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+      }
+    #endif
   }
 
+  
   void FeatureMap::swapFeaturesOnly(FeatureMap& from)
   {
     data_.swap(from.data_);

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -7,10 +7,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/config.h>
-#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <OpenMS/KERNEL/FeatureMap.h>
-
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -41,7 +41,6 @@ MSChromatogram &MSChromatogram::operator=(const MSChromatogram &source)
   }
 
   ContainerType::operator=(source);
-  RangeManagerType::operator=(source);
   ChromatogramSettings::operator=(source);
 
   name_ = source.name_;
@@ -56,7 +55,6 @@ bool MSChromatogram::operator==(const MSChromatogram &rhs) const
 {
   //name_ can differ => it is not checked
   return std::operator==(*this, rhs) &&
-         RangeManagerType::operator==(rhs) &&
          ChromatogramSettings::operator==(rhs)  &&
          float_data_arrays_ == rhs.float_data_arrays_ &&
          string_data_arrays_ == rhs.string_data_arrays_ &&

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -40,6 +40,7 @@ MSChromatogram &MSChromatogram::operator=(const MSChromatogram &source)
     return *this;
   }
 
+  RangeManagerType::operator=(source);
   ContainerType::operator=(source);
   ChromatogramSettings::operator=(source);
 
@@ -53,9 +54,9 @@ MSChromatogram &MSChromatogram::operator=(const MSChromatogram &source)
 
 bool MSChromatogram::operator==(const MSChromatogram &rhs) const
 {
-  //name_ can differ => it is not checked
+  //name_ can differ => it is not checked; also ranges are not checked
   return std::operator==(*this, rhs) &&
-         ChromatogramSettings::operator==(rhs)  &&
+         ChromatogramSettings::operator==(rhs) &&
          float_data_arrays_ == rhs.float_data_arrays_ &&
          string_data_arrays_ == rhs.string_data_arrays_ &&
          integer_data_arrays_ == rhs.integer_data_arrays_;

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -6,6 +6,9 @@
 // $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/KERNEL/MSChromatogram.h>
 
 using namespace OpenMS;
@@ -443,6 +446,36 @@ OpenMS::MSChromatogram::Iterator setSumSimilarUnion(OpenMS::MSChromatogram::Iter
   }
 }
 
+void MSChromatogram::updateRanges()
+{
+  #ifdef OPENMS_ASSERTIONS
+    double rt_min = RangeRT::isEmpty() ? 0 : getMinRT();
+    double rt_max = RangeRT::isEmpty() ? 0 : getMaxRT();
+    double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+    double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+  #endif
+
+  clearRanges();
+  for (const auto& peak : (ContainerType&) *this)
+  {
+    extendRT(peak.getRT());
+    extendIntensity(peak.getIntensity());
+  }
+
+  #ifdef OPENMS_ASSERTIONS
+    double rt_min_new = RangeRT::isEmpty() ? 0 : getMinRT();
+    double rt_max_new = RangeRT::isEmpty() ? 0 : getMaxRT();
+    double int_min_new = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+    double int_max_new = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+
+    // check if all are equal and no update range was necessary
+    if (rt_min_new == rt_min && rt_max_new == rt_max
+      && int_min_new == int_min && int_max_new == int_max)
+    {
+      OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+    }
+  #endif
+}
 
 void MSChromatogram::mergePeaks(MSChromatogram& other, bool add_meta)
 {

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -6,6 +6,8 @@
 // $Authors: Marc Sturm, Tom Waschischeck $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h> // for OPENMS_ASSERTIONS
+
 #include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -229,6 +231,17 @@ namespace OpenMS
   */
   void MSExperiment::updateRanges(Int ms_level)
   {
+    #ifdef OPENMS_ASSERTIONS
+      double rt_min = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+      double im_min = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+    #endif
+
     // reset mz/rt/int range
     this->clearRanges();
 
@@ -282,6 +295,28 @@ namespace OpenMS
       this->extendMZ(cp.getMZ());// MZ
       this->extend(cp);// RT and intensity from chroms's range
     }
+
+    #ifdef OPENMS_ASSERTIONS
+      // check if updateRanges() was necessary and find places where it was not
+      double im_min_new = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max_new = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+      double int_min_new =  RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max_new =  RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+      double rt_min_new = RangeRT::isEmpty() ? 0 : getMinRT();
+      double rt_max_new = RangeRT::isEmpty() ? 0 : getMaxRT();
+      double mz_min_new = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max_new = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+
+      if (im_min_new == im_min && im_max_new == im_max
+        && int_min_new == int_min && int_max_new == int_max
+        && mz_min_new == mz_min && mz_max_new == mz_max
+        && rt_min_new == rt_min && rt_max_new == rt_max
+        && im_min_new == im_min && im_max_new == im_max
+      )
+      {
+        OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+      }
+    #endif
   }
 
   /// returns the total number of peaks

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -311,7 +311,6 @@ namespace OpenMS
         && int_min_new == int_min && int_max_new == int_max
         && mz_min_new == mz_min && mz_max_new == mz_max
         && rt_min_new == rt_min && rt_max_new == rt_max
-        && im_min_new == im_min && im_max_new == im_max
       )
       {
         OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -471,7 +471,7 @@ namespace OpenMS
 
   bool MSSpectrum::operator==(const MSSpectrum &rhs) const
   {
-    //name_ can differ => it is not checked
+    //name_ can differ => it is not checked, range is not checked
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
     return std::operator==(*this, rhs) &&
@@ -495,6 +495,7 @@ namespace OpenMS
     }
     ContainerType::operator=(source);
     SpectrumSettings::operator=(source);
+    RangeManagerType::operator=(source);
 
     retention_time_ = source.retention_time_;
     drift_time_ = source.drift_time_;

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -6,6 +6,9 @@
 // $Authors: Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -526,6 +529,15 @@ namespace OpenMS
 
   void MSSpectrum::updateRanges()
   {
+    #ifdef OPENMS_ASSERTIONS
+      double im_min = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+      double mz_min = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+    #endif
+
     clearRanges();
     for (const auto& peak : (ContainerType&)*this)
     {
@@ -547,6 +559,22 @@ namespace OpenMS
     { 
       this->extendMobility(getDriftTime());
     }
+    #ifdef OPENMS_ASSERTIONS
+      double im_min_new = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max_new = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+      double mz_min_new = RangeMZ::isEmpty() ? 0 : getMinMZ();
+      double mz_max_new = RangeMZ::isEmpty() ? 0 : getMaxMZ();
+      double int_min_new = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max_new = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+
+      // check if all are equal and no update range was necessary
+      if (im_min_new == im_min && im_max_new == im_max
+        && int_min_new == int_min && int_max_new == int_max
+        && mz_min_new == mz_min && mz_max_new == mz_max)
+      {
+        OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+      }      
+    #endif
   }
 
   double MSSpectrum::getRT() const

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -475,7 +475,6 @@ namespace OpenMS
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
     return std::operator==(*this, rhs) &&
-           RangeManagerType::operator==(rhs) &&
            SpectrumSettings::operator==(rhs) &&
            retention_time_ == rhs.retention_time_ &&
            drift_time_ == rhs.drift_time_ &&
@@ -495,7 +494,6 @@ namespace OpenMS
       return *this;
     }
     ContainerType::operator=(source);
-    RangeManagerType::operator=(source);
     SpectrumSettings::operator=(source);
 
     retention_time_ = source.retention_time_;

--- a/src/openms/source/KERNEL/Mobilogram.cpp
+++ b/src/openms/source/KERNEL/Mobilogram.cpp
@@ -6,6 +6,9 @@
 // $Authors: Chris Bielow $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/config.h> // for OPENMS_ASSERTIONS
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/KERNEL/Peak1D.h>
 
 #include <OpenMS/KERNEL/Mobilogram.h>
@@ -26,12 +29,33 @@ namespace OpenMS
   }
   void Mobilogram::updateRanges()
   {
+    #ifdef OPENMS_ASSERTIONS
+      double im_min = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+      double int_min = RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max = RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+    #endif
+
     clearRanges();
     for (const auto& peak : data_)
     {
       extendMobility(peak.getMobility());
       extendIntensity(peak.getIntensity());
     }
+
+    #ifdef OPENMS_ASSERTIONS
+      // check if updateRanges() was necessary and find places where it was not
+      double im_min_new = RangeMobility::isEmpty() ? 0 : getMinMobility();
+      double im_max_new = RangeMobility::isEmpty() ? 0 : getMaxMobility();
+      double int_min_new =  RangeIntensity::isEmpty() ? 0 : getMinIntensity();
+      double int_max_new =  RangeIntensity::isEmpty() ? 0 : getMaxIntensity();
+
+      if (im_min_new == im_min && im_max_new == im_max 
+        && int_min_new == int_min && int_max_new == int_max)
+      {
+        OPENMS_LOG_WARN << "Update ranges was called but ranges were already up-to-date" << std::endl;
+      } 
+    #endif     
   }
 
   const Mobilogram::FloatDataArrays &Mobilogram::getFloatDataArrays() const

--- a/src/openms/source/KERNEL/RangeManager.cpp
+++ b/src/openms/source/KERNEL/RangeManager.cpp
@@ -14,7 +14,15 @@ namespace OpenMS
 {
   std::ostream& operator<<(std::ostream& out, const RangeBase& b)
   {
-    out << "[" << b.getMin() << ", " << b.getMax() << "]";
+    if (b.isInitialized())
+    {
+      out << "[" << b.getMin() << ", " << b.getMax() << "]";
+    }
+    else // uninitalized or empty 
+    {
+      out << "[, ]";
+    }
+    
     return out;
   }
   

--- a/src/openms/source/KERNEL/RangeManager.cpp
+++ b/src/openms/source/KERNEL/RangeManager.cpp
@@ -14,11 +14,11 @@ namespace OpenMS
 {
   std::ostream& operator<<(std::ostream& out, const RangeBase& b)
   {
-    if (b.isInitialized())
+    if (!b.isEmpty())
     {
       out << "[" << b.getMin() << ", " << b.getMax() << "]";
     }
-    else // uninitalized or empty 
+    else // empty range
     {
       out << "[, ]";
     }

--- a/src/tests/class_tests/openms/source/ConsensusMap_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMap_test.cpp
@@ -34,9 +34,7 @@ ConsensusMap* nullPointer = nullptr;
 START_SECTION((ConsensusMap()))
 	ptr = new ConsensusMap();
 	TEST_NOT_EQUAL(ptr, nullPointer)
-	TEST_EQUAL(ptr->isMetaEmpty(),true)
-  TEST_REAL_SIMILAR(ptr->getMinIntensity(), numeric_limits<double>::max())
-  TEST_REAL_SIMILAR(ptr->getMaxIntensity(), -numeric_limits<double>::max())
+	TEST_TRUE(ptr->isMetaEmpty())
 END_SECTION
 
 START_SECTION((~ConsensusMap()))

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -936,7 +936,7 @@ START_SECTION((bool operator==(const MSChromatogram &rhs) const ))
   edit.push_back(p2);
   edit.updateRanges();
   edit.clear(false);
-  TEST_EQUAL(empty==edit, false);
+  TEST_TRUE(empty == edit);
 
 }
 END_SECTION
@@ -986,7 +986,7 @@ START_SECTION((bool operator!=(const MSChromatogram &rhs) const ))
   edit.push_back(p2);
   edit.updateRanges();
   edit.clear(false);
-  TEST_EQUAL(edit!=empty,true);
+  TEST_TRUE(empty == edit);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -979,7 +979,7 @@ START_SECTION((bool operator!=(const MSChromatogram &rhs) const ))
   //name is not checked => no change
   edit = empty;
   edit.setName("bla");
-  TEST_EQUAL(edit!=empty,false);
+  TEST_EQUAL(edit == empty, true);
 
   edit = empty;
   edit.push_back(p1);

--- a/src/tests/class_tests/openms/source/MSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/MSExperiment_test.cpp
@@ -404,34 +404,6 @@ START_SECTION(([EXTRA] PeakMap()))
 }
 END_SECTION
 
-START_SECTION((CoordinateType getMinMZ() const))
-{
-  PeakMap tmp;
-  TEST_REAL_SIMILAR(tmp.getMinMZ(),numeric_limits<DPosition<2>::CoordinateType>::max())
-}
-END_SECTION
-
-START_SECTION((CoordinateType getMaxMZ() const))
-{
-  PeakMap tmp;
-  TEST_REAL_SIMILAR(tmp.getMaxMZ(),-numeric_limits<DPosition<2>::CoordinateType>::max())
-}
-END_SECTION
-
-START_SECTION((CoordinateType getMinRT() const))
-{
-  PeakMap tmp;
-  TEST_REAL_SIMILAR(tmp.getMinRT(),numeric_limits<DPosition<2>::CoordinateType>::max())
-}
-END_SECTION
-
-START_SECTION((CoordinateType getMaxRT() const))
-{
-  PeakMap tmp;
-  TEST_REAL_SIMILAR(tmp.getMaxRT(),-numeric_limits<DPosition<2>::CoordinateType>::max())
-}
-END_SECTION
-
 START_SECTION((const std::vector<UInt>& getMSLevels() const))
 {
   PeakMap tmp;

--- a/src/tests/class_tests/openms/source/PoseClusteringShiftSuperimposer_test.cpp
+++ b/src/tests/class_tests/openms/source/PoseClusteringShiftSuperimposer_test.cpp
@@ -64,6 +64,9 @@ START_SECTION((virtual void run(const ConsensusMap& map_model, const ConsensusMa
   input[1].push_back(ConsensusFeature(feat3));
   input[1].push_back(ConsensusFeature(feat4));
 
+  input[0].updateRanges();
+  input[1].updateRanges();
+
   TransformationDescription transformation;
   PoseClusteringShiftSuperimposer pcat;
 	Param params;

--- a/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
@@ -192,6 +192,8 @@ START_SECTION((void run(const std::vector<FeatureMap >& input_maps, ConsensusMap
   input[2].push_back(feat6);
   input[2].push_back(feat7);
 
+  input[2].updateRanges();
+  
 	finder.run(input, result);
 	TEST_EQUAL(result.size(), 4);
 	ABORT_IF(result.size() != 4);

--- a/src/tests/class_tests/openms/source/RangeManager_test.cpp
+++ b/src/tests/class_tests/openms/source/RangeManager_test.cpp
@@ -593,11 +593,6 @@ START_SECTION((void clearRanges()))
   TEST_EQUAL(rm.RangeMobility::isEmpty(), true)
 
   rm.clearRanges();
-  TEST_FALSE(rm.RangeRT::isInitialized())
-  TEST_FALSE(rm.RangeMZ::isInitialized())
-  TEST_FALSE(rm.RangeIntensity::isInitialized())
-  TEST_FALSE(rm.RangeMobility::isInitialized())
-
   TEST_TRUE(rm.RangeRT::isEmpty())
   TEST_TRUE(rm.RangeMZ::isEmpty())
   TEST_TRUE(rm.RangeIntensity::isEmpty())

--- a/src/tests/class_tests/openms/source/RangeManager_test.cpp
+++ b/src/tests/class_tests/openms/source/RangeManager_test.cpp
@@ -334,32 +334,6 @@ START_SECTION((~RangeMType()))
   delete ptr;
 END_SECTION
 
-START_SECTION((double getMinMZ() const))
-  TEST_EQUAL(RM().getMinMZ(), std::numeric_limits<double>::max())
-END_SECTION
-
-START_SECTION((double getMaxMZ() const))
-  TEST_EQUAL(RM().getMaxMZ(), -std::numeric_limits<double>::max())
-END_SECTION
-
-START_SECTION((double getMinIntensity() const))
-TEST_EQUAL(RM().getMinIntensity(), std::numeric_limits<double>::max())
-END_SECTION
-
-START_SECTION((double getMaxIntensity() const))
-TEST_EQUAL(RM().getMaxIntensity(), -std::numeric_limits<double>::max())
-END_SECTION
-
-START_SECTION((double getMinMobility() const))
-TEST_EQUAL(RM().getMinMobility(), std::numeric_limits<double>::max())
-END_SECTION
-
-START_SECTION((double getMaxMobility() const))
-TEST_EQUAL(RM().getMaxMobility(), -std::numeric_limits<double>::max())
-END_SECTION
-
-
-
 START_SECTION((RangeManager(const RangeManager& rhs)))
   RM rm0;
   rm0.updateRanges();
@@ -414,9 +388,7 @@ START_SECTION((virtual void updateRanges()=0))
   TEST_REAL_SIMILAR(rm.getMinIntensity(), 1.0)
   TEST_REAL_SIMILAR(rm.getMaxIntensity(), 47110.0)
   TEST_EQUAL(rm.RangeIntensity::isEmpty(), false)
-  TEST_EQUAL(rm.getMinMobility(), std::numeric_limits<double>::max())
-  TEST_EQUAL(rm.getMaxMobility(), -std::numeric_limits<double>::max())
-  TEST_EQUAL(rm.RangeMobility::isEmpty(), true)
+  TEST_TRUE(rm.RangeMobility::isEmpty())
 
   //test with only one point
   rm.updateRanges2(); //second time to check the initialization

--- a/src/tests/class_tests/openms/source/RangeManager_test.cpp
+++ b/src/tests/class_tests/openms/source/RangeManager_test.cpp
@@ -593,15 +593,15 @@ START_SECTION((void clearRanges()))
   TEST_EQUAL(rm.RangeMobility::isEmpty(), true)
 
   rm.clearRanges();
-  TEST_EQUAL(rm.RangeRT::isInitialized(), false)
-  TEST_EQUAL(rm.RangeMZ::isInitialized(), false)
-  TEST_EQUAL(rm.RangeIntensity::isInitialized(), false)
-  TEST_EQUAL(rm.RangeMobility::isInitialized(), false)
+  TEST_FALSE(rm.RangeRT::isInitialized())
+  TEST_FALSE(rm.RangeMZ::isInitialized())
+  TEST_FALSE(rm.RangeIntensity::isInitialized())
+  TEST_FALSE(rm.RangeMobility::isInitialized())
 
-  TEST_EQUAL(rm.RangeRT::isEmpty(), true)
-  TEST_EQUAL(rm.RangeMZ::isEmpty(), true)
-  TEST_EQUAL(rm.RangeIntensity::isEmpty(), true)
-  TEST_EQUAL(rm.RangeMobility::isEmpty(), true)
+  TEST_TRUE(rm.RangeRT::isEmpty())
+  TEST_TRUE(rm.RangeMZ::isEmpty())
+  TEST_TRUE(rm.RangeIntensity::isEmpty())
+  TEST_TRUE(rm.RangeMobility::isEmpty())
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/RangeManager_test.cpp
+++ b/src/tests/class_tests/openms/source/RangeManager_test.cpp
@@ -593,10 +593,11 @@ START_SECTION((void clearRanges()))
   TEST_EQUAL(rm.RangeMobility::isEmpty(), true)
 
   rm.clearRanges();
-  TEST_EQUAL(rm.getMinRT(), std::numeric_limits<double>::max())
-  TEST_EQUAL(rm.getMaxRT(), -std::numeric_limits<double>::max())
-  TEST_REAL_SIMILAR(rm.getMinIntensity(), numeric_limits<double>::max())
-  TEST_REAL_SIMILAR(rm.getMaxIntensity(), -numeric_limits<double>::max())
+  TEST_EQUAL(rm.RangeRT::isInitialized(), false)
+  TEST_EQUAL(rm.RangeMZ::isInitialized(), false)
+  TEST_EQUAL(rm.RangeIntensity::isInitialized(), false)
+  TEST_EQUAL(rm.RangeMobility::isInitialized(), false)
+
   TEST_EQUAL(rm.RangeRT::isEmpty(), true)
   TEST_EQUAL(rm.RangeMZ::isEmpty(), true)
   TEST_EQUAL(rm.RangeIntensity::isEmpty(), true)

--- a/src/tests/class_tests/openms/source/StablePairFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/StablePairFinder_test.cpp
@@ -84,6 +84,9 @@ START_SECTION((void run(const std::vector<ConsensusMap>& input_maps, ConsensusMa
   input[1].push_back(cons5);
   input[1].push_back(cons6);
 
+  input[0].updateRanges();
+  input[1].updateRanges();
+
   StablePairFinder spf;
 	Param param = spf.getDefaults();
 	spf.setParameters(param);
@@ -163,12 +166,20 @@ START_SECTION(([EXTRA] void run(const std::vector<ConsensusMap>& input_maps, Con
 	// best case:
   input[0].push_back(ConsensusFeature(0, feat1));
 	input[1].push_back(ConsensusFeature(1, feat1));
-	spf.run(input, result);
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
+  spf.run(input, result);
 	TEST_EQUAL(result.size(), 1);
 	TEST_EQUAL(result[0].size(), 2);
 	TEST_EQUAL(result[0].getQuality(), 1.0);
 	input[0] = result;
 	input[1][0] = ConsensusFeature(2, feat1);
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
 	spf.run(input, result);
 	TEST_EQUAL(result.size(), 1);
 	TEST_EQUAL(result[0].size(), 3);
@@ -186,12 +197,20 @@ START_SECTION(([EXTRA] void run(const std::vector<ConsensusMap>& input_maps, Con
 	input[1].clear();
 	input[0].push_back(ConsensusFeature(0, feat1));
 	input[1].push_back(ConsensusFeature(1, feat2));
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
 	spf.run(input, result);
 	ConsensusFeature cons1 = result[0];
 	TEST_EQUAL(cons1.size(), 2);
 	input[0] = result;
 	input[1][0] = ConsensusFeature(2, feat3);
-	spf.run(input, result);
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
+  spf.run(input, result);
 	ConsensusFeature cons2 = result[0];
 	TEST_EQUAL(cons2.size(), 3);
 	TEST_EQUAL(cons1.getQuality() > 0.0, true);
@@ -202,12 +221,20 @@ START_SECTION(([EXTRA] void run(const std::vector<ConsensusMap>& input_maps, Con
 	TEST_EQUAL(cons1.getQuality() > cons2.getQuality(), true);
 	input[0].clear();
 	input[0].push_back(ConsensusFeature(1, feat2));
-	spf.run(input, result);
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
+  spf.run(input, result);
 	ConsensusFeature cons3 = result[0];
 	// quality(feat2, feat3) > quality(feat1, feat2), feat3):
 	TEST_EQUAL(cons3.getQuality() > cons2.getQuality(), true);
 	input[0][0] = ConsensusFeature(0, feat1);
-	spf.run(input, result);
+
+  input[0].updateRanges();
+  input[1].updateRanges();
+
+  spf.run(input, result);
 	ConsensusFeature cons4 = result[0];
 	// quality(feat1, feat3) < quality(feat1, feat2), feat3):
 	TEST_EQUAL(cons4.getQuality() < cons2.getQuality(), true);

--- a/src/tests/topp/FileInfo_1_output.txt
+++ b/src/tests/topp/FileInfo_1_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_1_input.dta
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_1_input.dta
 File type: dta
 
 Instrument: 
@@ -13,9 +13,8 @@ Number of spectra: 1
 Ranges:
   retention time: -1.00 .. -1.00 sec (0.0 min)
   mass-to-charge: 261.30 .. 783.50
-    ion mobility: <none>
-       intensity: 3672.00 .. 272411.00
-
+  ion mobility: <none> .. <none>
+  intensity: 3672.00 .. 272411.00
 Number of spectra per MS level:
   level 2: 1
 

--- a/src/tests/topp/FileInfo_2_output.txt
+++ b/src/tests/topp/FileInfo_2_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_2_input.dta2d
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_2_input.dta2d
 File type: dta2d
 
 Instrument: 
@@ -13,9 +13,8 @@ Number of spectra: 8
 Ranges:
   retention time: 0.00 .. 6.00 sec (0.1 min)
   mass-to-charge: 500.00 .. 1100.00
-    ion mobility: <none>
-       intensity: 50.00 .. 400.00
-
+  ion mobility: <none> .. <none>
+  intensity: 50.00 .. 400.00
 Number of spectra per MS level:
   level 1: 8
 

--- a/src/tests/topp/FileInfo_4_output.txt
+++ b/src/tests/topp/FileInfo_4_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_4_input.mzXML
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_4_input.mzXML
 File type: mzXML
 
 Instrument: 
@@ -14,8 +14,8 @@ Number of spectra: 20
 Ranges:
   retention time: 0.26 .. 37.64 sec (0.6 min)
   mass-to-charge: 207.51 .. 1496.08
-    ion mobility: <none>
-       intensity: 12.15 .. 25903.89
+  ion mobility: <none> .. <none>
+  intensity: 12.15 .. 25903.89
 
 Number of spectra per MS level:
   level 1: 14

--- a/src/tests/topp/FileInfo_5_output.txt
+++ b/src/tests/topp/FileInfo_5_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_5_input.mzDat
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_5_input.mzDat
 File type: mzData
 
 Instrument: MS-Instrument
@@ -15,8 +15,8 @@ Number of spectra: 10
 Ranges:
   retention time: 20.87 .. 39.97 sec (0.3 min)
   mass-to-charge: 500.07 .. 1497.28
-    ion mobility: <none>
-       intensity: 16.30 .. 38920.12
+  ion mobility: <none> .. <none>
+  intensity: 16.30 .. 38920.12
 
 Number of spectra per MS level:
   level 1: 4

--- a/src/tests/topp/FileInfo_6_output.txt
+++ b/src/tests/topp/FileInfo_6_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_6_input.mzData
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_6_input.mzData
 File type: mzData
 
 Instrument: 
@@ -14,8 +14,8 @@ Number of spectra: 2
 Ranges:
   retention time: 474.56 .. 475.32 sec (0.0 min)
   mass-to-charge: 937.28 .. 941.20
-    ion mobility: <none>
-       intensity: 1639.00 .. 18025.00
+  ion mobility: <none> .. <none>
+  intensity: 1639.00 .. 18025.00
 
 Number of spectra per MS level:
   level 1: 2

--- a/src/tests/topp/FileInfo_9_output.txt
+++ b/src/tests/topp/FileInfo_9_output.txt
@@ -1,7 +1,7 @@
 
 -- General information --
 
-File name: C:/dev/openms_test/src/tests/topp/FileInfo_9_input.mzML
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FileInfo_9_input.mzML
 File type: mzML
 
 Instrument: LCQ Deca
@@ -15,8 +15,8 @@ Number of spectra: 4
 Ranges:
   retention time: 5.10 .. 5.40 sec (0.0 min)
   mass-to-charge: 0.00 .. 18.00
-    ion mobility:  <none>
-       intensity: 1.00 .. 20.00
+  ion mobility: <none> .. <none>
+  intensity: 1.00 .. 20.00
 
 Number of spectra per MS level:
   level 1: 3

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -11,8 +11,6 @@
 
 #include <OpenMS/config.h>
 
-
-
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h> // for operator<< on StringList
@@ -170,27 +168,74 @@ protected:
   template <class Map>
   void writeRangesHumanReadable_(const Map& map, ostream &os)
   {
-    os << "Ranges:" << '\n'
-       << "  retention time: " << String::number(map.getMinRT(), 2) << " .. " << String::number(map.getMaxRT(), 2) << " sec ("
-       << String::number((map.getMaxRT() - map.getMinRT()) / 60, 1) << " min)\n"
-       << "  mass-to-charge: " << String::number(map.getMinMZ(), 2) << " .. " << String::number(map.getMaxMZ(), 2) << '\n';
+    if (map.RangeRT::isEmpty())
+    {
+      os << "Ranges:'\n'  retention time: <none> .. <none> sec (<none> min)\n";
+    }
+    else
+    {
+      os << "Ranges:" << '\n'
+        << "  retention time: " << String::number(map.getMinRT(), 2) << " .. " << String::number(map.getMaxRT(), 2) << " sec ("
+        << String::number((map.getMaxRT() - map.getMinRT()) / 60, 1) << " min)\n";
+    }
+
+    if (map.RangeMZ::isEmpty())
+    {
+      os << "  mass-to-charge: <none> .. <none>\n";
+    }
+    else
+    {
+      os << "  mass-to-charge: " << String::number(map.getMinMZ(), 2) << " .. " << String::number(map.getMaxMZ(), 2) << '\n';
+    }
+    
+
     if constexpr (std::is_base_of < RangeMobility, Map>())
     {
-      os << "    ion mobility: ";
-      if (map.RangeMobility::isEmpty()) os << "<none>\n";
-      else os << String::number(map.getMinMobility(), 2) << " .. " << String::number(map.getMaxMobility(), 2) << '\n';
+      if (map.RangeMobility::isEmpty())
+      {
+        os << "  ion mobility: <none> .. <none>\n";
+      }
+      else
+      {
+        os << "  ion mobility: " << String::number(map.getMinMobility(), 2) << " .. " << String::number(map.getMaxMobility(), 2) << '\n';
+      }
     }
-    os << "       intensity: " << String::number(map.getMinIntensity(), 2) << " .. " << String::number(map.getMaxIntensity(), 2) << '\n'
-       << '\n';
+
+    if (map.RangeIntensity::isEmpty())
+    {
+      os << "  intensity: <none> .. <none>\n";
+    }
+    else
+    {
+      os << "  intensity: " << String::number(map.getMinIntensity(), 2) << " .. " << String::number(map.getMaxIntensity(), 2) << '\n';
+    }    
   }
 
   template <class Map>
   void writeRangesMachineReadable_(const Map& map, ostream &os)
   {
-    os << "general: ranges: retention time: min" << '\t' << String::number(map.getMinRT(), 2) << '\n'
-       << "general: ranges: retention time: max" << '\t' << String::number(map.getMaxRT(), 2) << '\n'
-       << "general: ranges: mass-to-charge: min" << '\t' << String::number(map.getMinMZ(), 2) << '\n'
-       << "general: ranges: mass-to-charge: max" << '\t' << String::number(map.getMaxMZ(), 2) << '\n';
+    if (!map.RangeRT::isEmpty())
+    {
+      os << "general: ranges: retention time: min" << '\t' << String::number(map.getMinRT(), 2) << '\n'
+         << "general: ranges: retention time: max" << '\t' << String::number(map.getMaxRT(), 2) << '\n';
+    }
+    else
+    {
+      os << "general: ranges: retention time: min" << '\t' << "<none>" << '\n'
+         << "general: ranges: retention time: max" << '\t' << "<none>" << '\n';
+    }
+    
+    if (!map.RangeMZ::isEmpty())
+    {
+      os << "general: ranges: mass-to-charge: min" << '\t' << String::number(map.getMinMZ(), 2) << '\n'
+         << "general: ranges: mass-to-charge: max" << '\t' << String::number(map.getMaxMZ(), 2) << '\n';
+    }
+    else
+    {
+      os << "general: ranges: mass-to-charge: min" << '\t' << "<none>" << '\n'
+         << "general: ranges: mass-to-charge: max" << '\t' << "<none>" << '\n';
+    }
+
     if constexpr (std::is_base_of < RangeMobility, Map>())
     {
       if (!map.RangeMobility::isEmpty())
@@ -199,10 +244,19 @@ protected:
            << "general: ranges: ion-mobility: max" << '\t' << String::number(map.getMaxMobility(), 2) << '\n';
       }
     }
-    os << "general: ranges: intensity: min"
-       << '\t' << String::number(map.getMinIntensity(), 2) << '\n'
-       << "general: ranges: intensity: max"
-       << '\t' << String::number(map.getMaxIntensity(), 2) << '\n';
+
+    if (!map.RangeIntensity::isEmpty())
+    {
+      os << "general: ranges: intensity: min"
+         << '\t' << String::number(map.getMinIntensity(), 2) << '\n'
+         << "general: ranges: intensity: max"
+         << '\t' << String::number(map.getMaxIntensity(), 2) << '\n';
+    }
+    else
+    {
+      os << "general: ranges: intensity: min" << '\t' << "<none>" << '\n'
+         << "general: ranges: intensity: max" << '\t' << "<none>" << '\n';
+    }
   }
 
   template <class T>

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -203,11 +203,11 @@ protected:
 
     if (map.RangeIntensity::isEmpty())
     {
-      os << "  intensity: <none> .. <none>\n";
+      os << "  intensity: <none> .. <none>\n\n";
     }
     else
     {
-      os << "  intensity: " << String::number(map.getMinIntensity(), 2) << " .. " << String::number(map.getMaxIntensity(), 2) << '\n';
+      os << "  intensity: " << String::number(map.getMinIntensity(), 2) << " .. " << String::number(map.getMaxIntensity(), 2) << "\n\n";
     }    
   }
 


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the `RangeManager` and its related classes to improve range validation and error handling. Key changes include adding a check if ranges are properly initialized, updating methods to throw exceptions when accessing uninitialized ranges, and modifying test cases to reflect these updates.

### Enhancements to range validation:

* Updated `getMin` and `getMax` methods in `RangeBase` to throw an `Exception::InvalidRange` if the range is not initialized. This ensures that uninitialized ranges cannot be accessed without proper validation.

### Refactoring of derived range classes:

* Modified `getMinIntensity`, `getMaxIntensity`, `getMinMobility`, and `getMaxMobility` methods in `RangeIntensity` and `RangeMobility` to delegate to the updated `getMin` and `getMax` methods in `RangeBase`. [[1]](diffhunk://#diff-31c2483a4466f6a0ba818b23de880dc560077c5aac545e1d13674c8160f3971dL435-R456) [[2]](diffhunk://#diff-31c2483a4466f6a0ba818b23de880dc560077c5aac545e1d13674c8160f3971dL494-R515)

### Improvements to output and test cases:

* Updated the `operator<<` for `RangeBase` to display a placeholder (`"[, ]"`) for uninitialized ranges instead of attempting to print invalid values.

### Fixes in tutorial examples:

* Corrected a typo in the tutorial example `Tutorial_MSExperiment.cpp` by replacing `getMinMobility` with `getMaxIntensity` in the output message.

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected tutorial code example to display the maximum intensity value instead of the minimum ion mobility.
  - Added runtime checks to prevent access to uninitialized or empty range values, improving error handling and reliability.

- **New Features**
  - Ensured internal range information is updated immediately after data loading, parsing, and before processing in clustering and matching operations.
  - Added diagnostic warnings for redundant range updates in various data structures to aid debugging.

- **Style**
  - Updated output format for empty ranges to explicitly show "<none>" placeholders, improving clarity in range reporting.

- **Tests**
  - Simplified tests to verify range emptiness rather than extreme numeric values.
  - Added explicit range updates before running clustering and matching tests to ensure accurate internal states.

- **Behavior Changes**
  - Adjusted equality and assignment operations for chromatogram and spectrum objects to exclude range management state, refining comparison semantics.
  - Modified chromatogram equality tests to align with updated object equivalence expectations after clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->