### PR TITLE
Zlibcompression using zlib, not Qt and Base64 decoding using SIMD, not Qt

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,30 +26,36 @@ Dependencies:
     - PyOpenMS now depends on Autowrap 0.23.0
     - PyOpenMS now supports Cython 3.1
 
-MassTraceExtractor:
-    - Support for Bruker Ion Mobility (experimental). Note: requires IM peak picked data.
+TOPP tools:
+  Changes:
+    MassTraceExtractor:
+      - support for Bruker Ion Mobility (experimental). Note: requires IM peak picked data.
+    NucleicAcidSearchEngine:
+      - add support for global fixed modifications as a search parameter
+    all:
+      - show load/store progress for files in all TOPP tools (#8041)
+  Added Tools:
+    - OpenNuXL - A peptide-RNA/DNA cross-linking search engine
+  Removed Tools:
+    - /
 
-NucleicAcidSearchEngine:
-    - add support for global fixed modifications as a search parameter
-
-Misc:
- - show load/store progress for files in all TOPP tools (#8041)
- 
-Fixes:
- - unify isotopic distributions (coarse vs. fine) for EmpiricalFormulas with charge (#8099)
+GUI tools:
  - fix TOPPAS crash when using TOPP tools with multiple output formats (#8120)
+ 
 
-Library:
-- Removed `assignRanks` and `sortByRanks` in PeptideIdentifications and sort and filter by score instead. Also removed `updateHitRanks` in IDFilter (#7991)
-- Remove ranke member in PeptideHit and store ranks as meta value (for backwards compatibility). (#7997)
-- std::vector<PeptideIdentification> now is encapsulated in a class PeptideIdentificationList.
-- Added `EnzymaticDigestion.semiSpecificDigestion_()`
-- ProteaseDigestion: add support for semi-specific digestion (#8130)
+OpenMS Library:
+  Fixes:
+    - unify isotopic distributions (coarse vs. fine) for EmpiricalFormulas with charge (#8099)
+  Changes:
+    - removed `assignRanks` and `sortByRanks` in PeptideIdentifications and sort and filter by score instead. Also removed `updateHitRanks` in IDFilter (#7991)
+    - remove rank member in PeptideHit and store ranks as meta value (for backwards compatibility). (#7997)
+    - std::vector<PeptideIdentification> now is encapsulated in a class PeptideIdentificationList.
+    - Zlibcompression using zlib (not Qt) and Base64 decoding for zlib-compressed data using SIMD (not Qt) (#8161)
+  New Features:
+    - added `EnzymaticDigestion.semiSpecificDigestion_()`
+    - ProteaseDigestion: add support for semi-specific digestion (#8130)
 
-Added tools:
-- OpenNuXL - A peptide-RNA/DNA cross-linking search engine
 
-Removed tools:
 
 ------------------------------------------------------------------------------------------
 ----                                OpenMS 3.4.1     (May 2025)                       ----

--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -21,8 +21,6 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/FORMAT/ZlibCompression.h>
 
-#include <QtCore/QByteArray>
-
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -122,10 +120,10 @@ public:
         @brief Decodes a Base64 string to a QByteArray
 
         @param in A String containing the Base64 encoded data
-        @param base64_uncompressed A ByteArray containing the decoded data
+        @param out A String containing the decoded data
         @param zlib_compression Whether the data should be decompressed with zlib after decoding in Base64
     */
-    static void decodeSingleString(const String& in, QByteArray& base64_uncompressed, bool zlib_compression);
+    static void decodeSingleString(const String& in, String& out, bool zlib_compression);
 
 private:
 
@@ -278,36 +276,22 @@ private:
   void Base64::decodeCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out)
   {
     out.clear();
-    if (in.empty()) return;
+    if (in.empty())
+    {
+      return;
+    }
 
     constexpr Size element_size = sizeof(ToType);
 
-    String decompressed;
-
     String s;
     stringSimdDecoder_(in, s);
-    QByteArray bazip = QByteArray::fromRawData(s.c_str(), (int) s.size());
+    String decompressed;
+    ZlibCompression::uncompressData((const void*)s.data(), s.size(), decompressed);
 
-   /////////////////////////////////////////////////////////////////////////////////////if faster: first encode then call fromRawData
-   // QByteArray qt_byte_array = QByteArray::fromRawData(in.c_str(), (int) in.size());
-   // QByteArray bazip = QByteArray::fromBase64(qt_byte_array);
-    QByteArray czip;
-    czip.resize(4);
-    czip[0] = (bazip.size() & 0xff000000) >> 24;
-    czip[1] = (bazip.size() & 0x00ff0000) >> 16;
-    czip[2] = (bazip.size() & 0x0000ff00) >> 8;
-    czip[3] = (bazip.size() & 0x000000ff);
-    czip += bazip;
-    QByteArray base64_uncompressed = qUncompress(czip);
-
-    if (base64_uncompressed.isEmpty())
+    if (decompressed.empty())
     {
       throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression error?");
     }
-    decompressed.resize(base64_uncompressed.size());
-
-    std::copy(base64_uncompressed.begin(), base64_uncompressed.end(), decompressed.begin());
-
     void* byte_buffer = reinterpret_cast<void *>(&decompressed[0]);
     Size buffer_size = decompressed.size();
 
@@ -436,32 +420,17 @@ private:
     if (in.empty())
       return;
 
-    void * byte_buffer;
-    Size buffer_size;
     constexpr Size element_size = sizeof(ToType);
 
     String decompressed;
-
-    QByteArray qt_byte_array = QByteArray::fromRawData(in.c_str(), (int) in.size());
-    QByteArray bazip = QByteArray::fromBase64(qt_byte_array);
-    QByteArray czip;
-    czip.resize(4);
-    czip[0] = (bazip.size() & 0xff000000) >> 24;
-    czip[1] = (bazip.size() & 0x00ff0000) >> 16;
-    czip[2] = (bazip.size() & 0x0000ff00) >> 8;
-    czip[3] = (bazip.size() & 0x000000ff);
-    czip += bazip;
-    QByteArray base64_uncompressed = qUncompress(czip);
-    if (base64_uncompressed.isEmpty())
+    Base64::decodeSingleString(in, decompressed, true);
+    if (decompressed.empty())
     {
       throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression error?");
     }
-    decompressed.resize(base64_uncompressed.size());
 
-    std::copy(base64_uncompressed.begin(), base64_uncompressed.end(), decompressed.begin());
-
-    byte_buffer = reinterpret_cast<void *>(&decompressed[0]);
-    buffer_size = decompressed.size();
+    void* byte_buffer = reinterpret_cast<void*>(&decompressed[0]);
+    Size buffer_size = buffer_size = decompressed.size();
 
     // change endianness if necessary
     if ((OPENMS_IS_BIG_ENDIAN && from_byte_order == Base64::BYTEORDER_LITTLEENDIAN) || (!OPENMS_IS_BIG_ENDIAN && from_byte_order == Base64::BYTEORDER_BIGENDIAN))

--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -428,7 +428,7 @@ private:
     }
 
     void* byte_buffer = reinterpret_cast<void*>(&decompressed[0]);
-    Size buffer_size = buffer_size = decompressed.size();
+    Size buffer_size = decompressed.size();
 
     // change endianness if necessary
     if ((OPENMS_IS_BIG_ENDIAN && from_byte_order == Base64::BYTEORDER_LITTLEENDIAN) || (!OPENMS_IS_BIG_ENDIAN && from_byte_order == Base64::BYTEORDER_BIGENDIAN))

--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -117,11 +117,11 @@ public:
     static void decodeStrings(const String & in, std::vector<String> & out, bool zlib_compression = false);
 
     /**
-        @brief Decodes a Base64 string to a QByteArray
+        @brief Decodes a Base64 string
 
-        @param in A String containing the Base64 encoded data
-        @param out A String containing the decoded data
-        @param zlib_compression Whether the data should be decompressed with zlib after decoding in Base64
+        @param[in] in A String containing the Base64 encoded data
+        @param[out] out A String containing the decoded data
+        @param[in] zlib_compression Should the data be decompressed with zlib after decoding in Base64?
     */
     static void decodeSingleString(const String& in, String& out, bool zlib_compression);
 
@@ -273,7 +273,7 @@ private:
 
 
   template <typename ToType>
-  void Base64::decodeCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out)
+  void Base64::decodeCompressed_(const String& in, ByteOrder from_byte_order, std::vector<ToType>& out)
   {
     out.clear();
     if (in.empty())
@@ -281,19 +281,14 @@ private:
       return;
     }
 
-    constexpr Size element_size = sizeof(ToType);
-
     String decompressed;
     Base64::decodeSingleString(in, decompressed, true);
 
-    if (decompressed.empty())
-    {
-      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression error?");
-    }
-    void* byte_buffer = reinterpret_cast<void *>(&decompressed[0]);
+    void* byte_buffer = reinterpret_cast<void*>(&decompressed[0]);
     Size buffer_size = decompressed.size();
 
     const ToType * float_buffer = reinterpret_cast<const ToType *>(byte_buffer);
+    constexpr Size element_size = sizeof(ToType);
     if (buffer_size % element_size != 0)
     {
       throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Bad BufferCount?");

--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -283,10 +283,8 @@ private:
 
     constexpr Size element_size = sizeof(ToType);
 
-    String s;
-    stringSimdDecoder_(in, s);
     String decompressed;
-    ZlibCompression::uncompressData((const void*)s.data(), s.size(), decompressed);
+    Base64::decodeSingleString(in, decompressed, true);
 
     if (decompressed.empty())
     {

--- a/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
+++ b/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Hannes Roest $
-// $Authors: Hannes Roest $
+// $Authors: Hannes Roest, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #pragma once
@@ -14,8 +14,6 @@
 
 #include <string>
 #include <vector>
-
-class QByteArray;
 
 namespace OpenMS
 {
@@ -51,34 +49,26 @@ public:
      */
     static void compressData(const void* raw_data, const size_t in_length, std::string& compressed_data);
 
-
     /**
-      * @brief Compresses data using Qt
-      *
-      * @param raw_data Data to be compressed
-      * @param compressed_data Compressed result data
+      * @brief Uncompresses data using zlib
+        
+        If available, provide the size of the uncompressed data in @p output_size for a small performance gain.
+
+        @note Does not support gzip format decompression (only zlib format).
+       
+        @param[in] compressed_data The zlib compressed data
+        @param[in] nr_bytes Number of bytes in @p compressed data
+        @param[out] out Uncompressed result data
+        @param[in] output_size [optional] If known, provide the size of the uncompressed data
+        
+        @throws Exception::InvalidValue if output_size specified turns out to be smaller than actual size of uncompressed data.
+        @throws Exception::InternalToolError if zlib cannot decompress the data (e.g. due to data corruption or unsupported gzip format)
       * 
     */
-    static void compressString(const QByteArray& raw_data, QByteArray& compressed_data);
+    static void uncompressData(const void* compressed_data, size_t nr_bytes, std::string& out, size_t output_size = 0);
 
-    /**
-      * @brief Uncompresses data using Qt (wrapper around Qt function)
-      *
-      * @param compressed_data Compressed data
-      * @param nr_bytes Number of bytes in compressed data
-      * @param raw_data Uncompressed result data
-      * 
-    */
-    static void uncompressString(const void * compressed_data, size_t nr_bytes, std::string& raw_data);
-
-    /**
-      * @brief Uncompresses data using Qt
-      *
-      * @param compressed_data Compressed data
-      * @param raw_data Uncompressed result data
-      * 
-    */
-    static void uncompressString(const QByteArray& compressed_data, QByteArray& raw_data);
+    /// Convencience function calling @p uncompressData 
+    static void uncompressString(const String& in, std::string& out, size_t output_size = 0);
 
   };
 

--- a/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
+++ b/src/openms/include/OpenMS/FORMAT/ZlibCompression.h
@@ -59,15 +59,15 @@ public:
         @param[in] compressed_data The zlib compressed data
         @param[in] nr_bytes Number of bytes in @p compressed data
         @param[out] out Uncompressed result data
-        @param[in] output_size [optional] If known, provide the size of the uncompressed data
+        @param[in] output_size [optional] If known (!=0), provide the size of the uncompressed data
         
-        @throws Exception::InvalidValue if output_size specified turns out to be smaller than actual size of uncompressed data.
+        @throws Exception::InvalidValue if output_size was specified (>0) and turns out to be smaller than actual size of uncompressed data.
         @throws Exception::InternalToolError if zlib cannot decompress the data (e.g. due to data corruption or unsupported gzip format)
       * 
     */
     static void uncompressData(const void* compressed_data, size_t nr_bytes, std::string& out, size_t output_size = 0);
 
-    /// Convencience function calling @p uncompressData 
+    /// Convencience function calling @p uncompressData
     static void uncompressString(const String& in, std::string& out, size_t output_size = 0);
 
   };

--- a/src/openms/source/FORMAT/Base64.cpp
+++ b/src/openms/source/FORMAT/Base64.cpp
@@ -7,10 +7,6 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/Base64.h>
-
-#include <QtCore/QList>
-#include <QtCore/QString>
-
 #include <OpenMS/SYSTEM/SIMDe.h>
 
 using namespace std;
@@ -247,20 +243,24 @@ namespace OpenMS
     {
       return;
     }
+    String decoded;
+    decodeSingleString(in, decoded, zlib_compression);
 
-    QByteArray base64_uncompressed;
-    decodeSingleString(in, base64_uncompressed, zlib_compression);    //////////////////////////////////////////////the magic happenes here
-    QList<QByteArray> null_strings = base64_uncompressed.split('\0');
-    for (QList<QByteArray>::iterator it = null_strings.begin(); it < null_strings.end(); ++it)
+    const char* first_sep = decoded.data(); // start of current string
+    const char* next_sep = 0;  // end of current string (past the end)
+    while (first_sep < decoded.data() + decoded.size())
     {
-      if (!it->isEmpty())
-      {
-        out.emplace_back(QString(*it).toStdString());
+      next_sep = strchr(first_sep, '\0');
+     
+      if (first_sep + 1 < next_sep) // non-empty string
+      { 
+        out.push_back(String(first_sep, next_sep - first_sep));
       }
+      first_sep = next_sep + 1; // move to substring
     }
   }
 
-  void Base64::decodeSingleString(const String& in, QByteArray& base64_uncompressed, bool zlib_compression)
+  void Base64::decodeSingleString(const String& in, String& out, bool zlib_compression)
   {
     // The length of a base64 string is a always a multiple of 4 (always 3
     // bytes are encoded as 4 characters)
@@ -268,24 +268,16 @@ namespace OpenMS
     {
       return;
     }
-    ////////////////////compare our decoding to QT decoding, and possibly decode first using simde, then copy into QByte Array
-    QByteArray herewego = QByteArray::fromRawData(in.c_str(), (int) in.size());
-    base64_uncompressed = QByteArray::fromBase64(herewego);
+
     if (zlib_compression)
     {
-      QByteArray czip;
-      czip.resize(4);
-      czip[0] = (base64_uncompressed.size() & 0xff000000) >> 24;
-      czip[1] = (base64_uncompressed.size() & 0x00ff0000) >> 16;
-      czip[2] = (base64_uncompressed.size() & 0x0000ff00) >> 8;
-      czip[3] = (base64_uncompressed.size() & 0x000000ff);
-      czip += base64_uncompressed;
-      base64_uncompressed = qUncompress(czip);
-
-      if (base64_uncompressed.isEmpty())
-      {
-        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression error?");
-      }
+      String decoded;
+      stringSimdDecoder_(in, decoded);
+      ZlibCompression::uncompressString(decoded, out);
+    }
+    else
+    {
+      stringSimdDecoder_(in, out);
     }
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -152,6 +152,7 @@ namespace OpenMS::Internal
           catch (...)
           {
             ++errCount;
+            error_message = "Unknown exception during spectrum data population";
           }
         }
         }

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -121,42 +121,39 @@ namespace OpenMS::Internal
       // Whether spectrum should be populated with data
       if (options_.getFillData())
       {
-        size_t errCount = 0;
+        std::atomic<int> errCount = 0;
         String error_message;
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
+        #pragma omp parallel for
         for (SignedSize i = 0; i < (SignedSize)spectrum_data_.size(); i++)
         {
           // parallel exception catching and re-throwing business
           if (!errCount) // no need to parse further if already an error was encountered
           {
-            try
+          try
+          {
+            populateSpectraWithData_(spectrum_data_[i].data,
+                                      spectrum_data_[i].default_array_length,
+                                      options_,
+                                      spectrum_data_[i].spectrum);
+            if (options_.getSortSpectraByMZ() && !spectrum_data_[i].spectrum.isSorted())
             {
-              populateSpectraWithData_(spectrum_data_[i].data,
-                                       spectrum_data_[i].default_array_length,
-                                       options_,
-                                       spectrum_data_[i].spectrum);
-              if (options_.getSortSpectraByMZ() && !spectrum_data_[i].spectrum.isSorted())
-              {
-                spectrum_data_[i].spectrum.sortByPosition();
-              }
-            }
-
-            catch (OpenMS::Exception::BaseException& e)
-            {
-#pragma omp critical(MZMLErrorHandling)
-              {
-                ++errCount;
-                error_message = e.what();
-              }
-            }
-            catch (...)
-            {
-#pragma omp atomic
-              ++errCount;
+              spectrum_data_[i].spectrum.sortByPosition();
             }
           }
+
+          catch (OpenMS::Exception::BaseException& e)
+          {
+            #pragma omp critical(MZMLErrorHandling)
+            {
+              ++errCount;
+              error_message = e.what();
+            }
+          }
+          catch (...)
+          {
+            ++errCount;
+          }
+        }
         }
         if (errCount != 0)
         {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -118,7 +118,7 @@ namespace OpenMS::Internal
         stemp.clear();
         if (compression == 1)
         {
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
+          OpenMS::ZlibCompression::uncompressData(raw_text, blob_bytes, stemp);
 
           void* byte_buffer = reinterpret_cast<void *>(&stemp[0]);
           Size buffer_size = stemp.size();
@@ -133,14 +133,14 @@ namespace OpenMS::Internal
         }
         else if (compression == 5)
         {
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
+          OpenMS::ZlibCompression::uncompressData(raw_text, blob_bytes, stemp);
           MSNumpressCoder::NumpressConfig config;
           config.setCompression("linear");
           MSNumpressCoder().decodeNPRaw(stemp, data, config);
         }
         else if (compression == 6)
         {
-          OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, stemp);
+          OpenMS::ZlibCompression::uncompressData(raw_text, blob_bytes, stemp);
           MSNumpressCoder::NumpressConfig config;
           config.setCompression("slof");
           MSNumpressCoder().decodeNPRaw(stemp, data, config);
@@ -273,7 +273,7 @@ namespace OpenMS::Internal
           {
             MzMLFile f;
             std::string uncompressed;
-            OpenMS::ZlibCompression::uncompressString(raw_text, blob_bytes, uncompressed);
+            OpenMS::ZlibCompression::uncompressData(raw_text, blob_bytes, uncompressed);
             f.loadBuffer(uncompressed, exp);
 
             nr_results++;

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -61,11 +61,10 @@ namespace OpenMS
   void MSNumpressCoder::decodeNP(const String & in, std::vector<double> & out,
       bool zlib_compression, const NumpressConfig & config)
   {
-    QByteArray base64_uncompressed;
-    Base64::decodeSingleString(in, base64_uncompressed, zlib_compression);
+    String tmpstring;
+    Base64::decodeSingleString(in, tmpstring, zlib_compression);
 
     // Create a temporary string (*not* null-terminated) to hold the data
-    std::string tmpstring(base64_uncompressed.constData(), base64_uncompressed.size());
     decodeNPRaw(tmpstring, out, config);
 
     // NOTE: it is possible (and likely faster) to call directly the const

--- a/src/openms/source/FORMAT/ZlibCompression.cpp
+++ b/src/openms/source/FORMAT/ZlibCompression.cpp
@@ -8,8 +8,9 @@
 
 #include <OpenMS/FORMAT/ZlibCompression.h>
 
-#include <QtCore/QByteArray>
+#include <OpenMS/CONCEPT/LogStream.h>
 
+#include <array>
 #include <zlib.h>
 
 using namespace std;
@@ -31,20 +32,18 @@ namespace OpenMS
       sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + 11; // taken from zlib's compress.c, as we cannot use compressBound*
 
     int zlib_error;
-    do
+
+    compressed.resize(compressed_length); // reserve enough space -- we may not need all of it
+    zlib_error = compress(reinterpret_cast<Bytef*>(&compressed[0]), &compressed_length, (Bytef*)raw_data, sourceLen);
+
+    switch (zlib_error)
     {
-      compressed.resize(compressed_length); // reserve enough space -- we may not need all of it
-      zlib_error = compress(reinterpret_cast<Bytef*>(&compressed[0]), &compressed_length, (Bytef*)raw_data, sourceLen);
-
-      switch (zlib_error)
-      {
-        case Z_MEM_ERROR:
-          throw Exception::OutOfMemory(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, compressed_length);
-
-        case Z_BUF_ERROR:
-          compressed_length *= 2;
-      }
-    } while (zlib_error == Z_BUF_ERROR);
+      case Z_MEM_ERROR:
+      case Z_BUF_ERROR:
+        throw Exception::OutOfMemory(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, compressed_length);
+      case Z_OK: // ok
+        break;
+    }
 
     if (zlib_error != Z_OK)
     {
@@ -53,41 +52,89 @@ namespace OpenMS
     compressed.resize(compressed_length); // cut down to the actual data
   }
 
-  void ZlibCompression::compressString(const QByteArray& raw_data, QByteArray& compressed_data)
+  void uncompressStringSingleShot___(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)
   {
-    compressed_data = qCompress(raw_data);
-    compressed_data.remove(0, 4);
-  }
+    raw_data.resize(output_size);
+    uLongf uncompressedSize = output_size;
+    int ret = uncompress((Bytef*)raw_data.data(), &uncompressedSize, (Bytef*)compressed_data, nr_bytes);
 
-  void ZlibCompression::uncompressString(const void * tt, size_t blob_bytes, std::string& uncompressed)
-  {
-    // take a leap of faith and assume the input is valid
-    QByteArray compressed_data = QByteArray::fromRawData((const char*)tt, (int)blob_bytes);
-    QByteArray raw_data;
-
-    ZlibCompression::uncompressString(compressed_data, raw_data);
-
-    // Note that we may have zero bytes in the string, so we cannot use QString
-    uncompressed.clear();
-    uncompressed = std::string(raw_data.data(), raw_data.size());
-  }
-
-  void ZlibCompression::uncompressString(const QByteArray& compressed_data, QByteArray& raw_data)
-  {
-    QByteArray czip;
-    czip.resize(4);
-    czip[0] = (compressed_data.size() & 0xff000000) >> 24;
-    czip[1] = (compressed_data.size() & 0x00ff0000) >> 16;
-    czip[2] = (compressed_data.size() & 0x0000ff00) >> 8;
-    czip[3] = (compressed_data.size() & 0x000000ff);
-    czip += compressed_data;
-    raw_data = qUncompress(czip);
-
-    if (raw_data.isEmpty())
+    if (ret == Z_OK)
     {
-      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression error?");
+      if (uncompressedSize != raw_data.size())
+      {
+        OPENMS_LOG_INFO << "ZlibCompression::uncompressString: Warning: decompressed data was smaller (" << std::to_string(uncompressedSize) << ") than anticipated: " << std::to_string(output_size) << std::endl;
+        raw_data.resize(output_size);
+      }
+    }
+    else if (ret == Z_BUF_ERROR)
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Decompression failed because specified output_size was too small. Size of data after decompression is larger than anticipated: " + std::to_string(uncompressedSize), std::to_string(output_size));
+    }
+    else
+    {
+      throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflate failed with code " + std::to_string(ret) + " .");
+    }
+
+  }
+
+  void uncompressStringIterative___(const void* compressed_data, size_t nr_bytes, std::string& uncompressed)
+  {
+    const size_t CHUNK_SIZE = 16384;
+    uncompressed.clear();
+    z_stream strm = {};
+
+    // Setup input
+    strm.next_in = (Bytef*)(compressed_data);
+    strm.avail_in = nr_bytes;
+
+    int ret;
+
+    // Initialize zlib (use inflateInit2 for gzip or raw deflate)
+    ret = inflateInit(&strm);
+    if (ret != Z_OK)
+    {
+      throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflateInit failed with code " + std::to_string(ret) + " .");
+    }
+
+    // Decompress loop
+    std::array<char, CHUNK_SIZE> buffer;
+
+    do
+    {
+      strm.avail_out = CHUNK_SIZE;
+      strm.next_out = (Bytef*)buffer.data();
+
+      ret = inflate(&strm, Z_NO_FLUSH);
+      if (ret == Z_STREAM_ERROR || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR)
+      {
+        inflateEnd(&strm);
+        throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflate failed with code " + std::to_string(ret) + " .");
+      }
+
+      size_t bytesDecompressed = CHUNK_SIZE - strm.avail_out;
+      uncompressed.insert(uncompressed.end(), buffer.begin(), buffer.begin() + bytesDecompressed);
+
+    } while (ret != Z_STREAM_END);
+
+    inflateEnd(&strm);
+  }
+
+  
+  void ZlibCompression::uncompressData(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)
+  {
+    if (output_size == 0)
+    { // unknown output size - decompress chunk by chunk
+      uncompressStringIterative___(compressed_data, nr_bytes, raw_data);
+    }
+    else
+    { // known output size - decompress into a preallocated string
+      uncompressStringSingleShot___(compressed_data, nr_bytes, raw_data, output_size);
     }
   }
 
-}
-
+  void ZlibCompression::uncompressString(const String& in, std::string& out, size_t output_size)
+  {
+    uncompressData(in.data(), in.size(), out, output_size);
+  }
+  
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/ZlibCompression.cpp
+++ b/src/openms/source/FORMAT/ZlibCompression.cpp
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Hannes Roest $
-// $Authors: Hannes Roest $
+// $Authors: Hannes Roest, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/ZlibCompression.h>
@@ -77,7 +77,6 @@ namespace OpenMS
     {
       throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflate failed with code " + std::to_string(ret) + " .");
     }
-
   }
 
   void uncompressStringIterative___(const void* compressed_data, size_t nr_bytes, std::string& uncompressed)
@@ -113,13 +112,11 @@ namespace OpenMS
 
       size_t bytes_decompressed = CHUNK_SIZE - strm.avail_out;
       uncompressed.insert(uncompressed.end(), buffer.begin(), buffer.begin() + bytes_decompressed);
-
     } while (ret != Z_STREAM_END);
 
     inflateEnd(&strm);
   }
 
-  
   void ZlibCompression::uncompressData(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)
   {
     if (output_size == 0)

--- a/src/openms/source/FORMAT/ZlibCompression.cpp
+++ b/src/openms/source/FORMAT/ZlibCompression.cpp
@@ -39,10 +39,11 @@ namespace OpenMS
     switch (zlib_error)
     {
       case Z_MEM_ERROR:
-      case Z_BUF_ERROR:
         throw Exception::OutOfMemory(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, compressed_length);
-      case Z_OK: // ok
-        break;
+      case Z_BUF_ERROR:
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
+                                      "Destination buffer too small for compressed output",
+                                      String(compressed_length));
     }
 
     if (zlib_error != Z_OK)
@@ -63,7 +64,7 @@ namespace OpenMS
       if (uncompressedSize != raw_data.size())
       {
         OPENMS_LOG_INFO << "ZlibCompression::uncompressString: Warning: decompressed data was smaller (" << std::to_string(uncompressedSize) << ") than anticipated: " << std::to_string(output_size) << std::endl;
-        raw_data.resize(output_size);
+        raw_data.resize(uncompressedSize);
       }
     }
     else if (ret == Z_BUF_ERROR)

--- a/src/openms/source/FORMAT/ZlibCompression.cpp
+++ b/src/openms/source/FORMAT/ZlibCompression.cpp
@@ -30,31 +30,34 @@ namespace OpenMS
     const unsigned long sourceLen = (unsigned long)in_length;
     unsigned long compressed_length =                         // compressBound((unsigned long)str.size());
       sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + 11; // taken from zlib's compress.c, as we cannot use compressBound*
-
-    int zlib_error;
-
     compressed.resize(compressed_length); // reserve enough space -- we may not need all of it
-    zlib_error = compress(reinterpret_cast<Bytef*>(&compressed[0]), &compressed_length, (Bytef*)raw_data, sourceLen);
+
+    int zlib_error = compress(reinterpret_cast<Bytef*>(&compressed[0]), &compressed_length, (Bytef*)raw_data, sourceLen);
 
     switch (zlib_error)
     {
+      case Z_OK:         // Compression successful
+        break;
       case Z_MEM_ERROR:
         throw Exception::OutOfMemory(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, compressed_length);
       case Z_BUF_ERROR:
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
                                       "Destination buffer too small for compressed output",
                                       String(compressed_length));
+      default:
+        throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Compression error!");
     }
 
-    if (zlib_error != Z_OK)
-    {
-      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Compression error?");
-    }
     compressed.resize(compressed_length); // cut down to the actual data
   }
 
   void uncompressStringSingleShot___(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)
   {
+    if (nr_bytes == 0)
+    {
+      raw_data.clear();
+      return;
+    }
     raw_data.resize(output_size);
     uLongf uncompressedSize = output_size;
     int ret = uncompress((Bytef*)raw_data.data(), &uncompressedSize, (Bytef*)compressed_data, nr_bytes);
@@ -80,40 +83,37 @@ namespace OpenMS
 
   void uncompressStringIterative___(const void* compressed_data, size_t nr_bytes, std::string& uncompressed)
   {
-    const size_t CHUNK_SIZE = 16384;
     uncompressed.clear();
-    z_stream strm = {};
 
     // Setup input
+    z_stream strm = {};
     strm.next_in = (Bytef*)(compressed_data);
     strm.avail_in = nr_bytes;
 
-    int ret;
-
     // Initialize zlib (use inflateInit2 for gzip or raw deflate)
-    ret = inflateInit(&strm);
+    int ret = inflateInit(&strm);
     if (ret != Z_OK)
     {
       throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflateInit failed with code " + std::to_string(ret) + " .");
     }
 
     // Decompress loop
+    const size_t CHUNK_SIZE = 16384;
     std::array<char, CHUNK_SIZE> buffer;
-
     do
     {
       strm.avail_out = CHUNK_SIZE;
       strm.next_out = (Bytef*)buffer.data();
 
       ret = inflate(&strm, Z_NO_FLUSH);
-      if (ret == Z_STREAM_ERROR || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR)
+      if (ret == Z_STREAM_ERROR || ret == Z_DATA_ERROR || ret == Z_MEM_ERROR || ret == Z_BUF_ERROR)
       {
         inflateEnd(&strm);
         throw Exception::InternalToolError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "zlib::inflate failed with code " + std::to_string(ret) + " .");
       }
 
-      size_t bytesDecompressed = CHUNK_SIZE - strm.avail_out;
-      uncompressed.insert(uncompressed.end(), buffer.begin(), buffer.begin() + bytesDecompressed);
+      size_t bytes_decompressed = CHUNK_SIZE - strm.avail_out;
+      uncompressed.insert(uncompressed.end(), buffer.begin(), buffer.begin() + bytes_decompressed);
 
     } while (ret != Z_STREAM_END);
 

--- a/src/openms/source/FORMAT/ZlibCompression.cpp
+++ b/src/openms/source/FORMAT/ZlibCompression.cpp
@@ -28,8 +28,7 @@ namespace OpenMS
     compressed.clear();
 
     const unsigned long sourceLen = (unsigned long)in_length;
-    unsigned long compressed_length =                         // compressBound((unsigned long)str.size());
-      sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + 11; // taken from zlib's compress.c, as we cannot use compressBound*
+    unsigned long compressed_length = compressBound(in_length);
     compressed.resize(compressed_length); // reserve enough space -- we may not need all of it
 
     int zlib_error = compress(reinterpret_cast<Bytef*>(&compressed[0]), &compressed_length, (Bytef*)raw_data, sourceLen);

--- a/src/tests/class_tests/openms/source/Base64_test.cpp
+++ b/src/tests/class_tests/openms/source/Base64_test.cpp
@@ -315,7 +315,7 @@ START_SECTION((template < typename ToType > void decodeIntegers(const String &in
   vector<Int64> double_res;
   //with zlib compression
   src="eJwNw4c2QgEAANAniezMIrKyUrKyMooIIdki4/8/wr3n3CAIgjZDthu2w4iddhm12x577bPfAQeNOeSwI4465rhxE044adIpp00546xzzrtg2kWXXHbFVTOumTXnunk33HTLbXcsuOue+x54aNEjjz3x1JJlzzy34oWXVr3y2htr3nrnvXUfbPjok8+++Oqb737Y9NMvW377469//gPgoxL0";
-
+  
   b64.decodeIntegers(src, Base64::BYTEORDER_LITTLEENDIAN,res,true);
   
   for(Size i = 0 ; i < res.size();++i)

--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -13,8 +13,6 @@
 #include <OpenMS/FORMAT/ZlibCompression.h>
 ///////////////////////////
 
-#include <QByteArray>
-
 #define MULTI_LINE_STRING(...) #__VA_ARGS__ 
 
 
@@ -84,56 +82,34 @@ START_SECTION((static void compressString(std::string& raw_data, std::string& co
 }
 END_SECTION
 
-START_SECTION((static void compressString(const QByteArray& raw_data, QByteArray& compressed_data)))
-{
-  QByteArray raw_data_q = QByteArray::fromRawData(&raw_data[0], raw_data.size());
-  QByteArray raw_data_q2 = QByteArray::fromRawData(&raw_data2[0], raw_data2.size());
-  QByteArray raw_data_q3 = QByteArray::fromRawData(&raw_data3[0], raw_data3.size());
-  QByteArray raw_data_q4 = QByteArray::fromRawData(&raw_data4[0], raw_data4.size());
-  QByteArray compressed_data;
-
-  ZlibCompression::compressString(raw_data_q, compressed_data);
-  TEST_TRUE(compressed_data.size() < raw_data_q.size())
-
-  ZlibCompression::compressString(raw_data_q2, compressed_data);
-  TEST_TRUE(compressed_data.size() >= raw_data_q2.size())
-
-  ZlibCompression::compressString(raw_data_q3, compressed_data);
-  TEST_TRUE(compressed_data.size() < raw_data_q3.size())
-
-  ZlibCompression::compressString(raw_data_q4, compressed_data);
-  TEST_TRUE(compressed_data.size() < raw_data_q4.size())
-}
-END_SECTION
-
 START_SECTION((static void uncompressString(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)))
 {
   std::string compressed_data;
   std::string uncompressed_data;
 
   ZlibCompression::compressString(raw_data, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data.size());
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data, raw_data.size());
   TEST_EQUAL(raw_data.size(), 58)
   TEST_TRUE(compressed_data.size() < raw_data.size())
   TEST_EQUAL(uncompressed_data.size(), 58)
   TEST_TRUE(uncompressed_data == raw_data)
 
   ZlibCompression::compressString(raw_data2, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data2.size());
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data, raw_data2.size());
   TEST_EQUAL(raw_data2.size(), 64)
   TEST_TRUE(compressed_data.size() >= raw_data2.size())  // difficult to compress...
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data2)
 
   ZlibCompression::compressString(raw_data3, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data3.size());
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data, raw_data3.size());
   TEST_EQUAL(raw_data3.size(), 105)
   TEST_TRUE(compressed_data.size() < raw_data3.size())
   TEST_EQUAL(uncompressed_data.size(), 105)
   TEST_TRUE(uncompressed_data == raw_data3)
 
   ZlibCompression::compressString(raw_data4, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data4.size());
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data, raw_data4.size());
   TEST_EQUAL(raw_data4.size(), 1052)
   TEST_TRUE(compressed_data.size() < raw_data4.size())
   TEST_EQUAL(uncompressed_data.size(), 1052)
@@ -144,40 +120,40 @@ START_SECTION((static void uncompressString(const void* compressed_data, size_t 
   ////////////////
   ZlibCompression::compressString(raw_data, compressed_data);
   // Invalid output_size
-  TEST_EXCEPTION(Exception::InvalidValue, ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, 10);)
+  TEST_EXCEPTION(Exception::InvalidValue, ZlibCompression::uncompressString(compressed_data, uncompressed_data, 10);)
   // Truncated data
-  TEST_EXCEPTION(Exception::InternalToolError, ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size()-10, uncompressed_data, raw_data.size());)
+  TEST_EXCEPTION(Exception::InternalToolError, ZlibCompression::uncompressData(&compressed_data[0], compressed_data.size()-10, uncompressed_data, raw_data.size());)
 }
 END_SECTION
 
 START_SECTION((static void uncompressString(const void * compressed_data, size_t nr_bytes, std::string& raw_data)))
 {
-  std::string compressed_data;
-  std::string uncompressed_data;
+  String compressed_data;
+  String uncompressed_data;
 
   ZlibCompression::compressString(raw_data, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data.size(), 58)
   TEST_TRUE(compressed_data.size() < raw_data.size())  
   TEST_EQUAL(uncompressed_data.size(), 58)
   TEST_TRUE(uncompressed_data == raw_data)
 
   ZlibCompression::compressString(raw_data2, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data2.size(), 64)
   TEST_TRUE(compressed_data.size() >= raw_data2.size())  //  "ABCD..." string is difficult to compress
   TEST_EQUAL(uncompressed_data.size(), 64)
   TEST_TRUE(uncompressed_data == raw_data2)
 
   ZlibCompression::compressString(raw_data3, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data3.size(), 105)
   TEST_TRUE(compressed_data.size() < raw_data3.size())  
   TEST_EQUAL(uncompressed_data.size(), 105)
   TEST_TRUE(uncompressed_data == raw_data3)
 
   ZlibCompression::compressString(raw_data4, compressed_data);
-  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data);
+  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
   TEST_EQUAL(raw_data4.size(), 1052)
   TEST_TRUE(compressed_data.size() < raw_data4.size())  
   TEST_EQUAL(uncompressed_data.size(), 1052)

--- a/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
+++ b/src/tests/class_tests/openms/source/ZlibCompression_test.cpp
@@ -106,6 +106,50 @@ START_SECTION((static void compressString(const QByteArray& raw_data, QByteArray
 }
 END_SECTION
 
+START_SECTION((static void uncompressString(const void* compressed_data, size_t nr_bytes, std::string& raw_data, size_t output_size)))
+{
+  std::string compressed_data;
+  std::string uncompressed_data;
+
+  ZlibCompression::compressString(raw_data, compressed_data);
+  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data.size());
+  TEST_EQUAL(raw_data.size(), 58)
+  TEST_TRUE(compressed_data.size() < raw_data.size())
+  TEST_EQUAL(uncompressed_data.size(), 58)
+  TEST_TRUE(uncompressed_data == raw_data)
+
+  ZlibCompression::compressString(raw_data2, compressed_data);
+  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data2.size());
+  TEST_EQUAL(raw_data2.size(), 64)
+  TEST_TRUE(compressed_data.size() >= raw_data2.size())  // difficult to compress...
+  TEST_EQUAL(uncompressed_data.size(), 64)
+  TEST_TRUE(uncompressed_data == raw_data2)
+
+  ZlibCompression::compressString(raw_data3, compressed_data);
+  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data3.size());
+  TEST_EQUAL(raw_data3.size(), 105)
+  TEST_TRUE(compressed_data.size() < raw_data3.size())
+  TEST_EQUAL(uncompressed_data.size(), 105)
+  TEST_TRUE(uncompressed_data == raw_data3)
+
+  ZlibCompression::compressString(raw_data4, compressed_data);
+  ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, raw_data4.size());
+  TEST_EQUAL(raw_data4.size(), 1052)
+  TEST_TRUE(compressed_data.size() < raw_data4.size())
+  TEST_EQUAL(uncompressed_data.size(), 1052)
+  TEST_TRUE(uncompressed_data == raw_data4)
+
+  ////////////////
+  // Exceptions //
+  ////////////////
+  ZlibCompression::compressString(raw_data, compressed_data);
+  // Invalid output_size
+  TEST_EXCEPTION(Exception::InvalidValue, ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size(), uncompressed_data, 10);)
+  // Truncated data
+  TEST_EXCEPTION(Exception::InternalToolError, ZlibCompression::uncompressString(&compressed_data[0], compressed_data.size()-10, uncompressed_data, raw_data.size());)
+}
+END_SECTION
+
 START_SECTION((static void uncompressString(const void * compressed_data, size_t nr_bytes, std::string& raw_data)))
 {
   std::string compressed_data;
@@ -138,46 +182,6 @@ START_SECTION((static void uncompressString(const void * compressed_data, size_t
   TEST_TRUE(compressed_data.size() < raw_data4.size())  
   TEST_EQUAL(uncompressed_data.size(), 1052)
   TEST_TRUE(uncompressed_data == raw_data4)
-}
-END_SECTION
-  
-START_SECTION((static void uncompressString(const QByteArray& compressed_data, QByteArray& raw_data)))
-{
-  QByteArray raw_data_q = QByteArray::fromRawData(&raw_data[0], raw_data.size());
-  QByteArray raw_data_q2 = QByteArray::fromRawData(&raw_data2[0], raw_data2.size());
-  QByteArray raw_data_q3 = QByteArray::fromRawData(&raw_data3[0], raw_data3.size());
-  QByteArray raw_data_q4 = QByteArray::fromRawData(&raw_data4[0], raw_data4.size());
-
-  QByteArray compressed_data;
-  QByteArray uncompressed_data;
-
-  ZlibCompression::compressString(raw_data_q, compressed_data);
-  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
-  TEST_EQUAL(raw_data_q.size(), 58)
-  TEST_TRUE(compressed_data.size() < raw_data_q.size())  
-  TEST_EQUAL(uncompressed_data.size(), 58)
-  TEST_TRUE(uncompressed_data == raw_data_q)
-
-  ZlibCompression::compressString(raw_data_q2, compressed_data);
-  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
-  TEST_EQUAL(raw_data_q2.size(), 64)
-  TEST_TRUE(compressed_data.size() >= raw_data_q2.size())  // difficult to compress...
-  TEST_EQUAL(uncompressed_data.size(), 64)
-  TEST_TRUE(uncompressed_data == raw_data_q2)
-
-  ZlibCompression::compressString(raw_data_q3, compressed_data);
-  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
-  TEST_EQUAL(raw_data_q3.size(), 105)
-  TEST_TRUE(compressed_data.size() < raw_data_q3.size())  
-  TEST_EQUAL(uncompressed_data.size(), 105)
-  TEST_TRUE(uncompressed_data == raw_data_q3)
-
-  ZlibCompression::compressString(raw_data_q4, compressed_data);
-  ZlibCompression::uncompressString(compressed_data, uncompressed_data);
-  TEST_EQUAL(raw_data_q4.size(), 1052)
-  TEST_TRUE(compressed_data.size() < raw_data_q4.size())  
-  TEST_EQUAL(uncompressed_data.size(), 1052)
-  TEST_TRUE(uncompressed_data == raw_data_q4)
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

supersedes #8153, fixes https://github.com/OpenMS/OpenMS/issues/8129

uses local zlib directly; avoids Qt overhead (due to 4 byte prefix of quncompress and copying).

Also, for concatenated strings, uses SIMD Base64 decoding now, instead of Qt decoding (as normal strings already do).

Overall speed improvement when loading mzML which contains zlib-compressed base64 data is ~4%.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compressed-data handling and decoding for faster, more robust loading of compressed files; reduced library dependencies.
* **Bug Fixes**
  * Increased stability and thread-safety when populating spectra in parallel; better error detection/reporting on parse failures.
* **Tests**
  * Updated tests to match new compression/decompression behavior and to cover invalid/truncated input cases.
* **Chores**
  * Updated authorship metadata and reorganized changelog entries (TOPP/GUI/OpenMS Library).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->