### PR TITLE
Disable WITH_PARQUET option in CI workflow

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -431,7 +431,7 @@ jobs:
           ENABLE_GCC_WERROR: "OFF" # TODO think about that
           SEARCH_ENGINES_DIRECTORY: ${{ github.workspace }}/_thirdparty
           WITH_GUI: "ON"
-          WITH_PARQUET: "ON" # Conda on windows, Apt on Ubuntu, Brew on MacOS
+          WITH_PARQUET: "OFF" # Conda on windows, Apt on Ubuntu, Brew on MacOS
           SIGNING_IDENTITY: "-"
           ADDRESS_SANITIZER: "Off"
           BUILD_TYPE: "Release"

--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -28,7 +28,9 @@
   - @subpage TOPP_IDFileConverter - Converts between different identification file formats.
   - @subpage TOPP_MSstatsConverter - Convert to MSstats input file format.
   - @subpage TOPP_MzTabExporter - Exports various XML formats to an mzTab file.
+/// @cond WITH_PARQUET
   - @subpage TOPP_QuantmsIOConverter - Converts IdXML files to parquet format following quantms.io PSM specification.
+/// @endcond
   - @subpage TOPP_TargetedFileConverter - Converts targeted files (such as tsv or TraML files).
   - @subpage TOPP_TextExporter - Exports various XML formats to a text file.
   - @subpage TOPP_TriqlerConverter - Convert to Triqler input file format.

--- a/src/topp/QuantmsIOConverter.cpp
+++ b/src/topp/QuantmsIOConverter.cpp
@@ -71,7 +71,7 @@ PEP scores are automatically detected from metavalues using known PEP score name
 @verbinclude TOPP_QuantmsIOConverter.cli
 <B>INI file documentation of this tool:</B>
 @htmlinclude TOPP_QuantmsIOConverter.html
-
+/// @endcond
 */
 
 // We do not want this class to show up in the docu:

--- a/src/topp/QuantmsIOConverter.cpp
+++ b/src/topp/QuantmsIOConverter.cpp
@@ -20,6 +20,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
+/// @cond WITH_PARQUET
 @page TOPP_QuantmsIOConverter QuantmsIOConverter
 
 @brief Converts IdXML files to parquet format following quantms.io PSM specification.


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI build matrix updated to disable Parquet/Arrow-related builds, streamlining the pipeline with no change to shipped features or binaries.

* **Documentation**
  * Parquet-related internal documentation sections are now excluded from generated public docs, reducing clutter and improving discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->