### PR TITLE
Restrict PeakPickerIM output tests to Linux amd64

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1855,16 +1855,16 @@ set_tests_properties("TOPP_PeakPickerIterative_2_out1" PROPERTIES DEPENDS "TOPP_
 # TOPP_PeakPickerIM
 # test default 'mobilogram' method
 add_test("TOPP_PeakPickerIM_1" ${TOPP_BIN_PATH}/PeakPickerIM -in ${DATA_DIR_TOPP}/PeakPickerIM_input_1.mzML -ini ${DATA_DIR_TOPP}/PeakPickerIM_parameters_1.ini -out PeakPickerIM_1.tmp.mzML -test)
-add_test("TOPP_PeakPickerIM_1_out1" ${DIFF} -whitelist ${INDEX_WHITELIST} -in1 PeakPickerIM_1.tmp.mzML -in2 ${DATA_DIR_TOPP}/PeakPickerIM_1_output.mzML)
-set_tests_properties("TOPP_PeakPickerIM_1_out1" PROPERTIES DEPENDS "TOPP_PeakPickerIM_1")
 # test 'cluster' method
 add_test("TOPP_PeakPickerIM_2" ${TOPP_BIN_PATH}/PeakPickerIM -in ${DATA_DIR_TOPP}/PeakPickerIM_input_1.mzML -ini ${DATA_DIR_TOPP}/PeakPickerIM_parameters_2.ini -out PeakPickerIM_2.tmp.mzML -test)
-add_test("TOPP_PeakPickerIM_2_out1" ${DIFF} -whitelist ${INDEX_WHITELIST} -in1 PeakPickerIM_2.tmp.mzML -in2 ${DATA_DIR_TOPP}/PeakPickerIM_2_output.mzML)
-set_tests_properties("TOPP_PeakPickerIM_2_out1" PROPERTIES DEPENDS "TOPP_PeakPickerIM_2")
 # test 'trace' method
 add_test("TOPP_PeakPickerIM_3" ${TOPP_BIN_PATH}/PeakPickerIM -in ${DATA_DIR_TOPP}/PeakPickerIM_input_1.mzML -ini ${DATA_DIR_TOPP}/PeakPickerIM_parameters_3.ini -out PeakPickerIM_3.tmp.mzML -test)
-# Disabled on Linux and macOS ARM64 due to numeric differences
-if (NOT ((CMAKE_SYSTEM_NAME STREQUAL "Linux") OR (APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64")))
+# Output comparison tests are limited to Linux amd64 due to numeric differences on other platforms
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "amd64"))
+  add_test("TOPP_PeakPickerIM_1_out1" ${DIFF} -whitelist ${INDEX_WHITELIST} -in1 PeakPickerIM_1.tmp.mzML -in2 ${DATA_DIR_TOPP}/PeakPickerIM_1_output.mzML)
+  set_tests_properties("TOPP_PeakPickerIM_1_out1" PROPERTIES DEPENDS "TOPP_PeakPickerIM_1")
+  add_test("TOPP_PeakPickerIM_2_out1" ${DIFF} -whitelist ${INDEX_WHITELIST} -in1 PeakPickerIM_2.tmp.mzML -in2 ${DATA_DIR_TOPP}/PeakPickerIM_2_output.mzML)
+  set_tests_properties("TOPP_PeakPickerIM_2_out1" PROPERTIES DEPENDS "TOPP_PeakPickerIM_2")
   add_test("TOPP_PeakPickerIM_3_out1" ${DIFF} -whitelist ${INDEX_WHITELIST} -in1 PeakPickerIM_3.tmp.mzML -in2 ${DATA_DIR_TOPP}/PeakPickerIM_3_output.mzML)
   set_tests_properties("TOPP_PeakPickerIM_3_out1" PROPERTIES DEPENDS "TOPP_PeakPickerIM_3")
 endif()


### PR DESCRIPTION
## Summary
- limit TOPP PeakPickerIM output comparison tests to Linux amd64 to avoid platform-specific numeric differences
- align the three output checks under a single architecture guard

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69327f2c276883288a36ae601194b382)