### PR TITLE
Semi specific digestion

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ the authors tag in the respective file header.
  - Holger Plattfaut
  - Immanuel Luhn
  - Jang Jang Jin
+ - Jeremi Maciejewski
  - Jihyung Kim
  - Johan Teleman
  - Johannes Junker

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,9 +29,6 @@ Dependencies:
 NucleicAcidSearchEngine:
     - add support for global fixed modifications as a search parameter
 
-ProteaseDigestion:
-    - add support for semi-specific digestion in objects where specificity is set to SPEC_SEMI (1)
-
 Misc:
  - show load/store progress for files in all TOPP tools (#8041)
  
@@ -43,6 +40,7 @@ Library:
 - Remove ranke member in PeptideHit and store ranks as meta value (for backwards compatibility). (#7997)
 - std::vector<PeptideIdentification> now is encapsulated in a class PeptideIdentificationList
 - Added `EnzymaticDigestion.semiSpecificDigestion_()`
+- ProteaseDigestion: add support for semi-specific digestion (#8130)
 
 Added tools:
 - OpenNuXL - A peptide-RNA/DNA cross-linking search engine

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,9 @@ Dependencies:
 NucleicAcidSearchEngine:
     - add support for global fixed modifications as a search parameter
 
+ProteaseDigestion:
+    - add support for semi-specific digestion in objects where specificity is set to SPEC_SEMI (1)
+
 Misc:
  - show load/store progress for files in all TOPP tools (#8041)
  
@@ -39,6 +42,7 @@ Library:
 - Removed `assignRanks` and `sortByRanks` in PeptideIdentifications and sort and filter by score instead. Also removed `updateHitRanks` in IDFilter (#7991)
 - Remove ranke member in PeptideHit and store ranks as meta value (for backwards compatibility). (#7997)
 - std::vector<PeptideIdentification> now is encapsulated in a class PeptideIdentificationList
+- Added `EnzymaticDigestion.semiSpecificDigestion_()`
 
 Added tools:
 - OpenNuXL - A peptide-RNA/DNA cross-linking search engine

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -193,6 +193,8 @@ namespace OpenMS
       @param max_length Maximal length of reported products
 
       @return number of digestion products NOT matching the length restrictions.
+      @throw Exception::InvalidValue if number of cleavage_positions is smaller than 2 (at least sequence termini are required).
+      @throw Exception::Precondition if vector cleavage_positions is not sorted.
     */
     Size semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length = 0, Size max_length = -1) const;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow, Xiao Liang $
-// $Authors: Marc Sturm, Chris Bielow $
+// $Authors: Marc Sturm, Chris Bielow, Jeremi Maciejewski $
 // --------------------------------------------------------------------------
 
 #pragma once
@@ -178,6 +178,21 @@ namespace OpenMS
       @return Cleavage positions (this includes @p start, but not @p end)
      */
     std::vector<int> tokenize_(const String& sequence, int start = 0, int end = -1) const;
+
+    /**
+      @brief Generates semi-specific digestion products
+
+      Function handling semi-specific digestion (specificity == 1).
+      It is intended for calling after tokenizing and missed cleavages variants generation.
+
+      @param cleavage_positions A (sorted!) vector of cleavage positions, as returned by tokenize_(). First and last cleavage should be sequence termini.
+      @param output A vector into which produced variants are emplaced.
+      @param min_length Minimal length of reported products
+      @param max_length Maximal length of reported products
+
+      @return number of digestion products NOT matching the length restrictions.
+    */
+    Size semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length = 0, Size max_length = -1) const;
 
     /**
        @brief Helper function for digestUnmodified()

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -182,8 +182,10 @@ namespace OpenMS
     /**
       @brief Generates semi-specific digestion products
 
-      Function handling semi-specific digestion (specificity == 1).
+      Function handling semi-specific digestion (specificity_ == Specificity::SPEC_SEMI).
       It is intended for calling after tokenizing and missed cleavages variants generation.
+      Fully-specific variants are skipped.
+      Also generates semi-specific variants with missed cleavages.
 
       @param cleavage_positions A (sorted!) vector of cleavage positions, as returned by tokenize_(). First and last cleavage should be sequence termini.
       @param output A vector into which produced variants are emplaced.

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
@@ -37,7 +37,8 @@ namespace OpenMS
     void setEnzyme(const String& name);
 
     /** 
-       @brief Performs the enzymatic digestion of a protein represented as AASequence
+       @brief Performs the enzymatic digestion of a protein represented as AASequence.
+       Digestion logic is implemented by overloaded function @p digest .
 
        @param protein Sequence to digest
        @param output Digestion products (peptides)
@@ -50,14 +51,19 @@ namespace OpenMS
 
     /** 
        @brief Performs the enzymatic digestion of a protein represented as AASequence.
-       By default, only fully specific products are generated.
-       If object's Specificity is set to SPEC_SEMI (1), also generates semi-specific products.
+       Digestion takes into account the value of
+       - the **missed cleavages** member, see @p setMissedCleavages()
+       - the **specificity** member, see @p setSpecificity()
+
+       Currently, Specificity::SPEC_SEMI and Specificity::SPEC_FULL are supported.
+       Others raise an exception
 
        @param protein Sequence to digest
        @param output Digestion products (start and end indices of peptides)
        @param min_length Minimal length of reported products
        @param max_length Maximal length of reported products (0 = no restriction)
        @return Number of discarded digestion products (which are not matching length restrictions)
+       @throw Exception::InvalidValue If object's specificity_ value is not supported.
 
     */
     Size digest(const AASequence& protein, std::vector<std::pair<size_t,size_t>>& output, Size min_length = 1, Size max_length = 0) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
@@ -49,7 +49,9 @@ namespace OpenMS
     Size digest(const AASequence& protein, std::vector<AASequence>& output, Size min_length = 1, Size max_length = 0) const;
 
     /** 
-       @brief Performs the enzymatic digestion of a protein represented as AASequence
+       @brief Performs the enzymatic digestion of a protein represented as AASequence.
+       By default, only fully specific products are generated.
+       If object's Specificity is set to SPEC_SEMI (1), also generates semi-specific products.
 
        @param protein Sequence to digest
        @param output Digestion products (start and end indices of peptides)

--- a/src/openms/source/CHEMISTRY/DecoyGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/DecoyGenerator.cpp
@@ -42,7 +42,7 @@ AASequence DecoyGenerator::reversePeptides(const AASequence& protein, const Stri
   ProteaseDigestion ed;
   ed.setMissedCleavages(0); // important as we want to reverse between all cutting sites
   ed.setEnzyme(protease);
-  ed.setSpecificity(EnzymaticDigestion::SPEC_NONE);
+  ed.setSpecificity(EnzymaticDigestion::SPEC_FULL);
   ed.digest(protein, peptides);    
   String pseudo_reversed;
   for (int i = 0; i < static_cast<int>(peptides.size()) - 1; ++i)
@@ -70,7 +70,7 @@ AASequence DecoyGenerator::shufflePeptides(
   ProteaseDigestion ed;
   ed.setMissedCleavages(0); // important as we want to reverse between all cutting sites
   ed.setEnzyme(protease);
-  ed.setSpecificity(EnzymaticDigestion::SPEC_NONE);
+  ed.setSpecificity(EnzymaticDigestion::SPEC_FULL);
   ed.digest(protein, peptides);    
   String protein_shuffled;
   for (int i = 0; i < static_cast<int>(peptides.size()) - 1; ++i)

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -125,6 +125,14 @@ namespace OpenMS
         String("Too few cleavage positions - at least sequence start and end positions are required."), value);
     }
 
+    // cleavage_positions has to be sorted
+    if (! is_sorted(cleavage_positions.begin(), cleavage_positions.end()))
+    {
+      String value(cleavage_positions.begin(), cleavage_positions.end());
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        String("Vector of cleavage positions (cleavage_positions) is not sorted, but it should be."));
+    }
+
     int mc = missed_cleavages_;
     Size wrong = 0;
 

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -117,6 +117,14 @@ namespace OpenMS
 
   Size EnzymaticDigestion::semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length, Size max_length) const
   {
+    // Too few cleavage sites - should be at least sequence start and end
+    if (cleavage_positions.size() < 2)
+    {
+      String value(cleavage_positions.begin(), cleavage_positions.end());
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        String("Too few cleavage positions - at least sequence start and end positions are required."), value);
+    }
+
     int mc = missed_cleavages_;
     Size wrong = 0;
 
@@ -132,8 +140,8 @@ namespace OpenMS
     // Lambda checking min & max conditions and adding to output
     auto variant = [&output, &wrong, min_length, max_length](Size x, Size y)
     {
-      if (min_length <= std::abs((int)y - (int)x) &&
-          max_length >= std::abs((int)y - (int)x))
+      if (min_length <= y - x &&
+          max_length >= y - x)
       {
         output.emplace_back(x, y);
       } else ++wrong;

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow, Xiao Liang $
-// $Authors: Marc Sturm, Chris Bielow$
+// $Authors: Marc Sturm, Chris Bielow, Jeremi Maciejewski $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
@@ -113,6 +113,65 @@ namespace OpenMS
       positions.push_back(start);
     }
     return positions;
+  }
+
+  Size EnzymaticDigestion::semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length, Size max_length) const
+  {
+    int mc = missed_cleavages_;
+    Size wrong = 0;
+
+    // For every position, add an "extension" of it until next cleavage, in both directions.
+    // This is done by iterating through sequence from both ends at the same time.
+    // Warning: cleavage_positions array has to be sorted.
+    // Warning: this assumes first and last cleavages to be sequence termini.
+
+    const int first_c = cleavage_positions.front(); // First cleavage
+    const int last_c = cleavage_positions.back(); // Last cleavage
+    const int lgth = last_c - first_c;
+
+    // Lambda checking min & max conditions and adding to output
+    auto variant = [&output, &wrong, min_length, max_length](Size x, Size y)
+    {
+      if (min_length <= std::abs((int)y - (int)x) &&
+          max_length >= std::abs((int)y - (int)x))
+      {
+        output.emplace_back(x, y);
+      } else ++wrong;
+    };
+
+    auto fwd = cleavage_positions.cbegin();
+    auto bwd = cleavage_positions.crbegin(); // Reverse iterator!
+    ++fwd; ++bwd;
+    // Iterate from both sides of sequence (by calculating shift from start/end)
+    for (int shift = 1;shift < lgth;++shift)
+    {
+      // Forward position is not a cleavage site
+      if (first_c+shift != *fwd)
+      {
+        // For every cleavage site ahead try to add variant extented until it.
+        for (int i=0;
+            i < (mc + 1); // 1 cleavage is always included
+            ++i)
+        {
+          variant(first_c + shift, *(fwd+i)); // Extend until current cleavage
+          if (*(fwd+i) == last_c) break; // This was the last cleavage
+        }
+      } else ++fwd; // Prepare for encountering next cleavage site
+
+      // Backwards position
+      if (last_c - shift != *bwd)
+      {
+        for (int i=0;
+            i < (mc + 1);
+            ++i)
+        {
+          variant(*(bwd+i), last_c - shift); // Reverse iterator!
+          if (*(bwd+i) == first_c) break;
+        }
+      } else ++bwd;
+    }
+
+    return wrong;
   }
 
   Size EnzymaticDigestion::countInternalCleavageSites(const String& sequence) const

--- a/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
@@ -139,6 +139,13 @@ namespace OpenMS
         }
       }
     }
+
+    // semi-specific variants
+    if (specificity_ == SPEC_SEMI)
+    {
+      wrong_size = wrong_size + semiSpecificDigestion_(pep_positions, output, min_length, max_length);
+    }
+
     return wrong_size;
   }
 

--- a/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDigestion.cpp
@@ -89,6 +89,14 @@ namespace OpenMS
     // initialization
     output.clear();
 
+    // verify if currently set specificity is supported
+    if (! (specificity_ == Specificity::SPEC_FULL ||
+           specificity_ == Specificity::SPEC_SEMI))
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        String("Specificity value set on current ProteaseDigestion object is not supported by ProteaseDigestion::digest()."), String(specificity_));
+    }
+
     // disable max length filter by setting to maximum length
     if (max_length == 0 || max_length > protein.size())
     {

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -572,6 +572,7 @@ endif()
 
 # Please add your test here when you decide to write a new testfile in the tests/unittests folder
 set(pyopenms_unittest_testfiles
+  test_ProteaseDigestion.py
   test000.py
   test_tutorial.py
   test_BaselineFiltering.py

--- a/src/pyOpenMS/pxds/ProteaseDigestion.pxd
+++ b/src/pyOpenMS/pxds/ProteaseDigestion.pxd
@@ -50,7 +50,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ProteaseDigestion.h>" namespace "OpenMS":
         #        #
         #        # Semi-specific digestion
         #        result_semispecific = []
-        #        dig.setSpecificity(1)
+        #        dig.setSpecificity(EnzymaticDigestion.SPEC_SEMI)
         #        dig.digest(bsa_aaseq, result_semispecific)
         #        #
         #        # Using digestUnmodified without the need for AASequence from the EnzymaticDigestion base class

--- a/src/pyOpenMS/pxds/ProteaseDigestion.pxd
+++ b/src/pyOpenMS/pxds/ProteaseDigestion.pxd
@@ -17,6 +17,8 @@ cdef extern from "<OpenMS/CHEMISTRY/ProteaseDigestion.h>" namespace "OpenMS":
         #  due to enzyme malfunction/access restrictions. If n missed cleavages are allowed, all possible resulting
         #  peptides (cleaved and uncleaved) with up to n missed cleavages are returned.
         #  Thus no random selection of just n specific missed cleavage sites is performed.
+        #  If specificity is set to semi-specific, digestion also returns semi-specific products,
+        #  i.e. with only one end at actual cleavage sites.
         #    
         #  Usage:
         #  
@@ -45,6 +47,11 @@ cdef extern from "<OpenMS/CHEMISTRY/ProteaseDigestion.h>" namespace "OpenMS":
         #        print(len(result_digest)) # 57 peptides
         #        print(result_digest_min_max[4].toString()) # LVNELTEFAK
         #        print(len(result_digest_min_max)) # 42 peptides
+        #        #
+        #        # Semi-specific digestion
+        #        result_semispecific = []
+        #        dig.setSpecificity(1)
+        #        dig.digest(bsa_aaseq, result_semispecific)
         #        #
         #        # Using digestUnmodified without the need for AASequence from the EnzymaticDigestion base class
         #        result_digest_unmodified = []

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8  -*-
+
+## ----------------------------------------------------------------------------
+## $Maintainer: $
+## $Authors: Hannes Roest, Timo Sachsenberg, axelwalter,
+##           Samuel Wein, Uwe Schmitt, Joshua Charkow,
+##           Nikos Patikas, Chris Bielow, Julianus Pfeuffer,
+##           Oliver Alka, Stephan Aiche $
+## ----------------------------------------------------------------------------
 from __future__ import print_function
 
 import pyopenms

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1689,39 +1689,6 @@ def testTransitionTSVFile():
     assert pyopenms.TransitionTSVFile().validateTargetedExperiment is not None
 
 @report
-def testProteaseDigestion():
-    """
-    @tests: ProteaseDigestion
-     ProteaseDigestion.__init__
-     ProteaseDigestion.getMissedCleavages()
-     ProteaseDigestion.setMissedCleavages()
-     ProteaseDigestion.digest()
-     ProteaseDigestion.peptideCount()
-    """
-    # removed due to name clashes
-    # ProteaseDigestion.getEnzyme()
-    # ProteaseDigestion.setEnzyme()
-    # ProteaseDigestion.getEnzymeByName()
-
-    ff = pyopenms.ProteaseDigestion()
-    #enz = pyopenms.ProteaseDigestion().Enzyme()
-
-    assert pyopenms.ProteaseDigestion().getMissedCleavages is not None
-    assert pyopenms.ProteaseDigestion().setMissedCleavages is not None
-    #assert pyopenms.ProteaseDigestion().getEnzyme is not None
-    #assert pyopenms.ProteaseDigestion().setEnzyme is not None
-    #assert pyopenms.ProteaseDigestion().getEnzymeByName is not None
-
-    assert pyopenms.ProteaseDigestion().digest is not None
-    assert pyopenms.ProteaseDigestion().peptideCount is not None
-
-    ff.setMissedCleavages(5)
-    assert ff.getMissedCleavages() == 5
-
-    #ff.setEnzyme(enz.TRYPSIN)
-    #assert ff.getEnzyme() == enz.TRYPSIN
-
-@report
 def testIDDecoyProbability():
     """
     @tests: IDDecoyProbability

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8  -*-
+import pyopenms
+
+@report
+def testProteaseDigestion():
+    """
+    @tests: ProteaseDigestion
+     ProteaseDigestion.__init__
+     ProteaseDigestion.setEnzyme()
+     ProteaseDigestion.digest()
+     ProteaseDigestion.peptideCount()
+     ProteaseDigestion.isValidProduct()
+     ProteaseDigestion.getMissedCleavages()
+     ProteaseDigestion.setMissedCleavages()
+    """
+
+    ff = pyopenms.ProteaseDigestion()
+
+    assert pyopenms.ProteaseDigestion().setEnzyme is not None
+    ff.setEnzyme("Trypsin/P")
+    assert ff.getEnzymeName() == "Trypsin/P"
+
+    assert pyopenms.ProteaseDigestion().digest is not None
+    seq = AASequence.fromString("MHARLVP")
+    output = []
+    ff.digest(seq, output)
+    # MHAR, LVP
+    assert len(output) == 2
+    ff.setSpecificity(1) # Semi-specific
+    output = []
+    ff.digest(seq, output)
+    # MHAR, LVP, HAR, LV, AR, L, R, MHA, VP, MH, P, M
+    assert len(output) == 12
+
+    assert pyopenms.ProteaseDigestion().peptideCount is not None
+    ff.setSpecificity(2)
+    assert ff.peptideCount() == 2
+
+    assert pyopenms.ProteaseDigestion().isValidProduct is not None
+    assert ff.isValidProduct(seq, 0, 4) == True
+    assert ff.isValidProduct(seq, 3, 4) == False
+    ff.setSpecificity(1)
+    assert ff.isValidProduct(seq, 1, 3) == True
+
+    assert pyopenms.ProteaseDigestion().getMissedCleavages is not None
+    assert pyopenms.ProteaseDigestion().setMissedCleavages is not None
+
+    ff.setMissedCleavages(5)
+    assert ff.getMissedCleavages() == 5

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -7,6 +7,7 @@
 ##           Jeremi Maciejewski $
 ## ----------------------------------------------------------------------------
 import pyopenms
+from functools import wraps
 
 def report(f):
     @wraps(f)

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -49,7 +49,7 @@ def testProteaseDigestion():
 
     assert pyopenms.ProteaseDigestion().peptideCount is not None
     ff.setSpecificity(2)
-    assert ff.peptideCount() == 2
+    assert ff.peptideCount(seq) == 2
 
     assert pyopenms.ProteaseDigestion().isValidProduct is not None
     assert ff.isValidProduct(seq, 0, 4)

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -52,10 +52,10 @@ def testProteaseDigestion():
     assert ff.peptideCount(seq) == 2
 
     assert pyopenms.ProteaseDigestion().isValidProduct is not None
-    assert ff.isValidProduct(seq, 0, 4)
-    assert not ff.isValidProduct(seq, 3, 4)
+    assert ff.isValidProduct(seq, 0, 4, True, False)
+    assert not ff.isValidProduct(seq, 3, 4, True, False)
     ff.setSpecificity(1)
-    assert ff.isValidProduct(seq, 1, 3)
+    assert ff.isValidProduct(seq, 1, 3, True, False)
 
     assert pyopenms.ProteaseDigestion().getMissedCleavages is not None
     assert pyopenms.ProteaseDigestion().setMissedCleavages is not None

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -52,10 +52,10 @@ def testProteaseDigestion():
     assert ff.peptideCount() == 2
 
     assert pyopenms.ProteaseDigestion().isValidProduct is not None
-    assert ff.isValidProduct(seq, 0, 4) == True
-    assert ff.isValidProduct(seq, 3, 4) == False
+    assert ff.isValidProduct(seq, 0, 4)
+    assert  !(ff.isValidProduct(seq, 3, 4))
     ff.setSpecificity(1)
-    assert ff.isValidProduct(seq, 1, 3) == True
+    assert ff.isValidProduct(seq, 1, 3)
 
     assert pyopenms.ProteaseDigestion().getMissedCleavages is not None
     assert pyopenms.ProteaseDigestion().setMissedCleavages is not None

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -8,6 +8,13 @@
 ## ----------------------------------------------------------------------------
 import pyopenms
 
+def report(f):
+    @wraps(f)
+    def wrapper(*a, **kw):
+        print("run ", f.__name__)
+        f(*a, **kw)
+    return wrapper
+
 @report
 def testProteaseDigestion():
     """
@@ -28,7 +35,7 @@ def testProteaseDigestion():
     assert ff.getEnzymeName() == "Trypsin/P"
 
     assert pyopenms.ProteaseDigestion().digest is not None
-    seq = AASequence.fromString("MHARLVP")
+    seq = pyopenms.AASequence.fromString("MHARLVP")
     output = []
     ff.digest(seq, output)
     # MHAR, LVP

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8  -*-
+
+## ----------------------------------------------------------------------------
+## $Maintainer: $
+## $Authors: Hendrik Weisser, Hannes Roest, Stephan Aiche,
+##           Jeremi Maciejewski $
+## ----------------------------------------------------------------------------
 import pyopenms
 
 @report

--- a/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
+++ b/src/pyOpenMS/tests/unittests/test_ProteaseDigestion.py
@@ -53,7 +53,7 @@ def testProteaseDigestion():
 
     assert pyopenms.ProteaseDigestion().isValidProduct is not None
     assert ff.isValidProduct(seq, 0, 4)
-    assert  !(ff.isValidProduct(seq, 3, 4))
+    assert not ff.isValidProduct(seq, 3, 4)
     ff.setSpecificity(1)
     assert ff.isValidProduct(seq, 1, 3)
 

--- a/src/tests/class_tests/openms/source/DecoyGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/DecoyGenerator_test.cpp
@@ -47,7 +47,7 @@ START_SECTION((AASequence reverseProtein(const AASequence& protein)))
   TEST_EQUAL(dg->reverseProtein(AASequence::fromString("PRTEINE")).toString(), "ENIETRP")
 END_SECTION
 
-START_SECTION((AASequence reversePeptide(const AASequence& protein, const String& protease)))
+START_SECTION((AASequence reversePeptides(const AASequence& protein, const String& protease)))
   TEST_EQUAL(dg->reversePeptides(AASequence::fromString("TESTPEPTIDE"), "Trypsin").toString(),"EDITPEPTSET")
   TEST_EQUAL(dg->reversePeptides(AASequence::fromString("TESTRPEPTRIDE"), "Trypsin/P").toString(),"TSETRTPEPREDI")
   TEST_EQUAL(dg->reversePeptides(AASequence::fromString("TESTRPEPTRIDE"), "Trypsin").toString(),"TPEPRTSETREDI")

--- a/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
@@ -287,24 +287,29 @@ START_SECTION((Size semiSpecificDigestion_(const std::vector<int>& cleavage_posi
     class TempChild : public EnzymaticDigestion
     {
         public:
-            void tmpSetEnzyme(const DigestionEnzyme* enzyme)
-            {
-                this->setEnzyme(enzyme);
-            }
-
             Size tmpSemiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length = 1, Size max_length = 100) const
             {
                 return this->semiSpecificDigestion_(cleavage_positions, output, min_length, max_length);
             }
     };
     TempChild tmp;
-    tmp.tmpSetEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
+    tmp.setEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
 
     std::vector<std::pair<size_t,size_t>> output = {};
 
+    // Test normal behaviour
+    std::vector<int> cleavage_positions = {0, 3, 5};
+    tmp.tmpSemiSpecificDigestion_(cleavage_positions, output);
+    TEST_EQUAL(output.size(), 6) // {1,3},{3,4},{2,3},{0,2},{4,5},{0,1}
+
     // Test too few cleavage sites exception
-    std::vector<int> cleavage_positions = {};
+    cleavage_positions = {};
     TEST_EXCEPTION(Exception::InvalidValue,
+        tmp.tmpSemiSpecificDigestion_(cleavage_positions, output));
+
+    // Test cleavage positions vector not sorted exception
+    cleavage_positions = {0, 12, 7};
+    TEST_EXCEPTION(Exception::Precondition,
         tmp.tmpSemiSpecificDigestion_(cleavage_positions, output));
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow $
-// $Authors: Marc Sturm, Chris Bielow $
+// $Authors: Marc Sturm, Chris Bielow, Jeremi Maciejewski $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -279,6 +279,33 @@ START_SECTION((Size digestUnmodified(const StringView sequence, std::vector<Stri
     s = "ABC";
     ed.digestUnmodified(s, out);
     TEST_EQUAL(out.size(), 4 * 3 / 2);
+}
+END_SECTION
+
+START_SECTION((Size semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length, Size max_length) const))
+{
+    class TempChild : public EnzymaticDigestion
+    {
+        public:
+            void tmpSetEnzyme(const DigestionEnzyme* enzyme)
+            {
+                this->setEnzyme(enzyme);
+            }
+
+            Size tmpSemiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length = 1, Size max_length = 100) const
+            {
+                return this->semiSpecificDigestion_(cleavage_positions, output, min_length, max_length);
+            }
+    };
+    TempChild tmp;
+    tmp.tmpSetEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
+
+    std::vector<std::pair<size_t,size_t>> output = {};
+
+    // Test too few cleavage sites exception
+    std::vector<int> cleavage_positions = {};
+    TEST_EXCEPTION(Exception::InvalidValue,
+        tmp.tmpSemiSpecificDigestion_(cleavage_positions, output));
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -258,25 +258,25 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
     TEST_EQUAL(out[1].toString(), "MHP");
     // Are there semi-specific variants?
     ref = "AGL";
-    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_TRUE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     ref = "HP";
-    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_TRUE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     // Make sure cleavage sites are iterated over in right order.
     // (forward for N-terminus cleavage, backwards for C-terminus cleavage)
     ref = "GLRMHP";
-    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_FALSE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     ref = "AGLRMH";
-    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_FALSE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
 
     // Test if it works with missed cleavages
     pd.setMissedCleavages(2);
     pd.digest(AASequence::fromString("AGLRMHPQGHKWYV"), out);
     ref = "AGLRMHPQGHKW";
-    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_TRUE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     ref = "GHKWYV";
-    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_TRUE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     ref = "A";
-    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_TRUE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
 
     // Test if it works with protein without internal cleavage sites
     pd.setMissedCleavages(1);
@@ -289,9 +289,9 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
 
     pd.digest(AASequence::fromString("AGLRMHPQGHKWYV"), out, 3, 10);
     ref = "AG";
-    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_FALSE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
     ref = "AGLRMHPQGHKW";
-    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    TEST_FALSE(std::find_if(out.begin(),out.end(),compare_aa) != out.end());
 
     // ------------------------
     // Exceptions

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -236,7 +236,7 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
 
     // Lambda to allow searching 'out' with std::find_if()
     std::string ref = "";
-    auto compare_aa = [&ref](AASequence seq) -> bool
+    auto compare_aa = [&ref](const AASequence& seq) -> bool
     {
         return seq.toUnmodifiedString() == ref;
     };
@@ -278,6 +278,11 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
     ref = "A";
     TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
 
+    // Test if it works with protein without internal cleavage sites
+    pd.setMissedCleavages(1);
+    pd.digest(AASequence::fromString("AHLW"), out);
+    TEST_EQUAL(out.size(), 7); // AHLW, HLW, AHL, LW, AH, W, A
+
     // Test if min_size and max_size apply to semi-specific products
     discarded = pd.digest(AASequence::fromString("AGLRMHP"), out, 2);
     TEST_EQUAL(discarded, 4); // A, R, P, M
@@ -287,6 +292,14 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
     TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
     ref = "AGLRMHPQGHKW";
     TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+
+    // ------------------------
+    // Exceptions
+    // ------------------------
+    pd.setSpecificity(pd.SIZE_OF_SPECIFICITY);
+    TEST_EXCEPTION_WITH_MESSAGE(Exception::InvalidValue,
+        pd.digest(AASequence::fromString("ABCDEF"), out),
+        "the value '10' was used but is not valid; Specificity value set on current ProteaseDigestion object is not supported by ProteaseDigestion::digest().");
 
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDigestion_test.cpp
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow $
-// $Authors: Marc Sturm, Chris Bielow $
+// $Authors: Marc Sturm, Chris Bielow, Jeremi Maciejewski $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -13,6 +13,7 @@
 
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <vector>
+#include <algorithm>
 using namespace OpenMS;
 using namespace std;
 
@@ -227,6 +228,66 @@ START_SECTION((Size digest(const AASequence& protein, std::vector<AASequence>& o
     TEST_EQUAL(out.size(), 11*10/2)
     pd.digest(AASequence::fromString("ABC"), out);
     TEST_EQUAL(out.size(), 4*3/2)
+
+    // ------------------------
+    // semi-specific digestion
+    // ------------------------
+    pd.setSpecificity(pd.SPEC_SEMI);
+
+    // Lambda to allow searching 'out' with std::find_if()
+    std::string ref = "";
+    auto compare_aa = [&ref](AASequence seq) -> bool
+    {
+        return seq.toUnmodifiedString() == ref;
+    };
+
+    // Make sure unspecific cleavage still works
+    pd.setEnzyme("unspecific cleavage");
+    pd.digest(AASequence::fromString("ABCDEFGHIJ"), out);
+    TEST_EQUAL(out.size(), 11*10/2);
+    pd.digest(AASequence::fromString("ABC"), out);
+    TEST_EQUAL(out.size(), 4*3/2);
+
+    pd.setEnzyme("Trypsin/P");
+    pd.digest(AASequence::fromString("AGLRMHP"), out);
+    // AGLR, MHP, GLR, MH, LR, M, R, AGL, HP, AG, P, A
+    TEST_EQUAL(out.size(), 12);
+    // Assumes output is sorted as: fully-specific -> missed clv -> semi-specific
+    // Are fully-specific variants still here?
+    TEST_EQUAL(out[0].toString(), "AGLR");
+    TEST_EQUAL(out[1].toString(), "MHP");
+    // Are there semi-specific variants?
+    ref = "AGL";
+    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    ref = "HP";
+    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    // Make sure cleavage sites are iterated over in right order.
+    // (forward for N-terminus cleavage, backwards for C-terminus cleavage)
+    ref = "GLRMHP";
+    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    ref = "AGLRMH";
+    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+
+    // Test if it works with missed cleavages
+    pd.setMissedCleavages(2);
+    pd.digest(AASequence::fromString("AGLRMHPQGHKWYV"), out);
+    ref = "AGLRMHPQGHKW";
+    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    ref = "GHKWYV";
+    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    ref = "A";
+    TEST_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+
+    // Test if min_size and max_size apply to semi-specific products
+    discarded = pd.digest(AASequence::fromString("AGLRMHP"), out, 2);
+    TEST_EQUAL(discarded, 4); // A, R, P, M
+
+    pd.digest(AASequence::fromString("AGLRMHPQGHKWYV"), out, 3, 10);
+    ref = "AG";
+    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+    ref = "AGLRMHPQGHKW";
+    TEST_NOT_EQUAL(std::find_if(out.begin(),out.end(),compare_aa) != out.end(), true);
+
 END_SECTION
 
 START_SECTION((bool isValidProduct(const String& protein, int pep_pos, int pep_length, bool ignore_missed_cleavages, bool allow_nterm_protein_cleavage, bool allow_random_asp_pro_cleavage)))


### PR DESCRIPTION
## Description

These changes implement support of performing semi-specific digestion to ProteaseDigestion, as requested in #8098 .
Also exposed via pyOpenMS.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for semi-specific digestion in protease digestion, allowing generation of peptides with only one end at a cleavage site when specificity is set accordingly.

* **Documentation**
  * Updated user documentation and code comments to describe semi-specific digestion functionality and provide usage examples.

* **Tests**
  * Introduced new unit tests to verify semi-specific digestion and related behaviors.
  * Removed outdated tests for protease digestion.
  * Added test coverage for error handling and edge cases in semi-specific digestion.

* **Chores**
  * Added a new contributor to the authors list.
  * Updated digestion specificity in decoy peptide generation to enforce full enzymatic specificity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->