### PR TITLE
add __len__ append extend to some classes

### DIFF
--- a/src/pyOpenMS/addons/ConsensusMap.pyx
+++ b/src/pyOpenMS/addons/ConsensusMap.pyx
@@ -40,6 +40,57 @@ from UniqueIdInterface cimport setUniqueId as _setUniqueId
         
         return f"ConsensusMap({', '.join(parts)})"
 
+    def __len__(self):
+        """
+        __len__(self: ConsensusMap) -> int
+
+        Return the number of consensus features in the map.
+
+        Enables use of Python's built-in len() function.
+
+        Returns:
+            int: The number of consensus features in this map.
+        """
+        return self.inst.get().size()
+
+    def append(self, ConsensusFeature item):
+        """
+        append(self: ConsensusMap, item: ConsensusFeature) -> None
+
+        Add a single consensus feature to the end of the map.
+
+        This method provides a Pythonic interface equivalent to push_back().
+
+        Args:
+            item: A single ConsensusFeature object to append.
+        """
+        self.inst.get().push_back(deref(item.inst.get()))
+
+    def extend(self, items):
+        """
+        extend(self: ConsensusMap, items: Iterable[ConsensusFeature]) -> None
+
+        Add multiple consensus features to the end of the map.
+
+        Args:
+            items: Can be:
+                - A list/iterable of ConsensusFeature objects
+                - Another ConsensusMap object
+
+        Raises:
+            TypeError: If items is not iterable or another ConsensusMap.
+        """
+        if hasattr(items, '__iter__') and not hasattr(items, 'inst'):
+            # Handle regular iterables (list, tuple, etc.)
+            for consensus_feature in items:
+                self.inst.get().push_back(deref((<ConsensusFeature>consensus_feature).inst.get()))
+        elif hasattr(items, 'inst') and hasattr(items, '__len__'):
+            # Handle another ConsensusMap
+            for consensus_feature in items:
+                self.inst.get().push_back(deref((<ConsensusFeature>consensus_feature).inst.get()))
+        else:
+            raise TypeError("extend() argument must be iterable or another ConsensusMap")
+
     def getColumnHeaders(self):
         """
         getColumnHeaders(self: ConsensusMap) -> Dict[int, ColumnHeader]

--- a/src/pyOpenMS/addons/FeatureMap.pyx
+++ b/src/pyOpenMS/addons/FeatureMap.pyx
@@ -29,3 +29,54 @@ from UniqueIdInterface cimport setUniqueId as _setUniqueId
             parts.append(f"unassigned_peptide_ids={len(unassigned_peptide_ids)}")
         
         return f"FeatureMap({', '.join(parts)})"
+
+    def __len__(self):
+        """
+        __len__(self: FeatureMap) -> int
+
+        Return the number of features in the map.
+
+        Enables use of Python's built-in len() function.
+
+        Returns:
+            int: The number of features in this map.
+        """
+        return self.inst.get().size()
+
+    def append(self, Feature item):
+        """
+        append(self: FeatureMap, item: Feature) -> None
+
+        Add a single feature to the end of the map.
+
+        This method provides a Pythonic interface equivalent to push_back().
+
+        Args:
+            item: A single Feature object to append.
+        """
+        self.inst.get().push_back(deref(item.inst.get()))
+
+    def extend(self, items):
+        """
+        extend(self: FeatureMap, items: Iterable[Feature]) -> None
+
+        Add multiple features to the end of the map.
+
+        Args:
+            items: Can be:
+                - A list/iterable of Feature objects
+                - Another FeatureMap object
+
+        Raises:
+            TypeError: If items is not iterable or another FeatureMap.
+        """
+        if hasattr(items, '__iter__') and not hasattr(items, 'inst'):
+            # Handle regular iterables (list, tuple, etc.)
+            for feature in items:
+                self.inst.get().push_back(deref((<Feature>feature).inst.get()))
+        elif hasattr(items, 'inst') and hasattr(items, '__len__'):
+            # Handle another FeatureMap
+            for feature in items:
+                self.inst.get().push_back(deref((<Feature>feature).inst.get()))
+        else:
+            raise TypeError("extend() argument must be iterable or another FeatureMap")

--- a/src/pyOpenMS/addons/PeptideIdentificationList.pyx
+++ b/src/pyOpenMS/addons/PeptideIdentificationList.pyx
@@ -2,8 +2,55 @@
 
 
     def __len__(self):
-        """Return the number of peptide identifications in the list."""
+        """
+        __len__(self: PeptideIdentificationList) -> int
+
+        Return the number of peptide identifications in the list.
+
+        Enables use of Python's built-in len() function.
+
+        Returns:
+            int: The number of peptide identifications in this list.
+        """
         return self.size()
+
+    def append(self, PeptideIdentification item):
+        """
+        append(self: PeptideIdentificationList, item: PeptideIdentification) -> None
+
+        Add a single peptide identification to the end of the list.
+
+        This method provides a Pythonic interface equivalent to push_back().
+
+        Args:
+            item: A single PeptideIdentification object to append.
+        """
+        self.push_back(item)
+
+    def extend(self, items):
+        """
+        extend(self: PeptideIdentificationList, items: Iterable[PeptideIdentification]) -> None
+
+        Add multiple peptide identifications to the end of the list.
+
+        Args:
+            items: Can be:
+                - A list/iterable of PeptideIdentification objects
+                - Another PeptideIdentificationList object
+
+        Raises:
+            TypeError: If items is not iterable or another PeptideIdentificationList.
+        """
+        if hasattr(items, '__iter__') and not hasattr(items, 'inst'):
+            # Handle regular iterables (list, tuple, etc.)
+            for peptide_identification in items:
+                self.push_back(peptide_identification)
+        elif hasattr(items, 'inst') and hasattr(items, '__len__'):
+            # Handle another PeptideIdentificationList
+            for peptide_identification in items:
+                self.push_back(peptide_identification)
+        else:
+            raise TypeError("extend() argument must be iterable or another PeptideIdentificationList")
 
     def __str__(self):
         """

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -911,11 +911,14 @@ def testConsensusMap():
      ConsensusMap.__init__
      ConsensusMap.__iter__
      ConsensusMap.__le__
