### PR TITLE
[DOCKER] Don't use `git submodule` unless necessary

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -85,12 +85,16 @@ WORKDIR ${SOURCE_DIR}
 RUN mkdir -p ${THIRDPARTY_DIR}
 RUN <<-EOF
     set -eux
-    git submodule update --depth=1 --init THIRDPARTY
+
+    ALL_DIR=THIRDPARTY/All
+    LINUX_DIR=THIRDPARTY/Linux/x86_64
+
+    if [ ! -d "$ALL_DIR" ] || [ ! -d "$LINUX_DIR" ]; then
+      git submodule update --depth=1 --init THIRDPARTY
+    fi
 
     # copying only the binaries that are relevant to Linux
-    cp -r THIRDPARTY/All/* ${THIRDPARTY_DIR}
-    cp -r THIRDPARTY/Linux/x86_64/* ${THIRDPARTY_DIR}
-
+    cp -vr "$ALL_DIR"/* "$LINUX_DIR"/* ${THIRDPARTY_DIR}
     rm -rf THIRDPARTY
 EOF
 


### PR DESCRIPTION
## Description

This change allows users to build the Docker container without needing to have a copy of the git repository.  As long as they have a complete copy of the third party repo locally everything will just work.

NOTE: I tested these changes using our container deployment workflow.  I was surprised to find that the `git submodule` command does not get executed in the runner!  This is because the workflow is somehow fetching the submodules even though that setting is disabled.

## Checklist

- [X] Make sure that you are listed in the AUTHORS file
- [X] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved Docker build process for handling third-party dependencies, resulting in a more efficient and reliable build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->