### PR TITLE
Add id_merge_index to peptide identification in IsobaricWorkflow 

### DIFF
--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -34,6 +34,7 @@
 #include <OpenMS/FORMAT/MzTabFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <string>
 #include <vector>
 
@@ -858,6 +859,65 @@ protected:
     String out_mzTab = getStringOption_("out_mzTab");
     if (! out_mzTab.empty()) 
     {
+      // Fix for MzTab export: if multiple files are present but no id_merge_index,
+      // add id_merge_index to peptide identifications
+      auto& protein_id = cmap.getProteinIdentifications()[0];
+      StringList file_paths;
+      protein_id.getPrimaryMSRunPath(file_paths);
+
+      if (file_paths.size() > 1)
+      {
+        OPENMS_LOG_INFO << "Multiple files detected in ProteinIdentification (" << file_paths.size()
+                        << " files). Adding id_merge_index to peptide identifications..." << std::endl;
+
+        // Create a map from filename to index
+        std::map<String, Size> file_to_index;
+        for (Size i = 0; i < file_paths.size(); ++i)
+        {
+          file_to_index[file_paths[i]] = i;
+        }
+
+        // Add id_merge_index to each peptide identification based on the column header filename
+        const auto& column_headers = cmap.getColumnHeaders();
+
+        for (auto& cf : cmap)
+        {
+          for (auto& pid : cf.getPeptideIdentifications())
+          {
+            // Find the filename from the first FeatureHandle's map index
+            Size map_index = 0; // default to first map
+            if (! cf.empty()) { map_index = cf.begin()->getMapIndex(); }
+
+            // Get filename from column headers using map index
+            auto col_it = column_headers.find(map_index);
+            if (col_it != column_headers.end())
+            {
+              String filename = col_it->second.filename;
+              auto it = file_to_index.find(filename);
+              if (it != file_to_index.end()) { pid.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, it->second); }
+              else
+              {
+                OPENMS_LOG_WARN << "Warning: Could not find file index for " << filename << std::endl;
+                pid.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 0); // fallback to first file
+              }
+            }
+            else
+            {
+              OPENMS_LOG_WARN << "Warning: Could not find column header for map index " << map_index << std::endl;
+              pid.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 0); // fallback to first file
+            }
+          }
+        }
+
+        // Also handle unassigned peptide identifications if any
+        for (auto& pid : cmap.getUnassignedPeptideIdentifications())
+        {
+          pid.setMetaValue(Constants::UserParam::ID_MERGE_INDEX, 0); // fallback to first file
+        }
+
+        OPENMS_LOG_INFO << "Added id_merge_index to peptide identifications." << std::endl;
+      }
+
       const bool report_unidentified_features(false);
       const bool report_unmapped(true);
       const bool report_subfeatures(false);


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->
When I tested the new TMT workflow in quantms, I encountered the following error in IsobaricWorkflow when there were multiple paired mzML and idXML files:

> Error: Unexpected internal error (Multiple files in a run, but no id_merge_index in PeptideIdentification found.)

In addition, the exported mzTab file was incomplete, containing only the protein section while missing the peptide and PSM sections.
Therefore, I attempted to add the id_merge_index, but I am not sure if this is the correct way to set id_merge_index.
## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mzTab export to correctly populate metadata for peptide identifications when processing multiple input files, ensuring accurate source file tracking and indexing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->