### PR TITLE
[TEST]: Run pyOpenMS tests on Ubuntu

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -384,12 +384,23 @@ jobs:
           # do not fail immediately
           set +e
 
+          # On Linux we always build pyOpenMS
+          if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
+            export PYOPENMS=ON
+          fi
+
           # Generate the CWL descriptors if we are going to build a package
-          if [ ${{steps.set-vars.outputs.pkg_type }} != "none" ]; then
+          if [[ "${{steps.set-vars.outputs.pkg_type}}" != "none" ]] ||
+             [[ "${PYOPENMS:-}" == "ON" ]]
+          then
             python -m venv openms-cwl
             source openms-cwl/bin/activate
             pip install -q cwltool
             export ENABLE_CWL=ON
+          fi
+
+          if [[ "${PYOPENMS:-}" == "ON" ]]; then
+            python -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
           fi
 
           mkdir $GITHUB_WORKSPACE/OpenMS/bld/
@@ -447,6 +458,11 @@ jobs:
     - name: Test
       shell: bash
       run: |
+          # On Linux we always build pyOpenMS
+          if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
+            export PYOPENMS=ON
+          fi
+
           ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/citest.cmake
       env:
           SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"

--- a/tools/ci/cibuild.cmake
+++ b/tools/ci/cibuild.cmake
@@ -181,22 +181,28 @@ endif()
 
 # we only build when we do non-style testing and we may have special targets like pyopenms
 if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "OFF")
+  ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
+
   if("$ENV{PYOPENMS}" STREQUAL "ON")
-    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "pyopenms" NUMBER_ERRORS _build_errors)
-    # Generate and validate the CWL files if "ENABLE_CWL_GENERATION" is set
-  else()
-    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
+    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "pyopenms" NUMBER_ERRORS _py_build_errors)
+    math(EXPR _build_errors "${_build_errors} + ${_py_build_errors}")
   endif()
-    # Only build compile_pxds if PYOPENMS is not ON (since it's already a subtarget of pyopenms)  
+
+  # Only build compile_pxds if PYOPENMS is not ON (since it's already a subtarget of pyopenms)
   if("$ENV{COMPILE_PXDS}" STREQUAL "ON" AND "$ENV{PYOPENMS}" STREQUAL "OFF")
-    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "compile_pxds" NUMBER_ERRORS _build_errors)
+    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "compile_pxds" NUMBER_ERRORS _pdxs_build_errors)
+    math(EXPR _build_errors "${_build_errors} + ${_pdxs_build_errors}")
   endif()
+
+  # Generate and validate the CWL files if "ENABLE_CWL_GENERATION" is set
   if("$ENV{ENABLE_CWL_GENERATION}" STREQUAL "ON")
-    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "generate_cwl_files" NUMBER_ERRORS _build_errors)
+    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "generate_cwl_files" NUMBER_ERRORS _cwl_build_errors)
+    math(EXPR _build_errors "${_build_errors} + ${_cwl_build_errors}")
   endif()
 else()
   set(_build_errors 0)
 endif()
+
 ## send test results to CDash
 ctest_submit(PARTS Build CAPTURE_CMAKE_ERROR _submit_result)
 

--- a/tools/ci/citest.cmake
+++ b/tools/ci/citest.cmake
@@ -27,12 +27,8 @@ set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 ctest_start(APPEND)
 
 ## run tests
-## for pyopenms build, only run pyopenms tests
-if("$ENV{PYOPENMS}" STREQUAL "ON")
-  ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" INCLUDE "pyopenms" PARALLEL_LEVEL 3 RETURN_VALUE _test_errors)
-else()
-  ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 3 RETURN_VALUE _test_errors)
-endif()
+ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 3 RETURN_VALUE _test_errors)
+
 ## send test results to CDash
 ctest_submit(PARTS Test Done CAPTURE_CMAKE_ERROR _submit_result)
 


### PR DESCRIPTION
## Description

Run pyOpenMS tests on Ubuntu before merging PRs.

Fixes #8104.

CI run with the changes:

https://github.com/OpenMS/OpenMS/actions/runs/16197103504

Note: Windows tests are failing but that's from another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to always build pyOpenMS on Linux runners and ensure Python build dependencies are installed.
  * Improved error accumulation in the build process to provide more comprehensive error reporting across all relevant build targets.
  * Simplified test execution to run all tests consistently, regardless of pyOpenMS build settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->