### PR TITLE
feat: add isDecoy to PeptideHit + the more specialized types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,9 @@ GUI tools:
  
 
 OpenMS Library:
+  Added:
+    - PeptideHit: Added TargetDecoyType enum and setTargetDecoyType()/getTargetDecoyType() methods for type-safe handling of target/decoy annotations, including support for target+decoy hits that match both target and decoy proteins
+    - PeptideHit: Added isDecoy() method implementation
   Fixes:
     - unify isotopic distributions (coarse vs. fine) for EmpiricalFormulas with charge (#8099)
   Changes:

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -81,7 +81,7 @@ public:
       are used to separate the parts easily when parsing the annotation.
 
    */
-  struct PeakAnnotation
+  struct OPENMS_DLLAPI PeakAnnotation
   {
     String annotation = "";  // e.g. [alpha|ci$y3-H2O-NH3]
     int charge = 0;

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -49,6 +49,14 @@ namespace OpenMS
     public MetaInfoInterface
   {
 public:
+    /// Enum for target/decoy annotation
+    enum class TargetDecoyType
+    {
+      TARGET,       ///< Only matches target proteins
+      DECOY,        ///< Only matches decoy proteins
+      TARGET_DECOY  ///< Matches BOTH target and decoy proteins
+    };
+
     /**
    * @brief Contains annotations of a peak
 
@@ -278,6 +286,12 @@ public:
 
     /// returns true if this is a decoy hit
     bool isDecoy() const;
+
+    /// sets the target/decoy type
+    void setTargetDecoyType(TargetDecoyType type);
+
+    /// returns the target/decoy type
+    TargetDecoyType getTargetDecoyType() const;
 
     //@}
 

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -276,6 +276,9 @@ public:
     /// sets the fragment annotations
     void setPeakAnnotations(std::vector<PeptideHit::PeakAnnotation> frag_annotations);
 
+    /// returns true if this is a decoy hit
+    bool isDecoy() const;
+
     //@}
 
     /// extracts the set of non-empty protein accessions from peptide evidences

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -54,7 +54,8 @@ public:
     {
       TARGET,       ///< Only matches target proteins
       DECOY,        ///< Only matches decoy proteins
-      TARGET_DECOY  ///< Matches BOTH target and decoy proteins
+      TARGET_DECOY, ///< Matches BOTH target and decoy proteins
+      UNKNOWN       ///< Target/decoy status is unknown (meta value not set)
     };
 
     /**
@@ -284,13 +285,39 @@ public:
     /// sets the fragment annotations
     void setPeakAnnotations(std::vector<PeptideHit::PeakAnnotation> frag_annotations);
 
-    /// returns true if this is a decoy hit
+    /**
+     * @brief Returns true if this hit is annotated as decoy.
+     */
     bool isDecoy() const;
 
-    /// sets the target/decoy type
+    /** @brief Sets the target/decoy type for this peptide hit
+     *
+     * This method provides a type-safe way to annotate peptide hits with their
+     * target/decoy status. Use TARGET_DECOY for peptides that match both target
+     * and decoy protein sequences (these are treated as targets in FDR calculations).
+     * Note: UNKNOWN should only be used in special cases where the status needs to
+     * be explicitly marked as unknown.
+     *
+     * @param type The target/decoy classification:
+     *   - TARGET: Only matches target proteins
+     *   - DECOY: Only matches decoy proteins
+     *   - TARGET_DECOY: Matches both target and decoy proteins
+     *   - UNKNOWN: Target/decoy status is unknown (explicit unknown state)
+     */
     void setTargetDecoyType(TargetDecoyType type);
 
-    /// returns the target/decoy type
+    /** @brief Returns the target/decoy type for this peptide hit
+     *
+     * This method performs case-insensitive parsing of the "target_decoy" meta value
+     * and returns the corresponding enum value. Returns UNKNOWN if the meta value
+     * does not exist.
+     *
+     * @return The target/decoy classification:
+     *   - TARGET: Only matches target proteins
+     *   - DECOY: Only matches decoy proteins
+     *   - TARGET_DECOY: Matches both target and decoy proteins
+     *   - UNKNOWN: Target/decoy status not set (meta value missing)
+     */
     TargetDecoyType getTargetDecoyType() const;
 
     //@}

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -286,7 +286,7 @@ public:
     void setPeakAnnotations(std::vector<PeptideHit::PeakAnnotation> frag_annotations);
 
     /**
-     * @brief Returns true if this hit is annotated as decoy.
+     * @brief Returns true if this hit is annotated as mapping to decoy sequences only. Warning: an unknown/unannotated state will yield false.
      */
     bool isDecoy() const;
 

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -139,35 +139,36 @@ namespace OpenMS
               continue;
             }
 
-            if (!it->getHits()[i].metaValueExists("target_decoy"))
+            auto target_decoy_type = it->getHits()[i].getTargetDecoyType();
+            
+            if (target_decoy_type == PeptideHit::TargetDecoyType::UNKNOWN)
             {
               OPENMS_LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' first (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << it->getHits().size() << ")!" << endl;
               throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
             }
 
-            bool is_decoy = it->getHits()[i].isDecoy();
             const String peptide_sequence = it->getHits()[i].getSequence().toUnmodifiedString();
             const double score = it->getHits()[i].getScore();
 
-            if (target_decoy == "target" || target_decoy == "target+decoy")
+            if (target_decoy_type == PeptideHit::TargetDecoyType::TARGET || target_decoy_type == PeptideHit::TargetDecoyType::TARGET_DECOY)
             {
               target_scores.push_back(score);
 
               if (annotate_peptide_fdr)
               {
-                // store best score for peptide (unmodified sequence)              
+                // store best score for peptide (unmodified sequence)
                 auto [entry_it, success] = peptide_to_best_target_score.emplace(peptide_sequence, score); // try to construct in place (performance)
 
                 if (!success && // emplace failed because key was already present -> replace if current score is better?
-                    isFirstBetterScore(score, entry_it->second, higher_score_better)) 
+                    isFirstBetterScore(score, entry_it->second, higher_score_better))
                 {
                   entry_it->second = score;
-                }                           
+                }
               }
             }
             else
             {
-              if (target_decoy == "decoy")
+              if (target_decoy_type == PeptideHit::TargetDecoyType::DECOY)
               {
                 decoy_scores.push_back(score);
 
@@ -182,13 +183,7 @@ namespace OpenMS
                   }
                 }
               }
