### PR TITLE
Fix iBAQ normalization accession mismatch issue

### DIFF
--- a/.github/workflows/update_version_numbers.yml
+++ b/.github/workflows/update_version_numbers.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   updating_package_version_number:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       # Getting files (OpenMS)
       - uses: actions/checkout@v4

--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -91,8 +91,18 @@ public:
     std::ostream & getStream(const String & stream_name);
 
     /**
-      @brief Sets a minimum @p log_level by removing all streams from loggers lower than that level.
-      order of log_level: "DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"
+      @brief Sets a minimum @p log_level by removing all streams from loggers lower than that level,
+      and restoring configured streams for loggers at or above that level.
+      
+      This method allows dynamic adjustment of the logging level. When increasing the log level
+      (e.g., from INFO to ERROR), streams are removed from lower priority levels. When decreasing
+      the log level (e.g., from ERROR to INFO), previously configured streams are restored.
+      
+      Order of log_level: "DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR", "NONE"
+      
+      Special value "NONE" disables all logging by removing streams from all levels.
+      
+      @param log_level The minimum log level to enable. Levels below this will have their streams removed.
      */
     void setLogLevel(const String & log_level);
 

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -376,6 +376,9 @@ public:
 
       /**
         Remove all streams associated to this LogStream, effectively silencing it.
+        
+        Flushes all buffers to ensure any pending log messages are written to their
+        respective streams before they are removed.
       */
       void removeAllStreams();
 

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -1277,29 +1277,87 @@ namespace OpenMS
 
   void PeptideAndProteinQuant::performIbaqNormalization_(const ProteinIdentification& proteins)
   {
-    EnzymaticDigestion digest{};
-    for (auto & hit : proteins.getHits())
-    {
-      const OpenMS::String & hit_accession = hit.getAccession();
-      const OpenMS::String & hit_sequence = hit.getSequence();
+    // Build mapping from accession to leader (for indistinguishable protein groups)
+    // This is the same mapping used by transferPeptideDataToProteins_ to populate prot_quant_
+    std::map<String, String> accession_to_leader = mapAccessionToLeader(proteins);
 
-      if (prot_quant_.find(hit_accession) != prot_quant_.end())
+    // Build reverse mapping: leader -> list of all accessions in that group
+    // This allows us to find any protein hit that belongs to a leader's group
+    std::map<String, std::vector<String>> leader_to_members;
+    if (!accession_to_leader.empty())
+    {
+      for (const auto& entry : accession_to_leader)
       {
-        if (hit_sequence.empty())
+        leader_to_members[entry.second].push_back(entry.first);
+      }
+    }
+
+    // Build a map from accession to protein hit for quick lookup
+    std::map<String, const ProteinHit*> accession_to_hit;
+    for (const auto& hit : proteins.getHits())
+    {
+      accession_to_hit[hit.getAccession()] = &hit;
+    }
+
+    // Iterate over prot_quant_ entries (which are keyed by leader accessions)
+    // rather than protein hits, to avoid accession mismatch issues (issue #8466)
+    EnzymaticDigestion digest{};
+    std::vector<String> to_erase;  // Collect entries to remove (can't modify during iteration)
+
+    for (auto& prot_entry : prot_quant_)
+    {
+      const String& leader_accession = prot_entry.first;
+      ProteinData& prot_data = prot_entry.second;
+
+      // Find a protein hit with a sequence for this leader accession
+      // First try the leader directly, then try group members
+      String sequence;
+
+      // 1. Try direct lookup of the leader accession
+      auto hit_it = accession_to_hit.find(leader_accession);
+      if (hit_it != accession_to_hit.end() && !hit_it->second->getSequence().empty())
+      {
+        sequence = hit_it->second->getSequence();
+      }
+      // 2. If leader not found or has no sequence, try group members
+      else if (leader_to_members.count(leader_accession))
+      {
+        for (const String& member_acc : leader_to_members.at(leader_accession))
         {
-          prot_quant_.erase(hit_accession);
-          OPENMS_LOG_WARN << "Removed " << hit_accession <<  ", no protein sequence found!" << endl;
-        }
-        else
-        {
-          std::vector<StringView> peptides {};
-          digest.digestUnmodified(StringView(hit_sequence), peptides);
-          for (auto& total_abundance : prot_quant_[hit_accession].total_abundances)
+          auto member_hit_it = accession_to_hit.find(member_acc);
+          if (member_hit_it != accession_to_hit.end() && !member_hit_it->second->getSequence().empty())
           {
-            total_abundance.second /= double(peptides.size());
+            sequence = member_hit_it->second->getSequence();
+            break;  // Use first available sequence
           }
         }
       }
+
+      if (sequence.empty())
+      {
+        to_erase.push_back(leader_accession);
+        OPENMS_LOG_WARN << "Removed " << leader_accession << ", no protein sequence found!" << endl;
+      }
+      else
+      {
+        std::vector<StringView> peptides{};
+        digest.digestUnmodified(StringView(sequence), peptides);
+        if (peptides.empty())
+        {
+          OPENMS_LOG_WARN << "No theoretical peptides for " << leader_accession << ", iBAQ not applied." << endl;
+          continue;
+        }
+        for (auto& total_abundance : prot_data.total_abundances)
+        {
+          total_abundance.second /= static_cast<double>(peptides.size());
+        }
+      }
+    }
+
+    // Remove entries with missing sequences
+    for (const String& acc : to_erase)
+    {
+      prot_quant_.erase(acc);
     }
   }
 }

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -217,10 +217,55 @@ namespace OpenMS
   void LogConfigHandler::setLogLevel(const String & log_level)
   {
     std::vector<String> lvls = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
+    
+    bool found_target_level = false;
     for (const auto& lvl : lvls)
     {
-      if (lvl == log_level) break;
-      getLogStreamByName_(lvl).removeAllStreams();
+      if (lvl == log_level)
+      {
+        found_target_level = true;
+      }
+      
+      if (!found_target_level)
+      {
+        // Remove all streams from levels below the target level
+        getLogStreamByName_(lvl).removeAllStreams();
+      }
+      else
+      {
+        // Restore streams for levels at or above the target level based on configuration
+        Logger::LogStream& log = getLogStreamByName_(lvl);
+        const std::set<String>& configured_streams = getConfigSetByName_(lvl);
+        
+        // First, remove all current streams
+        log.removeAllStreams();
+        
+        // Then add back the configured streams
+        for (const String& stream_name : configured_streams)
+        {
+          if (stream_name == "cout")
+          {
+            log.insert(cout);
+          }
+          else if (stream_name == "cerr")
+          {
+            log.insert(cerr);
+          }
+          else
+          {
+            // Handle file/string streams from StreamHandler
+            if (stream_type_map_.count(stream_name) != 0)
+            {
+              StreamHandler::StreamType type = stream_type_map_[stream_name];
+              if (STREAM_HANDLER.hasStream(type, stream_name))
+              {
+                log.insert(STREAM_HANDLER.getStream(type, stream_name));
+                log.setPrefix(STREAM_HANDLER.getStream(type, stream_name), "[%S] ");
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -216,7 +216,7 @@ namespace OpenMS
 
   void LogConfigHandler::setLogLevel(const String & log_level)
   {
-    std::vector<String> lvls = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
+    static const std::vector<String> lvls = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
     
     // Special case: "NONE" means disable all logging
     if (log_level == "NONE")
@@ -264,9 +264,10 @@ namespace OpenMS
           else
           {
             // Handle file/string streams from StreamHandler
-            if (stream_type_map_.count(stream_name) != 0)
+            auto it = stream_type_map_.find(stream_name);
+            if (it != stream_type_map_.end())
             {
-              StreamHandler::StreamType type = stream_type_map_[stream_name];
+              StreamHandler::StreamType type = it->second;
               if (STREAM_HANDLER.hasStream(type, stream_name))
               {
                 log.insert(STREAM_HANDLER.getStream(type, stream_name));

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -218,6 +218,16 @@ namespace OpenMS
   {
     std::vector<String> lvls = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
     
+    // Special case: "NONE" means disable all logging
+    if (log_level == "NONE")
+    {
+      for (const auto& lvl : lvls)
+      {
+        getLogStreamByName_(lvl).removeAllStreams();
+      }
+      return;
+    }
+    
     bool found_target_level = false;
     for (const auto& lvl : lvls)
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -111,9 +111,10 @@ namespace OpenMS
           const String & stream_type = commands[3];
 
           // check if a stream with the same name, but different type was already registered
-          if (stream_type_map_.count(stream_name) != 0)
+          auto existing = stream_type_map_.find(stream_name);
+          if (existing != stream_type_map_.end())
           {
-            if (stream_type_map_[stream_name] != getStreamTypeByName_(stream_type))
+            if (existing->second != getStreamTypeByName_(stream_type))
             {
               throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "A stream with the same name but different type was already registered.");
             }
@@ -344,9 +345,10 @@ namespace OpenMS
 
   std::ostream & LogConfigHandler::getStream(const String & name)
   {
-    if (stream_type_map_.count(name) != 0)
+    auto it = stream_type_map_.find(name);
+    if (it != stream_type_map_.end())
     {
-      return STREAM_HANDLER.getStream(stream_type_map_[name], name);
+      return STREAM_HANDLER.getStream(it->second, name);
     }
     else
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <iostream>
+#include <algorithm>
 
 #include <OpenMS/CONCEPT/LogConfigHandler.h>
 
@@ -17,6 +18,12 @@ using std::endl;
 namespace OpenMS
 {
   String LogConfigHandler::PARAM_NAME = "log";
+  
+  namespace 
+  {
+    // Order of log levels from lowest to highest priority
+    const std::vector<String> LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
+  }
 
   LogConfigHandler::LogConfigHandler()
   {
@@ -217,63 +224,64 @@ namespace OpenMS
 
   void LogConfigHandler::setLogLevel(const String & log_level)
   {
-    static const std::vector<String> lvls = {"DEBUG", "INFO", "WARNING", "ERROR", "FATAL_ERROR"};
-    
     // Special case: "NONE" means disable all logging
     if (log_level == "NONE")
     {
-      for (const auto& lvl : lvls)
+      for (const auto& lvl : LOG_LEVELS)
       {
         getLogStreamByName_(lvl).removeAllStreams();
       }
       return;
     }
     
-    bool found_target_level = false;
-    for (const auto& lvl : lvls)
+    // Find the index of the target log level
+    auto target_it = std::find(LOG_LEVELS.begin(), LOG_LEVELS.end(), log_level);
+    if (target_it == LOG_LEVELS.end())
     {
-      if (lvl == log_level)
-      {
-        found_target_level = true;
-      }
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, 
+                                       "Invalid log level '" + log_level + "'. Valid levels are: DEBUG, INFO, WARNING, ERROR, FATAL_ERROR, NONE");
+    }
+    
+    size_t target_index = std::distance(LOG_LEVELS.begin(), target_it);
+    
+    // Remove streams from all levels below the target level
+    for (size_t i = 0; i < target_index; ++i)
+    {
+      getLogStreamByName_(LOG_LEVELS[i]).removeAllStreams();
+    }
+    
+    // Restore configured streams for the target level and all levels above it
+    for (size_t i = target_index; i < LOG_LEVELS.size(); ++i)
+    {
+      const String& lvl = LOG_LEVELS[i];
+      Logger::LogStream& log = getLogStreamByName_(lvl);
+      const std::set<String>& configured_streams = getConfigSetByName_(lvl);
       
-      if (!found_target_level)
+      // First, remove all current streams
+      log.removeAllStreams();
+      
+      // Then add back the configured streams
+      for (const String& stream_name : configured_streams)
       {
-        // Remove all streams from levels below the target level
-        getLogStreamByName_(lvl).removeAllStreams();
-      }
-      else
-      {
-        // Restore streams for levels at or above the target level based on configuration
-        Logger::LogStream& log = getLogStreamByName_(lvl);
-        const std::set<String>& configured_streams = getConfigSetByName_(lvl);
-        
-        // First, remove all current streams
-        log.removeAllStreams();
-        
-        // Then add back the configured streams
-        for (const String& stream_name : configured_streams)
+        if (stream_name == "cout")
         {
-          if (stream_name == "cout")
+          log.insert(cout);
+        }
+        else if (stream_name == "cerr")
+        {
+          log.insert(cerr);
+        }
+        else
+        {
+          // Handle file/string streams from StreamHandler
+          auto it = stream_type_map_.find(stream_name);
+          if (it != stream_type_map_.end())
           {
-            log.insert(cout);
-          }
-          else if (stream_name == "cerr")
-          {
-            log.insert(cerr);
-          }
-          else
-          {
-            // Handle file/string streams from StreamHandler
-            auto it = stream_type_map_.find(stream_name);
-            if (it != stream_type_map_.end())
+            StreamHandler::StreamType type = it->second;
+            if (STREAM_HANDLER.hasStream(type, stream_name))
             {
-              StreamHandler::StreamType type = it->second;
-              if (STREAM_HANDLER.hasStream(type, stream_name))
-              {
-                log.insert(STREAM_HANDLER.getStream(type, stream_name));
-                log.setPrefix(STREAM_HANDLER.getStream(type, stream_name), "[%S] ");
-              }
+              log.insert(STREAM_HANDLER.getStream(type, stream_name));
+              log.setPrefix(STREAM_HANDLER.getStream(type, stream_name), "[%S] ");
             }
           }
         }

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -469,6 +469,12 @@ namespace OpenMS
         return;
 
       rdbuf()->sync();
+      // Distribute any incomplete line before clearing streams
+      if (!rdbuf()->incomplete_line_.empty())
+      {
+        rdbuf()->distribute_(rdbuf()->incomplete_line_);
+        rdbuf()->incomplete_line_.clear();
+      }
       // Flush all streams before clearing the list
       for (auto& stream_struct : rdbuf()->stream_list_)
       {

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -469,6 +469,14 @@ namespace OpenMS
         return;
 
       rdbuf()->sync();
+      // Flush all streams before clearing the list
+      for (auto& stream_struct : rdbuf()->stream_list_)
+      {
+        if (stream_struct.stream != nullptr)
+        {
+          stream_struct.stream->flush();
+        }
+      }
       rdbuf()->stream_list_.clear();
     }
 

--- a/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
@@ -148,6 +148,74 @@ START_SECTION((static LogConfigHandler* getInstance()))
 }
 END_SECTION
 
+START_SECTION((void setLogLevel(const String &log_level) - restoring streams))
+{
+  // Test that setLogLevel can restore streams when lowering the log level
+  
+  // Setup: Create a string stream for INFO level
+  std::vector<std::string> settings;
+  settings.push_back("INFO add test_setloglevel_stream STRING");
+  
+  Param p;
+  p.setValue(LogConfigHandler::PARAM_NAME, settings, "List of all settings that should be applied to the current Logging Configuration");
+  LogConfigHandler::getInstance()->configure(p);
+  
+  // Write a message at INFO level - should appear
+  OPENMS_LOG_INFO << "message1" << endl;
+  
+  // Set log level to ERROR (should remove INFO streams)
+  LogConfigHandler::getInstance()->setLogLevel("ERROR");
+  
+  // Write a message at INFO level - should NOT appear
+  OPENMS_LOG_INFO << "message2" << endl;
+  
+  // Lower log level back to INFO (should restore INFO streams)
+  LogConfigHandler::getInstance()->setLogLevel("INFO");
+  
+  // Write a message at INFO level - should appear again
+  OPENMS_LOG_INFO << "message3" << endl;
+  
+  // Check the stream content
+  ostringstream& test_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance()->getStream("test_setloglevel_stream"));
+  String content(test_stream.str());
+  StringList result;
+  content.trim().split('\n', result, true);
+  
+  // Should have message1 and message3, but not message2
+  TEST_EQUAL(result.size(), 2)
+  TEST_TRUE(result[0].hasSubstring("message1"))
+  TEST_TRUE(result[1].hasSubstring("message3"))
+}
+END_SECTION
+
+START_SECTION((removeAllStreams flushes buffers))
+{
+  // Test that removeAllStreams flushes buffers before clearing
+  
+  // Setup: Create a string stream for WARNING level
+  std::vector<std::string> settings;
+  settings.push_back("WARNING add test_flush_stream STRING");
+  
+  Param p;
+  p.setValue(LogConfigHandler::PARAM_NAME, settings, "List of all settings that should be applied to the current Logging Configuration");
+  LogConfigHandler::getInstance()->configure(p);
+  
+  // Write without endl (no flush yet)
+  OPENMS_LOG_WARN << "unflushed_message";
+  
+  // Set log level to ERROR (which calls removeAllStreams on WARNING)
+  // This should flush the buffer before removing streams
+  LogConfigHandler::getInstance()->setLogLevel("ERROR");
+  
+  // Check the stream content - the unflushed message should be there
+  ostringstream& test_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance()->getStream("test_flush_stream"));
+  String content(test_stream.str());
+  
+  // The message should be in the stream even though it wasn't flushed with endl
+  TEST_TRUE(content.hasSubstring("unflushed_message"))
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
@@ -216,6 +216,53 @@ START_SECTION((removeAllStreams flushes buffers))
 }
 END_SECTION
 
+START_SECTION((void setLogLevel(const String &log_level) - NONE level))
+{
+  // Test that setLogLevel("NONE") disables all logging and can be restored
+  
+  // Setup: Create string streams for multiple levels
+  std::vector<std::string> settings;
+  settings.push_back("INFO add test_none_info_stream STRING");
+  settings.push_back("ERROR add test_none_error_stream STRING");
+  
+  Param p;
+  p.setValue(LogConfigHandler::PARAM_NAME, settings, "List of all settings that should be applied to the current Logging Configuration");
+  LogConfigHandler::getInstance()->configure(p);
+  
+  // Write messages - should appear
+  OPENMS_LOG_INFO << "before_none_info" << endl;
+  OPENMS_LOG_ERROR << "before_none_error" << endl;
+  
+  // Set log level to NONE (should remove all streams)
+  LogConfigHandler::getInstance()->setLogLevel("NONE");
+  
+  // Write messages - should NOT appear
+  OPENMS_LOG_INFO << "during_none_info" << endl;
+  OPENMS_LOG_ERROR << "during_none_error" << endl;
+  
+  // Restore log level to INFO (should restore INFO and higher streams)
+  LogConfigHandler::getInstance()->setLogLevel("INFO");
+  
+  // Write messages - should appear again
+  OPENMS_LOG_INFO << "after_none_info" << endl;
+  OPENMS_LOG_ERROR << "after_none_error" << endl;
+  
+  // Check INFO stream
+  ostringstream& info_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance()->getStream("test_none_info_stream"));
+  String info_content(info_stream.str());
+  TEST_TRUE(info_content.hasSubstring("before_none_info"))
+  TEST_FALSE(info_content.hasSubstring("during_none_info"))
+  TEST_TRUE(info_content.hasSubstring("after_none_info"))
+  
+  // Check ERROR stream
+  ostringstream& error_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance()->getStream("test_none_error_stream"));
+  String error_content(error_stream.str());
+  TEST_TRUE(error_content.hasSubstring("before_none_error"))
+  TEST_FALSE(error_content.hasSubstring("during_none_error"))
+  TEST_TRUE(error_content.hasSubstring("after_none_error"))
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
@@ -263,6 +263,13 @@ START_SECTION((void setLogLevel(const String &log_level) - NONE level))
 }
 END_SECTION
 
+START_SECTION((void setLogLevel(const String &log_level) - invalid level))
+{
+  // Test that setLogLevel throws an exception for invalid log levels
+  TEST_EXCEPTION(Exception::IllegalArgument, LogConfigHandler::getInstance()->setLogLevel("INVALID_LEVEL"))
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/PeptideAndProteinQuant_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideAndProteinQuant_test.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>
 #include <OpenMS/METADATA/ExperimentalDesign.h>
+#include <OpenMS/METADATA/PeptideEvidence.h>
 
 
 using namespace OpenMS;
@@ -368,6 +369,226 @@ START_SECTION((const ProteinQuant& getProteinResults()))
   TEST_REAL_SIMILAR(protein.total_abundances[0], 308.5);
   TEST_REAL_SIMILAR(protein.total_abundances[1], 58.5);
   TEST_REAL_SIMILAR(protein.total_abundances[2], 257.5);
+}
+END_SECTION
+
+// iBAQ test with indistinguishable protein groups - exposes accession mismatch bug (issue 8466)
+// This test demonstrates that iBAQ normalization is silently skipped when protein hit accessions
+// don't exactly match the leader accessions used as keys in prot_quant_
+START_SECTION((iBAQ with indistinguishable protein groups))
+{
+  // Create a scenario with:
+  // - Protein group containing ProteinLeader and ProteinMember (leader = ProteinLeader)
+  // - Peptides assigned to ProteinLeader
+  // - prot_quant_ will have key "ProteinLeader"
+  // - When iterating protein hits, if only ProteinMember has a sequence, iBAQ fails to normalize
+
+  PeptideAndProteinQuant quantifier;
+  PeptideAndProteinQuant::ProteinQuant quant;
+  PeptideAndProteinQuant::ProteinData protein;
+
+  Param parameters = quantifier.getDefaults();
+  parameters.setValue("method", "iBAQ");
+  quantifier.setParameters(parameters);
+
+  // Create a ConsensusMap with protein groups
+  ConsensusMap consensus;
+
+  // Set up mapList with one sample
+  consensus.getColumnHeaders()[0].filename = "sample1.mzML";
+  consensus.getColumnHeaders()[0].size = 1;
+  consensus.getColumnHeaders()[0].unique_id = 0;
+
+  // Create ProteinIdentification with indistinguishable protein group
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("PI_test");
+  prot_id.setPrimaryMSRunPath({"sample1.mzML"});
+
+  // Add two protein hits - both are members of the same indistinguishable group
+  // The key insight: prot_quant_ will be keyed by "ProteinLeader" (the group leader)
+  // But performIbaqNormalization_ iterates all hits and looks up by hit.getAccession()
+  ProteinHit hit_leader;
+  hit_leader.setAccession("ProteinLeader");
+  hit_leader.setSequence("AAAKCCCKEEEKGGG"); // 15 aa, trypsin digests to 4 peptides
+
+  ProteinHit hit_member;
+  hit_member.setAccession("ProteinMember");
+  hit_member.setSequence("AAAKCCCKEEEKGGG"); // Same sequence
+
+  prot_id.getHits().push_back(hit_leader);
+  prot_id.getHits().push_back(hit_member);
+
+  // Create indistinguishable protein group with ProteinLeader as leader
+  ProteinIdentification::ProteinGroup group;
+  group.probability = 0.9;
+  group.accessions = {"ProteinLeader", "ProteinMember"};
+  prot_id.getIndistinguishableProteins().push_back(group);
+
+  consensus.getProteinIdentifications().push_back(prot_id);
+
+  // Create a consensus element with peptide identification
+  ConsensusFeature cf;
+  cf.setUniqueId(1);
+  cf.setRT(100);
+  cf.setMZ(100);
+  cf.setIntensity(1234.0);  // This will be the raw abundance
+  cf.setCharge(2);
+
+  // Add a handle to link to the map
+  FeatureHandle fh;
+  fh.setMapIndex(0);
+  fh.setUniqueId(1);
+  fh.setRT(100);
+  fh.setMZ(100);
+  fh.setIntensity(1234.0);
+  fh.setCharge(2);
+  cf.insert(fh);
+
+  // Create peptide identification that references ProteinLeader
+  PeptideIdentification pep_id;
+  pep_id.setIdentifier("PI_test");
+  pep_id.setRT(100);
+  pep_id.setMZ(100);
+
+  PeptideHit pep_hit;
+  pep_hit.setSequence(AASequence::fromString("AAAK"));
+  pep_hit.setCharge(2);
+  pep_hit.setScore(1.0);
+
+  // Reference the leader protein
+  PeptideEvidence pe;
+  pe.setProteinAccession("ProteinLeader");
+  pep_hit.addPeptideEvidence(pe);
+
+  pep_id.getHits().push_back(pep_hit);
+  cf.getPeptideIdentifications().push_back(pep_id);
+
+  consensus.push_back(cf);
+
+  // Run quantification
+  ExperimentalDesign ed = ExperimentalDesign::fromConsensusMap(consensus);
+  quantifier.readQuantData(consensus, ed);
+  quantifier.quantifyPeptides();
+  quantifier.quantifyProteins(consensus.getProteinIdentifications()[0]);
+
+  quant = quantifier.getProteinResults();
+
+  // The protein should be quantified under "ProteinLeader" (the group leader)
+  TEST_EQUAL(quant.count("ProteinLeader"), 1);
+  protein = quant["ProteinLeader"];
+
+  // Raw abundance is 1234.0
+  // With iBAQ normalization (4 theoretical peptides), it should be 1234.0 / 4 = 308.5
+  // If iBAQ is silently skipped (the bug), it remains 1234.0
+  //
+  // NOTE: This test currently FAILS because of the accession mismatch bug.
+  // After the fix, iBAQ should properly normalize the value.
+  double expected_ibaq = 1234.0 / 4.0;  // = 308.5
+  TEST_REAL_SIMILAR(protein.total_abundances[0], expected_ibaq);
+}
+END_SECTION
+
+// iBAQ test: leader accession NOT in protein hits - severe case of issue 8466
+// This test demonstrates the bug when the leader protein hit is completely missing
+// from ProteinIdentification, only a group member exists
+START_SECTION((iBAQ with missing leader protein hit))
+{
+  PeptideAndProteinQuant quantifier;
+  PeptideAndProteinQuant::ProteinQuant quant;
+  PeptideAndProteinQuant::ProteinData protein;
+
+  Param parameters = quantifier.getDefaults();
+  parameters.setValue("method", "iBAQ");
+  quantifier.setParameters(parameters);
+
+  ConsensusMap consensus;
+
+  consensus.getColumnHeaders()[0].filename = "sample1.mzML";
+  consensus.getColumnHeaders()[0].size = 1;
+  consensus.getColumnHeaders()[0].unique_id = 0;
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("PI_test");
+  prot_id.setPrimaryMSRunPath({"sample1.mzML"});
+
+  // KEY BUG SCENARIO: Only add the member protein hit, NOT the leader!
+  // This can happen in real workflows when protein inference produces
+  // group leaders that are not present as individual protein hits.
+  ProteinHit hit_member;
+  hit_member.setAccession("ProteinMember");
+  hit_member.setSequence("AAAKCCCKEEEKGGG"); // 15 aa, trypsin digests to 4 peptides
+
+  prot_id.getHits().push_back(hit_member);
+
+  // Create indistinguishable protein group with ProteinLeader as leader
+  // But ProteinLeader is NOT in the protein hits!
+  ProteinIdentification::ProteinGroup group;
+  group.probability = 0.9;
+  group.accessions = {"ProteinLeader", "ProteinMember"};  // Leader first
+  prot_id.getIndistinguishableProteins().push_back(group);
+
+  consensus.getProteinIdentifications().push_back(prot_id);
+
+  ConsensusFeature cf;
+  cf.setUniqueId(1);
+  cf.setRT(100);
+  cf.setMZ(100);
+  cf.setIntensity(1234.0);
+  cf.setCharge(2);
+
+  FeatureHandle fh;
+  fh.setMapIndex(0);
+  fh.setUniqueId(1);
+  fh.setRT(100);
+  fh.setMZ(100);
+  fh.setIntensity(1234.0);
+  fh.setCharge(2);
+  cf.insert(fh);
+
+  // Peptide references the member protein (which maps to leader in prot_quant_)
+  PeptideIdentification pep_id;
+  pep_id.setIdentifier("PI_test");
+  pep_id.setRT(100);
+  pep_id.setMZ(100);
+
+  PeptideHit pep_hit;
+  pep_hit.setSequence(AASequence::fromString("AAAK"));
+  pep_hit.setCharge(2);
+  pep_hit.setScore(1.0);
+
+  PeptideEvidence pe;
+  pe.setProteinAccession("ProteinMember");  // References member, not leader
+  pep_hit.addPeptideEvidence(pe);
+
+  pep_id.getHits().push_back(pep_hit);
+  cf.getPeptideIdentifications().push_back(pep_id);
+
+  consensus.push_back(cf);
+
+  ExperimentalDesign ed = ExperimentalDesign::fromConsensusMap(consensus);
+  quantifier.readQuantData(consensus, ed);
+  quantifier.quantifyPeptides();
+  quantifier.quantifyProteins(consensus.getProteinIdentifications()[0]);
+
+  quant = quantifier.getProteinResults();
+
+  // The protein is quantified under "ProteinLeader" (the group leader from getAccession_)
+  // But the current buggy code:
+  //   1. transferPeptideDataToProteins_ stores under "ProteinLeader" key
+  //   2. performIbaqNormalization_ iterates hits and only sees "ProteinMember"
+  //   3. prot_quant_.find("ProteinMember") returns end() - no match!
+  //   4. iBAQ normalization is SILENTLY SKIPPED
+  //
+  // After the fix, the code should properly map ProteinMember -> ProteinLeader
+  // and use ProteinMember's sequence for normalization.
+
+  TEST_EQUAL(quant.count("ProteinLeader"), 1);
+  protein = quant["ProteinLeader"];
+
+  // Expected: 1234.0 / 4 = 308.5 (iBAQ normalized)
+  // Bug: Returns 1234.0 (unnormalized)
+  double expected_ibaq = 1234.0 / 4.0;
+  TEST_REAL_SIMILAR(protein.total_abundances[0], expected_ibaq);
 }
 END_SECTION
 

--- a/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/SageAdapter_1_out.idXML
@@ -43,10 +43,10 @@
 				<UserParam type="string" name="SageAdapter:1:predict_rt" value="false"/>
 				<UserParam type="string" name="SageAdapter:1:wide_window" value="false"/>
 				<UserParam type="string" name="SageAdapter:1:smoothing" value="false"/>
-				<UserParam type="int" name="SageAdapter:1:threads" value="1"/>
 				<UserParam type="string" name="SageAdapter:1:reindex" value="true"/>
 				<UserParam type="string" name="SageAdapter:1:log" value=""/>
 				<UserParam type="int" name="SageAdapter:1:debug" value="0"/>
+				<UserParam type="int" name="SageAdapter:1:threads" value="1"/>
 				<UserParam type="string" name="SageAdapter:1:no_progress" value="false"/>
 				<UserParam type="string" name="SageAdapter:1:force" value="false"/>
 				<UserParam type="string" name="SageAdapter:1:test" value="true"/>

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -613,7 +613,7 @@ protected:
     // Set RAYON_NUM_THREADS environment variable to control Sage's thread usage
     // Only set if threads > 0; if threads == 0, let Rayon auto-detect (use all CPUs)
     std::map<QString, QString> sage_env;
-    if (threads > 1)
+    if (threads > 0)
     {
       sage_env["RAYON_NUM_THREADS"] = String(threads).toQString();
     }

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -492,7 +492,6 @@ protected:
     registerStringOption_("predict_rt",  "<bool>", "false", "Use retention time prediction model as a feature for machine learning scoring. Note: This is incompatible with label-free quantification (LFQ). Default: false", false, false ); 
     registerStringOption_("wide_window", "<bool>", "false", "Enable wide-window/DIA search mode. When enabled, the precursor_tol parameter is ignored and a dynamic precursor tolerance is used. Default: false", false, false);
     registerStringOption_("smoothing", "<bool>", "true", "Whether to smooth the PTM (post-translational modification) mass histogram and pick local maxima. If false, uses raw histogram data. Default: true", false, false);  
-    registerIntOption_("threads", "<int>", 0, "Number of threads to use. 0 (default) = auto-detect and use all available CPUs via Rayon", false, false); 
 
     // register peptide indexing parameter (with defaults for this search engine)
     registerPeptideIndexingParameter_(PeptideIndexing().getParameters());

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -613,7 +613,7 @@ protected:
     // Set RAYON_NUM_THREADS environment variable to control Sage's thread usage
     // Only set if threads > 0; if threads == 0, let Rayon auto-detect (use all CPUs)
     std::map<QString, QString> sage_env;
-    if (threads > 0)
+    if (threads > 1)
     {
       sage_env["RAYON_NUM_THREADS"] = String(threads).toQString();
     }

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -492,7 +492,7 @@ protected:
     registerStringOption_("predict_rt",  "<bool>", "false", "Use retention time prediction model as a feature for machine learning scoring. Note: This is incompatible with label-free quantification (LFQ). Default: false", false, false ); 
     registerStringOption_("wide_window", "<bool>", "false", "Enable wide-window/DIA search mode. When enabled, the precursor_tol parameter is ignored and a dynamic precursor tolerance is used. Default: false", false, false);
     registerStringOption_("smoothing", "<bool>", "true", "Whether to smooth the PTM (post-translational modification) mass histogram and pick local maxima. If false, uses raw histogram data. Default: true", false, false);  
-    registerIntOption_("threads", "<int>", 1, "Amount of threads available to the program", false, false); 
+    registerIntOption_("threads", "<int>", 0, "Number of threads to use. 0 (default) = auto-detect and use all available CPUs via Rayon", false, false); 
 
     // register peptide indexing parameter (with defaults for this search engine)
     registerPeptideIndexingParameter_(PeptideIndexing().getParameters());
@@ -612,8 +612,12 @@ protected:
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
     
     // Set RAYON_NUM_THREADS environment variable to control Sage's thread usage
+    // Only set if threads > 0; if threads == 0, let Rayon auto-detect (use all CPUs)
     std::map<QString, QString> sage_env;
-    sage_env["RAYON_NUM_THREADS"] = String(threads).toQString();
+    if (threads > 0)
+    {
+      sage_env["RAYON_NUM_THREADS"] = String(threads).toQString();
+    }
     
     // Sage execution with the executable and the arguments StringList
     exit_code = runExternalProcess_(sage_executable.toQString(), arguments, "", sage_env);


### PR DESCRIPTION
The root cause was an accession mismatch between prot_quant_ keys and ProteinHit accessions:
- transferPeptideDataToProteins_() populates prot_quant_ using LEADER accessions from getAccession_() + mapAccessionToLeader()
- performIbaqNormalization_() iterated over protein hits directly and looked up hit.getAccession() in prot_quant_
- When protein groups exist, non-leader hits would fail the lookup, silently skipping iBAQ normalization

The fix changes performIbaqNormalization_() to:
1. Build the same accession_to_leader mapping used elsewhere
2. Create a reverse leader_to_members mapping
3. Iterate over prot_quant_ entries (keyed by leaders) instead of hits
4. For each leader, find a sequence from the leader hit or any member

This ensures iBAQ normalization is applied correctly even when:
- Leader accession differs from protein hit accessions
- Only group member hits have sequences
- Complex protein inference produces group structures

Added two test cases that expose the bug:
- iBAQ with indistinguishable protein groups (leader present)
- iBAQ with missing leader protein hit (only members present)

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Improved iBAQ normalization to better handle indistinguishable protein groups and missing sequences
  - Enhanced robustness of protein quantitation with additional sequence validation and warnings

* **Tests**
  - Added tests covering iBAQ behavior with indistinguishable groups and missing leader hits
  - Expanded logging-related tests for level restoration and flush behavior

* **Infrastructure / Packaging**
  - Multi-architecture CI/docker builds and updated CI actions
  - Updated package maintainer and changelog release info

* **Documentation / macOS**
  - Added macOS minimum version and relocatability flags in app bundles
  - Expanded tool and API documentation pages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->