### PR TITLE
Add Isotope class with half-life and decay mode support

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -13,6 +13,7 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
 #include <string>
+#include <vector>
 
 #define OPENMS_CHEMISTRY_ELEMENT_NAME_DEFAULT "unknown"
 #define OPENMS_CHEMISTRY_ELEMENT_SYMBOL_DEFAULT "??"
@@ -21,6 +22,9 @@
 
 namespace OpenMS
 {
+  // Forward declaration
+  class Isotope;
+
   /** @ingroup Chemistry
 
       @brief Representation of an element
@@ -81,6 +85,15 @@ public:
     /// returns the isotope distribution of the element
     const IsotopeDistribution & getIsotopeDistribution() const;
 
+    /// sets the list of isotopes for this element
+    void setIsotopes(const std::vector<const Isotope*>& isotopes);
+
+    /// returns the list of isotopes for this element
+    const std::vector<const Isotope*>& getIsotopes() const;
+
+    /// returns whether this is an isotope (false for Element, overridden in Isotope)
+    virtual bool isIsotope() const;
+
     /// set the name of the element
     void setName(const std::string & name);
 
@@ -136,6 +149,9 @@ protected:
 
     /// distribution of the isotopes (mass and natural frequency)
     IsotopeDistribution isotopes_;
+
+    /// list of isotopes for this element (pointers are not owned)
+    std::vector<const Isotope*> isotope_list_;
   };
 
   OPENMS_DLLAPI std::ostream & operator<<(std::ostream &, const Element &);

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -16,10 +16,12 @@
 #include <memory>
 #include <unordered_map>
 #include <string>
+#include <vector>
 
 namespace OpenMS
 {
   class Element;
+  class Isotope;
 
   /** @ingroup Chemistry
 
@@ -69,6 +71,49 @@ public:
 
     /// returns a pointer to the element of atomic number; if no element is found 0 is returned
     const Element* getElement(unsigned int atomic_number) const;
+
+    /** returns a pointer to the isotope with given element symbol/name and mass number;
+     *  if no isotope exists 0 is returned
+     *  @param element_symbol: symbol or name of the element (e.g., "C" or "Carbon")
+     *  @param mass_number: mass number of the isotope (e.g., 14 for Carbon-14)
+     */
+    const Isotope* getIsotope(const std::string& element_symbol, unsigned int mass_number) const;
+
+    /** returns a pointer to the isotope with given atomic number and mass number;
+     *  if no isotope exists 0 is returned
+     *  @param atomic_number: atomic number of the element
+     *  @param mass_number: mass number of the isotope
+     */
+    const Isotope* getIsotope(unsigned int atomic_number, unsigned int mass_number) const;
+
+    /// returns a hashmap that contains isotope symbols (e.g., "(14)C") mapped to pointers to the isotopes
+    const std::unordered_map<std::string, const Isotope*>& getIsotopeSymbols() const;
+
+    /// returns true if the db contains an isotope with the given element symbol and mass number
+    bool hasIsotope(const std::string& element_symbol, unsigned int mass_number) const;
+
+    /// returns true if the db contains an isotope with the given atomic number and mass number
+    bool hasIsotope(unsigned int atomic_number, unsigned int mass_number) const;
+
+    /** Adds a new isotope to the database
+     *
+     * @param element_symbol Symbol of the element (e.g., "C" for Carbon)
+     * @param mass_number Mass number (protons + neutrons)
+     * @param atomic_mass Atomic mass in Daltons
+     * @param abundance Natural abundance (0.0 to 1.0)
+     * @param half_life Half-life in seconds (negative for stable isotopes)
+     * @param decay_mode Decay mode as string ("STABLE", "ALPHA", "BETA_MINUS", "BETA_PLUS", "PROTON", "UNKNOWN")
+     * @param replace_existing If true, replace existing isotope; if false, throw exception if exists
+     *
+     * @throw Exception::IllegalArgument if isotope already exists and replace_existing is false
+     */
+    void addIsotope(const std::string& element_symbol,
+                    unsigned int mass_number,
+                    double atomic_mass,
+                    double abundance,
+                    double half_life = -1.0,
+                    const std::string& decay_mode = "STABLE",
+                    bool replace_existing = false);
 
     /** Adds or replaces a new element to the database
      *
@@ -130,6 +175,18 @@ protected:
     /// constructs isotope objects
     void storeIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& Z_to_mass, const IsotopeDistribution& isotopes);
 
+    /// builds and stores detailed isotope objects with half-life and decay mode
+    void buildIsotope_(const std::string& element_symbol,
+                       unsigned int atomic_number,
+                       unsigned int mass_number,
+                       double atomic_mass,
+                       double abundance,
+                       double half_life,
+                       const std::string& decay_mode);
+
+    /// stores additional isotope data (half-life, decay mode) for known isotopes
+    void storeDetailedIsotopes_();
+
     /**_ resets all containers
     **/
     void clear_();
@@ -139,6 +196,12 @@ protected:
     std::unordered_map<std::string, const Element*> symbols_;
 
     std::unordered_map<unsigned int, const Element*> atomic_numbers_;
+
+    /// map from isotope symbol (e.g., "(14)C") to isotope pointer
+    std::unordered_map<std::string, const Isotope*> isotope_symbols_;
+
+    /// map from (atomic_number, mass_number) pair to isotope pointer
+    std::map<std::pair<unsigned int, unsigned int>, const Isotope*> isotopes_;
 
 private:
     ElementDB();

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -1,0 +1,150 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+//
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CHEMISTRY/Element.h>
+
+#include <string>
+#include <vector>
+
+namespace OpenMS
+{
+  /** @ingroup Chemistry
+
+      @brief Representation of an isotope
+
+      This class extends Element to store additional isotope-specific properties
+      including half-life and decay mode. Isotopes are specific nuclear configurations
+      of an element characterized by their mass number (protons + neutrons).
+  */
+  class OPENMS_DLLAPI Isotope : public Element
+  {
+public:
+
+    /// Enum for decay modes
+    enum class DecayMode
+    {
+      STABLE,       ///< Stable isotope (no decay)
+      UNKNOWN,      ///< Decay mode unknown
+      ALPHA,        ///< Alpha decay
+      BETA_PLUS,    ///< Beta plus decay (positron emission)
+      BETA_MINUS,   ///< Beta minus decay (electron emission)
+      PROTON,       ///< Proton emission
+      SIZE_OF_DECAYMODE
+    };
+
+    /** @name Constructor and Destructors
+    */
+    //@{
+    /// default constructor
+    Isotope();
+
+    /// copy constructor
+    Isotope(const Isotope& isotope);
+
+    /// detailed constructor
+    Isotope(const std::string& name,
+            const std::string& symbol,
+            unsigned int atomic_number,
+            unsigned int mass_number,
+            double atomic_mass,
+            double abundance,
+            double half_life = -1.0,
+            DecayMode decay_mode = DecayMode::STABLE);
+
+    /// destructor
+    ~Isotope() override;
+    //@}
+
+    /** @name Accessors
+    */
+    //@{
+    /// sets the mass number (protons + neutrons)
+    void setMassNumber(unsigned int mass_number);
+
+    /// returns the mass number (protons + neutrons)
+    unsigned int getMassNumber() const;
+
+    /// returns the number of neutrons (mass_number - atomic_number)
+    unsigned int getNeutrons() const;
+
+    /// sets the natural abundance (0.0 to 1.0)
+    void setAbundance(double abundance);
+
+    /// returns the natural abundance (0.0 to 1.0)
+    double getAbundance() const;
+
+    /// sets the half-life in seconds (negative value means stable)
+    void setHalfLife(double half_life);
+
+    /// returns the half-life in seconds (negative value means stable)
+    double getHalfLife() const;
+
+    /// sets the decay mode
+    void setDecayMode(DecayMode decay_mode);
+
+    /// returns the decay mode
+    DecayMode getDecayMode() const;
+
+    /// returns whether the isotope is stable (half_life < 0)
+    bool isStable() const;
+
+    /// returns whether this is an isotope (always true for Isotope class)
+    virtual bool isIsotope() const;
+    //@}
+
+    /** @name Assignment
+    */
+    //@{
+    /// assignment operator
+    Isotope& operator=(const Isotope& isotope);
+    //@}
+
+    /** @name Predicates
+    */
+    //@{
+    /// equality operator
+    bool operator==(const Isotope& isotope) const;
+
+    /// inequality operator
+    bool operator!=(const Isotope& isotope) const;
+
+    /// less operator (compares by mass number)
+    bool operator<(const Isotope& isotope) const;
+    //@}
+
+    /// writes the isotope to an output stream
+    friend OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const Isotope& isotope);
+
+    /// Convert DecayMode enum to string
+    static std::string decayModeToString(DecayMode mode);
+
+    /// Convert string to DecayMode enum
+    static DecayMode stringToDecayMode(const std::string& mode_str);
+
+protected:
+
+    /// mass number (protons + neutrons)
+    unsigned int mass_number_;
+
+    /// natural abundance (0.0 to 1.0)
+    double abundance_;
+
+    /// half-life in seconds (negative means stable)
+    double half_life_;
+
+    /// decay mode
+    DecayMode decay_mode_;
+  };
+
+  OPENMS_DLLAPI std::ostream& operator<<(std::ostream&, const Isotope&);
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
+++ b/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
@@ -10,6 +10,7 @@ CrossLinksDB.h
 DecoyGenerator.h
 Element.h
 ElementDB.h
+Isotope.h
 EmpiricalFormula.h
 EnzymaticDigestion.h
 DigestionEnzyme.h

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -9,6 +9,7 @@
 
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CHEMISTRY/Isotope.h>
 
 #include <ostream>
 #include <algorithm>
@@ -86,6 +87,21 @@ namespace OpenMS
   const IsotopeDistribution & Element::getIsotopeDistribution() const
   {
     return isotopes_;
+  }
+
+  void Element::setIsotopes(const std::vector<const Isotope*>& isotopes)
+  {
+    isotope_list_ = isotopes;
+  }
+
+  const std::vector<const Isotope*>& Element::getIsotopes() const
+  {
+    return isotope_list_;
+  }
+
+  bool Element::isIsotope() const
+  {
+    return false;
   }
 
   void Element::setName(const string & name)

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -12,10 +12,12 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CHEMISTRY/Isotope.h>
 
 #include <iostream>
 #include <cmath>
 #include <memory>
+#include <utility>
 
 using namespace std;
 
@@ -24,6 +26,7 @@ namespace OpenMS
   ElementDB::ElementDB()
   {
     storeElements_();
+    storeDetailedIsotopes_();
   }
 
   ElementDB::~ElementDB()
@@ -85,6 +88,73 @@ namespace OpenMS
   bool ElementDB::hasElement(unsigned int atomic_number) const
   {
     return atomic_numbers_.find(atomic_number) != atomic_numbers_.end();
+  }
+
+  const Isotope* ElementDB::getIsotope(const string& element_symbol, unsigned int mass_number) const
+  {
+    // First, resolve element_symbol to atomic number
+    const Element* elem = getElement(element_symbol);
+    if (elem == nullptr)
+    {
+      return nullptr;
+    }
+    return getIsotope(elem->getAtomicNumber(), mass_number);
+  }
+
+  const Isotope* ElementDB::getIsotope(unsigned int atomic_number, unsigned int mass_number) const
+  {
+    auto key = make_pair(atomic_number, mass_number);
+    auto it = isotopes_.find(key);
+    if (it != isotopes_.end())
+    {
+      return it->second;
+    }
+    return nullptr;
+  }
+
+  const unordered_map<string, const Isotope*>& ElementDB::getIsotopeSymbols() const
+  {
+    return isotope_symbols_;
+  }
+
+  bool ElementDB::hasIsotope(const string& element_symbol, unsigned int mass_number) const
+  {
+    const Element* elem = getElement(element_symbol);
+    if (elem == nullptr)
+    {
+      return false;
+    }
+    return hasIsotope(elem->getAtomicNumber(), mass_number);
+  }
+
+  bool ElementDB::hasIsotope(unsigned int atomic_number, unsigned int mass_number) const
+  {
+    auto key = make_pair(atomic_number, mass_number);
+    return isotopes_.find(key) != isotopes_.end();
+  }
+
+  void ElementDB::addIsotope(const string& element_symbol,
+                             unsigned int mass_number,
+                             double atomic_mass,
+                             double abundance,
+                             double half_life,
+                             const string& decay_mode,
+                             bool replace_existing)
+  {
+    const Element* elem = getElement(element_symbol);
+    if (elem == nullptr)
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        "Element with symbol " + element_symbol + " not found");
+    }
+
+    if (hasIsotope(elem->getAtomicNumber(), mass_number) && !replace_existing)
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                        String("Isotope ") + element_symbol + "-" + mass_number + " already exists");
+    }
+
+    buildIsotope_(element_symbol, elem->getAtomicNumber(), mass_number, atomic_mass, abundance, half_life, decay_mode);
   }
 
   void ElementDB::addElement(const std::string& name,
@@ -671,7 +741,88 @@ namespace OpenMS
         addIfUniqueOrThrow(symbols_, iso_symbol, iso_element);
         iso_element.release(); // allocation will be cleaned up by ~ElementDB now
       }
