### PR TITLE
[OSW,auto_iRT] Add priority peptides for sampling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@ OpenMS Library:
       - Added automated iRT calibration using input transition list (#8146)
       - Added automated RT, m/z, and IM extraction window estimation based on iRT calibration (#8188)
       - Added lowess span grid search params and updated documentation for OpenSwathWorkflow TOPP tool (#8297)
+      - Added priority inclusion list for iRT sampling from PQP when using automated iRT calibration (#8373)
 
 
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h
@@ -195,6 +195,9 @@ public:
      *                              If zero, will use std::random_device for non-deterministic.
      * @param[in] sort_by_intensity     Whether to sort the assays by the highest cumulative intense transitions. This is useful for sampling the most intense peptides for iRTs.
      * @param[in] top_fraction     Only sample from the top N fraction of sorted assays to narrow down on only really intense peptides. This is useful for selecting a few "high quality" peptides to use for linear iRTs.
+     * @param[in] priority_peptides Optional set of peptide sequences to prioritize during sampling. If provided, these peptides
+     *                              will be sampled first if found in @p exp, before the remaining quota is filled with regular sampling.
+     *                              Useful for ensuring common iRT peptides (e.g., from irtkit or cirtkit) are included when present.
      *
      * @return A new LightTargetedExperiment containing only the sampled
      *         compounds, their transitions, and associated proteins.
@@ -205,7 +208,8 @@ public:
       Size peptides_per_bin,
       unsigned int seed = 0,
       bool sort_by_intensity = false,
-      double top_fraction = 1.0);
+      double top_fraction = 1.0,
+      const std::unordered_set<std::string> & priority_peptides = std::unordered_set<std::string>());
 
     /**
       @brief Returns the feature with the highest score for each transition group.

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
@@ -173,7 +173,8 @@ namespace OpenMS
     Size peptides_per_bin,
     unsigned int seed,
     bool sort_by_intensity,
-    double top_fraction)
+    double top_fraction,
+    const std::unordered_set<std::string> & priority_peptides)
   {
     OPENMS_PRECONDITION(bins >= 1, "bins must be >= 1");
     OPENMS_PRECONDITION(peptides_per_bin >= 1, "peptides_per_bin must be >= 1");
@@ -182,6 +183,7 @@ namespace OpenMS
 
     // 0) initial candidate selection: exclude decoys 
     std::vector<OpenSwath::LightCompound> candidates;
+    std::vector<OpenSwath::LightCompound> priority_candidates;
 
     std::unordered_set<String> good_ids;
     for (auto & tr : exp.getTransitions())
@@ -189,10 +191,22 @@ namespace OpenMS
       if (!tr.decoy)
         good_ids.insert(tr.getPeptideRef());
     }
+    
+    // Separate compounds into priority and regular candidates
     for (auto & cmp : exp.getCompounds())
     {
       if (good_ids.count(cmp.id))
-        candidates.push_back(cmp);
+      {
+        // Check if this peptide sequence is in the priority list
+        if (!priority_peptides.empty() && priority_peptides.count(cmp.sequence))
+        {
+          priority_candidates.push_back(cmp);
+        }
+        else
+        {
+          candidates.push_back(cmp);
+        }
+      }
     }
 
     // 1) optionally sort by library intensities and trim to top fraction
@@ -208,7 +222,7 @@ namespace OpenMS
         }
       }
 
-      // sort candidates by descending sum
+      // sort regular candidates by descending sum
       std::sort(candidates.begin(), candidates.end(), [&](auto & a, auto & b) {
         return intensity_sum[a.id] > intensity_sum[b.id];
       });
@@ -216,45 +230,121 @@ namespace OpenMS
       // trim to top N%
       Size max_keep = std::max<Size>(1, static_cast<Size>(candidates.size() * top_fraction));
       candidates.resize(std::min(max_keep, candidates.size()));
+      
+      // Also sort priority candidates by intensity (but don't trim them)
+      std::sort(priority_candidates.begin(), priority_candidates.end(), [&](auto & a, auto & b) {
+        return intensity_sum[a.id] > intensity_sum[b.id];
+      });
     }
 
-    if (candidates.size() < 3)
+    // Combine all available candidates for sampling
+    std::vector<OpenSwath::LightCompound> all_candidates;
+    all_candidates.reserve(priority_candidates.size() + candidates.size());
+    all_candidates.insert(all_candidates.end(), priority_candidates.begin(), priority_candidates.end());
+    all_candidates.insert(all_candidates.end(), candidates.begin(), candidates.end());
+
+    if (all_candidates.size() < 3)
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       "Insufficient candidates for sampling: " + String(candidates.size()) +
+                                       "Insufficient candidates for sampling: " + String(all_candidates.size()) +
                                          " found, minimum 3 required for meaningful iRT calibration.");
     }
 
-    // 2) estimate RT range using filtered candidates
+    // 2) estimate RT range using all available candidates
     double rt_min = std::numeric_limits<double>::max();
     double rt_max = std::numeric_limits<double>::lowest();
-    for (auto & cmp : candidates)
+    for (auto & cmp : all_candidates)
     {
       rt_min = std::min(rt_min, cmp.rt);
       rt_max = std::max(rt_max, cmp.rt);
     }
     double bin_width = (rt_max - rt_min) / static_cast<double>(bins);
 
-    // 3) sample uniformly across RT bins
+    // 3) sample priority peptides first, then fill remaining quota with uniform sampling
     std::vector<OpenSwath::LightCompound> picked;
+    std::unordered_set<std::string> picked_sequences; // Track which sequences we've already picked
+    
     // Initialize OpenMS random shuffler
     Math::RandomShuffler rshuffler;
     rshuffler.seed(seed == 0 ? std::random_device{}() : seed);
-    for (Size b = 0; b < bins; ++b)
+    
+    // First pass: sample priority peptides
+    if (!priority_candidates.empty())
     {
-      double lo = rt_min + b * bin_width;
-      double hi = (b + 1 == bins ? rt_max : lo + bin_width);
-      std::vector<OpenSwath::LightCompound> bucket;
-      for (auto & cmp : candidates)
+      OPENMS_LOG_INFO << "Sampling " << priority_candidates.size() 
+                      << " priority peptides from the input experiment" << std::endl;
+      
+      for (Size b = 0; b < bins; ++b)
       {
-        if (cmp.rt >= lo && cmp.rt < hi)
-          bucket.push_back(cmp);
+        double lo = rt_min + b * bin_width;
+        double hi = (b + 1 == bins ? rt_max : lo + bin_width);
+        std::vector<OpenSwath::LightCompound> bucket;
+        
+        for (auto & cmp : priority_candidates)
+        {
+          if (cmp.rt >= lo && cmp.rt < hi && picked_sequences.find(cmp.sequence) == picked_sequences.end())
+            bucket.push_back(cmp);
+        }
+        
+        if (!bucket.empty())
+        {
+          rshuffler.portable_random_shuffle(bucket.begin(), bucket.end());
+          Size take = std::min(peptides_per_bin, bucket.size());
+          for (Size i = 0; i < take; ++i)
+          {
+            picked.push_back(bucket[i]);
+            picked_sequences.insert(bucket[i].sequence);
+          }
+        }
       }
-      if (!bucket.empty())
+      
+      OPENMS_LOG_INFO << "Successfully sampled " << picked.size() 
+                      << " priority peptides" << std::endl;
+    }
+    
+    // Second pass: fill remaining quota with regular sampling
+    Size total_quota = bins * peptides_per_bin;
+    if (picked.size() < total_quota && !candidates.empty())
+    {
+      OPENMS_LOG_INFO << "Filling remaining quota (" << (total_quota - picked.size()) 
+                      << " peptides) from regular candidates" << std::endl;
+      
+      for (Size b = 0; b < bins; ++b)
       {
-        rshuffler.portable_random_shuffle(bucket.begin(), bucket.end());
-        Size take = std::min(peptides_per_bin, bucket.size());
-        picked.insert(picked.end(), bucket.begin(), bucket.begin() + take);
+        double lo = rt_min + b * bin_width;
+        double hi = (b + 1 == bins ? rt_max : lo + bin_width);
+        
+        // Count how many priority peptides we already have in this bin
+        Size priority_in_bin = 0;
+        for (auto & p : picked)
+        {
+          if (p.rt >= lo && p.rt < hi)
+            priority_in_bin++;
+        }
+        
+        // Calculate how many more we need from this bin
+        Size needed = (peptides_per_bin > priority_in_bin) ? (peptides_per_bin - priority_in_bin) : 0;
+        
+        if (needed > 0)
+        {
+          std::vector<OpenSwath::LightCompound> bucket;
+          for (auto & cmp : candidates)
+          {
+            if (cmp.rt >= lo && cmp.rt < hi && picked_sequences.find(cmp.sequence) == picked_sequences.end())
+              bucket.push_back(cmp);
+          }
+          
+          if (!bucket.empty())
+          {
+            rshuffler.portable_random_shuffle(bucket.begin(), bucket.end());
+            Size take = std::min(needed, bucket.size());
+            for (Size i = 0; i < take; ++i)
+            {
+              picked.push_back(bucket[i]);
+              picked_sequences.insert(bucket[i].sequence);
+            }
+          }
+        }
       }
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathHelper.cpp
@@ -197,8 +197,7 @@ namespace OpenMS
     {
       if (good_ids.count(cmp.id))
       {
-        // Check if this peptide sequence is in the priority list
-        if (!priority_peptides.empty() && priority_peptides.count(cmp.sequence))
+        if (priority_peptides.count(cmp.sequence))
         {
           priority_candidates.push_back(cmp);
         }

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -802,12 +802,6 @@ protected:
         return PARSE_ERROR;
       }
     }
-      if (irt_pep_lin == 0)
-      {
-        writeLogError_("Parameter error: --irt_peptides_per_bin must be > 0 when auto_irt is enabled.");
-        return PARSE_ERROR;
-      }
-    }
 
     // Check swath window input
     if (!swath_windows_file.empty())

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -393,6 +393,9 @@ protected:
       // one of the following two needs to be set
       p.setValue("tr_irt_nonlinear", "", "additional nonlinear transition file ('TraML'). Takes precedent even when `auto_rt` is set to 'true'");
 
+      // priority peptides for sampling
+      p.setValue("tr_irt_priority_sampling", "", "Optional custom transition file (TSV format only) containing additional priority peptides for iRT sampling. These peptides will be prioritized alongside the built-in irtkit and cirtkit peptides when `auto_irt` is enabled. Useful for including project-specific or custom iRT peptides.");
+
       p.setValue("rt_norm", "", "RT normalization file (how to map the RTs of this run to the ones stored in the library). If set, tr_irt may be omitted.");
 
       return p;
@@ -707,6 +710,7 @@ protected:
 
     String irt_tr_file = irt_calibration_params.getValue("tr_irt").toString();
     String nonlinear_irt_tr_file = irt_calibration_params.getValue("tr_irt_nonlinear").toString();
+    String priority_sampling_irt_tr_file = irt_calibration_params.getValue("tr_irt_priority_sampling").toString();
     String trafo_in = irt_calibration_params.getValue("rt_norm").toString();
     String swath_windows_file = getStringOption_("swath_windows_file");
 
@@ -774,6 +778,30 @@ protected:
         writeLogError_("Parameter error: --irt_bins must be > 0 when auto_irt is enabled.");
         return PARSE_ERROR;
       }
+      if (irt_pep_lin == 0)
+      {
+        writeLogError_("Parameter error: --irt_peptides_per_bin must be > 0 when auto_irt is enabled.");
+        return PARSE_ERROR;
+      }
+    }
+    
+    // Validate priority iRT sampling file format if provided
+    if (!priority_sampling_irt_tr_file.empty())
+    {
+      if (!File::exists(priority_sampling_irt_tr_file))
+      {
+        writeLogError_("Parameter error: Priority iRT file does not exist: " + priority_sampling_irt_tr_file);
+        return PARSE_ERROR;
+      }
+      
+      FileTypes::Type priority_file_type = FileHandler::getType(priority_sampling_irt_tr_file);
+      if (priority_file_type != FileTypes::TSV)
+      {
+        writeLogError_("Parameter error: Priority iRT file must be in TSV format. Provided: " + 
+                       FileTypes::typeToName(priority_file_type));
+        return PARSE_ERROR;
+      }
+    }
       if (irt_pep_lin == 0)
       {
         writeLogError_("Parameter error: --irt_peptides_per_bin must be > 0 when auto_irt is enabled.");
@@ -1005,6 +1033,16 @@ protected:
       else
       {
         OPENMS_LOG_WARN << "cirtkit.tsv not found at: " << cirtkit_path << std::endl;
+      }
+      
+      // Add custom priority iRT file if provided
+      if (!priority_sampling_irt_tr_file.empty())
+      {
+        if (File::exists(priority_sampling_irt_tr_file))
+        {
+          priority_files.push_back(priority_sampling_irt_tr_file);
+          OPENMS_LOG_DEBUG << "Including custom priority iRT file: " << priority_sampling_irt_tr_file << std::endl;
+        }
       }
       
       if (!priority_files.empty())

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -603,6 +603,60 @@ protected:
       }
     }
 
+  /**
+    @brief Load priority peptide sequences from TSV files (irtkit and cirtkit)
+    
+    Loads peptide sequences from the specified TSV files and returns them as a
+    set for quick lookup. Used to prioritize common iRT peptides during sampling.
+    
+    @param[in] tsv_files Vector of file paths to TSV files to load
+    @param[in] tsv_reader_param Parameters for the TSV reader
+    
+    @return Set of unique peptide sequences from the loaded files
+  */
+  std::unordered_set<std::string> loadPriorityPeptideSequences(
+    const std::vector<String>& tsv_files,
+    const Param& tsv_reader_param)
+  {
+    std::unordered_set<std::string> priority_sequences;
+    
+    for (const auto& tsv_file : tsv_files)
+    {
+      if (tsv_file.empty() || !File::exists(tsv_file))
+      {
+        OPENMS_LOG_WARN << "Priority peptide file not found: " << tsv_file << std::endl;
+        continue;
+      }
+      
+      try
+      {
+        FileTypes::Type file_type = FileHandler::getType(tsv_file);
+        OpenSwath::LightTargetedExperiment priority_exp = loadTransitionList(file_type, tsv_file, tsv_reader_param);
+        
+        for (const auto& compound : priority_exp.getCompounds())
+        {
+          if (!compound.sequence.empty())
+          {
+            priority_sequences.insert(compound.sequence);
+          }
+        }
+        
+        OPENMS_LOG_INFO << "Loaded " << priority_exp.getCompounds().size() 
+                        << " compounds from priority file: " << tsv_file << std::endl;
+      }
+      catch (const Exception::BaseException& e)
+      {
+        OPENMS_LOG_WARN << "Failed to load priority peptide file " << tsv_file 
+                        << ": " << e.what() << std::endl;
+      }
+    }
+    
+    OPENMS_LOG_INFO << "Total unique priority peptide sequences: " 
+                    << priority_sequences.size() << std::endl;
+    
+    return priority_sequences;
+  }
+
   ExitCodes main_(int, const char **) override
   {
     ///////////////////////////////////
@@ -925,6 +979,45 @@ protected:
     calibration_param.setValue("mz_estimation_padding_factor", getDoubleOption_("mz_estimation_padding_factor"));
     calibration_param.setValue("mz_correction_function", mz_correction_function);
 
+    // Load priority peptide sequences from irtkit and cirtkit if auto_irt is enabled
+    std::unordered_set<std::string> priority_peptides;
+    if (auto_irt)
+    {
+      String data_path = File::getOpenMSDataPath();
+      std::vector<String> priority_files;
+      
+      String irtkit_path = data_path + "/CHEMISTRY/irtkit.tsv";
+      String cirtkit_path = data_path + "/CHEMISTRY/cirtkit.tsv";
+      
+      if (File::exists(irtkit_path))
+      {
+        priority_files.push_back(irtkit_path);
+      }
+      else
+      {
+        OPENMS_LOG_WARN << "irtkit.tsv not found at: " << irtkit_path << std::endl;
+      }
+      
+      if (File::exists(cirtkit_path))
+      {
+        priority_files.push_back(cirtkit_path);
+      }
+      else
+      {
+        OPENMS_LOG_WARN << "cirtkit.tsv not found at: " << cirtkit_path << std::endl;
+      }
+      
+      if (!priority_files.empty())
+      {
+        Param priority_tsv_param = TransitionTSVFile().getDefaults();
+        priority_peptides = loadPriorityPeptideSequences(priority_files, priority_tsv_param);
+      }
+      else
+      {
+        OPENMS_LOG_WARN << "No priority peptide files found. Continuing without priority sampling." << std::endl;
+      }
+    }
+
     // 1) Prepare in‐memory iRT experiments for linear + nonlinear
     OpenSwath::LightTargetedExperiment lin_irt_exp;
     if (!irt_tr_file.empty())
@@ -949,7 +1042,8 @@ protected:
         irt_pep_lin,
         irt_seed,
         true,
-        0.4
+        0.4,
+        priority_peptides
       );
     }
 
@@ -976,7 +1070,8 @@ protected:
         irt_pep_nl,
         irt_seed,
         true,
-        0.7
+        0.7,
+        priority_peptides
       );
     }
 


