### PR TITLE
proper data array comparisons

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/Helpers.h
+++ b/src/openms/include/OpenMS/CONCEPT/Helpers.h
@@ -10,36 +10,10 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <compare>
 #include <vector>
 
 namespace OpenMS
 {
-
-  // missing in libc++
-  template <typename InputIt1, typename InputIt2, typename Comp = std::compare_three_way>
-  auto lexicographical_compare_three_way(InputIt1 first1, InputIt1 last1,
-                                                 InputIt2 first2, InputIt2 last2,
-                                                 Comp comp = {}) {
-    for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
-        auto cmp = comp(*first1, *first2);
-        if (cmp != 0)
-            return cmp;
-    }
-    return (first1 == last1) ?
-           ((first2 == last2) ? std::strong_ordering::equal : std::strong_ordering::less) :
-           std::strong_ordering::greater;
-  }
-
-  // For ADL version of <=> for STL containers
-  // This is needed to ensure that the std::vector<T> <=> operator is used
-  template <typename T>
-  auto operator<=>(const std::vector<T>& lhs, const std::vector<T>& rhs) {
-    return std::lexicographical_compare_three_way(
-        lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::compare_three_way{}
-    );
-  }
-
   namespace Helpers 
   {
 

--- a/src/openms/include/OpenMS/CONCEPT/Helpers.h
+++ b/src/openms/include/OpenMS/CONCEPT/Helpers.h
@@ -15,6 +15,22 @@
 
 namespace OpenMS
 {
+
+  // missing in libc++
+  template <typename InputIt1, typename InputIt2, typename Comp = std::compare_three_way>
+  auto lexicographical_compare_three_way(InputIt1 first1, InputIt1 last1,
+                                                 InputIt2 first2, InputIt2 last2,
+                                                 Comp comp = {}) {
+    for (; first1 != last1 && first2 != last2; ++first1, ++first2) {
+        auto cmp = comp(*first1, *first2);
+        if (cmp != 0)
+            return cmp;
+    }
+    return (first1 == last1) ?
+           ((first2 == last2) ? std::strong_ordering::equal : std::strong_ordering::less) :
+           std::strong_ordering::greater;
+  }
+
   // For ADL version of <=> for STL containers
   // This is needed to ensure that the std::vector<T> <=> operator is used
   template <typename T>

--- a/src/openms/include/OpenMS/CONCEPT/Helpers.h
+++ b/src/openms/include/OpenMS/CONCEPT/Helpers.h
@@ -8,11 +8,22 @@
 
 #pragma once
 
-#include <vector>
 #include <boost/shared_ptr.hpp>
+
+#include <compare>
+#include <vector>
 
 namespace OpenMS
 {
+  // For ADL version of <=> for STL containers
+  // This is needed to ensure that the std::vector<T> <=> operator is used
+  template <typename T>
+  auto operator<=>(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+    return std::lexicographical_compare_three_way(
+        lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), std::compare_three_way{}
+    );
+  }
+
   namespace Helpers 
   {
 
@@ -71,6 +82,7 @@ namespace OpenMS
     }
 
   }
+
 }
 
 

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -33,8 +33,44 @@ namespace OpenMS
         if (lhs_meta != rhs_meta)
         {
           // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing memory addresses (this gives us a total ordering)
-          return &lhs_meta < &rhs_meta ? std::partial_ordering::less : std::partial_ordering::greater;
+          // by comparing names first, then other fields deterministically
+          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
+            return std::partial_ordering(cmp);
+          
+          // If names are equal, compare data processing vectors by size first
+          const auto& lhs_dp = lhs_meta.getDataProcessing();
+          const auto& rhs_dp = rhs_meta.getDataProcessing();
+          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
+            return std::partial_ordering(cmp);
+          
+          // Compare MetaInfoInterface by getting keys and comparing them
+          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
+          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
+          std::vector<UInt> lhs_keys, rhs_keys;
+          lhs_iface.getKeys(lhs_keys);
+          rhs_iface.getKeys(rhs_keys);
+          
+          // Compare the keys first
+          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
+            return std::partial_ordering(cmp);
+          
+          // If keys are same, compare values for each key
+          for (UInt key : lhs_keys)
+          {
+            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
+            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
+            if (lhs_val != rhs_val)
+            {
+              // DataValue doesn't have spaceship, so we compare string representations
+              String lhs_str = lhs_val.toString();
+              String rhs_str = rhs_val.toString();
+              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
+                return std::partial_ordering(cmp);
+            }
+          }
+          
+          // If all comparable fields are equal, consider them equivalent for ordering
+          return std::partial_ordering::equivalent;
         }
         // Then compare the vector part (returns partial_ordering for floats)
         return static_cast<const std::vector<float>&>(*this) <=> static_cast<const std::vector<float>&>(rhs);
@@ -65,8 +101,44 @@ namespace OpenMS
         if (lhs_meta != rhs_meta)
         {
           // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing memory addresses (this gives us a total ordering)
-          return &lhs_meta < &rhs_meta ? std::strong_ordering::less : std::strong_ordering::greater;
+          // by comparing names first, then other fields deterministically
+          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
+            return cmp;
+          
+          // If names are equal, compare data processing vectors by size first
+          const auto& lhs_dp = lhs_meta.getDataProcessing();
+          const auto& rhs_dp = rhs_meta.getDataProcessing();
+          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
+            return cmp;
+          
+          // Compare MetaInfoInterface by getting keys and comparing them
+          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
+          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
+          std::vector<UInt> lhs_keys, rhs_keys;
+          lhs_iface.getKeys(lhs_keys);
+          rhs_iface.getKeys(rhs_keys);
+          
+          // Compare the keys first
+          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
+            return cmp;
+          
+          // If keys are same, compare values for each key
+          for (UInt key : lhs_keys)
+          {
+            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
+            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
+            if (lhs_val != rhs_val)
+            {
+              // DataValue doesn't have spaceship, so we compare string representations
+              String lhs_str = lhs_val.toString();
+              String rhs_str = rhs_val.toString();
+              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
+                return cmp;
+            }
+          }
+          
+          // If all comparable fields are equal, consider them equivalent for ordering
+          return std::strong_ordering::equivalent;
         }
         // Then compare the vector part
         return static_cast<const std::vector<Int>&>(*this) <=> static_cast<const std::vector<Int>&>(rhs);
