### PR TITLE
Notify on broken

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -1134,3 +1134,174 @@ jobs:
               git push --set-upstream origin releaseannouncement${{ needs.build-and-test.outputs.version_number }}
               gh pr create --title "Release announcement for ${{ needs.build-and-test.outputs.version_number }}" --body "announces ${{ needs.build-and-test.outputs.version_number }}"
             popd
+
+  nightly-failure-notification:
+    if: always() && github.ref == 'refs/heads/nightly'
+    runs-on: ubuntu-latest
+    needs: [build-and-test]
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if current run failed
+        id: check-failure
+        run: |
+          BUILD_AND_TEST_RESULT="${{ needs.build-and-test.result }}"
+          
+          if [ "$BUILD_AND_TEST_RESULT" != "failure" ]; then
+            echo "Build and test did not fail, no notification needed"
+            echo "should_notify=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Current build failed, proceeding with notification check..."
+          echo "should_notify=true" >> $GITHUB_OUTPUT
+
+      - name: Get last successful build
+        if: steps.check-failure.outputs.should_notify == 'true'
+        id: last-successful
+        uses: SamhammerAG/last-successful-build-action@v4
+        with:
+          branch: "nightly"
+          workflow: "openms_ci_matrix_full.yml"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if this is the first failure after success
+        if: steps.check-failure.outputs.should_notify == 'true' && steps.last-successful.outputs.sha != ''
+        id: check-first-failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the most recent workflow run before this one on nightly
+          PREVIOUS_RUN=$(gh api \
+            --method GET \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/actions/workflows/openms_ci_matrix_full.yml/runs?branch=nightly&per_page=10" \
+            --jq '.workflow_runs[] | select(.id < ${{ github.run_id }}) | first')
+
+          if [ "$PREVIOUS_RUN" = "null" ] || [ -z "$PREVIOUS_RUN" ]; then
+            echo "No previous run found, treating as first failure"
+            echo "is_first_failure=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          PREVIOUS_CONCLUSION=$(echo "$PREVIOUS_RUN" | jq -r '.conclusion')
+          echo "Previous run conclusion: $PREVIOUS_CONCLUSION"
+          
+          if [ "$PREVIOUS_CONCLUSION" = "success" ]; then
+            echo "Previous run succeeded, this is the first failure"
+            echo "is_first_failure=true" >> $GITHUB_OUTPUT
+          else
+            echo "Previous run was not successful, this is a subsequent failure"
+            echo "is_first_failure=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find merged PRs since last success
+        if: steps.check-failure.outputs.should_notify == 'true' && steps.last-successful.outputs.sha != '' && steps.check-first-failure.outputs.is_first_failure == 'true'
+        id: find-prs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST_SUCCESS_SHA="${{ steps.last-successful.outputs.sha }}"
+          
+          if [ "$LAST_SUCCESS_SHA" = "${{ github.sha }}" ]; then
+            echo "Last successful commit is the same as current commit, no PRs to notify"
+            echo "pr_numbers=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Finding commits between $LAST_SUCCESS_SHA and ${{ github.sha }}"
+          
+          # Get commits between last success and current commit
+          COMMITS=$(git rev-list $LAST_SUCCESS_SHA..${{ github.sha }} 2>/dev/null || echo "")
+          
+          if [ -z "$COMMITS" ]; then
+            echo "No new commits found"
+            echo "pr_numbers=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Find PRs for these commits
+          PR_NUMBERS=""
+          for commit in $COMMITS; do
+            # Look for merge commits that mention PR numbers
+            COMMIT_MSG=$(git log --format="%s" -n 1 $commit)
+            if echo "$COMMIT_MSG" | grep -q "Merge pull request #"; then
+              PR_NUM=$(echo "$COMMIT_MSG" | grep -o "#[0-9]\+" | sed 's/#//' | head -1)
+              if [ -n "$PR_NUM" ]; then
+                if [ -z "$PR_NUMBERS" ]; then
+                  PR_NUMBERS="$PR_NUM"
+                else
+                  PR_NUMBERS="$PR_NUMBERS,$PR_NUM"
+                fi
+              fi
+            fi
+          done
+
+          # Remove duplicates
+          if [ -n "$PR_NUMBERS" ]; then
+            PR_NUMBERS=$(echo "$PR_NUMBERS" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
+          fi
+
+          echo "Found PR numbers: $PR_NUMBERS"
+          echo "pr_numbers=$PR_NUMBERS" >> $GITHUB_OUTPUT
+
+      - name: Comment on PRs
+        if: steps.check-failure.outputs.should_notify == 'true' && steps.check-first-failure.outputs.is_first_failure == 'true' && steps.find-prs.outputs.pr_numbers != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBERS="${{ steps.find-prs.outputs.pr_numbers }}"
+          LAST_SUCCESS_SHA="${{ steps.last-successful.outputs.sha }}"
+          LAST_SUCCESS_RUN_ID="${{ steps.last-successful.outputs.run_id }}"
+          
+          IFS=',' read -ra PRS <<< "$PR_NUMBERS"
+          for pr in "${PRS[@]}"; do
+            if [ -n "$pr" ]; then
+              echo "Commenting on PR #$pr"
+              
+              # Check if PR is still accessible
+              PR_INFO=$(gh api \
+                --method GET \
+                -H "Accept: application/vnd.github+json" \
+                "/repos/${{ github.repository }}/pulls/$pr" 2>/dev/null || echo "not_found")
+              
+              if [ "$PR_INFO" != "not_found" ]; then
+                COMMENT_BODY="🚨 **Nightly Build Failure Alert** 🚨
+
+Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
+
+**What this means:**
+- The nightly build on the \`nightly\` branch is currently failing
+- Your PR (#$pr) was merged between the [last successful run](${{ github.server_url }}/${{ github.repository }}/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
+- Your changes might be related to the failure (but not necessarily the cause)
+
+**What you should do:**
+1. 🔍 **Check the [failed workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})** to see what went wrong
+2. 🧐 **Review your changes** to see if they could be related to the failure
+3. 🛠️ **If your changes are the cause**, please create a fix as soon as possible
+4. 💬 **If you're unsure**, please engage with the team to help diagnose the issue
+
+**Note:** This is an automated message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
+
+---
+*Last successful commit: \`$LAST_SUCCESS_SHA\`*
+*Current failing commit: \`${{ github.sha }}\`*"
+
+                gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  "/repos/${{ github.repository }}/issues/$pr/comments" \
+                  -f body="$COMMENT_BODY" || echo "Failed to comment on PR #$pr"
+              else
+                echo "PR #$pr not found or inaccessible"
+              fi
+            fi
+          done

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -1261,6 +1261,10 @@ jobs:
           PR_NUMBERS="${{ steps.find-prs.outputs.pr_numbers }}"
           LAST_SUCCESS_SHA="${{ steps.last-successful.outputs.sha }}"
           LAST_SUCCESS_RUN_ID="${{ steps.last-successful.outputs.run_id }}"
+          GITHUB_SERVER_URL="${{ github.server_url }}"
+          GITHUB_REPOSITORY="${{ github.repository }}"
+          GITHUB_RUN_ID="${{ github.run_id }}"
+          GITHUB_SHA="${{ github.sha }}"
           
           IFS=',' read -ra PRS <<< "$PR_NUMBERS"
           for pr in "${PRS[@]}"; do
@@ -1271,37 +1275,39 @@ jobs:
               PR_INFO=$(gh api \
                 --method GET \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/pulls/$pr" 2>/dev/null || echo "not_found")
+                "/repos/$GITHUB_REPOSITORY/pulls/$pr" 2>/dev/null || echo "not_found")
               
               if [ "$PR_INFO" != "not_found" ]; then
-                COMMENT_BODY=$(cat << 'EOF'
+                COMMENT_BODY=$(cat << EOF
 🚨 **Nightly Build Failure Alert** 🚨
 
 Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
 
 **What this means:**
-- The nightly build on the `nightly` branch is currently failing
-- Your PR (#$pr) was merged between the [last successful run](${{ github.server_url }}/${{ github.repository }}/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
+- The nightly build on the \`nightly\` branch is currently failing
+- Your PR (#$pr) was merged between the [last successful run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
 - Your changes might be related to the failure (but not necessarily the cause)
 
 **What you should do:**
-1. 🔍 **Check the [failed workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})** to see what went wrong
+1. 🔍 **Check the [failed workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)** to see what went wrong
 2. 🧐 **Review your changes** to see if they could be related to the failure
 3. 🛠️ **If your changes are the cause**, please create a fix as soon as possible
 4. 💬 **If you're unsure**, please engage with the team to help diagnose the issue
 
 **Note:** This is an automated message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
 
+Thank you for helping keep the nightly builds healthy! 🙏
+
 ---
-*Last successful commit: `$LAST_SUCCESS_SHA`*
-*Current failing commit: `${{ github.sha }}`*
+*Last successful commit: \`$LAST_SUCCESS_SHA\`*
+*Current failing commit: \`$GITHUB_SHA\`*
 EOF
 )
 
                 gh api \
                   --method POST \
                   -H "Accept: application/vnd.github+json" \
-                  "/repos/${{ github.repository }}/issues/$pr/comments" \
+                  "/repos/$GITHUB_REPOSITORY/issues/$pr/comments" \
                   -f body="$COMMENT_BODY" || echo "Failed to comment on PR #$pr"
               else
                 echo "PR #$pr not found or inaccessible"

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -132,12 +132,12 @@ jobs:
           echo "contrib_compiler=msvc-14.2/" >> $GITHUB_OUTPUT
           echo "xvfb=" >> $GITHUB_OUTPUT
           echo "static_boost=ON" >> $GITHUB_OUTPUT
+          # Build the docs on windows during testing so we don't have any post-merge surprises
+          echo "enable_docs=ON" >> $GITHUB_OUTPUT
           if [ "$DO_PACKAGE" = true ]; then
             echo "pkg_type=nsis" >> $GITHUB_OUTPUT
-            echo "enable_docs=ON" >> $GITHUB_OUTPUT
           else
-            echo "pkg_type=none" >> $GITHUB_OUTPUT           
-            echo "enable_docs=OFF" >> $GITHUB_OUTPUT
+            echo "pkg_type=none" >> $GITHUB_OUTPUT
           fi
           echo "cxx_compiler=${{ matrix.compiler }}" >> $GITHUB_OUTPUT
         fi
@@ -149,13 +149,12 @@ jobs:
           echo "contrib_compiler=appleclang-11.0.0/" >> $GITHUB_OUTPUT
           echo "xvfb=" >> $GITHUB_OUTPUT
           echo "static_boost=OFF" >> $GITHUB_OUTPUT
+          # build docs on Mac so we don't end up with any nasty post-merge surprises
+          echo "enable_docs=ON" >> $GITHUB_OUTPUT
           if [ "$DO_PACKAGE" = true ]; then
             echo "pkg_type=pkg" >> $GITHUB_OUTPUT
-            echo "enable_docs=ON" >> $GITHUB_OUTPUT
           else
             echo "pkg_type=none" >> $GITHUB_OUTPUT
-            echo "enable_docs=OFF" >> $GITHUB_OUTPUT
-
           fi
           if [[ "${{ matrix.compiler }}" == "xcode" ]]; then
             sudo xcode-select -s '/Applications/Xcode_${{ matrix.compiler_ver }}.app/Contents/Developer'

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -1279,30 +1279,30 @@ jobs:
               
               if [ "$PR_INFO" != "not_found" ]; then
                 COMMENT_BODY=$(cat << EOF
-🚨 **Nightly Build Failure Alert** 🚨
+          🚨 **Nightly Build Failure Alert** 🚨
 
-Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
+          Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
 
-**What this means:**
-- The nightly build on the \`nightly\` branch is currently failing
-- Your PR (#$pr) was merged between the [last successful run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
-- Your changes might be related to the failure (but not necessarily the cause)
+          **What this means:**
+          - The nightly build on the "nightly" branch is currently failing
+          - Your PR (#$pr) was merged between the [last successful run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
+          - Your changes might be related to the failure (but not necessarily the cause)
 
-**What you should do:**
-1. 🔍 **Check the [failed workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)** to see what went wrong
-2. 🧐 **Review your changes** to see if they could be related to the failure
-3. 🛠️ **If your changes are the cause**, please create a fix as soon as possible
-4. 💬 **If you're unsure**, please engage with the team to help diagnose the issue
+          **What you should do:**
+          1. 🔍 **Check the [failed workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)** to see what went wrong
+          2. 🧐 **Review your changes** to see if they could be related to the failure
+          3. 🛠️ **If your changes are the cause**, please create a fix as soon as possible
+          4. 💬 **If you're unsure**, please engage with the team to help diagnose the issue
 
-**Note:** This is an automated message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
+          **Note:** This is an automated message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
 
-Thank you for helping keep the nightly builds healthy! 🙏
+          Thank you for helping keep the nightly builds healthy! 🙏
 
----
-*Last successful commit: \`$LAST_SUCCESS_SHA\`*
-*Current failing commit: \`$GITHUB_SHA\`*
-EOF
-)
+          ---
+          *Last successful commit: $LAST_SUCCESS_SHA*
+          *Current failing commit: $GITHUB_SHA*
+          EOF
+          )
 
                 gh api \
                   --method POST \

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -1274,12 +1274,13 @@ jobs:
                 "/repos/${{ github.repository }}/pulls/$pr" 2>/dev/null || echo "not_found")
               
               if [ "$PR_INFO" != "not_found" ]; then
-                COMMENT_BODY="🚨 **Nightly Build Failure Alert** 🚨
+                COMMENT_BODY=$(cat << 'EOF'
+🚨 **Nightly Build Failure Alert** 🚨
 
 Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
 
 **What this means:**
-- The nightly build on the \`nightly\` branch is currently failing
+- The nightly build on the `nightly` branch is currently failing
 - Your PR (#$pr) was merged between the [last successful run](${{ github.server_url }}/${{ github.repository }}/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
 - Your changes might be related to the failure (but not necessarily the cause)
 
@@ -1292,8 +1293,10 @@ Hello! The nightly build has failed, and your PR was merged since the last succe
 **Note:** This is an automated message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
 
 ---
-*Last successful commit: \`$LAST_SUCCESS_SHA\`*
-*Current failing commit: \`${{ github.sha }}\`*"
+*Last successful commit: `$LAST_SUCCESS_SHA`*
+*Current failing commit: `${{ github.sha }}`*
+EOF
+)
 
                 gh api \
                   --method POST \

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         description: Update website and create announcement material for release
         default: false
+      test_nightly_notification:
+        type: boolean
+        description: Test the nightly failure notification (dry run mode)
+        default: false
   push:
     branches:
       - nightly
@@ -1136,7 +1140,7 @@ jobs:
             popd
 
   nightly-failure-notification:
-    if: always() && github.ref == 'refs/heads/nightly'
+    if: always() && (github.ref == 'refs/heads/nightly' || inputs.test_nightly_notification)
     runs-on: ubuntu-latest
     needs: [build-and-test]
     permissions:
@@ -1153,15 +1157,22 @@ jobs:
         id: check-failure
         run: |
           BUILD_AND_TEST_RESULT="${{ needs.build-and-test.result }}"
+          TEST_MODE="${{ inputs.test_nightly_notification }}"
           
-          if [ "$BUILD_AND_TEST_RESULT" != "failure" ]; then
+          if [ "$TEST_MODE" = "true" ]; then
+            echo "TEST MODE: Simulating failure condition"
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+            echo "test_mode=true" >> $GITHUB_OUTPUT
+          elif [ "$BUILD_AND_TEST_RESULT" != "failure" ]; then
             echo "Build and test did not fail, no notification needed"
             echo "should_notify=false" >> $GITHUB_OUTPUT
+            echo "test_mode=false" >> $GITHUB_OUTPUT
             exit 0
+          else
+            echo "Current build failed, proceeding with notification check..."
+            echo "should_notify=true" >> $GITHUB_OUTPUT
+            echo "test_mode=false" >> $GITHUB_OUTPUT
           fi
-          
-          echo "Current build failed, proceeding with notification check..."
-          echo "should_notify=true" >> $GITHUB_OUTPUT
 
       - name: Get last successful build
         if: steps.check-failure.outputs.should_notify == 'true'
@@ -1173,11 +1184,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if this is the first failure after success
-        if: steps.check-failure.outputs.should_notify == 'true' && steps.last-successful.outputs.sha != ''
+        if: steps.check-failure.outputs.should_notify == 'true' && (steps.last-successful.outputs.sha != '' || steps.check-failure.outputs.test_mode == 'true')
         id: check-first-failure
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TEST_MODE="${{ steps.check-failure.outputs.test_mode }}"
+          
+          if [ "$TEST_MODE" = "true" ]; then
+            echo "TEST MODE: Simulating first failure after success"
+            echo "is_first_failure=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
           # Get the most recent workflow run before this one on nightly
           PREVIOUS_RUN=$(gh api \
             --method GET \
@@ -1204,11 +1223,26 @@ jobs:
           fi
 
       - name: Find merged PRs since last success
-        if: steps.check-failure.outputs.should_notify == 'true' && steps.last-successful.outputs.sha != '' && steps.check-first-failure.outputs.is_first_failure == 'true'
+        if: steps.check-failure.outputs.should_notify == 'true' && (steps.last-successful.outputs.sha != '' || steps.check-failure.outputs.test_mode == 'true') && steps.check-first-failure.outputs.is_first_failure == 'true'
         id: find-prs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          TEST_MODE="${{ steps.check-failure.outputs.test_mode }}"
+          
+          if [ "$TEST_MODE" = "true" ]; then
+            echo "TEST MODE: Using recent PR numbers for testing"
+            # Get the 3 most recent merged PRs for testing
+            RECENT_PRS=$(gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${{ github.repository }}/pulls?state=closed&per_page=3" \
+              --jq '.[] | select(.merged_at != null) | .number' | tr '\n' ',' | sed 's/,$//')
+            echo "TEST MODE: Found recent PRs for testing: $RECENT_PRS"
+            echo "pr_numbers=$RECENT_PRS" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
           LAST_SUCCESS_SHA="${{ steps.last-successful.outputs.sha }}"
           
           if [ "$LAST_SUCCESS_SHA" = "${{ github.sha }}" ]; then
@@ -1278,7 +1312,37 @@ jobs:
                 "/repos/$GITHUB_REPOSITORY/pulls/$pr" 2>/dev/null || echo "not_found")
               
               if [ "$PR_INFO" != "not_found" ]; then
-                COMMENT_BODY=$(cat << EOF
+                TEST_MODE="${{ steps.check-failure.outputs.test_mode }}"
+                
+                if [ "$TEST_MODE" = "true" ]; then
+                  COMMENT_BODY=$(cat << EOF
+          🧪 **TEST MODE - Nightly Build Failure Alert** 🧪
+
+          This is a TEST of the nightly failure notification system.
+
+          Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
+
+          **What this means:**
+          - The nightly build on the "nightly" branch is currently failing
+          - Your PR (#$pr) was merged between the [last successful run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$LAST_SUCCESS_RUN_ID) and this failure
+          - Your changes might be related to the failure (but not necessarily the cause)
+
+          **What you should do:**
+          1. 🔍 **Check the [failed workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)** to see what went wrong
+          2. 🧐 **Review your changes** to see if they could be related to the failure
+          3. 🛠️ **If your changes are the cause**, please create a fix as soon as possible
+          4. 💬 **If you're unsure**, please engage with the team to help diagnose the issue
+
+          **Note:** This is an automated TEST message. Multiple PRs may have been merged since the last successful run, so the failure might not be caused by your specific changes.
+
+          ---
+          *This was a test of the nightly failure notification system.*
+          EOF
+          )
+                  echo "TEST MODE: Would post this comment to PR #$pr:"
+                  echo "$COMMENT_BODY"
+                else
+                  COMMENT_BODY=$(cat << EOF
           🚨 **Nightly Build Failure Alert** 🚨
 
           Hello! The nightly build has failed, and your PR was merged since the last successful nightly run.
@@ -1304,11 +1368,12 @@ jobs:
           EOF
           )
 
-                gh api \
-                  --method POST \
-                  -H "Accept: application/vnd.github+json" \
-                  "/repos/$GITHUB_REPOSITORY/issues/$pr/comments" \
-                  -f body="$COMMENT_BODY" || echo "Failed to comment on PR #$pr"
+                  gh api \
+                    --method POST \
+                    -H "Accept: application/vnd.github+json" \
+                    "/repos/$GITHUB_REPOSITORY/issues/$pr/comments" \
+                    -f body="$COMMENT_BODY" || echo "Failed to comment on PR #$pr"
+                fi
               else
                 echo "PR #$pr not found or inaccessible"
               fi


### PR DESCRIPTION
add to our main CI some logic to check if:
- this is nightly
- build-and-test failed on this run
- build-and-test was successful on the last nightly run

If all of those things are true it:
- enumerates PR's that have been merged since the last successful nightly
- leaves a comment on those PRs to notify their authors that they should check and see if their code could be responsible

