### PR TITLE
[DOC]: Fix invalid method references

### DIFF
--- a/src/openms/include/OpenMS/FEATUREFINDER/ExtendedIsotopeModel.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/ExtendedIsotopeModel.h
@@ -20,7 +20,7 @@ namespace OpenMS
     If you only want the distribution (no widening), use either
     EmpiricalFormula::getIsotopeDistribution() // for a certain sum formula
     or
-    IsotopeDistribution::estimateFromPeptideWeight (double average_weight)  // for averagine
+    CoarseIsotopePatternGenerator::estimateFromPeptideWeight (double average_weight)  // for averagine
 
     Peak widening is achieved by a Gaussian shape.
 

--- a/src/openms/include/OpenMS/FEATUREFINDER/IsotopeModel.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/IsotopeModel.h
@@ -23,7 +23,7 @@ namespace OpenMS
     If you only want the distribution (no widening), use either
     EmpiricalFormula::getIsotopeDistribution() // for a certain sum formula
     or
-    IsotopeDistribution::estimateFromPeptideWeight (double average_weight)  // for averagine
+    CoarseIsotopePatternGenerator::estimateFromPeptideWeight (double average_weight)  // for averagine
 
     Peak widening is achieved by either a Gaussian or Lorentzian shape.
 


### PR DESCRIPTION
## Description

Update header documentation that refers to the wrong class.

Fixes #8066.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reference the recommended method for estimating isotope distributions from peptide average weight. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->