### PR TITLE
Ignore SpectrumAccessTransforming again

### DIFF
--- a/src/pyOpenMS/pxds/SpectrumAccessTransforming.pxd
+++ b/src/pyOpenMS/pxds/SpectrumAccessTransforming.pxd
@@ -10,9 +10,7 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessTransformi
     cdef cppclass SpectrumAccessTransforming(ISpectrumAccess) :
         # wrap-inherits:
         #  ISpectrumAccess
-
-        #TODO: This was included in wrap-ignore with autowrap 22. 22 just didn't ignore it. 23 does, so we remove the annotiation since derived classes refer to it.
-
+        # wrap-ignore
 
         SpectrumAccessTransforming(SpectrumAccessTransforming) except + nogil  # wrap-ignore
 


### PR DESCRIPTION
## Description

It just does not make sense to have this exposed in python. Was introduced in #8106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal comments for improved clarity; no changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->