### PR TITLE
Create placeholder documentation for missing tools

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -228,6 +228,14 @@ if(ENABLE_DOCS)
 
     add_dependencies(doc_param_internal doc_progs)
 
+    if(NOT WITH_PARQUET)
+      add_custom_command(TARGET doc_param_internal POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E echo "Creating placeholder documentation for tools disabled due to missing dependencies..."
+      COMMAND ${CMAKE_COMMAND} -E echo "<html><body><h2>Tool not available</h2><p>QuantmsIOConverter requires Parquet support which was disabled during compilation (WITH_PARQUET=OFF).</p></body></html>" > ${CMAKE_CURRENT_BINARY_DIR}/doxygen/parameters/output/TOPP_QuantmsIOConverter.html
+      COMMENT "Generate placeholder HTML for disabled tools"
+      VERBATIM)
+    endif()
+
     #------------------------------------------------------------------------------
     # doc(_html) generation code reused in two independent targets
     set(_DOC_HTML_CODE


### PR DESCRIPTION
## Description

fixes doxygen warning when parquet is disabled

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an automatic placeholder page for QuantmsIOConverter when Parquet support is disabled, clearly explaining the tool is unavailable in this build. Prevents broken or missing documentation pages.
* **Bug Fixes**
  * Documentation generation no longer fails or produces missing pages when Parquet is turned off, improving reliability across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->