### PR TITLE
refactor: replace boost shared_ptr with STL one

### DIFF
--- a/doc/code_examples/Tutorial_GUI_Plot1D.cpp
+++ b/doc/code_examples/Tutorial_GUI_Plot1D.cpp
@@ -11,7 +11,7 @@
 #include <OpenMS/openms_data_path.h> // exotic header for path to tutorial data
 #include <QApplication>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 using namespace OpenMS;
 using namespace std;
@@ -23,7 +23,7 @@ Int main(int argc, const char** argv)
   QApplication app(argc, const_cast<char**>(argv));
 
   AnnotatedMSRun exp;
-  auto exp_sptr = boost::make_shared<AnnotatedMSRun>();
+  auto exp_sptr = std::make_shared<AnnotatedMSRun>();
   MSSpectrum spec;
   // demonstrating how to load a single spectrum from file formats which only contain a single spec
   // alternatively: use FileHandler().loadExperiment() if you need an experiment anyway

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
@@ -15,7 +15,7 @@
 #include <OpenMS/KERNEL/MRMTransitionGroup.h>
 #include <OpenMS/PROCESSING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // These classes are minimal implementations of the interfaces defined in ITransition:
 //  - IFeature
@@ -63,9 +63,9 @@ public:
 
     ~MRMFeatureOpenMS() override;
 
-    boost::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) override;
+    std::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) override;
 
-    boost::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) override;
+    std::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) override;
 
     std::vector<std::string> getNativeIDs() const override;
 
@@ -81,8 +81,8 @@ public:
 
 private:
     const MRMFeature& mrmfeature_;
-    std::map<std::string, boost::shared_ptr<FeatureOpenMS> > features_;
-    std::map<std::string, boost::shared_ptr<FeatureOpenMS> > precursor_features_;
+    std::map<std::string, std::shared_ptr<FeatureOpenMS> > features_;
+    std::map<std::string, std::shared_ptr<FeatureOpenMS> > precursor_features_;
   };
 
   /**

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h
@@ -13,7 +13,7 @@
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -25,11 +25,11 @@ namespace OpenMS
   public:
 
     /// Simple Factory method to get a SpectrumAccess Ptr from an MSExperiment
-    static OpenSwath::SpectrumAccessPtr getSpectrumAccessOpenMSPtr(const boost::shared_ptr<OpenMS::PeakMap>& exp);
+    static OpenSwath::SpectrumAccessPtr getSpectrumAccessOpenMSPtr(const std::shared_ptr<OpenMS::PeakMap>& exp);
 
   private:
 
-    static bool isExperimentCached(const boost::shared_ptr<OpenMS::PeakMap>& exp);
+    static bool isExperimentCached(const std::shared_ptr<OpenMS::PeakMap>& exp);
   };
 }
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h
@@ -15,7 +15,7 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -32,7 +32,7 @@ public:
     typedef OpenMS::MSChromatogram MSChromatogramType;
 
     /// Constructor
-    explicit SpectrumAccessOpenMS(boost::shared_ptr<MSExperimentType> ms_experiment);
+    explicit SpectrumAccessOpenMS(std::shared_ptr<MSExperimentType> ms_experiment);
 
     /// Destructor
     ~SpectrumAccessOpenMS() override;
@@ -55,7 +55,7 @@ public:
       the same underlying MSExperiment.
 
     */
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
+    std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
 
     OpenSwath::SpectrumPtr getSpectrumById(int id) override;
 
@@ -79,7 +79,7 @@ public:
     std::string getChromatogramNativeID(int id) const override;
 
 private:
-    boost::shared_ptr<MSExperimentType> ms_experiment_;
+    std::shared_ptr<MSExperimentType> ms_experiment_;
 
   };
 } //end namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.h
@@ -64,7 +64,7 @@ public:
     SpectrumAccessOpenMSCached(const SpectrumAccessOpenMSCached & rhs);
 
     /// Light clone operator (actual data will not get copied)
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
+    std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
 
     OpenSwath::SpectrumPtr getSpectrumById(int id) override;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSInMemory.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSInMemory.h
@@ -15,7 +15,7 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -62,7 +62,7 @@ public:
     SpectrumAccessOpenMSInMemory(const SpectrumAccessOpenMSInMemory & rhs);
 
     /// Light clone operator (actual data will not get copied)
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
+    std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
 
     OpenSwath::SpectrumPtr getSpectrumById(int id) override;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessQuadMZTransforming.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessQuadMZTransforming.h
@@ -42,7 +42,7 @@ public:
         
     ~SpectrumAccessQuadMZTransforming() override;
 
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
+    std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
 
     OpenSwath::SpectrumPtr getSpectrumById(int id) override;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessSqMass.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessSqMass.h
@@ -17,7 +17,7 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -78,7 +78,7 @@ public:
     SpectrumAccessSqMass(const SpectrumAccessSqMass & rhs);
 
     /// Light clone operator (actual data will not get copied)
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
+    std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const override;
 
     OpenSwath::SpectrumPtr getSpectrumById(int /* id */) override;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessTransforming.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessTransforming.h
@@ -27,7 +27,7 @@ public:
         
     ~SpectrumAccessTransforming() override = 0;
 
-    boost::shared_ptr<ISpectrumAccess> lightClone() const override = 0;
+    std::shared_ptr<ISpectrumAccess> lightClone() const override = 0;
 
     OpenSwath::SpectrumPtr getSpectrumById(int id) override;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMScoring.h
@@ -59,7 +59,7 @@ namespace OpenSwath
         typedef OpenSwath::LightCompound PeptideType;
         typedef OpenSwath::LightProtein ProteinType;
 
-        typedef boost::shared_ptr<OpenSwath::IFeature> FeatureType;
+        using FeatureType = std::shared_ptr<OpenSwath::IFeature>;
         //@}
 
         /** @name Accessors */

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -25,7 +25,6 @@
 
 #include <vector>
 #include <memory>
-#include <memory>
 
 //logging
 #include <OpenMS/CONCEPT/LogStream.h>

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -24,8 +24,8 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
+#include <memory>
 
 //logging
 #include <OpenMS/CONCEPT/LogStream.h>

--- a/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
@@ -66,7 +66,7 @@ private:
                        const bool split_file,
                        const String& tmp,
                        const String& readoptions,
-                       boost::shared_ptr<ExperimentalSettings > & exp_meta,
+                       std::shared_ptr<ExperimentalSettings > & exp_meta,
                        std::vector< OpenSwath::SwathMap > & swath_maps,
                        Interfaces::IMSDataConsumer* plugin_consumer)
   {
@@ -129,7 +129,7 @@ protected:
    *
    */
   bool loadSwathFiles(const StringList& file_list,
-                      boost::shared_ptr<ExperimentalSettings >& exp_meta,
+                      std::shared_ptr<ExperimentalSettings >& exp_meta,
                       std::vector< OpenSwath::SwathMap >& swath_maps,
                       const bool split_file,
                       const String& tmp,
@@ -225,7 +225,7 @@ protected:
    * @param run_id Unique identifier which links the sqMass and OSW file
    */
   void prepareChromOutput(Interfaces::IMSDataConsumer ** chromatogramConsumer,
-                          const boost::shared_ptr<ExperimentalSettings>& exp_meta,
+                          const std::shared_ptr<ExperimentalSettings>& exp_meta,
                           const OpenSwath::LightTargetedExperiment& transition_exp,
                           const String& out_chrom,
                           const UInt64 run_id)

--- a/src/openms/include/OpenMS/CONCEPT/Helpers.h
+++ b/src/openms/include/OpenMS/CONCEPT/Helpers.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 
@@ -21,10 +21,10 @@ namespace OpenMS
         @brief Helper function to add constness to a vector of shared pointers
     */
     template <class T>
-    const std::vector<boost::shared_ptr<const T> >&
-    constifyPointerVector(const std::vector<boost::shared_ptr<T> >& vec) 
+    const std::vector<std::shared_ptr<const T> >&
+    constifyPointerVector(const std::vector<std::shared_ptr<T> >& vec)
     {
-      return reinterpret_cast<const std::vector<boost::shared_ptr<const T> >&>(vec);
+      return reinterpret_cast<const std::vector<std::shared_ptr<const T> >&>(vec);
     }
 
 

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
@@ -16,7 +16,7 @@
 #include <vector>
 #include <string>
 #include <fstream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
@@ -301,8 +301,8 @@ protected:
     std::vector<OpenSwath::SwathMap> swath_map_boundaries_;
 
     /// A list of SWATH maps and the MS1 map
-    std::vector<boost::shared_ptr<PeakMap > > swath_maps_;
-    boost::shared_ptr<PeakMap > ms1_map_;
+    std::vector<std::shared_ptr<PeakMap > > swath_maps_;
+    std::shared_ptr<PeakMap > ms1_map_;
 
     /// The Experimental settings
     // (MSExperiment has no constructor using ExperimentalSettings)
@@ -342,7 +342,7 @@ public:
 protected:
     void addNewSwathMap_()
     {
-      boost::shared_ptr<PeakMap > exp(new PeakMap(settings_));
+      std::shared_ptr<PeakMap > exp(new PeakMap(settings_));
       swath_maps_.push_back(exp);
     }
 
@@ -358,7 +358,7 @@ protected:
 
     void addMS1Map_()
     {
-      boost::shared_ptr<PeakMap > exp(new PeakMap(settings_));
+      std::shared_ptr<PeakMap > exp(new PeakMap(settings_));
       ms1_map_ = exp;
     }
 
@@ -437,7 +437,7 @@ protected:
       swath_consumers_.push_back(consumer);
 
       // maps for meta data
-      boost::shared_ptr<PeakMap > exp(new PeakMap(settings_));
+      std::shared_ptr<PeakMap > exp(new PeakMap(settings_));
       swath_maps_.push_back(exp);
     }
 
@@ -457,7 +457,7 @@ protected:
       String cached_file = meta_file + ".cached";
       ms1_consumer_ = new MSDataCachedConsumer(cached_file, true);
       ms1_consumer_->setExpectedSize(nr_ms1_spectra_, 0);
-      boost::shared_ptr<PeakMap > exp(new PeakMap(settings_));
+      std::shared_ptr<PeakMap > exp(new PeakMap(settings_));
       ms1_map_ = exp;
     }
 
@@ -497,7 +497,7 @@ protected:
 
       if (have_ms1)
       {
-        boost::shared_ptr<PeakMap > exp(new PeakMap);
+        std::shared_ptr<PeakMap > exp(new PeakMap);
         String meta_file = cachedir_ + basename_ + "_ms1.mzML";
         // write metadata to disk and store the correct data processing tag
         Internal::CachedMzMLHandler().writeMetadata(*ms1_map_, meta_file, true);
@@ -510,7 +510,7 @@ protected:
 #endif
       for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_consumers_size); i++)
       {
-        boost::shared_ptr<PeakMap > exp(new PeakMap);
+        std::shared_ptr<PeakMap > exp(new PeakMap);
         String meta_file = cachedir_ + basename_ + "_" + String(i) +  ".mzML";
         // write metadata to disk and store the correct data processing tag
         Internal::CachedMzMLHandler().writeMetadata(*swath_maps_[i], meta_file, true);

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
@@ -181,7 +181,7 @@ protected:
       inline void writeBinary_(std::ostream & os, Size size, const String & tag, const String & name = "", SignedSize id = -1);
 
       //Data processing auxiliary variable
-      boost::shared_ptr< DataProcessing > data_processing_;
+      std::shared_ptr< DataProcessing > data_processing_;
 
     };
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
@@ -169,7 +169,7 @@ protected:
       void populateSpectraWithData_();
 
       /// data processing auxiliary variable
-      std::vector< boost::shared_ptr< DataProcessing> > data_processing_;
+      std::vector< std::shared_ptr< DataProcessing> > data_processing_;
 
 
 private:

--- a/src/openms/include/OpenMS/FORMAT/IBSpectraFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IBSpectraFile.h
@@ -11,7 +11,6 @@
 #include <OpenMS/config.h>
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 
-// boost shared_ptr
 #include <memory>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/IBSpectraFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IBSpectraFile.h
@@ -12,7 +12,7 @@
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 
 // boost shared_ptr
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -61,7 +61,7 @@ private:
 
       @throws Exception::InvalidParameter if the ConsensusMap does not hold the result of an isobaric quantification experiment (e.g., itraq).
     */
-    boost::shared_ptr<IsobaricQuantitationMethod> guessExperimentType_(const ConsensusMap& cm);
+    std::shared_ptr<IsobaricQuantitationMethod> guessExperimentType_(const ConsensusMap& cm);
 
     /**
       @brief Constructs the matching file header for the given quantitation method.

--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -15,7 +15,7 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -46,7 +46,7 @@ public:
     /// Loads a Swath run from a list of split mzML files
     std::vector<OpenSwath::SwathMap> loadSplit(StringList file_list,
                                                const String& tmp,
-                                               boost::shared_ptr<ExperimentalSettings>& exp_meta, 
+                                               std::shared_ptr<ExperimentalSettings>& exp_meta, 
                                                const String& readoptions = "normal");
 
     /**
@@ -67,27 +67,27 @@ public:
     */
     std::vector<OpenSwath::SwathMap> loadMzML(const String& file, 
                                               const String& tmp,
-                                              boost::shared_ptr<ExperimentalSettings>& exp_meta,
+                                              std::shared_ptr<ExperimentalSettings>& exp_meta,
                                               const String& readoptions = "normal",
                                               Interfaces::IMSDataConsumer* plugin_consumer = nullptr);
 
     /// Loads a Swath run from a single mzXML file
     std::vector<OpenSwath::SwathMap> loadMzXML(const String& file, 
                                                const String& tmp,
-                                               boost::shared_ptr<ExperimentalSettings>& exp_meta,
+                                               std::shared_ptr<ExperimentalSettings>& exp_meta,
                                                const String& readoptions = "normal");
 
     /// Loads a Swath run from a single sqMass file
