### PR TITLE
Feat/option to toggle tdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,8 @@ option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
 option(NO_WEBENGINE_WIDGETS "Do not use QtWebengineWidgets. Disables Javascript views in TOPPView." OFF)
 option(WITH_HDF5 "Build HDF5 parts of OpenMS." OFF)
-option(ENABLE_CWL "Build and validate the CWL description files for all TOPP tools." OFF)
+option(ENABLE_CWL_GENERATION "Build and validate the CWL description files for all TOPP tools." OFF)
+
 
 if(MSVC)
   option(MT_ENABLE_NESTED_OPENMP "Enable nested parallelism." OFF)
@@ -476,7 +477,7 @@ endif()
 #------------------------------------------------------------------------------
 # CWL generation (updates openms/share/commonwl/*.cwl files for all TOPP tools)
 #------------------------------------------------------------------------------
-if (ENABLE_CWL)
+if (ENABLE_CWL_GENERATION)
   include(${OPENMS_HOST_DIRECTORY}/cmake/cwl_generation.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,12 @@ option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
 option(NO_WEBENGINE_WIDGETS "Do not use QtWebengineWidgets. Disables Javascript views in TOPPView." OFF)
 option(WITH_HDF5 "Build HDF5 parts of OpenMS." OFF)
-option(ENABLE_CWL_GENERATION "Build and validate the CWL description files for all TOPP tools." OFF)
+option(ENABLE_TDL "Load dependency and compile against TDL (required for CWL file support)." ON)
+option(ENABLE_CWL_GENERATION "Build and validate the CWL description files for all TOPP tools (Requires ENABLE_TDL=ON)." OFF)
+
+if(ENABLE_CWL_GENERATION AND NOT ENABLE_TDL)
+    message(FATAL_ERROR "ENABLE_CWL_GENERATION requires ENABLE_TDL to be ON.")
+endif()
 
 
 if(MSVC)

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -57,7 +57,7 @@ include (${PROJECT_SOURCE_DIR}/includes.cmake)
 # all the dependency libraries are linked into libOpenMS.so
 set(OPENMS_DEP_LIBRARIES Evergreen LibSVM::LibSVM XercesC::XercesC Eigen3::Eigen Qt6::Core Qt6::Network)
 
-## setup the argumentes to 'target_link_libraries(OpenMS PRIVATE ${OPENMS_DEP_PRIVATE_LIBRARIES})'
+## setup the arguments to 'target_link_libraries(OpenMS PRIVATE ${OPENMS_DEP_PRIVATE_LIBRARIES})'
 set(OPENMS_DEP_PRIVATE_LIBRARIES
   $<$<BOOL:${WITH_HDF5}>:HDF5::HDF5>
   ${LPTARGET}
@@ -72,8 +72,13 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   SQLiteCpp
   ZLIB::ZLIB
   nlohmann_json::nlohmann_json
-  tdl::tdl
   )
+if (ENABLE_TDL)
+set(OPENMS_DEP_PRIVATE_LIBRARIES
+    ${OPENMS_DEP_PRIVATE_LIBRARIES}
+    tdl::tdl
+    )
+endif()
 
 # Xerces requires linking against CoreFoundation&CoreServices on macOS
 # TODO check if this is still the case
@@ -113,6 +118,11 @@ if (MSVC)
   ## treat warning of unused local variable as error, similar to -Werror=unused-variable on GCC
   target_compile_options(OpenMS PRIVATE "/we4189")
 endif()
+
+if (ENABLE_TDL)
+    target_compile_definitions(OpenMS PUBLIC ENABLE_TDL)
+endif()
+
 
 #------------------------------------------------------------------------------
 # since the share basically belongs to OpenMS core we control its installation

--- a/src/openms/extern/CMakeLists.txt
+++ b/src/openms/extern/CMakeLists.txt
@@ -55,7 +55,10 @@ add_subdirectory(eol-bspline)
 add_subdirectory(IsoSpec)
 add_subdirectory(GTE)
 add_subdirectory(Quadtree)
-add_subdirectory(tool_description_lib)
+
+if(ENABLE_TDL)
+    add_subdirectory(tool_description_lib)
+endif()
 
 ##
 ## external packages (with fallback option to local version)

--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -12,7 +12,12 @@
 #include <iostream>
 #include <limits>
 #include <nlohmann/json.hpp>
+
+#if defined(ENABLE_TDL)
 #include <tdl/tdl.h>
+#else
+#include <stdexcept>
+#endif
 
 using json = nlohmann::json;
 
@@ -56,6 +61,7 @@ namespace OpenMS
 
   void ParamCWLFile::writeCWLToStream(std::ostream* os_ptr, const Param& param, const ToolInfo& tool_info) const
   {
+#if defined(ENABLE_TDL)
     std::ostream& os = *os_ptr;
     os.precision(std::numeric_limits<double>::digits10);
 
@@ -316,5 +322,8 @@ namespace OpenMS
           "# SPDX-License-Identifier: Apache-2.0\n";
 
     os << convertToCWL(tdl_tool_info) << "\n";
+#else
+    throw std::runtime_error{"TDL support is not available. Rebuild with -DENABLE_TDL=ON to enable this feature."};
+#endif
   }
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ParamJSONFile.cpp
+++ b/src/openms/source/FORMAT/ParamJSONFile.cpp
@@ -11,7 +11,11 @@
 #include <iostream>
 #include <limits>
 #include <nlohmann/json.hpp>
+#if defined(ENABLE_TDL)
 #include <tdl/tdl.h>
+#else
+#include <stdexcept>
+#endif
 
 using json = nlohmann::json;
 
@@ -174,6 +178,7 @@ namespace OpenMS
 
   void ParamJSONFile::writeToStream(std::ostream* os_ptr, const Param& param) const
   {
+#if defined(ENABLE_TDL)
     std::ostream& os = *os_ptr;
 
     // discover the name of the first nesting Level
@@ -303,5 +308,8 @@ namespace OpenMS
     assert(stack.size() == 1);
 
     os << jsonDoc.dump(2);
+#else
+    throw std::runtime_error{"TDL support is not available. Rebuild with -DENABLE_TDL=ON to enable this feature."};
+#endif
   }
 } // namespace OpenMS