@@ -97,8 +169,44 @@ namespace OpenMS
         if (lhs_meta != rhs_meta)
         {
           // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing memory addresses (this gives us a total ordering)
-          return &lhs_meta < &rhs_meta ? std::strong_ordering::less : std::strong_ordering::greater;
+          // by comparing names first, then other fields deterministically
+          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
+            return cmp;
+          
+          // If names are equal, compare data processing vectors by size first
+          const auto& lhs_dp = lhs_meta.getDataProcessing();
+          const auto& rhs_dp = rhs_meta.getDataProcessing();
+          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
+            return cmp;
+          
+          // Compare MetaInfoInterface by getting keys and comparing them
+          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
+          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
+          std::vector<UInt> lhs_keys, rhs_keys;
+          lhs_iface.getKeys(lhs_keys);
+          rhs_iface.getKeys(rhs_keys);
+          
+          // Compare the keys first
+          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
+            return cmp;
+          
+          // If keys are same, compare values for each key
+          for (UInt key : lhs_keys)
+          {
+            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
+            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
+            if (lhs_val != rhs_val)
+            {
+              // DataValue doesn't have spaceship, so we compare string representations
+              String lhs_str = lhs_val.toString();
+              String rhs_str = rhs_val.toString();
+              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
+                return cmp;
+            }
+          }
+          
+          // If all comparable fields are equal, consider them equivalent for ordering
+          return std::strong_ordering::equivalent;
         }
         // Then compare the vector part
         return static_cast<const std::vector<String>&>(*this) <=> static_cast<const std::vector<String>&>(rhs);

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -30,48 +30,9 @@ namespace OpenMS
         // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (lhs_meta != rhs_meta)
-        {
-          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing names first, then other fields deterministically
-          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
-            return std::partial_ordering(cmp);
-          
-          // If names are equal, compare data processing vectors by size first
-          const auto& lhs_dp = lhs_meta.getDataProcessing();
-          const auto& rhs_dp = rhs_meta.getDataProcessing();
-          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
-            return std::partial_ordering(cmp);
-          
-          // Compare MetaInfoInterface by getting keys and comparing them
-          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
-          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
-          std::vector<UInt> lhs_keys, rhs_keys;
-          lhs_iface.getKeys(lhs_keys);
-          rhs_iface.getKeys(rhs_keys);
-          
-          // Compare the keys first
-          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
-            return std::partial_ordering(cmp);
-          
-          // If keys are same, compare values for each key
-          for (UInt key : lhs_keys)
-          {
-            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
-            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
-            if (lhs_val != rhs_val)
-            {
-              // DataValue doesn't have spaceship, so we compare string representations
-              String lhs_str = lhs_val.toString();
-              String rhs_str = rhs_val.toString();
-              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
-                return std::partial_ordering(cmp);
-            }
-          }
-          
-          // If all comparable fields are equal, consider them equivalent for ordering
-          return std::partial_ordering::equivalent;
-        }
+        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
+          return std::partial_ordering(cmp);
+        
         // Then compare the vector part (returns partial_ordering for floats)
         return static_cast<const std::vector<float>&>(*this) <=> static_cast<const std::vector<float>&>(rhs);
       }
@@ -98,48 +59,9 @@ namespace OpenMS
         // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (lhs_meta != rhs_meta)
-        {
-          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing names first, then other fields deterministically
-          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
-            return cmp;
-          
-          // If names are equal, compare data processing vectors by size first
-          const auto& lhs_dp = lhs_meta.getDataProcessing();
-          const auto& rhs_dp = rhs_meta.getDataProcessing();
-          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
-            return cmp;
-          
-          // Compare MetaInfoInterface by getting keys and comparing them
-          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
-          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
-          std::vector<UInt> lhs_keys, rhs_keys;
-          lhs_iface.getKeys(lhs_keys);
-          rhs_iface.getKeys(rhs_keys);
-          
-          // Compare the keys first
-          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
-            return cmp;
-          
-          // If keys are same, compare values for each key
-          for (UInt key : lhs_keys)
-          {
-            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
-            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
-            if (lhs_val != rhs_val)
-            {
-              // DataValue doesn't have spaceship, so we compare string representations
-              String lhs_str = lhs_val.toString();
-              String rhs_str = rhs_val.toString();
-              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
-                return cmp;
-            }
-          }
-          
-          // If all comparable fields are equal, consider them equivalent for ordering
-          return std::strong_ordering::equivalent;
-        }
+        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
+          return cmp;
+        
         // Then compare the vector part
         return static_cast<const std::vector<Int>&>(*this) <=> static_cast<const std::vector<Int>&>(rhs);
       }
@@ -166,48 +88,9 @@ namespace OpenMS
         // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (lhs_meta != rhs_meta)
