### PR TITLE
correct arch name for amd64 docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "OpenMS Dev Container",
-    "image": "ghcr.io/openms/contrib_manylinux_2_34:latest",
+    "image": "ghcr.io/openms/contrib_manylinux_2_34:latest-${localArch}",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.github/workflows/pyopenms-wheels.yml
+++ b/.github/workflows/pyopenms-wheels.yml
@@ -502,7 +502,7 @@ jobs:
 
   build-lnx:
     runs-on: [ubuntu-latest]
-    container: ghcr.io/openms/contrib_manylinux_2_34:latest-x86_64
+    container: ghcr.io/openms/contrib_manylinux_2_34:latest-amd64
 
     steps:
     # Cancels older builds if still running


### PR DESCRIPTION
x86_64 is apparently not the standard designator for that architecture, we should use amd64 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to support dynamic architecture detection.
  * Updated Linux build container image reference for improved architecture compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->