### PR TITLE
TOPPView: open theoretical spectra immediately

### DIFF
--- a/src/openms/include/OpenMS/PROCESSING/MISC/DataFilters.h
+++ b/src/openms/include/OpenMS/PROCESSING/MISC/DataFilters.h
@@ -28,6 +28,9 @@ namespace OpenMS
 public:
     DataFilters() = default;
 
+    /// Equality operator
+    bool operator==(const DataFilters&) const = default;
+
     ///Information to filter
     enum FilterType
     {

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -357,7 +357,12 @@ namespace OpenMS
     }
 
     /**
-        @brief Sets the filters applied to the data before drawing (for the current layer)
+      @brief Sets filters, but does not repaint (useful when setting up a new layer)
+    */
+    virtual void initFilters(const DataFilters& filters);
+
+    /**
+        @brief Sets the filters applied to the data; and redraws
     */
     virtual void setFilters(const DataFilters& filters);
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1929,12 +1929,14 @@ namespace OpenMS
 
       PeakMap new_exp;
       new_exp.addSpectrum(spectrum);
+      new_exp.updateRanges();
       ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));
       FeatureMapSharedPtrType f_dummy(new FeatureMapType());
       ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
       ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
       vector<PeptideIdentification> p_dummy;
-      addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerDataBase::DT_PEAK, false, true, true, "", spec_gen_dialog_.getSequence() + " (theoretical)");
+      // open as 1D (since its a single spectrum); 3D view does not support MS2 (yet)
+      addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerDataBase::DT_PEAK, true, false, true, "", spec_gen_dialog_.getSequence() + " (theoretical)");
 
       // ensure spectrum is drawn as sticks
       draw_group_1d_->button(Plot1DCanvas::DM_PEAKS)->setChecked(true);

--- a/src/openms_gui/source/VISUAL/FilterList.cpp
+++ b/src/openms_gui/source/VISUAL/FilterList.cpp
@@ -51,6 +51,11 @@ namespace OpenMS::Internal
 
     void FilterList::set(const DataFilters& filters)
     {
+      if (filters == filters_)
+      { // avoid unnecessary updates
+        return;
+      }
+
       filters_ = filters;
 
       ui_->filter->clear();

--- a/src/openms_gui/source/VISUAL/PlotCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/PlotCanvas.cpp
@@ -84,6 +84,12 @@ namespace OpenMS
 #endif
   }
 
+  
+  void PlotCanvas::initFilters(const DataFilters& filters)
+  {
+    layers_.getCurrentLayer().filters = filters;
+  }
+
   void PlotCanvas::setFilters(const DataFilters& filters)
   {
     // set filters
@@ -443,7 +449,7 @@ namespace OpenMS
       auto cutoff = estimateNoiseFromRandomScans(*map, 1, 10, 5); // 5% of low intensity data is considered noise
       DataFilters filters;
       filters.add(DataFilters::DataFilter(DataFilters::INTENSITY, DataFilters::GREATER_EQUAL, cutoff));
-      setFilters(filters);
+      initFilters(filters);
     }
     else // no mower, hide zeros if wanted
     {
@@ -451,7 +457,7 @@ namespace OpenMS
       {
         DataFilters filters;
         filters.add(DataFilters::DataFilter(DataFilters::INTENSITY, DataFilters::GREATER_EQUAL, 0.001));
-        setFilters(filters);
+        initFilters(filters);
       }
     }
 


### PR DESCRIPTION
opening a single MS2 spec in 3D view should not be allowed (3D view does not support MS2 spectra), so we open them immediately as 1D

fixes #8014

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Theoretical spectra are now correctly displayed in a 1D view with updated data ranges.
  - Improved handling ensures appropriate display settings for theoretical spectra, avoiding unsupported 3D views.

- **Performance Improvements**
  - Filter updates now avoid unnecessary UI refreshes when filter settings remain unchanged.

- **New Features**
  - Introduced a new method to initialize data filters without triggering immediate redraws, enhancing performance during layer setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->