### PR TITLE
refactor:make-libsvm-dependency-private

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -55,10 +55,11 @@ include (${PROJECT_SOURCE_DIR}/includes.cmake)
 
 #------------------------------------------------------------------------------
 # all the dependency libraries are linked into libOpenMS.so
-set(OPENMS_DEP_LIBRARIES Evergreen LibSVM::LibSVM XercesC::XercesC Qt6::Core Qt6::Network)
+set(OPENMS_DEP_LIBRARIES Evergreen XercesC::XercesC Qt6::Core Qt6::Network)
 
 ## setup the arguments to 'target_link_libraries(OpenMS PRIVATE ${OPENMS_DEP_PRIVATE_LIBRARIES})'
 ## Note: Eigen3::Eigen is PRIVATE because Eigen types are not exposed in the public API
+## Note: LibSVM::LibSVM is PRIVATE because LibSVM types are not exposed in the public API
 set(OPENMS_DEP_PRIVATE_LIBRARIES
   $<$<BOOL:${WITH_HDF5}>:HDF5::HDF5>
   $<$<BOOL:${WITH_PARQUET}>:${OPENMS_ARROW_TARGET} ${OPENMS_PARQUET_TARGET}>
@@ -69,6 +70,7 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   Boost::iostreams
   Boost::regex
   Eigen3::Eigen
+  LibSVM::LibSVM
   GTE
   Quadtree
   SIMDe


### PR DESCRIPTION
## Description

This PR addresses issue #8547  by making the `LibSVM` dependency private in the CMake configuration.

**Analysis:** After reviewing all public headers, I found that LibSVM types are not exposed in OpenMS's public API. The only reference in public headers is a commented-out include in [SimpleSVM.h](cci:7://file:///Users/sahilshadwal/Desktop/OpenMS/src/openms/include/OpenMS/ML/SVM/SimpleSVM.h:0:0-0:0). Since downstream users never interact with LibSVM types directly, it can safely be moved to private dependencies.

**Changes:**
- Removed `LibSVM::LibSVM` from `OPENMS_DEP_LIBRARIES` (public dependencies)
- Added `LibSVM::LibSVM` to `OPENMS_DEP_PRIVATE_LIBRARIES` (private dependencies)
- Added explanatory comment following the existing pattern for `Eigen3::Eigen`

**Note:** Other dependencies like XercesC and Qt6 must remain public as their types appear in public API signatures (e.g., `XMLHandler` class, `QObject` inheritance).

Closes #8547

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration for improved API encapsulation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->