-    std::vector<OpenSwath::SwathMap> loadSqMass(const String& file, boost::shared_ptr<ExperimentalSettings>& /* exp_meta */);
+    std::vector<OpenSwath::SwathMap> loadSqMass(const String& file, std::shared_ptr<ExperimentalSettings>& /* exp_meta */);
 
 protected:
 
     /// Cache a file to disk
     OpenSwath::SpectrumAccessPtr doCacheFile_(const String& in, const String& tmp, const String& tmp_fname,
-                                              const boost::shared_ptr<PeakMap >& experiment_metadata);
+                                              const std::shared_ptr<PeakMap >& experiment_metadata);
 
     /// Only read the meta data from a file and use it to populate exp_meta
-    boost::shared_ptr< PeakMap > populateMetaData_(const String& file);
+    std::shared_ptr< PeakMap > populateMetaData_(const String& file);
 
     /// Counts the number of scans in a full Swath file (e.g. concatenated non-split file)
     void countScansInSwath_(const std::vector<MSSpectrum>& exp,

--- a/src/openms/include/OpenMS/FORMAT/XMassFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XMassFile.h
@@ -138,8 +138,8 @@ public:
       data_processing.setProcessingActions(actions);
       data_processing.setCompletionTime(DateTime::now());
 
-      std::vector< boost::shared_ptr< DataProcessing> > data_processing_vector;
-      data_processing_vector.push_back( boost::shared_ptr< DataProcessing>(new DataProcessing(data_processing)) );
+      std::vector< std::shared_ptr< DataProcessing> > data_processing_vector;
+      data_processing_vector.push_back( std::shared_ptr< DataProcessing>(new DataProcessing(data_processing)) );
       spectrum.setDataProcessing(data_processing_vector);
     }
 

--- a/src/openms/include/OpenMS/INTERFACES/DataStructures.h
+++ b/src/openms/include/OpenMS/INTERFACES/DataStructures.h
@@ -10,7 +10,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <OpenMS/config.h>
 
@@ -51,7 +51,7 @@ namespace Interfaces
     /// the binary data.
     std::vector<double> data;
   };
-  typedef boost::shared_ptr<BinaryDataArray> BinaryDataArrayPtr;
+  using BinaryDataArrayPtr = std::shared_ptr<BinaryDataArray>;
 
   /// Identifying information for a chromatogram
   struct OPENMS_DLLAPI ChromatogramMeta
@@ -70,7 +70,7 @@ namespace Interfaces
     }
 
   };
-  typedef boost::shared_ptr<ChromatogramMeta> ChromatogramMetaPtr;
+  using ChromatogramMetaPtr = std::shared_ptr<ChromatogramMeta>;
 
   /// A single chromatogram.
   struct OPENMS_DLLAPI Chromatogram
@@ -96,8 +96,7 @@ private:
     {
       for (std::size_t i = 0; i < defaultArrayLength; ++i)
       {
-        BinaryDataArrayPtr empty(new BinaryDataArray);
-        binaryDataArrayPtrs[i] = empty;
+        binaryDataArrayPtrs[i] = std::make_shared<BinaryDataArray>();
       }
     }
 
@@ -127,7 +126,7 @@ public:
     }
 
   };
-  typedef boost::shared_ptr<Chromatogram> ChromatogramPtr;
+  using ChromatogramPtr = std::shared_ptr<Chromatogram>;
 
   /// Identifying information for a spectrum
   struct OPENMS_DLLAPI SpectrumMeta
@@ -150,7 +149,7 @@ public:
     }
 
   };
-  typedef boost::shared_ptr<SpectrumMeta> SpectrumMetaPtr;
+  using SpectrumMetaPtr = std::shared_ptr<SpectrumMeta>;
 
   /// The structure that captures the generation of a peak list (including the underlying acquisitions)
   struct OPENMS_DLLAPI Spectrum
@@ -176,8 +175,7 @@ private:
     {
       for (std::size_t i = 0; i < defaultArrayLength; ++i)
       {
-        BinaryDataArrayPtr empty(new BinaryDataArray);
-        binaryDataArrayPtrs[i] = empty;
+        binaryDataArrayPtrs[i] = std::make_shared<BinaryDataArray>();
       }
     }
 
@@ -207,7 +205,7 @@ public:
     }
 
   };
-  typedef boost::shared_ptr<Spectrum> SpectrumPtr;
+  using SpectrumPtr = std::shared_ptr<Spectrum>;
 
 } //end namespace Interfaces
 } //end namespace OpenMS

--- a/src/openms/include/OpenMS/INTERFACES/ISpectrumAccess.h
+++ b/src/openms/include/OpenMS/INTERFACES/ISpectrumAccess.h
@@ -12,7 +12,7 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -46,7 +46,7 @@ public:
     ConstSpectraIterator endSpectra() const;
     */
   };
-  typedef boost::shared_ptr<ISpectraReader> SpectraReaderPtr;
+  using SpectraReaderPtr = std::shared_ptr<ISpectraReader>;
 
 
   /**
@@ -75,7 +75,7 @@ public:
     ConstChromatogramIterator endChromatograms() const;
     */
   };
-  typedef boost::shared_ptr<IChromatogramsReader> ChromatogramsReaderPtr;
+  using ChromatogramsReaderPtr = std::shared_ptr<IChromatogramsReader>;
 
 
   class OPENMS_DLLAPI ISpectraWriter
@@ -87,7 +87,7 @@ public:
     /// write all cached data to disk
     virtual void flush() = 0;
   };
-  typedef boost::shared_ptr<ISpectraWriter> SpectraWriterPtr;
+  using SpectraWriterPtr = std::shared_ptr<ISpectraWriter>;
 
 
   class OPENMS_DLLAPI IChromatogramsWriter
@@ -99,7 +99,7 @@ public:
     /// write all cached data to disk
     virtual void flush() = 0;
   };
-  typedef boost::shared_ptr<IChromatogramsWriter> ChromatogramsWriterPtr;
+  using ChromatogramsWriterPtr = std::shared_ptr<IChromatogramsWriter>;
 
 } //end namespace Interfaces
 } //end namespace OpenMS

--- a/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
@@ -19,7 +19,7 @@
 #include <vector>
 #include <limits>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -136,12 +136,12 @@ public:
     }
 
     /// returns the meta information of this experiment (const access)
-    boost::shared_ptr<const ExperimentalSettings> getExperimentalSettings() const
+    std::shared_ptr<const ExperimentalSettings> getExperimentalSettings() const
     {
-      return boost::static_pointer_cast<const ExperimentalSettings>(meta_ms_experiment_);
+      return std::static_pointer_cast<const ExperimentalSettings>(meta_ms_experiment_);
     }
 
-    boost::shared_ptr<PeakMap> getMetaData() const
+    std::shared_ptr<PeakMap> getMetaData() const
     {
       return meta_ms_experiment_;
     }
@@ -228,7 +228,7 @@ protected:
     /// The index of the underlying data file
     Internal::IndexedMzMLHandler indexed_mzml_file_;
     /// The meta-data
-    boost::shared_ptr<PeakMap> meta_ms_experiment_;
+    std::shared_ptr<PeakMap> meta_ms_experiment_;
     /// Mapping of chromatogram native ids to offsets
     std::unordered_map< std::string, Size > chromatograms_native_ids_;
     /// Mapping of spectra native ids to offsets

--- a/src/openms/include/OpenMS/METADATA/ChromatogramSettings.h
+++ b/src/openms/include/OpenMS/METADATA/ChromatogramSettings.h
@@ -132,7 +132,7 @@ public:
     std::vector< DataProcessingPtr > & getDataProcessing();
 
     /// returns a const reference to the description of the applied processing
-    const std::vector< boost::shared_ptr<const DataProcessing > > getDataProcessing() const;
+    const std::vector< std::shared_ptr<const DataProcessing > > getDataProcessing() const;
 
 protected:
 

--- a/src/openms/include/OpenMS/METADATA/DataProcessing.h
+++ b/src/openms/include/OpenMS/METADATA/DataProcessing.h
@@ -13,7 +13,7 @@
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <set>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace OpenMS
 {
@@ -108,7 +108,7 @@ protected:
     DateTime completion_time_;
   };
 
-  typedef boost::shared_ptr<DataProcessing> DataProcessingPtr;
-  typedef boost::shared_ptr<const DataProcessing> ConstDataProcessingPtr;
+  using DataProcessingPtr = std::shared_ptr<DataProcessing>;
+  using ConstDataProcessingPtr = std::shared_ptr<const DataProcessing>;
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
@@ -130,7 +130,7 @@ public:
     std::vector< DataProcessingPtr > & getDataProcessing();
 
     /// returns a const reference to the description of the applied processing
-    const std::vector< boost::shared_ptr<const DataProcessing > > getDataProcessing() const;
+    const std::vector< std::shared_ptr<const DataProcessing > > getDataProcessing() const;
 
 protected:
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
+#include <algorithm>
 #include <iostream>
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.cpp
@@ -21,7 +21,7 @@ namespace OpenMS
     mrmfeature.getFeatureIDs(ids);
     for (std::vector<String>::iterator it = ids.begin(); it != ids.end(); ++it)
     {
-      boost::shared_ptr<FeatureOpenMS> ptr = boost::shared_ptr<FeatureOpenMS>(new FeatureOpenMS(mrmfeature.getFeature(*it)));
+      std::shared_ptr<FeatureOpenMS> ptr = std::shared_ptr<FeatureOpenMS>(new FeatureOpenMS(mrmfeature.getFeature(*it)));
       features_[*it] = ptr;
     }
 
@@ -29,7 +29,7 @@ namespace OpenMS
     mrmfeature.getPrecursorFeatureIDs(p_ids);
     for (std::vector<String>::iterator it = p_ids.begin(); it != p_ids.end(); ++it)
     {
-      boost::shared_ptr<FeatureOpenMS> ptr = boost::shared_ptr<FeatureOpenMS>(new FeatureOpenMS(mrmfeature.getPrecursorFeature(*it)));
+      std::shared_ptr<FeatureOpenMS> ptr = std::shared_ptr<FeatureOpenMS>(new FeatureOpenMS(mrmfeature.getPrecursorFeature(*it)));
       precursor_features_[*it] = ptr;
     }
   }
@@ -73,22 +73,22 @@ namespace OpenMS
 
   MRMFeatureOpenMS::~MRMFeatureOpenMS() = default;
 
-  boost::shared_ptr<OpenSwath::IFeature> MRMFeatureOpenMS::getFeature(std::string nativeID)
+  std::shared_ptr<OpenSwath::IFeature> MRMFeatureOpenMS::getFeature(std::string nativeID)
   {
     OPENMS_PRECONDITION(features_.find(nativeID) != features_.end(), "Feature needs to exist");
-    return boost::static_pointer_cast<OpenSwath::IFeature>(features_[nativeID]);
+    return std::static_pointer_cast<OpenSwath::IFeature>(features_[nativeID]);
   }
 
