### PR TITLE
speedup simpleSVM test (60 -> 2 seconds)

### DIFF
--- a/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleSVM_test.cpp
@@ -249,6 +249,10 @@ START_SECTION(regression_train_and_predict_on_all)
 
   auto param = svm.getParameters();
   param.setValue("kernel", "RBF");
+  param.setValue("log2_C", ListUtils::create<double>("9,11,13"));
+  param.setValue("log2_gamma", ListUtils::create<double>("-1,1,3"));
+  param.setValue("log2_p", ListUtils::create<double>("-6,-3.32192809489,0,3.32192809489"));
+
   svm.setParameters(param);
 
   svm.setup(x, y, false); // set up regression


### PR DESCRIPTION
## Description

This fixes one of the most long running tests in Debug mode.


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded SVM parameter configurations in regression test cases with additional kernel parameter settings for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->