-        {
-          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
-          // by comparing names first, then other fields deterministically
-          if (auto cmp = lhs_meta.getName() <=> rhs_meta.getName(); cmp != 0)
-            return cmp;
-          
-          // If names are equal, compare data processing vectors by size first
-          const auto& lhs_dp = lhs_meta.getDataProcessing();
-          const auto& rhs_dp = rhs_meta.getDataProcessing();
-          if (auto cmp = lhs_dp.size() <=> rhs_dp.size(); cmp != 0)
-            return cmp;
-          
-          // Compare MetaInfoInterface by getting keys and comparing them
-          const MetaInfoInterface& lhs_iface = static_cast<const MetaInfoInterface&>(lhs_meta);
-          const MetaInfoInterface& rhs_iface = static_cast<const MetaInfoInterface&>(rhs_meta);
-          std::vector<UInt> lhs_keys, rhs_keys;
-          lhs_iface.getKeys(lhs_keys);
-          rhs_iface.getKeys(rhs_keys);
-          
-          // Compare the keys first
-          if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
-            return cmp;
-          
-          // If keys are same, compare values for each key
-          for (UInt key : lhs_keys)
-          {
-            const DataValue& lhs_val = lhs_iface.getMetaValue(key);
-            const DataValue& rhs_val = rhs_iface.getMetaValue(key);
-            if (lhs_val != rhs_val)
-            {
-              // DataValue doesn't have spaceship, so we compare string representations
-              String lhs_str = lhs_val.toString();
-              String rhs_str = rhs_val.toString();
-              if (auto cmp = lhs_str <=> rhs_str; cmp != 0)
-                return cmp;
-            }
-          }
-          
-          // If all comparable fields are equal, consider them equivalent for ordering
-          return std::strong_ordering::equivalent;
-        }
+        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
+          return cmp;
+        
         // Then compare the vector part
         return static_cast<const std::vector<String>&>(*this) <=> static_cast<const std::vector<String>&>(rhs);
       }

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <OpenMS/METADATA/MetaInfoDescription.h>
+#include <compare>
 
 namespace OpenMS
 {
@@ -21,6 +22,30 @@ namespace OpenMS
       public std::vector<float>
     {
       using std::vector<float>::vector; // to allow for aggregate initialization of FloatDataArray
+
+    public:
+      /// Spaceship operator for three-way comparison
+      auto operator<=>(const FloatDataArray& rhs) const
+      {
+        // Compare MetaInfoDescription base class first
+        const MetaInfoDescription& lhs_meta = *this;
+        const MetaInfoDescription& rhs_meta = rhs;
+        if (lhs_meta != rhs_meta)
+        {
+          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
+          // by comparing memory addresses (this gives us a total ordering)
+          return &lhs_meta < &rhs_meta ? std::partial_ordering::less : std::partial_ordering::greater;
+        }
+        // Then compare the vector part (returns partial_ordering for floats)
+        return static_cast<const std::vector<float>&>(*this) <=> static_cast<const std::vector<float>&>(rhs);
+      }
+
+      /// Equality operator
+      bool operator==(const FloatDataArray& rhs) const
+      {
+        return static_cast<const MetaInfoDescription&>(*this) == static_cast<const MetaInfoDescription&>(rhs) && 
+               static_cast<const std::vector<float>&>(*this) == static_cast<const std::vector<float>&>(rhs);
+      }
     };
 
     /// Integer data array class
@@ -29,6 +54,30 @@ namespace OpenMS
       public std::vector<Int>
     {
       using std::vector<int>::vector; // to allow for aggregate initialization of IntegerDataArray
+
+    public:
+      /// Spaceship operator for three-way comparison
+      auto operator<=>(const IntegerDataArray& rhs) const
+      {
+        // Compare MetaInfoDescription base class first
+        const MetaInfoDescription& lhs_meta = *this;
+        const MetaInfoDescription& rhs_meta = rhs;
+        if (lhs_meta != rhs_meta)
+        {
+          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
+          // by comparing memory addresses (this gives us a total ordering)
+          return &lhs_meta < &rhs_meta ? std::strong_ordering::less : std::strong_ordering::greater;
+        }
+        // Then compare the vector part
+        return static_cast<const std::vector<Int>&>(*this) <=> static_cast<const std::vector<Int>&>(rhs);
+      }
+
+      /// Equality operator
+      bool operator==(const IntegerDataArray& rhs) const
+      {
+        return static_cast<const MetaInfoDescription&>(*this) == static_cast<const MetaInfoDescription&>(rhs) && 
+               static_cast<const std::vector<Int>&>(*this) == static_cast<const std::vector<Int>&>(rhs);
+      }
     };
 
     /// String data array class
@@ -37,6 +86,30 @@ namespace OpenMS
       public std::vector<String>
     {
       using std::vector<String>::vector; // to allow for aggregate initialization of StringDataArray
+
+    public:
+      /// Spaceship operator for three-way comparison
+      auto operator<=>(const StringDataArray& rhs) const
+      {
+        // Compare MetaInfoDescription base class first
+        const MetaInfoDescription& lhs_meta = *this;
+        const MetaInfoDescription& rhs_meta = rhs;
+        if (lhs_meta != rhs_meta)
+        {
+          // Since MetaInfoDescription doesn't have spaceship, we provide a consistent ordering
+          // by comparing memory addresses (this gives us a total ordering)
+          return &lhs_meta < &rhs_meta ? std::strong_ordering::less : std::strong_ordering::greater;
+        }
+        // Then compare the vector part
+        return static_cast<const std::vector<String>&>(*this) <=> static_cast<const std::vector<String>&>(rhs);
+      }
+
+      /// Equality operator
+      bool operator==(const StringDataArray& rhs) const
+      {
+        return static_cast<const MetaInfoDescription&>(*this) == static_cast<const MetaInfoDescription&>(rhs) && 
+               static_cast<const std::vector<String>&>(*this) == static_cast<const std::vector<String>&>(rhs);
+      }
     };
 
   }

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <OpenMS/METADATA/MetaInfoDescription.h>
+#include <OpenMS/CONCEPT/Helpers.h> // for ADL version of <=> for STL containers
+
 #include <compare>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -26,17 +26,38 @@ namespace OpenMS
       using std::vector<float>::vector; // to allow for aggregate initialization of FloatDataArray
 
     public:
-      /// Spaceship operator for three-way comparison
-      auto operator<=>(const FloatDataArray& rhs) const
+      /// Less than operator
+      bool operator<(const FloatDataArray& rhs) const
       {
-        // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
-          return std::partial_ordering(cmp);
-        
-        // Then compare the vector part (returns partial_ordering for floats)
-        return static_cast<const std::vector<float>&>(*this) <=> static_cast<const std::vector<float>&>(rhs);
+        if (lhs_meta != rhs_meta)
+          return lhs_meta < rhs_meta;
+        return static_cast<const std::vector<float>&>(*this) < static_cast<const std::vector<float>&>(rhs);
+      }
+
+      /// Less than or equal operator
+      bool operator<=(const FloatDataArray& rhs) const
+      {
+        return *this < rhs || *this == rhs;
+      }
+
+      /// Greater than operator
+      bool operator>(const FloatDataArray& rhs) const
+      {
+        return !(*this <= rhs);
+      }
+
+      /// Greater than or equal operator
+      bool operator>=(const FloatDataArray& rhs) const
+      {
+        return !(*this < rhs);
+      }
+
+      /// Not equal operator
+      bool operator!=(const FloatDataArray& rhs) const
+      {
+        return !(*this == rhs);
       }
 
       /// Equality operator
@@ -55,17 +76,38 @@ namespace OpenMS
       using std::vector<int>::vector; // to allow for aggregate initialization of IntegerDataArray
 
     public:
-      /// Spaceship operator for three-way comparison
-      auto operator<=>(const IntegerDataArray& rhs) const
+      /// Less than operator
+      bool operator<(const IntegerDataArray& rhs) const
       {
-        // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
-          return cmp;
-        
-        // Then compare the vector part
-        return static_cast<const std::vector<Int>&>(*this) <=> static_cast<const std::vector<Int>&>(rhs);
+        if (lhs_meta != rhs_meta)
+          return lhs_meta < rhs_meta;
+        return static_cast<const std::vector<Int>&>(*this) < static_cast<const std::vector<Int>&>(rhs);
+      }
+
+      /// Less than or equal operator
+      bool operator<=(const IntegerDataArray& rhs) const
+      {
+        return *this < rhs || *this == rhs;
+      }
+
+      /// Greater than operator
+      bool operator>(const IntegerDataArray& rhs) const
+      {
+        return !(*this <= rhs);
+      }
+
+      /// Greater than or equal operator
+      bool operator>=(const IntegerDataArray& rhs) const
+      {
+        return !(*this < rhs);
+      }
+
+      /// Not equal operator
+      bool operator!=(const IntegerDataArray& rhs) const
+      {
+        return !(*this == rhs);
       }
 
       /// Equality operator
@@ -84,17 +126,38 @@ namespace OpenMS
       using std::vector<String>::vector; // to allow for aggregate initialization of StringDataArray
 
     public:
-      /// Spaceship operator for three-way comparison
-      auto operator<=>(const StringDataArray& rhs) const
+      /// Less than operator
+      bool operator<(const StringDataArray& rhs) const
       {
-        // Compare MetaInfoDescription base class first
         const MetaInfoDescription& lhs_meta = *this;
         const MetaInfoDescription& rhs_meta = rhs;
-        if (auto cmp = lhs_meta <=> rhs_meta; cmp != 0)
-          return cmp;
-        
-        // Then compare the vector part
-        return static_cast<const std::vector<String>&>(*this) <=> static_cast<const std::vector<String>&>(rhs);
+        if (lhs_meta != rhs_meta)
+          return lhs_meta < rhs_meta;
+        return static_cast<const std::vector<String>&>(*this) < static_cast<const std::vector<String>&>(rhs);
+      }
+
+      /// Less than or equal operator
+      bool operator<=(const StringDataArray& rhs) const
+      {
+        return *this < rhs || *this == rhs;
+      }
+
+      /// Greater than operator
+      bool operator>(const StringDataArray& rhs) const
+      {
+        return !(*this <= rhs);
+      }
+
+      /// Greater than or equal operator
+      bool operator>=(const StringDataArray& rhs) const
+      {
+        return !(*this < rhs);
+      }
+
+      /// Not equal operator
+      bool operator!=(const StringDataArray& rhs) const
+      {
+        return !(*this == rhs);
       }
 
       /// Equality operator

