### PR TITLE
enable Digestor to resolve ambiguous AA's randomly to simulate real search engine output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,8 @@ TOPP tools:
       - support for Bruker Ion Mobility (experimental). Note: requires IM peak picked data.
     NucleicAcidSearchEngine:
       - add support for global fixed modifications as a search parameter
+    Digestor:
+      - supports replacing ambiguous amino acids (X,B,J,Z) in the FASTA input with random unambiguous amino acids in the output (#8167)
     all:
       - show load/store progress for files in all TOPP tools (#8041)
   Added Tools:

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -170,6 +170,29 @@ namespace OpenMS
       return r;
     }
 
+    /// Create an unambiguous AA from an index (0..21 ~ A..V)
+    static AA fromIndex(unsigned int index)
+    {
+      assert(index < unambiguousAACount());
+      AA r;
+      r.aa_ = index;
+      return r;
+    }
+
+    /// Returns the number of unambiguous amino acids (A-Z, excluding B, J, Z, X), i.e. 22
+    static int unambiguousAACount()
+    {
+      static_assert(AA('V').aa_ - AA('A').aa_ + 1 == 22, "Unambiguous AA count must be 22 (A-Z, excluding B, J, Z, X)");
+      static_assert(AA('A').aa_ == 0, "A must be the first AA in the enumeration");
+      static_assert(AA('V').aa_ == 21, "V must be the last unambiguous AA in the enumeration");
+      return AA('V').aa_ - AA('A').aa_ + 1;
+    }
+
+    const char toChar() const
+    {
+      return AAtoChar[aa_];
+    }
+     
   private:
     uint8_t aa_; ///< internal representation as 1-byte integer
   };

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -170,17 +170,24 @@ namespace OpenMS
       return r;
     }
 
-    /// Create an unambiguous AA from an index (0..21 ~ A..V)
-    static AA fromIndex(unsigned int index)
+    /// Convert this AA to a single letter representation, i.e. 'A'..'V', 'B', 'J', 'Z', 'X', '$', or '?' (invalid AA)
+    constexpr char toChar() const
     {
-      assert(index < unambiguousAACount());
+      return AAtoChar[aa_];
+    }
+
+    /// Create an unambiguous AA from an index (0..21 inclusive -> 'A'..'V').
+    /// @throw OpenMS::Precondition if not index < unambiguousAACount().
+    static AA fromIndex(size_t index) noexcept
+    {
+      OPENMS_PRECONDITION(index < unambiguousAACount(), "AA::fromIndex(): index must be in [0, unambiguousAACount())");
       AA r;
-      r.aa_ = index;
+      r.aa_ = static_cast<uint8_t>(index);
       return r;
     }
 
     /// Returns the number of unambiguous amino acids (A-Z, excluding B, J, Z, X), i.e. 22
-    static int unambiguousAACount()
+    static size_t unambiguousAACount()
     {
       static_assert(AA('V').aa_ - AA('A').aa_ + 1 == 22, "Unambiguous AA count must be 22 (A-Z, excluding B, J, Z, X)");
       static_assert(AA('A').aa_ == 0, "A must be the first AA in the enumeration");
@@ -188,11 +195,6 @@ namespace OpenMS
       return AA('V').aa_ - AA('A').aa_ + 1;
     }
 
-    const char toChar() const
-    {
-      return AAtoChar[aa_];
-    }
-     
   private:
     uint8_t aa_; ///< internal representation as 1-byte integer
   };

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDigestion.h
@@ -59,7 +59,7 @@ namespace OpenMS
        Others raise an exception
 
        @param protein Sequence to digest