-    } 
+    }
+  }
+
+  void ElementDB::buildIsotope_(const string& element_symbol,
+                                unsigned int atomic_number,
+                                unsigned int mass_number,
+                                double atomic_mass,
+                                double abundance,
+                                double half_life,
+                                const string& decay_mode)
+  {
+    const Element* elem = getElement(atomic_number);
+    if (elem == nullptr)
+    {
+      return;
+    }
+
+    string iso_name = "(" + to_string(mass_number) + ")" + elem->getName();
+    string iso_symbol = "(" + to_string(mass_number) + ")" + element_symbol;
+
+    auto iso = make_unique<Isotope>(
+      iso_name,
+      iso_symbol,
+      atomic_number,
+      mass_number,
+      atomic_mass,
+      abundance,
+      half_life,
+      Isotope::stringToDecayMode(decay_mode)
+    );
+
+    auto key = make_pair(atomic_number, mass_number);
+
+    // Check if isotope already exists
+    auto it = isotopes_.find(key);
+    if (it != isotopes_.end())
+    {
+      // Delete old isotope and replace
+      delete it->second;
+      isotopes_.erase(it);
+      isotope_symbols_.erase(iso_symbol);
+    }
+
+    isotopes_[key] = iso.get();
+    isotope_symbols_[iso_symbol] = iso.get();
+    iso.release(); // ownership transferred
+  }
+
+  void ElementDB::storeDetailedIsotopes_()
+  {
+    // Carbon-14 (radioactive, used in radiocarbon dating)
+    // Half-life: 5730 years = 5730 * 365.25 * 24 * 3600 seconds
+    const double c14_half_life = 5730.0 * 365.25 * 24.0 * 3600.0; // ~1.807e11 seconds
+    buildIsotope_("C", 6, 14, 14.003241989, 0.0, c14_half_life, "BETA_MINUS");
+
+    // Uranium isotopes with half-lives and decay modes
+    // U-234: half-life 245,500 years, alpha decay
+    const double u234_half_life = 245500.0 * 365.25 * 24.0 * 3600.0;
+    buildIsotope_("U", 92, 234, 234.040950, 0.000054, u234_half_life, "ALPHA");
+
+    // U-235: half-life 703.8 million years, alpha decay
+    const double u235_half_life = 703.8e6 * 365.25 * 24.0 * 3600.0;
+    buildIsotope_("U", 92, 235, 235.043928, 0.007204, u235_half_life, "ALPHA");
+
+    // U-238: half-life 4.468 billion years, alpha decay
+    const double u238_half_life = 4.468e9 * 365.25 * 24.0 * 3600.0;
+    buildIsotope_("U", 92, 238, 238.05079, 0.992742, u238_half_life, "ALPHA");
+
+    // Hydrogen isotopes
+    // H-1 (protium): stable
+    buildIsotope_("H", 1, 1, 1.0078250319, 0.999885, -1.0, "STABLE");
+    // H-2 (deuterium): stable
+    buildIsotope_("H", 1, 2, 2.01410178, 0.000115, -1.0, "STABLE");
+    // H-3 (tritium): half-life 12.32 years, beta minus decay
+    const double h3_half_life = 12.32 * 365.25 * 24.0 * 3600.0;
+    buildIsotope_("H", 1, 3, 3.01604927, 0.0, h3_half_life, "BETA_MINUS");
+
+    // Carbon stable isotopes
+    // C-12: stable, most abundant
+    buildIsotope_("C", 6, 12, 12.0, 0.9893, -1.0, "STABLE");
+    // C-13: stable
+    buildIsotope_("C", 6, 13, 13.003355, 0.0107, -1.0, "STABLE");
   }
 
   IsotopeDistribution ElementDB::parseIsotopeDistribution_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