### PR DESCRIPTION
## Description

This PR adds support for prioritizing specific peptide sequences during iRT peptide sampling in the OpenSwath workflow (when using `-auto_irt`). Users can specify a custom transition TSV file containing priority peptides, which will be sampled first (alongside the share/OpenMS/CHEMISTRY irtkit and cirtkit peptides), ensuring a set of peptides that are typically conserved/more likely to be present are included in the iRT sampling for calibration. 

**iRT Peptide Sampling Improvements**
* Added a new `priority_peptides` parameter to the `sampleExperiment` function, allowing users to specify peptide sequences that should be prioritized during sampling. Priority peptides are sampled first, followed by regular candidates to fill the remaining quota. [[1]](diffhunk://#diff-bd1b1d1cdc641393fdb76fce2814a9846a32b01f82e28e5544cbab07af94a6c4R198-R200) [[2]](diffhunk://#diff-bd1b1d1cdc641393fdb76fce2814a9846a32b01f82e28e5544cbab07af94a6c4L208-R212) [[3]](diffhunk://#diff-3e76a548fc82449960a21db83c9c59466fa0e5205f85bfb54919ef888f1964ffL176-R177) [[4]](diffhunk://#diff-3e76a548fc82449960a21db83c9c59466fa0e5205f85bfb54919ef888f1964ffR186-R210) [[5]](diffhunk://#diff-3e76a548fc82449960a21db83c9c59466fa0e5205f85bfb54919ef888f1964ffL211-R347)
* Priority and regular candidate peptides are now sorted independently by intensity, and the sampling logic ensures that priority peptides are distributed across RT bins before regular peptides are considered.

**Command-Line Interface & Configuration**
* Added a new CLI parameter `tr_irt_priority_sampling` to allow users to specify a custom TSV file containing priority peptides for iRT sampling. The workflow validates the existence and format of this file. [[1]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6R396-R398) [[2]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6R713) [[3]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6R788-R805)

**Integration with Built-In Kits**
* When `auto_irt` is enabled, the workflow automatically loads built-in irtkit and cirtkit peptide sequences as priority peptides, and includes any user-specified custom priority file if provided.

**Supporting Functions**
* Added a helper function `loadPriorityPeptideSequences` to load peptide sequences from one or more TSV files, used to aggregate all priority peptides for sampling.

**Workflow Updates**
* Updated calls to `sampleExperiment` in the main workflow to pass the new `priority_peptides` parameter for both linear and nonlinear iRT calibration steps. [[1]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6L952-R1078) [[2]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6L979-R1106)

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority peptide inclusion for automated iRT calibration: users can supply built-in or custom TSV priority lists; listed peptides are preferentially sampled if present.
  * New configuration option to specify priority TSV files; the tool logs files found and the count of loaded sequences, warns if none are available, and proceeds without priority peptides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->