### PR TITLE
Fix: use equal_by_mass comparator instead of less_by_mass for marker ion deduplicationFeature/nuxl

### DIFF
--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -39,9 +39,14 @@ std::vector<NuXLFragmentAdductDefinition> NuXLParameterParsing::getMarkerIonsMas
       return a.mass < b.mass; 
     };
 
+    auto equal_by_mass = [](const NuXLFragmentAdductDefinition & a, const NuXLFragmentAdductDefinition & b) -> bool
+    { 
+      return std::abs(a.mass - b.mass) < 1e-6; // compares mass values with a small tolerance
+    };
+
   sort(marker_ions_unique_by_mass.begin(), marker_ions_unique_by_mass.end(), less_by_mass);
   marker_ions_unique_by_mass.erase(
-    unique(marker_ions_unique_by_mass.begin(), marker_ions_unique_by_mass.end(), less_by_mass), 
+    unique(marker_ions_unique_by_mass.begin(), marker_ions_unique_by_mass.end(), equal_by_mass), 
     marker_ions_unique_by_mass.end());
 
   return marker_ions_unique_by_mass;

--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -41,7 +41,7 @@ std::vector<NuXLFragmentAdductDefinition> NuXLParameterParsing::getMarkerIonsMas
 
     auto equal_by_mass = [](const NuXLFragmentAdductDefinition & a, const NuXLFragmentAdductDefinition & b) -> bool
     { 
-      return std::abs(a.mass - b.mass) < 1e-6; // compares mass values with a small tolerance
+      return a.mass == b.mass;
     };
 
   sort(marker_ions_unique_by_mass.begin(), marker_ions_unique_by_mass.end(), less_by_mass);


### PR DESCRIPTION
## Description
This PR builds on top of #7815, fixes a bug in the marker ion deduplication logic in NuXLAnnotateAndLocate.

Previously, std::unique was used with a less-than comparator (less_by_mass), which is not valid
for deduplication. This has been replaced with a proper equality comparator (equal_by_mass) using
a floating-point tolerance (1e-6), ensuring stable and correct behavior.