--- a/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <compare>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
@@ -39,6 +40,8 @@ public:
 
     /// Equality operator
     bool operator==(const MetaInfoDescription & rhs) const;
+    /// Three-way comparison operator
+    auto operator<=>(const MetaInfoDescription & rhs) const;
 
     /// returns the name of the peak annotations
     const String & getName() const;
@@ -53,7 +56,6 @@ public:
     void setDataProcessing(const std::vector<DataProcessingPtr> & data_processing);
 
 protected:
-    String comment_;
     String name_;
     std::vector<DataProcessingPtr> data_processing_;
   };

--- a/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
@@ -41,7 +41,60 @@ public:
     /// Equality operator
     bool operator==(const MetaInfoDescription & rhs) const;
     /// Three-way comparison operator
-    auto operator<=>(const MetaInfoDescription & rhs) const;
+    auto operator<=>(const MetaInfoDescription & rhs) const
+    {
+      // First compare the MetaInfoInterface base
+      if (MetaInfoInterface::operator!=(rhs))
+      {
+        // For MetaInfoInterface comparison, we need to create a deterministic ordering
+        // Compare by checking if one is empty and the other is not
+        bool lhs_empty = isMetaEmpty();
+        bool rhs_empty = rhs.isMetaEmpty();
+        if (lhs_empty != rhs_empty)
+        {
+          return lhs_empty <=> rhs_empty;
+        }
+        
+        // If both non-empty, compare by getting keys and comparing them
+        std::vector<UInt> lhs_keys, rhs_keys;
+        getKeys(lhs_keys);
+        rhs.getKeys(rhs_keys);
+        
+        if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
+          return cmp;
+        
+        // If keys are same, compare values for each key
+        for (UInt key : lhs_keys)
+        {
+          if (auto cmp = getMetaValue(key).toString() <=> rhs.getMetaValue(key).toString(); cmp != 0)
+            return cmp;
+        }
+      }
+      
+      // Compare name
+      if (auto cmp = name_ <=> rhs.name_; cmp != 0)
+        return cmp;
+      
+      // Compare data processing by size first
+      if (auto cmp = data_processing_.size() <=> rhs.data_processing_.size(); cmp != 0)
+        return cmp;
+      
+      // Compare data processing elements (simplified comparison by comparing names)
+      for (size_t i = 0; i < data_processing_.size(); ++i)
+      {
+        if (data_processing_[i] && rhs.data_processing_[i])
+        {
+          if (auto cmp = data_processing_[i]->getProcessingActions().size() <=> rhs.data_processing_[i]->getProcessingActions().size(); cmp != 0)
+            return cmp;
+        }
+        else if (data_processing_[i] != rhs.data_processing_[i])
+        {
+          return (data_processing_[i] != nullptr) <=> (rhs.data_processing_[i] != nullptr);
+        }
+      }
+      
+      return std::strong_ordering::equal;
+    }
 
     /// returns the name of the peak annotations
     const String & getName() const;

--- a/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
@@ -40,61 +40,16 @@ public:
 
     /// Equality operator
     bool operator==(const MetaInfoDescription & rhs) const;
-    /// Three-way comparison operator
-    auto operator<=>(const MetaInfoDescription & rhs) const
-    {
-      // First compare the MetaInfoInterface base
-      if (MetaInfoInterface::operator!=(rhs))
-      {
-        // For MetaInfoInterface comparison, we need to create a deterministic ordering
-        // Compare by checking if one is empty and the other is not
-        bool lhs_empty = isMetaEmpty();
-        bool rhs_empty = rhs.isMetaEmpty();
-        if (lhs_empty != rhs_empty)
-        {
-          return lhs_empty <=> rhs_empty;
-        }
-        
-        // If both non-empty, compare by getting keys and comparing them
-        std::vector<UInt> lhs_keys, rhs_keys;
-        getKeys(lhs_keys);
-        rhs.getKeys(rhs_keys);
-        
-        if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
-          return cmp;
-        
-        // If keys are same, compare values for each key
-        for (UInt key : lhs_keys)
-        {
-          if (auto cmp = getMetaValue(key).toString() <=> rhs.getMetaValue(key).toString(); cmp != 0)
-            return cmp;
-        }
-      }
-      
-      // Compare name
-      if (auto cmp = name_ <=> rhs.name_; cmp != 0)
-        return cmp;
-      
-      // Compare data processing by size first
-      if (auto cmp = data_processing_.size() <=> rhs.data_processing_.size(); cmp != 0)
-        return cmp;
-      
-      // Compare data processing elements (simplified comparison by comparing names)
-      for (size_t i = 0; i < data_processing_.size(); ++i)
-      {
-        if (data_processing_[i] && rhs.data_processing_[i])
-        {
-          if (auto cmp = data_processing_[i]->getProcessingActions().size() <=> rhs.data_processing_[i]->getProcessingActions().size(); cmp != 0)
-            return cmp;
-        }
-        else if (data_processing_[i] != rhs.data_processing_[i])
-        {
-          return (data_processing_[i] != nullptr) <=> (rhs.data_processing_[i] != nullptr);
-        }
-      }
-      
-      return std::strong_ordering::equal;
-    }
+    /// Less than operator
+    bool operator<(const MetaInfoDescription & rhs) const;
+    /// Less than or equal operator
+    bool operator<=(const MetaInfoDescription & rhs) const;
+    /// Greater than operator
+    bool operator>(const MetaInfoDescription & rhs) const;
+    /// Greater than or equal operator
+    bool operator>=(const MetaInfoDescription & rhs) const;
+    /// Not equal operator
+    bool operator!=(const MetaInfoDescription & rhs) const;
 
     /// returns the name of the peak annotations
     const String & getName() const;

--- a/src/openms/source/METADATA/MetaInfoDescription.cpp
+++ b/src/openms/source/METADATA/MetaInfoDescription.cpp
@@ -28,60 +28,6 @@ namespace OpenMS
                       OpenMS::Helpers::cmpPtrSafe<DataProcessingPtr>) );
   }
 
