### PR TITLE
Use unsigned channel identifiers in peptide quantification

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h
@@ -38,7 +38,7 @@ public:
     struct PeptideData
     {
       /// mapping: fraction -> filename -> charge -> channel/label -> abundance
-      std::map<Int, std::map<String, std::map<Int, std::map<Int, double>>>> abundances;
+      std::map<Int, std::map<String, std::map<Int, std::map<UInt, double>>>> abundances;
 
       /// mapping: fraction -> filename -> charge -> abundance
       std::map<Int, std::map<String, std::map<Int, UInt64>>> psm_counts;
@@ -71,7 +71,7 @@ public:
       std::map<String, SampleAbundances> peptide_psm_counts;
 
       /// mapping: filename -> channel/label -> abundance
-      std::map<String, std::map<Int, double>> channel_level_abundances;
+      std::map<String, std::map<UInt, double>> channel_level_abundances;
 
       /// mapping: filename -> PSM counts
       std::map<String, UInt64> file_level_psm_counts;
@@ -222,13 +222,14 @@ private:
          @p fraction, use 0 for first fraction (or if no fractionation was performed)
          @p filename, the base filename (without path/extension) from which the feature originates
          @p channel_or_label, the channel/label identifier (e.g., TMT channel, typically 1 for LFQ)
+         Channel identifiers originate from consensus map headers/experimental designs and are therefore non-negative.
          If @p hit is empty ("ambiguous/no annotation"), nothing is stored.
     */
     void quantifyFeature_(const FeatureHandle& feature,
       size_t fraction,
       const String& filename,
       const PeptideHit& hit,
-      Int channel_or_label);
+      UInt channel_or_label);
 
     /**
      *   @brief Determine fraction, filename, charge state, and channel of a peptide with the highest
@@ -238,8 +239,8 @@ private:
      *   @return true if at least one abundance was found, false otherwise
      */
     bool getBest_(
-      const std::map<Int, std::map<String, std::map<Int, std::map<Int, double>>>> & peptide_abundances,
-      std::tuple<size_t, String, size_t, Int> & best);
+      const std::map<Int, std::map<String, std::map<Int, std::map<UInt, double>>>> & peptide_abundances,
+      std::tuple<size_t, String, size_t, UInt> & best);
 
     /**
          @brief Order keys (charges/peptides for peptide/protein quantification) according to how many samples they allow to quantify, breaking ties by total abundance.
@@ -381,7 +382,7 @@ private:
          @return The sample ID corresponding to the filename and channel
     */
     size_t getSampleIDFromFilenameAndChannel_(const String& filename,
-                                           Int channel_or_label,
+                                           UInt channel_or_label,
                                            const ExperimentalDesign& ed) const;
 
     /// Clear all data when parameters are set

--- a/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
                                                 const size_t fraction,
                                                 const String& filename,
                                                 const PeptideHit& hit,
-                                                Int channel_or_label)
+                                                UInt channel_or_label)
   {
     // return if annotation for the feature is ambiguous or missing
     if (hit == PeptideHit()) { return; }
@@ -129,7 +129,7 @@ namespace OpenMS
       feature.getIntensity(); // new map element is initialized with 0
   }
 
-  bool PeptideAndProteinQuant::getBest_(const std::map<Int, std::map<String, std::map<Int, std::map<Int, double>>>>& peptide_abundances, std::tuple<size_t, String, size_t, Int>& best)
+  bool PeptideAndProteinQuant::getBest_(const std::map<Int, std::map<String, std::map<Int, std::map<UInt, double>>>>& peptide_abundances, std::tuple<size_t, String, size_t, UInt>& best)
   {
     size_t best_n_quant(0);
     double best_abundance(0);
@@ -146,7 +146,7 @@ namespace OpenMS
             const Int & fraction = fa.first;
             const String & filename = fna.first;
             const Int & charge = ca.first;
-            const Int & channel = cha.first;
+            const UInt & channel = cha.first;
 
             double current_abundance = cha.second;
 
@@ -174,7 +174,7 @@ namespace OpenMS
   }
 
   size_t PeptideAndProteinQuant::getSampleIDFromFilenameAndChannel_(const String& filename,
-                                                                 Int channel_or_label,
+                                                                 UInt channel_or_label,
                                                                  const ExperimentalDesign& ed) const
   {
     // Map filename and label to sample using experimental design
@@ -265,7 +265,7 @@ namespace OpenMS
 
         // determine which fraction, filename, charge state, and channel yields the maximum abundance
         // (break ties by total abundance)
-        std::tuple<size_t, String, size_t, Int> best_combination;
+        std::tuple<size_t, String, size_t, UInt> best_combination;
 
         // return false: only identified, not quantified
         if (!getBest_(pep_q.second.abundances, best_combination))
@@ -277,7 +277,7 @@ namespace OpenMS
         size_t best_fraction = std::get<0>(best_combination);
         String best_filename = std::get<1>(best_combination);
         size_t best_charge = std::get<2>(best_combination);
-        Int best_channel = std::get<3>(best_combination);
+        UInt best_channel = std::get<3>(best_combination);
         
         double abundance = pep_q.second.abundances[best_fraction][best_filename][best_charge][best_channel];
         size_t sample_id = getSampleIDFromFilenameAndChannel_(best_filename, best_channel, experimental_design_);
@@ -294,7 +294,7 @@ namespace OpenMS
               for (auto & cha : ca.second) // for all channels
               {
                 const String & filename = fna.first;
-                const Int & channel = cha.first;
+                const UInt & channel = cha.first;
                 const double & abundance = cha.second;
                 
                 // Map (filename, channel) to sample using ExperimentalDesign
@@ -398,7 +398,7 @@ namespace OpenMS
             for (auto & cha : ca.second) // for all channels
             {
               const String & filename = fna.first;
-              const Int & channel = cha.first;
+              const UInt & channel = cha.first;
               size_t sample_id = getSampleIDFromFilenameAndChannel_(filename, channel, experimental_design_);
               cha.second *= scale_factors[sample_id];
             }
@@ -1189,7 +1189,7 @@ namespace OpenMS
     ProteinData& pd = prot_it->second;
 
     // organize detailed abundances by (fraction, filename, channel) combinations
-    map<tuple<Int, String, Int>, DoubleList> channel_level_abundances_for_selected_peptides;
+    map<tuple<Int, String, UInt>, DoubleList> channel_level_abundances_for_selected_peptides;
     
     // collect detailed abundances from selected peptides
     for (const auto& pep : selected_peptides)    // for all selected peptides
@@ -1239,7 +1239,7 @@ namespace OpenMS
     {
       const auto& selected_peptide = detailed_ab.first;
       String filename = get<1>(selected_peptide);
-      Int channel = get<2>(selected_peptide);
+      UInt channel = get<2>(selected_peptide);
       
       DoubleList& all_abundances = detailed_ab.second;
       


### PR DESCRIPTION
## Summary
- store channel identifiers as unsigned values in peptide/protein quantification data structures
- align helper functions and best-combination logic to use unsigned channel IDs and document non-negative expectation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943cc94a9e883289c0f478da329b6d8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated channel identifier types in the quantification module for improved type safety and correctness. Functions and data structures now use unsigned integer types for channel/label identifiers, providing stricter semantic guarantees and preventing invalid negative channel values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->