-              else
-              {
-                if (!target_decoy.empty())
-                {
-                  throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown value of meta value 'target_decoy'", target_decoy);
-                }
-              }
+              // Note: All other cases (UNKNOWN) are handled at the beginning of the loop
             }
           }
         }
@@ -257,7 +252,9 @@ namespace OpenMS
                 continue;
               }
 
-              if (!hits[i].metaValueExists("target_decoy"))
+              auto target_decoy_type = hits[i].getTargetDecoyType();
+              
+              if (target_decoy_type == PeptideHit::TargetDecoyType::UNKNOWN)
               {
                 OPENMS_LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << hits.size() << ")!" << endl;
                 throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
@@ -272,13 +269,7 @@ namespace OpenMS
                 new_hits.back().setMetaValue(score_type, new_hits.back().getScore());
                 new_hits.back().setScore(0);
               }
-              else
-              {
-                if (target_decoy != "decoy")
-                {
-                  throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown value of meta value 'target_decoy'", target_decoy);
-                }
-              }
+              // Note: decoy hits are skipped (not added to new_hits)
             }
             it->setHits(new_hits);
           }

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -145,7 +145,7 @@ namespace OpenMS
               throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
             }
 
-            String target_decoy(it->getHits()[i].getMetaValue("target_decoy"));
+            bool is_decoy = it->getHits()[i].isDecoy();
             const String peptide_sequence = it->getHits()[i].getSequence().toUnmodifiedString();
             const double score = it->getHits()[i].getScore();
 
@@ -263,8 +263,8 @@ namespace OpenMS
                 throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
               }
 
