### PR TITLE
Revert "Ignore SpectrumAccessTransforming again"

### DIFF
--- a/src/pyOpenMS/pxds/SpectrumAccessTransforming.pxd
+++ b/src/pyOpenMS/pxds/SpectrumAccessTransforming.pxd
@@ -10,7 +10,9 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessTransformi
     cdef cppclass SpectrumAccessTransforming(ISpectrumAccess) :
         # wrap-inherits:
         #  ISpectrumAccess
-        # wrap-ignore
+
+        #TODO: This was included in wrap-ignore with autowrap 22. 22 just didn't ignore it. 23 does, so we remove the annotiation since derived classes refer to it.
+
 
         SpectrumAccessTransforming(SpectrumAccessTransforming) except + nogil  # wrap-ignore
 


### PR DESCRIPTION
Reverts OpenMS/OpenMS#8113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal comments to reflect changes in class wrapping behavior; no impact on functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->