### PR TITLE
Update CHANGELOG for OpenMS 3.5.0 development

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,16 +15,24 @@ PR - Pull Request (on GitHub), i.e. integration of a new feature or bugfix
 ------------------------------------------------------------------------------------------
 ----                                OpenMS 3.5.0     (under development)              ----
 ------------------------------------------------------------------------------------------
+NOTICE: 3.5.0 is going to be the last official release for MacOS on Intel processors.
+If you need support for OpenMS on that platform moving forward, please contact us.
 
 General:
  - speed improvements:
     - loading .gz files is about 7% faster (#8069)
     - loading of mzML files with more than than m/z+intensity (e.g. ion mobility) is 20-40% faster (#8074)
     - loading of mzML files is 7-25% faster in general (SIMD ASCII conversion) (#8105)
+ - linux arm64 support:
+	- OpenMS releases now include a .deb for arm64 machines
+	- PyOpenMS now has wheels for arm64 linux machines
     
 Dependencies:
     - PyOpenMS now depends on Autowrap 0.23.0
     - PyOpenMS now supports Cython 3.1
+
+PyOpenMS:
+	- PyOpenMS wheels are now available for Python 3.14 on all supported operating systems
 
 TOPP tools:
   Changes:


### PR DESCRIPTION
Add changes to our changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenMS 3.5.0 changelog noting this as the final official macOS Intel release.
  * Added Linux arm64 support details including .deb packages and PyOpenMS wheels for arm64.
  * Added PyOpenMS compatibility note for Python 3.14 across all supported operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->