### PR TITLE
Strengthen TIC compute unit test

### DIFF
--- a/src/tests/class_tests/openms/source/TIC_test.cpp
+++ b/src/tests/class_tests/openms/source/TIC_test.cpp
@@ -12,6 +12,7 @@
 ///////////////////////////
 
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/QC/TIC.h>
 
 ///////////////////////////
@@ -44,9 +45,69 @@ TEST_EQUAL((tic.requirements() == QCBase::Status(QCBase::Requires::RAWMZML)), tr
 END_SECTION
 
 START_SECTION(void compute(const MSExperiment& exp, float bin_size))
-// very simple test ATM, check if compute returns an empty Result struct
+// build an experiment with a few MS1 spectra to verify the computed TIC metrics
 MSExperiment exp;
-TEST_EQUAL(tic.compute(exp, 0) == TIC::Result(), true)
+{
+  MSSpectrum spec;
+  spec.setMSLevel(1);
+  spec.setRT(0.5);
+  spec.emplace_back(100.0, 30.0f);
+  spec.emplace_back(150.0, 70.0f);
+  exp.addSpectrum(spec);
+}
+{
+  MSSpectrum spec;
+  spec.setMSLevel(1);
+  spec.setRT(1.0);
+  spec.emplace_back(200.0, 500.0f);
+  spec.emplace_back(250.0, 2000.0f);
+  exp.addSpectrum(spec);
+}
+{
+  MSSpectrum spec;
+  spec.setMSLevel(1);
+  spec.setRT(1.5);
+  spec.emplace_back(300.0, 5.0f);
+  spec.emplace_back(350.0, 15.0f);
+  exp.addSpectrum(spec);
+}
+{
+  MSSpectrum spec;
+  spec.setMSLevel(1);
+  spec.setRT(2.0);
+  spec.emplace_back(400.0, 1000.0f);
+  spec.emplace_back(450.0, 3000.0f);
+  exp.addSpectrum(spec);
+}
+
+TIC::Result result = tic.compute(exp, 0);
+
+TEST_EQUAL(result.intensities.size(), 4);
+TEST_EQUAL(result.retention_times.size(), 4);
+TEST_EQUAL(result.relative_intensities.size(), 4);
+
+TEST_EQUAL(result.intensities[0], 100);
+TEST_EQUAL(result.intensities[1], 2500);
+TEST_EQUAL(result.intensities[2], 20);
+TEST_EQUAL(result.intensities[3], 4000);
+
+TEST_REAL_SIMILAR(result.relative_intensities[0], 2.5);
+TEST_REAL_SIMILAR(result.relative_intensities[1], 62.5);
+TEST_REAL_SIMILAR(result.relative_intensities[2], 0.5);
+TEST_REAL_SIMILAR(result.relative_intensities[3], 100.0);
+
+TEST_REAL_SIMILAR(result.retention_times[0], 0.5);
+TEST_REAL_SIMILAR(result.retention_times[1], 1.0);
+TEST_REAL_SIMILAR(result.retention_times[2], 1.5);
+TEST_REAL_SIMILAR(result.retention_times[3], 2.0);
+
+TEST_EQUAL(result.area, 6620);
+TEST_EQUAL(result.jump, 2);
+TEST_EQUAL(result.fall, 1);
+
+// empty experiment still yields an empty result
+MSExperiment empty_exp;
+TEST_EQUAL(tic.compute(empty_exp, 0) == TIC::Result(), true)
 END_SECTION
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- add explicit MSExperiment setup in the TIC unit test to verify the computed intensities and derived metrics
- ensure compute continues to return an empty result for experiments without spectra

## Testing
- ctest -R TIC_test *(fails: No tests were found in the current directory)*

------
https://chatgpt.com/codex/tasks/task_e_6908a58c8df8832897f3f34fe2c9462a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for TIC computation with additional validation scenarios, including multi-spectrum experiments and result verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->