-       @param output Digestion products (start and end indices of peptides)
+       @param output Digestion products (start and past-the-end indices of peptides)
        @param min_length Minimal length of reported products
        @param max_length Maximal length of reported products (0 = no restriction)
        @return Number of discarded digestion products (which are not matching length restrictions)

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -3154,6 +3154,16 @@ add_test("TOPP_RNAMassCalculator_1_out" ${DIFF} -in1 RNAMassCalculator.tmp.txt -
 set_tests_properties("TOPP_RNAMassCalculator_1_out" PROPERTIES DEPENDS "TOPP_RNAMassCalculator_1")
 
 #------------------------------------------------------------------------------
+# Digestor:
+add_test("TOPP_Digestor_1" ${TOPP_BIN_PATH}/Digestor -test -in ${DATA_DIR_TOPP}/Digestor_1_input.fasta -out Digestor_1_output.tmp.fasta)
+add_test("TOPP_Digestor_1_out" ${DIFF} -in1 Digestor_1_output.tmp.fasta -in2 ${DATA_DIR_TOPP}/Digestor_1_output.fasta)
+set_tests_properties("TOPP_Digestor_1_out" PROPERTIES DEPENDS "TOPP_Digestor_1")
+add_test("TOPP_Digestor_2" ${TOPP_BIN_PATH}/Digestor -test -in ${DATA_DIR_TOPP}/Digestor_1_input.fasta -out Digestor_2_output.tmp.fasta -min_length 1 -missed_cleavages 0 -replace_ambiguous)
+add_test("TOPP_Digestor_2_out" ${DIFF} -in1 Digestor_2_output.tmp.fasta -in2 ${DATA_DIR_TOPP}/Digestor_2_output.fasta)
+set_tests_properties("TOPP_Digestor_2_out" PROPERTIES DEPENDS "TOPP_Digestor_2")
+
+
+#------------------------------------------------------------------------------
 # EPIFANY:
 add_test("TOPP_Epifany_1" ${TOPP_BIN_PATH}/Epifany -test -in ${DATA_DIR_TOPP}/THIRDPARTY/FidoAdapter_1_input.idXML -algorithm:model_parameters:prot_prior 0.7 -algorithm:model_parameters:pep_spurious_emission 0.001 -algorithm:model_parameters:pep_emission 0.1 -out Epifany_1_out.tmp.idXML)
 add_test("TOPP_Epifany_1_out" ${DIFF} -whitelist "InferenceEngineVersion" -in1 Epifany_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/Epifany_1_out.idXML)

--- a/src/tests/topp/Digestor_1_input.fasta
+++ b/src/tests/topp/Digestor_1_input.fasta
@@ -1,0 +1,4 @@
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA
+ABCJGRGXGZGKAAAA
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA
+DFIANRGRAAAAAAA

--- a/src/tests/topp/Digestor_1_output.fasta
+++ b/src/tests/topp/Digestor_1_output.fasta
@@ -1,0 +1,16 @@
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+ABCJGR
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+ABCJGRGX
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+GXGZGK
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+GZGKAAAA
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+DFIANR
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+AAAAAAA
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+DFIANRGR
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+GRAAAAAAA

--- a/src/tests/topp/Digestor_2_output.fasta
+++ b/src/tests/topp/Digestor_2_output.fasta
@@ -1,0 +1,14 @@
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+ADCLGR
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+GT
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+GEGK
+>test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
+AAAA
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+DFIANR
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+GR
+>more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 
+AAAAAAA

--- a/src/tests/topp/Digestor_2_output.fasta
+++ b/src/tests/topp/Digestor_2_output.fasta
@@ -1,9 +1,9 @@
 >test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
-ADCLGR
+ANCIGR
 >test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
 GT
 >test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
-GEGK
+GQGK
 >test_prot_with_lots_of_ambiguous_AA's:ABCJGRGXGZGKAAAA 
 AAAA
 >more_prots,_with_no_AAA's:DFIANRGRAAAAAAA 

--- a/src/topp/Digestor.cpp
+++ b/src/topp/Digestor.cpp
@@ -13,7 +13,7 @@
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 
-#include <map>
+#include <OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h> // for AA's
 
 using namespace OpenMS;
 using namespace std;
@@ -70,11 +70,11 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "input file");
-    setValidFormats_("in", ListUtils::create<String>("fasta"));
+    setValidFormats_("in", {"fasta"});
     registerOutputFile_("out", "<file>", "", "Output file (peptides)");
