### PR TITLE
Disable pip build isolation.

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -94,7 +94,15 @@ jobs:
       run: |
         PYTHON_VERSIONS=$(cat OpenMS/.github/workflows/python_versions.json)
         CMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}"
+        #mkdir bld
+        #pushd bld
         # TODO: set generator via variable, then we can share this step
+        # cmake --version
+        # cmake -G "Visual Studio 17 2022" -A x64 -DOPENMS_CONTRIB_LIBS="$GITHUB_WORKSPACE/OpenMS/contrib" -DCMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" ../OpenMS
+        # Note: multiple --targets only supported by CMake 3.15+
+        # cmake --build . --config Release --target OpenMS
+        
+        #ctest --progress --output-on-failure -VV -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake
         export CXXFLAGS="-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR $CXXFLAGS"
       
         mkdir pyopenms_whls
@@ -120,8 +128,6 @@ jobs:
           CURRENT_PYTHON_EXECUTABLE=$(which python)
 
           ${CURRENT_PYTHON_EXECUTABLE} -m pip install --upgrade pip
-          # setuptools needs numpy
-          ${CURRENT_PYTHON_EXECUTABLE} -m pip install "numpy>=2.0"
           # pip install all the stuff
           ${CURRENT_PYTHON_EXECUTABLE} -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
           
@@ -269,7 +275,7 @@ jobs:
           conda create -n pyoms-bld-"${pynodot}" python="${py}"
           source activate pyoms-bld-"${pynodot}"
           python -m pip install --upgrade pip
-          python -m pip install "numpy>=2.0"
+
           # pip install all the stuff
           python -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -437,7 +443,7 @@ jobs:
           conda create -n pyoms-bld-"${pynodot}" python="${py}"
           source activate pyoms-bld-"${pynodot}"
           python -m pip install --upgrade pip
-          python -m pip install "numpy>=2.0"
+
           # pip install all the stuff
           python -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -568,7 +574,6 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -695,7 +700,6 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -842,7 +846,6 @@ jobs:
 
           # pip install all the stuff
           python -m pip install --upgrade pip
-          python -m pip install "numpy>=2.0"
           python -m pip install $CURRENT_WHL
 
           # check if package was installed

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -568,7 +568,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" install "numpy>=2.0"
+          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -695,7 +695,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" install "numpy>=2.0"
+          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -568,7 +568,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
+          "$PYBIN/bin/pip" install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -695,7 +695,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
-          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
+          "$PYBIN/bin/pip" install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -94,15 +94,7 @@ jobs:
       run: |
         PYTHON_VERSIONS=$(cat OpenMS/.github/workflows/python_versions.json)
         CMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}"
-        #mkdir bld
-        #pushd bld
         # TODO: set generator via variable, then we can share this step
-        # cmake --version
-        # cmake -G "Visual Studio 17 2022" -A x64 -DOPENMS_CONTRIB_LIBS="$GITHUB_WORKSPACE/OpenMS/contrib" -DCMAKE_PREFIX_PATH="$(echo $Qt6_Dir)/lib/cmake;${Qt6_Dir}" ../OpenMS
-        # Note: multiple --targets only supported by CMake 3.15+
-        # cmake --build . --config Release --target OpenMS
-        
-        #ctest --progress --output-on-failure -VV -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake
         export CXXFLAGS="-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR $CXXFLAGS"
       
         mkdir pyopenms_whls
@@ -128,6 +120,8 @@ jobs:
           CURRENT_PYTHON_EXECUTABLE=$(which python)
 
           ${CURRENT_PYTHON_EXECUTABLE} -m pip install --upgrade pip
+          # setuptools needs numpy
+          ${CURRENT_PYTHON_EXECUTABLE} -m pip install "numpy>=2.0"
           # pip install all the stuff
           ${CURRENT_PYTHON_EXECUTABLE} -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
           
@@ -275,7 +269,7 @@ jobs:
           conda create -n pyoms-bld-"${pynodot}" python="${py}"
           source activate pyoms-bld-"${pynodot}"
           python -m pip install --upgrade pip
-
+          python -m pip install "numpy>=2.0"
           # pip install all the stuff
           python -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -443,7 +437,7 @@ jobs:
           conda create -n pyoms-bld-"${pynodot}" python="${py}"
           source activate pyoms-bld-"${pynodot}"
           python -m pip install --upgrade pip
-
+          python -m pip install "numpy>=2.0"
           # pip install all the stuff
           python -m pip install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -574,6 +568,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
+          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -700,6 +695,7 @@ jobs:
           source $pynodot/bin/activate
           
           "$PYBIN/bin/pip" install --upgrade pip
+          "$PYBIN/bin/pip" -m pip install "numpy>=2.0"
           # pip install all the stuff
           "$PYBIN/bin/pip" install -r $GITHUB_WORKSPACE/OpenMS/src/pyOpenMS/requirements_bld.txt
 
@@ -846,6 +842,7 @@ jobs:
 
           # pip install all the stuff
           python -m pip install --upgrade pip
+          python -m pip install "numpy>=2.0"
           python -m pip install $CURRENT_WHL
 
           # check if package was installed

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -525,7 +525,7 @@ endif()
 IF(LINUX AND PY_NO_OUTPUT)
     add_custom_target(pyopenms
             #COMMAND ${Python_EXECUTABLE} setup.py bdist_egg 2> /dev/null
-            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms .
+            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms --no-build-isolation .
             #COMMAND ${Python_EXECUTABLE} setup.py bdist --format=zip 2> /dev/null
             #COMMAND ${Python_EXECUTABLE} setup.py build_ext --inplace 2> /dev/null
             COMMENT "Packaging pyopenms wheel."
@@ -540,7 +540,7 @@ ELSE()
             COMMAND codesign --force --sign "-" ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms/Qt*
             COMMAND codesign --force --sign "-" ${CMAKE_BINARY_DIR}/pyOpenMS/pyopenms/*.dylib
             #COMMAND ${Python_EXECUTABLE} setup.py bdist_egg
-            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms .
+            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms --no-build-isolation .
             #COMMAND ${Python_EXECUTABLE} setup.py bdist --format=zip
             #COMMAND ${Python_EXECUTABLE} setup.py build_ext --inplace
             COMMENT "Packaging pyopenms wheel."
@@ -549,7 +549,7 @@ ELSE()
     ELSE()
         add_custom_target(pyopenms
             #COMMAND ${Python_EXECUTABLE} setup.py bdist_egg
-            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms .
+            COMMAND ${Python_EXECUTABLE} -m pip wheel -w dist --no-deps --no-binary=pyopenms --no-build-isolation .
             #COMMAND ${Python_EXECUTABLE} setup.py bdist --format=zip
             #COMMAND ${Python_EXECUTABLE} setup.py build_ext --inplace
             COMMENT "Packaging pyopenms wheel."


### PR DESCRIPTION
A recent update to pip improved build-isolation. This is overall a good thing, but it breaks our pyopenms ci since we don't ensure that numpy is installed in our isolated environment. This pr disables the new build isolation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for package wheel creation to optimize the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->