### PR TITLE
Resolve undefined behavior w.r.t. basic_string<unsigned_char>

### DIFF
--- a/src/openms/source/FORMAT/OSWFile.cpp
+++ b/src/openms/source/FORMAT/OSWFile.cpp
@@ -80,7 +80,7 @@ namespace OpenMS
 
       // Generate features
       int k = 0;
-      std::vector<std::basic_string<unsigned char>> group_id_index;
+      std::vector<std::string> group_id_index;
       OpenMS::String tmp;
       while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
       {
@@ -98,7 +98,8 @@ namespace OpenMS
           }
           if (strcmp(sqlite3_column_name(stmt, i), "GROUP_ID") == 0)
           {
-            auto it = std::find(group_id_index.begin(), group_id_index.end(), sqlite3_column_text(stmt, i));
+            std::string group_id(reinterpret_cast<const char*>(sqlite3_column_text(stmt, i)));
+            auto it = std::find(group_id_index.begin(), group_id_index.end(), group_id);
             if (it != group_id_index.end())
             {
               scan_id = it - group_id_index.begin();
@@ -106,7 +107,7 @@ namespace OpenMS
             else
             {
               scan_id = group_id_index.size();
-              group_id_index.emplace_back(sqlite3_column_text(stmt, i));
+              group_id_index.emplace_back(group_id);
             }
           }
           if (strcmp(sqlite3_column_name(stmt, i), "DECOY") == 0)


### PR DESCRIPTION
## Description

`std::char_traits<unsigned char>` has been undefined behavior since at least C++11 and was recently removed in LLVM/clang.  Therefore the latest version of XCode no longer allows:

    std::basic_string<unsigned char>

This means that OpenMS will no longer compile on macOS after recently released system updates are installed.

I "fixed" the issue by replacing `std::basic_string` with `std::string` and a cast.  Since SQLite is returning a UTF-8 character string, there's a chance that string comparisons will not work the way we expect if wide characters are returned.

I still need to verify that the `OSWFile` test is actually checking the section of code changed in this commit.

## Checklist
- [X] Make sure that you are listed in the AUTHORS file
- [ ] New and existing unit tests pass locally with my changes

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of group identifiers to ensure consistent and reliable string processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->