### PR TITLE
Check the return value of configure so that we stop on configure errors

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -274,9 +274,6 @@ jobs:
           # WARNING: Don't add any dependency install commands here.
           # Instead edit the following script:
           bash OpenMS/tools/ci/deps-ubuntu.sh
-          if [[ "${{ steps.set-vars.outputs.pkg_type }}" == "deb" ]]; then
-            bash OpenMS/tools/ci/deps-ubuntu-deb.sh
-          fi
           # Install libomp for clang compiler (needed for OpenMP support)
           # Use version-specific package matching the clang version
           if [[ "${{ matrix.compiler }}" == clang* ]]; then

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -579,11 +579,6 @@ jobs:
           "apple@openms.de" \
           "APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD" \
           "$TEAM_ID" \
-e.sh \
-          "$PKG_FILE" \
-          "de.openms" \
-          "apple@openms.de" \
-          "APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD" \
           "$GITHUB_WORKSPACE/OpenMS/bld/"
 
         echo "=== Notarization complete ==="

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -274,6 +274,9 @@ jobs:
           # WARNING: Don't add any dependency install commands here.
           # Instead edit the following script:
           bash OpenMS/tools/ci/deps-ubuntu.sh
+          if [[ "${{ steps.set-vars.outputs.pkg_type }}" == "deb" ]]; then
+            bash OpenMS/tools/ci/deps-ubuntu-deb.sh
+          fi
           # Install libomp for clang compiler (needed for OpenMP support)
           # Use version-specific package matching the clang version
           if [[ "${{ matrix.compiler }}" == clang* ]]; then
@@ -298,6 +301,8 @@ jobs:
             curl --no-progress-meter -L -o NSIS.tar.gz https://github.com/OpenMS/NSIS/raw/main/NSIS.tar.gz
             ## overwrite existing NSIS (which has only 1k-string support)
             7z x -so NSIS.tar.gz | 7z x -si -ttar -aoa -o"C:/Program Files (x86)/NSIS/"
+            # Ensure makensis.exe is discoverable during CMake configuration
+            echo "C:\Program Files (x86)\NSIS" >> $GITHUB_PATH
           fi
 
           echo "cmake_prefix=" >>"$GITHUB_OUTPUT"
@@ -358,11 +363,7 @@ jobs:
           git submodule update --init THIRDPARTY
           cd ..
           # add third-party binaries to PATH
-          # use flat THIRDPARTY structure
-          THIRDPARTY_DIR="OpenMS/THIRDPARTY"
-          mkdir -p _thirdparty
-          # Copy the correct architecture
-          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/
+          # use flat          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/
           # Copy architecture independent tools
           cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
           # add third-party binaries to PATH
@@ -578,6 +579,11 @@ jobs:
           "apple@openms.de" \
           "APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD" \
           "$TEAM_ID" \
+e.sh \
+          "$PKG_FILE" \
+          "de.openms" \
+          "apple@openms.de" \
+          "APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD" \
           "$GITHUB_WORKSPACE/OpenMS/bld/"
 
         echo "=== Notarization complete ==="

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -363,7 +363,11 @@ jobs:
           git submodule update --init THIRDPARTY
           cd ..
           # add third-party binaries to PATH
-          # use flat          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/
+          # use flat THIRDPARTY structure
+          THIRDPARTY_DIR="OpenMS/THIRDPARTY"
+          mkdir -p _thirdparty
+          # Copy the correct architecture
+          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/
           # Copy architecture independent tools
           cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
           # add third-party binaries to PATH

--- a/tools/ci/cipackage.cmake
+++ b/tools/ci/cipackage.cmake
@@ -36,6 +36,12 @@ ctest_start(Nightly GROUP Package)
 # we assume the configuration is correct for this. So please no KNIME, PYOPENMS, STYLE or COVERAGE.
 
 ctest_configure(OPTIONS "${CONFIGURE_OPTIONS}" RETURN_VALUE _reconfig_package_ret_val)
+
+# Check if configuration failed (e.g., due to FATAL_ERROR in package scripts)
+if(NOT _reconfig_package_ret_val EQUAL 0)
+  message(FATAL_ERROR "CMake configuration for packaging failed with return code: ${_reconfig_package_ret_val}")
+endif()
+
 ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" TARGET "dist" NUMBER_ERRORS _build_errors)
 ctest_submit(PARTS Build CAPTURE_CMAKE_ERROR _submit_result)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Packaging now aborts immediately on configuration errors to prevent incomplete artifacts.
  * CI pipeline updates: ensure Windows installer tool is added to PATH so the installer is discoverable during runs; other CI dependency and staging adjustments remain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->