### PR TITLE
Fix getAAFrequencies loop bug in pyOpenMS AASequence addon

### DIFF
--- a/src/pyOpenMS/addons/AASequence.pyx
+++ b/src/pyOpenMS/addons/AASequence.pyx
@@ -1,16 +1,22 @@
 from libcpp.map cimport map as libcpp_map
+from cython.operator cimport dereference as deref, preincrement as inc
 
 
     def getAAFrequencies(self, dict mmap):
         """
         getAAFrequencies(self: AASequence, mmap: dict) -> None
-        
+
         Get amino acid frequencies and populate the provided dictionary.
         """
         cdef libcpp_map[_String, size_t] c_mmap
         self.inst.get().getAAFrequencies(c_mmap)
-        for k,v in mmap.iteritems():
-            v = c_mmap[ _String(<char *>k) ]
+        # Clear the dictionary to match C++ behavior
+        mmap.clear()
+        # Copy results from C++ map to Python dict
+        cdef libcpp_map[_String, size_t].iterator it = c_mmap.begin()
+        while it != c_mmap.end():
+            mmap[<bytes>deref(it).first.c_str()] = deref(it).second
+            inc(it)
 
     def __iter__(self):
         """

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -214,6 +214,7 @@ def testAASequence():
      AASequence.setNTerminalModification
      AASequence.toString
      AASequence.toUnmodifiedString
+     AASequence.getAAFrequencies
     """
     aas = pyopenms.AASequence()
 
@@ -299,6 +300,20 @@ def testAASequence():
     aas_unmod = pyopenms.AASequence.fromString("PEPTIDE")
     repr_unmod = repr(aas_unmod)
     assert "modified=True" not in repr_unmod
+
+    # Test getAAFrequencies - matching C++ test case
+    aas_freq = pyopenms.AASequence.fromString("THREEAAAWITHYYY")
+    freq_table = {}
+    aas_freq.getAAFrequencies(freq_table)
+    assert freq_table[b"T"] == 2
+    assert freq_table[b"H"] == 2
+    assert freq_table[b"R"] == 1
+    assert freq_table[b"E"] == 2
+    assert freq_table[b"A"] == 3
+    assert freq_table[b"W"] == 1
+    assert freq_table[b"I"] == 1
+    assert freq_table[b"Y"] == 3
+    assert len(freq_table) == 8
 
 
 @report


### PR DESCRIPTION
The previous implementation had a bug where `v = c_mmap[...]` only reassigned the local variable instead of updating the dictionary. The dict `mmap` was never modified.

Fix by properly iterating over the C++ map and copying key-value pairs to the Python dict, matching the C++ behavior (clearing the dict first then populating it with frequencies).

Also add Python unit test mirroring the C++ test case.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * getAAFrequencies now reliably clears and completely repopulates the returned frequency mapping so Python-visible amino acid counts exactly match the underlying data.

* **Tests**
  * Added unit test coverage for AASequence.getAAFrequencies, validating correct counts across multiple amino acids and protecting against regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->