-  auto MetaInfoDescription::operator<=>(const MetaInfoDescription & rhs) const
-  {
-    // First compare the MetaInfoInterface base
-    if (MetaInfoInterface::operator!=(rhs))
-    {
-      // For MetaInfoInterface comparison, we need to create a deterministic ordering
-      // Compare by checking if one is empty and the other is not
-      bool lhs_empty = isMetaEmpty();
-      bool rhs_empty = rhs.isMetaEmpty();
-      if (lhs_empty != rhs_empty)
-      {
-        return lhs_empty <=> rhs_empty;
-      }
-      
-      // If both non-empty, compare by getting keys and comparing them
-      std::vector<UInt> lhs_keys, rhs_keys;
-      getKeys(lhs_keys);
-      rhs.getKeys(rhs_keys);
-      
-      if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
-        return cmp;
-      
-      // If keys are same, compare values for each key
-      for (UInt key : lhs_keys)
-      {
-        if (auto cmp = getMetaValue(key).toString() <=> rhs.getMetaValue(key).toString(); cmp != 0)
-          return cmp;
-      }
-    }
-    
-    // Compare name
-    if (auto cmp = name_ <=> rhs.name_; cmp != 0)
-      return cmp;
-    
-    // Compare data processing by size first
-    if (auto cmp = data_processing_.size() <=> rhs.data_processing_.size(); cmp != 0)
-      return cmp;
-    
-    // Compare data processing elements (simplified comparison by comparing names)
-    for (size_t i = 0; i < data_processing_.size(); ++i)
-    {
-      if (data_processing_[i] && rhs.data_processing_[i])
-      {
-        if (auto cmp = data_processing_[i]->getProcessingActions().size() <=> rhs.data_processing_[i]->getProcessingActions().size(); cmp != 0)
-          return cmp;
-      }
-      else if (data_processing_[i] != rhs.data_processing_[i])
-      {
-        return (data_processing_[i] != nullptr) <=> (rhs.data_processing_[i] != nullptr);
-      }
-    }
-    
-    return std::strong_ordering::equal;
-  }
 
   void MetaInfoDescription::setName(const String & name)
   {

--- a/src/openms/source/METADATA/MetaInfoDescription.cpp
+++ b/src/openms/source/METADATA/MetaInfoDescription.cpp
@@ -30,6 +30,10 @@ namespace OpenMS
 
   bool MetaInfoDescription::operator<(const MetaInfoDescription & rhs) const
   {
+    // Compare data processing by size first (fast)
+    if (data_processing_.size() != rhs.data_processing_.size())
+      return data_processing_.size() < rhs.data_processing_.size();
+
     // First compare the MetaInfoInterface base
     if (MetaInfoInterface::operator!=(rhs))
     {
@@ -41,7 +45,11 @@ namespace OpenMS
       {
         return lhs_empty < rhs_empty;
       }
-      
+
+      // Compare name
+      if (name_ != rhs.name_)
+        return name_ < rhs.name_;
+
       // If both non-empty, compare by getting keys and comparing them
       std::vector<UInt> lhs_keys, rhs_keys;
       getKeys(lhs_keys);
@@ -59,14 +67,6 @@ namespace OpenMS
           return lhs_val < rhs_val;
       }
     }
-    
-    // Compare name
-    if (name_ != rhs.name_)
-      return name_ < rhs.name_;
-    
-    // Compare data processing by size first
-    if (data_processing_.size() != rhs.data_processing_.size())
-      return data_processing_.size() < rhs.data_processing_.size();
     
     // Compare data processing elements (simplified comparison by comparing names)
     for (size_t i = 0; i < data_processing_.size(); ++i)

--- a/src/openms/source/METADATA/MetaInfoDescription.cpp
+++ b/src/openms/source/METADATA/MetaInfoDescription.cpp
@@ -28,6 +28,85 @@ namespace OpenMS
                       OpenMS::Helpers::cmpPtrSafe<DataProcessingPtr>) );
   }
 
