### PR TITLE
do not merge: Fix iBAQ normalization silently skipped for protein groups (issue #8466)

### DIFF
--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -1277,29 +1277,87 @@ namespace OpenMS
 
   void PeptideAndProteinQuant::performIbaqNormalization_(const ProteinIdentification& proteins)
   {
-    EnzymaticDigestion digest{};
-    for (auto & hit : proteins.getHits())
-    {
-      const OpenMS::String & hit_accession = hit.getAccession();
-      const OpenMS::String & hit_sequence = hit.getSequence();
+    // Build mapping from accession to leader (for indistinguishable protein groups)
+    // This is the same mapping used by transferPeptideDataToProteins_ to populate prot_quant_
+    std::map<String, String> accession_to_leader = mapAccessionToLeader(proteins);
 
-      if (prot_quant_.find(hit_accession) != prot_quant_.end())
+    // Build reverse mapping: leader -> list of all accessions in that group
+    // This allows us to find any protein hit that belongs to a leader's group
+    std::map<String, std::vector<String>> leader_to_members;
+    if (!accession_to_leader.empty())
+    {
+      for (const auto& entry : accession_to_leader)
       {
-        if (hit_sequence.empty())
+        leader_to_members[entry.second].push_back(entry.first);
+      }
+    }
+
+    // Build a map from accession to protein hit for quick lookup
+    std::map<String, const ProteinHit*> accession_to_hit;
+    for (const auto& hit : proteins.getHits())
+    {
+      accession_to_hit[hit.getAccession()] = &hit;
+    }
+
+    // Iterate over prot_quant_ entries (which are keyed by leader accessions)
+    // rather than protein hits, to avoid accession mismatch issues (issue #8466)
+    EnzymaticDigestion digest{};
+    std::vector<String> to_erase;  // Collect entries to remove (can't modify during iteration)
+
+    for (auto& prot_entry : prot_quant_)
+    {
+      const String& leader_accession = prot_entry.first;
+      ProteinData& prot_data = prot_entry.second;
+
+      // Find a protein hit with a sequence for this leader accession
+      // First try the leader directly, then try group members
+      String sequence;
+
+      // 1. Try direct lookup of the leader accession
+      auto hit_it = accession_to_hit.find(leader_accession);
+      if (hit_it != accession_to_hit.end() && !hit_it->second->getSequence().empty())
+      {
+        sequence = hit_it->second->getSequence();
+      }
+      // 2. If leader not found or has no sequence, try group members
+      else if (leader_to_members.count(leader_accession))
+      {
+        for (const String& member_acc : leader_to_members.at(leader_accession))
         {
-          prot_quant_.erase(hit_accession);
-          OPENMS_LOG_WARN << "Removed " << hit_accession <<  ", no protein sequence found!" << endl;
-        }
-        else
-        {
-          std::vector<StringView> peptides {};
-          digest.digestUnmodified(StringView(hit_sequence), peptides);
-          for (auto& total_abundance : prot_quant_[hit_accession].total_abundances)
+          auto member_hit_it = accession_to_hit.find(member_acc);
+          if (member_hit_it != accession_to_hit.end() && !member_hit_it->second->getSequence().empty())
           {
-            total_abundance.second /= double(peptides.size());
+            sequence = member_hit_it->second->getSequence();
+            break;  // Use first available sequence
           }
         }
       }
+
+      if (sequence.empty())
+      {
+        to_erase.push_back(leader_accession);
+        OPENMS_LOG_WARN << "Removed " << leader_accession << ", no protein sequence found!" << endl;
+      }
+      else
+      {
+        std::vector<StringView> peptides{};
+        digest.digestUnmodified(StringView(sequence), peptides);
+        if (peptides.empty())
+        {
+          OPENMS_LOG_WARN << "No theoretical peptides for " << leader_accession << ", iBAQ not applied." << endl;
+          continue;
+        }
+        for (auto& total_abundance : prot_data.total_abundances)
+        {
+          total_abundance.second /= static_cast<double>(peptides.size());
+        }
+      }
+    }
+
+    // Remove entries with missing sequences
+    for (const String& acc : to_erase)
+    {
+      prot_quant_.erase(acc);
     }
   }
 }

--- a/src/tests/class_tests/openms/source/PeptideAndProteinQuant_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideAndProteinQuant_test.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>
 #include <OpenMS/METADATA/ExperimentalDesign.h>
+#include <OpenMS/METADATA/PeptideEvidence.h>
 
 
 using namespace OpenMS;
@@ -368,6 +369,196 @@ START_SECTION((const ProteinQuant& getProteinResults()))
   TEST_REAL_SIMILAR(protein.total_abundances[0], 308.5);
   TEST_REAL_SIMILAR(protein.total_abundances[1], 58.5);
   TEST_REAL_SIMILAR(protein.total_abundances[2], 257.5);
+}
+END_SECTION
+
+// iBAQ test with indistinguishable protein groups (regression test for issue 8466)
+START_SECTION((iBAQ with indistinguishable protein groups))
+{
+  PeptideAndProteinQuant quantifier;
+  PeptideAndProteinQuant::ProteinQuant quant;
+  PeptideAndProteinQuant::ProteinData protein;
+
+  Param parameters = quantifier.getDefaults();
+  parameters.setValue("method", "iBAQ");
+  quantifier.setParameters(parameters);
+
+  // Create a ConsensusMap with protein groups
+  ConsensusMap consensus;
+
+  // Set up mapList with one sample
+  consensus.getColumnHeaders()[0].filename = "sample1.mzML";
+  consensus.getColumnHeaders()[0].size = 1;
+  consensus.getColumnHeaders()[0].unique_id = 0;
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("PI_test");
+  prot_id.setPrimaryMSRunPath({"sample1.mzML"});
+
+  // Two protein hits in an indistinguishable group
+  ProteinHit hit_leader;
+  hit_leader.setAccession("ProteinLeader");
+  hit_leader.setSequence("AAAKCCCKEEEKGGG"); // 15 aa, trypsin digests to 4 peptides
+
+  ProteinHit hit_member;
+  hit_member.setAccession("ProteinMember");
+  hit_member.setSequence("AAAKCCCKEEEKGGG"); // Same sequence
+
+  prot_id.getHits().push_back(hit_leader);
+  prot_id.getHits().push_back(hit_member);
+
+  // Create indistinguishable protein group with ProteinLeader as leader
+  ProteinIdentification::ProteinGroup group;
+  group.probability = 0.9;
+  group.accessions = {"ProteinLeader", "ProteinMember"};
+  prot_id.getIndistinguishableProteins().push_back(group);
+
+  consensus.getProteinIdentifications().push_back(prot_id);
+
+  ConsensusFeature cf;
+  cf.setUniqueId(1);
+  cf.setRT(100);
+  cf.setMZ(100);
+  cf.setIntensity(1234.0);  // This will be the raw abundance
+  cf.setCharge(2);
+
+  FeatureHandle fh;
+  fh.setMapIndex(0);
+  fh.setUniqueId(1);
+  fh.setRT(100);
+  fh.setMZ(100);
+  fh.setIntensity(1234.0);
+  fh.setCharge(2);
+  cf.insert(fh);
+
+  // Create peptide identification that references ProteinLeader
+  PeptideIdentification pep_id;
+  pep_id.setIdentifier("PI_test");
+  pep_id.setRT(100);
+  pep_id.setMZ(100);
+
+  PeptideHit pep_hit;
+  pep_hit.setSequence(AASequence::fromString("AAAK"));
+  pep_hit.setCharge(2);
+  pep_hit.setScore(1.0);
+
+  // Reference the leader protein
+  PeptideEvidence pe;
+  pe.setProteinAccession("ProteinLeader");
+  pep_hit.addPeptideEvidence(pe);
+
+  pep_id.getHits().push_back(pep_hit);
+  cf.getPeptideIdentifications().push_back(pep_id);
+
+  consensus.push_back(cf);
+
+  // Run quantification
+  ExperimentalDesign ed = ExperimentalDesign::fromConsensusMap(consensus);
+  quantifier.readQuantData(consensus, ed);
+  quantifier.quantifyPeptides();
+  quantifier.quantifyProteins(consensus.getProteinIdentifications()[0]);
+
+  quant = quantifier.getProteinResults();
+
+  // The protein should be quantified under "ProteinLeader" (the group leader)
+  TEST_EQUAL(quant.count("ProteinLeader"), 1);
+  protein = quant["ProteinLeader"];
+
+  // iBAQ: raw abundance 1234.0 / 4 theoretical peptides = 308.5
+  double expected_ibaq = 1234.0 / 4.0;
+  TEST_REAL_SIMILAR(protein.total_abundances[0], expected_ibaq);
+}
+END_SECTION
+
+// iBAQ test with missing leader protein hit (regression test for issue 8466)
+START_SECTION((iBAQ with missing leader protein hit))
+{
+  PeptideAndProteinQuant quantifier;
+  PeptideAndProteinQuant::ProteinQuant quant;
+  PeptideAndProteinQuant::ProteinData protein;
+
+  Param parameters = quantifier.getDefaults();
+  parameters.setValue("method", "iBAQ");
+  quantifier.setParameters(parameters);
+
+  ConsensusMap consensus;
+
+  consensus.getColumnHeaders()[0].filename = "sample1.mzML";
+  consensus.getColumnHeaders()[0].size = 1;
+  consensus.getColumnHeaders()[0].unique_id = 0;
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("PI_test");
+  prot_id.setPrimaryMSRunPath({"sample1.mzML"});
+
+  // KEY BUG SCENARIO: Only add the member protein hit, NOT the leader!
+  // This can happen in real workflows when protein inference produces
+  // group leaders that are not present as individual protein hits.
+  ProteinHit hit_member;
+  hit_member.setAccession("ProteinMember");
+  hit_member.setSequence("AAAKCCCKEEEKGGG"); // 15 aa, trypsin digests to 4 peptides
+
+  prot_id.getHits().push_back(hit_member);
+
+  // Create indistinguishable protein group with ProteinLeader as leader
+  // But ProteinLeader is NOT in the protein hits!
+  ProteinIdentification::ProteinGroup group;
+  group.probability = 0.9;
+  group.accessions = {"ProteinLeader", "ProteinMember"};  // Leader first
+  prot_id.getIndistinguishableProteins().push_back(group);
+
+  consensus.getProteinIdentifications().push_back(prot_id);
+
+  ConsensusFeature cf;
+  cf.setUniqueId(1);
+  cf.setRT(100);
+  cf.setMZ(100);
+  cf.setIntensity(1234.0);
+  cf.setCharge(2);
+
+  FeatureHandle fh;
+  fh.setMapIndex(0);
+  fh.setUniqueId(1);
+  fh.setRT(100);
+  fh.setMZ(100);
+  fh.setIntensity(1234.0);
+  fh.setCharge(2);
+  cf.insert(fh);
+
+  // Peptide references the member protein (which maps to leader in prot_quant_)
+  PeptideIdentification pep_id;
+  pep_id.setIdentifier("PI_test");
+  pep_id.setRT(100);
+  pep_id.setMZ(100);
+
+  PeptideHit pep_hit;
+  pep_hit.setSequence(AASequence::fromString("AAAK"));
+  pep_hit.setCharge(2);
+  pep_hit.setScore(1.0);
+
+  PeptideEvidence pe;
+  pe.setProteinAccession("ProteinMember");  // References member, not leader
+  pep_hit.addPeptideEvidence(pe);
+
+  pep_id.getHits().push_back(pep_hit);
+  cf.getPeptideIdentifications().push_back(pep_id);
+
+  consensus.push_back(cf);
+
+  ExperimentalDesign ed = ExperimentalDesign::fromConsensusMap(consensus);
+  quantifier.readQuantData(consensus, ed);
+  quantifier.quantifyPeptides();
+  quantifier.quantifyProteins(consensus.getProteinIdentifications()[0]);
+
+  quant = quantifier.getProteinResults();
+
+  // Quantified under group leader even though only member hit exists
+  TEST_EQUAL(quant.count("ProteinLeader"), 1);
+  protein = quant["ProteinLeader"];
+
+  // iBAQ: raw abundance 1234.0 / 4 theoretical peptides = 308.5
+  double expected_ibaq = 1234.0 / 4.0;
+  TEST_REAL_SIMILAR(protein.total_abundances[0], expected_ibaq);
 }
 END_SECTION
 


### PR DESCRIPTION
The root cause could be an accession mismatch between prot_quant_ keys and ProteinHit accessions:
- transferPeptideDataToProteins_() populates prot_quant_ using LEADER accessions from getAccession_() + mapAccessionToLeader()
- performIbaqNormalization_() iterated over protein hits directly and looked up hit.getAccession() in prot_quant_
- When protein groups exist, non-leader hits would fail the lookup, silently skipping iBAQ normalization

The fix changes performIbaqNormalization_() to:
1. Build the same accession_to_leader mapping used elsewhere
2. Create a reverse leader_to_members mapping
3. Iterate over prot_quant_ entries (keyed by leaders) instead of hits
4. For each leader, find a sequence from the leader hit or any member

This ensures iBAQ normalization is applied correctly even when:
- Leader accession differs from protein hit accessions
- Only group member hits have sequences
- Complex protein inference produces group structures

Added two test cases that expose the bug:
- iBAQ with indistinguishable protein groups (leader present)
- iBAQ with missing leader protein hit (only members present)

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).