-    setValidFormats_("out", ListUtils::create<String>("idXML,fasta"));
+    setValidFormats_("out", {"idXML", "fasta"});
     registerStringOption_("out_type", "<type>", "", "Set this if you cannot control the filename of 'out', e.g., in TOPPAS.", false);
-    setValidStrings_("out_type", ListUtils::create<String>("idXML,fasta"));
+    setValidStrings_("out_type", {"idXML", "fasta"});
 
     registerIntOption_("missed_cleavages", "<number>", 1, "The number of allowed missed cleavages", false);
     setMinInt_("missed_cleavages", 0);
@@ -87,9 +87,14 @@ protected:
 
     registerTOPPSubsection_("FASTA", "Options for FASTA output files");
     registerStringOption_("FASTA:ID", "<option>", "parent", "Identifier to use for each peptide: copy from parent protein (parent); a consecutive number (number); parent ID + consecutive number (both)", false);
-    setValidStrings_("FASTA:ID", ListUtils::create<String>("parent,number,both"));
+    setValidStrings_("FASTA:ID", {"parent", "number", "both"});
     registerStringOption_("FASTA:description", "<option>", "remove", "Keep or remove the (possibly lengthy) FASTA header description. Keeping it can increase resulting FASTA file significantly.", false);
-    setValidStrings_("FASTA:description", ListUtils::create<String>("remove,keep"));
+    setValidStrings_("FASTA:description", {"remove", "keep"});
+
+    registerFlag_("replace_ambiguous",
+                  "Replace ambiguous amino acids with a random unambiguous amino acid. This is useful for generating an output file that "
+                  "mimics a search engine result (since they usually do not contain ambiguous amino acids).",
+                  false);
   }
 
   enum FASTAID {PARENT, NUMBER, BOTH};
@@ -182,22 +187,47 @@ protected:
         temp_peptide_hit.setPeptideEvidences(vector<PeptideEvidence>(1, temp_pe));
       }
 
-      vector<AASequence> current_digest;
+      std::vector<std::pair<size_t, size_t>> current_digest;
       if (enzyme == "none")
       {
-        current_digest.push_back(AASequence::fromString(fe.sequence));
+        current_digest.emplace_back(0, fe.sequence.size());
       }
       else
       {
         dropped_by_length += digestor.digest(AASequence::fromString(fe.sequence), current_digest, min_size, max_size);
       }
 
+      std::srand(123); // for reproducibility
       String id = fe.identifier;
-      for (auto const& s : current_digest)
+      for (auto [pep_start, pep_end] : current_digest)
       {
+        if (getFlag_("replace_ambiguous"))
+        {
+          for (auto pos = pep_start; pos < pep_end; ++pos)
+          { // look at all AA's of the peptide, and replace if ambiguous
+            switch (fe.sequence[pos])
+            {
+              case 'B': // asparagine or aspartic acid
+                fe.sequence[pos] = (rand() % 2 ? 'N' : 'D');
+                break; 
+              case 'Z': // glutamine or glutamic acid
+                fe.sequence[pos] = (rand() % 2 ? 'Q' : 'E');
+                break;
+              case 'J': // leucine or isoleucine
+                fe.sequence[pos] = (rand() % 2 ? 'L' : 'I');
+                break;
+              case 'X': // any amino acid
+                fe.sequence[pos] = AA::fromIndex(rand() % AA::unambiguousAACount()).toChar();
+                break;
+              default:
+                break; // do nothing for other residues
+            }
+          }
+        }
+
         if (!has_FASTA_output)
         {
-          temp_peptide_hit.setSequence(s);
+          temp_peptide_hit.setSequence(AASequence(fe.sequence.substr(pep_start, pep_end-pep_start)));
           peptide_identification.insertHit(temp_peptide_hit);
           identifications.push_back(peptide_identification);
           peptide_identification.setHits(std::vector<PeptideHit>()); // clear
@@ -211,7 +241,7 @@ protected:
             case NUMBER: id = String(fasta_out_count); break;
             case BOTH: id = fe.identifier + "_" + String(fasta_out_count); break;
           }
-          ff.writeNext(FASTAFile::FASTAEntry(id, keep_FASTA_desc ? fe.description : "", s.toString()));
+          ff.writeNext(FASTAFile::FASTAEntry(id, keep_FASTA_desc ? fe.description : "", fe.sequence.substr(pep_start, pep_end - pep_start)));
         }
       }
     }

