### PR TITLE
Fix macOS CI: Use minimal arrow/parquet libraries via conda

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -245,6 +245,27 @@ jobs:
         echo "$(conda info --base)/envs/openms-parquet/bin" >> $GITHUB_PATH
         echo "$(conda info --base)/envs/openms-parquet/Library/bin" >> $GITHUB_PATH
 
+    - name: Setup conda environment for Parquet (macOS only)
+      if: startsWith(matrix.os, 'macos')
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        python-version: 3.9
+        activate-environment: openms-parquet
+        use-mamba: true
+
+    - name: Install Parquet dependencies (macOS only)
+      if: startsWith(matrix.os, 'macos')
+      shell: bash -el {0}
+      run: |
+        conda activate openms-parquet
+        # Install minimal arrow/parquet libraries without the full LLVM dependency
+        conda install -c conda-forge libarrow libparquet -y
+        # Get the conda environment path for later use
+        echo "CONDA_ENV_PATH=$(conda info --base)/envs/openms-parquet" >> $GITHUB_ENV
+        # Add conda environment to PATH for cmake to find the libraries
+        echo "$(conda info --base)/envs/openms-parquet/bin" >> $GITHUB_PATH
+
     - name: Install Qt (Windows)
       if: startsWith(matrix.os, 'windows')
       uses: jurplel/install-qt-action@v4
@@ -296,7 +317,9 @@ jobs:
           # WARNING: Don't add any brew install commands here, edit
           # the following script instead:
           bash OpenMS/tools/ci/deps-macos.sh
-          echo "cmake_prefix=$(brew --prefix qt)/lib/cmake;$(brew --prefix qt);$(brew --prefix libomp)" >>$GITHUB_OUTPUT
+          # Add conda environment paths to CMAKE_PREFIX_PATH for finding Arrow/Parquet
+          CONDA_CMAKE_PREFIX="$CONDA_ENV_PATH;$CONDA_ENV_PATH/lib/cmake"
+          echo "cmake_prefix=$(brew --prefix qt)/lib/cmake;$(brew --prefix qt);$(brew --prefix libomp);$CONDA_CMAKE_PREFIX" >>$GITHUB_OUTPUT
         fi
 
     - name: Cache contrib (Windows)
@@ -441,7 +464,7 @@ jobs:
           ENABLE_GCC_WERROR: "OFF" # TODO think about that
           SEARCH_ENGINES_DIRECTORY: ${{ github.workspace }}/_thirdparty
           WITH_GUI: "ON"
-          WITH_PARQUET: "OFF" # Conda on windows, Apt on Ubuntu, Brew on MacOS
+          WITH_PARQUET: "ON" # Using conda for minimal arrow/parquet on macOS and Windows, Apt on Ubuntu
           SIGNING_IDENTITY: "-"
           ADDRESS_SANITIZER: "Off"
           BUILD_TYPE: "Release"

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -318,8 +318,8 @@ jobs:
           # the following script instead:
           bash OpenMS/tools/ci/deps-macos.sh
           # Add conda environment paths to CMAKE_PREFIX_PATH for finding Arrow/Parquet
-          CONDA_CMAKE_PREFIX="$CONDA_ENV_PATH;$CONDA_ENV_PATH/lib/cmake"
-          echo "cmake_prefix=$(brew --prefix qt)/lib/cmake;$(brew --prefix qt);$(brew --prefix libomp);$CONDA_CMAKE_PREFIX" >>$GITHUB_OUTPUT
+          CONDA_CMAKE_PREFIX="$CONDA_ENV_PATH:$CONDA_ENV_PATH/lib/cmake"
+          echo "cmake_prefix=$(brew --prefix qt)/lib/cmake:$(brew --prefix qt):$(brew --prefix libomp):$CONDA_CMAKE_PREFIX" >>$GITHUB_OUTPUT
         fi
 
     - name: Cache contrib (Windows)

--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ the authors tag in the respective file header.
  - Andreas Simon
  - Anton Kriese
  - Anton Pervukhin
+ - Aviral Garg
  - Bastian Blank
  - Chenghao Zhu
  - Chirag Dave

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ General:
 Dependencies:
     - PyOpenMS now depends on Autowrap 0.23.0
     - PyOpenMS now supports Cython 3.1
+    - macOS CI now uses minimal Apache Arrow/Parquet libraries via conda instead of brew to avoid bundling 2GB LLVM dependency (#8236)
 
 PyOpenMS:
 	- PyOpenMS wheels are now available for Python 3.14 on all supported operating systems

--- a/tools/ci/deps-macos.sh
+++ b/tools/ci/deps-macos.sh
@@ -48,8 +48,7 @@ brew install \
   cbc \
   cgl \
   clp \
-  qt \
-  apache-arrow
+  qt
 
 # Optional dependencies:
 brew install \


### PR DESCRIPTION


## Description

<!-- Please include a summary of the change and which issue is fixed here. -->
Addresses issue #8236  by replacing brew's apache-arrow installation with conda-based minimal arrow/parquet libraries on macOS. This avoids downloading the full LLVM dependency (2GB) that comes with Gandiva JIT engine.

Changes:
- Removed apache-arrow from brew dependencies in tools/ci/deps-macos.sh
- Added conda environment setup for arrow/parquet on macOS in CI workflow
- Enabled WITH_PARQUET flag for macOS builds
- Updated CMAKE_PREFIX_PATH to include conda environment paths

This approach mirrors the Windows CI configuration and provides only the necessary arrow/parquet sublibraries without unnecessary dependencies.
## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized macOS CI to use a lightweight Parquet/Arrow setup and streamlined macOS build steps.
  * Removed a large macOS system dependency to reduce CI footprint.

* **Documentation**
  * Noted macOS CI change in the changelog.
  * Added a new author entry (Aviral Garg) to AUTHORS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->