--- a/tools/ci/cibuild.cmake
+++ b/tools/ci/cibuild.cmake
@@ -89,7 +89,7 @@ set(VARS_TO_LOAD
   "ENABLE_TOPP_TESTING"
   "ENABLE_PIPELINE_TESTING"
   "ENABLE_DOCS"
-  "ENABLE_CWL"
+  "ENABLE_CWL_GENERATION"
   "ENABLE_TUTORIALS"
   "ENABLE_UPDATE_CHECK"
   "MT_ENABLE_OPENMP"
@@ -179,11 +179,11 @@ endif()
 if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "OFF")
   if("$ENV{PYOPENMS}" STREQUAL "ON")
     ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "pyopenms" NUMBER_ERRORS _build_errors)
-    # Generate and valdiate the CWL files if "ENABLE_CWL" is set
+    # Generate and validate the CWL files if "ENABLE_CWL_GENERATION" is set
   else()
     ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
   endif()
-  if("$ENV{ENABLE_CWL}" STREQUAL "ON")
+  if("$ENV{ENABLE_CWL_GENERATION}" STREQUAL "ON")
   ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "generate_cwl_files" NUMBER_ERRORS _build_errors)
   endif()
 else()


### PR DESCRIPTION
Workaround for issue #7982 .

## ENABLE_TDL
This adds a new option `ENABLE_TDL` which is by default ON. It is possible to turn it off, which will not load
TDL as a dependency and therefor does not allow to generate CWL-Description files (loading .json files as params still works).

In some unknown/not understood cases (see #7982) the tool_description_lib
increases cmake run time to multiple minutes instead of just running in seconds. For these cases giving cmake the additional Parameter `-DENABLE_TDL=OFF" to workaround this issue.


## rename ENABLE_CWL_GENERATION
Also, ticket #7982 showed that the existing option `ENABLE_CWL` was easy to be misunterstood. I renamed it to `ENABLE_CWL_GENERATION` to make it purpose clearer (it is by default OFF).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build configuration options for CWL support, introducing separate options for TDL dependency management and CWL file generation.
	- Improved conditional inclusion of TDL-related components and libraries in the build process.
	- Clarified error messaging when TDL support is disabled.
	- Renamed environment variables and updated related comments for consistency in build scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->