### PR TITLE
Pjones/backports

### DIFF
--- a/.github/workflows/update_version_numbers.yml
+++ b/.github/workflows/update_version_numbers.yml
@@ -21,52 +21,10 @@ jobs:
       # Update files with new package version numbers
       - name: update files
         run: |
-          # setting variables
-          package_version_major="${{ github.event.inputs.major }}"
-          package_version_minor="${{ github.event.inputs.minor }}"
-          package_version_patch="${{ github.event.inputs.patch }}"
-          package_version="${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.${{ github.event.inputs.patch }}"
-          echo "Setting version $package_version"
-
-          # update main cmakelist
-          sed -i '' "s#.*set(OPENMS_PACKAGE_VERSION_MAJOR.*#set(OPENMS_PACKAGE_VERSION_MAJOR \"$package_version_major\")#" CMakeLists.txt
-          sed -i '' "s#.*set(OPENMS_PACKAGE_VERSION_MINOR.*#set(OPENMS_PACKAGE_VERSION_MINOR \"$package_version_minor\")#" CMakeLists.txt
-          sed -i '' "s#.*set(OPENMS_PACKAGE_VERSION_PATCH.*#set(OPENMS_PACKAGE_VERSION_PATCH \"$package_version_patch\")#" CMakeLists.txt
-
-          # update version info test
-          sed -i '' "s#detail.version_major =.*#detail.version_major = $package_version_major;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
-          sed -i '' "s#detail.version_minor =.*#detail.version_minor = $package_version_minor;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
-          sed -i '' "s#detail.version_patch =.*#detail.version_patch = $package_version_patch;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
-
-          # update vcpkg.json
-          sed -i '' "s/\"version-string\": \".*\"/\"version-string\": \"$package_version\"/" vcpkg.json
-
-          # update test write ini out:
-          sed -i '' "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" ./src/tests/topp/WRITE_INI_OUT.ini
-          # update INIUpdater version
-          sed -i '' "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" ./src/tests/topp/INIUpdater_1_noupdate.toppas
-
-
-          # update INIs in tests topp:
-          find ./src/tests/topp/ -type f -name '*.ini' -exec grep -q "<ITEM name=\"version\" value=\".*\" type=\"string\"" {} \; -exec sed -i '' "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" {} \;
-          # Update Changelog
-          # Define the new section using a here-doc
-          section_header=$(cat <<EOF
-          ------------------------------------------------------------------------------------------
-          ----                                OpenMS ${package_version}     (under development)              ----
-          ------------------------------------------------------------------------------------------
-          
-          
-          .    # ends with a period for preserve trailing newlines
-          EOF
-          )
-          section_header=${section_header%.*}   # remove the period
-
-          # Get the line number of the first line starting with more than 10 "-"
-          line_num=$(grep -n "^-\{10,\}" CHANGELOG | head -n 1 | cut -d ":" -f 1)
-
-          # Use perl to insert the text at the specified line number in the file
-          perl -i -pe "print '${section_header}' if \$. == ${line_num}" CHANGELOG
+          bash tools/update_version_numbers.sh \
+            "${{ github.event.inputs.major }}" \
+            "${{ github.event.inputs.minor }}" \
+            "${{ github.event.inputs.patch }}"
 
       # Check for changes
       - name: check for changed files

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -89,7 +89,7 @@ RUN <<-EOF
 
     # copying only the binaries that are relevant to Linux
     cp -r THIRDPARTY/All/* ${THIRDPARTY_DIR}
-    cp -r THIRDPARTY/Linux/64bit/* ${THIRDPARTY_DIR}
+    cp -r THIRDPARTY/Linux/x86_64/* ${THIRDPARTY_DIR}
 
     rm -rf THIRDPARTY
 EOF

--- a/tools/update_version_numbers.sh
+++ b/tools/update_version_numbers.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+################################################################################
+set -eu
+set -o pipefail
+
+################################################################################
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options] major minor patch
+
+  -h      This message
+
+Update the OpenMS version number.
+
+EOF
+}
+
+################################################################################
+while getopts "h" o; do
+  case "${o}" in
+  h)
+    usage
+    exit
+    ;;
+
+  *)
+    exit 1
+    ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [ $# -ne 3 ]; then
+  echo >&2 "ERROR: please provide three numbers (use --help for more info)"
+  exit 1
+fi
+
+################################################################################
+package_version_major=$1
+package_version_minor=$2
+package_version_patch=$3
+package_version="$1.$2.$3"
+
+echo "Setting version $package_version"
+
+################################################################################
+# update main cmakelist
+sed -i -e "s#.*set(OPENMS_PACKAGE_VERSION_MAJOR.*#set(OPENMS_PACKAGE_VERSION_MAJOR \"$package_version_major\")#" CMakeLists.txt
+sed -i -e "s#.*set(OPENMS_PACKAGE_VERSION_MINOR.*#set(OPENMS_PACKAGE_VERSION_MINOR \"$package_version_minor\")#" CMakeLists.txt
+sed -i -e "s#.*set(OPENMS_PACKAGE_VERSION_PATCH.*#set(OPENMS_PACKAGE_VERSION_PATCH \"$package_version_patch\")#" CMakeLists.txt
+
+# update version info test
+sed -i -e "s#detail.version_major =.*#detail.version_major = $package_version_major;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
+sed -i -e "s#detail.version_minor =.*#detail.version_minor = $package_version_minor;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
+sed -i -e "s#detail.version_patch =.*#detail.version_patch = $package_version_patch;#" ./src/tests/class_tests/openms/source/VersionInfo_test.cpp
+
+# update vcpkg.json
+sed -i -e "s/\"version-string\": \".*\"/\"version-string\": \"$package_version\"/" vcpkg.json
+
+# update test write ini out:
+sed -i -e "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" ./src/tests/topp/WRITE_INI_OUT.ini
+# update INIUpdater version
+sed -i -e "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" ./src/tests/topp/INIUpdater_1_noupdate.toppas
+
+# update INIs in tests topp:
+find ./src/tests/topp/ \
+  -type f \
+  -name '*.ini' \
+  -exec grep -q "<ITEM name=\"version\" value=\".*\" type=\"string\"" {} \; \
+  -exec sed -i -e "s#<ITEM name=\"version\" value=\".*\" type=\"string\"#<ITEM name=\"version\" value=\"$package_version\" type=\"string\"#g" {} \;
+
+# Update Changelog
+#
+# Create a banner with line endings that sed wants (add a backslash
+# in front of each newline except the last.
+section_header=$(
+  sed -Ee '$!s/$/\\/' <<<"
+------------------------------------------------------------------------------------------
+----                                OpenMS ${package_version}     (under development)              ----
+------------------------------------------------------------------------------------------
+
+ " # NOTE: this line should start with a single blank space!
+)
+
+# Get the line number of the first line starting with more than 10 "-"
+line_num=$(
+  grep \
+    --extended-regexp \
+    --line-number \
+    --max-count=1 "^-{10,}" CHANGELOG |
+    cut -d: -f1
+)
+
+sed -i \
+  -e "${line_num}i $section_header" \
+  CHANGELOG
+
+################################################################################
+echo "done."


### PR DESCRIPTION
## Description

Backport changes from the 3.4.1 release branch to `develop`:

  - Extract the version update script from a CI workflow so it can be used by developers as needed.
  - Update the `THIRDPARTY` directory name in the Dockerfile (fix for #8048)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated script to update version numbers across project files, streamlining the version update process.

- **Chores**
  - Updated the workflow to use the new script for version updates, replacing previous inline commands.
  - Modified the Dockerfile to adjust the source directory for Linux-specific third-party binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->