### PR TITLE
build static sqlite libs on Windows

### DIFF
--- a/src/openms/extern/SQLiteCpp/CMakeLists.txt
+++ b/src/openms/extern/SQLiteCpp/CMakeLists.txt
@@ -225,14 +225,6 @@ if (SQLITE_USE_LEGACY_STRUCT)
     target_compile_definitions(SQLiteCpp PUBLIC SQLITE_USE_LEGACY_STRUCT)
 endif (SQLITE_USE_LEGACY_STRUCT)
 
-if (BUILD_SHARED_LIBS)
-    if (WIN32)
-        message(STATUS "Build shared libraries (DLLs).")
-        target_compile_definitions(SQLiteCpp PUBLIC "SQLITECPP_COMPILE_DLL")
-        target_compile_definitions(SQLiteCpp PRIVATE "SQLITECPP_DLL_EXPORT")
-    endif()
-endif()
-
 option(SQLITE_OMIT_LOAD_EXTENSION "Enable omit load extension" OFF)
 if (SQLITE_OMIT_LOAD_EXTENSION)
     # Enable the user definition of load_extension().

--- a/src/openms/extern/SQLiteCpp/sqlite3/CMakeLists.txt
+++ b/src/openms/extern/SQLiteCpp/sqlite3/CMakeLists.txt
@@ -6,16 +6,11 @@
 # or copy at http://opensource.org/licenses/MIT) 
 
 # add sources of the "sqlite3" static library
-add_library(sqlite3
+add_library(sqlite3 STATIC
  sqlite3.c
  sqlite3.h
 )
 
-if (WIN32)
-    if (BUILD_SHARED_LIBS)
-            add_definitions("-DSQLITE_API=__declspec(dllexport)")
-    endif()
-endif()
 
 add_library(SQLite::SQLite3 ALIAS sqlite3)
 


### PR DESCRIPTION
## Description

augments #8060

In collaboration with Simon :)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to always use a static library for the sqlite3 component.
	- Removed Windows-specific settings related to building shared libraries (DLLs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->