### PR TITLE
added update ranges to other file formats

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/DTA2DFile.h
+++ b/src/openms/include/OpenMS/FORMAT/DTA2DFile.h
@@ -230,6 +230,7 @@ public:
       }
 
       is.close();
+      map.updateRanges();
       endProgress();
     }
 

--- a/src/openms/include/OpenMS/FORMAT/MS2File.h
+++ b/src/openms/include/OpenMS/FORMAT/MS2File.h
@@ -162,14 +162,8 @@ public:
         spec.setNativeID(String("index=") + (spectrum_number++));
         exp.addSpectrum(spec);
       }
+      exp.updateRanges();
     }
-
-    /*
-    template <typename MapType> void store(const String& filename, MapType& map)
-    {
-
-    }
-    */
 
 protected:
 

--- a/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
@@ -93,7 +93,7 @@ public:
         setProgress(is.tellg());
         ++spectrum_number;
       } // next spectrum
-
+      exp.updateRanges();
       endProgress();
     }
 

--- a/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -916,7 +916,8 @@ namespace OpenMS
       throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS1 spectra in input file.");
     }
 
-    //TODO allow skipping?
+    // clear chromatograms (otherwise they are used to calculate optimal RT and m/z ranges)
+    exp.getChromatograms().clear();
 
     // update m/z and RT ranges
     exp.updateRanges();

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cpp
@@ -247,7 +247,6 @@ namespace OpenMS::Internal
   {
     OpenMS::MSSpectrum s;
     getMSSpectrumById(id, s);
-    s.updateRanges();
     return s;
   }
 

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -284,13 +284,6 @@ namespace OpenMS
       // update range of EACH chrom, if we need them individually later
       cp.updateRanges();
 
-      // ignore TICs and ECs for the whole experiments range (as these are usually positioned at 0 and therefor lead to a large white margin in plots if included)
-      if (cp.getChromatogramType() == ChromatogramSettings::TOTAL_ION_CURRENT_CHROMATOGRAM ||
-        cp.getChromatogramType() == ChromatogramSettings::EMISSION_CHROMATOGRAM)
-      {
-        continue;
-      }
-
       // ranges
       this->extendMZ(cp.getMZ());// MZ
       this->extend(cp);// RT and intensity from chroms's range

--- a/src/tests/topp/FileInfo_19_output.txt
+++ b/src/tests/topp/FileInfo_19_output.txt
@@ -1,20 +1,20 @@
 
 -- General information --
 
-File name: /workspace/OpenMS/src/tests/topp/FAIMS_test_data.mzML
+File name: /home/sachsenb/Development/OpenMS/src/tests/topp/FAIMS_test_data.mzML
 File type: mzML
 
 Instrument: 
 
 MS levels: 1, 2
-Total number of peaks: 2679
+Total number of peaks: 2681
 Number of spectra: 2
 
 Ranges:
   retention time: 18.25 .. 18.39 sec (0.0 min)
-  mass-to-charge: 110.07 .. 1590.88
-    ion mobility: -65.00 .. -65.00
-       intensity: 0.00 .. 5057372.00
+  mass-to-charge: 0.00 .. 1590.88
+  ion mobility: -65.00 .. -65.00
+  intensity: 0.00 .. 31878566.00
 
 Number of spectra per MS level:
   level 1: 1


### PR DESCRIPTION
## Description

This pull request introduces changes to improve the handling of range updates and chromatogram data in the OpenMS library, along with adjustments to tests to reflect these updates. The most significant changes involve ensuring that range information is consistently updated across multiple file formats and clearing chromatograms to avoid unintended side effects during processing.

### Improvements to range updates:

* Added calls to `updateRanges()` in the `DTA2DFile`, `MS2File`, and `MascotGenericFile` classes to ensure that range information is updated after processing spectra or experiments. (`[[1]](diffhunk://#diff-10c2ea67a2da981d5f5f01d79bbddb8bd7acd13aa6863ee1f9e0c38290f1d704R233)`, `[[2]](diffhunk://#diff-93b4bac23d06e7f3d2693a8efe996c5148ac905a1c3f9bc5c9dd14c48792f76fR165-L173)`, `[[3]](diffhunk://#diff-f54cf1724f64cf819ae96ccb8bc6466890de8f4087a1bba7d42cccf63ca8fdedL96-R96)`)
* Removed an unnecessary call to `updateRanges()` in the `IndexedMzMLHandler` class, as it was redundant when retrieving spectra. (`[src/openms/source/FORMAT/HANDLERS/IndexedMzMLHandler.cppL250](diffhunk://#diff-ba2b617e652a2a74a13630c3d5daf2978fae2040a937592e3a16551687bf5d4dL250)`)

### Handling of chromatogram data:

* Modified the `FeatureFinderMultiplexAlgorithm` to clear chromatograms before updating ranges, preventing their inclusion in range calculations for optimal RT and m/z values. (`[src/openms/source/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cppL919-R920](diffhunk://#diff-cc886d76d710c353b043c775e2d55ffcd0b75ce998df0c302fd25cfbcbb4e3bfL919-R920)`)

### Test adjustments:

* Updated the test output in `FileInfo_19_output.txt` to reflect changes in range calculations, including updates to the total number of peaks, mass-to-charge range, and intensity range. (`[src/tests/topp/FileInfo_19_output.txtL4-R17](diffhunk://#diff-ad88380c850baa1223d09bfbd671c79b98e5464ea07e8bee723d570d0213edcbL4-R17)`)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of experiment metadata by ensuring range information (such as m/z, retention time, and intensity) is consistently updated after loading spectra.
	- Chromatograms are now excluded from certain range calculations, preventing them from affecting optimal range values.
	- Updated logic to include all chromatogram types when updating experiment ranges.

- **Documentation**
	- Updated output in test files to reflect corrected peak counts and measurement ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->