### PR TITLE
Wrap ProteomicsLFQ dependencies in pyOpenMS

### DIFF
--- a/src/pyOpenMS/pxds/BinaryTreeNode.pxd
+++ b/src/pyOpenMS/pxds/BinaryTreeNode.pxd
@@ -1,0 +1,10 @@
+from Types cimport *
+
+cdef extern from "<OpenMS/DATASTRUCTURES/BinaryTreeNode.h>" namespace "OpenMS":
+
+    cdef cppclass BinaryTreeNode:
+        BinaryTreeNode(Size left_child, Size right_child, float distance) except + nogil
+        BinaryTreeNode(BinaryTreeNode&) except + nogil
+        Size left_child
+        Size right_child
+        float distance

--- a/src/pyOpenMS/pxds/ConsensusMapMergerAlgorithm.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapMergerAlgorithm.pxd
@@ -1,0 +1,19 @@
+from libcpp.map cimport map as libcpp_map
+from DefaultParamHandler cimport *
+from ProgressLogger cimport *
+from ConsensusMap cimport *
+from ExperimentalDesign cimport *
+
+cdef extern from "<OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>" namespace "OpenMS":
+
+    cdef cppclass ConsensusMapMergerAlgorithm(DefaultParamHandler, ProgressLogger):
+        # wrap-inherits:
+        #   DefaultParamHandler
+        #   ProgressLogger
+        ConsensusMapMergerAlgorithm() except + nogil
+        ConsensusMapMergerAlgorithm(ConsensusMapMergerAlgorithm&) except + nogil
+        void mergeProteinsAcrossFractionsAndReplicates(ConsensusMap& cmap,
+                                                       const ExperimentalDesign& exp_design) except + nogil
+        void mergeAllIDRuns(ConsensusMap& cmap) except + nogil
+        void mergeProteinIDRuns(ConsensusMap& cmap,
+                                const libcpp_map[unsigned int, unsigned int]& mapIdx_to_new_protIDRun) except + nogil

--- a/src/pyOpenMS/pxds/DDAWorkflowCommons.pxd
+++ b/src/pyOpenMS/pxds/DDAWorkflowCommons.pxd
@@ -1,4 +1,5 @@
 from libcpp.map cimport map as libcpp_map
+from libcpp.string cimport string as libcpp_string
 from String cimport *
 from StringList cimport *
 from MSExperiment cimport *
@@ -12,8 +13,8 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/DDAWorkflowCommons.h>" namespace
         DDAWorkflowCommons() except + nogil
         DDAWorkflowCommons(DDAWorkflowCommons&) except + nogil
 
