### PR TITLE
Generate TOPP doc placeholders by scanning tool sources

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -234,13 +234,19 @@ if(ENABLE_DOCS)
 
     add_dependencies(doc_param_internal doc_progs)
 
-    if(NOT WITH_PARQUET)
-      add_custom_command(TARGET doc_param_internal POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E echo "Creating placeholder documentation for tools disabled due to missing dependencies..."
-      COMMAND ${CMAKE_COMMAND} -E echo "<html><body><h2>Tool not available</h2><p>QuantmsIOConverter requires Parquet support which was disabled during compilation (WITH_PARQUET=OFF).</p></body></html>" > ${CMAKE_CURRENT_BINARY_DIR}/doxygen/parameters/output/TOPP_QuantmsIOConverter.html
-      COMMENT "Generate placeholder HTML for disabled tools"
+    set(_TOPP_DOC_PLACEHOLDER_SEARCH_ROOTS
+        "${OPENMS_HOST_DIRECTORY}/src/topp"
+        "${OPENMS_HOST_DIRECTORY}/src/openms_gui/source/VISUAL/APPLICATIONS"
+    )
+    list(JOIN _TOPP_DOC_PLACEHOLDER_SEARCH_ROOTS ";" _TOPP_DOC_PLACEHOLDER_SEARCH_ROOTS_JOINED)
+
+    add_custom_command(TARGET doc_param_internal POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+              -DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/doxygen/parameters/output
+              -DSEARCH_ROOTS=${_TOPP_DOC_PLACEHOLDER_SEARCH_ROOTS_JOINED}
+              -P ${PROJECT_SOURCE_DIR}/doxygen/create_topp_doc_placeholders.cmake
+      COMMENT "Ensure placeholder CLI/HTML documentation exists for TOPP documentation pages"
       VERBATIM)
-    endif()
 
     #------------------------------------------------------------------------------
     # doc(_html) generation code reused in two independent targets

--- a/doc/doxygen/create_topp_doc_placeholders.cmake
+++ b/doc/doxygen/create_topp_doc_placeholders.cmake
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.15)
+
+if(NOT DEFINED OUTPUT_DIR)
+  message(FATAL_ERROR "OUTPUT_DIR must be defined")
+endif()
+
+if(NOT DEFINED SEARCH_ROOTS)
+  message(FATAL_ERROR "SEARCH_ROOTS must be defined")
+endif()
+
+set(_tool_names)
+
+foreach(_root ${SEARCH_ROOTS})
+  if(NOT EXISTS "${_root}")
+    message(WARNING "TOPP documentation placeholder search path '${_root}' does not exist.")
+    continue()
+  endif()
+
+  file(GLOB_RECURSE _candidates LIST_DIRECTORIES FALSE
+    "${_root}/*.cpp"
+    "${_root}/*.h"
+    "${_root}/*.hpp"
+  )
+
+  foreach(_candidate ${_candidates})
+    file(STRINGS "${_candidate}" _doc_lines REGEX "@page[ \t]+TOPP_[A-Za-z0-9_]+")
+    foreach(_line ${_doc_lines})
+      string(REGEX MATCH "@page[ \t]+TOPP_[A-Za-z0-9_]+" _match "${_line}")
+      if(_match)
+        string(REGEX REPLACE "^@page[ \t]+TOPP_" "" _tool "${_match}")
+        list(APPEND _tool_names "${_tool}")
+      endif()
+    endforeach()
+  endforeach()
+endforeach()
+
+if(_tool_names)
+  list(REMOVE_DUPLICATES _tool_names)
+  list(SORT _tool_names)
+endif()
+
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
+foreach(_tool ${_tool_names})
+  set(_cli_file "${OUTPUT_DIR}/TOPP_${_tool}.cli")
+  if(NOT EXISTS "${_cli_file}")
+    file(WRITE "${_cli_file}" "The TOPP tool '${_tool}' is not available in this build.\n")
+  endif()
+
+  set(_html_file "${OUTPUT_DIR}/TOPP_${_tool}.html")
+  if(NOT EXISTS "${_html_file}")
+    file(WRITE "${_html_file}"
+         "<html><body><h2>Tool not available</h2><p>The TOPP tool '${_tool}' is not part of this build configuration.</p></body></html>\n")
+  endif()
+endforeach()


### PR DESCRIPTION
## Summary
- ensure the documentation build always creates placeholder CLI/HTML files for TOPP tools whose binaries are not built
- update the helper CMake script to discover TOPP documentation pages by scanning the source tree instead of relying on the executables list

## Testing
- cmake -DOUTPUT_DIR=/tmp/topp_docs -DSEARCH_ROOTS="${PWD}/src/topp;${PWD}/src/openms_gui/source/VISUAL/APPLICATIONS" -P doc/doxygen/create_topp_doc_placeholders.cmake

------
https://chatgpt.com/codex/tasks/task_e_6908a8c822dc83289172a3c751bcffeb