@@ -699,6 +850,14 @@ namespace OpenMS
     names_.clear();
     symbols_.clear();
     atomic_numbers_.clear();
+
+    // Clear isotopes
+    for (auto& it : isotopes_)
+    {
+      delete it.second;
+    }
+    isotopes_.clear();
+    isotope_symbols_.clear();
   }
 
 } // namespace OpenMS

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+//
+
+#include <OpenMS/CHEMISTRY/Isotope.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+
+#include <ostream>
+#include <stdexcept>
+
+using namespace std;
+
+namespace OpenMS
+{
+  Isotope::Isotope() :
+    Element(),
+    mass_number_(0),
+    abundance_(0.0),
+    half_life_(-1.0),
+    decay_mode_(DecayMode::STABLE)
+  {
+  }
+
+  Isotope::Isotope(const Isotope& isotope) = default;
+
+  Isotope::Isotope(const string& name,
+                   const string& symbol,
+                   unsigned int atomic_number,
+                   unsigned int mass_number,
+                   double atomic_mass,
+                   double abundance,
+                   double half_life,
+                   DecayMode decay_mode) :
+    Element(),
+    mass_number_(mass_number),
+    abundance_(abundance),
+    half_life_(half_life),
+    decay_mode_(decay_mode)
+  {
+    // Set Element properties
+    setName(name);
+    setSymbol(symbol);
+    setAtomicNumber(atomic_number);
+    setMonoWeight(atomic_mass);
+    setAverageWeight(atomic_mass); // For a single isotope, average = mono
+
+    // Create isotope distribution with single peak
+    IsotopeDistribution iso_dist;
+    IsotopeDistribution::ContainerType container;
+    container.push_back(Peak1D(atomic_mass, 1.0));
+    iso_dist.set(container);
+    setIsotopeDistribution(iso_dist);
+  }
+
+  Isotope::~Isotope() = default;
+
+  void Isotope::setMassNumber(unsigned int mass_number)
+  {
+    mass_number_ = mass_number;
+  }
+
+  unsigned int Isotope::getMassNumber() const
+  {
+    return mass_number_;
+  }
+
+  unsigned int Isotope::getNeutrons() const
+  {
+    return mass_number_ - getAtomicNumber();
+  }
+
+  void Isotope::setAbundance(double abundance)
+  {
+    if (abundance < 0.0 || abundance > 1.0)
+    {
+      throw std::invalid_argument("Abundance must be between 0.0 and 1.0");
+    }
+    abundance_ = abundance;
+  }
+
+  double Isotope::getAbundance() const
+  {
+    return abundance_;
+  }
+
+  void Isotope::setHalfLife(double half_life)
+  {
+    half_life_ = half_life;
+  }
+
+  double Isotope::getHalfLife() const
+  {
+    return half_life_;
+  }
+
+  void Isotope::setDecayMode(DecayMode decay_mode)
+  {
+    decay_mode_ = decay_mode;
+  }
+
+  Isotope::DecayMode Isotope::getDecayMode() const
+  {
+    return decay_mode_;
+  }
+
+  bool Isotope::isStable() const
+  {
+    return half_life_ < 0.0;
+  }
+
+  bool Isotope::isIsotope() const
+  {
+    return true;
+  }
+
+  Isotope& Isotope::operator=(const Isotope& isotope) = default;
+
+  bool Isotope::operator==(const Isotope& isotope) const
+  {
+    return Element::operator==(isotope) &&
+           mass_number_ == isotope.mass_number_ &&
+           abundance_ == isotope.abundance_ &&
+           half_life_ == isotope.half_life_ &&
+           decay_mode_ == isotope.decay_mode_;
+  }
+
+  bool Isotope::operator!=(const Isotope& isotope) const
+  {
+    return !(*this == isotope);
+  }
+
+  bool Isotope::operator<(const Isotope& isotope) const
+  {
+    if (getAtomicNumber() != isotope.getAtomicNumber())
+    {
+      return getAtomicNumber() < isotope.getAtomicNumber();
+    }
+    return mass_number_ < isotope.mass_number_;
+  }
+
+  string Isotope::decayModeToString(DecayMode mode)
+  {
+    switch (mode)
+    {
+      case DecayMode::STABLE:
+        return "STABLE";
+      case DecayMode::UNKNOWN:
+        return "UNKNOWN";
+      case DecayMode::ALPHA:
+        return "ALPHA";
+      case DecayMode::BETA_PLUS:
+        return "BETA_PLUS";
+      case DecayMode::BETA_MINUS:
+        return "BETA_MINUS";
+      case DecayMode::PROTON:
+        return "PROTON";
+      default:
+        return "UNKNOWN";
+    }
+  }
+
+  Isotope::DecayMode Isotope::stringToDecayMode(const string& mode_str)
+  {
+    if (mode_str == "STABLE")
+      return DecayMode::STABLE;
+    if (mode_str == "ALPHA")
+      return DecayMode::ALPHA;
+    if (mode_str == "BETA_PLUS")
+      return DecayMode::BETA_PLUS;
+    if (mode_str == "BETA_MINUS")
+      return DecayMode::BETA_MINUS;
+    if (mode_str == "PROTON")
+      return DecayMode::PROTON;
+    return DecayMode::UNKNOWN;
+  }
+
+  ostream& operator<<(ostream& os, const Isotope& isotope)
+  {
+    os << isotope.getName() << " "
+       << isotope.getSymbol() << " "
+       << "Z=" << isotope.getAtomicNumber() << " "
+       << "A=" << isotope.getMassNumber() << " "
+       << "mass=" << isotope.getMonoWeight() << " "
+       << "abundance=" << isotope.getAbundance() * 100 << "% ";
+
+    if (isotope.isStable())
+    {
+      os << "(stable)";
+    }
+    else
+    {
+      os << "half-life=" << isotope.getHalfLife() << "s "
+         << "decay=" << Isotope::decayModeToString(isotope.getDecayMode());
+    }
+    return os;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/CHEMISTRY/sources.cmake
+++ b/src/openms/source/CHEMISTRY/sources.cmake
@@ -10,6 +10,7 @@ CrossLinksDB.cpp
 DecoyGenerator.cpp
 Element.cpp
 ElementDB.cpp
+Isotope.cpp
 EmpiricalFormula.cpp
 EnzymaticDigestion.cpp
 DigestionEnzyme.cpp

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -390,6 +390,7 @@ set(chemistry_executables_list
   DigestionEnzymeProtein_test
   ElementDB_test
   Element_test
+  Isotope_test
   EmpiricalFormula_test
   EnzymaticDigestion_test
   FineIsotopeDistribution_test

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -1,0 +1,257 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+//
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/Isotope.h>
+#include <OpenMS/CHEMISTRY/ElementDB.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+
+using namespace OpenMS;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(Isotope, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+Isotope* iso_ptr = nullptr;
+Isotope* iso_nullPointer = nullptr;
+
+START_SECTION(Isotope())
+  iso_ptr = new Isotope;
+  TEST_NOT_EQUAL(iso_ptr, iso_nullPointer)
+END_SECTION
+
+START_SECTION(~Isotope())
+  delete iso_ptr;
+END_SECTION
+
+START_SECTION((Isotope(const std::string& name, const std::string& symbol, unsigned int atomic_number, unsigned int mass_number, double atomic_mass, double abundance, double half_life, DecayMode decay_mode)))
+  iso_ptr = new Isotope("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  TEST_NOT_EQUAL(iso_ptr, iso_nullPointer)
+  TEST_EQUAL(iso_ptr->getName(), "(14)Carbon")
+  TEST_EQUAL(iso_ptr->getSymbol(), "(14)C")
+  TEST_EQUAL(iso_ptr->getAtomicNumber(), 6)
+  TEST_EQUAL(iso_ptr->getMassNumber(), 14)
+  TEST_REAL_SIMILAR(iso_ptr->getMonoWeight(), 14.003241989)
+  TEST_REAL_SIMILAR(iso_ptr->getAbundance(), 0.0)
+  TEST_REAL_SIMILAR(iso_ptr->getHalfLife(), 1.807e11)
+  TEST_EQUAL(iso_ptr->getDecayMode(), Isotope::DecayMode::BETA_MINUS)
+  TEST_EQUAL(iso_ptr->isStable(), false)
+  delete iso_ptr;
+END_SECTION
+
+START_SECTION(Isotope(const Isotope& isotope))
+  Isotope original("(12)Carbon", "(12)C", 6, 12, 12.0, 0.9893, -1.0, Isotope::DecayMode::STABLE);
+  Isotope copy(original);
+  TEST_EQUAL(copy == original, true)
+END_SECTION
+
+iso_ptr = new Isotope("(235)Uranium", "(235)U", 92, 235, 235.043928, 0.007204, 2.22e16, Isotope::DecayMode::ALPHA);
+
+START_SECTION(void setMassNumber(unsigned int mass_number))
+  iso_ptr->setMassNumber(238);
+  NOT_TESTABLE
+END_SECTION
+
+START_SECTION(unsigned int getMassNumber() const)
+  TEST_EQUAL(iso_ptr->getMassNumber(), 238)
+END_SECTION
+
+START_SECTION(unsigned int getNeutrons() const)
+  // Neutrons = mass_number - atomic_number = 238 - 92 = 146
+  TEST_EQUAL(iso_ptr->getNeutrons(), 146)
+END_SECTION
+
+START_SECTION(void setAbundance(double abundance))
+  iso_ptr->setAbundance(0.5);
+  NOT_TESTABLE
+END_SECTION
+
+START_SECTION(double getAbundance() const)
+  TEST_REAL_SIMILAR(iso_ptr->getAbundance(), 0.5)
+END_SECTION
+
+START_SECTION(void setHalfLife(double half_life))
+  iso_ptr->setHalfLife(1.0e10);
+  NOT_TESTABLE
+END_SECTION
+
+START_SECTION(double getHalfLife() const)
+  TEST_REAL_SIMILAR(iso_ptr->getHalfLife(), 1.0e10)
+END_SECTION
+
+START_SECTION(void setDecayMode(DecayMode decay_mode))
+  iso_ptr->setDecayMode(Isotope::DecayMode::BETA_MINUS);
+  NOT_TESTABLE
+END_SECTION
+
+START_SECTION(DecayMode getDecayMode() const)
+  TEST_EQUAL(iso_ptr->getDecayMode(), Isotope::DecayMode::BETA_MINUS)
+END_SECTION
+
+START_SECTION(bool isStable() const)
+  // With positive half-life, not stable
+  TEST_EQUAL(iso_ptr->isStable(), false)
+
+  // With negative half-life, stable
+  iso_ptr->setHalfLife(-1.0);
+  TEST_EQUAL(iso_ptr->isStable(), true)
+END_SECTION
+
+START_SECTION(virtual bool isIsotope() const)
+  TEST_EQUAL(iso_ptr->isIsotope(), true)
+END_SECTION
+
+START_SECTION(Isotope& operator=(const Isotope& isotope))
+  Isotope original("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  Isotope copy;
+  copy = original;
+  TEST_EQUAL(copy == original, true)
+END_SECTION
+
+START_SECTION(bool operator==(const Isotope& isotope) const)
+  Isotope iso1("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  Isotope iso2("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  TEST_EQUAL(iso1 == iso2, true)
+
+  iso2.setMassNumber(15);
+  TEST_EQUAL(iso1 == iso2, false)
+END_SECTION
+
+START_SECTION(bool operator!=(const Isotope& isotope) const)
+  Isotope iso1("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  Isotope iso2("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  TEST_EQUAL(iso1 != iso2, false)
+
+  iso2.setMassNumber(15);
+  TEST_EQUAL(iso1 != iso2, true)
+END_SECTION
+
+START_SECTION(bool operator<(const Isotope& isotope) const)
+  Isotope iso1("(12)Carbon", "(12)C", 6, 12, 12.0, 0.9893, -1.0, Isotope::DecayMode::STABLE);
+  Isotope iso2("(14)Carbon", "(14)C", 6, 14, 14.003241989, 0.0, 1.807e11, Isotope::DecayMode::BETA_MINUS);
+  TEST_EQUAL(iso1 < iso2, true)
+  TEST_EQUAL(iso2 < iso1, false)
+END_SECTION
+
+START_SECTION(static std::string decayModeToString(DecayMode mode))
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::STABLE), "STABLE")
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::ALPHA), "ALPHA")
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::BETA_PLUS), "BETA_PLUS")
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::BETA_MINUS), "BETA_MINUS")
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::PROTON), "PROTON")
+  TEST_EQUAL(Isotope::decayModeToString(Isotope::DecayMode::UNKNOWN), "UNKNOWN")
+END_SECTION
+
+START_SECTION(static DecayMode stringToDecayMode(const std::string& mode_str))
+  TEST_EQUAL(Isotope::stringToDecayMode("STABLE"), Isotope::DecayMode::STABLE)
+  TEST_EQUAL(Isotope::stringToDecayMode("ALPHA"), Isotope::DecayMode::ALPHA)
+  TEST_EQUAL(Isotope::stringToDecayMode("BETA_PLUS"), Isotope::DecayMode::BETA_PLUS)
+  TEST_EQUAL(Isotope::stringToDecayMode("BETA_MINUS"), Isotope::DecayMode::BETA_MINUS)
+  TEST_EQUAL(Isotope::stringToDecayMode("PROTON"), Isotope::DecayMode::PROTON)
+  TEST_EQUAL(Isotope::stringToDecayMode("UNKNOWN"), Isotope::DecayMode::UNKNOWN)
+  TEST_EQUAL(Isotope::stringToDecayMode("invalid"), Isotope::DecayMode::UNKNOWN)
+END_SECTION
+
+delete iso_ptr;
+
+// Test ElementDB isotope retrieval
+START_SECTION([EXTRA] ElementDB::getIsotope)
+{
+  ElementDB* db = ElementDB::getInstance();
+
+  // Test Carbon-14
+  const Isotope* c14 = db->getIsotope("C", 14);
+  TEST_NOT_EQUAL(c14, iso_nullPointer)
+  if (c14 != nullptr)
+  {
+    TEST_EQUAL(c14->getMassNumber(), 14)
+    TEST_EQUAL(c14->getAtomicNumber(), 6)
+    TEST_EQUAL(c14->isStable(), false)
+    TEST_EQUAL(c14->getDecayMode(), Isotope::DecayMode::BETA_MINUS)
+  }
+
+  // Test Carbon-12 (stable)
+  const Isotope* c12 = db->getIsotope("C", 12);
+  TEST_NOT_EQUAL(c12, iso_nullPointer)
+  if (c12 != nullptr)
+  {
+    TEST_EQUAL(c12->getMassNumber(), 12)
+    TEST_EQUAL(c12->isStable(), true)
+    TEST_EQUAL(c12->getDecayMode(), Isotope::DecayMode::STABLE)
+  }
+
+  // Test Uranium-235
+  const Isotope* u235 = db->getIsotope("U", 235);
+  TEST_NOT_EQUAL(u235, iso_nullPointer)
+  if (u235 != nullptr)
+  {
+    TEST_EQUAL(u235->getMassNumber(), 235)
+    TEST_EQUAL(u235->getAtomicNumber(), 92)
+    TEST_EQUAL(u235->isStable(), false)
+    TEST_EQUAL(u235->getDecayMode(), Isotope::DecayMode::ALPHA)
+  }
+
+  // Test Uranium-238
+  const Isotope* u238 = db->getIsotope("U", 238);
+  TEST_NOT_EQUAL(u238, iso_nullPointer)
+  if (u238 != nullptr)
+  {
+    TEST_EQUAL(u238->getMassNumber(), 238)
+    TEST_EQUAL(u238->getDecayMode(), Isotope::DecayMode::ALPHA)
+  }
+
+  // Test retrieval by atomic number
+  const Isotope* c14_by_an = db->getIsotope(6, 14);
+  TEST_EQUAL(c14_by_an, c14)
+
+  // Test non-existent isotope
+  const Isotope* non_existent = db->getIsotope("C", 100);
+  TEST_EQUAL(non_existent, iso_nullPointer)
+}
+END_SECTION
+
+START_SECTION([EXTRA] ElementDB::hasIsotope)
+{
+  ElementDB* db = ElementDB::getInstance();
+
+  TEST_EQUAL(db->hasIsotope("C", 12), true)
+  TEST_EQUAL(db->hasIsotope("C", 13), true)
+  TEST_EQUAL(db->hasIsotope("C", 14), true)
+  TEST_EQUAL(db->hasIsotope("C", 100), false)
+
+  TEST_EQUAL(db->hasIsotope("U", 234), true)
+  TEST_EQUAL(db->hasIsotope("U", 235), true)
+  TEST_EQUAL(db->hasIsotope("U", 238), true)
+
+  // Test by atomic number
+  TEST_EQUAL(db->hasIsotope(6, 14), true)
+  TEST_EQUAL(db->hasIsotope(92, 235), true)
+}
+END_SECTION
+
+START_SECTION([EXTRA] ElementDB::getIsotopeSymbols)
+{
+  ElementDB* db = ElementDB::getInstance();
+
+  const auto& iso_symbols = db->getIsotopeSymbols();
+  TEST_EQUAL(iso_symbols.count("(14)C") > 0, true)
+  TEST_EQUAL(iso_symbols.count("(235)U") > 0, true)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
This implements the isotope feature requested in PR #5956:

- New Isotope class extending Element with:
  - Mass number (protons + neutrons)
  - Natural abundance (0.0 to 1.0)
  - Half-life in seconds (negative = stable)
  - Decay mode enum (STABLE, ALPHA, BETA_PLUS, BETA_MINUS, PROTON, UNKNOWN)
  - Helper methods: isStable(), isIsotope(), getNeutrons()
  - Utility methods for DecayMode enum/string conversion

- Enhanced Element class with:
  - setIsotopes()/getIsotopes() for isotope list management
  - Virtual isIsotope() method (false for Element, true for Isotope)

- Enhanced ElementDB with:
  - getIsotope() methods by symbol/name + mass number or atomic number + mass number
  - hasIsotope() predicates
  - addIsotope() for adding custom isotopes
  - getIsotopeSymbols() accessor
  - Pre-populated isotope data for Carbon (C-12, C-13, C-14) and
    Uranium (U-234, U-235, U-238) with accurate half-lives and decay modes
  - Hydrogen isotopes (H-1, H-2, H-3/tritium)

- Comprehensive test suite in Isotope_test.cpp covering:
  - Isotope class functionality
  - ElementDB isotope retrieval
  - Decay mode conversions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Isotope class providing comprehensive isotope representation with mass number, natural abundance, half-life, and decay mode.
  * Extended element database with isotope retrieval capabilities by element symbol/atomic number and mass number.
  * Added isotope management operations including existence checks and symbol lookups.

* **Tests**
  * Added full test suite for isotope and element database integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->