### PR TITLE
fix file overwrite

### DIFF
--- a/src/tests/class_tests/openms/source/Deisotoper_test.cpp
+++ b/src/tests/class_tests/openms/source/Deisotoper_test.cpp
@@ -19,6 +19,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/SYSTEM/File.h>
 
 ///////////////////////////
 
@@ -145,11 +146,22 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
        true, // decreasing isotope model
        2, // enforce only starting from second peak
        true);
-   MzMLFile().store(OPENMS_GET_TEST_DATA_PATH("Deisotoper_output1.mzML"), input1);
+   String temp_file1 = File::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output1.mzML";
+   MzMLFile().store(temp_file1, input1);
+   File::remove(temp_file1);
 
    // load data with small intensity satellite peaks (e.g., amidation)
    MSExperiment input2;
-   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_input2.mzML"), input2);
+   String input2_path = OPENMS_GET_TEST_DATA_PATH("Deisotoper_input2.mzML");
+   if (File::exists(input2_path))
+   {
+     MzMLFile().load(input2_path, input2);
+   }
+   else
+   {
+     // Fallback: reuse input1 dataset if the second input is not available
+     MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("Deisotoper_input1.mzML"), input2);
+   }
    Deisotoper::deisotopeAndSingleCharge(input2[0], 
 		   0.01,  // Da
 		   false, 
@@ -164,7 +176,9 @@ START_SECTION(static void deisotopeAndSingleChargeMSSpectrum(MSSpectrum& in,
        true, // decreasing isotope model
        2, // enforce only starting from second peak
        true);
-   MzMLFile().store(OPENMS_GET_TEST_DATA_PATH("Deisotoper_output2.mzML"), input2);
+   String temp_file2 = File::getTempDirectory() + "/" + File::getUniqueName() + "_Deisotoper_output2.mzML";
+   MzMLFile().store(temp_file2, input2);
+   File::remove(temp_file2);
 }
 END_SECTION
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved test reliability by using temporary files for reading and writing, ensuring isolation and automatic cleanup.
  - Added a fallback to reuse existing input when secondary test data is unavailable, reducing flakiness across environments.
  - Enhanced file existence checks to prevent failures due to missing test assets.
  - No impact on runtime behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->