### PR TITLE
Feature/param field updater

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,7 @@ OpenMS Library:
     - TransformationModelLowess: Add option to automate span selection via cross-validation (#8166)
     - OpenSwath:
       - Added automated iRT calibration using input transition list (#8146)
+    - Param: add method for updating a key value in a Param object (#8205)
 
 
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
@@ -205,7 +205,7 @@ public:
       bool commit{true};
       /// optional, e.g. "auto-estimated", "calibration"
       String context{};
-      /// optional; default chosen in .cpp
+      /// optional custom validator
       std::function<bool(const ParamValue&)> validator;
       /// allow silent updates if needed
       bool log{true};

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
@@ -10,7 +10,9 @@
 
 #include <OpenMS/DATASTRUCTURES/ParamValue.h>
 #include <OpenMS/OpenMSConfig.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
+#include <functional>
 #include <set>
 #include <string>
 #include <map>
@@ -159,6 +161,54 @@ public:
       std::vector<ParamEntry> entries;
       /// Subnodes
       std::vector<ParamNode> nodes;
+    };
+
+    /**
+      @brief Options that control the behavior of Param::updateValue().
+
+      Semantics overview:
+        - If `applicable == false`: the update is skipped *without* validating the
+          candidate. The current value is kept and `updateValue()` returns `false`.
+          If `log == true`, an informational message is emitted.
+        - Otherwise the candidate is validated
+            1) against the registered `ParamEntry` restrictions for the key
+               (type, valid strings, min/max, etc.), and
+            2) against the optional user-supplied `validator` (if provided).
+          If either check fails, the value is not changed and the call returns `false`.
+        - If validation passes and `commit == true`, the value is written in-place and
+          the call returns `true`.
+        - If validation passes and `commit == false`, this is a dry-run: nothing is
+          written, a message may be logged, and the call returns `false`.
+
+      Notes:
+        - `context` is appended in square brackets to log messages to indicate provenance
+          (e.g., "auto-estimated", "calibration").
+        - When `log == false`, both info and warning messages from `updateValue()` are suppressed.
+        - The `validator` should be thread-safe if `updateValue()` is called concurrently.
+
+      @code
+      Param p; p.setValue("algo:max_iter", 3);
+      Param::UpdateOptions uo;
+      uo.context = "auto-estimated";
+      uo.validator = [](const ParamValue& v){ return Int(v) >= 0; };
+
+      p.updateValue("algo:max_iter", ParamValue(5), uo); // applies, returns true
+      uo.commit = false;
+      p.updateValue("algo:max_iter", ParamValue(7), uo); // dry-run, returns false
+      @endcode
+    */
+    struct OPENMS_DLLAPI UpdateOptions
+    {
+      /// if false, then do nothing (log message says so)
+      bool applicable{true};
+      /// if false, then dry-run (report but keep old)
+      bool commit{true};
+      /// optional, e.g. "auto-estimated", "calibration"
+      String context{};
+      /// optional; default chosen in .cpp
+      std::function<bool(const ParamValue&)> validator;
+      /// allow silent updates if needed
+      bool log{true};
     };
 
 public:
@@ -314,6 +364,46 @@ protected:
       @return Returns end() if leaf does not exist.
     */
     ParamIterator findNext(const std::string& leaf, const ParamIterator& start_leaf) const;
+
+    /**
+      @brief Validate and (optionally) write a new value for an existing parameter.
+
+      The candidate value is applied to the entry at @p key according to @p opts:
+
+          - If `opts.applicable == false`: skip without validating; keep the current value and return `false`.
+          - Otherwise, validate @p candidate
+              1) against the entry’s registered restrictions (type, valid strings, min/max, list members), and
+              2) against `opts.validator` if provided.
+            If either check fails, keep the current value and return `false`.
+          - If validation passes and `opts.commit == true`: replace the stored value and return `true`.
+          - If validation passes and `opts.commit == false`: perform a dry-run (no write) and return `false`.
+
+        Logging: when `opts.log == true`, info/warn messages are emitted; `opts.context` (if non-empty) is
+        appended in square brackets for provenance (e.g., “auto-estimated”, “calibration”).
+        The entry’s description, tags, and constraints are preserved; only the value may change.
+
+        @param key       Fully qualified parameter key (e.g., "algo:max_iter"). Must already exist.
+        @param candidate Proposed new value.
+        @param opts      Update behavior controls; see Param::UpdateOptions.
+
+        @return `true` only if the stored value actually changed (i.e., validation passed and `opts.commit` was `true`).
+
+        @throws Exception::ElementNotFound if @p key does not exist.
+
+        @code
+          Param p; p.setValue("algo:max_iter", 3);
+          Param::UpdateOptions uo;
+          uo.context  = "auto-estimated";
+          uo.validator = [](const ParamValue& v){ return Int(v) >= 0; };
+
+          bool changed = p.updateValue("algo:max_iter", ParamValue(5), uo); // writes, returns true
+          uo.commit = false;
+          changed = p.updateValue("algo:max_iter", ParamValue(7), uo); // dry-run, returns false
+        @endcode
+    */
+    bool updateValue(const String& key,
+                     const ParamValue& candidate,
+                     const UpdateOptions& opts);
     //@}
 
     ///@name Tags handling

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -1690,4 +1690,53 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
     return *entry;
   }
 
-} //namespace
+  bool Param::updateValue(const String& key, const ParamValue& candidate, const Param::UpdateOptions& opts)
+  {
+    ParamEntry& e = getEntry_(key); // throws if unknown key
+
+    auto log_info = [&](const String& s){ if (opts.log) OPENMS_LOG_INFO  << s << std::endl; };
+    auto log_warn = [&](const String& s){ if (opts.log) OPENMS_LOG_WARN  << s << std::endl; };
+    const String ctx = opts.context.empty() ? "" : " [" + opts.context + "]";
+
+    // 1) applicability gate
+    if (!opts.applicable)
+    {
+      log_info("" + ctx + " Param '" + key + "' not applicable; keeping " + e.value.toString());
+      return false;
+    }
+
+    // 2) validate against registered ParamEntry restrictions
+    ParamEntry probe = e;                 // copy to reuse isValid()
+    probe.value = candidate;
+    std::string msg;
+    const bool ok_entry = probe.isValid(msg);
+
+    // 3) optional caller-supplied validator
+    const bool ok_custom = opts.validator ? opts.validator(candidate) : true;
+
+    if (!ok_entry || !ok_custom)
+    {
+      String why = ok_entry ? "custom validation failed" : String(msg);
+      log_warn("" + ctx + " Param '" + key + "' estimate invalid=" + candidate.toString() +
+               "; keeping " + e.value.toString() +
+               (why.empty() ? "" : "  [" + why + "]"));
+      return false;
+    }
+
+    // 4) apply or report
+    if (opts.commit)
+    {
+      const String old = e.value.toString();
+      e.value = candidate;                       // in-place to preserve restrictions/tags
+      log_info("" + ctx + " Param '" + key + "' updated: " + old + " -> " + e.value.toString());
+      return true;
+    }
+    else
+    {
+      log_info("" + ctx + " Param '" + key + "' candidate=" + candidate.toString() +
+               "; keeping " + e.value.toString());
+      return false;
+    }
+  }
+
+  } //namespace

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -1707,6 +1707,81 @@ START_SECTION((void checkDefaults(const std::string &name, const Param &defaults
     TEST_EXCEPTION(Exception::InvalidParameter,p.checkDefaults("Param_test",d,""))
 END_SECTION
 
+START_SECTION((bool updateValue(const String& key, const ParamValue& candidate, const Param::UpdateOptions& opts)))
+{
+  // String param with valid-strings restriction
+  Param p;
+  p.setValue("algo:mode", "A");
+  p.setValidStrings("algo:mode", std::vector<std::string>{"A","B"});
+  p.setValue("algo:param1", 1000.0);
+  p.setMaxFloat("algo:param1", 2000.0);
+
+  // Defaults: applicable=true, commit=true;
+  Param::UpdateOptions opts;
+  opts.context = "Param Update Value Testing";
+
+  // 1) Happy path: valid candidate -> applied, returns true
+  TEST_EQUAL(p.updateValue("algo:mode", ParamValue("B"), opts), true);
+  TEST_EQUAL(p.getValue("algo:mode"), "B");
+  TEST_EQUAL(p.getValue("algo:param1"), 1000.0); // algo:param1 should not be affected/changed
+
+  // 2) Violates ParamEntry restrictions -> not applied, returns false
+  TEST_EQUAL(p.updateValue("algo:mode", ParamValue("C"), opts), false);
+  TEST_EQUAL(p.getValue("algo:mode"), "B"); // unchanged
+
+  // 3) Custom validator blocks the change even if ParamEntry restriction passes
+  Param::UpdateOptions opts_custom = opts;
+  opts_custom.validator = [](const ParamValue& v) {
+    // only allow "B"
+    return v.toString() == "B";
+  };
+  TEST_EQUAL(p.updateValue("algo:mode", ParamValue("A"), opts_custom), false);
+  TEST_EQUAL(p.getValue("algo:mode"), "B"); // unchanged
+
+  // 4) Not applicable -> no change, returns false
+  Param::UpdateOptions opts_na = opts;
+  opts_na.applicable = false;
+  TEST_EQUAL(p.updateValue("algo:mode", ParamValue("A"), opts_na), false);
+  TEST_EQUAL(p.getValue("algo:mode"), "B"); // unchanged
+
+  // 5) Dry-run (commit=false) -> validation passes but no change, returns false
+  Param::UpdateOptions opts_dry = opts;
+  opts_dry.commit = false;
+  TEST_EQUAL(p.updateValue("algo:mode", ParamValue("A"), opts_dry), false);
+  TEST_EQUAL(p.getValue("algo:mode"), "B"); // unchanged
+
+  // 6) Numeric integer param with range restrictions
+  p.setValue("algo:max_iter", 3);
+  p.setMinInt("algo:max_iter", 0);
+  p.setMaxInt("algo:max_iter", 5);
+
+  TEST_EQUAL(p.updateValue("algo:max_iter", ParamValue(4), opts), true);
+  TEST_EQUAL(Int(p.getValue("algo:max_iter")), 4);
+
+  // out-of-range -> not applied
+  TEST_EQUAL(p.updateValue("algo:max_iter", ParamValue(6), opts), false);
+  TEST_EQUAL(Int(p.getValue("algo:max_iter")), 4); // unchanged
+
+  // 7) Numeric float param with range restrictions
+  p.setValue("algo:max_iter", 3.0);
+  p.setMinFloat("algo:max_iter", 0.0);
+  p.setMaxFloat("algo:max_iter", 5.0);
+
+  TEST_EQUAL(p.updateValue("algo:max_iter", ParamValue(4.0), opts), true);
+  TEST_EQUAL(double(p.getValue("algo:max_iter")), 4.0);
+
+  // out-of-range -> not applied
+  TEST_EQUAL(p.updateValue("algo:max_iter", ParamValue(6.0), opts), false);
+  TEST_EQUAL(double(p.getValue("algo:max_iter")), 4.0); // unchanged
+
+  // 8) Unknown key -> throws
+  Param p2;
+  TEST_EXCEPTION(Exception::ElementNotFound,
+                 p2.updateValue("does:not:exist", ParamValue(1), opts));
+}
+END_SECTION
+
+
 START_SECTION((void update(const Param& old_version, const bool add_unknown = false)))
 {
   NOT_TESTABLE // see full implementation below


### PR DESCRIPTION
## Description

This pull request adds a flexible mechanism for updating parameter values in the `Param` class by adding the `updateValue` method and its associated `UpdateOptions` struct. This allows for controlled, validated, and optionally logged parameter updates, supporting dry-run, custom validation. See PR [[OpenSwathWorkflow] Feature/auto extraction windows #8188 discussion](https://github.com/OpenMS/OpenMS/pull/8188#discussion_r2310878288)

**Core API Enhancements:**

* Added a new struct `Param::UpdateOptions` to control parameter update behavior, including applicability, commit (dry-run), context for logging, optional custom validator, and logging control.
* Introduced the `Param::updateValue` method, which validates and (optionally) updates a parameter value according to the provided `UpdateOptions`, supporting restrictions, custom validation, dry-run, and provenance logging. [[1]](diffhunk://#diff-0b11531368d47736f99b1b45c1a0ef153daef9ffd4166beb262be25937e24c90R367-R406) [[2]](diffhunk://#diff-7753a1a978f9fee292a1a5c2140f24950b62fe9549f370f917363a308164f745R1693-R1741)

**Testing Improvements:**

* Added comprehensive unit tests for `updateValue`, covering valid updates, restriction violations, custom validators, inapplicability, dry-run, numeric range enforcement, and unknown keys.

**Internal/Dependency Updates:**

* Included necessary headers (`String.h`, `<functional>`) to support the new features.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a public API to update parameter values with built-in validation, optional custom validators, dry-run support, contextual logging, and change-detection. Attempts on unknown parameters now surface clear errors.

* Tests
  * Comprehensive tests cover valid updates, validation failures, custom validator rejections, non-applicable scenarios, dry-run behavior, numeric range checks, and unknown keys.

* Documentation
  * Changelog updated to reflect the new parameter update capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->