-        libcpp_map[String, String] mapMzML2Ids(StringList& in_files, StringList& in_id_files) except + nogil
-        libcpp_map[String, String] mapId2MzMLs(const libcpp_map[String, String]& mz_to_id) except + nogil
+        libcpp_map[libcpp_string, libcpp_string] mapMzML2Ids(StringList& in_files, StringList& in_id_files) except + nogil
+        libcpp_map[libcpp_string, libcpp_string] mapId2MzMLs(const libcpp_map[libcpp_string, libcpp_string]& mz_to_id) except + nogil
         double estimateMedianChromatographicFWHM(MSExperiment& ms_centroided) except + nogil
         void recalibrateMS1(MSExperiment& ms_centroided,
                            PeptideIdentificationList& peptide_ids,

--- a/src/pyOpenMS/pxds/DDAWorkflowCommons.pxd
+++ b/src/pyOpenMS/pxds/DDAWorkflowCommons.pxd
@@ -1,0 +1,26 @@
+from libcpp.map cimport map as libcpp_map
+from String cimport *
+from StringList cimport *
+from MSExperiment cimport *
+from FeatureMap cimport *
+from PeptideIdentificationList cimport *
+from Types cimport *
+
+cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/DDAWorkflowCommons.h>" namespace "OpenMS":
+
+    cdef cppclass DDAWorkflowCommons:
+        DDAWorkflowCommons() except + nogil
+        DDAWorkflowCommons(DDAWorkflowCommons&) except + nogil
+
+        libcpp_map[String, String] mapMzML2Ids(StringList& in_files, StringList& in_id_files) except + nogil
+        libcpp_map[String, String] mapId2MzMLs(const libcpp_map[String, String]& mz_to_id) except + nogil
+        double estimateMedianChromatographicFWHM(MSExperiment& ms_centroided) except + nogil
+        void recalibrateMS1(MSExperiment& ms_centroided,
+                           PeptideIdentificationList& peptide_ids,
+                           const String& id_file_abs_path) except + nogil
+        void calculateSeeds(const MSExperiment& ms_centroided,
+                            double intensity_threshold,
+                            FeatureMap& seeds,
+                            double median_fwhm,
+                            Size charge_min,
+                            Size charge_max) except + nogil

--- a/src/pyOpenMS/pxds/IDScoreSwitcherAlgorithm.pxd
+++ b/src/pyOpenMS/pxds/IDScoreSwitcherAlgorithm.pxd
@@ -1,0 +1,76 @@
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp.map cimport map as libcpp_map
+from libcpp cimport bool
+from DefaultParamHandler cimport *
+from String cimport *
+from ConsensusMap cimport *
+from PeptideIdentificationList cimport *
+from Types cimport *
+
+cdef extern from "<OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>" namespace "OpenMS":
+
+    cdef cppclass IDScoreSwitcherAlgorithm(DefaultParamHandler):
+        # wrap-inherits:
+        #   DefaultParamHandler
+        IDScoreSwitcherAlgorithm() except + nogil
+        IDScoreSwitcherAlgorithm(IDScoreSwitcherAlgorithm&) except + nogil
+
+        bool isScoreType(const String& score_name, IDScoreSwitcherAlgorithm_ScoreType score_type) except + nogil
+        @staticmethod
+        IDScoreSwitcherAlgorithm_ScoreType toScoreTypeEnum(String score_type) except + nogil
+        bool isScoreTypeHigherBetter(IDScoreSwitcherAlgorithm_ScoreType score_type) except + nogil
+        libcpp_vector[String] getScoreNames() except + nogil
+        void switchToGeneralScoreType(PeptideIdentificationList& pep_ids,
+                                      IDScoreSwitcherAlgorithm_ScoreType score_type,
+                                      Size& counter) except + nogil
+        void switchToGeneralScoreType(ConsensusMap& cmap,
+                                      IDScoreSwitcherAlgorithm_ScoreType score_type,
+                                      Size& counter,
+                                      bool unassigned_peptides_too) except + nogil
+        void determineScoreNameOrientationAndType(const PeptideIdentificationList& pep_ids,
+                                                  String& name,
+                                                  bool& higher_better,
+                                                  IDScoreSwitcherAlgorithm_ScoreType& score_type) except + nogil
+        void determineScoreNameOrientationAndType(const ConsensusMap& cmap,
+                                                  String& name,
+                                                  bool& higher_better,
+                                                  IDScoreSwitcherAlgorithm_ScoreType& score_type,
+                                                  bool include_unassigned) except + nogil
+        void switchScores(ConsensusMap& cmap, Size& counter, bool unassigned_peptides_too) except + nogil
+        void switchScores(PeptideIdentificationList& pep_ids, Size& counter) except + nogil
+        @staticmethod
+        IDScoreSwitcherAlgorithm_IDSwitchResult switchToScoreType(ConsensusMap& cmap,
+                                                                  String requested_score_type_as_string,
+                                                                  bool include_unassigned) except + nogil
+        @staticmethod
+        IDScoreSwitcherAlgorithm_IDSwitchResult switchToScoreType(PeptideIdentificationList& pep_ids,
+                                                                  String requested_score_type_as_string) except + nogil
+        @staticmethod
+        void switchBackScoreType(ConsensusMap& cmap,
+                                 IDScoreSwitcherAlgorithm_IDSwitchResult isr,
+                                 bool include_unassigned) except + nogil
+        @staticmethod
+        void switchBackScoreType(PeptideIdentificationList& pep_ids,
+                                 IDScoreSwitcherAlgorithm_IDSwitchResult isr) except + nogil
+
+cdef extern from "<OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>" namespace "OpenMS::IDScoreSwitcherAlgorithm":
+    cdef enum IDScoreSwitcherAlgorithm_ScoreType "OpenMS::IDScoreSwitcherAlgorithm::ScoreType":
+        # wrap-attach:
+        #   IDScoreSwitcherAlgorithm
+        RAW
+        RAW_EVAL
+        PP
+        PEP
+        FDR
+        QVAL
+
+    cdef cppclass IDScoreSwitcherAlgorithm_IDSwitchResult "OpenMS::IDScoreSwitcherAlgorithm::IDSwitchResult":
+        IDScoreSwitcherAlgorithm_IDSwitchResult() except + nogil
+        IDScoreSwitcherAlgorithm_IDSwitchResult(IDScoreSwitcherAlgorithm_IDSwitchResult&) except + nogil
+        String original_score_name
+        bool original_score_higher_better
+        IDScoreSwitcherAlgorithm_ScoreType original_score_type
+        bool requested_score_higher_better
+        IDScoreSwitcherAlgorithm_ScoreType requested_score_type
+        String requested_score_name
+        bool score_switched

--- a/src/pyOpenMS/pxds/MapAlignerBase.pxd
+++ b/src/pyOpenMS/pxds/MapAlignerBase.pxd
@@ -1,0 +1,11 @@
+from String cimport *
+from Param cimport *
+
+cdef extern from "<OpenMS/APPLICATIONS/MapAlignerBase.h>" namespace "OpenMS":
+
+    cdef cppclass MapAlignerBase:
+        pass
+
+cdef extern from "<OpenMS/APPLICATIONS/MapAlignerBase.h>" namespace "OpenMS::MapAlignerBase":
+
+    Param getModelDefaults(const String& default_model) except + nogil  # wrap-attach:MapAlignerBase

--- a/src/pyOpenMS/pxds/MapAlignmentAlgorithmTreeGuided.pxd
+++ b/src/pyOpenMS/pxds/MapAlignmentAlgorithmTreeGuided.pxd
@@ -1,0 +1,34 @@
+from libcpp.vector cimport vector as libcpp_vector
+from DefaultParamHandler cimport *
+from ProgressLogger cimport *
+from FeatureMap cimport *
+from TransformationDescription cimport *
+from BinaryTreeNode cimport *
+from Types cimport *
+
+cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmTreeGuided.h>" namespace "OpenMS":
+
+    cdef cppclass MapAlignmentAlgorithmTreeGuided(DefaultParamHandler, ProgressLogger):
+        # wrap-inherits:
+        #   DefaultParamHandler
+        #   ProgressLogger
+        MapAlignmentAlgorithmTreeGuided() except + nogil
+        MapAlignmentAlgorithmTreeGuided(MapAlignmentAlgorithmTreeGuided&) except + nogil
+        void treeGuidedAlignment(const libcpp_vector[BinaryTreeNode]& tree,
+                                 libcpp_vector[FeatureMap]& feature_maps_transformed,
+                                 libcpp_vector[libcpp_vector[double]]& maps_ranges,
+                                 FeatureMap& map_transformed,
+                                 libcpp_vector[Size]& trafo_order) except + nogil
+        void align(libcpp_vector[FeatureMap]& data,
+                   libcpp_vector[TransformationDescription]& transformations) except + nogil
+        void computeTrafosByOriginalRT(libcpp_vector[FeatureMap]& feature_maps,
+                                       FeatureMap& map_transformed,
+                                       libcpp_vector[TransformationDescription]& transformations,
+                                       const libcpp_vector[Size]& trafo_order) except + nogil
+        @staticmethod
+        void buildTree(libcpp_vector[FeatureMap]& feature_maps,
+                       libcpp_vector[BinaryTreeNode]& tree,
+                       libcpp_vector[libcpp_vector[double]]& maps_ranges) except + nogil
+        @staticmethod
+        void computeTransformedFeatureMaps(libcpp_vector[FeatureMap]& feature_maps,
+                                           const libcpp_vector[TransformationDescription]& transformations) except + nogil

--- a/src/pyOpenMS/pxds/SimpleSVM.pxd
+++ b/src/pyOpenMS/pxds/SimpleSVM.pxd
@@ -25,9 +25,9 @@ cdef extern from "<OpenMS/ML/SVM/SimpleSVM.h>" namespace "OpenMS":
                    const libcpp_map[Size, double]& outcomes,
                    bool classification) except + nogil
         void predict(libcpp_vector[SimpleSVM_Prediction]& predictions,
-                     libcpp_vector[Size] indexes) const except + nogil
+                     libcpp_vector[Size] indexes) except + nogil
         void predict(SimpleSVM_PredictorMap& predictors,
-                     libcpp_vector[SimpleSVM_Prediction]& predictions) const except + nogil
-        void getFeatureWeights(libcpp_map[String, double]& feature_weights) const except + nogil
-        void writeXvalResults(const String& path) const except + nogil
-        SimpleSVM_ScaleMap getScaling() const except + nogil
+                     libcpp_vector[SimpleSVM_Prediction]& predictions) except + nogil
+        void getFeatureWeights(libcpp_map[String, double]& feature_weights) except + nogil
+        void writeXvalResults(const String& path) except + nogil
+        SimpleSVM_ScaleMap getScaling() except + nogil

