### PR TITLE
Fix library handling and C++ standard issues

### DIFF
--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -84,11 +84,11 @@ for OPEN_MS_CONTRIB_BUILD_DIR in OPEN_MS_CONTRIB_BUILD_DIRS.split(";"):
 #
 if iswin:
     if IS_DEBUG:
-        libraries = ["OpenMSd", "OpenSwathAlgod", "Qt5Cored", "Qt5Networkd"]
+        libraries = ["OpenMSd", "OpenSwathAlgod", "Qt6Cored", "Qt6Networkd"]
     else:
-        libraries = ["OpenMS", "OpenSwathAlgo", "Qt5Core", "Qt5Network"]
+        libraries = ["OpenMS", "OpenSwathAlgo", "Qt6Core", "Qt6Network"]
 elif sys.platform.startswith("linux"):
-    libraries = ["OpenMS", "OpenSwathAlgo", "Qt5Core", "Qt5Network"]
+    libraries = ["OpenMS", "OpenSwathAlgo", "Qt6Core", "Qt6Network"]
 elif sys.platform == "darwin":
     libraries = ["OpenMS", "OpenSwathAlgo"]
 else:
@@ -169,8 +169,8 @@ if iswin:
     # such that  boost::throw_excption() is declared but not implemented.
     # The linker does not like that very much ...
     extra_compile_args = ["/EHs", "/bigobj"]
-    extra_compile_args.append("/std:c++17")
-    extra_link_args.append("/std:c++17")
+    extra_compile_args.append("/std:c++20")
+    extra_link_args.append("/std:c++20")
 
 elif sys.platform.startswith("linux"):
     extra_link_args = ["-Wl,-s"]
@@ -192,8 +192,8 @@ if OMP and OPENMP_CXX_FLAGS:
     extra_compile_args.extend(OPENMP_CXX_FLAGS.split(";"))
 
 if not iswin:
-    extra_link_args.append("-std=c++17")
-    extra_compile_args.append("-std=c++17")
+    extra_link_args.append("-std=c++20")
+    extra_compile_args.append("-std=c++20")
     if isosx: # MacOS
         extra_compile_args.append("-stdlib=libc++")
         extra_link_args.append("-stdlib=libc++") # MacOS libstdc++ does not include c++11+ lib support.
@@ -222,9 +222,6 @@ if not iswin:
 
 mnames = ["_pyopenms_%s" % (k+1) for k in range(int(PY_NUM_MODULES))]
 ext = []
-
-##WARNING debug
-libraries.extend("boost_regex-mt-x64")
 
 for module in mnames:
 


### PR DESCRIPTION
- Fix extend() on string to append() for boost_regex library (extend splits string into chars: ['b','o','o','s','t',...])
- Update Qt5 references to Qt6 to match CMake configuration
- Update C++ standard from C++17 to C++20 to match OpenMS codebase (required for C++20 concepts used in ExposedVector.h, GridSearch.h)

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Qt framework from version 5 to version 6 across Windows and Linux platforms.
  * Upgraded C++ standard from C++17 to C++20 for enhanced language features and performance.
  * Improved library dependency configuration for boost packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->