+     ConsensusMap.__len__
      ConsensusMap.__lt__
      ConsensusMap.__ne__
+     ConsensusMap.append
      ConsensusMap.clear
      ConsensusMap.clearUniqueId
      ConsensusMap.ensureUniqueId
+     ConsensusMap.extend
      ConsensusMap.getDataProcessing
      ConsensusMap.getColumnHeaders
      ConsensusMap.getProteinIdentifications
@@ -1016,6 +1019,49 @@ def testConsensusMap():
     repr_str = repr(cm_repr)
     assert "ConsensusMap(" in repr_str
     assert "num_consensus_features=" in repr_str
+
+    # Test __len__, append, and extend methods
+    cm_len = pyopenms.ConsensusMap()
+    assert len(cm_len) == 0
+    assert len(cm_len) == cm_len.size()
+
+    cf_test1 = pyopenms.ConsensusFeature()
+    cf_test1.setRT(100.0)
+    cf_test1.setMZ(500.0)
+
+    cf_test2 = pyopenms.ConsensusFeature()
+    cf_test2.setRT(200.0)
+    cf_test2.setMZ(600.0)
+
+    cf_test3 = pyopenms.ConsensusFeature()
+    cf_test3.setRT(300.0)
+    cf_test3.setMZ(700.0)
+
+    # Test append (single item)
+    cm_len.append(cf_test1)
+    assert len(cm_len) == 1
+    assert len(cm_len) == cm_len.size()
+
+    # Test extend with list
+    cm_len.extend([cf_test2, cf_test3])
+    assert len(cm_len) == 3
+    assert len(cm_len) == cm_len.size()
+
+    # Verify the features were added correctly
+    assert cm_len[0].getRT() == 100.0
+    assert cm_len[1].getRT() == 200.0
+    assert cm_len[2].getRT() == 300.0
+
+    # Test extend with another ConsensusMap
+    cm_source = pyopenms.ConsensusMap()
+    cf_test4 = pyopenms.ConsensusFeature()
+    cf_test4.setRT(400.0)
+    cf_test4.setMZ(800.0)
+    cm_source.push_back(cf_test4)
+
+    cm_len.extend(cm_source)
+    assert len(cm_len) == 4
+    assert cm_len[3].getRT() == 400.0
 
 @report
 def testConsensusXMLFile():
@@ -1987,9 +2033,12 @@ def testFeatureMap():
      FeatureMap.__radd__
      FeatureMap.__getitem__
      FeatureMap.__iter__
+     FeatureMap.__len__
+     FeatureMap.append
      FeatureMap.clear
      FeatureMap.clearUniqueId
      FeatureMap.ensureUniqueId
+     FeatureMap.extend
      FeatureMap.getDataProcessing
      FeatureMap.getProteinIdentifications
      FeatureMap.getUnassignedPeptideIdentifications
@@ -2112,6 +2161,49 @@ def testFeatureMap():
     repr_str = repr(fm_repr)
     assert "FeatureMap(" in repr_str
     assert "num_features=" in repr_str