--- a/src/pyOpenMS/pxds/SimpleSVM.pxd
+++ b/src/pyOpenMS/pxds/SimpleSVM.pxd
@@ -1,0 +1,33 @@
+from libcpp.map cimport map as libcpp_map
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp.pair cimport pair as libcpp_pair
+from DefaultParamHandler cimport *
+from String cimport *
+from Types cimport *
+
+cdef extern from "<OpenMS/ML/SVM/SimpleSVM.h>" namespace "OpenMS":
+
+    ctypedef libcpp_map[String, libcpp_vector[double]] SimpleSVM_PredictorMap "OpenMS::SimpleSVM::PredictorMap"
+    ctypedef libcpp_map[String, libcpp_pair[double, double]] SimpleSVM_ScaleMap "OpenMS::SimpleSVM::ScaleMap"
+
+    cdef cppclass SimpleSVM_Prediction "OpenMS::SimpleSVM::Prediction":
+        SimpleSVM_Prediction() except + nogil
+        SimpleSVM_Prediction(SimpleSVM_Prediction&) except + nogil
+        double outcome
+        libcpp_map[double, double] probabilities
+
+    cdef cppclass SimpleSVM(DefaultParamHandler):
+        # wrap-inherits:
+        #   DefaultParamHandler
+        SimpleSVM() except + nogil
+        SimpleSVM(SimpleSVM&) except + nogil
+        void setup(SimpleSVM_PredictorMap& predictors,
+                   const libcpp_map[Size, double]& outcomes,
+                   bool classification) except + nogil
+        void predict(libcpp_vector[SimpleSVM_Prediction]& predictions,
+                     libcpp_vector[Size] indexes) const except + nogil
+        void predict(SimpleSVM_PredictorMap& predictors,
+                     libcpp_vector[SimpleSVM_Prediction]& predictions) const except + nogil
+        void getFeatureWeights(libcpp_map[String, double]& feature_weights) const except + nogil
+        void writeXvalResults(const String& path) const except + nogil
+        SimpleSVM_ScaleMap getScaling() const except + nogil