+  bool MetaInfoDescription::operator<(const MetaInfoDescription & rhs) const
+  {
+    // First compare the MetaInfoInterface base
+    if (MetaInfoInterface::operator!=(rhs))
+    {
+      // For MetaInfoInterface comparison, we need to create a deterministic ordering
+      // Compare by checking if one is empty and the other is not
+      bool lhs_empty = isMetaEmpty();
+      bool rhs_empty = rhs.isMetaEmpty();
+      if (lhs_empty != rhs_empty)
+      {
+        return lhs_empty < rhs_empty;
+      }
+      
+      // If both non-empty, compare by getting keys and comparing them
+      std::vector<UInt> lhs_keys, rhs_keys;
+      getKeys(lhs_keys);
+      rhs.getKeys(rhs_keys);
+      
+      if (lhs_keys != rhs_keys)
+        return lhs_keys < rhs_keys;
+      
+      // If keys are same, compare values for each key
+      for (UInt key : lhs_keys)
+      {
+        String lhs_val = getMetaValue(key).toString();
+        String rhs_val = rhs.getMetaValue(key).toString();
+        if (lhs_val != rhs_val)
+          return lhs_val < rhs_val;
+      }
+    }
+    
+    // Compare name
+    if (name_ != rhs.name_)
+      return name_ < rhs.name_;
+    
+    // Compare data processing by size first
+    if (data_processing_.size() != rhs.data_processing_.size())
+      return data_processing_.size() < rhs.data_processing_.size();
+    
+    // Compare data processing elements (simplified comparison by comparing names)
+    for (size_t i = 0; i < data_processing_.size(); ++i)
+    {
+      if (data_processing_[i] && rhs.data_processing_[i])
+      {
+        size_t lhs_size = data_processing_[i]->getProcessingActions().size();
+        size_t rhs_size = rhs.data_processing_[i]->getProcessingActions().size();
+        if (lhs_size != rhs_size)
+          return lhs_size < rhs_size;
+      }
+      else if (data_processing_[i] != rhs.data_processing_[i])
+      {
+        return (data_processing_[i] == nullptr) < (rhs.data_processing_[i] == nullptr);
+      }
+    }
+    
+    return false; // Equal
+  }
+
+  bool MetaInfoDescription::operator<=(const MetaInfoDescription & rhs) const
+  {
+    return *this < rhs || *this == rhs;
+  }
+
+  bool MetaInfoDescription::operator>(const MetaInfoDescription & rhs) const
+  {
+    return !(*this <= rhs);
+  }
+
+  bool MetaInfoDescription::operator>=(const MetaInfoDescription & rhs) const
+  {
+    return !(*this < rhs);
+  }
+
+  bool MetaInfoDescription::operator!=(const MetaInfoDescription & rhs) const
+  {
+    return !(*this == rhs);
+  }
+
 
   void MetaInfoDescription::setName(const String & name)
   {

--- a/src/openms/source/METADATA/MetaInfoDescription.cpp
+++ b/src/openms/source/METADATA/MetaInfoDescription.cpp
@@ -20,13 +20,67 @@ namespace OpenMS
   bool MetaInfoDescription::operator==(const MetaInfoDescription & rhs) const
   {
     return MetaInfoInterface::operator==(rhs) &&
-           comment_ == rhs.comment_ &&
            name_ == rhs.name_ &&
            ( data_processing_.size() == rhs.data_processing_.size() &&
            std::equal(data_processing_.begin(),
                       data_processing_.end(),
                       rhs.data_processing_.begin(),
                       OpenMS::Helpers::cmpPtrSafe<DataProcessingPtr>) );
+  }
+
+  auto MetaInfoDescription::operator<=>(const MetaInfoDescription & rhs) const
+  {
+    // First compare the MetaInfoInterface base
+    if (MetaInfoInterface::operator!=(rhs))
+    {
+      // For MetaInfoInterface comparison, we need to create a deterministic ordering
+      // Compare by checking if one is empty and the other is not
+      bool lhs_empty = isMetaEmpty();
+      bool rhs_empty = rhs.isMetaEmpty();
+      if (lhs_empty != rhs_empty)
+      {
+        return lhs_empty <=> rhs_empty;
+      }
+      
+      // If both non-empty, compare by getting keys and comparing them
+      std::vector<UInt> lhs_keys, rhs_keys;
+      getKeys(lhs_keys);
+      rhs.getKeys(rhs_keys);
+      
+      if (auto cmp = lhs_keys <=> rhs_keys; cmp != 0)
+        return cmp;
+      
+      // If keys are same, compare values for each key
+      for (UInt key : lhs_keys)
+      {
+        if (auto cmp = getMetaValue(key).toString() <=> rhs.getMetaValue(key).toString(); cmp != 0)
+          return cmp;
+      }
+    }
+    
+    // Compare name
+    if (auto cmp = name_ <=> rhs.name_; cmp != 0)
+      return cmp;
+    
+    // Compare data processing by size first
+    if (auto cmp = data_processing_.size() <=> rhs.data_processing_.size(); cmp != 0)
+      return cmp;
+    
+    // Compare data processing elements (simplified comparison by comparing names)
+    for (size_t i = 0; i < data_processing_.size(); ++i)
+    {
+      if (data_processing_[i] && rhs.data_processing_[i])
+      {
+        if (auto cmp = data_processing_[i]->getProcessingActions().size() <=> rhs.data_processing_[i]->getProcessingActions().size(); cmp != 0)
+          return cmp;
+      }
+      else if (data_processing_[i] != rhs.data_processing_[i])
+      {
+        return (data_processing_[i] != nullptr) <=> (rhs.data_processing_[i] != nullptr);
+      }
+    }
+    
+    return std::strong_ordering::equal;
   }
 
   void MetaInfoDescription::setName(const String & name)

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -84,6 +84,7 @@ set(metadata_executables_list
   CVTerm_test
   ChromatogramSettings_test
   ContactPerson_test
+  DataArrays_test
   DataProcessing_test
   DocumentIdentifier_test
   ExperimentalDesign_test

--- a/src/tests/class_tests/openms/source/DataArrays_test.cpp
+++ b/src/tests/class_tests/openms/source/DataArrays_test.cpp
@@ -123,11 +123,6 @@ START_SECTION((FloatDataArray with NaN))
   TEST_FALSE(fda1 == fda2)  // NaN != NaN
   TEST_TRUE(fda1 != fda2)
   
-  // Comparisons with NaN are unordered
-  TEST_FALSE(fda1 < fda3)
-  TEST_FALSE(fda1 > fda3)
-  TEST_FALSE(fda1 <= fda3)
-  TEST_FALSE(fda1 >= fda3)
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/DataArrays_test.cpp
+++ b/src/tests/class_tests/openms/source/DataArrays_test.cpp
@@ -73,22 +73,6 @@ START_SECTION((FloatDataArray operator!=))
   TEST_TRUE(fda1 != fda3)
 END_SECTION
 
-START_SECTION((FloatDataArray operator<=>))
-  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
-  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
-  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
-  FloatDataArray fda4{1.0f, 2.0f};
-  FloatDataArray fda5{2.0f, 3.0f, 4.0f};
-  
-  // Test three-way comparison
-  TEST_TRUE((fda1 <=> fda2) == 0)
-  TEST_TRUE((fda1 <=> fda3) < 0)
-  TEST_TRUE((fda3 <=> fda1) > 0)
-  TEST_TRUE((fda4 <=> fda1) < 0)
-  TEST_TRUE((fda1 <=> fda4) > 0)
-  TEST_TRUE((fda1 <=> fda5) < 0)
-END_SECTION
-
 START_SECTION((FloatDataArray operator<))
   FloatDataArray fda1{1.0f, 2.0f, 3.0f};
   FloatDataArray fda2{1.0f, 2.0f, 3.0f};
@@ -191,18 +175,6 @@ START_SECTION((IntegerDataArray operator!=))
   TEST_TRUE(ida1 != ida3)
 END_SECTION
 
-START_SECTION((IntegerDataArray operator<=>))
-  IntegerDataArray ida1{1, 2, 3};
-  IntegerDataArray ida2{1, 2, 3};
-  IntegerDataArray ida3{1, 2, 4};
-  IntegerDataArray ida4{1, 2};
-  
-  TEST_TRUE((ida1 <=> ida2) == 0)
-  TEST_TRUE((ida1 <=> ida3) < 0)
-  TEST_TRUE((ida3 <=> ida1) > 0)
-  TEST_TRUE((ida4 <=> ida1) < 0)
-END_SECTION
-
 START_SECTION((IntegerDataArray operator<))
   IntegerDataArray ida1{1, 2, 3};
   IntegerDataArray ida2{1, 2, 3};
@@ -286,18 +258,6 @@ START_SECTION((StringDataArray operator!=))
   
   TEST_FALSE(sda1 != sda2)
   TEST_TRUE(sda1 != sda3)
-END_SECTION
-
-START_SECTION((StringDataArray operator<=>))
-  StringDataArray sda1{"apple", "banana", "cherry"};
-  StringDataArray sda2{"apple", "banana", "cherry"};
-  StringDataArray sda3{"apple", "banana", "date"};
-  StringDataArray sda4{"apple", "banana"};
-  
-  TEST_TRUE((sda1 <=> sda2) == 0)
-  TEST_TRUE((sda1 <=> sda3) < 0)
-  TEST_TRUE((sda3 <=> sda1) > 0)
-  TEST_TRUE((sda4 <=> sda1) < 0)
 END_SECTION
 
 START_SECTION((StringDataArray operator<))

--- a/src/tests/class_tests/openms/source/DataArrays_test.cpp
+++ b/src/tests/class_tests/openms/source/DataArrays_test.cpp
@@ -1,0 +1,426 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Your Name $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/METADATA/DataArrays.h>
+
+using namespace OpenMS;
+using namespace OpenMS::DataArrays;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(DataArrays, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+FloatDataArray* fda_ptr = nullptr;
+FloatDataArray* fda_nullPointer = nullptr;
+
+START_SECTION((FloatDataArray()))
+  fda_ptr = new FloatDataArray;
+  TEST_NOT_EQUAL(fda_ptr, fda_nullPointer)
+  TEST_EQUAL(fda_ptr->size(), 0)
+END_SECTION
+
+START_SECTION(([EXTRA] ~FloatDataArray()))
+  delete fda_ptr;
+END_SECTION
+
+START_SECTION((FloatDataArray copy constructor))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  fda1.setName("test_array");
+  FloatDataArray fda2(fda1);
+  TEST_EQUAL(fda2.size(), 3)
+  TEST_EQUAL(fda2[0], 1.0f)
+  TEST_EQUAL(fda2[1], 2.0f)
+  TEST_EQUAL(fda2[2], 3.0f)
+  TEST_EQUAL(fda2.getName(), "test_array")
+END_SECTION
+
+START_SECTION((FloatDataArray operator==))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  FloatDataArray fda4{1.0f, 2.0f};
+  
+  TEST_TRUE(fda1 == fda2)
+  TEST_FALSE(fda1 == fda3)
+  TEST_FALSE(fda1 == fda4)
+  
+  // Test with metadata
+  fda1.setName("array1");
+  TEST_FALSE(fda1 == fda2)
+  fda2.setName("array1");
+  TEST_TRUE(fda1 == fda2)
+END_SECTION
+
+START_SECTION((FloatDataArray operator!=))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  
+  TEST_FALSE(fda1 != fda2)
+  TEST_TRUE(fda1 != fda3)
+END_SECTION
+
+START_SECTION((FloatDataArray operator<=>))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  FloatDataArray fda4{1.0f, 2.0f};
+  FloatDataArray fda5{2.0f, 3.0f, 4.0f};
+  
+  // Test three-way comparison
+  TEST_TRUE((fda1 <=> fda2) == 0)
+  TEST_TRUE((fda1 <=> fda3) < 0)
+  TEST_TRUE((fda3 <=> fda1) > 0)
+  TEST_TRUE((fda4 <=> fda1) < 0)
+  TEST_TRUE((fda1 <=> fda4) > 0)
+  TEST_TRUE((fda1 <=> fda5) < 0)
+END_SECTION
+
+START_SECTION((FloatDataArray operator<))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  
+  TEST_FALSE(fda1 < fda2)
+  TEST_TRUE(fda1 < fda3)
+  TEST_FALSE(fda3 < fda1)
+END_SECTION
+
+START_SECTION((FloatDataArray operator<=))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  
+  TEST_TRUE(fda1 <= fda2)
+  TEST_TRUE(fda1 <= fda3)
+  TEST_FALSE(fda3 <= fda1)
+END_SECTION
+
+START_SECTION((FloatDataArray operator>))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  
+  TEST_FALSE(fda1 > fda2)
+  TEST_FALSE(fda1 > fda3)
+  TEST_TRUE(fda3 > fda1)
+END_SECTION
+
+START_SECTION((FloatDataArray operator>=))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 4.0f};
+  
+  TEST_TRUE(fda1 >= fda2)
+  TEST_FALSE(fda1 >= fda3)
+  TEST_TRUE(fda3 >= fda1)
+END_SECTION
+
+// Test special float cases
+START_SECTION((FloatDataArray with NaN))
+  FloatDataArray fda1{1.0f, std::numeric_limits<float>::quiet_NaN(), 3.0f};
+  FloatDataArray fda2{1.0f, std::numeric_limits<float>::quiet_NaN(), 3.0f};
+  FloatDataArray fda3{1.0f, 2.0f, 3.0f};
+  
+  // NaN comparisons should follow IEEE 754 rules
+  TEST_FALSE(fda1 == fda2)  // NaN != NaN
+  TEST_TRUE(fda1 != fda2)
+  
+  // Comparisons with NaN are unordered
+  TEST_FALSE(fda1 < fda3)
+  TEST_FALSE(fda1 > fda3)
+  TEST_FALSE(fda1 <= fda3)
+  TEST_FALSE(fda1 >= fda3)
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// IntegerDataArray tests
+
+IntegerDataArray* ida_ptr = nullptr;
+IntegerDataArray* ida_nullPointer = nullptr;
+
+START_SECTION((IntegerDataArray()))
+  ida_ptr = new IntegerDataArray;
+  TEST_NOT_EQUAL(ida_ptr, ida_nullPointer)
+  TEST_EQUAL(ida_ptr->size(), 0)
+END_SECTION
+
+START_SECTION(([EXTRA] ~IntegerDataArray()))
+  delete ida_ptr;
+END_SECTION
+
+START_SECTION((IntegerDataArray copy constructor))
+  IntegerDataArray ida1{1, 2, 3};
+  ida1.setName("int_array");
+  IntegerDataArray ida2(ida1);
+  TEST_EQUAL(ida2.size(), 3)
+  TEST_EQUAL(ida2[0], 1)
+  TEST_EQUAL(ida2[1], 2)
+  TEST_EQUAL(ida2[2], 3)
+  TEST_EQUAL(ida2.getName(), "int_array")
+END_SECTION
+
+START_SECTION((IntegerDataArray operator==))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_TRUE(ida1 == ida2)
+  TEST_FALSE(ida1 == ida3)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator!=))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_FALSE(ida1 != ida2)
+  TEST_TRUE(ida1 != ida3)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator<=>))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  IntegerDataArray ida4{1, 2};
+  
+  TEST_TRUE((ida1 <=> ida2) == 0)
+  TEST_TRUE((ida1 <=> ida3) < 0)
+  TEST_TRUE((ida3 <=> ida1) > 0)
+  TEST_TRUE((ida4 <=> ida1) < 0)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator<))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_FALSE(ida1 < ida2)
+  TEST_TRUE(ida1 < ida3)
+  TEST_FALSE(ida3 < ida1)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator<=))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_TRUE(ida1 <= ida2)
+  TEST_TRUE(ida1 <= ida3)
+  TEST_FALSE(ida3 <= ida1)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator>))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_FALSE(ida1 > ida2)
+  TEST_FALSE(ida1 > ida3)
+  TEST_TRUE(ida3 > ida1)
+END_SECTION
+
+START_SECTION((IntegerDataArray operator>=))
+  IntegerDataArray ida1{1, 2, 3};
+  IntegerDataArray ida2{1, 2, 3};
+  IntegerDataArray ida3{1, 2, 4};
+  
+  TEST_TRUE(ida1 >= ida2)
+  TEST_FALSE(ida1 >= ida3)
+  TEST_TRUE(ida3 >= ida1)
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// StringDataArray tests
+
+StringDataArray* sda_ptr = nullptr;
+StringDataArray* sda_nullPointer = nullptr;
+
+START_SECTION((StringDataArray()))
+  sda_ptr = new StringDataArray;
+  TEST_NOT_EQUAL(sda_ptr, sda_nullPointer)
+  TEST_EQUAL(sda_ptr->size(), 0)
+END_SECTION
+
+START_SECTION(([EXTRA] ~StringDataArray()))
+  delete sda_ptr;
+END_SECTION
+
+START_SECTION((StringDataArray copy constructor))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  sda1.setName("string_array");
+  StringDataArray sda2(sda1);
+  TEST_EQUAL(sda2.size(), 3)
+  TEST_EQUAL(sda2[0], "apple")
+  TEST_EQUAL(sda2[1], "banana")
+  TEST_EQUAL(sda2[2], "cherry")
+  TEST_EQUAL(sda2.getName(), "string_array")
+END_SECTION
+
+START_SECTION((StringDataArray operator==))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_TRUE(sda1 == sda2)
+  TEST_FALSE(sda1 == sda3)
+END_SECTION
+
+START_SECTION((StringDataArray operator!=))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_FALSE(sda1 != sda2)
+  TEST_TRUE(sda1 != sda3)
+END_SECTION
+
+START_SECTION((StringDataArray operator<=>))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  StringDataArray sda4{"apple", "banana"};
+  
+  TEST_TRUE((sda1 <=> sda2) == 0)
+  TEST_TRUE((sda1 <=> sda3) < 0)
+  TEST_TRUE((sda3 <=> sda1) > 0)
+  TEST_TRUE((sda4 <=> sda1) < 0)
+END_SECTION
+
+START_SECTION((StringDataArray operator<))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_FALSE(sda1 < sda2)
+  TEST_TRUE(sda1 < sda3)
+  TEST_FALSE(sda3 < sda1)
+END_SECTION
+
+START_SECTION((StringDataArray operator<=))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_TRUE(sda1 <= sda2)
+  TEST_TRUE(sda1 <= sda3)
+  TEST_FALSE(sda3 <= sda1)
+END_SECTION
+
+START_SECTION((StringDataArray operator>))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_FALSE(sda1 > sda2)
+  TEST_FALSE(sda1 > sda3)
+  TEST_TRUE(sda3 > sda1)
+END_SECTION
+
+START_SECTION((StringDataArray operator>=))
+  StringDataArray sda1{"apple", "banana", "cherry"};
+  StringDataArray sda2{"apple", "banana", "cherry"};
+  StringDataArray sda3{"apple", "banana", "date"};
+  
+  TEST_TRUE(sda1 >= sda2)
+  TEST_FALSE(sda1 >= sda3)
+  TEST_TRUE(sda3 >= sda1)
+END_SECTION
+
+// Test std::vector functionality inheritance
+START_SECTION((DataArrays std::vector functionality))
+  FloatDataArray fda;
+  fda.push_back(1.0f);
+  fda.push_back(2.0f);
+  fda.push_back(3.0f);
+  
+  TEST_EQUAL(fda.size(), 3)
+  TEST_EQUAL(fda.front(), 1.0f)
+  TEST_EQUAL(fda.back(), 3.0f)
+  
+  fda.clear();
+  TEST_EQUAL(fda.size(), 0)
+  TEST_TRUE(fda.empty())
+  
+  // Test reserve and capacity
+  fda.reserve(100);
+  TEST_TRUE(fda.capacity() >= 100)
+  
+  // Test iteration
+  IntegerDataArray ida{1, 2, 3, 4, 5};
+  int sum = 0;
+  for (const auto& val : ida)
+  {
+    sum += val;
+  }
+  TEST_EQUAL(sum, 15)
+END_SECTION
+
+// Test MetaInfoDescription functionality inheritance
+START_SECTION((DataArrays MetaInfoDescription functionality))
+  FloatDataArray fda;
+  fda.setName("my_float_array");
+  TEST_EQUAL(fda.getName(), "my_float_array")
+  
+  IntegerDataArray ida;
+  ida.setName("my_int_array");
+  TEST_EQUAL(ida.getName(), "my_int_array")
+  
+  StringDataArray sda;
+  sda.setName("my_string_array");
+  TEST_EQUAL(sda.getName(), "my_string_array")
+  
+  // Test that metadata affects comparison
+  FloatDataArray fda1{1.0f, 2.0f};
+  FloatDataArray fda2{1.0f, 2.0f};
+  
+  TEST_TRUE(fda1 == fda2)
+  
+  fda1.setName("array1");
+  TEST_FALSE(fda1 == fda2)
+  
+  fda2.setName("array1");
+  TEST_TRUE(fda1 == fda2)
+  
+  // Test MetaInfo functionality
+  fda1.setMetaValue("label", "test_label");
+  TEST_FALSE(fda1 == fda2)
+  
+  fda2.setMetaValue("label", "test_label");
+  TEST_TRUE(fda1 == fda2)
+END_SECTION
+
+// Test mixed comparisons with different metadata
+START_SECTION((DataArrays comparison with mixed metadata))
+  FloatDataArray fda1{1.0f, 2.0f, 3.0f};
+  FloatDataArray fda2{1.0f, 2.0f, 3.0f};
+  
+  // Same data, different names
+  fda1.setName("A");
+  fda2.setName("B");
+  
+  // Arrays with different metadata should compare consistently
+  // The exact ordering doesn't matter as long as it's consistent
+  bool less_than = fda1 < fda2;
+  bool greater_than = fda1 > fda2;
+  TEST_TRUE(less_than != greater_than) // One should be true, one false
+  TEST_FALSE(fda1 == fda2)
+  TEST_TRUE(fda1 != fda2)
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+
+END_TEST