+
+    # Test __len__, append, and extend methods
+    fm_len = pyopenms.FeatureMap()
+    assert len(fm_len) == 0
+    assert len(fm_len) == fm_len.size()
+
+    f_test1 = pyopenms.Feature()
+    f_test1.setRT(100.0)
+    f_test1.setMZ(500.0)
+
+    f_test2 = pyopenms.Feature()
+    f_test2.setRT(200.0)
+    f_test2.setMZ(600.0)
+
+    f_test3 = pyopenms.Feature()
+    f_test3.setRT(300.0)
+    f_test3.setMZ(700.0)
+
+    # Test append (single item)
+    fm_len.append(f_test1)
+    assert len(fm_len) == 1
+    assert len(fm_len) == fm_len.size()
+
+    # Test extend with list
+    fm_len.extend([f_test2, f_test3])
+    assert len(fm_len) == 3
+    assert len(fm_len) == fm_len.size()
+
+    # Verify the features were added correctly
+    assert fm_len[0].getRT() == 100.0
+    assert fm_len[1].getRT() == 200.0
+    assert fm_len[2].getRT() == 300.0
+
+    # Test extend with another FeatureMap
+    fm_source = pyopenms.FeatureMap()
+    f_test4 = pyopenms.Feature()
+    f_test4.setRT(400.0)
+    f_test4.setMZ(800.0)
+    fm_source.push_back(f_test4)
+
+    fm_len.extend(fm_source)
+    assert len(fm_len) == 4
+    assert fm_len[3].getRT() == 400.0
 
 
 @report
@@ -5166,12 +5258,15 @@ def testPeptideIdentificationList():
     """
     @tests: PeptideIdentificationList
      PeptideIdentificationList.__init__
-     PeptideIdentificationList.size
-     PeptideIdentificationList.empty
-     PeptideIdentificationList.clear
-     PeptideIdentificationList.push_back
      PeptideIdentificationList.__getitem__
      PeptideIdentificationList.__iter__
+     PeptideIdentificationList.__len__
+     PeptideIdentificationList.append
+     PeptideIdentificationList.clear
+     PeptideIdentificationList.empty
+     PeptideIdentificationList.extend
+     PeptideIdentificationList.push_back
+     PeptideIdentificationList.size
     """
     import pyopenms
 
@@ -5230,6 +5325,57 @@ def testPeptideIdentificationList():
     pil.clear()
     assert pil.empty()
     assert pil.size() == 0
+
+    # Test __len__, append, and extend methods
+    pil_len = pyopenms.PeptideIdentificationList()
+    assert len(pil_len) == 0
+    assert len(pil_len) == pil_len.size()
+
+    pi_test1 = pyopenms.PeptideIdentification()
+    pi_test1.setRT(100.0)
+    pi_test1.setMZ(500.0)
+    pi_test1.setIdentifier("test_append_1")
+
+    pi_test2 = pyopenms.PeptideIdentification()
+    pi_test2.setRT(200.0)
+    pi_test2.setMZ(600.0)
+    pi_test2.setIdentifier("test_append_2")
+
+    pi_test3 = pyopenms.PeptideIdentification()
+    pi_test3.setRT(300.0)
+    pi_test3.setMZ(700.0)
+    pi_test3.setIdentifier("test_append_3")
+
+    # Test append (single item)
+    pil_len.append(pi_test1)
+    assert len(pil_len) == 1
+    assert len(pil_len) == pil_len.size()
+
+    # Test extend with list
+    pil_len.extend([pi_test2, pi_test3])
+    assert len(pil_len) == 3
+    assert len(pil_len) == pil_len.size()
+
+    # Verify the peptide identifications were added correctly
+    assert pil_len[0].getRT() == 100.0
+    assert pil_len[0].getIdentifier() == "test_append_1"
+    assert pil_len[1].getRT() == 200.0
+    assert pil_len[1].getIdentifier() == "test_append_2"
+    assert pil_len[2].getRT() == 300.0
+    assert pil_len[2].getIdentifier() == "test_append_3"
+
+    # Test extend with another PeptideIdentificationList
+    pil_source = pyopenms.PeptideIdentificationList()
+    pi_test4 = pyopenms.PeptideIdentification()
+    pi_test4.setRT(400.0)
+    pi_test4.setMZ(800.0)
+    pi_test4.setIdentifier("test_append_4")
+    pil_source.push_back(pi_test4)
+
+    pil_len.extend(pil_source)
+    assert len(pil_len) == 4
+    assert pil_len[3].getRT() == 400.0
+    assert pil_len[3].getIdentifier() == "test_append_4"
 
 
 @report


### PR DESCRIPTION
…_ support

NOTE: not sure yet if this is the right way to do it. e.g. an append function exists also in the maps on the c++ side



Implements feature request #8124 by adding Pythonic methods to:
- ConsensusMap: __len__, append, extend
- FeatureMap: __len__, append, extend
- PeptideIdentificationList: append, extend (already had __len__)

These methods provide a more Pythonic interface:
- __len__() enables use of built-in len() function
- append() adds single items (equivalent to push_back())
- extend() adds multiple items from iterables or other map objects

Includes comprehensive unit tests for all new methods.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ConsensusMap, FeatureMap, and PeptideIdentificationList now support standard Python collection operations: `len()` for item count, `append()` to add single items, and `extend()` to add multiple items or merge from another container.

* **Tests**
  * Added comprehensive test coverage validating the new collection methods and their behavior across all three classes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->