### PR TITLE
Add security patterns to .gitignore to prevent credential leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,133 @@ vcpkg_installed
 build-release/*
 build-debug/*
 doc/*
+
+# Security - Credentials, tokens, and secrets
+.env
+.env.*
+.env.local
+.env.*.local
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+*.der
+!*.crt.example
+!*.key.example
+credentials.json
+credentials.yaml
+credentials.yml
+secrets.json
+secrets.yaml
+secrets.yml
+secrets.toml
+**/secrets/
+**/credentials/
+.secrets
+.credentials
+*.secret
+*.secrets
+
+# AWS
+.aws/
+aws_credentials
+.boto
+
+# SSH keys
+id_rsa
+id_rsa.pub
+id_dsa
+id_dsa.pub
+id_ecdsa
+id_ecdsa.pub
+id_ed25519
+id_ed25519.pub
+*.ppk
+
+# API tokens and keys
+.npmrc
+.pypirc
+.netrc
+.htpasswd
+.htaccess
+*.token
+api_key*
+apikey*
+auth.json
+auth.yaml
+auth.yml
+
+# Docker secrets
+docker-compose.override.yml
+docker-compose.*.yml
+!docker-compose.example.yml
+
+# Kubernetes
+kubeconfig
+*.kubeconfig
+kube/config
+
+# Database files with potential credentials
+*.sqlite
+*.sqlite3
+*.db
+!test*.db
+!*test.db
+
+# OAuth
+oauth_token*
+oauth-token*
+client_secret*
+client-secret*
+
+# GPG
+*.gpg
+secring.*
+pubring.*
+trustdb.*
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform/
+
+# Ansible
+*.vault
+vault.yml
+vault.yaml
+group_vars/*/vault*
+host_vars/*/vault*
+
+# IDE credential storage
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+
+# Shell history (may contain credentials)
+.bash_history
+.zsh_history
+.sh_history
+
+# Local configuration that may contain secrets
+config.local.*
+settings.local.*
+*.local.json
+*.local.yaml
+*.local.yml
+*.local.toml
+
+# Jupyter notebooks checkpoints (may contain credentials in outputs)
+.ipynb_checkpoints/
+
+# GitHub tokens
+.github_token
+github_token*
+
+# Claude/AI tokens
+.claude_token
+.anthropic_key

--- a/.gitignore
+++ b/.gitignore
@@ -109,13 +109,6 @@ kubeconfig
 *.kubeconfig
 kube/config
 
-# Database files with potential credentials
-*.sqlite
-*.sqlite3
-*.db
-!test*.db
-!*test.db
-
 # OAuth
 oauth_token*
 oauth-token*


### PR DESCRIPTION
Add comprehensive gitignore rules for common credential and secret files:
- Environment files (.env, .env.*)
- Private keys and certificates (.pem, .key, .p12, .pfx, .crt)
- Credential files (credentials.json, secrets.yaml, etc.)
- Cloud provider credentials (AWS, SSH keys)
- API tokens and keys (.npmrc, .pypirc, .netrc, *.token)
- Docker and Kubernetes secrets
- Database files that may contain credentials
- OAuth tokens and client secrets
- GPG keys
- Terraform and Ansible vault files
- IDE credential storage
- Shell history files
- Local config files that may contain secrets
- Jupyter notebook checkpoints
- GitHub and AI service tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded repository ignore rules to prevent accidental commits of a wide range of sensitive files (credentials, secrets, keys, tokens, environment files, local IDE and shell artifacts, container/orchestration metadata, and infrastructure state), while preserving existing documentation directory handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->