### PR TITLE
Clarify MSExperiment aggregate documentation

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -453,10 +453,10 @@ struct SumIntensityReduction {
  *   (`MSSpectrum::ConstIterator`) and returns a `CoordinateType`. The function defines how to reduce or aggregate
  *   the peaks within the specified m/z range (e.g., summing intensities, computing the mean m/z, etc.).
  *
- * @param[in,out] mz_rt_ranges
+ * @param[in] mz_rt_ranges
  *   A vector of pairs of `RangeMZ` and `RangeRT` specifying the m/z and RT ranges over which to aggregate data.
- *   Each pair defines a rectangular region in the m/z-RT plane. The vector will be sorted in-place by ascending
- *   minimum m/z and descending maximum m/z within the function.
+ *   Each pair defines a rectangular region in the m/z-RT plane. The ranges are processed in the order supplied and
+ *   are not modified by this function.
  *
  * @param[in] ms_level
  *   The MS level of the spectra to be processed. Only spectra matching this MS level will be considered in the aggregation.
@@ -474,14 +474,13 @@ struct SumIntensityReduction {
  *
  * @note
  * - If `mz_rt_ranges` is empty or there are no spectra at the specified MS level, the function returns an empty vector.
- * - The `mz_rt_ranges` vector will be sorted within the function by ascending minimum m/z and descending maximum m/z.
  * - The function uses OpenMP for parallelization over spectra. Ensure that your reduction function is thread-safe.
  * - The aggregation is performed only on the peaks that fall within both the specified m/z and RT ranges.
  * - This methods works best with larger number of m/z and RT ranges and a large number of spectra.
  *
  * @warning
- * - The function modifies `mz_rt_ranges` by sorting it. If the original order is important, make a copy before calling.
  * - The provided `func_mz_reduction` must be able to handle empty ranges (i.e., when `begin_it == end_it`).
+ * - The function does not reorder or otherwise mutate `mz_rt_ranges`; pass a pre-sorted range if a particular order is required.
  *
  * @exception None
  */


### PR DESCRIPTION
## Summary
- update MSExperiment::aggregate documentation to avoid claiming the input ranges are resorted
- clarify that the function processes ranges in the supplied order without mutating them

## Testing
- `cmake -S . -B build -G Ninja -DOPENMS_BUILD_DOCS=ON` *(fails: missing XercesC dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6908a58b42fc8328a8f4cf8d9787dc8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that input range parameters to `aggregate` and `extractXICs` functions are read-only and will not be modified during function execution. Updated documentation to explicitly state that ranges are processed in supplied order without in-place mutation. Developers should pass pre-sorted ranges if specific ordering is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->