### PR TITLE
specify eigen 3 for brew

### DIFF
--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -243,7 +243,7 @@ jobs:
       run: |
         ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
         brew install --force --overwrite --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
-        brew install --force --overwrite libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@6 libomp
+        brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
         brew link --force libomp        
         echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix libomp)" >> $GITHUB_OUTPUT
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
@@ -410,7 +410,7 @@ jobs:
         ## Update the package lists for Brew
         ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
         brew install --force --overwrite --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
-        brew install --force --overwrite libsvm xerces-c boost eigen sqlite coinutils cbc cgl clp qt@6 libomp
+        brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
         echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix qt@6);$(brew --prefix libomp)" >> $GITHUB_OUTPUT
         brew link --force --overwrite libomp 
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -244,7 +244,8 @@ jobs:
         ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
         brew install --force --overwrite --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
         brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
-        brew link --force libomp        
+        brew link --force libomp
+        brew link --force eigen@3
         echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix libomp);$(brew --prefix eigen@3)" >> $GITHUB_OUTPUT
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
@@ -413,6 +414,7 @@ jobs:
         brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
         echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix qt@6);$(brew --prefix libomp);$(brew --prefix eigen@3)" >> $GITHUB_OUTPUT
         brew link --force --overwrite libomp 
+        brew link --force --overwrite eigen@3
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
           brew install --force --overwrite --quiet doxygen ghostscript graphviz

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -245,7 +245,7 @@ jobs:
         brew install --force --overwrite --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
         brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
         brew link --force libomp        
-        echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix libomp)" >> $GITHUB_OUTPUT
+        echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix libomp);$(brew --prefix eigen@3)" >> $GITHUB_OUTPUT
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
           brew install --force --overwrite --quiet doxygen ghostscript graphviz
@@ -411,7 +411,7 @@ jobs:
         ## Needed for Qt. Install before to overwrite the default softlinks on the GH runners
         brew install --force --overwrite --quiet ccache autoconf automake libtool ninja && brew link --overwrite ccache
         brew install --force --overwrite libsvm xerces-c boost eigen@3 sqlite coinutils cbc cgl clp qt@6 libomp
-        echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix qt@6);$(brew --prefix libomp)" >> $GITHUB_OUTPUT
+        echo "cmake_prefix=$(brew --prefix qt@6)/lib/cmake;$(brew --prefix qt@6);$(brew --prefix libomp);$(brew --prefix eigen@3)" >> $GITHUB_OUTPUT
         brew link --force --overwrite libomp 
         echo "Qt6_DIR=$(brew --prefix qt@6)/lib/cmake/Qt6" >> $GITHUB_ENV
         if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build environment updated to use Eigen 3 for macOS builds, adjusting build/linkage paths and packaging outputs to reference the Eigen 3 runtime. This streamlines macOS build consistency and resolves linkage path mismatches for components relying on Eigen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->