### PR DESCRIPTION
## Description


This pull request introduces enhancements to the `DataArrays` classes in OpenMS by adding comparison operators and updates the test configuration to include a new test for `DataArrays`. 

### Enhancements to `DataArrays` classes:

* **Spaceship operator (`<=>`) added for three-way comparison**:
  - Implemented for `FloatDataArray`, `IntegerDataArray`, and `StringDataArray` classes to provide consistent ordering. The comparison first evaluates the `MetaInfoDescription` base class (using memory addresses for ordering since it lacks a spaceship operator) and then compares the vector contents. (`[[1]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R25-R48)`, `[[2]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R57-R80)`, `[[3]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R89-R112)`)
* **Equality operator (`==`) added**:
  - Added for `FloatDataArray`, `IntegerDataArray`, and `StringDataArray` classes to check equality of both the `MetaInfoDescription` base class and the vector contents. (`[[1]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R25-R48)`, `[[2]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R57-R80)`, `[[3]](diffhunk://#diff-5f09977312933900e8f72b406ce032d58ec47fb5bf85ed1a37494038fdcd18e1R89-R112)`)

### Test configuration update:

* **New test added for `DataArrays`**:
  - Included `DataArrays_test` in the `metadata_executables_list` in the CMake configuration to ensure proper test coverage for the newly added operators. (`[src/tests/class_tests/openms/executables.cmakeR87](diffhunk://#diff-b383e931e63b075589578cc0e9114d5daf1f40ee10c7843561025466d44b39d0R87)`)

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relational comparison operators (<, <=, >, >=, !=, ==) for FloatDataArray, IntegerDataArray, StringDataArray, and MetaInfoDescription classes to improve data comparison and sorting.
* **Bug Fixes**
  * Removed unused comment field from MetaInfoDescription equality checks to enhance comparison accuracy.
* **Tests**
  * Introduced comprehensive unit tests for DataArrays covering construction, metadata influence, all comparison operators, and edge cases including NaN handling.
* **Chores**
  * Included DataArrays tests in the automated metadata test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->