-              String target_decoy(hits[i].getMetaValue("target_decoy"));
-              if (target_decoy == "target" || target_decoy == "target+decoy")
+              bool is_decoy = hits[i].isDecoy();
+              if (!is_decoy)
               {
                 // if it is a target hit, there are no decoys, fdr/q-value should be zero then
                 new_hits.push_back(hits[i]);
@@ -336,8 +336,8 @@ namespace OpenMS
             }
             if (hit.metaValueExists("target_decoy"))
             {
-              String meta_value = (String)hit.getMetaValue("target_decoy");
-              if (meta_value == "decoy" && !add_decoy_peptides)
+              bool is_decoy = hit.isDecoy();
+              if (is_decoy && !add_decoy_peptides)
               {
                 continue;
               }
@@ -346,7 +346,7 @@ namespace OpenMS
               {
                 const String peptide_sequence = hit.getSequence().toUnmodifiedString();
                 double peptide_fdr;
-                if (meta_value == "decoy")
+                if (is_decoy)
                 {
                   peptide_fdr = peptide_to_best_decoy_score[peptide_sequence];
                 }

--- a/src/openms/source/ANALYSIS/ID/IDDecoyProbability.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDDecoyProbability.cpp
@@ -67,12 +67,11 @@ namespace OpenMS
             }
           }
 
-          String target_decoy = (String)pit.getMetaValue("target_decoy");
-          if (target_decoy == "target")
+          if (!pit.isDecoy())
           {
             fwd_scores.push_back(score);
           }
-          else if (target_decoy == "decoy")
+          else
           {
             rev_scores.push_back(score);
           }

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -719,7 +719,7 @@ namespace OpenMS
       const PeptideHit& hit = p.getHits()[0];
 
       // don't quantify decoys
