### PR TITLE
fix TOPPAS crash when using TOPP tools with multiple output formats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@ Misc:
  - show load/store progress for files in all TOPP tools (#8041)
  
 Fixes:
+ - fix TOPPAS crash when using TOPP tools with multiple output formats (#8120)
 
 Library:
 - Removed `assignRanks` and `sortByRanks` in PeptideIdentifications and sort and filter by score instead. Also removed `updateHitRanks` in IDFilter (#7991)

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -79,10 +79,17 @@ namespace OpenMS
   {
     // display file type(s)
     std::map<String, Size> suffices;
-    for (const auto& fn : filenames_)
+    try 
     {
-      auto type = FileHandler::getType(fn.toStdString());
-      ++suffices[FileTypes::typeToName(type)];
+      for (const auto& fn : filenames_)
+      {
+        auto type = FileHandler::getType(fn.toStdString());
+        ++suffices[FileTypes::typeToName(type)];
+      }
+    }
+    catch (...)
+    { // in a dry-run, the file might not exist, so we cannot determine the type
+      ++suffices[FileTypes::typeToName(FileTypes::UNKNOWN)];
     }
     QStringList text_l;
     for (const auto& [suffix, count] : suffices)


### PR DESCRIPTION
## Description

TOPPAS would display an error message box when using a TOPP tool that has multiple output formats in one slot, such as Textexporter.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in TOPPAS when using TOPP tools that produce multiple output formats. Files that cannot be detected due to missing files are now handled gracefully and marked as unknown, preventing application errors.

* **Documentation**
  * Updated the changelog to reflect the latest bug fix for version 3.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->