### PR TITLE
SIMD XML conversion from UTF16 to ASCII (e.g. mzML)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,8 +19,9 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 General:
  - speed improvements:
     - loading .gz files is about 7% faster (#8069)
-    - loading of mzML files with more than than mz/intensity (e.g. ion mobility) is 20-40% faster (#8074)
-  
+    - loading of mzML files with more than than m/z+intensity (e.g. ion mobility) is 20-40% faster (#8074)
+    - loading of mzML files is 7-25% faster in general (SIMD ASCII conversion) (#8105)
+    
 Dependencies:
 
 Misc:

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -11,7 +11,7 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/Macros.h>
 
-#include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
+ 
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
@@ -210,30 +210,43 @@ namespace OpenMS
 
       typedef std::basic_string<XMLCh> XercesString;
 
-      // Converts from a narrow-character string to a wide-character string.
+      /// Converts from a narrow-character string to a wide-character string.
       inline static unique_xerces_ptr<XMLCh> fromNative_(const char* str)
       {
         return unique_xerces_ptr<XMLCh>(xercesc::XMLString::transcode(str));
       }
 
-      // Converts from a narrow-character string to a wide-character string.
+      /// Converts from a narrow-character string to a wide-character string.
       inline static unique_xerces_ptr<XMLCh> fromNative_(const String& str)
       {
         return fromNative_(str.c_str());
       }
 
-      // Converts from a wide-character string to a narrow-character string.
+      /// Converts from a wide-character string to a narrow-character string.
       inline static String toNative_(const XMLCh* str)
-      {
-        return String(unique_xerces_ptr<char>(xercesc::XMLString::transcode(str)).get());
+      { 
+        String r;
+        XMLSize_t l = strLength(str);
+        if(isASCII(str, l))
+        {
+          appendASCII(str,l,r);
+        }
+        else
+        {
+          r = (unique_xerces_ptr<char>(xercesc::XMLString::transcode(str)).get());
+        }
+        return r;
       }
 
-      // Converts from a wide-character string to a narrow-character string.
+      /// Converts from a wide-character string to a narrow-character string.
       inline static String toNative_(const unique_xerces_ptr<XMLCh>& str)
       {
         return toNative_(str.get());
       }
 
+protected:
+      /// Compresses eight 8x16bit Chars in XMLCh* to 8x8bit Chars by cutting upper byte
+      static void compress64_ (const XMLCh * input_it, char* output_it);
 
 public:
       /// Constructor
@@ -241,6 +254,9 @@ public:
 
       /// Destructor
       ~StringManager();
+
+      /// Calculates the length of a XMLCh* string using SIMDe 
+      static XMLSize_t strLength(const XMLCh* input_ptr);
 
       /// Transcode the supplied C string to a xerces string
       inline static XercesString convert(const char * str)
@@ -283,7 +299,11 @@ public:
       {
         return toNative_(str);
       }
+      /// Checks if supplied chars in XMLCh* can be encoded with ASCII (i.e. the upper byte of each char is 0)
+      static bool isASCII(const XMLCh * chars, const XMLSize_t length);
 
+      
+      
       /**
        * @brief Transcodes the supplied XMLCh* and appends it to the OpenMS String
        *

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -458,7 +458,7 @@ namespace OpenMS::Internal
               return processed_chars + char_pos_zero;
           }
   
-          // 8 chars (each 16 bytes) had no zero
+          // 8 chars (each 2 bytes) had no zero
           pos_ptr += 8;
           processed_chars += 8;
       }

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/SYSTEM/SIMDe.h>
 
 #include <algorithm>
 #include <set>
@@ -417,6 +418,142 @@ namespace OpenMS::Internal
       }
     }
 
+    size_t StringManager::strLength(const XMLCh* input_ptr) {
+      if (input_ptr == nullptr) {
+          return 0;
+      }
+  
+      XMLSize_t processed_chars = 0;
+      const XMLCh* pos_ptr = input_ptr;
+  
+      // Verarbeite einzelne Zeichen, bis der Pointer 16-Byte-aligned ist
+      uintptr_t ptr_value = reinterpret_cast<uintptr_t>(pos_ptr);
+      size_t misalignment = ptr_value & 0xF; // Berechnet Misalignment als (Adresswert) mod 16
+      size_t chars_to_align = misalignment ? (16 - misalignment) / sizeof(XMLCh) : 0;
+  
+      // Vorverarbeitung einzelner Zeichen bis zum Alignment oder bis zum Ende des Strings
+      for (size_t i = 0; i < chars_to_align; ++i) {
+          if (*pos_ptr == 0) {
+              return i;
+          }
+          ++pos_ptr;
+      }
+      processed_chars = chars_to_align;
+  
+      // Hauptschleife mit SIMD-Operationen
+      const simde__m128i zero = simde_mm_setzero_si128();
+      while (true) {
+          // SIMD-Operation
+          simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
+          simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero);
+          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);
+  
+          if (zero_mask != 0x0000) {
+              size_t byte_pos_zero = __builtin_ctz(zero_mask);
+              size_t char_pos_zero = byte_pos_zero / 2;
+              return processed_chars + char_pos_zero;
+          }
+  
+          // 8 Zeichen (16 Bytes) wurden verarbeitet, keine Null gefunden
+          pos_ptr += 8;
+          processed_chars += 8;
+      }
+  
+      // Diese Zeile wird nie erreicht
+      return processed_chars;
+  }
+
+    void StringManager::compress64_(const XMLCh* inputIt, char* outputIt)
+    {
+      simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputIt));
+    
+      // Select every second byte (little-endian lower byte of each UTF-16 character)
+      const simde__m128i shuffleMask = simde_mm_setr_epi8(
+        0, 2, 4, 6, 8, 10, 12, 14,
+        -1, -1, -1, -1, -1, -1, -1, -1
+      );
+    
+      simde__m128i compressed = simde_mm_shuffle_epi8(bits, shuffleMask);
+    
+      // Store the lower 64 bits (8 ASCII characters)
+      simde_mm_storel_epi64(reinterpret_cast<simde__m128i*>(outputIt), compressed);
+    }
+
+    bool StringManager::isASCII(const XMLCh* chars, const XMLSize_t length)
+  {
+    if (length == 0)
+    {
+      return true;
+    }
+
+    Size fullBlocks = length / 8;
+    Size remainder = length % 8;
+
+    const XMLCh* inputPtr = chars;
+    simde__m128i mask = simde_mm_set1_epi16(0xFF00);
+    bool bitmask = true;
+
+    // Process blocks of 8 UTF-16 characters using SIMD
+    for (Size i = 0; i < fullBlocks; ++i)
+    {
+      simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputPtr));
+      simde__m128i zero = simde_mm_setzero_si128();
+      simde__m128i andOp = simde_mm_and_si128(bits, mask);
+      simde__m128i cmp = simde_mm_cmpeq_epi16(andOp, zero);
+
+      if (simde_mm_movemask_epi8(cmp) != 0xFFFF)
+      {
+        return false;
+      }
+
+      inputPtr += 8;
+    }
+
+  // Check remaining characters individually
+    for (Size i = 0; i < remainder && bitmask; ++i)
+    {
+      if (inputPtr[i] & 0xFF00)
+      {
+        return false;
+      }
+    }
+
+    return bitmask;
+  }
+
+    void StringManager::appendASCII(const XMLCh* chars, const XMLSize_t length, String& result)
+    {
+      // XMLCh are characters in UTF16 (usually stored as 16-bit unsigned
+      // short but this is not guaranteed).
+      // We know that the Base64 string here can only contain plain ASCII
+      // and all bytes except the least significant one will be zero. Thus
+      // we can convert to char directly (only keeping the least
+      // significant byte).
+    
+      Size fullBlocks = length / 8;
+      Size remainder = length % 8;
+    
+      const XMLCh* inputPtr = chars;
+    
+      Size currentSize = result.size();
+      result.resize(currentSize + length);
+      char* outputPtr = &result[currentSize];
+    
+      // Copy blocks of 8 characters at a time
+      for (Size i = 0; i < fullBlocks; ++i)
+      {
+        compress64_(inputPtr, outputPtr);
+        inputPtr += 8;
+        outputPtr += 8;
+      }
+    
+      // Copy any remaining characters individually
+      for (Size i = 0; i < remainder; ++i)
+      {
+        outputPtr[i] = static_cast<char>(inputPtr[i] & 0xFF);
+      }
+    }
+
     //*******************************************************************************************************************
     
     StringManager::StringManager()
@@ -425,35 +562,7 @@ namespace OpenMS::Internal
     StringManager::~StringManager()
     = default;
 
-    void StringManager::appendASCII(const XMLCh * chars, const XMLSize_t length, String & result)
-    {
-      // XMLCh are characters in UTF16 (usually stored as 16bit unsigned
-      // short but this is not guaranteed).
-      // We know that the Base64 string here can only contain plain ASCII
-      // and all bytes except the least significant one will be zero. Thus
-      // we can convert to char directly (only keeping the least
-      // significant byte).
+    
 
-      const XMLCh* it = chars;
-      const XMLCh* end = it + length;
-
-      size_t curr_size = result.size();
-      result.resize(curr_size + length);
-      std::string::iterator str_it = result.begin();
-      std::advance(str_it, curr_size);
-      while (it!=end)
-      {   
-        *str_it = (char)*it;
-        ++str_it;
-        ++it;
-      }
-
-      // This is ca. 50 % faster than 
-      // for (size_t i = 0; i < length; i++)
-      // {
-      //   result[curr_size + i] = (char)chars[i];
-      // }
-
-    }
 
 } // namespace OpenMS   // namespace Internal

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/SYSTEM/SIMDe.h>
 
 #include <algorithm>
+#include <bit>
 #include <set>
 
 using namespace std;
@@ -418,7 +419,8 @@ namespace OpenMS::Internal
       }
     }
 
-    size_t StringManager::strLength(const XMLCh* input_ptr) {
+    size_t StringManager::strLength(const XMLCh* input_ptr)
+    {
       if (input_ptr == nullptr) {
           return 0;
       }
@@ -426,13 +428,14 @@ namespace OpenMS::Internal
       XMLSize_t processed_chars = 0;
       const XMLCh* pos_ptr = input_ptr;
   
-      // Verarbeite einzelne Zeichen, bis der Pointer 16-Byte-aligned ist
+      // find number of characters until we reach a 16-byte aligned address
       uintptr_t ptr_value = reinterpret_cast<uintptr_t>(pos_ptr);
-      size_t misalignment = ptr_value & 0xF; // Berechnet Misalignment als (Adresswert) mod 16
-      size_t chars_to_align = misalignment ? (16 - misalignment) / sizeof(XMLCh) : 0;
+      size_t misalignment = ptr_value & 15; // modulo 16 to find misalignment
+      int chars_to_align = misalignment ? (16 - misalignment) / sizeof(XMLCh) : 0;
   
-      // Vorverarbeitung einzelner Zeichen bis zum Alignment oder bis zum Ende des Strings
-      for (size_t i = 0; i < chars_to_align; ++i) {
+      // process one by one until we reach a 16-byte aligned address (where a SIMD load can be used)
+      for (int i = 0; i < chars_to_align; ++i)
+      {
           if (*pos_ptr == 0) {
               return i;
           }
@@ -440,28 +443,29 @@ namespace OpenMS::Internal
       }
       processed_chars = chars_to_align;
   
-      // Hauptschleife mit SIMD-Operationen
+      // SIMD loop: find the first zero character in blocks of 8 UTF-16 characters (16 bytes each)
       const simde__m128i zero = simde_mm_setzero_si128();
-      while (true) {
-          // SIMD-Operation
+      while (true)
+      {
           simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
-          simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero);
-          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);
+          simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
+          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte 
   
-          if (zero_mask != 0x0000) {
-              size_t byte_pos_zero = __builtin_ctz(zero_mask);
-              size_t char_pos_zero = byte_pos_zero / 2;
+          if (zero_mask != 0)
+          { // Found a zero character
+              auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
+              auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
               return processed_chars + char_pos_zero;
           }
   
-          // 8 Zeichen (16 Bytes) wurden verarbeitet, keine Null gefunden
+          // 8 chars (each 16 bytes) had no zero
           pos_ptr += 8;
           processed_chars += 8;
       }
   
-      // Diese Zeile wird nie erreicht
+      // never reached
       return processed_chars;
-  }
+    }
 
     void StringManager::compress64_(const XMLCh* inputIt, char* outputIt)
     {
@@ -480,46 +484,45 @@ namespace OpenMS::Internal
     }
 
     bool StringManager::isASCII(const XMLCh* chars, const XMLSize_t length)
-  {
-    if (length == 0)
     {
+      if (length == 0)
+      {
+        return true;
+      }
+
+      Size fullBlocks = length / 8;
+      Size remainder = length % 8;
+
+      const XMLCh* inputPtr = chars;
+      simde__m128i mask = simde_mm_set1_epi16(0xFF00);
+
+      // Process blocks of 8 UTF-16 characters using SIMD
+      for (Size i = 0; i < fullBlocks; ++i)
+      {
+        simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputPtr));
+        simde__m128i zero = simde_mm_setzero_si128();
+        simde__m128i andOp = simde_mm_and_si128(bits, mask);
+        simde__m128i cmp = simde_mm_cmpeq_epi16(andOp, zero);
+
+        if (simde_mm_movemask_epi8(cmp) != 0xFFFF)
+        {
+          return false;
+        }
+
+        inputPtr += 8;
+      }
+
+      // Check remaining characters individually
+      for (Size i = 0; i < remainder; ++i)
+      {
+        if (inputPtr[i] & 0xFF00)
+        {
+          return false;
+        }
+      }
+
       return true;
     }
-
-    Size fullBlocks = length / 8;
-    Size remainder = length % 8;
-
-    const XMLCh* inputPtr = chars;
-    simde__m128i mask = simde_mm_set1_epi16(0xFF00);
-    bool bitmask = true;
-
-    // Process blocks of 8 UTF-16 characters using SIMD
-    for (Size i = 0; i < fullBlocks; ++i)
-    {
-      simde__m128i bits = simde_mm_loadu_si128(reinterpret_cast<const simde__m128i*>(inputPtr));
-      simde__m128i zero = simde_mm_setzero_si128();
-      simde__m128i andOp = simde_mm_and_si128(bits, mask);
-      simde__m128i cmp = simde_mm_cmpeq_epi16(andOp, zero);
-
-      if (simde_mm_movemask_epi8(cmp) != 0xFFFF)
-      {
-        return false;
-      }
-
-      inputPtr += 8;
-    }
-
-  // Check remaining characters individually
-    for (Size i = 0; i < remainder && bitmask; ++i)
-    {
-      if (inputPtr[i] & 0xFF00)
-      {
-        return false;
-      }
-    }
-
-    return bitmask;
-  }
 
     void StringManager::appendASCII(const XMLCh* chars, const XMLSize_t length, String& result)
     {
@@ -556,13 +559,8 @@ namespace OpenMS::Internal
 
     //*******************************************************************************************************************
     
-    StringManager::StringManager()
-    = default;
+    StringManager::StringManager() = default;
 
-    StringManager::~StringManager()
-    = default;
+    StringManager::~StringManager() = default;
 
-    
-
-
-} // namespace OpenMS   // namespace Internal
+} // namespace OpenMS::Internal

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -252,6 +252,7 @@ set(format_executables_list
   UnimodXMLFile_test
   XMassFile_test
   XMLFile_test
+  XMLHandler_test
   XMLValidator_test
   XQuestResultXMLFile_test
   XTandemInfile_test

--- a/src/tests/class_tests/openms/source/XMLHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/XMLHandler_test.cpp
@@ -1,0 +1,159 @@
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+#include <string>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+
+#include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
+
+class StringManager_test : public OpenMS::Internal::StringManager
+{
+public:
+  StringManager_test() = default;
+  ~StringManager_test() = default;
+
+  static void compress64(const XMLCh* input_it, char* output_it)
+  {
+    StringManager::compress64_(input_it, output_it);
+  }
+};
+
+using namespace OpenMS::Internal;
+
+
+
+
+
+START_TEST(StringManager, "$Id$")
+
+
+const XMLCh russianHello[] = {
+    0x041F, 0x0440, 0x0438, 0x0432, 0x0435, 0x0442, 0x043C, 
+    0x0438, 0x0440,0x0000 // "Привет мир" (Hello World in Russian)
+};
+XMLSize_t r_length = xercesc::XMLString::stringLen(russianHello);
+
+const XMLCh ascii[] = { 
+    0x0048,0x0065,0x006C,0x006C,0x006F,0x002C,0x0057,0x006F,
+    0x0072,0x006C,0x0064,0x0021, 0x0000};
+XMLSize_t a_length = xercesc::XMLString::stringLen(ascii); 
+
+const XMLCh mixed[] = { 
+    0x0048, 0x0065,0x0432, 0x0435, 0x0442, 0x043C, 0x006F,
+    0x0072,0x006C,0x0064, 0x0021, 0x0000 };
+XMLSize_t m_length = xercesc::XMLString::stringLen(mixed);
+
+const XMLCh empty[] = {0};
+XMLSize_t e_length = xercesc::XMLString::stringLen(empty);
+
+const XMLCh upperBoundary [] = {0x00FF,0x00FF,0x0000};
+XMLSize_t u_length = xercesc::XMLString::stringLen(upperBoundary);
+
+bool isAscii = false;
+
+START_SECTION(isASCII(const XMLCh * chars, const XMLSize_t length))
+  isAscii = StringManager::isASCII(ascii,a_length);
+  TEST_TRUE(isAscii)
+
+  isAscii = StringManager::isASCII(russianHello,r_length);
+  TEST_FALSE(isAscii)
+
+  isAscii  = StringManager::isASCII(mixed,m_length);
+  TEST_FALSE(isAscii)
+
+  isAscii = StringManager::isASCII(empty,e_length);
+  TEST_TRUE(isAscii)
+
+  isAscii = StringManager::isASCII(upperBoundary,u_length);
+  TEST_TRUE(isAscii)
+END_SECTION
+
+const XMLCh eight_block_negative[] = {0x0148,0x0165,0x016C,0x016C,0x016F,0x012C,0x0157,0x016F};
+
+const XMLCh eight_block[] = {0x0048,0x0065,0x006C,0x006C,0x006F,0x002C,0x0057,0x006F};
+
+const XMLCh eight_block_mixed[] ={0x0042,0x0045,0x004C,0x0041,0x0142,0x0145,0x014C,0x0141};
+
+const XMLCh eight_block_kadabra[] = {
+    0x004B, // K
+    0x0041, // A
+    0x0044, // D
+    0x0041, // A
+    0x0042, // B
+    0x0052, // R
+    0x0041, // A
+    0x0021  // !
+};
+
+START_SECTION(compress64 (const XMLCh* input_it, char* output_it))
+    std::string o1_str(8,'\0');
+    StringManager_test::compress64(eight_block,o1_str.data());
+    std::string res1_str = "Hello,Wo";
+    TEST_STRING_EQUAL(o1_str,res1_str);
+    
+   
+    std::string o2_str(8,'\0'); 
+    StringManager_test::compress64(eight_block_negative,o2_str.data());
+    std::string res2_str = res1_str;
+    TEST_STRING_EQUAL(o2_str, res2_str);
+
+    
+    std::string o3_str(8,'\0');
+    StringManager_test::compress64(eight_block_mixed,o3_str.data());
+    std::string res3_str = {0x42,0x45,0x4C,0x41,0x42,0x45,0x4C,0x41};
+    TEST_STRING_EQUAL(o3_str, res3_str);
+
+    std::string o4_str(12,'\0');
+    o4_str [0]  ='A';
+    o4_str [1]  ='B';
+    o4_str [2]  ='R';
+    o4_str [3]  ='A';
+    
+    StringManager_test::compress64(eight_block_kadabra,((o4_str.data())+4));
+    std::string res4_str = "ABRAKADABRA!";
+    TEST_STRING_EQUAL(o4_str, res4_str);
+
+END_SECTION
+
+//Tests Number of Chars not Dividable by 8
+OpenMS::String o5_str;
+std::string res5_str = "Hello,World!";
+
+//Checks how the Function handles Data thats already stored in Output string
+OpenMS::String o6_str = "Gruess Gott und ";
+std::string res6_str = "Gruess Gott und Hello,World!";
+
+OpenMS::String o7_str;
+std::string res7_str = "";
+
+
+START_SECTION(appendASCII(const XMLCh * chars, const XMLSize_t length, String & result))
+
+    StringManager::appendASCII(ascii,a_length,o5_str);
+    TEST_STRING_EQUAL(o5_str, res5_str);
+
+    StringManager::appendASCII(ascii,a_length,o6_str);
+    TEST_STRING_EQUAL(o6_str, res6_str);
+
+    StringManager::appendASCII(empty,e_length,o7_str);
+    TEST_STRING_EQUAL(o7_str, res7_str);
+    
+
+END_SECTION
+XMLCh* nullPointer = nullptr;
+START_SECTION(strLength(const XMLCh* input_ptr))
+    int o_length = StringManager::strLength(ascii);
+    TEST_EQUAL(o_length, a_length);
+    o_length = StringManager::strLength(empty);
+    TEST_EQUAL(o_length, e_length);
+    o_length = StringManager::strLength(upperBoundary);
+    TEST_EQUAL(o_length, u_length);
+    o_length = StringManager::strLength(nullPointer);
+    TEST_EQUAL(o_length, 0);
+END_SECTION
+
+END_TEST
+
+
+    
+


### PR DESCRIPTION
## Description

SIMD-enabled parsing of mzML (and other XML formats) to convert Xerces XMLChar (16-bit type) to ASCII as fast as possible.
All XML formats benefit. 

Here are measurements for mzML on Linux and Windows using FileInfo with 1 or 10 threads.
Numbers are speed improvements as a factor when comparing vs. the previous non-SIMD code:
![image](https://github.com/user-attachments/assets/6b293707-7a2e-401f-bbc4-e25c310350ae)

Raw numbers in MB/sec:
![image](https://github.com/user-attachments/assets/f187493c-fdb3-4fa9-a232-60244f833845)


Improvements range from 7% to 26% speed increase, depending platform and type of mzML (internal zlib compression of base64 arrays is a performance bottleneck on all platforms).

This PR supersedes #8062 (fixes Windows; doc fixes and merged commits)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>


---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Loading of mzML files is now 7–25% faster due to optimized ASCII conversion.
* **Bug Fixes**
  * Corrected a typographical error in the changelog regarding mzML file loading speedup.
* **Tests**
  * Added new tests for string handling functions to ensure correct ASCII detection, compression, and length calculation in XML processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->