--- a/src/pyOpenMS/pxds/TriqlerFile.pxd
+++ b/src/pyOpenMS/pxds/TriqlerFile.pxd
@@ -1,0 +1,15 @@
+from String cimport *
+from StringList cimport *
+from ConsensusMap cimport *
+from ExperimentalDesign cimport *
+
+cdef extern from "<OpenMS/FORMAT/TriqlerFile.h>" namespace "OpenMS":
+
+    cdef cppclass TriqlerFile:
+        TriqlerFile() except + nogil
+        TriqlerFile(TriqlerFile&) except + nogil
+        void storeLFQ(const String& filename,
+                      const ConsensusMap& consensus_map,
+                      const ExperimentalDesign& design,
+                      const StringList& reannotate_filenames,
+                      const String& condition) except + nogil


### PR DESCRIPTION
## Summary
- add pyOpenMS interface files for DDAWorkflowCommons, MapAlignerBase, MapAlignmentAlgorithmTreeGuided, ConsensusMapMergerAlgorithm, IDScoreSwitcherAlgorithm, SimpleSVM, and TriqlerFile
- include a BinaryTreeNode wrapper needed by the new tree-guided map alignment bindings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c98f9262883289d1f806828bb6cd9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python bindings for eight OpenMS components: BinaryTreeNode, ConsensusMapMergerAlgorithm, DDAWorkflowCommons, IDScoreSwitcherAlgorithm, MapAlignerBase, MapAlignmentAlgorithmTreeGuided, SimpleSVM, and TriqlerFile — enabling tree-guided alignment, map merging, DDA workflow utilities, ID score switching, map alignment helpers, SVM-based predictions, and Triqler LFQ export from Python.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->