### PR TITLE
Fix ASan bug - do not merge

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/HANDLERS/IndexedMzMLDecoder.h>
+#include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 
 #include <boost/regex.hpp>
 #include <boost/lexical_cast.hpp>
@@ -236,8 +237,8 @@ namespace OpenMS
     }
     xercesc::DOMNode* indexListNode = li->item(0);
 
-    XMLCh* x_idref_tag = xercesc::XMLString::transcode("idRef");
-    XMLCh* x_name_tag = xercesc::XMLString::transcode("name");
+    Internal::unique_xerces_ptr<XMLCh> x_idref_tag(xercesc::XMLString::transcode("idRef"));
+    Internal::unique_xerces_ptr<XMLCh> x_name_tag(xercesc::XMLString::transcode("name"));
 
     xercesc::DOMNodeList* index_elems = indexListNode->getChildNodes();
     const  XMLSize_t nodeCount_ = index_elems->getLength();
@@ -272,22 +273,18 @@ namespace OpenMS
           {
             xercesc::DOMElement* currentElement = dynamic_cast<xercesc::DOMElement*>(currentONode);
 
-            char* x_name = xercesc::XMLString::transcode(currentElement->getAttribute(x_idref_tag));
-            char* x_offset = xercesc::XMLString::transcode(currentONode->getTextContent());
+            Internal::unique_xerces_ptr<char> x_name(xercesc::XMLString::transcode(currentElement->getAttribute(x_idref_tag.get())));
+            Internal::unique_xerces_ptr<char> x_offset(xercesc::XMLString::transcode(currentONode->getTextContent()));
 
-            std::streampos thisOffset = OpenMS::IndexedMzMLUtils::stringToStreampos( String(x_offset) );
-            result.emplace_back(String(x_name), thisOffset);
-
-            xercesc::XMLString::release(&x_name);
-            xercesc::XMLString::release(&x_offset);
+            std::streampos thisOffset = OpenMS::IndexedMzMLUtils::stringToStreampos( String(x_offset.get()) );
+            result.emplace_back(String(x_name.get()), thisOffset);
           }
         }
 
         // should be either spectrum or chromatogram ...
         xercesc::DOMElement* currentElement = dynamic_cast<xercesc::DOMElement*>(currentNode);
-        char* x_indexName = xercesc::XMLString::transcode(currentElement->getAttribute(x_name_tag));
-        std::string name(x_indexName);
-        xercesc::XMLString::release(&x_indexName);
+        Internal::unique_xerces_ptr<char> x_indexName(xercesc::XMLString::transcode(currentElement->getAttribute(x_name_tag.get())));
+        std::string name(x_indexName.get());
 
         if (name == "spectrum")
         {
@@ -302,14 +299,10 @@ namespace OpenMS
           std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: expected only " <<
             "'spectrum' or 'chromatogram' below indexList but found instead '" << 
             name << "'." << std::endl;
-          xercesc::XMLString::release(&x_idref_tag);
-          xercesc::XMLString::release(&x_name_tag);
           return -1;
         }
       }
     }
-    xercesc::XMLString::release(&x_idref_tag);
-    xercesc::XMLString::release(&x_name_tag);
 
     return 0;
   }

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -444,12 +444,12 @@ namespace OpenMS::Internal
       processed_chars = chars_to_align;
   
       // SIMD loop: find the first zero character in blocks of 8 UTF-16 characters (16 bytes each)
-      const simde__m128i zero = simde_mm_setzero_si128();
+      const simde__m128i zero = simde_mm_setzero_si128();  
       while (true)
       {
           simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
           simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
-          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte 
+          uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte
   
           if (zero_mask != 0)
           { // Found a zero character
@@ -457,7 +457,7 @@ namespace OpenMS::Internal
               auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
               return processed_chars + char_pos_zero;
           }
-  
+
           // 8 chars (each 2 bytes) had no zero
           pos_ptr += 8;
           processed_chars += 8;

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -447,6 +447,29 @@ namespace OpenMS::Internal
       const simde__m128i zero = simde_mm_setzero_si128();  
       while (true)
       {
+          // Check if we have at least 8 characters (16 bytes) remaining to safely load
+          // First do a quick check for null terminator in the next 8 characters
+          bool has_null_in_next_8 = false;
+          for (int i = 0; i < 8; ++i)
+          {
+              if (pos_ptr[i] == 0)
+              {
+                  has_null_in_next_8 = true;
+                  break;
+              }
+          }
+          
+          if (has_null_in_next_8)
+          {
+              // Fall back to character-by-character processing for the remainder
+              while (*pos_ptr != 0)
+              {
+                  ++pos_ptr;
+                  ++processed_chars;
+              }
+              return processed_chars;
+          }
+          
           simde__m128i bits = simde_mm_load_si128(reinterpret_cast<const simde__m128i*>(pos_ptr));
           simde__m128i cmp_zero = simde_mm_cmpeq_epi16(bits, zero); // sets bits to 0xFFFF (2 bytes) for each character that is zero
           uint16_t zero_mask = simde_mm_movemask_epi8(cmp_zero);    // extracts MSB from each byte

--- a/src/openms/source/FORMAT/XMLFile.cpp
+++ b/src/openms/source/FORMAT/XMLFile.cpp
@@ -160,8 +160,8 @@ private:
       // what if no encoding given http://xerces.apache.org/xerces-c/apiDocs-3/classInputSource.html
       if (!enforced_encoding_.empty())
       {
-        static const XMLCh* s_enc = xercesc::XMLString::transcode(enforced_encoding_.c_str());
-        source->setEncoding(s_enc);
+        Internal::unique_xerces_ptr<XMLCh> s_enc(xercesc::XMLString::transcode(enforced_encoding_.c_str()));
+        source->setEncoding(s_enc.get());
       }
       
       parse(source.get(), handler);
@@ -198,8 +198,8 @@ private:
       // what if no encoding given http://xerces.apache.org/xerces-c/apiDocs-3/classInputSource.html
       if (!enforced_encoding_.empty())
       {
-        static const XMLCh* s_enc = xercesc::XMLString::transcode(enforced_encoding_.c_str());
-        source->setEncoding(s_enc);
+        Internal::unique_xerces_ptr<XMLCh> s_enc(xercesc::XMLString::transcode(enforced_encoding_.c_str()));
+        source->setEncoding(s_enc.get());
       }
       
       parse(source.get(), handler);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved memory management for XML string handling, reducing the risk of memory leaks and enhancing code safety.
  * Enhanced robustness of UTF-16 string length calculations to prevent potential out-of-bounds memory access.

* **Bug Fixes**
  * Increased safety during XML parsing and string processing by ensuring proper handling and release of memory resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->