### PR TITLE
[DOC] Be specific about Boost flags and improve formatting

### DIFF
--- a/doc/doxygen/install/install-macs.doxygen
+++ b/doc/doxygen/install/install-macs.doxygen
@@ -100,7 +100,7 @@
         cmake -DBUILD_TYPE=ALL -DNUMBER_OF_JOBS=4 -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang <path_to_OpenMS_contrib>
         \endcode
 
-    Example:
+        Example:
 
         \code
         cd ~/openms-development/contrib_build
@@ -130,9 +130,17 @@
       brew install libsvm xerces-c boost glpk eigen hdf5
     \endcode
 
-  @note Until the CoinMP complete package is migrated to the coin-or-tools tap, we suggest to use our contrib version. You will then additionally need gfortran as a Fortran compiler to build.
-  @note The compression libraries bzip and zlib should come with your macOS/XCode/commandline tools.
-  @note If using Boost from brew, since v1.75, its CMake config file links all dependent libraries to icu4c when using boost::regex as static library. Therefore, we suggest to use dynamic libraries in the OpenMS build stage.
+  @note Until the CoinMP complete package is migrated to the
+  coin-or-tools tap, we suggest using our contrib version. You will
+  then additionally need <tt>gfortran</tt> as a Fortran compiler to
+  build.  The compression libraries <tt>bzip</tt> and <tt>zlib</tt>
+  should come with your macOS/XCode/command line tools.
+
+  @note If using Boost from brew, since v1.75, its CMake configuration
+  file links all dependent libraries to <tt>icu4c</tt> when using
+  <tt>boost::regex</tt> as a static library. Therefore, we suggest
+  using the <tt>-DBOOST_USE_STATIC=OFF</tt> CMake flag in the %OpenMS
+  build.
 
   For MacPorts the following sequence of commands installs some of the
   libraries required by %OpenMS.


### PR DESCRIPTION
## Description

Boost installed from brew requires dynamic linking.  This is mentioned in the install documentation but without saying which flag to pass to CMake.  This commit resolves that.

It also fixes the formatting for a code block.  The indentation under the `<li>` element needs to remain consistent otherwise the `\code` markers are ignored and the entire section is treated as code.

## Checklist
- [X] Make sure that you are listed in the AUTHORS file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and clarity of installation instructions for macOS.
  - Merged and rephrased notes on dependencies and build instructions for better readability.
  - Enhanced inline code formatting and updated recommendations for Boost library usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->