### PR TITLE
[GITHUB]: Add issue templates with forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-question.yml
+++ b/.github/ISSUE_TEMPLATE/01-question.yml
@@ -1,0 +1,58 @@
+name: Request for Help
+description: Ask a question or request support
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: markdown
+    attributes:
+      value: "## Please Read Before Continuing"
+  - type: markdown
+    attributes:
+      value: |
+        Before opening an issue *please* consider using the following options instead:
+
+        * [Search existing issues](/OpenMS/OpenMS/issues) for similar requests.
+        * Start a [new discussion](/OpenMS/OpenMS/discussions/categories/q-a) in the Q&A section.
+
+        Thank you!
+
+        <br>
+  - type: markdown
+    attributes:
+      value: "## Details About Your Environment"
+  - type: input
+    id: os
+    attributes:
+      label: Operating System and Hardware
+      description: What operating system are you using?  Which version?  On what hardware?
+      placeholder: "Example: Windows 11 on x86"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenMS Version
+      description: Which version and distribution of OpenMS are you using?
+      placeholder: "Example: pyOpenMS 3.4"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: markdown
+    attributes:
+      value: "## Describe Your Request"
+  - type: textarea
+    id: description
+    attributes:
+      label: Your Question
+      description: |
+        Please provide a detailed question along with any information
+        you think we would need to help you.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug-report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Create a report to help us improve OpenMS
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: markdown
+    attributes:
+      value: "## Details About Your Environment"
+  - type: input
+    id: os
+    attributes:
+      label: Operating System and Hardware
+      description: What operating system are you using?  Which version?  On what hardware?
+      placeholder: "Example: Windows 11 on x86"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenMS Version
+      description: Which version and distribution of OpenMS are you using?
+      placeholder: "Example: pyOpenMS 3.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: installer
+    attributes:
+      label: Installation Method
+      description: How did you install OpenMS?
+      options:
+        - "Official Installer"
+        - "Docker"
+        - "Python: Conda"
+        - "Python: Bioconda"
+        - "Python: pip"
+        - "Linux Package"
+        - "Other"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+  - type: markdown
+    attributes:
+      value: "## Describe the Bug"
+  - type: markdown
+    attributes:
+      value: |
+        When describing the problem you are experiencing please provide as much information as possible, including:
+
+        * What triggered the bug?
+        * The full text of any error message.
+        * Output from the tool you were using.
+        * Screenshots of misbehaving GUI tools.
+        * Example source code for problems with pyOpenMS.
+
+        Thank you!
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Please describe the problem you are experiencing.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature-request.yml
@@ -1,0 +1,12 @@
+name: Feature Request
+description: Suggest an idea for this project
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: enhancement
+    attributes:
+      label: Enhancement Description
+      description: Please describe the feature you would like added to OpenMS.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/04-maintainer.yml
+++ b/.github/ISSUE_TEMPLATE/04-maintainer.yml
@@ -1,0 +1,13 @@
+name: OpenMS Maintainer Report
+description: A way for OpenMS core team members to submit reports.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **NOTE:** This form is for OpenMS maintainers and core team members.  If you want to file a bug report or request help please use [another form](/OpenMS/OpenMS/issues/new) instead.
+  - type: textarea
+    id: report
+    attributes:
+      label: Report
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Description

Use GitHub issue forms to encourage users to report more information and to direct questions to more appropriate venues.

## Playground

I have these forms set up in [a test repository](https://github.com/pjones/test-templates/issues/new) if you want to play with them.

## Questions

For the help request form, I am directing users to search existing issues and to prefer to use the discussions section.  Are there any other places we should link to here?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced standardized issue templates for questions, bug reports, feature requests, and maintainer reports to guide users when submitting issues.
  * Added automatic labeling for each template to categorize issues appropriately.
  * Users are now required to provide relevant details when submitting issues, improving clarity and support.
* **Chores**
  * Disabled the creation of blank issues to ensure all new issues use a predefined template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->