--- a/src/topp/Digestor.cpp
+++ b/src/topp/Digestor.cpp
@@ -6,14 +6,18 @@
 // $Authors: Nico Pfeifer, Chris Bielow $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/FORMAT/FASTAFile.h>
-#include <OpenMS/METADATA/ProteinIdentification.h>
-#include <OpenMS/APPLICATIONS/TOPPBase.h>
-#include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
-#include <OpenMS/CHEMISTRY/ProteaseDB.h>
 
 #include <OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h> // for AA's
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
+#include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
+#include <OpenMS/FORMAT/FASTAFile.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
 
 using namespace OpenMS;
 using namespace std;
@@ -175,6 +179,11 @@ protected:
     Size fasta_out_count(0);
 
     FASTAFile::FASTAEntry fe;
+    
+    boost::random::mt19937 gen; // for cross-platform reproducibility
+    boost::random::uniform_int_distribution<> rng_X(0, AA::unambiguousAACount() - 1); // roll for unambiguous AA (boost uses a closed interval, i.e. [0, 21] for 22 unambiguous AA's)
+    boost::random::uniform_int_distribution<> rng_2(0, 1); // coin flip
+
     while (ff.readNext(fe))
     {
       if (!has_FASTA_output)
@@ -197,7 +206,6 @@ protected:
         dropped_by_length += digestor.digest(AASequence::fromString(fe.sequence), current_digest, min_size, max_size);
       }
 
-      std::srand(123); // for reproducibility
       String id = fe.identifier;
       for (auto [pep_start, pep_end] : current_digest)
       {
@@ -208,16 +216,16 @@ protected:
             switch (fe.sequence[pos])
             {
               case 'B': // asparagine or aspartic acid
-                fe.sequence[pos] = (rand() % 2 ? 'N' : 'D');
+                fe.sequence[pos] = rng_2(gen) ? 'N' : 'D';
                 break; 
               case 'Z': // glutamine or glutamic acid
-                fe.sequence[pos] = (rand() % 2 ? 'Q' : 'E');
+                fe.sequence[pos] = rng_2(gen) ? 'Q' : 'E';
                 break;
               case 'J': // leucine or isoleucine
-                fe.sequence[pos] = (rand() % 2 ? 'L' : 'I');
+                fe.sequence[pos] = rng_2(gen) ? 'L' : 'I';
                 break;
               case 'X': // any amino acid
-                fe.sequence[pos] = AA::fromIndex(rand() % AA::unambiguousAACount()).toChar();
+                fe.sequence[pos] = AA::fromIndex(rng_X(gen)).toChar();
                 break;
               default:
                 break; // do nothing for other residues


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Construct/convert amino‑acid values by index and get single‑letter representation.
  * Digestor gains a public option to replace ambiguous amino acids (B, Z, J, X) with selected unambiguous residues (randomized selection).

* **Documentation**
  * Clarified peptide position ranges to use past‑the‑end (half‑open) indexing.

* **Tests**
  * Added Digestor tests and FASTA fixtures covering ambiguous residues and replacement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->