### PR TITLE
Fix Typo In Matrix

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/Matrix.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Matrix.h
@@ -75,7 +75,7 @@ namespace OpenMS
     */
     const Value& getValue(size_t const i, size_t const j) const
     {
-      return *this(i, j);
+      return this->operator()(i, j);
     }
 
     /*

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4097,6 +4097,12 @@ def testMatrixDouble():
     assert m.getValue(1, 2) == 8.0
     assert m.getValue(3, 6) == 9.0
 
+    # Create a test matrix with known values
+    test_matrix = pyopenms.MatrixDouble(3, 4, 0.0)
+    test_matrix.setValue(2, 3, 120.7)
+
+    # Test getValue retrieves correct values
+    assert test_matrix.getValue(2, 3) == 120.7
 
 @report
 def testMapAlignmentIdentification():

--- a/src/tests/class_tests/openms/source/Matrix_test.cpp
+++ b/src/tests/class_tests/openms/source/Matrix_test.cpp
@@ -156,6 +156,29 @@ START_SECTION((reference operator() (size_type const i, size_type const j)))
 }
 END_SECTION
 
+START_SECTION((Value& getValue(size_t const i, size_t const j)))
+{
+  // Create a test matrix
+  Matrix<int> test_matrix(2, 2, 0);
+  
+  // Test non-const version of getValue by modifying values through it
+  test_matrix.getValue(0, 0) = 100;
+  test_matrix.getValue(0, 1) = 200;
+  test_matrix.getValue(1, 0) = 300;
+  test_matrix.getValue(1, 1) = 400;
+  
+  // Verify the values were set correctly
+  TEST_EQUAL(test_matrix(0, 0), 100);
+  TEST_EQUAL(test_matrix(0, 1), 200);
+  TEST_EQUAL(test_matrix(1, 0), 300);
+  TEST_EQUAL(test_matrix(1, 1), 400);
+  
+  // Verify getValue returns reference that can be modified
+  test_matrix.getValue(0, 0) += 5;
+  TEST_EQUAL(test_matrix(0, 0), 105);
+}
+END_SECTION
+
 START_SECTION((void operator()(size_type const i, size_type const j) = value_type value))
 {
   mi(1,1) = 18;


### PR DESCRIPTION
## Description
There was a typo in `Matrix.h` which caused issues with FLASHDeconv.

Due to operator precedence:

```cpp
*this(i, j)
```

is parsed as:

```cpp
*(this(i, j))
```

instead of the intended:

```cpp
(*this)(i, j)
```

This PR replaces it with the more explicit:

```cpp
this->operator()(i, j)
```

which also matches the style used in the rest of the header.

Credit goes to @KyowonJeong .

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matrix objects now provide a way to obtain and modify individual elements directly.

* **Refactor**
  * Internal read-only access to matrix elements streamlined for safer, more consistent behavior.

* **Tests**
  * New unit tests added to verify mutable and const element access and correct value propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->