-      if ((std::string)hit.getMetaValue("target_decoy", DataValue("target")) == "decoy") continue;
+      if (hit.isDecoy()) continue;
 
       stats_.quant_features++;
       const AASequence& seq = hit.getSequence();

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -1384,7 +1384,7 @@ namespace OpenMS
     // if we don't quantify decoys we don't add them to the peptide list
     if (!quantify_decoys_)
     {
-      if (hit.metaValueExists("target_decoy") && hit.getMetaValue("target_decoy") == "decoy")
+      if (hit.isDecoy())
       {
         unassignedIDs_.push_back(peptide);
         return;

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -338,8 +338,8 @@ void MSstatsFile::storeLFQ(const String& filename,
       for (const PeptideHit & pep_hit : pep_id.getHits())
       {
         // skip decoys
-        if (pep_hit.metaValueExists("target_decoy") && pep_hit.getMetaValue("target_decoy") == "decoy") 
-        { 
+        if (pep_hit.isDecoy())
+        {
           continue;
         }
 
@@ -575,8 +575,8 @@ void MSstatsFile::storeISO(const String& filename,
       for (const PeptideHit & pep_hit : pep_id.getHits())
       {
         // skip decoys
-        if (pep_hit.metaValueExists("target_decoy") && pep_hit.getMetaValue("target_decoy") == "decoy") 
-        { 
+        if (pep_hit.isDecoy())
+        {
           continue;
         }
 

--- a/src/openms/source/FORMAT/PercolatorInfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorInfile.cpp
@@ -427,17 +427,13 @@ namespace OpenMS
         hit.setMetaValue("SpecId", file_identifier + scan_identifier);
         hit.setMetaValue("ScanNr", scan_number);
         
-        if (!hit.metaValueExists("target_decoy") 
-          || hit.getMetaValue("target_decoy").toString().empty()) 
+        if (!hit.metaValueExists("target_decoy")
+          || hit.getMetaValue("target_decoy").toString().empty())
         {
           continue;
         }
         
-        int label = 1;
-        if (hit.getMetaValue("target_decoy") == "decoy")
-        {
-          label = -1;
-        }
+        int label = hit.isDecoy() ? -1 : 1;
         hit.setMetaValue("Label", label);
         
         int charge = hit.getCharge();

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -376,6 +376,11 @@ namespace OpenMS
     fragment_annotations_ = std::move(frag_annotations);
   }
 
+  bool PeptideHit::isDecoy() const
+  {
+    return getMetaValue("target_decoy", "target").toString().toLower() == "decoy";
+  }
+
   std::ostream& operator<< (std::ostream& stream, const PeptideHit& hit)
   {
     return stream << "peptide hit with sequence '" + hit.getSequence().toString() +

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -381,6 +381,30 @@ namespace OpenMS
     return getMetaValue("target_decoy", "target").toString().toLower() == "decoy";
   }
 
+  void PeptideHit::setTargetDecoyType(TargetDecoyType type)
+  {
+    switch(type)
+    {
+      case TargetDecoyType::TARGET:
+        setMetaValue("target_decoy", "target");
+        break;
+      case TargetDecoyType::DECOY:
+        setMetaValue("target_decoy", "decoy");
+        break;
+      case TargetDecoyType::TARGET_DECOY:
+        setMetaValue("target_decoy", "target+decoy");
+        break;
+    }
+  }
+
+  PeptideHit::TargetDecoyType PeptideHit::getTargetDecoyType() const
+  {
+    String td = getMetaValue("target_decoy", "target").toString().toLower();
+    if (td == "decoy") return TargetDecoyType::DECOY;
+    if (td == "target+decoy") return TargetDecoyType::TARGET_DECOY;
+    return TargetDecoyType::TARGET;  // default
+  }
+
   std::ostream& operator<< (std::ostream& stream, const PeptideHit& hit)
   {
     return stream << "peptide hit with sequence '" + hit.getSequence().toString() +

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -378,7 +378,7 @@ namespace OpenMS
 
   bool PeptideHit::isDecoy() const
   {
-    return getMetaValue("target_decoy", "target").toString().toLower() == "decoy";
+    return getTargetDecoyType() == TargetDecoyType::DECOY;
   }
 
   void PeptideHit::setTargetDecoyType(TargetDecoyType type)
@@ -394,15 +394,25 @@ namespace OpenMS
       case TargetDecoyType::TARGET_DECOY:
         setMetaValue("target_decoy", "target+decoy");
         break;
+      case TargetDecoyType::UNKNOWN:
+        removeMetaValue("target_decoy");
+        break;
     }
   }
 
   PeptideHit::TargetDecoyType PeptideHit::getTargetDecoyType() const
   {
-    String td = getMetaValue("target_decoy", "target").toString().toLower();
+    if (!metaValueExists("target_decoy"))
+    {
+      return TargetDecoyType::UNKNOWN;
+    }
+    
+    String td = getMetaValue("target_decoy").toString().toLower();
     if (td == "decoy") return TargetDecoyType::DECOY;
     if (td == "target+decoy") return TargetDecoyType::TARGET_DECOY;
-    return TargetDecoyType::TARGET;  // default
+    if (td == "target") return TargetDecoyType::TARGET;
+    
+    return TargetDecoyType::UNKNOWN;  // for unknown/invalid values
   }
 
   std::ostream& operator<< (std::ostream& stream, const PeptideHit& hit)

--- a/src/openms/source/QC/DBSuitability.cpp
+++ b/src/openms/source/QC/DBSuitability.cpp
@@ -161,12 +161,12 @@ namespace OpenMS
         throw(Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy information found! Make sure 'PeptideIndexer' is run beforehand."));
       }
 
-      if (decoy_1 == DBL_MAX && hit.getMetaValue("target_decoy") == "decoy")
+      if (decoy_1 == DBL_MAX && hit.isDecoy())
       {
         decoy_1 = extractScore_(hit);
         continue;
       }
-      if (decoy_1 < DBL_MAX && hit.getMetaValue("target_decoy") == "decoy")
+      if (decoy_1 < DBL_MAX && hit.isDecoy())
       {
         decoy_2 = extractScore_(hit);
         break;
@@ -454,7 +454,7 @@ namespace OpenMS
       {
         throw(Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy information found! Make sure 'PeptideIndexer' is run beforehand."));
       }
-      if (top_hit.getMetaValue("target_decoy") == "decoy") continue;
+      if (top_hit.isDecoy()) continue;
 
       // skip if top hit is out ouf FDR
       if (!checkScoreBetterThanThreshold_(top_hit, score_cut_off, hsb)) continue;
@@ -601,7 +601,7 @@ namespace OpenMS
         {
           throw(Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy information found! Make sure 'PeptideIndexer' is run beforehand."));
         }
-        if (hit.getMetaValue("target_decoy") == "decoy")
+        if (hit.isDecoy())
           continue;// skip if the hit is a decoy hit
 
         // insert protein accessions

--- a/src/openms/source/QC/MQEvidenceExporter.cpp
+++ b/src/openms/source/QC/MQEvidenceExporter.cpp
@@ -271,7 +271,7 @@ void MQEvidence::exportRowFromFeature_(
 
   file_ << f.getIntensity() << "\t"; // Intensity
 
-  ptr_best_hit->getMetaValue("target_decoy") == "decoy" ? file_ << "1\t" : file_ << "\t"; // reverse
+  ptr_best_hit->isDecoy() ? file_ << "1\t" : file_ << "\t"; // reverse
 
   String pot_containment = ptr_best_hit->getMetaValue("is_contaminant", "NA");
   if (pot_containment == "1")

--- a/src/openms/source/QC/MQMsmsExporter.cpp
+++ b/src/openms/source/QC/MQMsmsExporter.cpp
@@ -227,7 +227,7 @@ void MQMsms::exportRowFromFeature_(
   file_ << "NA" << "\t"; // Neutral loss level
   file_ << "NA" << "\t"; // ETD identification type
 
-  ptr_best_hit->getMetaValue("target_decoy") == "decoy" ? file_ << "1\t" : file_ << "\t"; // reverse
+  ptr_best_hit->isDecoy() ? file_ << "1\t" : file_ << "\t"; // reverse
 
   file_ << "NA" << "\t"; // All scores
   file_ << "NA" << "\t"; // All sequences

--- a/src/openms/source/QC/Ms2IdentificationRate.cpp
+++ b/src/openms/source/QC/Ms2IdentificationRate.cpp
@@ -118,7 +118,7 @@ namespace OpenMS
     {
       return true;
     }
-    if (id.getHits()[0].getTargetDecoyType() == TargetDecoyType::UNKNOWN)
+    if (id.getHits()[0].getTargetDecoyType() == PeptideHit::TargetDecoyType::UNKNOWN)
     {
       throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target");
     }

--- a/src/openms/source/QC/Ms2IdentificationRate.cpp
+++ b/src/openms/source/QC/Ms2IdentificationRate.cpp
@@ -123,8 +123,7 @@ namespace OpenMS
       throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target");
     }
     // check for 'target' information, also allow "target+decoy" value
-    String td_info(id.getHits()[0].getMetaValue("target_decoy"));
-    return (td_info.find("target") == 0);
+    return !id.getHits()[0].isDecoy();
   }
 
   void Ms2IdentificationRate::writeResults_(Size pep_ids_count, Size ms2_spectra_count)

--- a/src/openms/source/QC/Ms2IdentificationRate.cpp
+++ b/src/openms/source/QC/Ms2IdentificationRate.cpp
@@ -118,7 +118,7 @@ namespace OpenMS
     {
       return true;
     }
-    if (!(id.getHits()[0].metaValueExists("target_decoy")))
+    if (id.getHits()[0].getTargetDecoyType() == TargetDecoyType::UNKNOWN)
     {
       throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No target/decoy annotation found. If you want to continue regardless use -MS2_id_rate:assume_all_target");
     }

--- a/src/pyOpenMS/pxds/PeptideHit.pxd
+++ b/src/pyOpenMS/pxds/PeptideHit.pxd
@@ -34,7 +34,7 @@ cdef extern from "<OpenMS/METADATA/PeptideHit.h>" namespace "OpenMS":
         void addPeptideEvidence(PeptideEvidence) except + nogil  # wrap-doc:Adds information on a peptide that is (potentially) identified by this PSM
         libcpp_set[String] extractProteinAccessionsSet() except + nogil  # wrap-doc:Extracts the set of non-empty protein accessions from peptide evidences
 
-        bool isDecoy() except + nogil  # wrap-doc:Returns true if this is a decoy hit
+        bool isDecoy() except + nogil  # wrap-doc:Returns true if this hit is annotated as mapping to decoy sequences only. Warning: an unknown/unannotated state will yield false.
 
         void setAnalysisResults(libcpp_vector[PeptideHit_AnalysisResult] aresult) except + nogil  # wrap-doc:Sets information on (search engine) sub scores associated with this PSM
         void addAnalysisResults(PeptideHit_AnalysisResult aresult) except + nogil  # wrap-doc:Add information on (search engine) sub scores associated with this PSM

--- a/src/pyOpenMS/pxds/PeptideHit.pxd
+++ b/src/pyOpenMS/pxds/PeptideHit.pxd
@@ -34,7 +34,7 @@ cdef extern from "<OpenMS/METADATA/PeptideHit.h>" namespace "OpenMS":
         void addPeptideEvidence(PeptideEvidence) except + nogil  # wrap-doc:Adds information on a peptide that is (potentially) identified by this PSM
         libcpp_set[String] extractProteinAccessionsSet() except + nogil  # wrap-doc:Extracts the set of non-empty protein accessions from peptide evidences
 
-        bool isDecoy() except + nogil  # wrap-doc:Returns true if this hit is annotated as mapping to decoy sequences only. Warning: an unknown/unannotated state will yield false.
+        bool isDecoy() except + nogil  # wrap-doc:Returns true if this hit is annotated as mapping to decoy sequences only.  If no target-decoy information is annotated, false is returned.
 
         void setAnalysisResults(libcpp_vector[PeptideHit_AnalysisResult] aresult) except + nogil  # wrap-doc:Sets information on (search engine) sub scores associated with this PSM
         void addAnalysisResults(PeptideHit_AnalysisResult aresult) except + nogil  # wrap-doc:Add information on (search engine) sub scores associated with this PSM

--- a/src/pyOpenMS/pxds/PeptideHit.pxd
+++ b/src/pyOpenMS/pxds/PeptideHit.pxd
@@ -34,6 +34,8 @@ cdef extern from "<OpenMS/METADATA/PeptideHit.h>" namespace "OpenMS":
         void addPeptideEvidence(PeptideEvidence) except + nogil  # wrap-doc:Adds information on a peptide that is (potentially) identified by this PSM
         libcpp_set[String] extractProteinAccessionsSet() except + nogil  # wrap-doc:Extracts the set of non-empty protein accessions from peptide evidences
 
+        bool isDecoy() except + nogil  # wrap-doc:Returns true if this is a decoy hit
+
         void setAnalysisResults(libcpp_vector[PeptideHit_AnalysisResult] aresult) except + nogil  # wrap-doc:Sets information on (search engine) sub scores associated with this PSM
         void addAnalysisResults(PeptideHit_AnalysisResult aresult) except + nogil  # wrap-doc:Add information on (search engine) sub scores associated with this PSM
         libcpp_vector[PeptideHit_AnalysisResult] getAnalysisResults() except + nogil  # wrap-doc:Returns information on (search engine) sub scores associated with this PSM

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -604,6 +604,57 @@ START_SECTION((bool isDecoy() const))
 }
 END_SECTION
 
+START_SECTION((void setTargetDecoyType(TargetDecoyType type)))
+{
+  PeptideHit hit;
+  
+  // Test setting TARGET
+  hit.setTargetDecoyType(PeptideHit::TargetDecoyType::TARGET);
+  TEST_EQUAL(hit.getMetaValue("target_decoy"), "target");
+  
+  // Test setting DECOY
+  hit.setTargetDecoyType(PeptideHit::TargetDecoyType::DECOY);
+  TEST_EQUAL(hit.getMetaValue("target_decoy"), "decoy");
+  
+  // Test setting TARGET_DECOY
+  hit.setTargetDecoyType(PeptideHit::TargetDecoyType::TARGET_DECOY);
+  TEST_EQUAL(hit.getMetaValue("target_decoy"), "target+decoy");
+}
+END_SECTION
+
+START_SECTION((TargetDecoyType getTargetDecoyType() const))
+{
+  PeptideHit hit;
+  
+  // Test default behavior (should return TARGET)
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET);
+  
+  // Test with explicit "target" value
+  hit.setMetaValue("target_decoy", "target");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET);
+  
+  // Test with "decoy" value
+  hit.setMetaValue("target_decoy", "decoy");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::DECOY);
+  
+  // Test with "DECOY" (case insensitive)
+  hit.setMetaValue("target_decoy", "DECOY");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::DECOY);
+  
+  // Test with "target+decoy" value
+  hit.setMetaValue("target_decoy", "target+decoy");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET_DECOY);
+  
+  // Test with "TARGET+DECOY" (case insensitive)
+  hit.setMetaValue("target_decoy", "TARGET+DECOY");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET_DECOY);
+  
+  // Test with unknown value (should default to TARGET)
+  hit.setMetaValue("target_decoy", "unknown");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET);
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -578,6 +578,32 @@ START_SECTION((PeptideHit& operator=(PeptideHit&& source) noexcept - with analys
 }
 END_SECTION
 
+START_SECTION((bool isDecoy() const))
+{
+  PeptideHit hit;
+  
+  // Test default behavior (no target_decoy meta value set)
+  // Should return false since default is "target"
+  TEST_EQUAL(hit.isDecoy(), false);
+  
+  // Test with explicit "target" value
+  hit.setMetaValue("target_decoy", "target");
+  TEST_EQUAL(hit.isDecoy(), false);
+  
+  // Test with "decoy" value
+  hit.setMetaValue("target_decoy", "decoy");
+  TEST_EQUAL(hit.isDecoy(), true);
+  
+  // Test with "DECOY" (case insensitive)
+  hit.setMetaValue("target_decoy", "DECOY");
+  TEST_EQUAL(hit.isDecoy(), true);
+  
+  // Test with other values
+  hit.setMetaValue("target_decoy", "target+decoy");
+  TEST_EQUAL(hit.isDecoy(), false);
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 

--- a/src/tests/class_tests/openms/source/PeptideHit_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideHit_test.cpp
@@ -619,6 +619,11 @@ START_SECTION((void setTargetDecoyType(TargetDecoyType type)))
   // Test setting TARGET_DECOY
   hit.setTargetDecoyType(PeptideHit::TargetDecoyType::TARGET_DECOY);
   TEST_EQUAL(hit.getMetaValue("target_decoy"), "target+decoy");
+  
+  // Test setting UNKNOWN (should remove meta value)
+  hit.setTargetDecoyType(PeptideHit::TargetDecoyType::UNKNOWN);
+  TEST_EQUAL(hit.metaValueExists("target_decoy"), false);
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::UNKNOWN);
 }
 END_SECTION
 
@@ -626,8 +631,8 @@ START_SECTION((TargetDecoyType getTargetDecoyType() const))
 {
   PeptideHit hit;
   
-  // Test default behavior (should return TARGET)
-  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET);
+  // Test default behavior (should return UNKNOWN when meta value doesn't exist)
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::UNKNOWN);
   
   // Test with explicit "target" value
   hit.setMetaValue("target_decoy", "target");
@@ -649,9 +654,13 @@ START_SECTION((TargetDecoyType getTargetDecoyType() const))
   hit.setMetaValue("target_decoy", "TARGET+DECOY");
   TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET_DECOY);
   
-  // Test with unknown value (should default to TARGET)
+  // Test with unknown value (should return UNKNOWN)
   hit.setMetaValue("target_decoy", "unknown");
-  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::TARGET);
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::UNKNOWN);
+  
+  // Test after removing meta value (should return UNKNOWN)
+  hit.removeMetaValue("target_decoy");
+  TEST_EQUAL(hit.getTargetDecoyType(), PeptideHit::TargetDecoyType::UNKNOWN);
 }
 END_SECTION
 

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -467,7 +467,7 @@ protected:
               hit.setMetaValue("target_decoy", "target");
             }
           }
-          else if (hit.getMetaValue("target_decoy").toString() == "decoy")
+          else if (hit.isDecoy())
           {
             found_decoys = true;
           }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added type-safe target/decoy support: new TargetDecoyType enum, set/get APIs and isDecoy(); Python binding exposes isDecoy(); supports target+decoy classification.

- **Bug Fixes**
  - Unified decoy detection across analysis, quantification, QC, exporters and adapters for consistent, robust handling (including explicit unknown handling).

- **Tests**
  - Added unit tests covering target/decoy behaviors and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->