-  boost::shared_ptr<OpenSwath::IFeature> MRMFeatureOpenMS::getPrecursorFeature(std::string nativeID)
+  std::shared_ptr<OpenSwath::IFeature> MRMFeatureOpenMS::getPrecursorFeature(std::string nativeID)
   {
     OPENMS_PRECONDITION(precursor_features_.find(nativeID) != precursor_features_.end(), "Precursor feature needs to exist");
-    return boost::static_pointer_cast<OpenSwath::IFeature>(precursor_features_[nativeID]);
+    return std::static_pointer_cast<OpenSwath::IFeature>(precursor_features_[nativeID]);
   }
 
   std::vector<std::string> MRMFeatureOpenMS::getNativeIDs() const
   {
     std::vector<std::string> v;
-    for (std::map<std::string, boost::shared_ptr<FeatureOpenMS> >::const_iterator it = features_.begin(); it != features_.end(); ++it)
+    for (std::map<std::string, std::shared_ptr<FeatureOpenMS> >::const_iterator it = features_.begin(); it != features_.end(); ++it)
     {
       v.push_back(it->first);
     }
@@ -98,7 +98,7 @@ namespace OpenMS
   std::vector<std::string> MRMFeatureOpenMS::getPrecursorIDs() const
   {
     std::vector<std::string> v;
-    for (std::map<std::string, boost::shared_ptr<FeatureOpenMS> >::const_iterator it = precursor_features_.begin(); it != precursor_features_.end(); ++it) 
+    for (std::map<std::string, std::shared_ptr<FeatureOpenMS> >::const_iterator it = precursor_features_.begin(); it != precursor_features_.end(); ++it) 
     {
       v.push_back(it->first);
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.cpp
@@ -13,7 +13,7 @@
 namespace OpenMS
 {
 
-  bool SimpleOpenMSSpectraFactory::isExperimentCached(const boost::shared_ptr<PeakMap>& exp)
+  bool SimpleOpenMSSpectraFactory::isExperimentCached(const std::shared_ptr<PeakMap>& exp)
   {
     for (std::size_t i = 0; i < exp->getSpectra().size(); ++i)
     {
@@ -38,7 +38,7 @@ namespace OpenMS
     return false;
   }
 
-  OpenSwath::SpectrumAccessPtr SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(const boost::shared_ptr<PeakMap>& exp)
+  OpenSwath::SpectrumAccessPtr SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(const std::shared_ptr<PeakMap>& exp)
   {
     bool is_cached = SimpleOpenMSSpectraFactory::isExperimentCached(exp);
     if (is_cached)

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.cpp
@@ -12,7 +12,7 @@
 
 namespace OpenMS
 {
-  SpectrumAccessOpenMS::SpectrumAccessOpenMS(boost::shared_ptr<MSExperimentType> ms_experiment)
+  SpectrumAccessOpenMS::SpectrumAccessOpenMS(std::shared_ptr<MSExperimentType> ms_experiment)
   {
     // store shared pointer to the actual MSExperiment
     ms_experiment_ = std::move(ms_experiment);
@@ -27,9 +27,9 @@ namespace OpenMS
   }
 
 
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMS::lightClone() const
+  std::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMS::lightClone() const
   {
-    return boost::shared_ptr<SpectrumAccessOpenMS>(new SpectrumAccessOpenMS(*this));
+    return std::shared_ptr<SpectrumAccessOpenMS>(new SpectrumAccessOpenMS(*this));
   }
 
   OpenSwath::SpectrumPtr SpectrumAccessOpenMS::getSpectrumById(int id)

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.cpp
@@ -26,9 +26,9 @@ namespace OpenMS
     // this only copies the indices and meta-data
   }
 
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMSCached::lightClone() const
+  std::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMSCached::lightClone() const
   {
-    return boost::shared_ptr<SpectrumAccessOpenMSCached>(new SpectrumAccessOpenMSCached(*this));
+    return std::shared_ptr<SpectrumAccessOpenMSCached>(new SpectrumAccessOpenMSCached(*this));
   }
 
   OpenSwath::SpectrumPtr SpectrumAccessOpenMSCached::getSpectrumById(int id)

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSInMemory.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSInMemory.cpp
@@ -51,9 +51,9 @@ namespace OpenMS
     // this only copies the pointers and not the actual data ... 
   }
 
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMSInMemory::lightClone() const
+  std::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessOpenMSInMemory::lightClone() const
   {
-    return boost::shared_ptr<SpectrumAccessOpenMSInMemory>(new SpectrumAccessOpenMSInMemory(*this));
+    return std::shared_ptr<SpectrumAccessOpenMSInMemory>(new SpectrumAccessOpenMSInMemory(*this));
   }
 
   OpenSwath::SpectrumPtr SpectrumAccessOpenMSInMemory::getSpectrumById(int id)

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessQuadMZTransforming.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessQuadMZTransforming.cpp
@@ -25,12 +25,12 @@ namespace OpenMS
         
     SpectrumAccessQuadMZTransforming::~SpectrumAccessQuadMZTransforming() = default;
 
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessQuadMZTransforming::lightClone() const
+    std::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessQuadMZTransforming::lightClone() const
     {
       // Create a light clone of *this by initializing a new
       // SpectrumAccessQuadMZTransforming with a light clone of the underlying
       // SpectrumAccess object and the parameters.
-      return boost::shared_ptr<SpectrumAccessQuadMZTransforming>(
+      return std::shared_ptr<SpectrumAccessQuadMZTransforming>(
           new SpectrumAccessQuadMZTransforming(sptr_->lightClone(), a_, b_, c_, ppm_));
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessSqMass.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessSqMass.cpp
@@ -58,9 +58,9 @@ namespace OpenMS
     }
 
     /// Light clone operator (actual data will not get copied)
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessSqMass::lightClone() const
+    std::shared_ptr<OpenSwath::ISpectrumAccess> SpectrumAccessSqMass::lightClone() const
     {
-      return boost::shared_ptr<SpectrumAccessSqMass>(new SpectrumAccessSqMass(*this));
+      return std::shared_ptr<SpectrumAccessSqMass>(new SpectrumAccessSqMass(*this));
     }
 
     OpenSwath::SpectrumPtr SpectrumAccessSqMass::getSpectrumById(int id)

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -23,7 +23,6 @@
 
 #include <boost/range/adaptor/map.hpp>
 #include <memory>
-#include <memory>
 #include <boost/foreach.hpp>
 
 #define run_identifier "unique_run_identifier"

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -22,8 +22,8 @@
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 
 #include <boost/range/adaptor/map.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
+#include <memory>
 #include <boost/foreach.hpp>
 
 #define run_identifier "unique_run_identifier"
@@ -158,8 +158,8 @@ namespace OpenMS
     OpenSwathDataAccessHelper::convertTargetedExp(transition_exp_, transition_exp);
     TransitionGroupMapType transition_group_map;
 
-    boost::shared_ptr<PeakMap > sh_chromatograms = boost::make_shared<PeakMap >(chromatograms);
-    boost::shared_ptr<PeakMap > sh_swath_map = boost::make_shared<PeakMap >(swath_map);
+    std::shared_ptr<PeakMap > sh_chromatograms = std::make_shared<PeakMap >(chromatograms);
+    std::shared_ptr<PeakMap > sh_swath_map = std::make_shared<PeakMap >(swath_map);
 
     OpenSwath::SpectrumAccessPtr chromatogram_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(sh_chromatograms);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(sh_swath_map);

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -29,7 +29,7 @@ namespace OpenMS
       // This creates an InMemory object that keeps all data in memory
       // but provides the same access functionality to the raw data as
       // any object implementing ISpectrumAccess
-      ms1_map = boost::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*ms1_map) );
+      ms1_map = std::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*ms1_map) );
     }
     return ms1_map;
   }
@@ -148,7 +148,7 @@ namespace OpenMS
     TransformationDescription empty_trafo; // empty transformation
 
     // Prepare the data with the chromatograms
-    boost::shared_ptr<PeakMap > xic_map(new PeakMap);
+    std::shared_ptr<PeakMap > xic_map(new PeakMap);
     xic_map->setChromatograms(chromatograms);
     OpenSwath::SpectrumAccessPtr chromatogram_ptr = OpenSwath::SpectrumAccessPtr(new OpenMS::SpectrumAccessOpenMS(xic_map));
 
@@ -371,7 +371,7 @@ namespace OpenMS
           if (load_into_memory)
           {
             // This creates an InMemory object that keeps all data in memory
-            current_swath_map = boost::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*current_swath_map) );
+            current_swath_map = std::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*current_swath_map) );
           }
 
           prepareExtractionCoordinates_(tmp_out, coordinates, transition_exp_used, trafo_inverse, cp);
@@ -489,7 +489,7 @@ namespace OpenMS
                      transition_exp, trafo_inverse, ms1_only, ms1_isotopes);
 
       FeatureMap featureFile;
