### PR TITLE
correctly report python error as error for cdash

### DIFF
--- a/tools/ci/cibuild.cmake
+++ b/tools/ci/cibuild.cmake
@@ -20,19 +20,22 @@ set (CTEST_CURL_OPTIONS       CURLOPT_SSL_VERIFYHOST_OFF CURLOPT_SSL_VERIFYPEER_
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
-# Define patterns that should be classified as errors
-set(CTEST_CUSTOM_ERROR_MATCH
-    "subprocess-exited-with-error"
-    "FAILED:"
-    "error:"
-    "Error:"
-    "ERROR:"
-    )
-
 set (CTEST_CUSTOM_WARNING_EXCEPTION
     # Suppress warnings imported from qt
     ".*qsharedpointer_impl.h:595:43.*"
     ".*src/openms/extern/.*"
+    # Ignore the generic "non-zero return value" warnings - let the actual errors be classified properly
+    ".*WARNING.*non-zero return value.*cmake.*"
+    )
+
+# Define patterns that should be classified as errors (these override warning classification)
+set(CTEST_CUSTOM_ERROR_MATCH
+    "subprocess-exited-with-error"
+    "FAILED:.*pyopenms"
+    "× Getting requirements to build wheel did not run successfully"
+    "error: subprocess-exited-with-error"
+    ".*FAILED:.*pyOpenMS.*"
+    ".*pip wheel.*"
     )
 
 message(STATUS "CTEST_SOURCE_DIRECTORY: ${CTEST_SOURCE_DIRECTORY}")

--- a/tools/ci/cibuild.cmake
+++ b/tools/ci/cibuild.cmake
@@ -20,6 +20,15 @@ set (CTEST_CURL_OPTIONS       CURLOPT_SSL_VERIFYHOST_OFF CURLOPT_SSL_VERIFYPEER_
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
+# Define patterns that should be classified as errors
+set(CTEST_CUSTOM_ERROR_MATCH
+    "subprocess-exited-with-error"
+    "FAILED:"
+    "error:"
+    "Error:"
+    "ERROR:"
+    )
+
 set (CTEST_CUSTOM_WARNING_EXCEPTION
     # Suppress warnings imported from qt
     ".*qsharedpointer_impl.h:595:43.*"

--- a/tools/ci/citest.cmake
+++ b/tools/ci/citest.cmake
@@ -24,13 +24,20 @@ set(CTEST_CUSTOM_TESTS_IGNORE
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
-# Define patterns that should be classified as errors
+# Define patterns that should NOT be classified as warnings
+set(CTEST_CUSTOM_WARNING_EXCEPTION
+    # Ignore the generic "non-zero return value" warnings - let the actual errors be classified properly
+    ".*WARNING.*non-zero return value.*cmake.*"
+    )
+
+# Define patterns that should be classified as errors (these override warning classification)
 set(CTEST_CUSTOM_ERROR_MATCH
     "subprocess-exited-with-error"
-    "FAILED:"
-    "error:"
-    "Error:"
-    "ERROR:"
+    "FAILED:.*pyopenms"
+    "× Getting requirements to build wheel did not run successfully"
+    "error: subprocess-exited-with-error"
+    ".*FAILED:.*pyOpenMS.*"
+    ".*pip wheel.*"
     )
 
 ctest_start(APPEND)

--- a/tools/ci/citest.cmake
+++ b/tools/ci/citest.cmake
@@ -24,6 +24,15 @@ set(CTEST_CUSTOM_TESTS_IGNORE
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
+# Define patterns that should be classified as errors
+set(CTEST_CUSTOM_ERROR_MATCH
+    "subprocess-exited-with-error"
+    "FAILED:"
+    "error:"
+    "Error:"
+    "ERROR:"
+    )
+
 ctest_start(APPEND)
 
 ## run tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI test classification: now ignores specific benign warning patterns while explicitly flagging subprocess, packaging/wheel, and pyOpenMS-related failures so test reports show more accurate pass/fail status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->