### PR TITLE
Only warn about OpenMS data path if env variable differs from default

### DIFF
--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -31,15 +31,16 @@ from ._version import version as __version__
 import os
 here = os.path.abspath(os.path.dirname(__file__))
 
-default_openms_data_path = os.path.join(here, "share/OpenMS")
+default_openms_data_path = os.path.join(here, "share", "OpenMS")
 env_openms_data_path = os.environ.get("OPENMS_DATA_PATH")
 
 if os.path.exists(default_openms_data_path):
     if not env_openms_data_path:
         os.environ["OPENMS_DATA_PATH"] = default_openms_data_path
-    else:
+    elif os.path.abspath(env_openms_data_path) != os.path.abspath(default_openms_data_path):
         warnings.warn(
-            "Warning: OPENMS_DATA_PATH environment variable already exists. "
+            "Warning: OPENMS_DATA_PATH environment exists and points to a different location "
+            "than the default share directory. "
             "pyOpenMS will use it ({env}) to locate data in the OpenMS share folder "
             "(e.g., the unimod database), instead of the default ({default})."
             .format(env=env_openms_data_path, default=default_openms_data_path)


### PR DESCRIPTION
Previous behavior resulted in pyOpenMS setting the env variable to its default, and later warning about it being set. The warning does not really make sense if the env variable is set to the same value as the default. The suggested behavior only warns if both values differ and notes that the value from the env variable is used.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenMS data directory path resolution to use proper path construction methods, improving consistency and reliability in locating data files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->