-      boost::shared_ptr<MSExperiment> empty_exp = boost::shared_ptr<MSExperiment>(new MSExperiment);
+      std::shared_ptr<MSExperiment> empty_exp = std::shared_ptr<MSExperiment>(new MSExperiment);
 
       const OpenSwath::LightTargetedExperiment& transition_exp_used = transition_exp;
       scoreAllChromatograms_(std::vector<MSChromatogram>(), ms1_chromatograms, swath_maps, transition_exp_used,
@@ -661,7 +661,7 @@ namespace OpenMS
           if (load_into_memory)
           {
             // This creates an InMemory object that keeps all data in memory
-            current_swath_map = boost::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*current_swath_map) );
+            current_swath_map = std::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*current_swath_map) );
           }
 
           int batch_size;

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -585,7 +585,7 @@ namespace OpenMS
     // Replace the swath files with a transforming wrapper.
     for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_maps.size()); ++i)
     {
-      swath_maps[i].sptr = boost::shared_ptr<OpenSwath::ISpectrumAccess>(
+      swath_maps[i].sptr = std::shared_ptr<OpenSwath::ISpectrumAccess>(
         new SpectrumAccessQuadMZTransforming(swath_maps[i].sptr,
           regression_params[0], regression_params[1], regression_params[2], is_ppm));
     }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2353,7 +2353,7 @@ namespace OpenMS
 
   void TOPPBase::addDataProcessing_(PeakMap& map, const DataProcessing& dp) const
   {
-    boost::shared_ptr< DataProcessing > dp_(new DataProcessing(dp));
+    std::shared_ptr< DataProcessing > dp_(new DataProcessing(dp));
     for (Size i = 0; i < map.size(); ++i)
     {
       map[i].getDataProcessing().push_back(dp_);

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -218,7 +218,7 @@ namespace OpenMS
     extractor.prepare_coordinates(chrom_temp, coords, library_,
                                   numeric_limits<double>::quiet_NaN(), false);
 
-    boost::shared_ptr<PeakMap> shared = boost::make_shared<PeakMap>(ms_data_);
+    std::shared_ptr<PeakMap> shared = std::make_shared<PeakMap>(ms_data_);
     OpenSwath::SpectrumAccessPtr spec_temp =
       SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(shared);
     extractor.extractChromatograms(spec_temp, chrom_temp, coords, mz_window_,

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -428,7 +428,7 @@ namespace OpenMS
     feat_finder_.setLogType(ProgressLogger::NONE);
     feat_finder_.setStrictFlag(false);
     // to use MS1 Swath scores:
-    feat_finder_.setMS1Map(SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(boost::make_shared<MSExperiment>(ms_data_)));
+    feat_finder_.setMS1Map(SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(std::make_shared<MSExperiment>(ms_data_)));
 
     bool with_external_ids = !peptides_ext.empty();
 
@@ -507,7 +507,7 @@ namespace OpenMS
       n_external_peps_ = peptide_map_.size() - n_internal_peps_;
     }
 
-    boost::shared_ptr<PeakMap> shared = boost::make_shared<PeakMap>(ms_data_);
+    std::shared_ptr<PeakMap> shared = std::make_shared<PeakMap>(ms_data_);
     OpenSwath::SpectrumAccessPtr spec_temp =
         SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(shared);
     auto chunks = chunk_(peptide_map_.begin(), peptide_map_.end(), batch_size_);

--- a/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
@@ -216,7 +216,7 @@ namespace OpenMS::Internal
     if (addCacheMetaValue)
     {
       // set dataprocessing on each spectrum/chromatogram
-      boost::shared_ptr< DataProcessing > dp = boost::shared_ptr< DataProcessing >(new DataProcessing);
+      std::shared_ptr< DataProcessing > dp = std::shared_ptr< DataProcessing >(new DataProcessing);
       std::set<DataProcessing::ProcessingAction> actions;
       actions.insert(DataProcessing::FORMAT_CONVERSION);
       dp->setProcessingActions(actions);
@@ -259,7 +259,7 @@ namespace OpenMS::Internal
     if (addCacheMetaValue)
     {
       // set dataprocessing on each spectrum/chromatogram
-      boost::shared_ptr< DataProcessing > dp = boost::shared_ptr< DataProcessing >(new DataProcessing);
+      std::shared_ptr< DataProcessing > dp = std::shared_ptr< DataProcessing >(new DataProcessing);
       std::set<DataProcessing::ProcessingAction> actions;
       actions.insert(DataProcessing::FORMAT_CONVERSION);
       dp->setProcessingActions(actions);

--- a/src/openms/source/FORMAT/IBSpectraFile.cpp
+++ b/src/openms/source/FORMAT/IBSpectraFile.cpp
@@ -75,7 +75,7 @@ namespace OpenMS
 
   IBSpectraFile& IBSpectraFile::operator=(const IBSpectraFile& /* rhs */) = default;
 
-  boost::shared_ptr<IsobaricQuantitationMethod> IBSpectraFile::guessExperimentType_(const ConsensusMap& cm)
+  std::shared_ptr<IsobaricQuantitationMethod> IBSpectraFile::guessExperimentType_(const ConsensusMap& cm)
   {
     if (cm.getExperimentType() != "labeled_MS2" && cm.getExperimentType() != "itraq")
     {
@@ -88,15 +88,15 @@ namespace OpenMS
     // we take the map count as approximation
     if (cm.getColumnHeaders().size() == 4)
     {
-      return boost::shared_ptr<IsobaricQuantitationMethod>(new ItraqFourPlexQuantitationMethod);
+      return std::shared_ptr<IsobaricQuantitationMethod>(new ItraqFourPlexQuantitationMethod);
     }
     else if (cm.getColumnHeaders().size() == 6)
     {
-      return boost::shared_ptr<IsobaricQuantitationMethod>(new TMTSixPlexQuantitationMethod);
+      return std::shared_ptr<IsobaricQuantitationMethod>(new TMTSixPlexQuantitationMethod);
     }
     else if (cm.getColumnHeaders().size() == 8)
     {
-      return boost::shared_ptr<IsobaricQuantitationMethod>(new ItraqEightPlexQuantitationMethod);
+      return std::shared_ptr<IsobaricQuantitationMethod>(new ItraqEightPlexQuantitationMethod);
     }
     else
     {
@@ -172,7 +172,7 @@ namespace OpenMS
 
 
     // guess experiment type
-    boost::shared_ptr<IsobaricQuantitationMethod> quantMethod = guessExperimentType_(cm);
+    std::shared_ptr<IsobaricQuantitationMethod> quantMethod = guessExperimentType_(cm);
 
     // we need the protein identifications to reference the protein names
     ProteinIdentification protIdent;

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -32,7 +32,7 @@ namespace OpenMS
   /// Loads a Swath run from a list of split mzML files
   std::vector<OpenSwath::SwathMap> SwathFile::loadSplit(StringList file_list,
         const String& tmp,
-    boost::shared_ptr<ExperimentalSettings>& exp_meta,
+    std::shared_ptr<ExperimentalSettings>& exp_meta,
     const String& readoptions)
   {
     int progress = 0;
@@ -54,7 +54,7 @@ namespace OpenMS
 
       String tmp_fname = "openswath_tmpfile_" + String(i) + ".mzML";
 
-      boost::shared_ptr<PeakMap > exp(new PeakMap);
+      std::shared_ptr<PeakMap > exp(new PeakMap);
       OpenSwath::SpectrumAccessPtr spectra_ptr;
 
       // Populate meta-data
@@ -120,7 +120,7 @@ namespace OpenMS
   /// Loads a Swath run from a single mzML file
   std::vector<OpenSwath::SwathMap> SwathFile::loadMzML(const String& file,
                                                        const String& tmp,
-                                                       boost::shared_ptr<ExperimentalSettings>& exp_meta,
+                                                       std::shared_ptr<ExperimentalSettings>& exp_meta,
                                                        const String& readoptions,
                                                        Interfaces::IMSDataConsumer* plugin_consumer)
   {
@@ -128,7 +128,7 @@ namespace OpenMS
     String tmp_fname = tmp.hasSuffix('/') ? File::getUniqueName() : ""; // use tmp-filename if just a directory was given
 
     startProgress(0, 1, "Loading metadata file " + file);
-    boost::shared_ptr<PeakMap> exp_stripped = populateMetaData_(file);
+    std::shared_ptr<PeakMap> exp_stripped = populateMetaData_(file);
     exp_meta = exp_stripped;
 
     // First pass through the file -> get the meta data
@@ -190,14 +190,14 @@ namespace OpenMS
   /// Loads a Swath run from a single mzXML file
   std::vector<OpenSwath::SwathMap> SwathFile::loadMzXML(const String& file,
     const String& tmp,
-    boost::shared_ptr<ExperimentalSettings>& exp_meta,
+    std::shared_ptr<ExperimentalSettings>& exp_meta,
     const String& readoptions)
   {
     std::cout << "Loading mzXML file " << file << " using readoptions " << readoptions << std::endl;
     String tmp_fname = "openswath_tmpfile";
 
     startProgress(0, 1, "Loading metadata file " + file);
-    boost::shared_ptr<PeakMap > experiment_metadata(new PeakMap);
+    std::shared_ptr<PeakMap > experiment_metadata(new PeakMap);
     FileHandler f;
     f.getOptions().setAlwaysAppendData(true);
     f.getOptions().setFillData(false);
@@ -246,7 +246,7 @@ namespace OpenMS
   }
 
   /// Loads a Swath run from a single sqMass file
-  std::vector<OpenSwath::SwathMap> SwathFile::loadSqMass(const String& file, boost::shared_ptr<ExperimentalSettings>& /* exp_meta */)
+  std::vector<OpenSwath::SwathMap> SwathFile::loadSqMass(const String& file, std::shared_ptr<ExperimentalSettings>& /* exp_meta */)
   {
     startProgress(0, 1, "Loading sqmass data file " + file);
 
@@ -279,7 +279,7 @@ namespace OpenMS
 
   /// Cache a file to disk
   OpenSwath::SpectrumAccessPtr SwathFile::doCacheFile_(const String& in, const String& tmp, const String& tmp_fname,
-    const boost::shared_ptr<PeakMap >& experiment_metadata)
+    const std::shared_ptr<PeakMap >& experiment_metadata)
   {
     String cached_file = tmp + tmp_fname + ".cached";
     String meta_file = tmp + tmp_fname;
@@ -291,15 +291,15 @@ namespace OpenMS
       Internal::CachedMzMLHandler().writeMetadata(*experiment_metadata.get(), meta_file, true);
     } // ensure that filestream gets closed
 
-    boost::shared_ptr<PeakMap > exp(new PeakMap);
+    std::shared_ptr<PeakMap > exp(new PeakMap);
     FileHandler().loadExperiment(meta_file, *exp.get(), {FileTypes::MZML});
     return SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
   }
 
   /// Only read the meta data from a file and use it to populate exp_meta
-  boost::shared_ptr< PeakMap > SwathFile::populateMetaData_(const String& file)
+  std::shared_ptr< PeakMap > SwathFile::populateMetaData_(const String& file)
   {
-    boost::shared_ptr<PeakMap > experiment_metadata(new PeakMap);
+    std::shared_ptr<PeakMap > experiment_metadata(new PeakMap);
     FileHandler f;
     f.getOptions().setAlwaysAppendData(true);
     f.getOptions().setFillData(false);

--- a/src/openms/source/KERNEL/OnDiscMSExperiment.cpp
+++ b/src/openms/source/KERNEL/OnDiscMSExperiment.cpp
@@ -35,7 +35,7 @@ namespace OpenMS
 
   void OnDiscMSExperiment::loadMetaData_(const String& filename)
   {
-    meta_ms_experiment_ = boost::shared_ptr< PeakMap >(new PeakMap);
+    meta_ms_experiment_ = std::shared_ptr< PeakMap >(new PeakMap);
 
     FileHandler f;
     PeakFileOptions options = f.getOptions();

--- a/src/openms/source/METADATA/ChromatogramSettings.cpp
+++ b/src/openms/source/METADATA/ChromatogramSettings.cpp
@@ -183,7 +183,7 @@ namespace OpenMS
     return data_processing_;
   }
 
-  const std::vector< boost::shared_ptr<const DataProcessing > > ChromatogramSettings::getDataProcessing() const 
+  const std::vector< std::shared_ptr<const DataProcessing > > ChromatogramSettings::getDataProcessing() const
   {
     return OpenMS::Helpers::constifyPointerVector(data_processing_);
   }

--- a/src/openms/source/METADATA/SpectrumSettings.cpp
+++ b/src/openms/source/METADATA/SpectrumSettings.cpp
@@ -203,7 +203,7 @@ namespace OpenMS
     return data_processing_;
   }
 
-  const std::vector< boost::shared_ptr<const DataProcessing > > SpectrumSettings::getDataProcessing() const
+  const std::vector< std::shared_ptr<const DataProcessing > > SpectrumSettings::getDataProcessing() const
   {
     return OpenMS::Helpers::constifyPointerVector(data_processing_);
   }

--- a/src/openms/source/QC/MzCalibration.cpp
+++ b/src/openms/source/QC/MzCalibration.cpp
@@ -36,7 +36,7 @@ namespace OpenMS
     {
       no_mzml_ = false;
       // check for Calibration
-      auto is_not_elem = [](const boost::shared_ptr<const OpenMS::DataProcessing>& dp) { return (dp->getProcessingActions().count(DataProcessing::CALIBRATION) == 0); };
+      auto is_not_elem = [](const std::shared_ptr<const OpenMS::DataProcessing>& dp) { return (dp->getProcessingActions().count(DataProcessing::CALIBRATION) == 0); };
       auto vdp = exp[0].getDataProcessing(); // get a copy to avoid calling .begin() and .end() on two different temporaries
       if (all_of(vdp.begin(), vdp.end(), is_not_elem))
       {

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataBase.h
@@ -26,7 +26,7 @@
 #include <OpenMS/VISUAL/MultiGradient.h>
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <bitset>
 #include <vector>
@@ -112,27 +112,27 @@ namespace OpenMS
     typedef FeatureMap FeatureMapType;
 
     /// SharedPtr on feature map
-    typedef boost::shared_ptr<FeatureMap> FeatureMapSharedPtrType;
+    using FeatureMapSharedPtrType = std::shared_ptr<FeatureMap>;
 
     /// consensus features
     typedef ConsensusMap ConsensusMapType;
 
     /// SharedPtr on consensus features
-    typedef boost::shared_ptr<ConsensusMap> ConsensusMapSharedPtrType;
+    using ConsensusMapSharedPtrType = std::shared_ptr<ConsensusMap>;
 
     /// Main data type (experiment)
     typedef AnnotatedMSRun ExperimentType;
 
     /// SharedPtr on MSExperiment
-    typedef boost::shared_ptr<ExperimentType> ExperimentSharedPtrType;
+    using ExperimentSharedPtrType = std::shared_ptr<ExperimentType>;
 
-    typedef boost::shared_ptr<const ExperimentType> ConstExperimentSharedPtrType;
+    using ConstExperimentSharedPtrType = std::shared_ptr<const ExperimentType>;
 
     /// SharedPtr on On-Disc MSExperiment
-    typedef boost::shared_ptr<OnDiscMSExperiment> ODExperimentSharedPtrType;
+    using ODExperimentSharedPtrType = std::shared_ptr<OnDiscMSExperiment>;
 
     /// SharedPtr on OSWData
-    typedef boost::shared_ptr<OSWData> OSWDataSharedPtrType;
+    using OSWDataSharedPtrType = std::shared_ptr<OSWData>;
   };
 
   /**

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerDataChrom.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerDataChrom.h
@@ -13,7 +13,7 @@
 namespace OpenMS
 {
   /// SharedPtr on OSWData
-  typedef boost::shared_ptr<OSWData> OSWDataSharedPtrType;
+  using OSWDataSharedPtrType = std::shared_ptr<OSWData>;
 
   /**
   @brief Class that stores the data for one layer of type Chromatogram

--- a/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/PlotCanvas.h
@@ -914,7 +914,7 @@ protected:
       std::set<DataProcessing::ProcessingAction> actions;
       actions.insert(action);
 
-      DataProcessingPtr p = boost::shared_ptr<DataProcessing>(new DataProcessing);
+      DataProcessingPtr p = std::shared_ptr<DataProcessing>(new DataProcessing);
       //actions
       p->setProcessingActions(actions);
       //software

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -64,7 +64,7 @@
 
 #include <cmath>
 #include <utility>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -1946,7 +1946,7 @@ namespace OpenMS
       // spectrum is generated in the dialog, so just receive it here
       PeakSpectrum spectrum = spec_gen_dialog_.getSpectrum();
 
-      ExperimentSharedPtrType new_exp_sptr = boost::make_shared<AnnotatedMSRun>();
+      ExperimentSharedPtrType new_exp_sptr = std::make_shared<AnnotatedMSRun>();
       new_exp_sptr->getMSExperiment().addSpectrum(spectrum);
       new_exp_sptr->getMSExperiment().updateRanges();
             
@@ -2027,7 +2027,7 @@ namespace OpenMS
   {
     const LayerDataBase& layer = getActiveCanvas()->getCurrentLayer();
     
-    ExperimentSharedPtrType exp = boost::make_shared<AnnotatedMSRun>();
+    ExperimentSharedPtrType exp = std::make_shared<AnnotatedMSRun>();
     exp.get()->getMSExperiment() = std::move(IMDataConverter::reshapeIMFrameToMany(spec));
     // hack, but currently not avoidable, because 2D widget does not support IM natively yet...
     // for (auto& spec : exp->getSpectra()) spec.setRT(spec.getDriftTime());
@@ -2058,7 +2058,7 @@ namespace OpenMS
     }
 
     // Add spectra into a MSExperiment, sort and prepare it for display
-    ExperimentSharedPtrType tmpe = boost::make_shared<AnnotatedMSRun>();
+    ExperimentSharedPtrType tmpe = std::make_shared<AnnotatedMSRun>();
 
     // Collect all MS2 spectra with the same precursor as the current spectrum
     // (they are in the same SWATH window)

--- a/src/openms_gui/source/VISUAL/LayerDataChrom.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataChrom.cpp
@@ -20,7 +20,7 @@
 #include <OpenMS/VISUAL/VISITORS/LayerStoreData.h>
 #include <OpenMS/METADATA/AnnotatedMSRun.h>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -136,7 +136,7 @@ namespace OpenMS
     // projection for m/z
     auto ptr_mz = make_unique<LayerData1DPeak>();
 
-    ExperimentSharedPtrType exp_mz = boost::make_shared<ExperimentType>();
+    ExperimentSharedPtrType exp_mz = std::make_shared<ExperimentType>();
     exp_mz->getMSExperiment().addSpectrum(std::move(projection_mz));
     ptr_mz->setPeakData(exp_mz);
 
@@ -145,7 +145,7 @@ namespace OpenMS
 
     exp_mz->getMSExperiment().addChromatogram(std::move(projection_rt));
 
-    ptr_rt->setChromData(boost::make_shared<AnnotatedMSRun>());
+    ptr_rt->setChromData(std::make_shared<AnnotatedMSRun>());
 
     auto assign_axis = [&](auto unit, auto& layer) {
       switch (unit)

--- a/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
+++ b/src/openms_gui/source/VISUAL/LayerDataPeak.cpp
@@ -298,7 +298,7 @@ namespace OpenMS
   
   const LayerDataBase::ConstExperimentSharedPtrType LayerDataPeak::getPeakData() const
   {
-    return boost::static_pointer_cast<const ExperimentType>(peak_map_);
+    return std::static_pointer_cast<const ExperimentType>(peak_map_);
   }
 
 } // namespace OpenMS

--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -37,7 +37,7 @@
 #include <QtWidgets/QMessageBox>
 #include <utility>
 
-#include <boost/make_shared.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -50,7 +50,7 @@ namespace OpenMS
   Plot1DCanvas::ExperimentSharedPtrType prepareChromatogram(Size index, const Plot1DCanvas::ExperimentSharedPtrType& exp_sptr, const Plot1DCanvas::ODExperimentSharedPtrType& ondisc_sptr)
   {
     // create a managed pointer fill it with a spectrum containing the chromatographic data
-    auto chrom_exp_sptr = boost::make_shared<AnnotatedMSRun>();
+    auto chrom_exp_sptr = std::make_shared<AnnotatedMSRun>();
 
     chrom_exp_sptr->getMSExperiment().setMetaValue("is_chromatogram", "true"); //this is a hack to store that we have chromatogram data
     LayerDataBase::ExperimentType::SpectrumType spectrum;

--- a/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
+++ b/src/openms_gui/source/VISUAL/TVIdentificationViewController.cpp
@@ -29,7 +29,7 @@
 #include <OpenMS/VISUAL/SpectraIDViewTab.h>
 
 #include <boost/range/adaptor/reversed.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <QtWidgets/QMessageBox>
 #include <QtCore/QString>
@@ -978,7 +978,7 @@ namespace OpenMS
     spec_id_view_->ignore_update = true;
     RAIICleanup cleanup([&]() { spec_id_view_->ignore_update = false; });
 
-    ExperimentSharedPtrType new_exp_sptr = boost::make_shared<AnnotatedMSRun>();
+    ExperimentSharedPtrType new_exp_sptr = std::make_shared<AnnotatedMSRun>();
     new_exp_sptr->getMSExperiment().addSpectrum(theo_spectrum);
     LayerDataBase::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     String layer_caption = aa_sequence.toString() + " (identification view)";

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h
@@ -10,7 +10,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>
 
@@ -50,7 +50,7 @@ namespace OpenSwath
     std::string description;
   };
   typedef OSBinaryDataArray BinaryDataArray;
-  typedef boost::shared_ptr<BinaryDataArray> BinaryDataArrayPtr;
+  using BinaryDataArrayPtr = std::shared_ptr<BinaryDataArray>;
 
   /// Identifying information for a chromatogram
   struct OPENSWATHALGO_DLLAPI OSChromatogramMeta
@@ -66,7 +66,7 @@ namespace OpenSwath
 
   };
   typedef OSChromatogramMeta ChromatogramMeta;
-  typedef boost::shared_ptr<ChromatogramMeta> ChromatogramMetaPtr;
+  using ChromatogramMetaPtr = std::shared_ptr<ChromatogramMeta>;
 
   /// A single chromatogram.
   struct OPENSWATHALGO_DLLAPI OSChromatogram
@@ -99,8 +99,7 @@ private:
     {
       for (std::size_t i = 0; i < defaultArrayLength; ++i)
       {
-        BinaryDataArrayPtr empty(new BinaryDataArray);
-        binaryDataArrayPtrs[i] = empty;
+        binaryDataArrayPtrs[i] = std::make_shared<BinaryDataArray>();
       }
     }
 
@@ -143,7 +142,7 @@ public:
 
   };
   typedef OSChromatogram Chromatogram;
-  typedef boost::shared_ptr<Chromatogram> ChromatogramPtr;
+  using ChromatogramPtr = std::shared_ptr<Chromatogram>;
 
   /// Identifying information for a spectrum
   struct OPENSWATHALGO_DLLAPI OSSpectrumMeta
@@ -174,7 +173,7 @@ public:
 
   };
   typedef OSSpectrumMeta SpectrumMeta;
-  typedef boost::shared_ptr<SpectrumMeta> SpectrumMetaPtr;
+  using SpectrumMetaPtr = std::shared_ptr<SpectrumMeta>;
 
   /// The structure that captures the generation of a peak list (including the underlying acquisitions)
   struct OPENSWATHALGO_DLLAPI OSSpectrum
@@ -200,8 +199,7 @@ private:
     {
       for (std::size_t i = 0; i < defaultArrayLength; ++i)
       {
-        BinaryDataArrayPtr empty(new BinaryDataArray);
-        binaryDataArrayPtrs[i] = empty;
+        binaryDataArrayPtrs[i] = std::make_shared<BinaryDataArray>();
       }
     }
 
@@ -273,6 +271,6 @@ public:
 
   };
   typedef OSSpectrum Spectrum;
-  typedef boost::shared_ptr<Spectrum> SpectrumPtr;
+  using SpectrumPtr = std::shared_ptr<Spectrum>;
 } //end Namespace OpenSwath
 

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h
@@ -11,7 +11,7 @@
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -44,7 +44,7 @@ public:
       individual copy on which it can operate.
 
     */
-    virtual boost::shared_ptr<ISpectrumAccess> lightClone() const = 0;
+    virtual std::shared_ptr<ISpectrumAccess> lightClone() const = 0;
 
     /// Return a pointer to a spectrum at the given id
     virtual SpectrumPtr getSpectrumById(int id) = 0;
@@ -91,7 +91,7 @@ public:
         //throw Exception::NullPointer(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
       //}
 
-      OpenSwath::SpectrumPtr output(new OpenSwath::Spectrum);
+      OpenSwath::SpectrumPtr output = std::make_shared<OpenSwath::Spectrum>();
 
       OpenSwath::BinaryDataArrayPtr mz_arr = input->getMZArray();
       OpenSwath::BinaryDataArrayPtr int_arr = input->getIntensityArray();
@@ -102,9 +102,9 @@ public:
       auto im_it = im_arr->data.cbegin();
       auto mz_end = mz_arr->data.cend();
 
-      OpenSwath::BinaryDataArrayPtr mz_arr_out(new OpenSwath::BinaryDataArray);
-      OpenSwath::BinaryDataArrayPtr intens_arr_out(new OpenSwath::BinaryDataArray);
-      OpenSwath::BinaryDataArrayPtr im_arr_out(new OpenSwath::BinaryDataArray);
+      OpenSwath::BinaryDataArrayPtr mz_arr_out = std::make_shared<OpenSwath::BinaryDataArray>();
+      OpenSwath::BinaryDataArrayPtr intens_arr_out = std::make_shared<OpenSwath::BinaryDataArray>();
+      OpenSwath::BinaryDataArrayPtr im_arr_out = std::make_shared<OpenSwath::BinaryDataArray>();
       im_arr_out->description = im_arr->description;
 
       while (mz_it != mz_end)
@@ -128,6 +128,6 @@ public:
 
    };
 
-  typedef boost::shared_ptr<ISpectrumAccess> SpectrumAccessPtr;
+  using SpectrumAccessPtr = std::shared_ptr<ISpectrumAccess>;
 }
 

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h
@@ -10,7 +10,7 @@
 
 #include <vector>
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>
 
@@ -30,10 +30,10 @@ public:
   class OPENSWATHALGO_DLLAPI IMRMFeature
   {
 public:
-    virtual ~IMRMFeature(){}
-    virtual boost::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) = 0;
-    virtual boost::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) = 0;
-    virtual std::vector<std::string> getNativeIDs() const = 0;
+  virtual ~IMRMFeature(){}
+  virtual std::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) = 0;
+  virtual std::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) = 0;
+  virtual std::vector<std::string> getNativeIDs() const = 0;
     virtual std::vector<std::string> getPrecursorIDs() const = 0;
     virtual float getIntensity() const = 0;
     virtual double getRT() const = 0;
@@ -54,7 +54,7 @@ public:
     virtual ~ISignalToNoise() {}
     virtual double getValueAtRT(double RT) = 0; // cannot be const due to OpenMS implementation
   };
-  typedef boost::shared_ptr<ISignalToNoise> ISignalToNoisePtr;
+  using ISignalToNoisePtr = std::shared_ptr<ISignalToNoise>;
 
 
 } //end Namespace OpenSwath

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/MockObjects.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/MockObjects.h
@@ -11,7 +11,7 @@
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <map>
 #include <vector>
 #include <string>
@@ -57,9 +57,9 @@ public:
 
     ~MockMRMFeature() override;
 
-    boost::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) override;
+    std::shared_ptr<OpenSwath::IFeature> getFeature(std::string nativeID) override;
 
-    boost::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) override;
+    std::shared_ptr<OpenSwath::IFeature> getPrecursorFeature(std::string nativeID) override;
 
     std::vector<std::string> getNativeIDs() const override;
 
@@ -73,8 +73,8 @@ public:
 
     size_t size() const override;
 
-    std::map<std::string, boost::shared_ptr<MockFeature> > m_features;
-    std::map<std::string, boost::shared_ptr<MockFeature> > m_precursor_features;
+    std::map<std::string, std::shared_ptr<MockFeature> > m_features;
+    std::map<std::string, std::shared_ptr<MockFeature> > m_precursor_features;
     float m_intensity;
     double m_rt;
     double m_metavalue;

--- a/src/openswathalgo/source/OPENSWATHALGO/DATAACCESS/MockObjects.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/DATAACCESS/MockObjects.cpp
@@ -48,20 +48,20 @@ namespace OpenSwath
   {
   }
 
-  boost::shared_ptr<OpenSwath::IFeature> MockMRMFeature::getFeature(std::string nativeID)
+  std::shared_ptr<OpenSwath::IFeature> MockMRMFeature::getFeature(std::string nativeID)
   {
-    return boost::static_pointer_cast<OpenSwath::IFeature>(m_features[nativeID]);
+    return std::static_pointer_cast<OpenSwath::IFeature>(m_features[nativeID]);
   }
 
-  boost::shared_ptr<OpenSwath::IFeature> MockMRMFeature::getPrecursorFeature(std::string nativeID)
+  std::shared_ptr<OpenSwath::IFeature> MockMRMFeature::getPrecursorFeature(std::string nativeID)
   {
-    return boost::static_pointer_cast<OpenSwath::IFeature>(m_precursor_features[nativeID]);
+    return std::static_pointer_cast<OpenSwath::IFeature>(m_precursor_features[nativeID]);
   }
 
   std::vector<std::string> MockMRMFeature::getNativeIDs() const
   {
     std::vector<std::string> v;
-    for (std::map<std::string, boost::shared_ptr<MockFeature> >::const_iterator
+    for (std::map<std::string, std::shared_ptr<MockFeature> >::const_iterator
          it = m_features.begin(); it != m_features.end(); ++it)
     {
       v.push_back(it->first);
@@ -72,7 +72,7 @@ namespace OpenSwath
   std::vector<std::string> MockMRMFeature::getPrecursorIDs() const
   {
     std::vector<std::string> v;
-    for (std::map<std::string, boost::shared_ptr<MockFeature> >::const_iterator
+    for (std::map<std::string, std::shared_ptr<MockFeature> >::const_iterator
          it = m_precursor_features.begin(); it != m_precursor_features.end(); ++it)
     {
       v.push_back(it->first);

--- a/src/pyOpenMS/pxds/ChromatogramExtractorAlgorithm.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramExtractorAlgorithm.pxd
@@ -8,7 +8,7 @@ from SpectrumAccessQuadMZTransforming cimport *
 from ISpectrumAccess cimport *
 from ProgressLogger cimport *
 
-# typedef boost::shared_ptr<ISpectrumAccess> SpectrumAccessPtr;
+# typedef std::shared_ptr<ISpectrumAccess> SpectrumAccessPtr;
 
 cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.h>" namespace "OpenMS":
 

--- a/src/pyOpenMS/pxds/OpenSwathDataStructures.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathDataStructures.pxd
@@ -21,7 +21,7 @@ cdef extern from "<OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>" namespace 
         void setMZArray(OSBinaryDataArrayPtr data) #wrap-ignore
         void setIntensityArray(OSBinaryDataArrayPtr data) #wrap-ignore
 
-  # boost::shared_ptr<OpenSwath::Spectrum> OpenSwath::SpectrumPtr;
+  # std::shared_ptr<OpenSwath::Spectrum> OpenSwath::SpectrumPtr;
   ctypedef shared_ptr[OSSpectrum] OSSpectrumPtr
 
   # See ../addons/OSChromatogram.pyx
@@ -34,6 +34,6 @@ cdef extern from "<OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>" namespace 
         void setTimeArray(OSBinaryDataArrayPtr data) #wrap-ignore
         void setIntensityArray(OSBinaryDataArrayPtr data) #wrap-ignore
 
-  # boost::shared_ptr<OpenSwath::Chromatogram> OpenSwath::ChromatogramPtr;
+  # std::shared_ptr<OpenSwath::Chromatogram> OpenSwath::ChromatogramPtr;
   ctypedef shared_ptr[OSChromatogram] OSChromatogramPtr
 

--- a/src/tests/class_tests/openms/source/ChromatogramExtractorAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramExtractorAlgorithm_test.cpp
@@ -57,7 +57,7 @@ END_SECTION
 START_SECTION(void extractChromatograms(const OpenSwath::SpectrumAccessPtr input, std::vector< OpenSwath::ChromatogramPtr > &output, std::vector< ExtractionCoordinates >& extraction_coordinates, double mz_extraction_window, bool ppm, String filter))
 {
   double extract_window = 0.05;
-  boost::shared_ptr<PeakMap > exp(new PeakMap);
+  std::shared_ptr<PeakMap > exp(new PeakMap);
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.mzML"), *exp);
   OpenSwath::SpectrumAccessPtr expptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
 
@@ -115,7 +115,7 @@ START_SECTION([EXTRA] void extractChromatograms(const OpenSwath::SpectrumAccessP
   typedef OpenMS::DataArrays::FloatDataArray FloatDataArray;
 
   double extract_window = 0.10;
-  boost::shared_ptr<PeakMap > exp(new PeakMap);
+  std::shared_ptr<PeakMap > exp(new PeakMap);
   // MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.mzML"), *exp);
   for (int i = 0; i < 4; i++)
   {

--- a/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
@@ -120,7 +120,7 @@ START_SECTION((template < typename TransitionExpT > static void return_chromatog
   TargetedExperiment transitions;
   TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.TraML"), transitions);
 
-  boost::shared_ptr<PeakMap > exp(new PeakMap);
+  std::shared_ptr<PeakMap > exp(new PeakMap);
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.mzML"), *exp);
   OpenSwath::SpectrumAccessPtr expptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
 

--- a/src/tests/class_tests/openms/source/ChromatogramSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramSettings_test.cpp
@@ -379,7 +379,7 @@ END_SECTION
 START_SECTION((std::vector<DataProcessing>& getDataProcessing()))
 {
   ChromatogramSettings tmp;
-  DataProcessingPtr dp = boost::shared_ptr<DataProcessing>(new DataProcessing); 
+  DataProcessingPtr dp = std::shared_ptr<DataProcessing>(new DataProcessing); 
   tmp.getDataProcessing().push_back(dp);
   TEST_EQUAL(tmp.getDataProcessing().size(),1);
 }

--- a/src/tests/class_tests/openms/source/DIAScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/DIAScoring_test.cpp
@@ -23,11 +23,11 @@ using namespace OpenSwath;
 
 void getMRMFeatureTest(MockMRMFeature * imrmfeature_test)
 {
-  boost::shared_ptr<MockFeature> f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
   f1_ptr->m_intensity = 0.3f;
   f2_ptr->m_intensity = 0.7f;
-  std::map<std::string, boost::shared_ptr<MockFeature> > features;
+  std::map<std::string, std::shared_ptr<MockFeature> > features;
   features["group1"] = f1_ptr;
   features["group2"] = f2_ptr;
   imrmfeature_test->m_features = features;

--- a/src/tests/class_tests/openms/source/MRMFeatureFinderScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFinderScoring_test.cpp
@@ -5,7 +5,7 @@
 // $Maintainer: Hannes Roest $
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
@@ -56,12 +56,12 @@ START_SECTION(void pickExperiment(OpenSwath::SpectrumAccessPtr input, FeatureMap
   MRMFeature feature;
   FeatureMap featureFile;
   TransformationDescription trafo;
-  boost::shared_ptr<PeakMap> swath_map (new PeakMap);
+  std::shared_ptr<PeakMap> swath_map (new PeakMap);
   TransitionGroupMapType transition_group_map;
   MRMFeatureFinderScoring::MRMTransitionGroupType transition_group;
 
   // Load the chromatograms (mzML) and the meta-information (TraML)
-  boost::shared_ptr<PeakMap> exp (new PeakMap);
+  std::shared_ptr<PeakMap> exp (new PeakMap);
   OpenSwath::LightTargetedExperiment transitions;
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_generic_input.mzML"), *exp);
   {
@@ -218,11 +218,11 @@ START_SECTION(void pickExperiment(OpenSwath::SpectrumAccessPtr input, FeatureMap
   MRMFeature feature;
   FeatureMap featureFile;
   TransformationDescription trafo;
-  boost::shared_ptr<PeakMap> swath_map (new PeakMap);
+  std::shared_ptr<PeakMap> swath_map (new PeakMap);
   TransitionGroupMapType transition_group_map;
 
   // Load the chromatograms (mzML) and the meta-information (TraML)
-  boost::shared_ptr<PeakMap> exp (new PeakMap);
+  std::shared_ptr<PeakMap> exp (new PeakMap);
   OpenSwath::LightTargetedExperiment transitions;
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_generic_input.mzML"), *exp);
   { 
@@ -304,7 +304,7 @@ START_SECTION(void mapExperimentToTransitionList(OpenSwath::SpectrumAccessPtr in
   MRMFeatureFinderScoring::MRMTransitionGroupType transition_group;
 
   // Load the chromatograms (mzML) and the meta-information (TraML)
-  boost::shared_ptr<PeakMap> exp (new PeakMap);
+  std::shared_ptr<PeakMap> exp (new PeakMap);
   OpenSwath::LightTargetedExperiment transitions;
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_generic_input.mzML"), *exp);
   {

--- a/src/tests/class_tests/openms/source/MRMScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMScoring_test.cpp
@@ -53,18 +53,18 @@ void fill_mock_objects(MockMRMFeature * imrmfeature, std::vector<std::string>& n
 
   std::vector<double> ms1intensity {0.0, 110.0, 200.0, 270.0, 320.0, 350.0, 360.0, 350.0, 320.0, 270.0, 200.0};
 
-  boost::shared_ptr<MockFeature> f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> ms1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> ms1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
   f1_ptr->m_intensity_vec = intensity1;
   f2_ptr->m_intensity_vec = intensity2;
   ms1_ptr->m_intensity_vec = ms1intensity;
-  std::map<std::string, boost::shared_ptr<MockFeature> > features;
+  std::map<std::string, std::shared_ptr<MockFeature> > features;
   features["group1"] = f1_ptr;
   features["group2"] = f2_ptr;
   imrmfeature->m_features = features; // add features
 
-  std::map<std::string, boost::shared_ptr<MockFeature> > ms1_features;
+  std::map<std::string, std::shared_ptr<MockFeature> > ms1_features;
   ms1_features["ms1trace"] = ms1_ptr;
   imrmfeature->m_precursor_features = ms1_features; // add ms1 feature
 }
@@ -91,11 +91,11 @@ void fill_mock_objects2(MockMRMFeature * imrmfeature, std::vector<std::string>& 
 
   std::vector<double> ms1intensity3 {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-  boost::shared_ptr<MockFeature> f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> ms1_f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> ms1_f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-  boost::shared_ptr<MockFeature> ms1_f3_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> ms1_f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> ms1_f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+  std::shared_ptr<MockFeature> ms1_f3_ptr = std::shared_ptr<MockFeature>(new MockFeature());
 
   f1_ptr->m_intensity_vec = intensity1;
   f2_ptr->m_intensity_vec = intensity2;
@@ -103,12 +103,12 @@ void fill_mock_objects2(MockMRMFeature * imrmfeature, std::vector<std::string>& 
   ms1_f2_ptr->m_intensity_vec = ms1intensity2;
   ms1_f3_ptr->m_intensity_vec = ms1intensity3;
 
-  std::map<std::string, boost::shared_ptr<MockFeature> > features;
+  std::map<std::string, std::shared_ptr<MockFeature> > features;
   features["group1"] = f1_ptr;
   features["group2"] = f2_ptr;
   imrmfeature->m_features = features; // add features
 
-  std::map<std::string, boost::shared_ptr<MockFeature> > ms1_features;
+  std::map<std::string, std::shared_ptr<MockFeature> > ms1_features;
   ms1_features["ms1trace1"] = ms1_f1_ptr;
   ms1_features["ms1trace2"] = ms1_f2_ptr;
   ms1_features["ms1trace3"] = ms1_f3_ptr;
@@ -590,13 +590,13 @@ END_SECTION*/
           MockMRMFeature * imrmfeature = new MockMRMFeature();
 
           // create mrmfeature, add "experimental" intensities
-          boost::shared_ptr<MockFeature> f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-          boost::shared_ptr<MockFeature> f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-          boost::shared_ptr<MockFeature> f3_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
+          std::shared_ptr<MockFeature> f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+          std::shared_ptr<MockFeature> f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+          std::shared_ptr<MockFeature> f3_ptr = std::shared_ptr<MockFeature>(new MockFeature());
           f1_ptr->m_intensity = (float)782.38073;
           f2_ptr->m_intensity = (float)58.384506;
           f3_ptr->m_intensity = (float)58.384506;
-          std::map<std::string, boost::shared_ptr<MockFeature> > features;
+          std::map<std::string, std::shared_ptr<MockFeature> > features;
           features["group1"] = f1_ptr;
           features["group2"] = f2_ptr;
           features["group3"] = f2_ptr;
@@ -640,19 +640,19 @@ END_SECTION*/
         {
           MRMScoring mrmscore;
           std::vector<OpenSwath::ISignalToNoisePtr> sn_estimators;
-          boost::shared_ptr<MockSignalToNoise> sn1 = boost::shared_ptr<MockSignalToNoise>(new MockSignalToNoise());
+          std::shared_ptr<MockSignalToNoise> sn1 = std::shared_ptr<MockSignalToNoise>(new MockSignalToNoise());
           sn1->m_sn_value = 500;
-          boost::shared_ptr<MockSignalToNoise> sn2 = boost::shared_ptr<MockSignalToNoise>(new MockSignalToNoise());
+          std::shared_ptr<MockSignalToNoise> sn2 = std::shared_ptr<MockSignalToNoise>(new MockSignalToNoise());
           sn2->m_sn_value = 1500;
           sn_estimators.push_back(sn1);
           sn_estimators.push_back(sn2);
 
           MockMRMFeature imrmfeature;
-          boost::shared_ptr<MockFeature> f1_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
-          boost::shared_ptr<MockFeature> f2_ptr = boost::shared_ptr<MockFeature>(new MockFeature());
+          std::shared_ptr<MockFeature> f1_ptr = std::shared_ptr<MockFeature>(new MockFeature());
+          std::shared_ptr<MockFeature> f2_ptr = std::shared_ptr<MockFeature>(new MockFeature());
           f1_ptr->m_rt = 1200;
           f2_ptr->m_rt = 1200;
-          std::map<std::string, boost::shared_ptr<MockFeature> > features;
+          std::map<std::string, std::shared_ptr<MockFeature> > features;
           features["group1"] = f1_ptr;
           features["group2"] = f2_ptr;
           imrmfeature.m_features = features;

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -1334,7 +1334,7 @@ START_SECTION( SpectrumSettings::SpectrumType MSSpectrum::getType(const bool que
   // second easiest: type is given in data processing
   DataProcessing dp;
   dp.setProcessingActions( { DataProcessing::PEAK_PICKING } );
-  boost::shared_ptr< DataProcessing > dp_(new DataProcessing(dp));
+  std::shared_ptr< DataProcessing > dp_(new DataProcessing(dp));
   edit.getDataProcessing().push_back(dp_);
   // still profile, since DP is only checked when type is unknown
   TEST_EQUAL(edit.getType(false), SpectrumSettings::PROFILE);

--- a/src/tests/class_tests/openms/source/MzCalibration_test.cpp
+++ b/src/tests/class_tests/openms/source/MzCalibration_test.cpp
@@ -71,7 +71,7 @@ MSExperiment exp_no_calibration = exp;
 // adding processing info
 DataProcessing p;
 p.setProcessingActions({OpenMS::DataProcessing::CALIBRATION});
-boost::shared_ptr<DataProcessing> p_(new DataProcessing(p));
+std::shared_ptr<DataProcessing> p_(new DataProcessing(p));
 for (Size i = 0; i < exp.size(); ++i)
 {
   exp[i].getDataProcessing().push_back(p_);

--- a/src/tests/class_tests/openms/source/OnDiscMSExperiment_test.cpp
+++ b/src/tests/class_tests/openms/source/OnDiscMSExperiment_test.cpp
@@ -162,11 +162,11 @@ START_SECTION((Size getNrChromatograms() const))
 }
 END_SECTION
 
-START_SECTION((boost::shared_ptr<const ExperimentalSettings> getExperimentalSettings() const))
+START_SECTION((std::shared_ptr<const ExperimentalSettings> getExperimentalSettings() const))
 {
   OnDiscPeakMap tmp; tmp.openFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_1.mzML"));
   OnDiscPeakMap tmp2; tmp2.openFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_1.mzML"), true);
-  boost::shared_ptr<const ExperimentalSettings> settings = tmp.getExperimentalSettings();
+  std::shared_ptr<const ExperimentalSettings> settings = tmp.getExperimentalSettings();
 
   TEST_EQUAL(settings->getInstrument().getName(), "LTQ FT")
   TEST_EQUAL(settings->getInstrument().getMassAnalyzers().size(), 1)

--- a/src/tests/class_tests/openms/source/OpenSwathScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathScoring_test.cpp
@@ -5,7 +5,7 @@
 // $Maintainer: Hannes Roest $
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <OpenMS/CONCEPT/ClassTest.h>
 
@@ -122,7 +122,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
   OpenMS::RangeMobility im_range_empty; // use this empty im range as input for all examples
   // test result for empty map
   {
-    boost::shared_ptr<PeakMap > swath_map (new PeakMap);
+    std::shared_ptr<PeakMap > swath_map (new PeakMap);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
 
     OpenSwathScoring sc;
@@ -142,7 +142,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
     s.push_back(p);
     s.setRT(20.0);
     eptr->addSpectrum(s);
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
 
     TEST_EQUAL(swath_ptr->getNrSpectra(), 1)
@@ -185,7 +185,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
     eptr->addSpectrum(s);
     s.setRT(30.0);
     eptr->addSpectrum(s);
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
 
     TEST_EQUAL(swath_ptr->getNrSpectra(), 3)
@@ -252,7 +252,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
       s.setRT(60.0);
       eptr->addSpectrum(s);
     }
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
 
     TEST_EQUAL(swath_ptr->getNrSpectra(), 4)
@@ -305,7 +305,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
   {
     PeakMap* eptr = new PeakMap;
     eptr->addSpectrum(generateImSpec(1,6,20.0));
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
     TEST_EQUAL(swath_ptr->getNrSpectra(), 1);
 
@@ -371,7 +371,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
     eptr->addSpectrum(generateImSpec(1,3,19.0));
     eptr->addSpectrum(generateImSpec(1,6,20.0));
     eptr->addSpectrum(generateImSpec(3,6,21.0));
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
     TEST_EQUAL(swath_ptr->getNrSpectra(), 3);
 
@@ -465,7 +465,7 @@ START_SECTION((OpenSwath::SpectrumPtr OpenSwathScoring::fetchSpectrumSwath(std::
     eptr->addSpectrum(generateImSpec(1,6,20.0));
     eptr->addSpectrum(generateImSpec(3,6,21.0));
     eptr->addSpectrum(generateImSpec(1,6,250));
-    boost::shared_ptr<PeakMap > swath_map (eptr);
+    std::shared_ptr<PeakMap > swath_map (eptr);
     OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
     TEST_EQUAL(swath_ptr->getNrSpectra(), 4);
 

--- a/src/tests/class_tests/openms/source/OpenSwathSpectrumAccessOpenMS_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathSpectrumAccessOpenMS_test.cpp
@@ -15,7 +15,7 @@
 
 ///////////////////////////
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 ///////////////////////////
 
 using namespace OpenMS;
@@ -31,7 +31,7 @@ SpectrumAccessOpenMS* nullPointer = nullptr;
 
 START_SECTION(SpectrumAccessOpenMS())
 {
-  boost::shared_ptr< PeakMap > exp ( new PeakMap );
+  std::shared_ptr< PeakMap > exp ( new PeakMap );
   ptr = new SpectrumAccessOpenMS(exp);
   TEST_NOT_EQUAL(ptr, nullPointer)
 }
@@ -46,7 +46,7 @@ END_SECTION
 START_SECTION( size_t getNrSpectra() const)
 {
   {
-    boost::shared_ptr< PeakMap > exp ( new PeakMap );
+    std::shared_ptr< PeakMap > exp ( new PeakMap );
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 0);
@@ -60,7 +60,7 @@ START_SECTION( size_t getNrSpectra() const)
     new_exp->addSpectrum(s);
     new_exp->addSpectrum(s);
     new_exp->addChromatogram(c);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 2);
@@ -69,7 +69,7 @@ START_SECTION( size_t getNrSpectra() const)
 }
 END_SECTION
 
-START_SECTION ( boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
+START_SECTION ( std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
 {
   PeakMap* new_exp = new PeakMap;
   MSSpectrum s;
@@ -77,13 +77,13 @@ START_SECTION ( boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const
   new_exp->addSpectrum(s);
   new_exp->addSpectrum(s);
   new_exp->addChromatogram(c);
-  boost::shared_ptr< PeakMap > exp (new_exp);
+  std::shared_ptr< PeakMap > exp (new_exp);
   SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
   TEST_EQUAL(spectrum_acc.getNrSpectra(), 2);
   TEST_EQUAL(spectrum_acc.getNrChromatograms(), 1);
 
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> sa_clone = spectrum_acc.lightClone();
+  std::shared_ptr<OpenSwath::ISpectrumAccess> sa_clone = spectrum_acc.lightClone();
   TEST_EQUAL(sa_clone->getNrSpectra(), 2);
   TEST_EQUAL(sa_clone->getNrChromatograms(), 1);
 }
@@ -92,7 +92,7 @@ END_SECTION
 START_SECTION ( OpenSwath::SpectrumPtr getSpectrumById(int id);)
 {
   {
-    boost::shared_ptr< PeakMap > exp ( new PeakMap );
+    std::shared_ptr< PeakMap > exp ( new PeakMap );
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 0);
@@ -109,7 +109,7 @@ START_SECTION ( OpenSwath::SpectrumPtr getSpectrumById(int id);)
     s.push_back(p);
 
     new_exp->addSpectrum(s);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 1);
@@ -142,7 +142,7 @@ START_SECTION ( OpenSwath::SpectrumPtr getSpectrumById(int id);)
     s.setIntegerDataArrays(idas);
 
     new_exp->addSpectrum(s);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 1)
@@ -165,7 +165,7 @@ START_SECTION ( OpenSwath::SpectrumMeta getSpectrumMetaById(int id) const)
     MSSpectrum s;
     s.setRT(20);
     new_exp->addSpectrum(s);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 1);
@@ -182,7 +182,7 @@ START_SECTION ( SpectrumSettings getSpectraMetaInfo(int id) const)
     MSSpectrum s;
     s.setComment("remember me");
     new_exp->addSpectrum(s);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 1);
@@ -203,7 +203,7 @@ START_SECTION ( std::vector<std::size_t> SpectrumAccessOpenMS::getSpectraByRT(do
     s.setRT(40);
     new_exp->addSpectrum(s);
     new_exp->addChromatogram(c);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 2);
@@ -228,7 +228,7 @@ END_SECTION
 START_SECTION(OpenSwath::ChromatogramPtr getChromatogramById(int id))
 {
   {
-    boost::shared_ptr< PeakMap > exp ( new PeakMap );
+    std::shared_ptr< PeakMap > exp ( new PeakMap );
     SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(spectrum_acc.getNrSpectra(), 0);
@@ -249,7 +249,7 @@ START_SECTION(OpenSwath::ChromatogramPtr getChromatogramById(int id))
     new_exp->addSpectrum(s);
     new_exp->addSpectrum(s);
     new_exp->addChromatogram(c);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS chrom_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(chrom_acc.getNrSpectra(), 2);
@@ -283,7 +283,7 @@ START_SECTION(OpenSwath::ChromatogramPtr getChromatogramById(int id))
     chrom.setIntegerDataArrays(idas);
 
     new_exp->addChromatogram(chrom);
-    boost::shared_ptr< PeakMap > exp (new_exp);
+    std::shared_ptr< PeakMap > exp (new_exp);
     SpectrumAccessOpenMS chrom_acc = SpectrumAccessOpenMS(exp);
 
     TEST_EQUAL(chrom_acc.getNrChromatograms(), 1)
@@ -314,7 +314,7 @@ START_SECTION(std::string getChromatogramNativeID(int id) const)
   new_exp->addSpectrum(s);
   new_exp->addSpectrum(s);
   new_exp->addChromatogram(c);
-  boost::shared_ptr< PeakMap > exp (new_exp);
+  std::shared_ptr< PeakMap > exp (new_exp);
   SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
   OpenSwath::ChromatogramPtr cptr = spectrum_acc.getChromatogramById(0);
@@ -328,7 +328,7 @@ START_SECTION (ChromatogramSettings getChromatogramMetaInfo(int id) const)
   MSChromatogram c;
   c.setComment("remember me");
   new_exp->addChromatogram(c);
-  boost::shared_ptr< PeakMap > exp (new_exp);
+  std::shared_ptr< PeakMap > exp (new_exp);
   SpectrumAccessOpenMS spectrum_acc = SpectrumAccessOpenMS(exp);
 
   TEST_EQUAL(spectrum_acc.getNrChromatograms(), 1);

--- a/src/tests/class_tests/openms/source/SpectrumAccessQuadMZTransforming_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAccessQuadMZTransforming_test.cpp
@@ -19,9 +19,9 @@ using namespace OpenMS;
 using namespace std;
 
 
-boost::shared_ptr<PeakMap > getData()
+std::shared_ptr<PeakMap > getData()
 {
-  boost::shared_ptr<PeakMap > exp2(new PeakMap);
+  std::shared_ptr<PeakMap > exp2(new PeakMap);
   MSSpectrum spec;
   Peak1D p;
   p.setMZ(100);
@@ -42,7 +42,7 @@ START_TEST(SpectrumAccessQuadMZTransforming, "$Id$")
 SpectrumAccessQuadMZTransforming* ptr = nullptr;
 SpectrumAccessQuadMZTransforming* nullPointer = nullptr;
 
-boost::shared_ptr<PeakMap > exp(new PeakMap);
+std::shared_ptr<PeakMap > exp(new PeakMap);
 OpenSwath::SpectrumAccessPtr expptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
 
 
@@ -62,12 +62,12 @@ END_SECTION
 
 START_SECTION(size_t getNrSpectra() const)
 {
-  boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr(new SpectrumAccessQuadMZTransforming(expptr, 0, 0, 0, false));
+  std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr(new SpectrumAccessQuadMZTransforming(expptr, 0, 0, 0, false));
   TEST_EQUAL(ptr->getNrSpectra(), 0)
 
-  boost::shared_ptr<PeakMap > exp2 = getData();
+  std::shared_ptr<PeakMap > exp2 = getData();
   OpenSwath::SpectrumAccessPtr expptr2 = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp2);
-  boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 0, 0, 0, false));
+  std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 0, 0, 0, false));
   TEST_EQUAL(ptr2->getNrSpectra(), 1)
 }
 END_SECTION
@@ -75,9 +75,9 @@ END_SECTION
 START_SECTION(OpenSwath::SpectrumPtr getSpectrumById(int id))
 {
   {
-    boost::shared_ptr<PeakMap > exp2 = getData();
+    std::shared_ptr<PeakMap > exp2 = getData();
     OpenSwath::SpectrumAccessPtr expptr2 = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp2);
-    boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 0, 0, 0, false));
+    std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 0, 0, 0, false));
     OpenSwath::SpectrumPtr spec1 = ptr2->getSpectrumById(0);
     TEST_NOT_EQUAL(spec1.get(), nullPointer) // pointer is present
     TEST_EQUAL(bool(spec1), true) // pointer is not null
@@ -91,9 +91,9 @@ START_SECTION(OpenSwath::SpectrumPtr getSpectrumById(int id))
   }
 
   {
-    boost::shared_ptr<PeakMap > exp2 = getData();
+    std::shared_ptr<PeakMap > exp2 = getData();
     OpenSwath::SpectrumAccessPtr expptr2 = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp2);
-    boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 10, 5, 2, false));
+    std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 10, 5, 2, false));
     OpenSwath::SpectrumPtr spec1 = ptr2->getSpectrumById(0);
     TEST_NOT_EQUAL(spec1.get(), nullPointer) // pointer is present
     TEST_EQUAL(bool(spec1), true) // pointer is not null
@@ -109,17 +109,17 @@ START_SECTION(OpenSwath::SpectrumPtr getSpectrumById(int id))
 }
 END_SECTION
 
-START_SECTION(boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
+START_SECTION(std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
 {
-  boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr(new SpectrumAccessQuadMZTransforming(expptr, 0, 0, 0, false));
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> clone_ptr_empty = ptr->lightClone();
+  std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr(new SpectrumAccessQuadMZTransforming(expptr, 0, 0, 0, false));
+  std::shared_ptr<OpenSwath::ISpectrumAccess> clone_ptr_empty = ptr->lightClone();
 
   TEST_EQUAL(ptr->getNrSpectra(), clone_ptr_empty->getNrSpectra())
 
   {
-    boost::shared_ptr<PeakMap > exp2 = getData();
+    std::shared_ptr<PeakMap > exp2 = getData();
     OpenSwath::SpectrumAccessPtr expptr2 = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp2);
-    boost::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 10, 5, 2, false));
+    std::shared_ptr<SpectrumAccessQuadMZTransforming> ptr2(new SpectrumAccessQuadMZTransforming(expptr2, 10, 5, 2, false));
     OpenSwath::SpectrumPtr spec1 = ptr2->getSpectrumById(0);
     TEST_NOT_EQUAL(spec1.get(), nullPointer) // pointer is present
     TEST_EQUAL(bool(spec1), true) // pointer is not null
@@ -131,7 +131,7 @@ START_SECTION(boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
     TEST_REAL_SIMILAR(spec1->getMZArray()->data[0], 10 + 100*5 + 100*100* 2)
     TEST_REAL_SIMILAR(spec1->getMZArray()->data[1], 10 + 500*5 + 500*500* 2)
 
-    boost::shared_ptr<OpenSwath::ISpectrumAccess> clone_ptr = ptr2->lightClone();
+    std::shared_ptr<OpenSwath::ISpectrumAccess> clone_ptr = ptr2->lightClone();
     TEST_EQUAL(ptr2->getNrSpectra(), clone_ptr->getNrSpectra())
 
     OpenSwath::SpectrumPtr spec_clone = ptr2->getSpectrumById(0);

--- a/src/tests/class_tests/openms/source/SpectrumAccessSqMass_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAccessSqMass_test.cpp
@@ -28,7 +28,7 @@ START_TEST(SpectrumAccessSqMass, "$Id$")
 SpectrumAccessSqMass* ptr = nullptr;
 SpectrumAccessSqMass* nullPointer = nullptr;
 
-boost::shared_ptr<PeakMap > exp(new PeakMap);
+std::shared_ptr<PeakMap > exp(new PeakMap);
 OpenSwath::SpectrumAccessPtr expptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
 
 
@@ -121,14 +121,14 @@ START_SECTION(size_t getNrSpectra() const)
 }
 END_SECTION
 
-START_SECTION(boost::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
+START_SECTION(std::shared_ptr<OpenSwath::ISpectrumAccess> lightClone() const)
 {
   OpenMS::Internal::MzMLSqliteHandler handler(OPENMS_GET_TEST_DATA_PATH("SqliteMassFile_1.sqMass"), 0);
 
   ptr = new SpectrumAccessSqMass(handler);
   TEST_EQUAL(ptr->getNrSpectra(), 2)
 
-  boost::shared_ptr<OpenSwath::ISpectrumAccess> ptr2 = ptr->lightClone();
+  std::shared_ptr<OpenSwath::ISpectrumAccess> ptr2 = ptr->lightClone();
   TEST_EQUAL(ptr2->getNrSpectra(), 2)
   delete ptr;
 }

--- a/src/tests/class_tests/openms/source/SpectrumSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumSettings_test.cpp
@@ -278,7 +278,7 @@ START_SECTION((bool operator== (const SpectrumSettings& rhs) const))
 	TEST_EQUAL(edit==empty, false);
 	
 	edit = empty;
-    DataProcessingPtr dp = boost::shared_ptr<DataProcessing>(new DataProcessing); 
+    DataProcessingPtr dp = std::shared_ptr<DataProcessing>(new DataProcessing); 
 	edit.getDataProcessing().push_back(dp);
 	TEST_EQUAL(edit==empty, false);
 
@@ -325,7 +325,7 @@ START_SECTION((bool operator!= (const SpectrumSettings& rhs) const))
 	TEST_FALSE(edit == empty);
 
 	edit = empty;
-    DataProcessingPtr dp = boost::shared_ptr<DataProcessing>(new DataProcessing); 
+    DataProcessingPtr dp = std::shared_ptr<DataProcessing>(new DataProcessing); 
 	edit.getDataProcessing().push_back(dp);
 	TEST_FALSE(edit == empty);
 
@@ -372,13 +372,13 @@ START_SECTION((void unify(const SpectrumSettings &rhs)))
   appended.getProducts().push_back(appended_product);
 
   // DataProcessings
-  DataProcessingPtr org_processing = boost::shared_ptr<DataProcessing>(new DataProcessing);
+  DataProcessingPtr org_processing = std::shared_ptr<DataProcessing>(new DataProcessing);
   Software org_software;
   org_software.setName("org_software");
   org_processing->setSoftware(org_software);
   org.getDataProcessing().push_back(org_processing);
 
-  DataProcessingPtr appended_processing = boost::shared_ptr<DataProcessing>(new DataProcessing);
+  DataProcessingPtr appended_processing = std::shared_ptr<DataProcessing>(new DataProcessing);
   Software appended_software;
   appended_software.setName("appended_software");
   appended_processing->setSoftware(appended_software);

--- a/src/tests/class_tests/openms/source/SwathFile_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathFile_test.cpp
@@ -102,11 +102,11 @@ START_SECTION(([EXTRA]virtual ~SwathFile()))
 END_SECTION
 
 // fast
-START_SECTION(std::vector< OpenSwath::SwathMap > loadMzML(String file, String tmp, boost::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal") )
+START_SECTION(std::vector< OpenSwath::SwathMap > loadMzML(String file, String tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal") )
 {
   Size nr_swathes = 6;
   storeSwathFile("swathFile_1.tmp", nr_swathes);
-  boost::shared_ptr<ExperimentalSettings> meta = boost::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
+  std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
   std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", "./", meta);
 
   TEST_EQUAL(maps.size(), nr_swathes+1)
@@ -125,11 +125,11 @@ START_SECTION(std::vector< OpenSwath::SwathMap > loadMzML(String file, String tm
 END_SECTION
 
 // medium (2x slower than normal mzML)
-START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadMzML(String file, String tmp, boost::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="cache") )
+START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadMzML(String file, String tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="cache") )
 {
   Size nr_swathes = 2;
   storeSwathFile("swathFile_1.tmp", nr_swathes);
-  boost::shared_ptr<ExperimentalSettings> meta = boost::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
+  std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
   std::vector< OpenSwath::SwathMap > maps = SwathFile().loadMzML("swathFile_1.tmp", "./", meta, "cache");
 
   TEST_EQUAL(maps.size(), nr_swathes+1)
@@ -148,7 +148,7 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadMzML(String file, St
 END_SECTION
 
 // medium (2x slower than normal mzML)
-START_SECTION(std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list, String tmp, boost::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal"))
+START_SECTION(std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list, String tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal"))
 {
   std::vector<String> swath_filenames;
   Size nr_swathes = 3;
@@ -158,7 +158,7 @@ START_SECTION(std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list,
     swath_filenames.push_back( String("swathFile_2_sw" ) + String(i) + ".tmp");
   }
   storeSplitSwathFile(swath_filenames);
-  boost::shared_ptr<ExperimentalSettings> meta = boost::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
+  std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
   std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, "./", meta);
 
   // ensure they are sorted ... 
@@ -181,7 +181,7 @@ START_SECTION(std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list,
 END_SECTION
 
 // slow (7x slower than normal mzML)
-START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list, String tmp, boost::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="cache"))
+START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList file_list, String tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="cache"))
 {
   std::vector<String> swath_filenames;
   Size nr_swathes = 2;
@@ -191,7 +191,7 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList fil
     swath_filenames.push_back( String("swathFile_3_sw" ) + String(i) + ".tmp");
   }
   storeSplitSwathFile(swath_filenames);
-  boost::shared_ptr<ExperimentalSettings> meta = boost::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
+  std::shared_ptr<ExperimentalSettings> meta = std::shared_ptr<ExperimentalSettings>(new ExperimentalSettings());
   std::vector< OpenSwath::SwathMap > maps = SwathFile().loadSplit(swath_filenames, "./", meta, "cache");
   // ensure they are sorted ... 
   std::sort(maps.begin(), maps.end(), sortSwathMaps);
@@ -212,7 +212,7 @@ START_SECTION([EXTRA]std::vector< OpenSwath::SwathMap > loadSplit(StringList fil
 }
 END_SECTION
 
-START_SECTION((std::vector< OpenSwath::SwathMap > loadMzXML(String file, String tmp, boost::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal") ) )
+START_SECTION((std::vector< OpenSwath::SwathMap > loadMzXML(String file, String tmp, std::shared_ptr<ExperimentalSettings>& exp_meta, String readoptions="normal") ) )
 {
   NOT_TESTABLE // mzXML is not supported
 }

--- a/src/tests/class_tests/openms/source/SwathMapMassCorrection_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathMapMassCorrection_test.cpp
@@ -163,7 +163,7 @@ START_SECTION( void correctMZ(OpenMS::MRMFeatureFinderScoring::TransitionGroupMa
   transition_group_map["group3"] = &transition_group;
 
   // Create a mock spectrum fitting to the transition group
-  boost::shared_ptr<PeakMap > exp(new PeakMap);
+  std::shared_ptr<PeakMap > exp(new PeakMap);
   {
     MSSpectrum spec;
     Peak1D p;
@@ -186,7 +186,7 @@ START_SECTION( void correctMZ(OpenMS::MRMFeatureFinderScoring::TransitionGroupMa
 
   // Create secondary mock spectrum for testing PASEF flag, this spectrum should never be used
 
-  boost::shared_ptr<PeakMap > exp2(new PeakMap);
+  std::shared_ptr<PeakMap > exp2(new PeakMap);
   {
     MSSpectrum spec;
     Peak1D p;
@@ -434,7 +434,7 @@ START_SECTION( void correctIM(const std::map<String, OpenMS::MRMFeatureFinderSco
   transition_group_map["group3"] = &gr3;
 
   // Create a mock spectrum fitting to the transition group
-  boost::shared_ptr<PeakMap > exp(new PeakMap);
+  std::shared_ptr<PeakMap > exp(new PeakMap);
   {
     MSSpectrum spec;
     Peak1D p;
@@ -475,7 +475,7 @@ START_SECTION( void correctIM(const std::map<String, OpenMS::MRMFeatureFinderSco
   }
 
   // Create a mock pasef spectrum, should not be used
-  boost::shared_ptr<PeakMap > exp2(new PeakMap);
+  std::shared_ptr<PeakMap > exp2(new PeakMap);
   {
     MSSpectrum spec;
     Peak1D p;
@@ -515,7 +515,7 @@ START_SECTION( void correctIM(const std::map<String, OpenMS::MRMFeatureFinderSco
     exp->addSpectrum(spec);
   }
 
-  boost::shared_ptr<PeakMap > exp_ms1(new PeakMap);
+  std::shared_ptr<PeakMap > exp_ms1(new PeakMap);
   {
     MSSpectrum spec;
     Peak1D p;

--- a/src/tests/class_tests/openms/source/SwathQC_test.cpp
+++ b/src/tests/class_tests/openms/source/SwathQC_test.cpp
@@ -55,7 +55,7 @@ START_SECTION(~SwathQC())
 END_SECTION
 
 // Create a mock spectrum fitting to the transition group
-boost::shared_ptr<MSExperiment> exp(new MSExperiment);
+std::shared_ptr<MSExperiment> exp(new MSExperiment);
 MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("PeakPickerHiRes_orbitrap_sn1_out.mzML"), *exp);
 OpenSwath::SpectrumAccessPtr sptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
 

--- a/src/topp/MRMMapper.cpp
+++ b/src/topp/MRMMapper.cpp
@@ -138,7 +138,7 @@ protected:
 
     // add all data processing information to all the chromatograms
     DataProcessing dp_ = getProcessingInfo_(DataProcessing::FORMAT_CONVERSION);
-    DataProcessingPtr dp = boost::shared_ptr<DataProcessing>(new DataProcessing(dp_));
+    DataProcessingPtr dp = std::shared_ptr<DataProcessing>(new DataProcessing(dp_));
     std::vector<MSChromatogram > chromatograms = output.getChromatograms();
     for (Size i=0; i<chromatograms.size(); ++i)
     {

--- a/src/topp/MRMTransitionGroupPicker.cpp
+++ b/src/topp/MRMTransitionGroupPicker.cpp
@@ -249,7 +249,7 @@ protected:
     String tr_file = getStringOption_("tr");
     bool force = getFlag_("force");
 
-    boost::shared_ptr<PeakMap > exp ( new PeakMap );
+    std::shared_ptr<PeakMap > exp ( new PeakMap );
     FileHandler().loadExperiment(in, *exp, {FileTypes::MZML}, log_type_);
 
     TargetedExpType transition_exp;

--- a/src/topp/OpenSwathAnalyzer.cpp
+++ b/src/topp/OpenSwathAnalyzer.cpp
@@ -17,7 +17,7 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 
 #include <fstream>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 using namespace OpenMS;
 using namespace std;
@@ -165,7 +165,7 @@ protected:
     Param feature_finder_param = getParam_().copy("algorithm:", true);
 
     // Create the output map, load the input TraML file and the chromatograms
-    boost::shared_ptr<MapType> exp (new MapType());
+    std::shared_ptr<MapType> exp (new MapType());
     FeatureMap out_featureFile;
     OpenSwath::LightTargetedExperiment transition_exp;
     std::cout << "Loading TraML file" << std::endl;
@@ -202,7 +202,7 @@ protected:
     for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(file_list.size()); ++i)
     {
       MRMFeatureFinderScoring featureFinder;
-      boost::shared_ptr<MapType> swath_map (new MapType());
+      std::shared_ptr<MapType> swath_map (new MapType());
       FeatureMap featureFile;
       cout << "Loading file " << file_list[i] << endl;
 

--- a/src/topp/OpenSwathChromatogramExtractor.cpp
+++ b/src/topp/OpenSwathChromatogramExtractor.cpp
@@ -217,7 +217,7 @@ protected:
 #pragma omp parallel for
     for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(file_list.size()); ++i)
     {
-      boost::shared_ptr<PeakMap > exp(new PeakMap);
+      std::shared_ptr<PeakMap > exp(new PeakMap);
       // Find the transitions to extract and extract them
       MapType tmp_out;
       OpenMS::TargetedExperiment transition_exp_used;

--- a/src/topp/OpenSwathDIAPreScoring.cpp
+++ b/src/topp/OpenSwathDIAPreScoring.cpp
@@ -56,7 +56,7 @@ public:
 protected:
 
   typedef PeakMap MapType;
-  typedef boost::shared_ptr<PeakMap> MapTypePtr;
+  typedef std::shared_ptr<PeakMap> MapTypePtr;
 
   void registerOptionsAndFlags_() override
   {

--- a/src/topp/OpenSwathFileSplitter.cpp
+++ b/src/topp/OpenSwathFileSplitter.cpp
@@ -64,7 +64,7 @@ protected:
     setValidFormats_("out_qc", ListUtils::create<String>("json"));
   }
 
-  void loadSwathFiles(const String& file_in, const String& tmp, const String& readoptions, boost::shared_ptr<ExperimentalSettings>& exp_meta, std::vector<OpenSwath::SwathMap>& swath_maps,
+  void loadSwathFiles(const String& file_in, const String& tmp, const String& readoptions, std::shared_ptr<ExperimentalSettings>& exp_meta, std::vector<OpenSwath::SwathMap>& swath_maps,
                       Interfaces::IMSDataConsumer* plugin_consumer = nullptr)
   {
     SwathFile swath_file;
@@ -104,7 +104,7 @@ protected:
     ///////////////////////////////////
     // Load the SWATH files
     ///////////////////////////////////
-    boost::shared_ptr<ExperimentalSettings> exp_meta(new ExperimentalSettings);
+    std::shared_ptr<ExperimentalSettings> exp_meta(new ExperimentalSettings);
     std::vector<OpenSwath::SwathMap> swath_maps;
 
     // collect some QC data

--- a/src/topp/OpenSwathRTNormalizer.cpp
+++ b/src/topp/OpenSwathRTNormalizer.cpp
@@ -194,8 +194,8 @@ protected:
     std::vector<std::pair<double, double> > pairs;
     for (Size i = 0; i < file_list.size(); ++i)
     {
-      boost::shared_ptr<MapType> swath_map (new MapType()); // the map with the extracted ion chromatograms
-      boost::shared_ptr<MapType> xic_map (new MapType());
+      std::shared_ptr<MapType> swath_map (new MapType()); // the map with the extracted ion chromatograms
+      std::shared_ptr<MapType> xic_map (new MapType());
       FeatureMap featureFile;
       std::cout << "RT Normalization working on " << file_list[i] << std::endl;
       FileHandler().loadExperiment(file_list[i], *xic_map.get(), {FileTypes::MZML}, log_type_);

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -909,7 +909,7 @@ protected:
     ///////////////////////////////////
     // Load the SWATH files
     ///////////////////////////////////
-    boost::shared_ptr<ExperimentalSettings> exp_meta(new ExperimentalSettings);
+    std::shared_ptr<ExperimentalSettings> exp_meta(new ExperimentalSettings);
     std::vector< OpenSwath::SwathMap > swath_maps;
 
     // collect some QC data


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Modernized memory handling across codebase by replacing Boost smart pointers with standard library shared pointers; improves compatibility and reduces external dependency.
  - Updated GUI components to match modernization.
- Bug Fixes
  - Stricter validation when detecting isobaric quantitation methods; unsupported mappings now produce a clear error.
- Tests
  - Unit tests updated to reflect pointer-type changes.
- Chores
  - Removed Boost shared_ptr/make_shared headers in favor of <memory>.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->