### PR TITLE
perf: replace std::endl with '\n' in high-impact files to improve I/O performance

### DIFF
--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -295,13 +295,13 @@ namespace OpenMS
             //TODO print graph with peptide probabilities to see which evidences cause problems with which params
           }
           OPENMS_LOG_WARN << "Warning: Loopy belief propagation encountered a problem in a connected component. Skipping"
-                      " inference there." << std::endl;
+                      " inference there." << '\n';
           return 0;
         }
       }
       else
       {
-        OPENMS_LOG_WARN << "Skipped cc with only one type (proteins or peptides)" << std::endl;
+        OPENMS_LOG_WARN << "Skipped cc with only one type (proteins or peptides)" << '\n';
         return 0;
       }
     }
@@ -444,14 +444,14 @@ namespace OpenMS
           // Graph builder needs to build otherwise it leaks memory.
           bigb.to_graph();
           std::cout << "Warning: Loopy belief propagation encountered a problem in a connected component. Skipping"
-                      "inference there." << std::endl;
+                      "inference there." << '\n';
           return 0;
         }
         //TODO we could write out the posteriors here, so we can easily read them for the best params of the grid search
       }
       else
       {
-        std::cout << "Skipped cc with only one type (proteins or peptides)" << std::endl;
+        std::cout << "Skipped cc with only one type (proteins or peptides)" << '\n';
         return 0;
       }
     }
@@ -471,10 +471,10 @@ namespace OpenMS
 
     double operator() (double alpha, double beta, double gamma)
     {
-      OPENMS_LOG_INFO << "Evaluating: " << alpha << " " << beta << " " << gamma << std::endl;
+      OPENMS_LOG_INFO << "Evaluating: " << alpha << " " << beta << " " << gamma << '\n';
       if (beta - alpha >= 0.3 && alpha + beta <= 1.0)
       {
-        OPENMS_LOG_INFO << "Skipping improbable parameter combination.. " << std::endl;
+        OPENMS_LOG_INFO << "Skipping improbable parameter combination.. " << '\n';
         return 0.;
       }
       param_.setValue("model_parameters:prot_prior", gamma);
@@ -835,7 +835,7 @@ namespace OpenMS
 
       // TODO try to calc AUC partial only (e.g. up to 5% FDR)
       if (!keep_all_psms)
-        OPENMS_LOG_INFO << "Peptide FDR AUC before protein inference: " << pepFDR.rocN(cmap, 0) << std::endl;
+        OPENMS_LOG_INFO << "Peptide FDR AUC before protein inference: " << pepFDR.rocN(cmap, 0) << '\n';
 
       setScoreTypeAndSettings_(proteinIDs[0]);
       IDBoostGraph ibg(proteinIDs[0], cmap, nr_top_psms, use_run_info, use_unannotated_ids, keep_all_psms, exp_des);
@@ -843,7 +843,7 @@ namespace OpenMS
       if (greedy_group_resolution) ibg.resolveGraphPeptideCentric(true);
 
       if (!keep_all_psms)
-        OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(cmap, 0) << std::endl;
+        OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(cmap, 0) << '\n';
 
       if (!use_unannotated_ids)
       {
@@ -888,19 +888,19 @@ namespace OpenMS
     //TODO think about running grid search on the small CCs only (maybe it's enough)
     if (gs.getNrCombos() > 1)
     {
-      OPENMS_LOG_INFO << "Testing " << gs.getNrCombos() << " param combinations." << std::endl;
+      OPENMS_LOG_INFO << "Testing " << gs.getNrCombos() << " param combinations." << '\n';
       gs.evaluate(GridSearchEvaluator(param_, ibg, debug_lvl_), -1.0, bestParams);
     }
     else
     {
-      OPENMS_LOG_INFO << "Only one combination specified: Skipping grid search." << std::endl;
+      OPENMS_LOG_INFO << "Only one combination specified: Skipping grid search." << '\n';
     }
 
     double bestGamma = gamma_search[bestParams[2]];
     double bestBeta = beta_search[bestParams[1]];
     double bestAlpha = alpha_search[bestParams[0]];
-    OPENMS_LOG_INFO << "Best params found at a=" << bestAlpha << ", b=" << bestBeta << ", g=" << bestGamma << std::endl;
-    OPENMS_LOG_INFO << "Running with best parameters:" << std::endl;
+    OPENMS_LOG_INFO << "Best params found at a=" << bestAlpha << ", b=" << bestBeta << ", g=" << bestGamma << '\n';
+    OPENMS_LOG_INFO << "Running with best parameters:" << '\n';
     param_.setValue("model_parameters:prot_prior", bestGamma);
     param_.setValue("model_parameters:pep_emission", bestAlpha);
     param_.setValue("model_parameters:pep_spurious_emission", bestBeta);
@@ -1002,7 +1002,7 @@ namespace OpenMS
         else
         {
           //TODO Exception
-          std::cerr << "Protein sequence not annotated" << std::endl;
+          std::cerr << "Protein sequence not annotated" << '\n';
         }
       }
     }*/
@@ -1011,7 +1011,7 @@ namespace OpenMS
     if (proteinIDs.size() > 1)
     {
       OPENMS_LOG_WARN << "Warning: more than one protein identification run provided for inference. Only "
-                         "the first will be processed for now." << std::endl;
+                         "the first will be processed for now." << '\n';
     }
 
     // groups will be reannotated
@@ -1057,7 +1057,7 @@ namespace OpenMS
     resetProteinScores_(proteinIDs[0], user_defined_priors);
 
     if (!keep_all_psms)
-      OPENMS_LOG_INFO << "Peptide FDR AUC before protein inference: " << pepFDR.rocN(peptideIDs, 0, proteinIDs[0].getIdentifier()) << std::endl;
+      OPENMS_LOG_INFO << "Peptide FDR AUC before protein inference: " << pepFDR.rocN(peptideIDs, 0, proteinIDs[0].getIdentifier()) << '\n';
 
     setScoreTypeAndSettings_(proteinIDs[0]);
     IDBoostGraph ibg(proteinIDs[0], peptideIDs, nr_top_psms, use_run_info, keep_all_psms, exp_des);
@@ -1066,7 +1066,7 @@ namespace OpenMS
     proteinIDs[0].fillIndistinguishableGroupsWithSingletons();
 
     if (!keep_all_psms)
-      OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(peptideIDs, 0, proteinIDs[0].getIdentifier()) << std::endl;
+      OPENMS_LOG_INFO << "Peptide FDR AUC after protein inference: " << pepFDR.rocN(peptideIDs, 0, proteinIDs[0].getIdentifier()) << '\n';
   }
 
   void BayesianProteinInferenceAlgorithm::resetProteinScores_(ProteinIdentification& protein_id, bool keep_old_as_prior)

--- a/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/BayesianProteinInferenceAlgorithm.cpp
@@ -1002,7 +1002,7 @@ namespace OpenMS
         else
         {
           //TODO Exception
-          std::cerr << "Protein sequence not annotated" << '\n';
+          std::cerr << "Protein sequence not annotated" << std::endl;
         }
       }
     }*/

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -209,7 +209,7 @@ namespace OpenMS
             }
             error_string += ")";
           }
-          OPENMS_LOG_ERROR << error_string << std::endl;
+          OPENMS_LOG_ERROR << error_string << '\n';
         }
 
         // check target scores
@@ -229,7 +229,7 @@ namespace OpenMS
             }
             error_string += ")";
           }
-          OPENMS_LOG_ERROR << error_string << std::endl;
+          OPENMS_LOG_ERROR << error_string << '\n';
         }
 
         if (target_scores.empty() || decoy_scores.empty())
@@ -1397,7 +1397,7 @@ namespace OpenMS
     std::sort(scores_labels.rbegin(), scores_labels.rend());
     double diff = diffEstimatedEmpirical(scores_labels, pepCutoff);
     double auc = rocN(scores_labels, fpCutoff);
-    OPENMS_LOG_INFO << "Evaluation of protein probabilities: Difference estimated vs. T-D FDR = " << diff << " and roc" << fpCutoff << " = " << auc << std::endl;
+    OPENMS_LOG_INFO << "Evaluation of protein probabilities: Difference estimated vs. T-D FDR = " << diff << " and roc" << fpCutoff << " = " << auc << '\n';
     // we want the score to get higher the lesser the difference. Subtract from one.
     // Then convex combination with the AUC.
     return (1.0 - diff) * (1.0 - diffWeight) + auc * diffWeight;
@@ -1408,7 +1408,7 @@ namespace OpenMS
     std::sort(scores_labels.rbegin(), scores_labels.rend());
     double diff = diffEstimatedEmpirical(scores_labels, pepCutoff);
     double auc = rocN(scores_labels, fpCutoff);
-    OPENMS_LOG_INFO << "Evaluation of protein probabilities: Difference estimated vs. T-D FDR = " << diff << " and roc" << fpCutoff << " = " << auc << std::endl;
+    OPENMS_LOG_INFO << "Evaluation of protein probabilities: Difference estimated vs. T-D FDR = " << diff << " and roc" << fpCutoff << " = " << auc << '\n';
     // we want the score to get higher the lesser the difference. Subtract from one.
     // Then convex combination with the AUC.
     return (1.0 - diff) * (1.0 - diffWeight) + auc * diffWeight;
@@ -1434,12 +1434,12 @@ namespace OpenMS
         r.is_prefix = true;
         r.name = "DECOY_";
         OPENMS_LOG_WARN << "Unable to determine decoy string automatically (not enough decoys were detected)! Using default " << (r.is_prefix ? "prefix" : "suffix") << " decoy string '" << r.name << "'\n"
-        << "If you think that this is incorrect, please provide a decoy_string and its position manually!" << std::endl;
+        << "If you think that this is incorrect, please provide a decoy_string and its position manually!" << '\n';
       }
       prefix = r.is_prefix;
       decoy_string = r.name;
       // decoy string and position was extracted successfully
-      OPENMS_LOG_INFO << "Using " << (prefix ? "prefix" : "suffix") << " decoy string '" << decoy_string << "'" << std::endl;
+      OPENMS_LOG_INFO << "Using " << (prefix ? "prefix" : "suffix") << " decoy string '" << decoy_string << "'" << '\n';
     }
 
     ScoreToTgtDecLabelPairs scores_labels;
@@ -1479,7 +1479,7 @@ namespace OpenMS
     bool conservative = param_.getValue("conservative").toBool();
     if (scores_labels.empty())
     {
-     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << std::endl;
+     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << '\n';
       return 1.0;
     }
 
@@ -1540,7 +1540,7 @@ namespace OpenMS
   {
     if (scores_labels.empty())
     {
-     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << std::endl;
+     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << '\n';
       return 0.0;
     }
 
@@ -1606,7 +1606,7 @@ namespace OpenMS
   {
     if (scores_labels.empty())
     {
-     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << std::endl;
+     OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << '\n';
       return;
     }
 
@@ -1672,7 +1672,7 @@ namespace OpenMS
     bool conservative = param_.getValue("conservative").toBool();
     if (scores_labels.empty())
     {
-      OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << std::endl;
+      OPENMS_LOG_WARN << "Warning: No scores extracted for FDR calculation. Skipping. Do you have target-decoy annotated Hits?" << '\n';
       return;
     }
 
@@ -1696,7 +1696,7 @@ namespace OpenMS
       if (std::abs(scores_labels[j].first - last_score) > 1e-12)
       {
         #ifdef FALSE_DISCOVERY_RATE_DEBUG
-        std::cerr << "Recording score: " << last_score << " with " << decoys << " decoys at index+1 = " << (j+1) << " -> fdr: " << decoys/(j+1.0) << std::endl;
+        std::cerr << "Recording score: " << last_score << " with " << decoys << " decoys at index+1 = " << (j+1) << " -> fdr: " << decoys/(j+1.0) << '\n';
         #endif
         //we are using the conservative formula (Decoy + 1) / (Tgts)
         if (conservative)
@@ -1740,7 +1740,7 @@ namespace OpenMS
         for (auto&& rit = scores_to_FDR.begin(); rit != scores_to_FDR.end(); ++rit)
         {
         #ifdef FALSE_DISCOVERY_RATE_DEBUG
-          std::cerr << "Comparing " << rit->second << " to " << cummin << std::endl;
+          std::cerr << "Comparing " << rit->second << " to " << cummin << '\n';
         #endif
           cummin = std::min(rit->second, cummin);
           rit->second = cummin;
@@ -1751,7 +1751,7 @@ namespace OpenMS
         for (auto&& rit = scores_to_FDR.rbegin(); rit != scores_to_FDR.rend(); ++rit)
         {
         #ifdef FALSE_DISCOVERY_RATE_DEBUG
-          std::cerr << "Comparing " << rit->second << " to " << cummin << std::endl;
+          std::cerr << "Comparing " << rit->second << " to " << cummin << '\n';
         #endif
           cummin = std::min(rit->second, cummin);
           rit->second = cummin;
@@ -1835,20 +1835,20 @@ namespace OpenMS
     // DEBUG ONLY: print counts of found decoys
     for (auto &a : decoy_count)
     {
-      OPENMS_LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << std::endl;
+      OPENMS_LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << '\n';
     }
 
     // less than 30% of proteins are decoys -> won't be able to determine a decoy string and its position
     // return default values
     if (static_cast<double>(all_prefix_occur + all_suffix_occur) < 0.3 * static_cast<double>(all_proteins_count))
     {
-      OPENMS_LOG_ERROR << "Unable to determine decoy string (not enough occurrences; <30%)!" << std::endl;
+      OPENMS_LOG_ERROR << "Unable to determine decoy string (not enough occurrences; <30%)!" << '\n';
       return {false, "?", true};
     }
 
     if (all_prefix_occur == all_suffix_occur)
     {
-      OPENMS_LOG_ERROR << "Unable to determine decoy string (prefix and suffix occur equally often)!" << std::endl;
+      OPENMS_LOG_ERROR << "Unable to determine decoy string (prefix and suffix occur equally often)!" << '\n';
       return {false, "?", true};
     }
 
@@ -1864,8 +1864,8 @@ namespace OpenMS
       {
         if (prefix_suffix_counts.first != all_prefix_occur)
         {
-          OPENMS_LOG_WARN << "More than one decoy prefix observed!" << std::endl;
-          OPENMS_LOG_WARN << "Using most frequent decoy prefix (" << (int)(freq_prefix * 100) << "%)" << std::endl;
+          OPENMS_LOG_WARN << "More than one decoy prefix observed!" << '\n';
+          OPENMS_LOG_WARN << "Using most frequent decoy prefix (" << (int)(freq_prefix * 100) << "%)" << '\n';
         }
 
         return { true, decoy_case_sensitive[case_insensitive_decoy_string], true};
@@ -1884,15 +1884,15 @@ namespace OpenMS
       {
         if (prefix_suffix_counts.second != all_suffix_occur)
         {
-          OPENMS_LOG_WARN << "More than one decoy suffix observed!" << std::endl;
-          OPENMS_LOG_WARN << "Using most frequent decoy suffix (" << (int)(freq_suffix * 100) << "%)" << std::endl;
+          OPENMS_LOG_WARN << "More than one decoy suffix observed!" << '\n';
+          OPENMS_LOG_WARN << "Using most frequent decoy suffix (" << (int)(freq_suffix * 100) << "%)" << '\n';
         }
 
         return { true, decoy_case_sensitive[case_insensitive_decoy_string], false};
       }
     }
 
-    OPENMS_LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << std::endl;
+    OPENMS_LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << '\n';
     return {false, "?", true};
   }
 

--- a/src/openms/source/ANALYSIS/ID/HyperScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/HyperScore.cpp
@@ -37,7 +37,7 @@ namespace OpenMS
   {
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
       return 0.0;
     }
 
@@ -49,7 +49,7 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
       return 0.0;
     }
 
@@ -111,7 +111,7 @@ namespace OpenMS
   {
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
       return 0.0;
     }
 
@@ -123,7 +123,7 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
       return 0.0;
     }
 
@@ -200,7 +200,7 @@ namespace OpenMS
 
     if (exp_spectrum.size() < 1 || theo_spectrum.size() < 1)
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
       return 0.0;
     }
 
@@ -212,19 +212,19 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
       return 0.0;
     }
 
     if (theo_charges.size() != theo_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << '\n';
+      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << std::endl;
       return 0.0;
     }
 
     if (exp_charges.size() != exp_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << '\n';
+      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << std::endl;
       return 0.0;
     }
 
@@ -293,7 +293,7 @@ namespace OpenMS
   {
     if (exp_spectrum.size() < 1 || theo_spectrum.size() < 1)
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
       return 0.0;
     }
 
@@ -305,19 +305,19 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
       return 0.0;
     }
 
     if (theo_charges.size() != theo_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << '\n';
+      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << std::endl;
       return 0.0;
     }
 
     if (exp_charges.size() != exp_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << '\n';
+      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << std::endl;
       return 0.0;
     }
 
@@ -325,7 +325,7 @@ namespace OpenMS
     const Size N = intensity_sum.size(); // length of peptide
     if (N == 0 || N > 100000) // peptides longer than 100k residues are unreasonable
     {
-      std::cout << "Error: HyperScore: intensity_sum has invalid size: " << N << '\n';
+      std::cout << "Error: HyperScore: intensity_sum has invalid size: " << N << std::endl;
       return 0.0;
     }
     std::vector<double> b_ions(N, 0.0);

--- a/src/openms/source/ANALYSIS/ID/HyperScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/HyperScore.cpp
@@ -37,7 +37,7 @@ namespace OpenMS
   {
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
       return 0.0;
     }
 
@@ -49,7 +49,7 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
       return 0.0;
     }
 
@@ -111,7 +111,7 @@ namespace OpenMS
   {
     if (exp_spectrum.empty() || theo_spectrum.empty())
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
       return 0.0;
     }
 
@@ -123,7 +123,7 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
       return 0.0;
     }
 
@@ -200,7 +200,7 @@ namespace OpenMS
 
     if (exp_spectrum.size() < 1 || theo_spectrum.size() < 1)
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
       return 0.0;
     }
 
@@ -212,19 +212,19 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
       return 0.0;
     }
 
     if (theo_charges.size() != theo_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << std::endl;
+      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << '\n';
       return 0.0;
     }
 
     if (exp_charges.size() != exp_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << std::endl;
+      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << '\n';
       return 0.0;
     }
 
@@ -243,7 +243,7 @@ namespace OpenMS
       const int theo_z = theo_charges[i];
 
       #ifdef DEBUG_HYPERSCORE
-        if (exp_z != theo_z) std::cout << "exp_z != theo_z " << exp_z << "\t" << theo_z << std::endl;
+        if (exp_z != theo_z) std::cout << "exp_z != theo_z " << exp_z << "\t" << theo_z << '\n';
       #endif
 
       // found peak match
@@ -255,7 +255,7 @@ namespace OpenMS
         {
           dot_product += exp_spectrum[index].getIntensity() * theo_intensity;
           #ifdef DEBUG_HYPERSCORE
-            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << std::endl;
+            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << '\n';
           #endif
           ++y_ion_count;
         }
@@ -264,7 +264,7 @@ namespace OpenMS
           dot_product += exp_spectrum[index].getIntensity() * theo_intensity;
 
           #ifdef DEBUG_HYPERSCORE
-            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << std::endl;
+            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << '\n';
           #endif
           ++b_ion_count;
         }
@@ -277,7 +277,7 @@ namespace OpenMS
     const double bFact = logfactorial_(b_ion_count);
     const double hyperScore = log1p(dot_product) + yFact + bFact;
     #ifdef DEBUG_HYPERSCORE
-      std::cout << "HyperScore/#y/#b: " << hyperScore << "/" << y_ion_count << "/" << b_ion_count << std::endl;
+      std::cout << "HyperScore/#y/#b: " << hyperScore << "/" << y_ion_count << "/" << b_ion_count << '\n';
     #endif
     return hyperScore;    
   } 
@@ -293,7 +293,7 @@ namespace OpenMS
   {
     if (exp_spectrum.size() < 1 || theo_spectrum.size() < 1)
     {
-      std::cout << "Warning: HyperScore: One of the given spectra is empty." << std::endl;
+      std::cout << "Warning: HyperScore: One of the given spectra is empty." << '\n';
       return 0.0;
     }
 
@@ -305,19 +305,19 @@ namespace OpenMS
     }
     else
     {
-      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << std::endl;
+      std::cout << "Error: HyperScore: Theoretical spectrum without StringDataArray (\"IonNames\" annotation) provided." << '\n';
       return 0.0;
     }
 
     if (theo_charges.size() != theo_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << std::endl;
+      std::cout << "Error: HyperScore: #charges != #peaks in theoretical spectrum." << '\n';
       return 0.0;
     }
 
     if (exp_charges.size() != exp_spectrum.size())
     {
-      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << std::endl;
+      std::cout << "Error: HyperScore: #charges != #peaks in experimental spectrum." << '\n';
       return 0.0;
     }
 
@@ -325,7 +325,7 @@ namespace OpenMS
     const Size N = intensity_sum.size(); // length of peptide
     if (N == 0 || N > 100000) // peptides longer than 100k residues are unreasonable
     {
-      std::cout << "Error: HyperScore: intensity_sum has invalid size: " << N << std::endl;
+      std::cout << "Error: HyperScore: intensity_sum has invalid size: " << N << '\n';
       return 0.0;
     }
     std::vector<double> b_ions(N, 0.0);
@@ -346,7 +346,7 @@ namespace OpenMS
       const int theo_z = theo_charges[i];
 
       #ifdef DEBUG_HYPERSCORE
-        if (exp_z != theo_z) std::cout << "exp_z != theo_z " << exp_z << "\t" << theo_z << std::endl;
+        if (exp_z != theo_z) std::cout << "exp_z != theo_z " << exp_z << "\t" << theo_z << '\n';
       #endif
 
       // found peak match
@@ -364,8 +364,8 @@ namespace OpenMS
 
 
           #ifdef DEBUG_HYPERSCORE
-            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << std::endl;
-            std::cout << "N:"  << N << "\t" << ii << "\t" << N-1 - (ii-1) << std::endl;            
+            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << '\n';
+            std::cout << "N:"  << N << "\t" << ii << "\t" << N-1 - (ii-1) << '\n';            
           #endif
           // we observed the suffix (N-1-ii, N-1] in 0-based AA coordinates
           y_ions[N-1 - (ii-1)] += exp_spectrum[index].getIntensity();
@@ -379,8 +379,8 @@ namespace OpenMS
           dot_product += exp_spectrum[index].getIntensity() * theo_intensity;
 
           #ifdef DEBUG_HYPERSCORE
-            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << std::endl;
-            std::cout << "N:"  << N << "\t" << ii << "\t" << (ii-1) << std::endl;
+            std::cout << (*ion_names)[i] << " intensity: " << exp_spectrum[index].getIntensity() << '\n';
+            std::cout << "N:"  << N << "\t" << ii << "\t" << (ii-1) << '\n';
           #endif
           // we observed the prefix [0, ii) in 0-based AA coordinates
           b_ions[ii - 1] += exp_spectrum[index].getIntensity();
@@ -414,7 +414,7 @@ namespace OpenMS
     const double bFact = logfactorial_(b_ion_count);
     const double hyperScore = log1p(dot_product) + yFact + bFact;
     #ifdef DEBUG_HYPERSCORE
-      std::cout << "HyperScore/#y/#b: " << hyperScore << "/" << y_ion_count << "/" << b_ion_count << std::endl;
+      std::cout << "HyperScore/#y/#b: " << hyperScore << "/" << y_ion_count << "/" << b_ion_count << '\n';
     #endif
     return hyperScore;    
   } 

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -131,7 +131,7 @@ using namespace std;
       else
       {
         //std::cerr << "REJECTED Peptide " << seq_pep << " with hit to protein "
-        //  << seq_prot << " at position " << position << std::endl;
+        //  << seq_prot << " at position " << position << '\n';
         ++filter_rejected;
       }
     }
@@ -292,12 +292,12 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
       r.is_prefix = true;
       r.name = "DECOY_";
       OPENMS_LOG_WARN << "Unable to determine decoy string automatically (not enough decoys were detected)! Using default " << (r.is_prefix ? "prefix" : "suffix") << " decoy string '" << r.name << "'\n"
-                      << "If you think that this is incorrect, please provide a decoy_string and its position manually!" << std::endl;
+                      << "If you think that this is incorrect, please provide a decoy_string and its position manually!" << '\n';
     }
     prefix_ = r.is_prefix;
     decoy_string_ = r.name;
     // decoy string and position was extracted successfully
-    OPENMS_LOG_INFO << "Using " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "'" << std::endl;
+    OPENMS_LOG_INFO << "Using " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "'" << '\n';
   }
 
   //---------------------------------------------------------------
@@ -310,12 +310,12 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
   }
   else if (!prot_ids.empty() && prot_ids[0].getSearchParameters().digestion_enzyme.getName() != "unknown_enzyme")
   { // take from meta (this assumes all runs used the same enzyme)
-    OPENMS_LOG_INFO << "Info: using '" << prot_ids[0].getSearchParameters().digestion_enzyme.getName() << "' as enzyme (obtained from idXML) for digestion." << std::endl;
+    OPENMS_LOG_INFO << "Info: using '" << prot_ids[0].getSearchParameters().digestion_enzyme.getName() << "' as enzyme (obtained from idXML) for digestion." << '\n';
     enzyme.setEnzyme(&prot_ids[0].getSearchParameters().digestion_enzyme);
   }
   else
   { // fall-back
-    OPENMS_LOG_WARN << "Warning: Enzyme name neither given nor deducible from input. Defaulting to Trypsin!" << std::endl;
+    OPENMS_LOG_WARN << "Warning: Enzyme name neither given nor deducible from input. Defaulting to Trypsin!" << '\n';
     enzyme.setEnzyme("Trypsin");
   } 
 
@@ -327,24 +327,24 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
   {
     String search_engine = prot_id.getOriginalSearchEngineName();
     StringUtils::toUpper(search_engine);
-    OPENMS_LOG_INFO << "Peptide identification engine: " << search_engine << std::endl;
+    OPENMS_LOG_INFO << "Peptide identification engine: " << search_engine << '\n';
     if (search_engine == "XTANDEM" || prot_id.getSearchParameters().metaValueExists("SE:XTandem")) { xtandem_fix_parameters = true; }
     if (search_engine == "MS-GF+" || search_engine == "MSGFPLUS" || prot_id.getSearchParameters().metaValueExists("SE:MS-GF+")) { msgfplus_fix_parameters = true; }
   }
 
   if (xtandem_fix_parameters)
   {
-    OPENMS_LOG_WARN << "X!Tandem detected. Allowing random Asp/Pro cleavage." << std::endl;
+    OPENMS_LOG_WARN << "X!Tandem detected. Allowing random Asp/Pro cleavage." << '\n';
   }
 
   // including MSGFPlus -> Trypsin/P as enzyme
   if (msgfplus_fix_parameters && enzyme.getEnzymeName() == "Trypsin")
   {
-    OPENMS_LOG_WARN << "MSGFPlus detected but enzyme cutting rules were set to Trypsin. Correcting to Trypsin/P to cope with special cutting rule in MSGFPlus." << std::endl;
+    OPENMS_LOG_WARN << "MSGFPlus detected but enzyme cutting rules were set to Trypsin. Correcting to Trypsin/P to cope with special cutting rule in MSGFPlus." << '\n';
     enzyme.setEnzyme("Trypsin/P");
   }
 
-  OPENMS_LOG_INFO << "Enzyme: " << enzyme.getEnzymeName() << std::endl;
+  OPENMS_LOG_INFO << "Enzyme: " << enzyme.getEnzymeName() << '\n';
 
   if (!enzyme_specificity_.empty() && (enzyme_specificity_.compare(AUTO_MODE) != 0))
   { // use param (not empty and not 'auto')
@@ -353,11 +353,11 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
   else if (!prot_ids.empty() && prot_ids[0].getSearchParameters().enzyme_term_specificity != ProteaseDigestion::SPEC_UNKNOWN)
   { // deduce from data ('auto')
     enzyme.setSpecificity(prot_ids[0].getSearchParameters().enzyme_term_specificity);
-    OPENMS_LOG_INFO << "Info: using '" << EnzymaticDigestion::NamesOfSpecificity[prot_ids[0].getSearchParameters().enzyme_term_specificity] << "' as enzyme specificity (obtained from idXML) for digestion." << std::endl;
+    OPENMS_LOG_INFO << "Info: using '" << EnzymaticDigestion::NamesOfSpecificity[prot_ids[0].getSearchParameters().enzyme_term_specificity] << "' as enzyme specificity (obtained from idXML) for digestion." << '\n';
   }
   else
   { // fall-back
-    OPENMS_LOG_WARN << "Warning: Enzyme specificity neither given nor present in the input file. Defaulting to 'full'!" << std::endl;
+    OPENMS_LOG_WARN << "Warning: Enzyme specificity neither given nor present in the input file. Defaulting to 'full'!" << '\n';
     enzyme.setSpecificity(ProteaseDigestion::SPEC_FULL);
   }
 
@@ -373,13 +373,13 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
 
   if (proteins.empty()) // we do not allow an empty database
   {
-    OPENMS_LOG_ERROR << "Error: An empty database was provided. Mapping makes no sense. Aborting..." << std::endl;
+    OPENMS_LOG_ERROR << "Error: An empty database was provided. Mapping makes no sense. Aborting..." << '\n';
     return DATABASE_EMPTY;
   }
 
   if (pep_ids.empty()) // Aho-Corasick requires non-empty input; but we allow this case, since the TOPP tool should not crash when encountering a bad raw file (with no PSMs)
   {
-    OPENMS_LOG_WARN << "Warning: An empty set of peptide identifications was provided. Output will be empty as well." << std::endl;
+    OPENMS_LOG_WARN << "Warning: An empty set of peptide identifications was provided. Output will be empty as well." << '\n';
     if (!keep_unreferenced_proteins_)
     {
       // delete only protein hits, not whole ID runs incl. meta data:
@@ -427,22 +427,22 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
       }
     }
     s.stop();
-    OPENMS_LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << std::endl;
+    OPENMS_LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << '\n';
     if (ac_trie.getNeedleCount() == 0)
     { // Aho-Corasick will crash if given empty needles as input
-      OPENMS_LOG_WARN << "Warning: Peptide identifications have no hits inside! Output will be empty as well." << std::endl;
+      OPENMS_LOG_WARN << "Warning: Peptide identifications have no hits inside! Output will be empty as well." << '\n';
       return PEPTIDE_IDS_EMPTY;
     }
     s.start();
-    OPENMS_LOG_INFO << "Compressing trie to BFS format ..." << std::endl;
+    OPENMS_LOG_INFO << "Compressing trie to BFS format ..." << '\n';
     ac_trie.compressTrie();
     s.stop();
-    OPENMS_LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << std::endl;
+    OPENMS_LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << '\n';
     s.reset();
     OPENMS_LOG_INFO << "Mapping " << ac_trie.getNeedleCount() << " peptides to " << (proteins.size() == PROTEIN_CACHE_SIZE ? "? (unknown number of)" : String(proteins.size())) << " proteins."
-                    << std::endl;
+                    << '\n';
 
-    OPENMS_LOG_INFO << "Searching with up to " << aaa_max_ << " ambiguous amino acid(s) and " << mm_max_ << " mismatch(es)!" << std::endl;
+    OPENMS_LOG_INFO << "Searching with up to " << aaa_max_ << " ambiguous amino acid(s) and " << mm_max_ << " mismatch(es)!" << '\n';
 
     uint16_t count_j_proteins(0);
     bool has_active_data = true; // becomes false if end of FASTA file is reached
@@ -595,14 +595,14 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
     
     // write some stats
     OPENMS_LOG_INFO << "Peptide hits passing enzyme filter: " << func.filter_passed << "\n"
-                    << "     ... rejected by enzyme filter: " << func.filter_rejected << std::endl;
+                    << "     ... rejected by enzyme filter: " << func.filter_rejected << '\n';
 
     if (count_j_proteins)
     {
       OPENMS_LOG_WARN << "PeptideIndexer found " << count_j_proteins << " protein sequences in your database containing the amino acid 'J'."
         << "To match 'J' in a protein, an ambiguous amino acid placeholder for I/L will be used.\n"
         << "This costs runtime and eats into the 'aaa_max' limit, leaving less opportunity for B/Z/X matches.\n"
-        << "If you want 'J' to be treated as unambiguous, enable '-IL_equivalent'!" << std::endl;
+        << "If you want 'J' to be treated as unambiguous, enable '-IL_equivalent'!" << '\n';
     }
 
   } // end local scope
@@ -740,7 +740,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
   OPENMS_LOG_INFO << "  mapping to proteins:\n";
   OPENMS_LOG_INFO << "    no match (to 0 protein)         : " << stats_unmatched << "\n";
   OPENMS_LOG_INFO << "    unique match (to 1 protein)     : " << stats_matched_unique << "\n";
-  OPENMS_LOG_INFO << "    non-unique match (to >1 protein): " << stats_matched_multi << std::endl;
+  OPENMS_LOG_INFO << "    non-unique match (to >1 protein): " << stats_matched_multi << '\n';
 
   /// for proteins --> peptides
   Size stats_matched_proteins(0), stats_matched_new_proteins(0), stats_orphaned_proteins(0), stats_proteins_target(0), stats_proteins_decoy(0);
@@ -819,7 +819,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
     OPENMS_LOG_INFO << "  matched decoy proteins : " << stats_proteins_decoy << " (" << stats_proteins_decoy * 100 / stats_matched_proteins << " %)\n";
   }
   OPENMS_LOG_INFO << "  orphaned proteins      : " << stats_orphaned_proteins << (keep_unreferenced_proteins_ ? " (all kept)" : " (all removed)\n");
-  OPENMS_LOG_INFO << "-----------------------------------" << std::endl;
+  OPENMS_LOG_INFO << "-----------------------------------" << '\n';
 
   // Store PeptideIndexer settings in SearchParameters metavalues for documentation
   for (Size run_idx = 0; run_idx < prot_ids.size(); ++run_idx)
@@ -853,12 +853,12 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
     String msg("No peptides were matched to the decoy portion of the database! Did you provide the correct concatenated database? Are your 'decoy_string' (=" + decoy_string_ + ") and 'decoy_string_position' (=" + std::string(param_.getValue("decoy_string_position")) + ") settings correct?");
     if (missing_decoy_action_ == MissingDecoy::IS_ERROR)
     {
-      OPENMS_LOG_ERROR << "Error: " << msg << "\nSet 'missing_decoy_action' to 'warn' if you are sure this is ok!\nAborting ..." << std::endl;
+      OPENMS_LOG_ERROR << "Error: " << msg << "\nSet 'missing_decoy_action' to 'warn' if you are sure this is ok!\nAborting ..." << '\n';
       has_error = true;
     }
     else if (missing_decoy_action_ == MissingDecoy::WARN)
     {
-      OPENMS_LOG_WARN << "Warn: " << msg << "\nSet 'missing_decoy_action' to 'error' if you want to elevate this to an error!" << std::endl;
+      OPENMS_LOG_WARN << "Warn: " << msg << "\nSet 'missing_decoy_action' to 'error' if you want to elevate this to an error!" << '\n';
     }
     else // silent
     {
@@ -899,7 +899,7 @@ PeptideIndexing::ExitCodes PeptideIndexing::run_(FASTAContainer<T>& proteins, st
 
   if (has_error)
   {
-    OPENMS_LOG_ERROR << "Result files will be written, but PeptideIndexer will exit with an error code." << std::endl;
+    OPENMS_LOG_ERROR << "Result files will be written, but PeptideIndexer will exit with an error code." << '\n';
     return UNEXPECTED_RESULT;
   }
   return EXECUTION_OK;

--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -27,7 +27,7 @@ namespace OpenMS
     {
       os << *prot_it << ",";
     }
-    os << std::endl;
+    os << '\n';
     os << "Peptides: ";
     for (std::set<Size>::const_iterator pep_it = conn_comp.pep_indices.begin();
           pep_it != conn_comp.pep_indices.end();
@@ -69,7 +69,7 @@ namespace OpenMS
           "No indistinguishable Groups annotated. Currently this class only resolves across groups.");
     }
 
-    OPENMS_LOG_INFO << "Resolving peptides between " << protein.getHits().size() << " proteins in " << groups.size() << " indistinguishable groups." << std::endl;
+    OPENMS_LOG_INFO << "Resolving peptides between " << protein.getHits().size() << " proteins in " << groups.size() << " indistinguishable groups." << '\n';
 
     // I don't think we need to assume sortedness here
     //if (!skip_sort) sort(groups.begin(), groups.end());
@@ -208,21 +208,21 @@ namespace OpenMS
           evToKeep = grpIdxToEvIdx[*toResolve->begin()];
           if (toResolve->size() > 1)
           {
-           OPENMS_LOG_INFO << "Resolution: Peptide " << pep.getHits()[0].getSequence().toString() << " had groups:" << std::endl;
+           OPENMS_LOG_INFO << "Resolution: Peptide " << pep.getHits()[0].getSequence().toString() << " had groups:" << '\n';
 
            OPENMS_LOG_INFO << "tgt: ";
             for (const auto& g : bestNonDecoyGrpTie)
             {
               OPENMS_LOG_INFO << g << "=" << groups[g].probability << ", ";
             }
-           OPENMS_LOG_INFO << std::endl;
+           OPENMS_LOG_INFO << '\n';
            OPENMS_LOG_INFO << "dec: ";
             for (const auto& g : bestDecoyGrpTie)
             {
               OPENMS_LOG_INFO << g << "=" << groups[g].probability << ", ";
             }
-           OPENMS_LOG_INFO << std::endl;
-           OPENMS_LOG_INFO << "Kept: " << *toResolve->begin() << std::endl;
+           OPENMS_LOG_INFO << '\n';
+           OPENMS_LOG_INFO << "Kept: " << *toResolve->begin() << '\n';
           }
         }
         else
@@ -243,7 +243,7 @@ namespace OpenMS
       }
       else
       {
-       OPENMS_LOG_WARN << "Warning PeptideProteinResolution: Skipping spectrum without hits." << std::endl;
+       OPENMS_LOG_WARN << "Warning PeptideProteinResolution: Skipping spectrum without hits." << '\n';
       }
     }
   }
@@ -264,7 +264,7 @@ namespace OpenMS
           "No indistinguishable Groups annotated. Currently this class only resolves across groups.");
     }
 
-   OPENMS_LOG_INFO << "Resolving peptides between " << protein.getHits().size() << " proteins in " << groups.size() << " indistinguishable groups." << std::endl;
+   OPENMS_LOG_INFO << "Resolving peptides between " << protein.getHits().size() << " proteins in " << groups.size() << " indistinguishable groups." << '\n';
 
 
     if (!skip_sort) sort(groups.begin(), groups.end());
@@ -330,7 +330,7 @@ namespace OpenMS
       }
       else
       {
-       OPENMS_LOG_WARN << "Warning PeptideProteinResolution: Skipping spectrum without hits." << std::endl;
+       OPENMS_LOG_WARN << "Warning PeptideProteinResolution: Skipping spectrum without hits." << '\n';
       }
     }
   }
@@ -530,7 +530,7 @@ namespace OpenMS
        OPENMS_LOG_FATAL_ERROR << "Something went terribly wrong. "
                            "Group with index " << *grp_it << "doesn't exist. "
                                                              " ProteinPeptideResolution: Groups changed"
-                                                             " after building data structures." << std::endl;
+                                                             " after building data structures." << '\n';
       }
 
       vector<String> accessions = origin_groups[*grp_it].accessions;
@@ -550,7 +550,7 @@ namespace OpenMS
           {
            OPENMS_LOG_DEBUG << s << ", ";
           }
-         OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << std::endl;
+         OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << '\n';
         }
         // Update all the peptides the current best point to
         for (set<Size>::iterator pepid_it =
@@ -600,7 +600,7 @@ namespace OpenMS
            OPENMS_LOG_FATAL_ERROR << "Something went terribly wrong. "
                                "Group with index " << *grp_it << "doesn't exist. "
                                                                  " ProteinPeptideResolution: Groups changed"
-                                                                 " after building data structures." << std::endl;
+                                                                 " after building data structures." << '\n';
           }
 
           vector<String> accessions = origin_groups[*grp_it].accessions;
@@ -620,7 +620,7 @@ namespace OpenMS
               {
                OPENMS_LOG_DEBUG << s << ", ";
               }
-             OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << std::endl;
+             OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << '\n';
             }
 
             // Update all the peptides the current best point to
@@ -710,7 +710,7 @@ namespace OpenMS
        OPENMS_LOG_FATAL_ERROR << "Something went terribly wrong. "
                               << "Group with index " << *grp_it << "doesn't exist. "
                               << " ProteinPeptideResolution: Groups changed"
-                              << " after building data structures." << std::endl;
+                              << " after building data structures." << '\n';
       }
 
       const vector<String>& accessions = origin_groups[*grp_it].accessions;
@@ -727,7 +727,7 @@ namespace OpenMS
         {
           OPENMS_LOG_DEBUG << s << ", ";
         }
-        OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << std::endl;
+        OPENMS_LOG_DEBUG << " steals " << indist_prot_grp_to_pep_[*grp_it].size() << " peptides for itself." << '\n';
       }
 
       // Update all the peptides the current best point to

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.cpp
@@ -148,7 +148,7 @@ namespace OpenMS
     {
       dump_pairs_filename = dump_pairs_basename + "_phase_two_" + String(dump_buckets_serial);
       dump_pairs_file.open(dump_pairs_filename.c_str());
-      dump_pairs_file << "#" << ' ' << "i" << ' ' << "j" << ' ' << "k" << ' ' << "l" << ' ' << std::endl;
+      dump_pairs_file << "#" << ' ' << "i" << ' ' << "j" << ' ' << "k" << ' ' << "l" << ' ' << '\n';
     }
 
     // first point in model map (i)
@@ -273,7 +273,7 @@ namespace OpenMS
               {
                 dump_pairs_file << i << ' ' << model_map[i].getRT() << ' ' << model_map[i].getMZ() << ' ' << j << ' ' << model_map[j].getRT() << ' '
                                 << model_map[j].getMZ() << ' ' << k << ' ' << scene_map[k].getRT() << ' ' << scene_map[k].getMZ() << ' ' << l << ' '
-                                << scene_map[l].getRT() << ' ' << scene_map[l].getMZ() << ' ' << similarity_ik_jl << ' ' << std::endl;
+                                << scene_map[l].getRT() << ' ' << scene_map[l].getMZ() << ' ' << similarity_ik_jl << ' ' << '\n';
               }
             }
           }   // l
@@ -318,7 +318,7 @@ namespace OpenMS
       dump_buckets_filename = dump_buckets_basename + "_scale_" + String(dump_buckets_serial);
       dump_buckets_file.open(dump_buckets_filename.c_str());
 
-      dump_buckets_file << "# rt scale hash table buckets dump ( scale, height ) : " << dump_buckets_filename << std::endl;
+      dump_buckets_file << "# rt scale hash table buckets dump ( scale, height ) : " << dump_buckets_filename << '\n';
       dump_buckets_file << "# unfiltered hash data\n";
       for (Size index = 0; index < scaling_hash_1.getData().size(); ++index)
       {
@@ -438,13 +438,13 @@ namespace OpenMS
         dump_buckets_file << "# loop: " << loop << "  mean: " << log_outside_mean << " [" << exp(log_outside_mean) << "]  stdev: " << log_outside_stdev
                           << " [" << scale_centroid_1 << "]  (mean-stdev): " << log_outside_mean - log_outside_stdev << " [" << scale_low_1 << "]  (mean+stdev): "
                           << log_outside_mean + log_outside_stdev << " [" << scale_high_1 << "]  data_range_begin: " << data_range_begin << "  data_range_end: "
-                          << data_range_end << std::endl;
+                          << data_range_end << '\n';
       }
     }
 
     if (do_dump_buckets)
     {
-      dump_buckets_file << "# EOF" << std::endl;
+      dump_buckets_file << "# EOF" << '\n';
       dump_buckets_file.close();
     }
   }
@@ -474,7 +474,7 @@ namespace OpenMS
       dump_buckets_low_filename = dump_buckets_basename + "_low_" + String(dump_buckets_serial);
       dump_buckets_low_file.open(dump_buckets_low_filename.c_str());
 
-      dump_buckets_low_file << "# rt low hash table buckets dump ( scale, height ) : " << dump_buckets_low_filename << std::endl;
+      dump_buckets_low_file << "# rt low hash table buckets dump ( scale, height ) : " << dump_buckets_low_filename << '\n';
       dump_buckets_low_file << "# unfiltered hash data\n";
       for (Size index = 0; index < rt_low_hash_.getData().size(); ++index)
       {
@@ -487,7 +487,7 @@ namespace OpenMS
       dump_buckets_high_filename = dump_buckets_basename + "_high_" + String(dump_buckets_serial);
       dump_buckets_high_file.open(dump_buckets_high_filename.c_str());
 
-      dump_buckets_high_file << "# rt high hash table buckets dump ( scale, height ) : " << dump_buckets_high_filename << std::endl;
+      dump_buckets_high_file << "# rt high hash table buckets dump ( scale, height ) : " << dump_buckets_high_filename << '\n';
       dump_buckets_high_file << "# unfiltered hash data\n";
       for (Size index = 0; index < rt_high_hash_.getData().size(); ++index)
       {
@@ -649,7 +649,7 @@ namespace OpenMS
         {
           dump_buckets_low_file << "# loop: " << loop << "  mean: " << outside_mean << "  stdev: " << outside_stdev << "  (mean-stdev): " << outside_mean
           - outside_stdev << "  (mean+stdev): " << outside_mean + outside_stdev << "  data_range_begin: " << data_range_begin << "  data_range_end: "
-                                << data_range_end << std::endl;
+                                << data_range_end << '\n';
         }
       }
     }
@@ -677,15 +677,15 @@ namespace OpenMS
         {
           dump_buckets_high_file << "# loop: " << loop << "  mean: " << outside_mean << "  stdev: " << outside_stdev << "  (mean-stdev): " << outside_mean
           - outside_stdev << "  (mean+stdev): " << outside_mean + outside_stdev << "  data_range_begin: " << data_range_begin << "  data_range_end: "
-                                 << data_range_end << std::endl;
+                                 << data_range_end << '\n';
         }
       }
     }
     if (do_dump_buckets)
     {
-      dump_buckets_low_file << "# EOF" << std::endl;
+      dump_buckets_low_file << "# EOF" << '\n';
       dump_buckets_low_file.close();
-      dump_buckets_high_file << "# EOF" << std::endl;
+      dump_buckets_high_file << "# EOF" << '\n';
       dump_buckets_high_file.close();
     }
   }
@@ -834,16 +834,16 @@ namespace OpenMS
       {
         std::cout << "WARNING: your map likely has a scaling around " << slope
           << " but your parameters only allow for a maximal scaling of " <<
-          param_.getValue("max_scaling") << std::endl;
-        std::cout << "It is strongly advised to adjust your max_scaling factor" << std::endl;
+          param_.getValue("max_scaling") << '\n';
+        std::cout << "It is strongly advised to adjust your max_scaling factor" << '\n';
       }
 
       if ( (double)param_.getValue("max_shift") < shift * 1.2)
       {
         std::cout << "WARNING: your map likely has a shift around " << shift
           << " but your parameters only allow for a maximal shift of " <<
-          param_.getValue("max_shift") << std::endl;
-        std::cout << "It is strongly advised to adjust your max_shift factor" << std::endl;
+          param_.getValue("max_shift") << '\n';
+        std::cout << "It is strongly advised to adjust your max_shift factor" << '\n';
       }
 
     }

--- a/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
@@ -147,7 +147,7 @@ namespace OpenMS
         {
           std::cout << rt << ", ";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
         #endif
 
         auto& rts = id_rts.second;
@@ -178,7 +178,7 @@ namespace OpenMS
       double min_tolerance = 20;
       double tol, q2, q3;
       OPENMS_LOG_INFO << "Calculating RT linking tolerance bins...\n";
-      OPENMS_LOG_INFO << "RT_bin_start, Tolerance" << std::endl;
+      OPENMS_LOG_INFO << "RT_bin_start, Tolerance" << '\n';
 
       // For every pair of median RT and differences, collect
       // differences until min_nr_diffs_per_bin_ is reached, then add the
@@ -200,14 +200,14 @@ namespace OpenMS
           tol = max(min_tolerance, q2 + 2. * 1.4826 * (q3-q2));
           bin_tolerances_.insert(make_pair(start_rt, tol));
 
-          OPENMS_LOG_INFO << start_rt << ", " << tol << std::endl;
+          OPENMS_LOG_INFO << start_rt << ", " << tol << '\n';
           #ifdef DEBUG_QTCLUSTERFINDER_IDS
           std::cout << "Differences used: ";
           for (const auto& diff : tmp_diffs)
           {
             std::cout << diff << ", ";
           }
-          std::cout << std::endl;
+          std::cout << '\n';
           #endif
           std::swap(tmp_diffs, last_tmp_diffs);
           tmp_diffs.clear();
@@ -231,18 +231,18 @@ namespace OpenMS
         tol = max(min_tolerance, q2 + 2. * 1.4826 * (q3-q2));
         bin_tolerances_.insert(make_pair(start_rt, tol));
 
-        OPENMS_LOG_INFO << start_rt << ", " << tol << std::endl;
+        OPENMS_LOG_INFO << start_rt << ", " << tol << '\n';
         #ifdef DEBUG_QTCLUSTERFINDER_IDS
         std::cout << "Differences used: ";
         for (const auto& diff : last_and_before_diffs)
         {
           std::cout << diff << ", ";
         }
-        std::cout << std::endl;
+        std::cout << '\n';
         #endif
 
         #ifdef DEBUG_QTCLUSTERFINDER_IDS
-        std::cout << "size of last bin: " << last_and_before_diffs.size() << std::endl;
+        std::cout << "size of last bin: " << last_and_before_diffs.size() << '\n';
         #endif
       }
       last_and_before_diffs.clear();
@@ -372,7 +372,7 @@ namespace OpenMS
     setParameters_(max_intensity, max_mz);
 
     // create the hash grid and fill it with features:
-    // std::cout << "Hashing..." << std::endl;
+    // std::cout << "Hashing..." << '\n';
     list<OpenMS::GridFeature> grid_features;
     Grid grid(Grid::ClusterCenter(max_diff_rt_, max_diff_mz_));
     for (Size map_index = 0; map_index < num_maps_; ++map_index)
@@ -396,7 +396,7 @@ namespace OpenMS
     }
 
     // compute QT clustering:
-    // std::cout << "Clustering..." << std::endl;
+    // std::cout << "Clustering..." << '\n';
 
     // "hot" cluster heads, we can extract the best efficiently 
     Heap cluster_heads;
@@ -425,7 +425,7 @@ namespace OpenMS
 
     while (!cluster_heads.empty())
     {
-      // std::cout << "Clusters: " << clustering.size() << std::endl;
+      // std::cout << "Clusters: " << clustering.size() << '\n';
 
       ConsensusFeature consensus_feature;
       // pops heap until a valid best cluster or empty, makes a consensusFeature and updates
@@ -465,17 +465,17 @@ namespace OpenMS
 
 #ifdef DEBUG_QTCLUSTERFINDER
     std::cout << "Elements: " << elements.size() << " with best "
-         << best->getQuality() << " invalid " << best->isInvalid() << std::endl;
+         << best->getQuality() << " invalid " << best->isInvalid() << '\n';
 #endif
 
     createConsensusFeature_(feature, best.getCurrentQuality(), elements);
 
 #ifdef DEBUG_QTCLUSTERFINDER
-    std::cout << " create new consensus feature " << feature.getRT() << " " << feature.getMZ() << " from " << best->getCenterPoint()->getFeature().getUniqueId() << std::endl;
+    std::cout << " create new consensus feature " << feature.getRT() << " " << feature.getMZ() << " from " << best->getCenterPoint()->getFeature().getUniqueId() << '\n';
     for (OpenMSBoost::unordered_map<Size, OpenMS::GridFeature*>::const_iterator
          it = elements.begin(); it != elements.end(); ++it)
     {
-      std::cout << "   = element id : " << it->second->getFeature().getUniqueId() << std::endl;
+      std::cout << "   = element id : " << it->second->getFeature().getUniqueId() << '\n';
     }
 #endif
 
@@ -658,11 +658,11 @@ void QTClusterFinder::createConsensusFeature_(ConsensusFeature& feature,
     cluster.initializeCluster();
 
 #ifdef DEBUG_QTCLUSTERFINDER
-    std::cout << " Compute Clustering: "<< x << " " << y << " with id " << center_feature->getFeature().getUniqueId() << std::endl;
+    std::cout << " Compute Clustering: "<< x << " " << y << " with id " << center_feature->getFeature().getUniqueId() << '\n';
     std::set<AASequence> a = cluster.getAnnotations();
     std::cout << " with annotations: ";
     for (std::set<AASequence>::iterator it = a.begin(); it != a.end(); ++it) std::cout << " " << *it;
-    std::cout << std::endl;
+    std::cout << '\n';
 #endif
 
     const int x = cluster.getXCoord(); 
@@ -685,7 +685,7 @@ void QTClusterFinder::createConsensusFeature_(ConsensusFeature& feature,
             OpenMS::GridFeature* neighbor_feature = it_cell->second;
 
 #ifdef DEBUG_QTCLUSTERFINDER
-            std::cout << " considering to add feature " << neighbor_feature->getFeature().getUniqueId() << " to cluster " <<  center_feature->getFeature().getUniqueId()<< std::endl;
+            std::cout << " considering to add feature " << neighbor_feature->getFeature().getUniqueId() << " to cluster " <<  center_feature->getFeature().getUniqueId()<< '\n';
 #endif
 
             // Skip features that we have already used -> we cannot add them to
@@ -725,18 +725,18 @@ void QTClusterFinder::createConsensusFeature_(ConsensusFeature& feature,
 
 #ifdef DEBUG_QTCLUSTERFINDER
     QTCluster::Elements elements = cluster.getElements();
-    std::cout << " Done with cluster -> get quality " << cluster.getQuality() << " and nr elements " << elements.size() << std::endl;
+    std::cout << " Done with cluster -> get quality " << cluster.getQuality() << " and nr elements " << elements.size() << '\n';
     for (OpenMSBoost::unordered_map<Size, OpenMS::GridFeature*>::const_iterator
          it = elements.begin(); it != elements.end(); ++it)
     {
-      std::cout << "   = element id : " << it->second->getFeature().getUniqueId() << std::endl;
+      std::cout << "   = element id : " << it->second->getFeature().getUniqueId() << '\n';
     }
 
     {
       std::set<AASequence> ax = cluster.getAnnotations();
       std::cout << " FINAL with annotations: ";
       for (std::set<AASequence>::iterator it = ax.begin(); it != ax.end(); ++it) std::cout << " " << *it;
-      std::cout << std::endl;
+      std::cout << '\n';
     }
 #endif
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
@@ -91,12 +91,12 @@ namespace OpenMS
         mobi_peak.setIntensity(0.0);
         mobi_peak.setMobility(im_grid[k]);
       }
-      // OPENMS_LOG_DEBUG << "grid position " << im_grid[k] << " profile position " << pr_it->first << std::endl;
+      // OPENMS_LOG_DEBUG << "grid position " << im_grid[k] << " profile position " << pr_it->first << '\n';
 
       // check that we did not advance past
       if (pr_it != profile.end() && (im_grid[k] - pr_it->getMobility()) > eps*10)
       {
-        std::cout << " This should never happen, pr_it has advanced past the master container: " << im_grid[k]  << "  / " <<  pr_it->getMobility()  << std::endl;
+        std::cout << " This should never happen, pr_it has advanced past the master container: " << im_grid[k]  << "  / " <<  pr_it->getMobility()  << '\n';
         throw Exception::OutOfRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
       }
 
@@ -269,7 +269,7 @@ namespace OpenMS
     {
       if (s->getDriftTimeArray() == nullptr)
       {
-        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << std::endl;
+        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << '\n';
         return;
       }
     }
@@ -278,7 +278,7 @@ namespace OpenMS
     {
       if (s->getDriftTimeArray() == nullptr)
       {
-        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in MS1 ion mobility spectrum!" << std::endl;
+        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in MS1 ion mobility spectrum!" << '\n';
         return;
       }
     }
@@ -341,7 +341,7 @@ namespace OpenMS
       OpenSwath::MRMScoring mrmscore_;
       mrmscore_.initializeXCorrPrecursorContrastMatrix({ms1_int_values}, aligned_int_vec);
       OPENMS_LOG_DEBUG << "all-all: Contrast Scores : coelution precursor : " << mrmscore_.calcXcorrPrecursorContrastCoelutionScore() << " / shape  precursor " <<
-        mrmscore_.calcXcorrPrecursorContrastShapeScore() << std::endl;
+        mrmscore_.calcXcorrPrecursorContrastShapeScore() << '\n';
       scores.im_ms1_contrast_coelution = mrmscore_.calcXcorrPrecursorContrastCoelutionScore();
       scores.im_ms1_contrast_shape = mrmscore_.calcXcorrPrecursorContrastShapeScore();
     }
@@ -361,7 +361,7 @@ namespace OpenMS
     // horribly broken: provides vector of length 1, but expects at least length 2 in calcXcorrPrecursorContrastCoelutionScore()
     mrmscore_.initializeXCorrPrecursorContrastMatrix({ms1_int_values}, {fragment_values});
     OPENMS_LOG_DEBUG << "Contrast Scores : coelution precursor : " << mrmscore_.calcXcorrPrecursorContrastSumFragCoelutionScore() << " / shape  precursor " <<
-       mrmscore_.calcXcorrPrecursorContrastSumFragShapeScore() << std::endl;
+       mrmscore_.calcXcorrPrecursorContrastSumFragShapeScore() << '\n';
 
     // in order to prevent assertion error call calcXcorrPrecursorContrastSumFragCoelutionScore, same as calcXcorrPrecursorContrastCoelutionScore() however different assertion
     scores.im_ms1_sum_contrast_coelution = mrmscore_.calcXcorrPrecursorContrastSumFragCoelutionScore();
@@ -385,7 +385,7 @@ namespace OpenMS
     for (auto s:spectra){
       if (s->getDriftTimeArray() == nullptr)
       {
-        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << std::endl;
+        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << '\n';
         return;
       }
     }
@@ -420,7 +420,7 @@ namespace OpenMS
     {
       if (s->getDriftTimeArray() == nullptr)
       {
-        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << std::endl;
+        OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << '\n';
         return;
       }
     }
@@ -459,7 +459,7 @@ namespace OpenMS
 
       delta_drift_abs += fabs(drift_target - im);
       delta_drift += drift_target - im;
-      OPENMS_LOG_DEBUG << "  -- have delta drift time " << fabs(drift_target -im ) << " with im " << im << std::endl;
+      OPENMS_LOG_DEBUG << "  -- have delta drift time " << fabs(drift_target -im ) << " with im " << im << '\n';
       computed_im += im;
       computed_im_weighted += im * intensity;
       sum_intensity += intensity;
@@ -482,8 +482,8 @@ namespace OpenMS
       computed_im_weighted = -1;
     }
 
-    OPENMS_LOG_DEBUG << " Scoring delta drift time " << delta_drift << std::endl;
-    OPENMS_LOG_DEBUG << " Scoring weighted delta drift time " << computed_im_weighted << " -> get difference " << std::fabs(computed_im_weighted - drift_target)<< std::endl;
+    OPENMS_LOG_DEBUG << " Scoring delta drift time " << delta_drift << '\n';
+    OPENMS_LOG_DEBUG << " Scoring weighted delta drift time " << computed_im_weighted << " -> get difference " << std::fabs(computed_im_weighted - drift_target)<< '\n';
     scores.im_delta_score = delta_drift_abs;
     scores.im_delta = delta_drift;
     scores.im_drift = computed_im;
@@ -562,7 +562,7 @@ namespace OpenMS
 
       // if (spectrum->getDriftTimeArray() == nullptr)
       // {
-      //   OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << std::endl;
+      //   OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << '\n';
       //   return;
       // }
 
@@ -571,7 +571,7 @@ namespace OpenMS
       {
         if (s->getDriftTimeArray() == nullptr)
         {
-          OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << std::endl;
+          OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!" << '\n';
           return;
         }
       }
@@ -593,7 +593,7 @@ namespace OpenMS
       scores.im_delta = drift_target - im;
 
       scores.im_log_intensity = std::log1p(intensity);
-      OPENMS_LOG_DEBUG << "Identification Transition IM Scoring for " << transition[0].transition_name << " range (" << im_range.getMin() << " - " << im_range.getMax() << ") IM = " << im << " im_delta = " << drift_target - im << " int = " << intensity << " log int = " << std::log(intensity+1) << std::endl;
+      OPENMS_LOG_DEBUG << "Identification Transition IM Scoring for " << transition[0].transition_name << " range (" << im_range.getMin() << " - " << im_range.getMax() << ") IM = " << im << " im_delta = " << drift_target - im << " int = " << intensity << " log int = " << std::log(intensity+1) << '\n';
 
       // Cross-Correlation of Identification against Detection Mobilogram Features
 
@@ -687,7 +687,7 @@ namespace OpenMS
           OPENMS_LOG_DEBUG << "all-all: Contrast Scores : coelution identification transition : "
                            << mrmscore_.calcXcorrPrecursorContrastCoelutionScore()
                            << " / shape  identification transition " <<
-                           mrmscore_.calcXcorrPrecursorContrastShapeScore() << std::endl;
+                           mrmscore_.calcXcorrPrecursorContrastShapeScore() << '\n';
           scores.im_ind_contrast_coelution = mrmscore_.calcXcorrPrecursorContrastCoelutionScore();
           scores.im_ind_contrast_shape = mrmscore_.calcXcorrPrecursorContrastShapeScore();
         }
@@ -709,7 +709,7 @@ namespace OpenMS
         OPENMS_LOG_DEBUG << "Contrast Scores : coelution identification transition : "
                          << mrmscore_.calcXcorrPrecursorContrastSumFragCoelutionScore()
                          << " / shape  identification transition " <<
-                         mrmscore_.calcXcorrPrecursorContrastSumFragShapeScore() << std::endl;
+                         mrmscore_.calcXcorrPrecursorContrastSumFragShapeScore() << '\n';
 
         // in order to prevent assertion error call calcXcorrPrecursorContrastSumFragCoelutionScore, same as calcXcorrPrecursorContrastCoelutionScore() however different assertion
         scores.im_ind_sum_contrast_coelution = mrmscore_.calcXcorrPrecursorContrastSumFragCoelutionScore();
@@ -717,7 +717,7 @@ namespace OpenMS
         // in order to prevent assertion error call calcXcorrPrecursorContrastSumFragShapeScore(), same as calcXcorrPrecursorContrastShapeScore() however different assertion.
         scores.im_ind_sum_contrast_shape = mrmscore_.calcXcorrPrecursorContrastSumFragShapeScore();
       } else {
-        OPENMS_LOG_DEBUG << "Identification Transition IM Scoring for " << transition[0].transition_name << " was -1. There was most likely no drift spectrum for the transition, setting cross-correlation scores to 0!" << std::endl;
+        OPENMS_LOG_DEBUG << "Identification Transition IM Scoring for " << transition[0].transition_name << " was -1. There was most likely no drift spectrum for the transition, setting cross-correlation scores to 0!" << '\n';
         scores.im_ind_contrast_coelution = 0;
         scores.im_ind_contrast_shape = 0;
         scores.im_ind_sum_contrast_coelution = 0;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -200,7 +200,7 @@ namespace OpenMS
               OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of N-Term " << OpenMS::String((*modifiable_nterm.begin())->getId()) <<
                                    " to last residue (" << temp_sequence[temp_sequence.size() - 1].getOneLetterCode() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable N-Term residue specificity (" <<
-                                   OpenMS::String((*modifiable_nterm.begin())->getOrigin()) << ") in ModificationDB." << std::endl;
+                                   OpenMS::String((*modifiable_nterm.begin())->getOrigin()) << ") in ModificationDB." << '\n';
               skip_invalid_mod_seq = true;
             }
           }
@@ -216,7 +216,7 @@ namespace OpenMS
               OPENMS_LOG_DEBUG << "[addModificationsSequences_] Skipping addition of C-Term " << OpenMS::String((*modifiable_cterm.begin())->getId()) <<
                                    " to last residue (" << temp_sequence.toUnmodifiedString().back() << ") of peptide " << temp_sequence.toUniModString() << 
                                    " , because it does not match viable C-Term residue specificity (" <<
-                                   OpenMS::String((*modifiable_cterm.begin())->getOrigin()) << ") in ModificationDB." << std::endl;
+                                   OpenMS::String((*modifiable_cterm.begin())->getOrigin()) << ") in ModificationDB." << '\n';
               skip_invalid_mod_seq = true;
             }
           }
@@ -396,7 +396,7 @@ namespace OpenMS
       // Some permutations might be too complex, skip if threshold is reached
       if (alternative_peptide_sequences.size() > max_num_alternative_localizations)
       {
-        OPENMS_LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << peptide.id << std::endl;
+        OPENMS_LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << peptide.id << '\n';
         continue;
       }
 
@@ -641,14 +641,14 @@ namespace OpenMS
           trn.setNativeID(identifier);
           trn.setMetaValue("Peptidoforms", ListUtils::concatenate(isoforms, "|"));
 
-          OPENMS_LOG_DEBUG << "[uis] Transition " << trn.getNativeID() << std::endl;
+          OPENMS_LOG_DEBUG << "[uis] Transition " << trn.getNativeID() << '\n';
 
           // Append transition
           transitions.push_back(trn);
         }
         transition_index++;
       }
-      OPENMS_LOG_DEBUG << "[uis] Peptide " << peptide.id << std::endl;
+      OPENMS_LOG_DEBUG << "[uis] Peptide " << peptide.id << '\n';
     }
     endProgress();
   }
@@ -716,7 +716,7 @@ namespace OpenMS
           trn.setNativeID(identifier);
           trn.setMetaValue("Peptidoforms", ListUtils::concatenate(decoy_isoforms, "|"));
 
-          OPENMS_LOG_DEBUG << "[uis] Decoy transition " << trn.getNativeID() << std::endl;
+          OPENMS_LOG_DEBUG << "[uis] Decoy transition " << trn.getNativeID() << '\n';
 
           // Check if decoy transition is overlapping with target transition
           vector<string> target_isoforms_overlap = getMatchingPeptidoforms_(
@@ -724,7 +724,7 @@ namespace OpenMS
 
           if (!target_isoforms_overlap.empty())
           {
-            OPENMS_LOG_DEBUG << "[uis] Skipping overlapping decoy transition " << trn.getNativeID() << std::endl;
+            OPENMS_LOG_DEBUG << "[uis] Skipping overlapping decoy transition " << trn.getNativeID() << '\n';
             continue;
           }
           else
@@ -808,12 +808,12 @@ namespace OpenMS
         {
           OPENMS_LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence.toString() 
             << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() 
-            << " " << tr.getMetaValue("annotation") << std::endl;
+            << " " << tr.getMetaValue("annotation") << '\n';
           continue;
         }
         else
         {
-          OPENMS_LOG_DEBUG << "[selected] " << target_peptide_sequence.toString() << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << " " << tr.getMetaValue("annotation") << std::endl;
+          OPENMS_LOG_DEBUG << "[selected] " << target_peptide_sequence.toString() << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << " " << tr.getMetaValue("annotation") << '\n';
         }
 
         // Set CV terms
@@ -859,7 +859,7 @@ namespace OpenMS
         {
           OPENMS_LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence 
             << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() 
-            << " " << tr.getMetaValue("annotation") << std::endl;
+            << " " << tr.getMetaValue("annotation") << '\n';
           continue;
         }
       }
@@ -869,7 +869,7 @@ namespace OpenMS
       {
         if (MRMAssay::isInSwath_(swathes, tr.getPrecursorMZ(), tr.getProductMZ()))
         {
-          OPENMS_LOG_DEBUG << "[swath] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
+          OPENMS_LOG_DEBUG << "[swath] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << '\n';
           continue;
         }
       }
@@ -877,7 +877,7 @@ namespace OpenMS
       // Check if product m/z is outside of m/z boundaries and if yes, skip
       if (tr.getProductMZ() < lower_mz_limit || tr.getProductMZ() > upper_mz_limit)
       {
-        OPENMS_LOG_DEBUG << "[mz_limit] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
+        OPENMS_LOG_DEBUG << "[mz_limit] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << '\n';
         continue;
       }
 
@@ -990,7 +990,7 @@ namespace OpenMS
       }
       else
       {
-        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << '\n';
       }
     }
 
@@ -1005,7 +1005,7 @@ namespace OpenMS
       }
       else
       {
-        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << std::endl;
+        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << '\n';
       }
     }
 
@@ -1168,7 +1168,7 @@ namespace OpenMS
       }
       else
       {
-        OPENMS_LOG_DEBUG << "[compound] Skipping " << compound.id << " - not enough transitions."<< std::endl;
+        OPENMS_LOG_DEBUG << "[compound] Skipping " << compound.id << " - not enough transitions."<< '\n';
       }
     }
     exp.setTransitions(transitions);
@@ -1231,7 +1231,7 @@ namespace OpenMS
       // Check if decoy was filtered
       if (std::find(single_decoy_id.begin(), single_decoy_id.end(), it.id) != single_decoy_id.end())
       {
-        OPENMS_LOG_DEBUG << "The decoy " << it.id << " was filtered due to missing a respective target." << std::endl;
+        OPENMS_LOG_DEBUG << "The decoy " << it.id << " was filtered due to missing a respective target." << '\n';
       }
       else
       {
@@ -1247,7 +1247,7 @@ namespace OpenMS
       if (std::find(single_decoy_id.begin(), single_decoy_id.end(), it.getCompoundRef()) != single_decoy_id.end())
       {
         OPENMS_LOG_DEBUG << "The decoy " << it.getCompoundRef()
-                         << " was filtered due to missing a respective target." << std::endl;
+                         << " was filtered due to missing a respective target." << '\n';
       }
       else
       {
@@ -1353,7 +1353,7 @@ namespace OpenMS
         if (targetion.first == "unannotated")
         {
           OPENMS_LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence.toString()
-            << " PrecursorMZ: " << tr->precursor_mz << " ProductMZ: " << tr->product_mz << std::endl;
+            << " PrecursorMZ: " << tr->precursor_mz << " ProductMZ: " << tr->product_mz << '\n';
           continue;
         }
 
@@ -1435,7 +1435,7 @@ namespace OpenMS
       {
         if (MRMAssay::isInSwath_(swathes, tr.precursor_mz, tr.product_mz))
         {
-          OPENMS_LOG_DEBUG << "[swath] Skipping PrecursorMZ: " << tr.precursor_mz << " ProductMZ: " << tr.product_mz << std::endl;
+          OPENMS_LOG_DEBUG << "[swath] Skipping PrecursorMZ: " << tr.precursor_mz << " ProductMZ: " << tr.product_mz << '\n';
           continue;
         }
       }
@@ -1443,7 +1443,7 @@ namespace OpenMS
       // Check if product m/z is outside of m/z boundaries and if yes, skip
       if (tr.product_mz < lower_mz_limit || tr.product_mz > upper_mz_limit)
       {
-        OPENMS_LOG_DEBUG << "[mz_limit] Skipping PrecursorMZ: " << tr.precursor_mz << " ProductMZ: " << tr.product_mz << std::endl;
+        OPENMS_LOG_DEBUG << "[mz_limit] Skipping PrecursorMZ: " << tr.precursor_mz << " ProductMZ: " << tr.product_mz << '\n';
         continue;
       }
 
@@ -1677,7 +1677,7 @@ namespace OpenMS
       }
       catch (Exception::BaseException&)
       {
-        OPENMS_LOG_DEBUG << "[uis] Skipping compound (cannot parse sequence): " << compound.id << std::endl;
+        OPENMS_LOG_DEBUG << "[uis] Skipping compound (cannot parse sequence): " << compound.id << '\n';
         continue;
       }
 
@@ -1691,7 +1691,7 @@ namespace OpenMS
       // Some permutations might be too complex, skip if threshold is reached
       if (alternative_peptide_sequences.size() > max_num_alternative_localizations)
       {
-        OPENMS_LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << compound.id << std::endl;
+        OPENMS_LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << compound.id << '\n';
         continue;
       }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -138,7 +138,7 @@ namespace OpenMS
     const int max_attempts) const
   {
 #ifdef DEBUG_MRMDECOY
-    std::cout << " shuffle peptide " << peptide.sequence << std::endl;
+    std::cout << " shuffle peptide " << peptide.sequence << '\n';
     seed = 41;
 #endif
     // Delegate to light implementation
@@ -152,7 +152,7 @@ namespace OpenMS
 #ifdef DEBUG_MRMDECOY
     for (Size j = 0; j < peptide.mods.size(); j++)
     {
-      std::cout << " position after shuffling " << peptide.mods[j].location << " mass difference " << peptide.mods[j].mono_mass_delta << std::endl;
+      std::cout << " position after shuffling " << peptide.mods[j].location << " mass difference " << peptide.mods[j].mono_mass_delta << '\n';
     }
 #endif
 
@@ -566,7 +566,7 @@ namespace OpenMS
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
         if (MRMDecoy::hasCNterminalMods_(peptide, do_switchKR))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(peptide.id);
         }
         else
@@ -580,7 +580,7 @@ namespace OpenMS
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
         if (MRMDecoy::hasCNterminalMods_(peptide, false))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(peptide.id);
         }
         else
@@ -593,7 +593,7 @@ namespace OpenMS
         peptide = MRMDecoy::shufflePeptide(peptide, identity_threshold, -1, max_attempts);
         if (do_switchKR && MRMDecoy::hasCNterminalMods_(peptide, do_switchKR))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(peptide.id);
         }
         else if (do_switchKR) { switchKR(peptide); }
@@ -604,13 +604,13 @@ namespace OpenMS
       const std::string peptide_key = MRMDecoy::getModifiedPeptideSequence_(peptide) + String(peptide.getChargeState());
       if (allPeptideSequences.find(peptide_key) != allPeptideSequences.end())
       {
-        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " since decoy peptide is also a target peptide or this decoy peptide is already present" << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " since decoy peptide is also a target peptide or this decoy peptide is already present" << '\n';
         exclusion_peptides.insert(peptide.id);
       }
       else
       {
         // Since this decoy will be added, add it to the precursor map so that the same decoy is not added twice
-        OPENMS_LOG_DEBUG << "[peptide] adding " << peptide.id << " to master list of peptides " << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] adding " << peptide.id << " to master list of peptides " << '\n';
         allPeptideSequences[peptide_key] = peptide.id;
       }
 
@@ -701,7 +701,7 @@ namespace OpenMS
         {
           // transition could not be annotated, remove whole peptide
           exclusion_peptides.insert(decoy_tr.getPeptideRef());
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to missing annotation" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to missing annotation" << '\n';
         }
       } // end loop over transitions
 
@@ -731,7 +731,7 @@ namespace OpenMS
       }
       else
       {
-        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to missing transitions" << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to missing transitions" << '\n';
       }
     }
 
@@ -745,7 +745,7 @@ namespace OpenMS
       }
       else
       {
-        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << " due to missing peptides" << std::endl;
+        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << " due to missing peptides" << '\n';
       }
     }
 
@@ -868,7 +868,7 @@ namespace OpenMS
       }
       catch (Exception::InvalidValue&)
       {
-        OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " - cannot parse sequence" << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " - cannot parse sequence" << '\n';
         exclusion_peptides.insert(decoy_compound.id);
         continue;
       }
@@ -885,7 +885,7 @@ namespace OpenMS
       {
         if (hasCNterminalModsLight_(decoy_compound.modifications, unmodified_sequence.size(), do_switchKR))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(decoy_compound.id);
           continue;
         }
@@ -898,7 +898,7 @@ namespace OpenMS
       {
         if (hasCNterminalModsLight_(decoy_compound.modifications, unmodified_sequence.size(), false))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(decoy_compound.id);
           continue;
         }
@@ -915,7 +915,7 @@ namespace OpenMS
         decoy_mods = result.second;
         if (do_switchKR && hasCNterminalModsLight_(decoy_mods, decoy_sequence.size(), do_switchKR))
         {
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " due to C/N-terminal modifications" << '\n';
           exclusion_peptides.insert(decoy_compound.id);
           continue;
         }
@@ -957,12 +957,12 @@ namespace OpenMS
       std::string decoy_key = full_decoy_sequence + String(decoy_compound.charge);
       if (allPeptideSequences.find(decoy_key) != allPeptideSequences.end())
       {
-        OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " since decoy peptide is also a target peptide or this decoy peptide is already present" << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_compound.id << " since decoy peptide is also a target peptide or this decoy peptide is already present" << '\n';
         exclusion_peptides.insert(decoy_compound.id);
         continue;
       }
       // Add to map with modified sequence (matching Heavy path line 612)
-      OPENMS_LOG_DEBUG << "[peptide] adding " << decoy_compound.id << " to master list of peptides" << std::endl;
+      OPENMS_LOG_DEBUG << "[peptide] adding " << decoy_compound.id << " to master list of peptides" << '\n';
       allPeptideSequences[decoy_key] = decoy_compound.id;
 
       // Update modifications
@@ -1034,7 +1034,7 @@ namespace OpenMS
       }
       catch (Exception::InvalidValue&)
       {
-        OPENMS_LOG_DEBUG << "[transition] Skipping transitions for " << peptide_ref << " - cannot parse sequence" << std::endl;
+        OPENMS_LOG_DEBUG << "[transition] Skipping transitions for " << peptide_ref << " - cannot parse sequence" << '\n';
         continue;
       }
 
@@ -1112,7 +1112,7 @@ namespace OpenMS
         else
         {
           // Transition could not be annotated, exclude whole peptide (matching Heavy path behavior)
-          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_peptide_ref << " due to missing annotation" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_peptide_ref << " due to missing annotation" << '\n';
           exclusion_peptides.insert(decoy_peptide_ref);
         }
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMScoring.cpp
@@ -206,7 +206,7 @@ namespace OpenSwath
           // compute normalized cross correlation
           xcorr_precursor_contrast_matrix_(i, j) = Scoring::normalizedCrossCorrelationPost(tmp_data_precursor[i], tmp_data_fragments[j], static_cast<int>(tmp_data_precursor[i].size()), 1);
 #ifdef MRMSCORING_TESTING
-          std::cout << " fill xcorr_precursor_contrast_matrix_ "<< tmp_data_precursor[i].size() << " / " << tmp_data_fragments[j].size() << " : " << xcorr_precursor_contrast_matrix_[i][j].data.size() << std::endl;
+          std::cout << " fill xcorr_precursor_contrast_matrix_ "<< tmp_data_precursor[i].size() << " / " << tmp_data_fragments[j].size() << " : " << xcorr_precursor_contrast_matrix_[i][j].data.size() << '\n';
 #endif
         }
       }
@@ -261,7 +261,7 @@ namespace OpenSwath
           //deltas.push_back(std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_.getValue(i, j))->first));
           msc(xcorr_matrix_max_peak_(i,j));
 #ifdef MRMSCORING_TESTING
-          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][j])->first) << std::endl;
+          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][j])->first) << '\n';
 #endif
         }
       }
@@ -289,7 +289,7 @@ namespace OpenSwath
                    * normalized_library_intensity[i]);
 #ifdef MRMSCORING_TESTING
         std::cout << "_xcoel_weighted " << i << " " << i << " " << Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][i])->first << " weight " <<
-        normalized_library_intensity[i] * normalized_library_intensity[i] << std::endl;
+        normalized_library_intensity[i] * normalized_library_intensity[i] << '\n';
       weights += normalized_library_intensity[i] * normalized_library_intensity[i];
 #endif
         for (long int j = i + 1; j < xcorr_matrix_max_peak_.rows(); j++)
@@ -300,7 +300,7 @@ namespace OpenSwath
                      * normalized_library_intensity[j] * 2);
 #ifdef MRMSCORING_TESTING
           std::cout << "_xcoel_weighted " << i << " " << j << " " << Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][j])->first << " weight " <<
-          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << std::endl;
+          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << '\n';
         weights += normalized_library_intensity[i] * normalized_library_intensity[j];
 #endif
 
@@ -308,7 +308,7 @@ namespace OpenSwath
       }
 
 #ifdef MRMSCORING_TESTING
-      std::cout << " all weights sum " << weights << std::endl;
+      std::cout << " all weights sum " << weights << '\n';
 #endif
 
       return deltas;
@@ -328,7 +328,7 @@ namespace OpenSwath
           auto x = Scoring::xcorrArrayGetMaxPeak(xcorr_contrast_matrix_(i, j));
           deltas_id += std::abs(x->first);
 #ifdef MRMSCORING_TESTING
-          std::cout << "&&_xcoel append " << xcorr_contrast_matrix_max_peak_getValue(i, j) << std::endl;
+          std::cout << "&&_xcoel append " << xcorr_contrast_matrix_max_peak_getValue(i, j) << '\n';
 #endif
         }
         deltas.push_back(deltas_id / xcorr_contrast_matrix_.cols());
@@ -350,7 +350,7 @@ namespace OpenSwath
           auto x = Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_matrix_(i, j));
           msc(std::abs(x->first));
 #ifdef MRMSCORING_TESTING
-          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_matrix_[i][j])->first) << std::endl;
+          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_matrix_[i][j])->first) << '\n';
 #endif
         }
       }
@@ -376,7 +376,7 @@ namespace OpenSwath
         auto e = *(em.data() + i);
         msc(std::abs(Scoring::xcorrArrayGetMaxPeak(e)->first));
 #ifdef MRMSCORING_TESTING
-        std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_contrast_matrix_[i][j])->first) << std::endl;
+        std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_contrast_matrix_[i][j])->first) << '\n';
 #endif
       }
 
@@ -401,7 +401,7 @@ namespace OpenSwath
         msc(std::abs(Scoring::xcorrArrayGetMaxPeak(e)->first));
 
 #ifdef MRMSCORING_TESTING
-        std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_contrast_matrix_[i][j])->first) << std::endl;
+        std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_contrast_matrix_[i][j])->first) << '\n';
 #endif
       }
 
@@ -425,7 +425,7 @@ namespace OpenSwath
           auto x = Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_combined_matrix_(i, j));
           msc(std::abs(x->first));
 #ifdef MRMSCORING_TESTING
-          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_combined_matrix_[i][j])->first) << std::endl;
+          std::cout << "&&_xcoel append " << std::abs(Scoring::xcorrArrayGetMaxPeak(xcorr_precursor_combined_matrix_[i][j])->first) << '\n';
 #endif
         }
       }
@@ -477,7 +477,7 @@ namespace OpenSwath
                         * normalized_library_intensity[i]);
 #ifdef MRMSCORING_TESTING
         std::cout << "_xcorr_weighted " << i << " " << i << " " << Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][i])->second << " weight " <<
-        normalized_library_intensity[i] * normalized_library_intensity[i] << std::endl;
+        normalized_library_intensity[i] * normalized_library_intensity[i] << '\n';
 #endif
         for (long int j = i + 1; j < xcorr_matrix_max_peak_sec_.rows(); j++)
         {
@@ -486,7 +486,7 @@ namespace OpenSwath
                           * normalized_library_intensity[j] * 2);
 #ifdef MRMSCORING_TESTING
           std::cout << "_xcorr_weighted " << i << " " << j << " " << Scoring::xcorrArrayGetMaxPeak(xcorr_matrix_[i][j])->second << " weight " <<
-          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << std::endl;
+          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << '\n';
 #endif
         }
       }
@@ -613,7 +613,7 @@ namespace OpenSwath
       for (std::size_t k = 0; k < transitions.size(); k++)
     {
       native_id = transitions[k].getNativeID();
-      std::cout << native_id << " Lib vs exp " << library_intensity[k] << " " << experimental_intensity[k] << std::endl;
+      std::cout << native_id << " Lib vs exp " << library_intensity[k] << " " << experimental_intensity[k] << '\n';
     }
 #endif
 
@@ -845,7 +845,7 @@ namespace OpenSwath
                      * normalized_library_intensity[i];
 #ifdef MRMSCORING_TESTING
         std::cout << "_mi_weighted " << i << " " << i << " " << mi_matrix_[i][i] << " weight " <<
-        normalized_library_intensity[i] * normalized_library_intensity[i] << std::endl;
+        normalized_library_intensity[i] * normalized_library_intensity[i] << '\n';
 #endif
         for (long int j = i + 1; j < mi_matrix_.rows(); j++)
         {
@@ -854,7 +854,7 @@ namespace OpenSwath
                        * normalized_library_intensity[j] * 2;
 #ifdef MRMSCORING_TESTING
           std::cout << "_mi_weighted " << i << " " << j << " " << mi_matrix_[i][j] << " weight " <<
-          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << std::endl;
+          normalized_library_intensity[i] * normalized_library_intensity[j] * 2 << '\n';
 #endif
         }
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -51,7 +51,7 @@ namespace OpenMS
     bool pasef,
     bool load_into_memory)
   {
-    OPENMS_LOG_DEBUG << "performRTNormalization method starting" << std::endl;
+    OPENMS_LOG_DEBUG << "performRTNormalization method starting" << '\n';
     std::vector< OpenMS::MSChromatogram > irt_chromatograms;
     TransformationDescription trafo; // dummy
     this->simpleExtractChromatograms_(swath_maps, irt_transitions, irt_chromatograms, trafo, cp_irt, pasef, load_into_memory);
@@ -71,11 +71,11 @@ namespace OpenMS
       }
       catch (OpenMS::Exception::UnableToCreateFile& /*e*/)
       {
-        OPENMS_LOG_DEBUG << "Error creating file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
+        OPENMS_LOG_DEBUG << "Error creating file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << '\n';
       }
       catch (OpenMS::Exception::BaseException& /*e*/)
       {
-        OPENMS_LOG_DEBUG << "Error writing to file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
+        OPENMS_LOG_DEBUG << "Error writing to file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << '\n';
       }
     }
     OPENMS_LOG_DEBUG << "Extracted number of chromatograms from iRT files: " << irt_chromatograms.size() <<  std::endl;
@@ -100,18 +100,18 @@ namespace OpenMS
     const Param& calibration_param,
     const bool pasef)
   {
-    OPENMS_LOG_DEBUG << "Start of doDataNormalization_ method" << std::endl;
+    OPENMS_LOG_DEBUG << "Start of doDataNormalization_ method" << '\n';
     this->startProgress(0, 1, "Retention time normalization");
 
     bool estimateBestPeptides = irt_detection_param.getValue("estimateBestPeptides").toBool();
     if (estimateBestPeptides)
     {
-      OPENMS_LOG_DEBUG << "Activated the 'estimateBestPeptides' option." << std::endl;
+      OPENMS_LOG_DEBUG << "Activated the 'estimateBestPeptides' option." << '\n';
     }
 
     // 1. Estimate the retention time range of the iRT peptides over all assays
     std::pair<double,double> RTRange = OpenSwathHelper::estimateRTRange(targeted_exp);
-    OPENMS_LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << std::endl;
+    OPENMS_LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << '\n';
 
     // 2. Store the peptide retention times in an intermediate map
     std::map<OpenMS::String, double> PeptideRTMap;
@@ -165,7 +165,7 @@ namespace OpenMS
     std::vector<std::pair<double, double> > pairs; // store the RT pairs to write the output trafoXML
     std::map<std::string, double> best_features = OpenSwathHelper::simpleFindBestFeature(transition_group_map,
       estimateBestPeptides, irt_detection_param.getValue("OverallQualityCutoff"));
-    OPENMS_LOG_DEBUG << "Extracted best features: " << best_features.size() << std::endl;
+    OPENMS_LOG_DEBUG << "Extracted best features: " << best_features.size() << '\n';
 
     // Create pairs vector and store peaks
     std::map<String, OpenMS::MRMFeatureFinderScoring::MRMTransitionGroupType *> trgrmap_allpeaks; // store all peaks above cutoff
@@ -208,7 +208,7 @@ namespace OpenMS
         String("Illegal argument '") + outlier_method +
         "' used for outlierMethod (valid: 'iter_residual', 'iter_jackknife', 'ransac', 'none').");
     }
-    OPENMS_LOG_DEBUG << "Performed outlier detection, left with features: " << pairs_corrected.size() << std::endl;
+    OPENMS_LOG_DEBUG << "Performed outlier detection, left with features: " << pairs_corrected.size() << '\n';
 
     // 6. Check whether the found peptides fulfill the binned coverage criteria
     // set by the user.
@@ -281,13 +281,13 @@ namespace OpenMS
     String model_type = irt_detection_param.getValue("alignmentMethod").toString();
     trafo_out.fitModel(model_type, model_params);
 
-    OPENMS_LOG_DEBUG << "Final RT mapping:" << std::endl;
+    OPENMS_LOG_DEBUG << "Final RT mapping:" << '\n';
     for (Size i = 0; i < pairs_corrected.size(); i++)
     {
-      OPENMS_LOG_DEBUG << pairs_corrected[i].first << " " <<  pairs_corrected[i].second << std::endl;
+      OPENMS_LOG_DEBUG << pairs_corrected[i].first << " " <<  pairs_corrected[i].second << '\n';
     }
 
-    OPENMS_LOG_DEBUG << "End of doDataNormalization_ method" << std::endl;
+    OPENMS_LOG_DEBUG << "End of doDataNormalization_ method" << '\n';
 
     this->endProgress();
     return trafo_out;
@@ -344,7 +344,7 @@ namespace OpenMS
                const OpenSwath::LightTransition& tr = irt_transitions.transitions[k];
                transition_exp_used.transitions.push_back(tr);
                matching_compounds.insert(tr.getPeptideRef());
-               OPENMS_LOG_DEBUG << "Adding Precursor with m/z " << tr.getPrecursorMZ() << " and IM of " << tr.getPrecursorIM() <<  " to swath with mz lower of " << swath_maps[map_idx].lower << " m/z upper of " << swath_maps[map_idx].upper << " im lower of " << swath_maps[map_idx].imLower << " and im upper of " << swath_maps[map_idx].imUpper << std::endl;
+               OPENMS_LOG_DEBUG << "Adding Precursor with m/z " << tr.getPrecursorMZ() << " and IM of " << tr.getPrecursorIM() <<  " to swath with mz lower of " << swath_maps[map_idx].lower << " m/z upper of " << swath_maps[map_idx].upper << " im lower of " << swath_maps[map_idx].imLower << " and im upper of " << swath_maps[map_idx].imUpper << '\n';
             }
           }
 
@@ -399,7 +399,7 @@ namespace OpenMS
           {
             int nr_empty_chromatograms = 0;
             OPENMS_LOG_DEBUG << "[simple] Extracted "  << tmp_chromatograms.size() << " chromatograms from SWATH map " <<
-              map_idx << " with m/z " << swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << ":" << std::endl;
+              map_idx << " with m/z " << swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << ":" << '\n';
             for (Size chrom_idx = 0; chrom_idx < tmp_chromatograms.size(); chrom_idx++)
             {
               // Check TIC and remove empty chromatograms (can happen if the
@@ -408,7 +408,7 @@ namespace OpenMS
               double tic = std::accumulate(tmp_out[chrom_idx]->getIntensityArray()->data.begin(),
                                            tmp_out[chrom_idx]->getIntensityArray()->data.end(),0.0);
               OPENMS_LOG_DEBUG << "Chromatogram "  << coordinates[chrom_idx].id << " with size "
-                << tmp_out[chrom_idx]->getIntensityArray()->data.size() << " and TIC " << tic  << std::endl;
+                << tmp_out[chrom_idx]->getIntensityArray()->data.size() << " and TIC " << tic  << '\n';
               if (tic > 0.0)
               {
                 // add the chromatogram to the output
@@ -417,21 +417,21 @@ namespace OpenMS
               else
               {
                 OPENMS_LOG_DEBUG << " - Warning: Empty chromatogram " << coordinates[chrom_idx].id <<
-                  " detected. Will skip it!" << std::endl;
+                  " detected. Will skip it!" << '\n';
                 nr_empty_chromatograms++;
               }
             }
 
             if (nr_empty_chromatograms > 0)
             {
-              std::cerr << " - Warning: Detected " << nr_empty_chromatograms << " empty chromatograms. Will skip them!" << std::endl;
+              std::cerr << " - Warning: Detected " << nr_empty_chromatograms << " empty chromatograms. Will skip them!" << '\n';
             }
           }
         }
         else
         {
           OPENMS_LOG_DEBUG << "Extracted no transitions from SWATH map " << map_idx << " with m/z " <<
-              swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << std::endl;
+              swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << '\n';
         }
       }
     }
@@ -519,7 +519,7 @@ namespace OpenMS
     TransformationDescription trafo_inverse = trafo;
     trafo_inverse.invert();
 
-    std::cout << "Will analyze " << transition_exp.transitions.size() << " transitions in total." << std::endl;
+    std::cout << "Will analyze " << transition_exp.transitions.size() << " transitions in total." << '\n';
     int progress = 0;
     this->startProgress(0, swath_maps.size(), "Extracting and scoring transitions");
 
@@ -561,7 +561,7 @@ namespace OpenMS
     //
     // currently not supported to do PASEF and PRM
     if (prm_ & pasef_) {
-      std::cerr << "Setting -pasef and -matching_window_only flags simultaneously is not currently supported." << std::endl;
+      std::cerr << "Setting -pasef and -matching_window_only flags simultaneously is not currently supported." << '\n';
       throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
     else if (prm_)
@@ -626,7 +626,7 @@ namespace OpenMS
             {
               // current DIA window "i" is a better match
               OPENMS_LOG_DEBUG << "For Precursor " << tr.getPrecursorIM() << "Replacing Swath Map with IM center of " <<
-                imOld << " with swath map of im center " << imNew << std::endl;
+                imOld << " with swath map of im center " << imNew << '\n';
               tr_win_map[k] = i;
             }
 
@@ -646,14 +646,14 @@ namespace OpenMS
     int total_nr_threads = omp_get_max_threads(); // store total number of threads we are allowed to use
     if (threads_outer_loop_ > -1)
     {
-      std::cout << "Setting up nested loop with " << std::min(threads_outer_loop_, omp_get_max_threads()) << " threads out of "<< omp_get_max_threads() << std::endl;
+      std::cout << "Setting up nested loop with " << std::min(threads_outer_loop_, omp_get_max_threads()) << " threads out of "<< omp_get_max_threads() << '\n';
       omp_set_nested(1);
       omp_set_dynamic(0);
       omp_set_num_threads(std::min(threads_outer_loop_, omp_get_max_threads()) ); // use at most threads_outer_loop_ threads here
     }
     else
     {
-      std::cout << "Use non-nested loop with " << total_nr_threads << " threads." << std::endl;
+      std::cout << "Use non-nested loop with " << total_nr_threads << " threads." << '\n';
     }
 #endif
 #pragma omp parallel for schedule(dynamic,1)
@@ -682,7 +682,7 @@ namespace OpenMS
                const OpenSwath::LightTransition& tr = transition_exp.transitions[k];
                transition_exp_used_all.transitions.push_back(tr);
                matching_compounds.insert(tr.getPeptideRef());
-               OPENMS_LOG_DEBUG << "Adding Precursor with m/z " << tr.getPrecursorMZ() << " and IM of " << tr.getPrecursorIM() <<  " to swath with mz upper of " << swath_maps[i].upper << " im lower of " << swath_maps[i].imLower << " and im upper of " << swath_maps[i].imUpper << std::endl;
+               OPENMS_LOG_DEBUG << "Adding Precursor with m/z " << tr.getPrecursorMZ() << " and IM of " << tr.getPrecursorIM() <<  " to swath with mz upper of " << swath_maps[i].upper << " im lower of " << swath_maps[i].imLower << " and im upper of " << swath_maps[i].imUpper << '\n';
             }
           }
 
@@ -773,7 +773,7 @@ namespace OpenMS
 #endif
               "will analyze " << transition_exp_used_all.getCompounds().size() <<  " compounds and "
               << transition_exp_used_all.getTransitions().size() <<  " transitions "
-              "from SWATH " << i << " (batch " << pep_idx << " out of " << nr_batches << ")" << std::endl;
+              "from SWATH " << i << " (batch " << pep_idx << " out of " << nr_batches << ")" << '\n';
             }
 
             // Create the new, batch-size transition experiment
@@ -936,7 +936,7 @@ namespace OpenMS
     }
     else if (use_ms1_traces_ && !ms1_map_)
     {
-      OPENMS_LOG_WARN << "WARNING: Attempted to use MS1 traces but no MS1 map was provided: Will not use MS1 signal!" << std::endl;
+      OPENMS_LOG_WARN << "WARNING: Attempted to use MS1 traces but no MS1 map was provided: Will not use MS1 signal!" << '\n';
     }
 
     // If use_total_mi_score is defined, we need to instruct MRMTransitionGroupPicker to compute the score

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerChromatogram.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerChromatogram.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
     {
         OPENMS_LOG_DEBUG << " ====  Picking chromatogram " << chromatogram.getNativeID() << 
         " with " << chromatogram.size() << " peaks (start at RT " << chromatogram[0].getRT() << " to RT " << chromatogram.back().getRT() << ") "
-        "using method \'" << method_ << "\'" << std::endl;
+        "using method \'" << method_ << "\'" << '\n';
     }
     picked_chrom.clear(true);
     // Crawdad has its own methods, so we can call the wrapper directly
@@ -101,7 +101,7 @@ namespace OpenMS
 
     // Find initial seeds (peak picking)
     pp_.pick(smoothed_chrom, picked_chrom);
-    OPENMS_LOG_DEBUG << "Picked " << picked_chrom.size() << " chromatographic peaks." << std::endl;
+    OPENMS_LOG_DEBUG << "Picked " << picked_chrom.size() << " chromatographic peaks." << '\n';
 
     if (method_ == "legacy")
     {
@@ -204,7 +204,7 @@ namespace OpenMS
 #ifdef WITH_CRAWDAD
   void PeakPickerChromatogram::pickChromatogramCrawdad_(const MSChromatogram& chromatogram, MSChromatogram& picked_chrom)
   {
-    OPENMS_LOG_DEBUG << "Picking chromatogram using crawdad " << std::endl;
+    OPENMS_LOG_DEBUG << "Picking chromatogram using crawdad " << '\n';
 
     // copy meta data of the input chromatogram
     picked_chrom.clear(true);
@@ -259,7 +259,7 @@ namespace OpenMS
   void PeakPickerChromatogram::removeOverlappingPeaks_(const MSChromatogram& chromatogram, MSChromatogram& picked_chrom)
   {
     if (picked_chrom.empty()) {return; }
-    OPENMS_LOG_DEBUG << "Remove overlapping peaks now (size " << picked_chrom.size() << ")" << std::endl;
+    OPENMS_LOG_DEBUG << "Remove overlapping peaks now (size " << picked_chrom.size() << ")" << '\n';
     Size current_peak = 0;
     // Find overlapping peaks
     for (Size i = 0; i < picked_chrom.size() - 1; i++)
@@ -273,8 +273,8 @@ namespace OpenMS
         const int current_right_idx = right_width_[i];
         const int next_left_idx = left_width_[i + 1];
         const int next_right_idx = right_width_[i + 1];
-        OPENMS_LOG_DEBUG << " Found overlapping " << i << " : " << current_left_idx << " " << current_right_idx << std::endl;
-        OPENMS_LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << std::endl;
+        OPENMS_LOG_DEBUG << " Found overlapping " << i << " : " << current_left_idx << " " << current_right_idx << '\n';
+        OPENMS_LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << '\n';
 
         // Find the peak width and best RT
         double central_peak_rt = picked_chrom[i].getPos();
@@ -301,7 +301,7 @@ namespace OpenMS
         // assert that the peaks are now not overlapping any more ...
         if (new_left_border < new_right_border)
         {
-          std::cerr << "Something went wrong, peaks are still overlapping!" << " - new left border " << new_left_border << " vs " << new_right_border << " -- will take the mean" << std::endl;
+          std::cerr << "Something went wrong, peaks are still overlapping!" << " - new left border " << new_left_border << " vs " << new_right_border << " -- will take the mean" << '\n';
           new_left_border = (new_left_border + new_right_border) / 2;
           new_right_border = (new_left_border + new_right_border) / 2;
 
@@ -309,10 +309,10 @@ namespace OpenMS
 
         OPENMS_LOG_DEBUG << "New peak l: " << chromatogram[current_left_idx].getPos() 
           << " " << chromatogram[new_right_border].getPos() 
-          << " int " << integrated_intensities_[i] << std::endl;
+          << " int " << integrated_intensities_[i] << '\n';
         OPENMS_LOG_DEBUG << "New peak r: " << chromatogram[new_left_border].getPos() 
           << " " << chromatogram[next_right_idx].getPos() 
-          << " int " << integrated_intensities_[i + 1] << std::endl;
+          << " int " << integrated_intensities_[i + 1] << '\n';
 
 
         right_width_[i] = new_right_border;

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -141,7 +141,7 @@ namespace OpenMS
     double im_extraction_win = im_extraction_window_;
     double im_estimation_padding_factor = im_estimation_padding_factor_;
 
-    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctIM " << " window " << im_extraction_win << " mz window " << mz_extr_window << " in ppm " << ppm << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctIM " << " window " << im_extraction_win << " mz window " << mz_extr_window << " in ppm " << ppm << '\n';
 
     if (im_extraction_win < 0)
     {
@@ -159,7 +159,7 @@ namespace OpenMS
     {
       std::cout.precision(16);
       os_im.open(debug_im_file_);
-      os_im << "mz" << "\t" << "im" << "\t" << "theo_im" << "\t" << "RT" << "\t" << "intensity" << std::endl;
+      os_im << "mz" << "\t" << "im" << "\t" << "theo_im" << "\t" << "RT" << "\t" << "intensity" << '\n';
       os_im.precision(writtenDigits(double()));
     }
 
@@ -257,10 +257,10 @@ namespace OpenMS
         // Check that the spectrum really has a drift time array
         if (sp_ms2->getDriftTimeArray() == nullptr)
         {
-          OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << std::endl;
+          OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << '\n';
           for (const auto& m : used_maps)
           {
-            OPENMS_LOG_DEBUG << " -- Used maps " << m.lower << " to " << m.upper << " MS1 : " << m.ms1 << true << std::endl;
+            OPENMS_LOG_DEBUG << " -- Used maps " << m.lower << " to " << m.upper << " MS1 : " << m.ms1 << true << '\n';
           }
           continue;
         }
@@ -281,10 +281,10 @@ namespace OpenMS
           theo_im.push_back(drift_target);
           if (!debug_im_file_.empty())
           {
-            os_im << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << std::endl;
+            os_im << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << '\n';
           }
         }
-        OPENMS_LOG_DEBUG << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << std::endl;
+        OPENMS_LOG_DEBUG << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << '\n';
       }
 
       // Always collect a few MS1 IM points for window estimation (independent of ms1_im_)
@@ -344,10 +344,10 @@ namespace OpenMS
         // Check that the spectrum really has a drift time array
         if (sp_ms1->getDriftTimeArray() == nullptr)
         {
-          OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << std::endl;
+          OPENMS_LOG_DEBUG << "Did not find a drift time array for peptide " << pepref << " at RT " << bestRT  << '\n';
           for (const auto& m : used_maps)
           {
-            OPENMS_LOG_DEBUG << " -- Used maps " << m.lower << " to " << m.upper << " MS1 : " << m.ms1 << true << std::endl;
+            OPENMS_LOG_DEBUG << " -- Used maps " << m.lower << " to " << m.upper << " MS1 : " << m.ms1 << true << '\n';
           }
           continue;
         }
@@ -368,10 +368,10 @@ namespace OpenMS
           theo_im.push_back(drift_target);
           if (!debug_im_file_.empty())
           {
-            os_im << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << std::endl;
+            os_im << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << '\n';
           }
         }
-        OPENMS_LOG_DEBUG << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << std::endl;
+        OPENMS_LOG_DEBUG << tr.precursor_mz << "\t" << im << "\t" << drift_target << "\t" << bestRT << "\t" << intensity << '\n';
       }
 
       #pragma omp critical (accum_points)
@@ -400,7 +400,7 @@ namespace OpenMS
     im_regression_params.push_back(0.0);
 
     std::cout << "# im regression parameters: Y = " << im_regression_params[0] << " + " <<
-      im_regression_params[1] << " X + " << im_regression_params[2] << " X^2" << std::endl;
+      im_regression_params[1] << " X + " << im_regression_params[2] << " X^2" << '\n';
 
     // store IM transformation, using the selected model
     im_trafo.setDataPoints(data_im);
@@ -432,7 +432,7 @@ namespace OpenMS
       setPrecursorImWindow(precursor_im_window);
     }
 
-    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctIM done." << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctIM done." << '\n';
   }
 
   void SwathMapMassCorrection::correctMZ(
@@ -447,7 +447,7 @@ namespace OpenMS
     double im_extraction = im_extraction_window_;
     double mz_estimation_padding_factor = mz_estimation_padding_factor_;
 
-    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ with type " << corr_type << " and window " << mz_extr_window << " in ppm " << ppm << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ with type " << corr_type << " and window " << mz_extr_window << " in ppm " << ppm << '\n';
 
     bool is_ppm = bool(corr_type == "quadratic_regression_delta_ppm" ||
                        corr_type == "weighted_quadratic_regression_delta_ppm" ||
@@ -463,7 +463,7 @@ namespace OpenMS
     {
       std::cout.precision(16);
       os.open(debug_mz_file_);
-      os << "mz" << "\t" << "theo_mz" << "\t" << "drift_time" << "\t" << "diff_ppm" << "\t" << "log_intensity" << "\t" << "RT" << std::endl;
+      os << "mz" << "\t" << "theo_mz" << "\t" << "drift_time" << "\t" << "diff_ppm" << "\t" << "log_intensity" << "\t" << "RT" << '\n';
       os.precision(writtenDigits(double()));
     }
 
@@ -557,9 +557,9 @@ namespace OpenMS
         delta_ppm.push_back(diff_ppm);
         if (!debug_mz_file_.empty())
         {
-          os << mz << "\t" << tr.product_mz << "\t" << drift_target << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << std::endl;
+          os << mz << "\t" << tr.product_mz << "\t" << drift_target << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << '\n';
         }
-        OPENMS_LOG_DEBUG << mz << "\t" << tr.product_mz << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << std::endl;
+        OPENMS_LOG_DEBUG << mz << "\t" << tr.product_mz << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << '\n';
       }
 
       // MS1 precursor processing for Δppm residuals
@@ -702,7 +702,7 @@ namespace OpenMS
            regression_params[2]);
 
     OPENMS_LOG_DEBUG << "# mz regression parameters: Y = " << regression_params[0] << " + " <<
-      regression_params[1] << " X + " << regression_params[2] << " X^2" << std::endl;
+      regression_params[1] << " X + " << regression_params[2] << " X^2" << '\n';
 
     if (!debug_mz_file_.empty()) {os.close();}
 
@@ -722,7 +722,7 @@ namespace OpenMS
       s_ppm_before += std::fabs(ppm_before);
       s_ppm_after += std::fabs(ppm_after);
     }
-    std::cout <<" sum residual sq ppm before " << s_ppm_before << " / after " << s_ppm_after << std::endl;
+    std::cout <<" sum residual sq ppm before " << s_ppm_before << " / after " << s_ppm_after << '\n';
 #endif
 
     // Replace the swath files with a transforming wrapper.
@@ -733,7 +733,7 @@ namespace OpenMS
           regression_params[0], regression_params[1], regression_params[2], is_ppm));
     }
 
-    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ done." << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ done." << '\n';
   }
 
   double SwathMapMassCorrection::estimateWindow(std::vector<double> residuals, double quantile, bool full_width, double padding_factor)
@@ -763,7 +763,7 @@ namespace OpenMS
       << " tail_frac=" << adaptive_quantile_res.tail_fraction
       << " => half_adapt=" << adaptive_quantile_res.blended
       << " full=" << full
-      << std::endl;
+      << '\n';
 
     return full;
   }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -190,7 +190,7 @@ namespace OpenMS
       const std::vector<Precursor>& precursors = spectrum.getPrecursors();
       if (precursors.empty())
       {
-        OPENMS_LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
+        OPENMS_LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << '\n';
       }
       const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
 
@@ -226,7 +226,7 @@ namespace OpenMS
           if (checkRtAndMzTol(spectrum_mz, spectrum_rt, target_mz, target_rt, mz_tol, rt_win))
           {
             OPENMS_LOG_DEBUG << "annotateSpectra(): " << peptide_ref_s << "]";
-            OPENMS_LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl;
+            OPENMS_LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << '\n';
             MSSpectrum annotated_spectrum = spectrum;
             annotated_spectrum.setName(peptide_ref_s);
             annotated_spectra.push_back(std::move(annotated_spectrum));
@@ -363,7 +363,7 @@ namespace OpenMS
       const std::vector<Precursor>& precursors = spectrum.getPrecursors();
       if (precursors.empty())
       {
-        OPENMS_LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
+        OPENMS_LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << '\n';
       }
       const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
       const double mz_tolerance = mz_unit_is_Da_ ? mz_tolerance_ : mz_tolerance_ / 1e6;
@@ -372,7 +372,7 @@ namespace OpenMS
       const double mz_left_lim = spectrum_mz ? spectrum_mz - mz_tolerance : std::numeric_limits<double>::min();
       const double mz_right_lim = spectrum_mz ? spectrum_mz + mz_tolerance : std::numeric_limits<double>::max();
 
-      OPENMS_LOG_DEBUG << "annotateSpectra(): [" << i << "] (RT: " << spectrum_rt << ") (MZ: " << spectrum_mz << ")" << std::endl;
+      OPENMS_LOG_DEBUG << "annotateSpectra(): [" << i << "] (RT: " << spectrum_rt << ") (MZ: " << spectrum_mz << ")" << '\n';
 
       for (Size j = 0; j < transitions.size(); ++j)
       {
@@ -387,7 +387,7 @@ namespace OpenMS
             target_mz >= mz_left_lim && target_mz <= mz_right_lim)
         {
           OPENMS_LOG_DEBUG << "annotateSpectra(): [" << j << "][" << transitions[j].getPeptideRef() << "]";
-          OPENMS_LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl << std::endl;
+          OPENMS_LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl << '\n';
           MSSpectrum annotated_spectrum = spectrum;
           annotated_spectrum.setName(transitions[j].getPeptideRef());
           annotated_spectra.push_back(annotated_spectrum);
@@ -402,7 +402,7 @@ namespace OpenMS
         }
       }
     }
-    OPENMS_LOG_DEBUG << "annotateSpectra(): (input size: " << spectra.size() << ") (annotated spectra: " << annotated_spectra.size() << ")\n" << std::endl;
+    OPENMS_LOG_DEBUG << "annotateSpectra(): (input size: " << spectra.size() << ") (annotated spectra: " << annotated_spectra.size() << ")\n" << '\n';
   }
 
   void TargetedSpectraExtractor::annotateSpectra(
@@ -482,7 +482,7 @@ namespace OpenMS
     }
 
     OPENMS_LOG_DEBUG << "pickSpectrum(): " << spectrum.getName() << " (input size: " <<
-      spectrum.size() << ") (picked: " << picked_spectrum.size() << ")\n" << std::endl;
+      spectrum.size() << ") (picked: " << picked_spectrum.size() << ")\n" << '\n';
   }
 
   void TargetedSpectraExtractor::scoreSpectra(
@@ -811,7 +811,7 @@ namespace OpenMS
       {
         warn_msg += std::to_string(idx) + " ";
       }
-      OPENMS_LOG_WARN << std:: endl << warn_msg << std::endl;
+      OPENMS_LOG_WARN << std:: endl << warn_msg << '\n';
     }
   }
 
@@ -843,7 +843,7 @@ namespace OpenMS
       const std::vector<Precursor>& precursors = spectrum.getPrecursors();
       if (precursors.empty())
       {
-        OPENMS_LOG_WARN << "untargetedMatching(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
+        OPENMS_LOG_WARN << "untargetedMatching(): No precursor MZ found. Setting spectrum_mz to 0." << '\n';
       }
       const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
       Feature feature;
@@ -1126,7 +1126,7 @@ namespace OpenMS
       library_.push_back(s);
       bs_library_.emplace_back(s, bin_size_, false, peak_spread_, bin_offset_);
     }
-    OPENMS_LOG_INFO << "The library contains " << bs_library_.size() << " spectra." << std::endl;
+    OPENMS_LOG_INFO << "The library contains " << bs_library_.size() << " spectra." << '\n';
   }
 
 }// namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
@@ -242,12 +242,12 @@ namespace OpenMS
 #ifdef TRANSITIONTSVREADER_TESTING
       for (Size i = 0; i < tmp_line.size(); i++)
       {
-        std::cout << "line " << i << " " << tmp_line[i] << std::endl;
+        std::cout << "line " << i << " " << tmp_line[i] << '\n';
       }
 
       for (const auto& iter : header_dict)
       {
-        std::cout << "header " << iter.first << " " << iter.second << std::endl;
+        std::cout << "header " << iter.first << " " << iter.second << '\n';
       }
 #endif
 
@@ -433,26 +433,26 @@ namespace OpenMS
       }
 
 #ifdef TRANSITIONTSVREADER_TESTING
-      std::cout << mytransition.precursor << std::endl;
-      std::cout << mytransition.product << std::endl;
-      std::cout << mytransition.rt_calibrated << std::endl;
-      std::cout << mytransition.transition_name << std::endl;
-      std::cout << mytransition.CE << std::endl;
-      std::cout << mytransition.library_intensity << std::endl;
-      std::cout << mytransition.group_id << std::endl;
-      std::cout << mytransition.decoy << std::endl;
-      std::cout << mytransition.PeptideSequence << std::endl;
-      std::cout << mytransition.ProteinName << std::endl;
-      std::cout << mytransition.Annotation << std::endl;
-      std::cout << mytransition.FullPeptideName << std::endl;
-      std::cout << mytransition.precursor_charge << std::endl;
-      std::cout << mytransition.peptide_group_label << std::endl;
-      std::cout << mytransition.fragment_charge << std::endl;
-      std::cout << mytransition.fragment_nr << std::endl;
-      std::cout << mytransition.fragment_mzdelta << std::endl;
-      std::cout << mytransition.fragment_modification << std::endl;
-      std::cout << mytransition.fragment_type << std::endl;
-      std::cout << mytransition.uniprot_id << std::endl;
+      std::cout << mytransition.precursor << '\n';
+      std::cout << mytransition.product << '\n';
+      std::cout << mytransition.rt_calibrated << '\n';
+      std::cout << mytransition.transition_name << '\n';
+      std::cout << mytransition.CE << '\n';
+      std::cout << mytransition.library_intensity << '\n';
+      std::cout << mytransition.group_id << '\n';
+      std::cout << mytransition.decoy << '\n';
+      std::cout << mytransition.PeptideSequence << '\n';
+      std::cout << mytransition.ProteinName << '\n';
+      std::cout << mytransition.Annotation << '\n';
+      std::cout << mytransition.FullPeptideName << '\n';
+      std::cout << mytransition.precursor_charge << '\n';
+      std::cout << mytransition.peptide_group_label << '\n';
+      std::cout << mytransition.fragment_charge << '\n';
+      std::cout << mytransition.fragment_nr << '\n';
+      std::cout << mytransition.fragment_mzdelta << '\n';
+      std::cout << mytransition.fragment_modification << '\n';
+      std::cout << mytransition.fragment_type << '\n';
+      std::cout << mytransition.uniprot_id << '\n';
 #endif
 
       tmp_line.clear();
@@ -460,7 +460,7 @@ namespace OpenMS
 
     if (spectrast_legacy && retentionTimeInterpretation_ == "iRT")
     {
-      std::cout << "Warning: SpectraST was not run in RT normalization mode but the converted list was interpreted to have iRT units. Check whether you need to adapt the parameter -algorithm:retentionTimeInterpretation. You can ignore this warning if you used a legacy SpectraST 4.0 file." << std::endl;
+      std::cout << "Warning: SpectraST was not run in RT normalization mode but the converted list was interpreted to have iRT units. Check whether you need to adapt the parameter -algorithm:retentionTimeInterpretation. You can ignore this warning if you used a legacy SpectraST 4.0 file." << '\n';
 
     }
   }
@@ -905,13 +905,13 @@ namespace OpenMS
           if (override_group_label_check_)
           {
             OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << effective_label <<
-              ". Since 'override_group_label_check' is on, nothing will be changed." << std::endl;
+              ". Since 'override_group_label_check' is on, nothing will be changed." << '\n';
           }
           else
           {
             OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << effective_label <<
               ". This is most likely an error and to fix this, a new peptide label group will be inferred - " <<
-              "to override this decision, please use the override_group_label_check parameter." << std::endl;
+              "to override this decision, please use the override_group_label_check parameter." << '\n';
             effective_label = mytransition.group_id;
           }
         }
@@ -993,7 +993,7 @@ namespace OpenMS
           }
           catch (Exception::InvalidValue&)
           {
-            OPENMS_LOG_DEBUG << "Could not parse modifications from sequence: " << sequence << std::endl;
+            OPENMS_LOG_DEBUG << "Could not parse modifications from sequence: " << sequence << '\n';
           }
         }
         else
@@ -1064,14 +1064,14 @@ namespace OpenMS
           {
             // We wont fix it but give out a warning
             OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
-              ". Since 'override_group_label_check' is on, nothing will be changed." << std::endl;
+              ". Since 'override_group_label_check' is on, nothing will be changed." << '\n';
           }
           else
           {
             // Lets fix it and inform the user
             OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
               ". This is most likely an error and to fix this, a new peptide label group will be inferred - " << 
-              "to override this decision, please use the override_group_label_check parameter." << std::endl;
+              "to override this decision, please use the override_group_label_check parameter." << '\n';
             tr_it->peptide_group_label = tr_it->group_id;
           }
         }
@@ -1381,13 +1381,13 @@ namespace OpenMS
       if (force_invalid_mods_)
       {
         // fallback: parse the "naked" peptide sequence which should always work
-        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
+        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << '\n';
         aa_sequence = AASequence::fromString(tr_it->PeptideSequence);
       }
       else
       {
-        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
-        std::cerr << "Error while reading file (use 'force_invalid_mods' parameter to override): " << e.what() << std::endl;
+        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << '\n';
+        std::cerr << "Error while reading file (use 'force_invalid_mods' parameter to override): " << e.what() << '\n';
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             "Invalid input, cannot parse: " + tr_it->FullPeptideName);
       }
@@ -1404,8 +1404,8 @@ namespace OpenMS
         return;
       }
       OPENMS_LOG_WARN << "Warning: The peptide sequence " << peptide.sequence << " and the full peptide name " << aa_sequence << 
-        " are not equal. Please check your input." << std::endl;
-      OPENMS_LOG_WARN << "(use force_invalid_mods to override)" << std::endl;
+        " are not equal. Please check your input." << '\n';
+      OPENMS_LOG_WARN << "(use force_invalid_mods to override)" << '\n';
     }
 
     // Unfortunately, we cannot store an AASequence here but have to work with
@@ -1514,7 +1514,7 @@ namespace OpenMS
 
 #ifdef TRANSITIONTSVREADER_TESTING
       OPENMS_LOG_DEBUG << "Peptide rts empty " <<
-      pep.rts.empty()  << " or no cv term " << pep.getRetentionTime() << std::endl;
+      pep.rts.empty()  << " or no cv term " << pep.getRetentionTime() << '\n';
 #endif
 
       if (pep.hasRetentionTime())
@@ -1733,7 +1733,7 @@ namespace OpenMS
         os << "\t";
       }
     }
-    os << std::endl;
+    os << '\n';
 
     for (const auto& it : mytransitions)
     {
@@ -1769,7 +1769,7 @@ namespace OpenMS
         + (String)it.quantifying_transition   + "\t"
         + ListUtils::concatenate(it.peptidoforms, "|");
 
-      os << line << std::endl;
+      os << line << '\n';
     }
     os.close();
   }
@@ -1835,7 +1835,7 @@ namespace OpenMS
         os << "\t";
       }
     }
-    os << std::endl;
+    os << '\n';
 
     Size progress = 0;
     startProgress(0, targeted_exp.transitions.size(), "writing OpenSWATH Transition List TSV file");
@@ -1990,7 +1990,7 @@ namespace OpenMS
         + String(tr.isQuantifyingTransition())  + "\t"
         + ListUtils::concatenate(std::vector<String>(tr.peptidoforms.begin(), tr.peptidoforms.end()), "|");
 
-      os << line << std::endl;
+      os << line << '\n';
     }
     endProgress();
     os.close();

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -246,7 +246,7 @@ namespace OpenMS
       if (min_diff < max_precursor_isotope_deviation_)
       {
 #ifdef ISOBARIC_CHANNEL_EXTRACTOR_DEBUG
-        std::cerr << "Mark peak as isotopic peak POS: " << precursor_spec[min_idx] << " (diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << std::endl;
+        std::cerr << "Mark peak as isotopic peak POS: " << precursor_spec[min_idx] << " (diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << '\n';
 #endif
         if (np_it->getMZ() > strict_lower_mz)
         {
@@ -265,7 +265,7 @@ namespace OpenMS
       else
       {
 #ifdef ISOBARIC_CHANNEL_EXTRACTOR_DEBUG
-        std::cerr << "No matching isotopic peak for expected pos: " << expected_next_mz << " (min reached diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << std::endl;
+        std::cerr << "No matching isotopic peak for expected pos: " << expected_next_mz << " (min reached diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << '\n';
 #endif
         // update expected_next_mz with theoretical position
         expected_next_mz -= charge_dist;
@@ -304,7 +304,7 @@ namespace OpenMS
       if (min_diff < max_precursor_isotope_deviation_)
       {
 #ifdef ISOBARIC_CHANNEL_EXTRACTOR_DEBUG
-        std::cerr << "Mark peak as isotopic peak POS: " << precursor_spec[min_idx] << " (diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << std::endl;
+        std::cerr << "Mark peak as isotopic peak POS: " << precursor_spec[min_idx] << " (diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << '\n';
 #endif
         if (np_it->getMZ() < strict_upper_mz)
         {
@@ -323,7 +323,7 @@ namespace OpenMS
       else
       {
 #ifdef ISOBARIC_CHANNEL_EXTRACTOR_DEBUG
-        std::cerr << "No matching isotopic peak for expected pos: " << expected_next_mz << " (min reached diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << std::endl;
+        std::cerr << "No matching isotopic peak for expected pos: " << expected_next_mz << " (min reached diff: " << min_diff << " vs " << max_precursor_isotope_deviation_ << ")" << '\n';
 #endif
         // update expected_next_mz with theoretical position
         expected_next_mz += charge_dist;
@@ -377,7 +377,7 @@ namespace OpenMS
     else
     {
 #ifdef ISOBARIC_CHANNEL_EXTRACTOR_DEBUG
-      std::cerr << "------------------ analyzing " << ms2_spec->getNativeID() << std::endl;
+      std::cerr << "------------------ analyzing " << ms2_spec->getNativeID() << '\n';
 #endif
 
       // compute purity of preceding ms1 scan
@@ -422,7 +422,7 @@ namespace OpenMS
     consensus_map.setExperimentType("labeled_MS2");
 
     // create predicate for spectrum checking
-    OPENMS_LOG_INFO << "Selecting scans with activation mode: " << selected_activation_ << std::endl;
+    OPENMS_LOG_INFO << "Selecting scans with activation mode: " << selected_activation_ << '\n';
     
     // Select the two possible HCD activation modes according to PSI-MS ontology: HCID and HCD
     if (selected_activation_ == "auto") 
@@ -453,7 +453,7 @@ namespace OpenMS
       {
         OPENMS_LOG_WARN << "  mode " << (it->first.empty() ? "<none>" : it->first) << ": " << it->second << " scans\n";
       }
-      OPENMS_LOG_WARN << "Result will be empty!" << std::endl;
+      OPENMS_LOG_WARN << "Result will be empty!" << '\n';
       return;
     }
     OPENMS_LOG_INFO << "Filtering by MS/MS(/MS) and activation mode:\n";
@@ -462,7 +462,7 @@ namespace OpenMS
       OPENMS_LOG_INFO << "  level " << it->first << ": " << it->second << " scans\n";
     }
     UInt quant_ms_level = ms_level.rbegin()->first;
-    OPENMS_LOG_INFO << "Using MS-level " << quant_ms_level << " for quantification." << std::endl;
+    OPENMS_LOG_INFO << "Using MS-level " << quant_ms_level << " for quantification." << '\n';
 
     // now we have picked data
     // --> assign peaks to channels
@@ -499,7 +499,7 @@ namespace OpenMS
       // check precursor constraints
       if (!isValidPrecursor_(it->getPrecursors()[0]))
       {
-        OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor doesn't fulfill all constraints." << std::endl;
+        OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor doesn't fulfill all constraints." << '\n';
         continue;
       }
 
@@ -511,13 +511,13 @@ namespace OpenMS
         // check if purity is high enough
         if (precursor_purity < min_precursor_purity_)
         {
-          OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor purity is below the threshold. [purity = " << precursor_purity << "]" << std::endl;
+          OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor purity is below the threshold. [purity = " << precursor_purity << "]" << '\n';
           continue;
         }
       }
       else
       {
-        OPENMS_LOG_INFO << "No precursor available for spectrum: " << it->getNativeID() << std::endl;
+        OPENMS_LOG_INFO << "No precursor available for spectrum: " << it->getNativeID() << '\n';
       }
 
       if (it->getMSLevel() == 3)
@@ -693,7 +693,7 @@ namespace OpenMS
 
       if (quant_spec.empty())
       {
-        OPENMS_LOG_WARN << "Quant. spectrum " << quant_spec.getNativeID() << " is empty. Skipping extraction." << std::endl;
+        OPENMS_LOG_WARN << "Quant. spectrum " << quant_spec.getNativeID() << " is empty. Skipping extraction." << '\n';
         return result;
       }
 
@@ -702,13 +702,13 @@ namespace OpenMS
       /*const auto& reporter_region_end = ++quant_spec.MZEnd(quant_method_->getChannelInformation().back().center + qc_dist_mz);
 
       const auto& reporter_region_start = quant_spec.MZBegin(quant_spec.begin(), quant_method_->getChannelInformation().front().center - qc_dist_mz, reporter_region_end);
-      std::cout << "reporter_region_start: " << reporter_region_start->getMZ() << std::endl;
+      std::cout << "reporter_region_start: " << reporter_region_start->getMZ() << '\n';
 
       if (reporter_region_end != quant_spec.end())
       {
-        std::cout << "reporter_region_end: " << reporter_region_end->getMZ() << std::endl;
+        std::cout << "reporter_region_end: " << reporter_region_end->getMZ() << '\n';
       } else {
-        std::cout << "reporter_region_end: " << "end" << std::endl;
+        std::cout << "reporter_region_end: " << "end" << '\n';
         return result;
       }*/
 
@@ -753,7 +753,7 @@ namespace OpenMS
           // pass user threshold
           if (fabs(mz_delta) < reporter_mass_shift_)
           {
-            //std::cout << "reporter_mz: " << reporter_mz << std::endl;
+            //std::cout << "reporter_mz: " << reporter_mz << '\n';
             result[map_index] = idx_nearest->getIntensity();
           }
         }
@@ -808,7 +808,7 @@ namespace OpenMS
     }
     if (impurities_found) OPENMS_LOG_INFO << "\nImpurities within the allowed reporter mass shift " << reporter_mass_shift_ << " Th have been found." 
                                    << "They can be ignored if the spectra are m/z calibrated (see above), since only the peak closest to the theoretical position is used for quantification!";
-    OPENMS_LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << '\n';
   }
 
   void IsobaricChannelExtractor::printStatsWithMissing(std::vector<ChannelQC>& stats) const
@@ -859,7 +859,7 @@ namespace OpenMS
     }
     if (impurities_found) OPENMS_LOG_INFO << "\nImpurities within the allowed reporter mass shift " << reporter_mass_shift_ << " m/z have been found." 
                                    << "They can be ignored if the spectra are m/z calibrated (see above), since only the peak closest to the theoretical position is used for quantification!";
-    OPENMS_LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << '\n';
   }
 
   /**

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -463,14 +463,14 @@ namespace OpenMS
           return ef + Residue::getInternalToZIon();
         }
         default:
-          OPENMS_LOG_ERROR << "AASequence::getFormula: unknown ResidueType" << std::endl;
+          OPENMS_LOG_ERROR << "AASequence::getFormula: unknown ResidueType" << '\n';
       }
 
       return ef;
     }
     else
     {
-      OPENMS_LOG_ERROR << "AASequence::getFormula: Formula for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
+      OPENMS_LOG_ERROR << "AASequence::getFormula: Formula for ResidueType " << type << " not defined for sequences of length 0." << '\n';
       return EmpiricalFormula("");
     }
   }
@@ -584,14 +584,14 @@ namespace OpenMS
           return mono_weight + Residue::getInternalToZIon().getMonoWeight();
         }
         default:
-          OPENMS_LOG_ERROR << "AASequence::getMonoWeight: unknown ResidueType" << std::endl;
+          OPENMS_LOG_ERROR << "AASequence::getMonoWeight: unknown ResidueType" << '\n';
       }
 
       return mono_weight;
     }
     else
     {
-      OPENMS_LOG_ERROR << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
+      OPENMS_LOG_ERROR << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 0." << '\n';
       return 0.0;
     }
 }
@@ -1129,7 +1129,7 @@ namespace OpenMS
         }
       }
 
-      OPENMS_LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+      OPENMS_LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << '\n';
     }
     else if (specificity == ResidueModification::ANYWHERE) // internal (not exclusively terminal) modification
     {
@@ -1214,7 +1214,7 @@ namespace OpenMS
       if (residue->getOneLetterCode() != "X") // don't warn for mass tags
       {
         OPENMS_LOG_WARN << "Warning: unknown modification '" + mod + "' of residue '" +
-            residue->getOneLetterCode() + "' - adding it to the database" << std::endl;
+            residue->getOneLetterCode() + "' - adding it to the database" << '\n';
       }
     }
     else if (specificity == ResidueModification::C_TERM)
@@ -1257,7 +1257,7 @@ namespace OpenMS
         }
       }
 
-      OPENMS_LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+      OPENMS_LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << '\n';
     }
 
     // -----------------------------------
@@ -1478,7 +1478,7 @@ namespace OpenMS
     }
     if (mod == nullptr)
     {
-      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << std::endl;
+      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << '\n';
       mod = ResidueModification::createUnknownFromMassString(String(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
@@ -1618,7 +1618,7 @@ namespace OpenMS
     if (n_term_mod_ == nullptr)
     {
 
-      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << std::endl;
+      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << '\n';
       n_term_mod_ = ResidueModification::createUnknownFromMassString(String(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,
@@ -1648,7 +1648,7 @@ namespace OpenMS
     if (n_term_mod_ == nullptr)
     {
 
-      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << std::endl;
+      OPENMS_LOG_WARN << "Modification with monoisotopic mass diff. of " << diffMonoMassStr << " not found in databases with tolerance " << tol << ". Adding unknown modification." << '\n';
       n_term_mod_ = ResidueModification::createUnknownFromMassString(String(diffMonoMass),
                                                                         diffMonoMass,
                                                                         true,

--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -193,7 +193,7 @@ namespace OpenMS::Internal::ClassTest
               stdcout << "Warning: unable to remove temporary file '"
                       << TEST::tmp_file_list[i]
                       << "'"
-                      << std::endl;
+                      << '\n';
             }
           }
       }
@@ -208,7 +208,7 @@ namespace OpenMS::Internal::ClassTest
         {
           TEST::initialNewline();
           stdcout << " +  line " << line << ":  WHITELIST(\"" << whitelist_
-                    << "\"):   whitelist is: " << TEST::whitelist << std::endl;
+                    << "\"):   whitelist is: " << TEST::whitelist << '\n';
         }
         return;
       }
@@ -219,7 +219,7 @@ namespace OpenMS::Internal::ClassTest
         if (!newline)
         {
           newline = true;
-          std::cout << std::endl;
+          std::cout << '\n';
         }
         return;
       }
@@ -241,7 +241,7 @@ namespace OpenMS::Internal::ClassTest
       bool
       validate(const std::vector<std::string>& file_names)
       {
-        std::cout << "checking (created temporary files)..." << std::endl;
+        std::cout << "checking (created temporary files)..." << '\n';
         bool passed_all = true;
         for (Size i = 0; i < file_names.size(); ++i)
         {
@@ -256,17 +256,17 @@ namespace OpenMS::Internal::ClassTest
             {
               if (!MzMLFile().isValid(file_names[i]))
               {
-                std::cout << " - Error: mzML file does not validate against XML schema '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: mzML file does not validate against XML schema '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               StringList errors, warnings;
               if (!MzMLFile().isSemanticallyValid(file_names[i], errors,
                                                   warnings))
               {
-                std::cout << " - Error: mzML file semantically invalid '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: mzML file semantically invalid '" << file_names[i] << "'" << '\n';
                 for (Size j = 0; j < errors.size(); ++j)
                 {
-                  std::cout << "Error - " << errors[j] << std::endl;
+                  std::cout << "Error - " << errors[j] << '\n';
                 }
                 passed_single = false;
               }
@@ -276,7 +276,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::MZDATA:
               if (!MzDataFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid mzData file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid mzData file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -284,7 +284,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::MZXML:
               if (!MzXMLFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid mzXML file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid mzXML file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -292,7 +292,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::FEATUREXML:
               if (!FeatureXMLFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid featureXML file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid featureXML file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -300,7 +300,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::IDXML:
               if (!IdXMLFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid idXML file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid idXML file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -308,7 +308,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::CONSENSUSXML:
               if (!ConsensusXMLFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid consensusXML file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid consensusXML file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -316,7 +316,7 @@ namespace OpenMS::Internal::ClassTest
             case FileTypes::INI:
               if (!ParamXMLFile().isValid(file_names[i], std::cerr))
               {
-                std::cout << " - Error: Invalid Param file '" << file_names[i] << "'" << std::endl;
+                std::cout << " - Error: Invalid Param file '" << file_names[i] << "'" << '\n';
                 passed_single = false;
               }
               break;
@@ -336,27 +336,27 @@ namespace OpenMS::Internal::ClassTest
             //output for single file
             if (skipped)
             {
-              std::cout << " +  skipped file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << std::endl;
+              std::cout << " +  skipped file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << '\n';
             }
             else if (passed_single)
             {
-              std::cout << " +  valid file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << std::endl;
+              std::cout << " +  valid file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << '\n';
             }
             else
             {
               passed_all = false;
-              std::cout << " -  invalid file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << std::endl;
+              std::cout << " -  invalid file '" << file_names[i] << "' (type: " << FileTypes::typeToName(type) << ")" << '\n';
             }
           }
         }
         //output for all files        
         if (passed_all)
         {
-          std::cout << ": passed" << std::endl << std::endl;
+          std::cout << ": passed" << std::endl << '\n';
         }
         else
         {
-          std::cout << ": failed" << std::endl << std::endl;
+          std::cout << ": failed" << std::endl << '\n';
         }
         return passed_all;
       }
@@ -393,7 +393,7 @@ namespace OpenMS::Internal::ClassTest
                     << number_2_stringified << "):"
                                      " argument " << number_1_stringified
                     << " does not have a floating point type!  Go fix your code!"
-                    << std::endl;
+                    << '\n';
           failed_lines_list.push_back(line);
         }
         TEST::test = TEST::test && TEST::this_test;
@@ -410,7 +410,7 @@ namespace OpenMS::Internal::ClassTest
                           << number_1_stringified << ',' << number_2_stringified
                           << "): got " << std::setprecision(number_1_written_digits)
                           << number_1 << ", expected "
-                          << std::setprecision(number_2_written_digits) << number_2 << std::endl;
+                          << std::setprecision(number_2_written_digits) << number_2 << '\n';
               }
             }
             else
@@ -424,7 +424,7 @@ namespace OpenMS::Internal::ClassTest
                         << " (absolute: " << TEST::absdiff << " ["
                         << TEST::absdiff_max_allowed << "], relative: "
                         << TEST::ratio << " [" << TEST::ratio_max_allowed
-                        << "], message: \"" << TEST::fuzzy_message << "\"" << std::endl;
+                        << "], message: \"" << TEST::fuzzy_message << "\"" << '\n';
               failed_lines_list.push_back(line);
             }
           }
@@ -577,7 +577,7 @@ namespace OpenMS::Internal::ClassTest
             stdcout << " +  line " << line << ":  TEST_STRING_EQUAL("
                     << string_1_stringified << ',' << string_2_stringified
                     << "): got \"" << string_1 << "\", expected \"" << string_2
-                    << "\"" << std::endl;            
+                    << "\"" << '\n';            
             }
           }
           else
@@ -585,7 +585,7 @@ namespace OpenMS::Internal::ClassTest
             stdcout << " -  line " << line << ":  TEST_STRING_EQUAL("
                       << string_1_stringified << ',' << string_2_stringified
                       << "): got \"" << string_1 << "\", expected \"" << string_2
-                      << "\"" << std::endl;
+                      << "\"" << '\n';
             failed_lines_list.push_back(line);
           }
         }
@@ -697,7 +697,7 @@ namespace OpenMS::Internal::ClassTest
             {
               out << " thrown in line " << e.getLine() << " of file '" << e.getFile() << "' in function '" << e.getFunction() << "'";
             }
-            out << " - Message: " << e.what() << std::endl;
+            out << " - Message: " << e.what() << '\n';
           }
         } /* catch std:: exceptions */
         catch (std::exception& e)
@@ -708,7 +708,7 @@ namespace OpenMS::Internal::ClassTest
           {
             TEST::initialNewline();
             out << "Error: Caught unexpected std::exception\n";
-            out << " - Message: " << e.what() << std::endl;
+            out << " - Message: " << e.what() << '\n';
           }
         } /* catch all other exceptions */
         catch (...)
@@ -718,7 +718,7 @@ namespace OpenMS::Internal::ClassTest
           TEST::all_tests = false;
           {
             TEST::initialNewline();
-            out << "Error: Caught unidentified and unexpected exception - No message." << std::endl;
+            out << "Error: Caught unidentified and unexpected exception - No message." << '\n';
           }
         }
       }
@@ -732,7 +732,7 @@ namespace OpenMS::Internal::ClassTest
         }
         if (TEST::verbose == 0)
         {
-          out << "Output of successful tests were suppressed. Set the environment variable 'OPENMS_TEST_VERBOSE=True' to enable them." << std::endl;
+          out << "Output of successful tests were suppressed. Set the environment variable 'OPENMS_TEST_VERBOSE=True' to enable them." << '\n';
         } /* check for exit code */
         if (!TEST::all_tests)
         {
@@ -744,7 +744,7 @@ namespace OpenMS::Internal::ClassTest
           {
             out << TEST::failed_lines_list[i] << " ";
           }
-          out << std::endl;
+          out << '\n';
           return 1;
         }
         else
@@ -753,7 +753,7 @@ namespace OpenMS::Internal::ClassTest
           out << "PASSED";
           if (TEST::add_message != "")
             out << " (" << TEST::add_message << ")";
-          out << std::endl;
+          out << '\n';
           return 0;
         }
       }
@@ -774,6 +774,6 @@ namespace OpenMS::Internal::ClassTest
           if (OpenMS::String(TEST::test_name).has('~'))
             out << "Warning: no subtests performed in '" << TEST::test_name << "' (line " << line << ")!\n";
         }
-        stdcout << std::endl;
+        stdcout << '\n';
       }
   }

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -183,7 +183,7 @@ namespace OpenMS
         prefix << "  relative_acceptable: " << ratio_max_allowed_ << "\n" <<
         prefix << " --------------------------------\n" <<
         prefix << "  absolute_max:        " << absdiff_max_ << "\n" <<
-        prefix << "  absolute_acceptable: " << absdiff_max_allowed_ << std::endl;
+        prefix << "  absolute_acceptable: " << absdiff_max_allowed_ << '\n';
 
       writeWhitelistCases_(prefix);
 
@@ -212,7 +212,7 @@ namespace OpenMS
         << " " << QDir::toNativeSeparators(File::absolutePath(input_1_name_).toQString()).toStdString()
         << " " << QDir::toNativeSeparators(File::absolutePath(input_2_name_).toQString()).toStdString()
         #endif
-        << std::endl;
+        << '\n';
     }
 
     // If verbose level is low, report only the first error.
@@ -241,17 +241,17 @@ namespace OpenMS
         prefix << "  relative_acceptable: " << ratio_max_allowed_ << '\n' <<
         prefix << '\n' <<
         prefix << "  absolute_max:        " << absdiff_max_ << '\n' <<
-        prefix << "  absolute_acceptable: " << absdiff_max_allowed_ << std::endl;
+        prefix << "  absolute_acceptable: " << absdiff_max_allowed_ << '\n';
 
       writeWhitelistCases_(prefix);
 
-      *log_dest_ << prefix << std::endl;
+      *log_dest_ << prefix << '\n';
 
       if (line_num_1_max_ == -1 && line_num_2_max_ == -1)
       {
         *log_dest_ <<
           prefix << "No numeric differences were found.\n" <<
-          prefix << std::endl;
+          prefix << '\n';
       }
       else
       {
@@ -322,7 +322,7 @@ namespace OpenMS
           if (element_2_.is_number) // we are comparing numbers
           {
 #ifdef DEBUG_FUZZY
-            std::cout << "cmp number: " << String(element_1_.number) << " : " << String(element_2_.number) << std::endl;
+            std::cout << "cmp number: " << String(element_1_.number) << " : " << String(element_2_.number) << '\n';
 #endif
             if (element_1_.number == element_2_.number)
             {
@@ -388,7 +388,7 @@ namespace OpenMS
                     ratio = 1.0 / ratio;
                   }
 #ifdef DEBUG_FUZZY
-                  std::cout << " check ratio:  " << ratio << " vs " << ratio_max_ << std::endl;
+                  std::cout << " check ratio:  " << ratio << " vs " << ratio_max_ << '\n';
 #endif
 
                   // by now, we are sure that ratio >= 1
@@ -401,7 +401,7 @@ namespace OpenMS
                     if (ratio > ratio_max_allowed_)
                     {
 #ifdef DEBUG_FUZZY
-                      std::cout << "Ratio test failed: is larger than ratio_max " << std::endl;
+                      std::cout << "Ratio test failed: is larger than ratio_max " << '\n';
 #endif
                       if (!is_absdiff_small_)
                       {
@@ -548,7 +548,7 @@ namespace OpenMS
       readNextLine_(input_2, line_str_2, line_num_2_);
 #ifdef DEBUG_FUZZY
       std::cout << "eof: " << input_2.eof() << " failbit: " << input_2.fail() << " badbit: " << input_2.bad() << " reading " << input_2.tellg () << "chars\n";
-      std::cout << line_str_1 << "\n" << line_str_2 << std::endl;
+      std::cout << line_str_1 << "\n" << line_str_2 << '\n';
 #endif
       // compare the two lines of input
       if (!compareLines_(line_str_1, line_str_2) && verbose_level_ < 3)

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
     //check name
     if (name.find(':') != std::string::npos)
     {
-      std::cerr << "Error ParamEntry name must not contain ':' characters!" << '\n';
+      std::cerr << "Error ParamEntry name must not contain ':' characters!" << std::endl;
     }
   }
 

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -758,7 +758,7 @@ namespace OpenMS
       const auto& n = root_.findEntry(entry.name);
       if (n == root_.entries.end())
       {
-        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter entry " << entry.name << '\n';
+        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter entry " << entry.name << std::endl;
       }
       else
       {
@@ -771,7 +771,7 @@ namespace OpenMS
       const auto& n = root_.findNode(node.name);
       if (n == root_.nodes.end())
       {
-        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter node " << node.name << '\n';
+        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter node " << node.name << std::endl;
       }
       else
       {
@@ -1087,7 +1087,7 @@ namespace OpenMS
         {
           OPENMS_LOG_WARN << " in '" << prefix2 << "'";
         }
-        OPENMS_LOG_WARN << "!" << '\n';
+        OPENMS_LOG_WARN << "!" << std::endl;
       }
 
       //different types

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
     //check name
     if (name.find(':') != std::string::npos)
     {
-      std::cerr << "Error ParamEntry name must not contain ':' characters!" << std::endl;
+      std::cerr << "Error ParamEntry name must not contain ':' characters!" << '\n';
     }
   }
 
@@ -187,7 +187,7 @@ namespace OpenMS
   {
       if (name.find(':') != std::string::npos) 
       {
-        std::cerr << "Error ParamNode name must not contain ':' characters!" << std::endl;
+        std::cerr << "Error ParamNode name must not contain ':' characters!" << '\n';
       }
   }
 
@@ -244,13 +244,13 @@ namespace OpenMS
 
   Param::ParamNode* Param::ParamNode::findParentOf(const std::string& local_name)
   {
-    //cout << "findParentOf nodename: " << this->name << " - nodes: " << this->nodes.size() << " - find: "<< name << std::endl;
+    //cout << "findParentOf nodename: " << this->name << " - nodes: " << this->nodes.size() << " - find: "<< name << '\n';
     if (local_name.find(':') != std::string::npos) //several subnodes to browse through
     {
         size_t pos = local_name.find(':');
         std::string prefix = local_name.substr(0, pos);
 
-        //cout << " - Prefix: '" << prefix << "'" << std::endl;
+        //cout << " - Prefix: '" << prefix << "'" << '\n';
         NodeIterator it = findNode(prefix);
         if (it == nodes.end()) //subnode not found
         {
@@ -258,7 +258,7 @@ namespace OpenMS
         }
         //recursively call findNode for the rest of the path
         std::string new_name = local_name.substr(it->name.size() + 1);
-        //cout << " - Next name: '" << new_name << "'" << std::endl;
+        //cout << " - Next name: '" << new_name << "'" << '\n';
         return it->findParentOf(new_name);
     }
     else // we are in the right child
@@ -301,7 +301,7 @@ namespace OpenMS
 
   void Param::ParamNode::insert(const ParamNode& node, const std::string& prefix)
   {
-    //std::cerr << "INSERT NODE  " << node.name << " (" << prefix << ")" << std::endl;
+    //std::cerr << "INSERT NODE  " << node.name << " (" << prefix << ")" << '\n';
     std::string prefix2 = prefix + node.name;
 
     ParamNode* insert_node = this;
@@ -319,7 +319,7 @@ namespace OpenMS
       {
         insert_node->nodes.emplace_back(local_name, "");
         insert_node = &(insert_node->nodes.back());
-        //std::cerr << " - Created new node: " << insert_node->name << std::endl;
+        //std::cerr << " - Created new node: " << insert_node->name << '\n';
       }
       //remove prefix
       prefix2 = prefix2.substr(local_name.size() + 1);
@@ -363,16 +363,16 @@ namespace OpenMS
 
   void Param::ParamNode::insert(const ParamEntry& entry, const std::string& prefix)
   {
-    //std::cerr << "INSERT ENTRY " << entry.name << " (" << prefix << ")" << std::endl;
+    //std::cerr << "INSERT ENTRY " << entry.name << " (" << prefix << ")" << '\n';
     std::string prefix2 = prefix + entry.name;
-    //std::cerr << " - inserting: " << prefix2 << std::endl;
+    //std::cerr << " - inserting: " << prefix2 << '\n';
 
     ParamNode* insert_node = this;
     while (prefix2.find(':') != std::string::npos)
     {
       size_t pos = prefix2.find(':');
       std::string local_name = prefix2.substr(0, pos);
-      //std::cerr << " - looking for node: " << name << std::endl;
+      //std::cerr << " - looking for node: " << name << '\n';
       //look up if the node already exists
       NodeIterator it = insert_node->findNode(local_name);
       if (it != insert_node->nodes.end()) //exists
@@ -383,11 +383,11 @@ namespace OpenMS
       {
         insert_node->nodes.emplace_back(local_name, "");
         insert_node = &(insert_node->nodes.back());
-        //std::cerr << " - Created new node: " << insert_node->name << std::endl;
+        //std::cerr << " - Created new node: " << insert_node->name << '\n';
       }
       //remove prefix
       prefix2 = prefix2.substr(local_name.size() + 1);
-      //std::cerr << " - new prefix: " << prefix2 << std::endl;
+      //std::cerr << " - new prefix: " << prefix2 << '\n';
     }
 
     // check if the entry exists as ParamNode
@@ -403,7 +403,7 @@ namespace OpenMS
     }
 
     //check if the entry already exists
-    //std::cerr << " - final entry name: " << prefix2 << std::endl;
+    //std::cerr << " - final entry name: " << prefix2 << '\n';
     EntryIterator it = insert_node->findEntry(prefix2);
     if (it != insert_node->entries.end()) //overwrite entry
     {
@@ -566,7 +566,7 @@ namespace OpenMS
 
   void Param::insert(const std::string& prefix, const Param& param)
   {
-    //std::cerr << "INSERT PARAM (" << prefix << ")" << std::endl;
+    //std::cerr << "INSERT PARAM (" << prefix << ")" << '\n';
     for (Param::ParamNode::NodeIterator it = param.root_.nodes.begin(); it != param.root_.nodes.end(); ++it)
     {
       root_.insert(*it, prefix);
@@ -594,7 +594,7 @@ namespace OpenMS
       if (!exists(prefix2 + it.getName()))
       {
         if (showMessage)
-          std::cerr << "Setting " << prefix2 + it.getName() << " to " << it->value << std::endl;
+          std::cerr << "Setting " << prefix2 + it.getName() << " to " << it->value << '\n';
         std::string name = prefix2 + it.getName();
         root_.insert(ParamEntry("", it->value, it->description), name);
         //copy tags
@@ -638,8 +638,8 @@ namespace OpenMS
           const std::string& description_new = defaults.getSectionDescription(real_pathname);
           if (description_old.empty())
           {
-            //std::cerr << "## Setting description of " << prefix+real_pathname << " to"<< std::endl;
-            //std::cerr << "## " << description_new << std::endl;
+            //std::cerr << "## Setting description of " << prefix+real_pathname << " to"<< '\n';
+            //std::cerr << "## " << description_new << '\n';
             setSectionDescription(prefix2 + real_pathname, description_new);
           }
         }
@@ -758,7 +758,7 @@ namespace OpenMS
       const auto& n = root_.findEntry(entry.name);
       if (n == root_.entries.end())
       {
-        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter entry " << entry.name << std::endl;
+        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter entry " << entry.name << '\n';
       }
       else
       {
@@ -771,7 +771,7 @@ namespace OpenMS
       const auto& n = root_.findNode(node.name);
       if (n == root_.nodes.end())
       {
-        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter node " << node.name << std::endl;
+        OPENMS_LOG_WARN << "Warning: Trying to copy non-existent parameter node " << node.name << '\n';
       }
       else
       {
@@ -878,7 +878,7 @@ namespace OpenMS
       {
         arg1_is_option = true;
       }
-      //cout << "Parse: '"<< arg << "' '" << arg1 << "'" << std::endl;
+      //cout << "Parse: '"<< arg << "' '" << arg1 << "'" << '\n';
 
       //flag (option without text argument)
       if (arg_is_option && arg1_is_option)
@@ -1043,7 +1043,7 @@ namespace OpenMS
       {
         os << " (" << it->description << ")";
       }
-      os << std::endl;
+      os << '\n';
     }
     return os;
   }
@@ -1087,7 +1087,7 @@ namespace OpenMS
         {
           OPENMS_LOG_WARN << " in '" << prefix2 << "'";
         }
-        OPENMS_LOG_WARN << "!" << std::endl;
+        OPENMS_LOG_WARN << "!" << '\n';
       }
 
       //different types
@@ -1274,7 +1274,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
           if (this->findNext(l1_entry.name, it_match) == this->end())
           {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-            stream << "Found '" << it.getName() << "' as '" << it_match.getName() << "' in new param." << std::endl;
+            stream << "Found '" << it.getName() << "' as '" << it_match.getName() << "' in new param." << '\n';
             new_entry = this->getEntry(it_match.getName());
             target_name = it_match.getName();
           }
@@ -1285,13 +1285,13 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
           if (fail_on_unknown_parameters)
           {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file!" << std::endl;
+            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file!" << '\n';
             is_update_success = false;
           }
           else if (add_unknown)
           {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Adding to current set." << std::endl;
+            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Adding to current set." << '\n';
             Param::ParamEntry local_entry = p_outdated.getEntry(it.getName());
             std::string prefix = "";
             if (it.getName().find(':') != std::string::npos)
@@ -1303,7 +1303,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
           else if (verbose)
           {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Ignoring parameter. " << std::endl;
+            stream << "Unknown (or deprecated) Parameter '" << it.getName() << "' given in outdated parameter file! Ignoring parameter. " << '\n';
           }
           continue;
         }
@@ -1324,7 +1324,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
             if (verbose) 
             {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-                stream << "Default-Parameter '" << target_name << "' overridden: '" << default_value << "' --> '" << it->value << "'!" << std::endl;
+                stream << "Default-Parameter '" << target_name << "' overridden: '" << default_value << "' --> '" << it->value << "'!" << '\n';
             }
             this->setValue(target_name, it->value, new_entry.description, this->getTags(target_name));
           }
@@ -1335,13 +1335,13 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
             if (fail_on_invalid_values)
             {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-              stream << " Updating failed!" << std::endl;
+              stream << " Updating failed!" << '\n';
               is_update_success = false;
             }
             else
             {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-              stream << " Ignoring invalid value (using new default '" << default_value << "')!" << std::endl;
+              stream << " Ignoring invalid value (using new default '" << default_value << "')!" << '\n';
               new_entry.value = default_value;
             }
           }
@@ -1358,13 +1358,13 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
         if (fail_on_invalid_values)
         {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-          stream << " Updating failed!" << std::endl;
+          stream << " Updating failed!" << '\n';
           is_update_success = false;
         } 
         else
         {
 OPENMS_THREAD_CRITICAL(LOGSTREAM)
-          stream << " Ignoring invalid value (using new default)!" << std::endl;
+          stream << " Ignoring invalid value (using new default)!" << '\n';
         }
       }
 
@@ -1389,7 +1389,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
       if (!this->exists(it.getName()))
       {
         Param::ParamEntry entry = *it;
-        OPENMS_LOG_DEBUG << "[Param::merge] merging " << it.getName() << std::endl;
+        OPENMS_LOG_DEBUG << "[Param::merge] merging " << it.getName() << '\n';
         this->root_.insert(entry, prefix);
       }
 
@@ -1399,12 +1399,12 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
       {
         if (traceIt->opened)
         {
-          OPENMS_LOG_DEBUG << "[Param::merge] extending param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
+          OPENMS_LOG_DEBUG << "[Param::merge] extending param trace " << traceIt->name << " (" << pathname << ")" << '\n';
           pathname += traceIt->name + ":";
         }
         else
         {
-          OPENMS_LOG_DEBUG << "[Param::merge] reducing param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
+          OPENMS_LOG_DEBUG << "[Param::merge] reducing param trace " << traceIt->name << " (" << pathname << ")" << '\n';
           std::string suffix = traceIt->name + ":";
           if (suffix.size() <= pathname.size() && pathname.compare(pathname.size() - suffix.size(), suffix.size(), suffix) == 0)
             pathname.resize(pathname.size() - traceIt->name.size() - 1);
@@ -1511,12 +1511,12 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
     {
       const Param::ParamNode* node = stack_.back();
 
-      //std::cout << "############ operator++ #### " << node->name << " ## " << current_ << std::endl;
+      //std::cout << "############ operator++ #### " << node->name << " ## " << current_ << '\n';
 
       //check if there is a next entry in the current node
       if (current_ + 1 < (int)node->entries.size())
       {
-        //std::cout << " - next entry" << std::endl;
+        //std::cout << " - next entry" << '\n';
         ++current_;
         return *this;
       }
@@ -1525,7 +1525,7 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
       {
         current_ = -1;
         stack_.push_back(&(node->nodes[0]));
-        //std::cout << " - entering into: " << node->nodes[0].name << std::endl;
+        //std::cout << " - entering into: " << node->nodes[0].name << '\n';
         //track changes (enter a node)
         trace_.emplace_back(node->nodes[0].name, node->nodes[0].description, true);
 
@@ -1539,18 +1539,18 @@ OPENMS_THREAD_CRITICAL(LOGSTREAM)
         {
           const Param::ParamNode* last = node;
           stack_.pop_back();
-          //std::cout << " - stack size: " << stack_.size() << std::endl;
+          //std::cout << " - stack size: " << stack_.size() << '\n';
           //we have reached the end
           if (stack_.empty())
           {
-            //std::cout << " - reached the end" << std::endl;
+            //std::cout << " - reached the end" << '\n';
             root_ = nullptr;
             return *this;
           }
           node = stack_.back();
 
-          //std::cout << " - last was: " << last->name << std::endl;
-          //std::cout << " - descended to: " << node->name << std::endl;
+          //std::cout << " - last was: " << last->name << '\n';
+          //std::cout << " - descended to: " << node->name << '\n';
 
           //track changes (leave a node)
           if (!trace_.empty() && trace_.back().name == last->name && trace_.back().opened) // was empty subnode

--- a/src/openms/source/FEATUREFINDER/EGHTraceFitter.cpp
+++ b/src/openms/source/FEATUREFINDER/EGHTraceFitter.cpp
@@ -321,8 +321,8 @@ namespace OpenMS
 
   void EGHTraceFitter::setInitialParameters_(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces)
   {
-    OPENMS_LOG_DEBUG << "EGHTraceFitter->setInitialParameters(...)" << std::endl;
-    OPENMS_LOG_DEBUG << "Number of traces: " << traces.size() << std::endl;
+    OPENMS_LOG_DEBUG << "EGHTraceFitter->setInitialParameters(...)" << '\n';
+    OPENMS_LOG_DEBUG << "Number of traces: " << traces.size() << '\n';
 
     // aggregate data; some peaks (where intensity is zero) can be missing!
     // mapping: RT -> total intensity over all mass traces
@@ -339,7 +339,7 @@ namespace OpenMS
            total_intensities.begin(); it != total_intensities.end(); ++it)
     {
       totals[index++] = it->second;
-      // OPENMS_LOG_DEBUG << it->second << std::endl;
+      // OPENMS_LOG_DEBUG << it->second << '\n';
     }
 
     std::vector<double> smoothed(N);
@@ -355,18 +355,18 @@ namespace OpenMS
       {
         max_index = i;
       }
-      // OPENMS_LOG_DEBUG << smoothed[i] << std::endl;
+      // OPENMS_LOG_DEBUG << smoothed[i] << '\n';
     }
-    OPENMS_LOG_DEBUG << "Maximum at index " << max_index << std::endl;
+    OPENMS_LOG_DEBUG << "Maximum at index " << max_index << '\n';
     height_ = smoothed[max_index] - traces.baseline;
-    OPENMS_LOG_DEBUG << "height: " << height_ << std::endl;
+    OPENMS_LOG_DEBUG << "height: " << height_ << '\n';
     std::list<std::pair<double, double> >::iterator it = total_intensities.begin();
     std::advance(it, max_index);
     apex_rt_ = it->first;
-    OPENMS_LOG_DEBUG << "apex_rt: " << apex_rt_ << std::endl;
+    OPENMS_LOG_DEBUG << "apex_rt: " << apex_rt_ << '\n';
     region_rt_span_ = (total_intensities.rbegin()->first -
                        total_intensities.begin()->first);
-    OPENMS_LOG_DEBUG << "region_rt_span: " << region_rt_span_ << std::endl;
+    OPENMS_LOG_DEBUG << "region_rt_span: " << region_rt_span_ << '\n';
 
     // find RT values where intensity is at half-maximum:
     index = static_cast<Int>(max_index);
@@ -379,7 +379,7 @@ namespace OpenMS
     std::advance(it, index);
     double left_rt = it->first;
     OPENMS_LOG_DEBUG << "Left half-maximum at index " << index << ", RT " << left_rt
-              << std::endl;
+              << '\n';
     index = static_cast<Int>(max_index);
     while ((index < Int(N - 1)) && (smoothed[index] > height_ * 0.5))
     {
@@ -390,12 +390,12 @@ namespace OpenMS
     std::advance(it, index - Int(N));
     double right_rt = it->first;
     OPENMS_LOG_DEBUG << "Right half-maximum at index " << index << ", RT "
-              << right_rt << std::endl;
+              << right_rt << '\n';
 
     double A = apex_rt_ - left_rt;
     double B = right_rt - apex_rt_;
-    //OPENMS_LOG_DEBUG << "A: " << A << std::endl;
-    //OPENMS_LOG_DEBUG << "B: " << B << std::endl;
+    //OPENMS_LOG_DEBUG << "A: " << A << '\n';
+    //OPENMS_LOG_DEBUG << "B: " << B << '\n';
 
     // compute estimates for tau / sigma based on A and B:
     double alpha = (left_height + right_height) * 0.5 / height_;   // ~0.5
@@ -407,9 +407,9 @@ namespace OpenMS
     {
       tau_ = std::numeric_limits<double>::epsilon();
     }
-    OPENMS_LOG_DEBUG << "tau: " << tau_ << std::endl;
+    OPENMS_LOG_DEBUG << "tau: " << tau_ << '\n';
     sigma_ = sqrt(-0.5 / log_alpha * B * A);
-    OPENMS_LOG_DEBUG << "sigma: " << sigma_ << std::endl;
+    OPENMS_LOG_DEBUG << "sigma: " << sigma_ << '\n';
   }
 
   void EGHTraceFitter::updateMembers_()

--- a/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
+++ b/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
@@ -264,12 +264,12 @@ namespace OpenMS
 
         // out debug info
 #ifdef DEBUG_EPD
-        std::cout << "findLocalExtrema: Identified potential minimum " << std::endl;
+        std::cout << "findLocalExtrema: Identified potential minimum " << '\n';
         std::cout << "    " << tr.getLabel() << ": left_idx,right_idx " << left_idx << "," << right_idx << 
           ":" << left_max_int << " min: " << min_int << " " << right_max_int << 
-          " l " << left_rt << " r " << right_rt << " m " << mid_rt << std::endl;
-        std::cout << "    Int: min " << min_int << ", left: " << left_max_int << ", right: " << right_max_int << std::endl;
-        std::cout << "    Distance: min " << min_dist << ", left: " << left_dist << ", right: " << right_dist << std::endl;
+          " l " << left_rt << " r " << right_rt << " m " << mid_rt << '\n';
+        std::cout << "    Int: min " << min_int << ", left: " << left_max_int << ", right: " << right_max_int << '\n';
+        std::cout << "    Distance: min " << min_dist << ", left: " << left_dist << ", right: " << right_dist << '\n';
 #endif
 
         // 2.4 Decide whether to split the masstrace (introduce a minimum):
@@ -282,7 +282,7 @@ namespace OpenMS
         {
 #ifdef DEBUG_EPD
         std::cout << "    -> add new minima " << ": left_idx,right_idx " << left_idx << "," << right_idx << 
-          " l " << left_rt << " r " << right_rt << " m " << mid_rt << std::endl;
+          " l " << left_rt << " r " << right_rt << " m " << mid_rt << '\n';
 #endif
 
           chrom_mins.push_back(min_rt);
@@ -366,13 +366,13 @@ namespace OpenMS
     {
       if (count_mt >= lower_quartile_idx && count_mt <= upper_quartile_idx)
       {
-        // std::cout << "pw added " << width_pair.first << std::endl;
+        // std::cout << "pw added " << width_pair.first << '\n';
         filt_mtraces.push_back(mt_vec[width_pair.second]);
       }
       ++count_mt;
     }
 
-    std::cout << "pw low: " << filt_mtraces[0].estimateFWHM(true) << " " << " pw high: " << filt_mtraces[filt_mtraces.size() - 1].estimateFWHM(true) << std::endl;
+    std::cout << "pw low: " << filt_mtraces[0].estimateFWHM(true) << " " << " pw high: " << filt_mtraces[filt_mtraces.size() - 1].estimateFWHM(true) << '\n';
 
     return;
   }
@@ -392,16 +392,16 @@ namespace OpenMS
 
 #ifdef DEBUG_EPD
     Size i = 0;
-    std::cout << "*****" << std::endl;
-    std::cout << "   finding elution peaks in mass traces RT "  << mt.getCentroidRT()  << " / mz " << mt.getCentroidMZ() << std::endl;
-    std::cout << "   used for smoothing: win_size "  << win_size << " FWHM scan num " /* << mt.getFWHMScansNum() */ << std::endl;
-    std::cout << "*****" << std::endl;
+    std::cout << "*****" << '\n';
+    std::cout << "   finding elution peaks in mass traces RT "  << mt.getCentroidRT()  << " / mz " << mt.getCentroidMZ() << '\n';
+    std::cout << "   used for smoothing: win_size "  << win_size << " FWHM scan num " /* << mt.getFWHMScansNum() */ << '\n';
+    std::cout << "*****" << '\n';
     for (const auto& peak : mt)
     {
-      // std::cout << peak.getIntensity() << " " << mt.getSmoothedIntensities()[i] << std::endl;
+      // std::cout << peak.getIntensity() << " " << mt.getSmoothedIntensities()[i] << '\n';
       ++i;
     }
-    std::cout << "*****" << std::endl;
+    std::cout << "*****" << '\n';
 #endif
 
     // *********************************************************************
@@ -411,7 +411,7 @@ namespace OpenMS
     findLocalExtrema(mt, win_size / 2, maxes, mins);
 
 #ifdef DEBUG_EPD
-    std::cout << "findLocalExtrema returned: maxima " << maxes.size() << " / minima " << mins.size() << std::endl;
+    std::cout << "findLocalExtrema returned: maxima " << maxes.size() << " / minima " << mins.size() << '\n';
 #endif
 
     // *********************************************************************
@@ -593,7 +593,7 @@ namespace OpenMS
     mt.setSmoothedIntensities(smoothed_intensities);
     //alternative end
 
-    // std::cout << "win_size elution: " << scan_time << " " << win_size << std::endl;
+    // std::cout << "win_size elution: " << scan_time << " " << win_size << '\n';
 
     // if there is no previous FWHM estimation... do it now
     //    if (win_size == 0)

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -238,7 +238,7 @@ namespace OpenMS
     // Step 1:
     // Precalculate intensity scores for peaks
     //---------------------------------------------------------------------------
-    if (debug_) log_ << "Precalculating intensity thresholds ..." << std::endl;
+    if (debug_) log_ << "Precalculating intensity thresholds ..." << '\n';
     //new scope to make local variables disappear
     {
       startProgress(0, intensity_bins_ * intensity_bins_, "Precalculating intensity scores");
@@ -258,8 +258,8 @@ namespace OpenMS
           setProgress(rt * intensity_bins_ + mz);
           double min_mz = mz_start + mz * intensity_mz_step_;
           double max_mz = mz_start + (mz + 1) * intensity_mz_step_;
-          //std::cout << "rt range: " << min_rt << " - " << max_rt << std::endl;
-          //std::cout << "mz range: " << min_mz << " - " << max_mz << std::endl;
+          //std::cout << "rt range: " << min_rt << " - " << max_rt << '\n';
+          //std::cout << "mz range: " << min_mz << " - " << max_mz << '\n';
           tmp.clear();
           for (MapType::ConstAreaIterator it = map_.areaBeginConst(min_rt, max_rt, min_mz, max_mz); it != map_.areaEndConst(); ++it)
           {
@@ -312,7 +312,7 @@ namespace OpenMS
           double pos = spectrum[p].getMZ();
           float intensity = spectrum[p].getIntensity();
 
-          //if(debug_) log_ << std::endl << "Peak: " << pos << std::endl;
+          //if(debug_) log_ << '\n' << "Peak: " << pos << '\n';
           bool is_max_peak = true; // checking the maximum intensity peaks -> use them later as feature seeds.
           for (Size i = 1; i <= min_spectra_; ++i)
           {
@@ -366,7 +366,7 @@ namespace OpenMS
       //calculate distribution if necessary
       for (Size index = 0; index < num_isotopes; ++index)
       {
-        //if(debug_) log_ << "Calculating iso dist for mass: " << 0.5*mass_window_width_ + index * mass_window_width_ << std::endl;
+        //if(debug_) log_ << "Calculating iso dist for mass: " << 0.5*mass_window_width_ + index * mass_window_width_ << '\n';
         CoarseIsotopePatternGenerator solver(max_isotopes);
         auto d = solver.estimateFromPeptideWeight(0.5 * mass_window_width_ + index * mass_window_width_);
         //trim left and right. And store the number of isotopes on the left, to reconstruct the monoisotopic peak
@@ -378,7 +378,7 @@ namespace OpenMS
         for (auto& peak : d)
         {
           isotope_distributions_[index].intensity.push_back(peak.getIntensity());
-          //if(debug_) log_ << " - " << it->second << std::endl;
+          //if(debug_) log_ << " - " << it->second << '\n';
         }
 
         //determine the number of optional peaks at the beginning/end
@@ -426,7 +426,7 @@ namespace OpenMS
           i /= max;
         }
 
-        //if(debug_) log_ << " - optional begin/end:" << begin << " / " << end << std::endl;
+        //if(debug_) log_ << " - optional begin/end:" << begin << " / " << end << '\n';
       }
 
       endProgress();
@@ -573,7 +573,7 @@ namespace OpenMS
       }
 
       endProgress();
-      std::cout << "Found " << seeds.size() << " seeds for charge " << c << "." << std::endl;
+      std::cout << "Found " << seeds.size() << " seeds for charge " << c << "." << '\n';
 
       //------------------------------------------------------------------
       // Step 3.3:
@@ -611,11 +611,11 @@ namespace OpenMS
 
           if (debug_)
           {
-            log_ << std::endl << "Seed " << i << ":" << std::endl;
+            log_ << '\n' << "Seed " << i << ":" << '\n';
             //If the intensity is zero this seed is already uses in another feature
-            log_ << " - Int: " << peak.getIntensity() << std::endl;
-            log_ << " - RT: " << spectrum.getRT() << std::endl;
-            log_ << " - MZ: " << peak.getMZ() << std::endl;
+            log_ << " - Int: " << peak.getIntensity() << '\n';
+            log_ << " - RT: " << spectrum.getRT() << '\n';
+            log_ << " - MZ: " << peak.getMZ() << '\n';
           }
         }
 
@@ -679,8 +679,8 @@ namespace OpenMS
         alt_fitter->setParameters(alt_p);
         alt_fitter->fit(traces);
 
-        OPENMS_LOG_DEBUG << "EGH:   " << fitter->getCenter() << " " << fitter->getHeight() << std::endl;
-        OPENMS_LOG_DEBUG << "GAUSS: " << alt_fitter->getCenter() << " " << alt_fitter->getHeight() << std::endl;
+        OPENMS_LOG_DEBUG << "EGH:   " << fitter->getCenter() << " " << fitter->getHeight() << '\n';
+        OPENMS_LOG_DEBUG << "GAUSS: " << alt_fitter->getCenter() << " " << alt_fitter->getHeight() << '\n';
 #endif
         // what should come out
         // left "sigma"
@@ -854,7 +854,7 @@ namespace OpenMS
       }
 
       IF_MASTERTHREAD endProgress();
-      std::cout << "Found " << feature_candidates << " feature candidates for charge " << c << "." << std::endl;
+      std::cout << "Found " << feature_candidates << " feature candidates for charge " << c << "." << '\n';
     }
     // END OPENMP
 
@@ -863,7 +863,7 @@ namespace OpenMS
     //Resolve contradicting and overlapping features
     //------------------------------------------------------------------
     startProgress(0, features_->size() * features_->size(), "Resolving overlapping features");
-    if (debug_) log_ << "Resolving intersecting features (" << features_->size() << " candidates)" << std::endl;
+    if (debug_) log_ << "Resolving intersecting features (" << features_->size() << " candidates)" << '\n';
     //sort features according to m/z in order to speed up the resolution
     features_->sortByMZ();
     //precalculate BBs and maximum mz span
@@ -912,7 +912,7 @@ namespace OpenMS
 
           if (debug_)
           {
-            log_ << " - Intersection (" << (i + 1) << "/" << (j + 1) << "): " << intersection << std::endl;
+            log_ << " - Intersection (" << (i + 1) << "/" << (j + 1) << "): " << intersection << '\n';
           }
           if (f1.getCharge() == f2.getCharge())
           {
@@ -920,7 +920,7 @@ namespace OpenMS
             {
               if (debug_)
               {
-                log_ << "   - same charge -> removing duplicate " << (j + 1) << std::endl;
+                log_ << "   - same charge -> removing duplicate " << (j + 1) << '\n';
               }
               f1.getSubordinates().push_back(f2);
               f2.setIntensity(0.0);
@@ -929,7 +929,7 @@ namespace OpenMS
             {
               if (debug_)
               {
-                log_ << "   - same charge -> removing duplicate " << (i + 1) << std::endl;
+                log_ << "   - same charge -> removing duplicate " << (i + 1) << '\n';
               }
               f2.getSubordinates().push_back(f1);
               f1.setIntensity(0.0);
@@ -939,7 +939,7 @@ namespace OpenMS
           {
             if (debug_)
             {
-              log_ << "   - different charge (one is the multiple of the other) -> removing lower charge " << (i + 1) << std::endl;
+              log_ << "   - different charge (one is the multiple of the other) -> removing lower charge " << (i + 1) << '\n';
             }
             f2.getSubordinates().push_back(f1);
             f1.setIntensity(0.0);
@@ -948,7 +948,7 @@ namespace OpenMS
           {
             if (debug_)
             {
-              log_ << "   - different charge (one is the multiple of the other) -> removing lower charge " << (i + 1) << std::endl;
+              log_ << "   - different charge (one is the multiple of the other) -> removing lower charge " << (i + 1) << '\n';
             }
             f1.getSubordinates().push_back(f2);
             f2.setIntensity(0.0);
@@ -959,7 +959,7 @@ namespace OpenMS
             {
               if (debug_)
               {
-                log_ << "   - different charge -> removing lower score " << (j + 1) << std::endl;
+                log_ << "   - different charge -> removing lower score " << (j + 1) << '\n';
               }
               f1.getSubordinates().push_back(f2);
               f2.setIntensity(0.0);
@@ -968,7 +968,7 @@ namespace OpenMS
             {
               if (debug_)
               {
-                log_ << "   - different charge -> removing lower score " << (i + 1) << std::endl;
+                log_ << "   - different charge -> removing lower score " << (i + 1) << '\n';
               }
               f2.getSubordinates().push_back(f1);
               f1.setIntensity(0.0);
@@ -977,7 +977,7 @@ namespace OpenMS
         }
       }
     }
-    OPENMS_LOG_INFO << "Removed " << removed << " overlapping features." << std::endl;
+    OPENMS_LOG_INFO << "Removed " << removed << " overlapping features." << '\n';
     // finally remove features with intensity 0
     FeatureMap tmp;
     tmp.reserve(features_->size());
@@ -1001,7 +1001,7 @@ namespace OpenMS
       OPENMS_LOG_INFO << " - " << reason.first << ": " << reason.second << " times\n";
     }
 
-    OPENMS_LOG_INFO << "\n" << features_->size() << " features found." << std::endl;
+    OPENMS_LOG_INFO << "\n" << features_->size() << " features found." << '\n';
 
     if (debug_)
     {
@@ -1058,7 +1058,7 @@ namespace OpenMS
       //Check if the peaks are sorted according to m/z
       if (!input_map.isSorted(true))
       {
-        OPENMS_LOG_WARN << "Input map is not sorted by RT and m/z! This is done now, before applying the algorithm!" << std::endl;
+        OPENMS_LOG_WARN << "Input map is not sorted by RT and m/z! This is done now, before applying the algorithm!" << '\n';
         input_map.sortSpectra(true);
         input_map.sortChromatograms(true);
       }
@@ -1097,7 +1097,7 @@ namespace OpenMS
       else
       {
         /// @todo that happens sometimes using IsotopeWaveletFeatureFinder (Rene, Marc, Andreas, Clemens)
-        std::cerr << "FeatureFinderAlgorithm_impl, line=" << __LINE__ << "; FixMe this cannot be, but happens" << std::endl;
+        std::cerr << "FeatureFinderAlgorithm_impl, line=" << __LINE__ << "; FixMe this cannot be, but happens" << '\n';
       }
     }
   }
@@ -1127,7 +1127,7 @@ namespace OpenMS
   {
     if (debug_)
     {
-      log_ << "Abort: " << reason << std::endl;
+      log_ << "Abort: " << reason << '\n';
     }
     aborts_[reason]++;
     if (debug_)
@@ -1209,19 +1209,19 @@ namespace OpenMS
   {
     if (debug_)
     {
-      log_ << "Testing isotope patterns for charge " << charge << ": " << std::endl;
+      log_ << "Testing isotope patterns for charge " << charge << ": " << '\n';
     }
     const SpectrumType& spectrum = map_[center.spectrum];
     const TheoreticalIsotopePattern& isotopes = getIsotopeDistribution_(spectrum[center.peak].getMZ() * charge);
     if (debug_)
     {
-      log_ << " - Seed: " << center.peak << " (mz:" << spectrum[center.peak].getMZ() << ")" << std::endl;
+      log_ << " - Seed: " << center.peak << " (mz:" << spectrum[center.peak].getMZ() << ")" << '\n';
     }
     //Find m/z boundaries of search space (linear search as this is local and we have the center already)
     double mass_window = (double)(isotopes.size() + 1) / (double)charge;
     if (debug_)
     {
-      log_ << " - Mass window: " << mass_window << std::endl;
+      log_ << " - Mass window: " << mass_window << '\n';
     }
     Size end = center.peak;
     while (end < spectrum.size() &&
@@ -1241,11 +1241,11 @@ namespace OpenMS
     ++begin;
     if (debug_)
     {
-      log_ << " - Begin: " << begin << " (mz:" << spectrum[begin].getMZ() << ")" << std::endl;
+      log_ << " - Begin: " << begin << " (mz:" << spectrum[begin].getMZ() << ")" << '\n';
     }
     if (debug_)
     {
-      log_ << " - End: " << end << " (mz:" << spectrum[end].getMZ() << ")" << std::endl;
+      log_ << " - End: " << end << " (mz:" << spectrum[end].getMZ() << ")" << '\n';
     }
     //fit isotope distribution to peaks
     double max_score = 0.0;
@@ -1256,7 +1256,7 @@ namespace OpenMS
       IsotopePattern pattern(isotopes.size());
       if (debug_)
       {
-        log_ << " - Fitting at " << start << " (mz:" << spectrum[start].getMZ() << ")" << std::endl;
+        log_ << " - Fitting at " << start << " (mz:" << spectrum[start].getMZ() << ")" << '\n';
       }
       for (Size iso = 0; iso < isotopes.size(); ++iso)
       {
@@ -1278,7 +1278,7 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - aborting: seed is not contained!" << std::endl;
+          log_ << "   - aborting: seed is not contained!" << '\n';
         }
         continue;
       }
@@ -1300,14 +1300,14 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - aborting: seed was removed during isotope fit!" << std::endl;
+          log_ << "   - aborting: seed was removed during isotope fit!" << '\n';
         }
         continue;
       }
 
       if (debug_)
       {
-        log_ << "   - final score: " << score << std::endl;
+        log_ << "   - final score: " << score << '\n';
       }
       if (score > max_score)
       {
@@ -1317,7 +1317,7 @@ namespace OpenMS
     }
     if (debug_)
     {
-      log_ << " - best score              : " << max_score << std::endl;
+      log_ << " - best score              : " << max_score << '\n';
     }
     best_pattern.theoretical_pattern = isotopes;
     return max_score;
@@ -1348,11 +1348,11 @@ namespace OpenMS
     double start_rt = map_[start_index].getRT();
     if (debug_)
     {
-      log_ << " - Trace " << max_trace_index << " (maximum intensity)" << std::endl;
+      log_ << " - Trace " << max_trace_index << " (maximum intensity)" << '\n';
     }
     if (debug_)
     {
-      log_ << "   - extending from: " << map_[start_index].getRT() << " / " << start_mz << " (int: " << start_peak->getIntensity() << ")" << std::endl;
+      log_ << "   - extending from: " << map_[start_index].getRT() << " / " << start_mz << " (int: " << start_peak->getIntensity() << ")" << '\n';
     }
     //initialize the trace and extend
     MassTrace max_trace;
@@ -1364,14 +1364,14 @@ namespace OpenMS
     double rt_min = max_trace.peaks.begin()->first;
     if (debug_)
     {
-      log_ << "   - rt bounds: " << rt_min << "-" << rt_max << std::endl;
+      log_ << "   - rt bounds: " << rt_min << "-" << rt_max << '\n';
     }
     //Abort if too few peak were found
     if (!max_trace.isValid() || max_trace.peaks.size() < 2 * min_spectra_ - max_missing_trace_peaks_)
     {
       if (debug_)
       {
-        log_ << "   - could not extend trace with maximum intensity => abort" << std::endl;
+        log_ << "   - could not extend trace with maximum intensity => abort" << '\n';
       }
       return;
     }
@@ -1379,13 +1379,13 @@ namespace OpenMS
     {
       if (debug_)
       {
-        log_ << " - Trace " << p << std::endl;
+        log_ << " - Trace " << p << '\n';
       }
       if (p == max_trace_index)
       {
         if (debug_)
         {
-          log_ << "   - previously extended maximum trace" << std::endl;
+          log_ << "   - previously extended maximum trace" << '\n';
         }
         traces.push_back(std::move(max_trace));
         traces.back().theoretical_int = pattern.theoretical_pattern.intensity[p];
@@ -1399,7 +1399,7 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - removed during isotope fit" << std::endl;
+          log_ << "   - removed during isotope fit" << '\n';
         }
         continue;
       }
@@ -1407,12 +1407,12 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - missing" << std::endl;
+          log_ << "   - missing" << '\n';
         }
         continue;
       }
       starting_peak.intensity = map_[starting_peak.spectrum][starting_peak.peak].getIntensity();
-      if (debug_) log_ << "   - trace seed: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")" << std::endl;
+      if (debug_) log_ << "   - trace seed: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")" << '\n';
 
       //search for nearby maximum of the mass trace as the extension assumes that it starts at the maximum
       Size begin = std::max((Size)0, starting_peak.spectrum - min_spectra_);
@@ -1442,7 +1442,7 @@ namespace OpenMS
       }
       if (debug_)
       {
-        log_ << "   - extending from: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")" << std::endl;
+        log_ << "   - extending from: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")" << '\n';
       }
       //------------------------------------------------------------------
       //Extend seed to a mass trace
@@ -1458,7 +1458,7 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - could not extend trace " << std::endl;
+          log_ << "   - could not extend trace " << '\n';
         }
         //Missing traces in the middle of a pattern are not acceptable => fix this
         if (p < traces.max_trace)
@@ -1577,7 +1577,7 @@ namespace OpenMS
     }
     if (debug_)
     {
-      log_ << "   - Added " << (trace.peaks.size() - peaks_before_extension) << " peaks (abort: " << abort_reason << ")" << std::endl;
+      log_ << "   - Added " << (trace.peaks.size() - peaks_before_extension) << " peaks (abort: " << abort_reason << ")" << '\n';
     }
   }
 
@@ -1678,7 +1678,7 @@ namespace OpenMS
     {
       if (debug_)
       {
-        log_ << " missing" << std::endl;
+        log_ << " missing" << '\n';
       }
       pattern.peak[pattern_index] = -1;
       pattern.mz_score[pattern_index] = 0.0;
@@ -1688,7 +1688,7 @@ namespace OpenMS
     {
       if (debug_)
       {
-        log_ << "=> " << intensity / matches << std::endl;
+        log_ << "=> " << intensity / matches << '\n';
       }
       pattern.mz_score[pattern_index] = pos_score / matches;
       pattern.intensity[pattern_index] = intensity / matches;
@@ -1712,7 +1712,7 @@ namespace OpenMS
   /// Calculates a score between 0 and 1 for the correlation between theoretical and found isotope pattern
   double FeatureFinderAlgorithmPicked::isotopeScore_(const TheoreticalIsotopePattern& isotopes, IsotopePattern& pattern, bool consider_mz_distances) const
   {
-    if (debug_) log_ << "   - fitting " << pattern.intensity.size() << " peaks" << std::endl;
+    if (debug_) log_ << "   - fitting " << pattern.intensity.size() << " peaks" << '\n';
     //Abort if a core peak is missing
     for (Size iso = 0 + isotopes.optional_begin; iso < pattern.peak.size() - isotopes.optional_end; ++iso)
     {
@@ -1720,7 +1720,7 @@ namespace OpenMS
       {
         if (debug_)
         {
-          log_ << "   - aborting: core peak is missing" << std::endl;
+          log_ << "   - aborting: core peak is missing" << '\n';
         }
         return 0.0;
       }
@@ -1749,7 +1749,7 @@ namespace OpenMS
     }
     if (debug_)
     {
-      log_ << "   - best_begin/end: " << best_begin << "/" << best_end << std::endl;
+      log_ << "   - best_begin/end: " << best_begin << "/" << best_end << '\n';
     }
     for (Size b = best_begin; b <= isotopes.optional_begin; ++b)
     {
@@ -1785,7 +1785,7 @@ namespace OpenMS
           }
           if (debug_)
           {
-            log_ << std::endl;
+            log_ << '\n';
           }
         }
       }
@@ -1896,13 +1896,13 @@ namespace OpenMS
     // choose fitter
     if (param_.getValue("feature:rt_shape") == "asymmetric")
     {
-      OPENMS_LOG_DEBUG << "use asymmetric rt peak shape" << std::endl;
+      OPENMS_LOG_DEBUG << "use asymmetric rt peak shape" << '\n';
       tau = -1.0;
       return std::make_unique<EGHTraceFitter>();
     }
     else // if (param_.getValue("feature:rt_shape") == "symmetric")
     {
-      OPENMS_LOG_DEBUG << "use symmetric rt peak shape" << std::endl;
+      OPENMS_LOG_DEBUG << "use symmetric rt peak shape" << '\n';
       return std::make_unique<GaussTraceFitter>();
     }
   }
@@ -1955,7 +1955,7 @@ namespace OpenMS
 
     if (debug_)
     {
-      log_ << "    => RT bounds: " << low_bound << " - " << high_bound << std::endl;
+      log_ << "    => RT bounds: " << low_bound << " - " << high_bound << '\n';
     }
     std::vector<double> v_theo, v_real;
     for (Size t = 0; t < traces.size(); ++t)
@@ -1963,7 +1963,7 @@ namespace OpenMS
       const MassTrace& trace = traces[t];
       if (debug_)
       {
-        log_ << "   - Trace " << t << ": (" << trace.theoretical_int << ")" << std::endl;
+        log_ << "   - Trace " << t << ": (" << trace.theoretical_int << ")" << '\n';
       }
       MassTrace new_trace;
       //compute average relative deviation and correlation
@@ -1995,7 +1995,7 @@ namespace OpenMS
       }
       if (debug_)
       {
-        log_ << "     - peaks: " << new_trace.peaks.size() << " / " << trace.peaks.size() << " - relative deviation: " << fit_score << " - correlation: " << correlation << " - final score: " << correlation << std::endl;
+        log_ << "     - peaks: " << new_trace.peaks.size() << " / " << trace.peaks.size() << " - relative deviation: " << fit_score << " - correlation: " << correlation << " - final score: " << correlation << '\n';
       }
       //remove badly fitting traces
       if (!new_trace.isValid() || final_score < min_trace_score_)
@@ -2005,7 +2005,7 @@ namespace OpenMS
           new_traces = MassTraces();
           if (debug_)
           {
-            log_ << "     - removed this and previous traces due to bad fit" << std::endl;
+            log_ << "     - removed this and previous traces due to bad fit" << '\n';
           }
           new_traces.clear(); //remove earlier traces
           continue;
@@ -2015,7 +2015,7 @@ namespace OpenMS
           new_traces = MassTraces();
           if (debug_)
           {
-            log_ << "     - aborting (max trace was removed)" << std::endl;
+            log_ << "     - aborting (max trace was removed)" << '\n';
           }
           break;
         }
@@ -2023,7 +2023,7 @@ namespace OpenMS
         {
           if (debug_)
           {
-            log_ << "     - removed due to bad fit => omitting the rest" << std::endl;
+            log_ << "     - removed due to bad fit => omitting the rest" << '\n';
           }
           break; //no more traces are possible
         }
@@ -2106,10 +2106,10 @@ namespace OpenMS
       //quality output
       if (debug_)
       {
-        log_ << "Quality estimation:" << std::endl;
-        log_ << " - relative deviation: " << fit_score << std::endl;
-        log_ << " - correlation: " << correlation << std::endl;
-        log_ << " => final score: " << final_score << std::endl;
+        log_ << "Quality estimation:" << '\n';
+        log_ << " - relative deviation: " << fit_score << '\n';
+        log_ << " - correlation: " << correlation << '\n';
+        log_ << " => final score: " << final_score << '\n';
       }
 
       if (final_score < min_feature_score)

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -1097,7 +1097,7 @@ namespace OpenMS
       else
       {
         /// @todo that happens sometimes using IsotopeWaveletFeatureFinder (Rene, Marc, Andreas, Clemens)
-        std::cerr << "FeatureFinderAlgorithm_impl, line=" << __LINE__ << "; FixMe this cannot be, but happens" << '\n';
+        std::cerr << "FeatureFinderAlgorithm_impl, line=" << __LINE__ << "; FixMe this cannot be, but happens" << std::endl;
       }
     }
   }

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -312,7 +312,7 @@ namespace OpenMS
     bool use_smoothed = param_.getValue("use_smoothed_intensities").toBool();
     bool report_smoothed = param_.getValue("report_smoothed_intensities").toBool();
     if (report_smoothed && !use_smoothed) {
-      OPENMS_LOG_WARN << "Warning: 'report_smoothed_intensities' is set to true, but 'use_smoothed_intensities' is false. Ignoring 'report_smoothed_intensities'." << std::endl;
+      OPENMS_LOG_WARN << "Warning: 'report_smoothed_intensities' is set to true, but 'use_smoothed_intensities' is false. Ignoring 'report_smoothed_intensities'." << '\n';
       report_smoothed = false;
     }
     use_smoothed_intensities_ = use_smoothed;
@@ -434,17 +434,17 @@ namespace OpenMS
     nodes[FEAT_NUM].value = 0;
 
     // debug output
-    //    std::cout << "isocheck for " << feat_hypo.getLabel() << " " << feat_hypo.getSize() << std::endl;
+    //    std::cout << "isocheck for " << feat_hypo.getLabel() << " " << feat_hypo.getSize() << '\n';
     //    for (Size i = 0; i < FEAT_NUM + 1; ++i)
     //    {
-    //        std::cout << "idx: " << nodes[i].index << " val: " << nodes[i].value << std::endl;
+    //        std::cout << "idx: " << nodes[i].index << " val: " << nodes[i].value << '\n';
     //    }
 
     // Use SVM model to predict the category in which the current trace group
     // belongs ...
     double predict = svm_predict(isotope_filt_svm_, nodes);
 
-    // std::cout << "predict: " << predict << std::endl;
+    // std::cout << "predict: " << predict << '\n';
     delete[] nodes;
 
     return (predict == 2.0) ? 1 : 0;
@@ -554,7 +554,7 @@ namespace OpenMS
     //standard deviation including the estimated isotope deviation
     double score_sigma(std::sqrt(std::exp(2 * std::log(sd)) + mt_variances));
 
-    // std::cout << std::setprecision(15) << "old " << score_sigma_old << " new " << score_sigma << std::endl;
+    // std::cout << std::setprecision(15) << "old " << score_sigma_old << " new " << score_sigma << '\n';
 
     if ((diff_mz < mu + sigma_mult * score_sigma) && (diff_mz > mu - sigma_mult * score_sigma))
     {
@@ -614,8 +614,8 @@ namespace OpenMS
     std::pair<Size, Size> tr1_fwhm_idx(tr1.getFWHMborders());
     std::pair<Size, Size> tr2_fwhm_idx(tr2.getFWHMborders());
 
-    //    std::cout << tr1_fwhm_idx.first << " " << tr1_fwhm_idx.second << std::endl;
-    //    std::cout << tr2_fwhm_idx.first << " " << tr2_fwhm_idx.second << std::endl;
+    //    std::cout << tr1_fwhm_idx.first << " " << tr1_fwhm_idx.second << '\n';
+    //    std::cout << tr2_fwhm_idx.first << " " << tr2_fwhm_idx.second << '\n';
 
     //    Size tr1_fwhm_size(tr1_fwhm_idx.second - tr1_fwhm_idx.first);
     //    Size tr2_fwhm_size(tr2_fwhm_idx.second - tr2_fwhm_idx.first);
@@ -626,7 +626,7 @@ namespace OpenMS
     double tr2_length(tr2.getFWHM());
     double max_length = (tr1_length > tr2_length) ? tr1_length : tr2_length;
 
-    // std::cout << "tr1 " << tr1_length << " tr2 " << tr2_length << std::endl;
+    // std::cout << "tr1 " << tr1_length << " tr2 " << tr2_length << '\n';
 
     // Extract peak shape between FWHM borders for both peaks
     for (Size i = tr1_fwhm_idx.first; i <= tr1_fwhm_idx.second; ++i)
@@ -777,7 +777,7 @@ namespace OpenMS
 
 #ifdef FFM_DEBUG
           std::cout << "scoring " << candidates[0]->getLabel() << " " << candidates[0]->getCentroidMZ() << 
-            " with " << candidates[mt_idx]->getLabel() << " " << candidates[mt_idx]->getCentroidMZ() << std::endl;
+            " with " << candidates[mt_idx]->getLabel() << " " << candidates[mt_idx]->getCentroidMZ() << '\n';
 #endif
 
           // Score current mass trace candidates against hypothesis
@@ -798,7 +798,7 @@ namespace OpenMS
 #ifdef FFM_DEBUG
           std::cout << fh_tmp.getLabel() << "_" << candidates[mt_idx]->getLabel() << 
             "\t" << "ch: " << charge << " isopos: " << iso_pos << " rt: " << 
-            rt_score << "mz: " << mz_score << "int: " << int_score << std::endl;
+            rt_score << "mz: " << mz_score << "int: " << int_score << '\n';
 #endif
 
           double total_pair_score(0.0);
@@ -839,7 +839,7 @@ namespace OpenMS
       } // end for iso_pos
 
 #ifdef FFM_DEBUG
-      std::cout << "best found for ch " << charge << ":" << fh_tmp.getLabel() << " score: " << fh_tmp.getScore() << std::endl;
+      std::cout << "best found for ch " << charge << ":" << fh_tmp.getLabel() << " score: " << fh_tmp.getScore() << '\n';
 #endif
     } // end for charge
   } // end of findLocalFeatures_(...)
@@ -851,7 +851,7 @@ namespace OpenMS
     {
       OPENMS_LOG_WARN << "Isotope filtering is not supported, when using the mz scoring by elements.\n"
                       << "The parameter isotope_filtering_model will be set to 'none'."
-                      << std::endl;
+                      << '\n';
       isotope_filtering_model_ = "none";
     }
 
@@ -873,12 +873,12 @@ namespace OpenMS
     // *********************************************************** //
     if (isotope_filtering_model_ == "metabolites (2% RMS)")
     {
-      OPENMS_LOG_INFO << "Loading metabolite isotope model with 2% RMS error" << std::endl;
+      OPENMS_LOG_INFO << "Loading metabolite isotope model with 2% RMS error" << '\n';
       loadIsotopeModel_("MetaboliteIsoModelNoised2");
     }
     else if (isotope_filtering_model_ == "metabolites (5% RMS)")
     {
-      OPENMS_LOG_INFO << "Loading metabolite isotope model with 5% RMS error" << std::endl;
+      OPENMS_LOG_INFO << "Loading metabolite isotope model with 5% RMS error" << '\n';
       loadIsotopeModel_("MetaboliteIsoModelNoised5");
     }
 
@@ -923,7 +923,7 @@ namespace OpenMS
         double diff_rt = std::fabs(input_mtraces[ext_idx].getCentroidRT() - ref_trace_rt);
         if (diff_rt <= local_rt_range_)
         {
-          // std::cout << " accepted!" << std::endl;
+          // std::cout << " accepted!" << '\n';
           local_traces.push_back(&input_mtraces[ext_idx]);
         }
       }
@@ -935,13 +935,13 @@ namespace OpenMS
     std::sort(feat_hypos.begin(), feat_hypos.end(), CmpHypothesesByScore());
 
 #ifdef FFM_DEBUG
-    std::cout << "size of hypotheses: " << feat_hypos.size() << std::endl;
+    std::cout << "size of hypotheses: " << feat_hypos.size() << '\n';
     // output all hypotheses:
     for (Size hypo_idx = 0; hypo_idx < feat_hypos.size(); ++ hypo_idx)
     {
       bool legal = isLegalIsotopePattern_(feat_hypos[hypo_idx]) > 0;
       std::cout << feat_hypos[hypo_idx].getLabel() << " ch: " << feat_hypos[hypo_idx].getCharge() << 
-        " score: " << feat_hypos[hypo_idx].getScore() << " legal: " << legal << std::endl;
+        " score: " << feat_hypos[hypo_idx].getScore() << " legal: " << legal << '\n';
     }
 #endif
 
@@ -953,7 +953,7 @@ namespace OpenMS
     std::map<String, bool> trace_excl_map;
     for (Size hypo_idx = 0; hypo_idx < feat_hypos.size(); ++hypo_idx)
     {
-      // std::cout << "score now: " <<  feat_hypos[hypo_idx].getScore() << std::endl;
+      // std::cout << "score now: " <<  feat_hypos[hypo_idx].getScore() << '\n';
       std::vector<String> labels(feat_hypos[hypo_idx].getLabels());
       bool trace_coll = false;   // trace collision?
       for (Size lab_idx = 0; lab_idx < labels.size(); ++lab_idx)
@@ -970,7 +970,7 @@ namespace OpenMS
       {
         std::cout << "check for collision: " << trace_coll << " " << 
           feat_hypos[hypo_idx].getLabel() << " " << isLegalIsotopePattern_(feat_hypos[hypo_idx]) << 
-          " " << feat_hypos[hypo_idx].getScore() << std::endl;
+          " " << feat_hypos[hypo_idx].getScore() << '\n';
       }
 #endif
 
@@ -989,7 +989,7 @@ namespace OpenMS
         pass_isotope_filter = isLegalIsotopePattern_(feat_hypos[hypo_idx]);
       }
     
-      // std::cout << "\nlegal iso? " << feat_hypos[hypo_idx].getLabel() << " score: " << feat_hypos[hypo_idx].getScore() << " " << result << std::endl;
+      // std::cout << "\nlegal iso? " << feat_hypos[hypo_idx].getLabel() << " score: " << feat_hypos[hypo_idx].getScore() << " " << result << '\n';
 
       if (pass_isotope_filter == 0) // not passing filter
       {

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -45,8 +45,8 @@ namespace OpenMS
       }
       catch (boost::bad_lexical_cast&)
       {
-        std::cerr << "Trying to convert corrupted / unreadable value to std::streampos : " << s << std::endl;
-        std::cerr << "This can also happen if the value exceeds 63 bits, please check your input." << std::endl;
+        std::cerr << "Trying to convert corrupted / unreadable value to std::streampos : " << s << '\n';
+        std::cerr << "This can also happen if the value exceeds 63 bits, please check your input." << '\n';
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             String("Could not convert string '") + s + "' to a 64 bit integer.");
       }
@@ -56,7 +56,7 @@ namespace OpenMS
       {
         std::cerr << "Your system may not support addressing a file of this size,"
           << " only addresses that fit into a " << sizeof(std::streamsize)*8 <<
-          " bit integer are supported on your system." << std::endl;
+          " bit integer are supported on your system." << '\n';
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             String("Could not convert string '") + s + "' to an integer on your system.");
       }
@@ -94,7 +94,7 @@ namespace OpenMS
     if (indexoffset < 0 || indexoffset > length)
     {
       std::cerr << "IndexedMzMLDecoder::parseOffsets Error: Offset was " <<
-        indexoffset << " (not between 0 and " << length << ")." << std::endl;
+        indexoffset << " (not between 0 and " << length << ")." << '\n';
       return -1;
     }
 
@@ -110,10 +110,10 @@ namespace OpenMS
     // catch case where not enough memory is available
     if (buffer == nullptr)
     {
-      // Warning: Index takes up more than 10 % of the whole file, please check your input file." << std::endl;
-      std::cerr << "IndexedMzMLDecoder::parseOffsets Could not allocate enough memory to read in index of indexedMzML" << std::endl; 
+      // Warning: Index takes up more than 10 % of the whole file, please check your input file." << '\n';
+      std::cerr << "IndexedMzMLDecoder::parseOffsets Could not allocate enough memory to read in index of indexedMzML" << '\n'; 
       std::cerr << "IndexedMzMLDecoder::parseOffsets calculated index offset " << indexoffset << " and file length " << length << 
-        ", consequently tried to read into memory " << readl << " bytes." << std::endl;
+        ", consequently tried to read into memory " << readl << " bytes." << '\n';
       return -1;
     }
 
@@ -167,8 +167,8 @@ namespace OpenMS
     buffer.get()[buffersize] = '\0';
 
 #ifdef DEBUG_READER
-    std::cout << " reading file " << filename  << " with size " << buffersize << std::endl;
-    std::cout << buffer << std::endl;
+    std::cout << " reading file " << filename  << " with size " << buffersize << '\n';
+    std::cout << buffer << '\n';
 #endif
 
     //-------------------------------------------------------------
@@ -187,7 +187,7 @@ namespace OpenMS
       }
       catch (Exception::ConversionError& /*e*/)
       {
-        std::cerr << "Corrupted / unreadable value in <indexListOffset> : " << thismatch << std::endl;
+        std::cerr << "Corrupted / unreadable value in <indexListOffset> : " << thismatch << '\n';
         // free resources and re-throw
         throw;  // re-throw conversion error
       }
@@ -196,7 +196,7 @@ namespace OpenMS
     {
       std::cerr << "IndexedMzMLDecoder::findIndexListOffset Error: Could not find element indexListOffset in the last "
                 << buffersize << " bytes. Maybe this is not a indexedMzML."
-                << buffer.get() << std::endl;
+                << buffer.get() << '\n';
     }
 
     return indexoffset;
@@ -244,7 +244,7 @@ namespace OpenMS
     if (!elementRoot)
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: " <<
-        "No root element found:" << std::endl << std::endl << in << std::endl;
+        "No root element found:" << std::endl << std::endl << in << '\n';
       return -1;
     }
 
@@ -255,7 +255,7 @@ namespace OpenMS
     if (li->getLength() != 1)
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: "
-        << "no indexList element found:" << std::endl << std::endl << in << std::endl;
+        << "no indexList element found:" << std::endl << std::endl << in << '\n';
       return -1;
     }
     xercesc::DOMNode* indexListNode = li->item(0);
@@ -325,7 +325,7 @@ namespace OpenMS
         {
           std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: expected only " <<
             "'spectrum' or 'chromatogram' below indexList but found instead '" << 
-            name << "'." << std::endl;
+            name << "'." << '\n';
           xercesc::XMLString::release(&x_idref_tag);
           xercesc::XMLString::release(&x_name_tag);
           return -1;

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -45,8 +45,8 @@ namespace OpenMS
       }
       catch (boost::bad_lexical_cast&)
       {
-        std::cerr << "Trying to convert corrupted / unreadable value to std::streampos : " << s << '\n';
-        std::cerr << "This can also happen if the value exceeds 63 bits, please check your input." << '\n';
+        std::cerr << "Trying to convert corrupted / unreadable value to std::streampos : " << s << std::endl;
+        std::cerr << "This can also happen if the value exceeds 63 bits, please check your input." << std::endl;
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             String("Could not convert string '") + s + "' to a 64 bit integer.");
       }
@@ -56,7 +56,7 @@ namespace OpenMS
       {
         std::cerr << "Your system may not support addressing a file of this size,"
           << " only addresses that fit into a " << sizeof(std::streamsize)*8 <<
-          " bit integer are supported on your system." << '\n';
+          " bit integer are supported on your system." << std::endl;
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             String("Could not convert string '") + s + "' to an integer on your system.");
       }
@@ -94,7 +94,7 @@ namespace OpenMS
     if (indexoffset < 0 || indexoffset > length)
     {
       std::cerr << "IndexedMzMLDecoder::parseOffsets Error: Offset was " <<
-        indexoffset << " (not between 0 and " << length << ")." << '\n';
+        indexoffset << " (not between 0 and " << length << ")." << std::endl;
       return -1;
     }
 
@@ -111,9 +111,9 @@ namespace OpenMS
     if (buffer == nullptr)
     {
       // Warning: Index takes up more than 10 % of the whole file, please check your input file." << '\n';
-      std::cerr << "IndexedMzMLDecoder::parseOffsets Could not allocate enough memory to read in index of indexedMzML" << '\n'; 
-      std::cerr << "IndexedMzMLDecoder::parseOffsets calculated index offset " << indexoffset << " and file length " << length << 
-        ", consequently tried to read into memory " << readl << " bytes." << '\n';
+      std::cerr << "IndexedMzMLDecoder::parseOffsets Could not allocate enough memory to read in index of indexedMzML" << std::endl;
+      std::cerr << "IndexedMzMLDecoder::parseOffsets calculated index offset " << indexoffset << " and file length " << length <<
+        ", consequently tried to read into memory " << readl << " bytes." << std::endl;
       return -1;
     }
 
@@ -187,7 +187,7 @@ namespace OpenMS
       }
       catch (Exception::ConversionError& /*e*/)
       {
-        std::cerr << "Corrupted / unreadable value in <indexListOffset> : " << thismatch << '\n';
+        std::cerr << "Corrupted / unreadable value in <indexListOffset> : " << thismatch << std::endl;
         // free resources and re-throw
         throw;  // re-throw conversion error
       }
@@ -196,7 +196,7 @@ namespace OpenMS
     {
       std::cerr << "IndexedMzMLDecoder::findIndexListOffset Error: Could not find element indexListOffset in the last "
                 << buffersize << " bytes. Maybe this is not a indexedMzML."
-                << buffer.get() << '\n';
+                << buffer.get() << std::endl;
     }
 
     return indexoffset;
@@ -244,7 +244,7 @@ namespace OpenMS
     if (!elementRoot)
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: " <<
-        "No root element found:" << std::endl << std::endl << in << '\n';
+        "No root element found:" << std::endl << std::endl << in << std::endl;
       return -1;
     }
 
@@ -255,7 +255,7 @@ namespace OpenMS
     if (li->getLength() != 1)
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: "
-        << "no indexList element found:" << std::endl << std::endl << in << '\n';
+        << "no indexList element found:" << std::endl << std::endl << in << std::endl;
       return -1;
     }
     xercesc::DOMNode* indexListNode = li->item(0);
@@ -324,8 +324,8 @@ namespace OpenMS
         else
         {
           std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: expected only " <<
-            "'spectrum' or 'chromatogram' below indexList but found instead '" << 
-            name << "'." << '\n';
+            "'spectrum' or 'chromatogram' below indexList but found instead '" <<
+            name << "'." << std::endl;
           xercesc::XMLString::release(&x_idref_tag);
           xercesc::XMLString::release(&x_name_tag);
           return -1;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -825,12 +825,12 @@ namespace OpenMS::Internal
               if (it->getMZ() != it->getMZ())
             {
               emz = "nan";
-              OPENMS_LOG_WARN << "Found no spectrum reference and no m/z position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+              OPENMS_LOG_WARN << "Found no spectrum reference and no m/z position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << '\n';
             }
             if (it->getRT() != it->getRT())
             {
               ert = "nan";
-              OPENMS_LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+              OPENMS_LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << '\n';
             }
             sid = String("MZ:") + emz + String("@RT:") + ert;
           }
@@ -849,7 +849,7 @@ namespace OpenMS::Internal
         }
         else
         {
-          OPENMS_LOG_WARN << "Falling back to referencing first spectrum file given because file or identifier could not be mapped." << std::endl;
+          OPENMS_LOG_WARN << "Falling back to referencing first spectrum file given because file or identifier could not be mapped." << '\n';
         }
 
         sidres += String("\t\t\t<SpectrumIdentificationResult spectraData_ref=\"")
@@ -917,7 +917,7 @@ namespace OpenMS::Internal
           else
           {
             //encountered a PeptideIdentification which is not linked to any ProteinIdentification
-            OPENMS_LOG_ERROR << "encountered a PeptideIdentification which is not linked to any ProteinIdentification" << std::endl;
+            OPENMS_LOG_ERROR << "encountered a PeptideIdentification which is not linked to any ProteinIdentification" << '\n';
           }
         }
 
@@ -945,7 +945,7 @@ namespace OpenMS::Internal
           else
           {
             //encountered a PeptideIdentification which is not linked to any ProteinIdentification
-            OPENMS_LOG_ERROR << "encountered a PeptideIdentification crosslink information which is not linked to any ProteinIdentification" << std::endl;
+            OPENMS_LOG_ERROR << "encountered a PeptideIdentification crosslink information which is not linked to any ProteinIdentification" << '\n';
           }
         }
       }
@@ -1219,7 +1219,7 @@ namespace OpenMS::Internal
           // TODO find ways to represent additional fragment types or filter out known incompatible types
 
           // OPENMS_LOG_WARN << "Well, fudge you very much, there is no matching annotation. ";
-          // OPENMS_LOG_WARN << pep.annotation << std::endl;
+          // OPENMS_LOG_WARN << pep.annotation << '\n';
           continue;
         }
         String lt = "frag: " + iontype + " ion";
@@ -1453,7 +1453,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << '\n';
             }
             if (pe->getEnd() != PeptideEvidence::UNKNOWN_POSITION)
             {
@@ -1465,7 +1465,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << '\n';
             }
             if (!idec.empty())
             {
@@ -1489,7 +1489,7 @@ namespace OpenMS::Internal
         if (sc.empty())
         {
           sc = "NA";
-          OPENMS_LOG_WARN << "No score assigned to this PSM: " /*<< hit.getSequence().toString()*/ << std::endl;
+          OPENMS_LOG_WARN << "No score assigned to this PSM: " /*<< hit.getSequence().toString()*/ << '\n';
         }
         String c(hit.getCharge()); //charge
 
@@ -1522,7 +1522,7 @@ namespace OpenMS::Internal
 
         if (pevid_ids.empty())
         {
-          OPENMS_LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << std::endl;
+          OPENMS_LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << '\n';
         }
         for (std::vector<String>::const_iterator pevref = pevid_ids.begin(); pevref != pevid_ids.end(); ++pevref)
         {
@@ -1595,7 +1595,7 @@ namespace OpenMS::Internal
           sii_tmp += String(5, '\t') + cv_.getTermByName("PSM-level search engine specific statistic").toXMLString(cv_ns);
           sii_tmp += "\n" + String(5, '\t') + "<userParam name=\"" + score_name_placeholder
                        + "\" unitName=\"" + "xsd:double" + "\" value=\"" + sc + "\"/>";
-          OPENMS_LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << std::endl;
+          OPENMS_LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << '\n';
         }
         sii_tmp += "\n";
 
@@ -2001,7 +2001,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << '\n';
             }
             if (pe->getEnd() != PeptideEvidence::UNKNOWN_POSITION)
             {
@@ -2013,7 +2013,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << '\n';
             }
             if (!idec.empty())
             {
@@ -2070,7 +2070,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << '\n';
             }
             if (end[ev] != String(PeptideEvidence::UNKNOWN_POSITION))
             {
@@ -2078,7 +2078,7 @@ namespace OpenMS::Internal
             }
             else
             {
-              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << std::endl;
+              OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << '\n';
             }
             if (!idec.empty())
             {
@@ -2119,7 +2119,7 @@ namespace OpenMS::Internal
       if (sc.empty())
       {
         sc = "NA";
-        OPENMS_LOG_WARN << "No score assigned to this PSM: " /*<< hit.getSequence().toString()*/ << std::endl;
+        OPENMS_LOG_WARN << "No score assigned to this PSM: " /*<< hit.getSequence().toString()*/ << '\n';
       }
       String c(hit.getCharge()); //charge
 
@@ -2152,7 +2152,7 @@ namespace OpenMS::Internal
 
       if (pevid_ids.empty())
       {
-        OPENMS_LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << std::endl;
+        OPENMS_LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << '\n';
       }
       for (std::vector<String>::const_iterator pevref = pevid_ids.begin(); pevref != pevid_ids.end(); ++pevref)
       {
@@ -2201,7 +2201,7 @@ namespace OpenMS::Internal
         sii_tmp += String(5, '\t') + cv_.getTermByName("PSM-level search engine specific statistic").toXMLString(cv_ns);
         sii_tmp += "\n" + String(5, '\t') + "<userParam name=\"" + score_name_placeholder
                      + "\" unitName=\"" + "xsd:double" + "\" value=\"" + sc + "\"/>";
-        OPENMS_LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << std::endl;
+        OPENMS_LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << '\n';
       }
       sii_tmp += "\n";
 

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -188,10 +188,10 @@ namespace OpenMS
       }
 
 #ifdef NUMPRESS_DEBUG
-      std::cout << "encodeNPRaw: numpressed array with with length " << numpressed.size() << std::endl;
+      std::cout << "encodeNPRaw: numpressed array with with length " << numpressed.size() << '\n';
       for (int i = 0; i < byteCount; i++)
       {
-        std::cout << "array[" << i << "] : " << (int)numpressed[i] << std::endl;
+        std::cout << "array[" << i << "] : " << (int)numpressed[i] << '\n';
       }
 #endif
 
@@ -219,7 +219,7 @@ namespace OpenMS
             if (!std::isfinite(u) || !std::isfinite(d))
             {
 #ifdef NUMPRESS_DEBUG
-              std::cout << "infinite u: " << u << " d: " << d << std::endl;
+              std::cout << "infinite u: " << u << " d: " << d << '\n';
 #endif
               break;
             }
@@ -228,7 +228,7 @@ namespace OpenMS
               if (fabs(u) > config.numpressErrorTolerance)
               {
 #ifdef NUMPRESS_DEBUG
-                std::cout << "fabs(u): " << fabs(u) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << std::endl;
+                std::cout << "fabs(u): " << fabs(u) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << '\n';
 #endif
                 break;
               }
@@ -238,7 +238,7 @@ namespace OpenMS
               if (fabs(d) > config.numpressErrorTolerance)
               {
 #ifdef NUMPRESS_DEBUG
-                std::cout << "fabs(d): " << fabs(d) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << std::endl;
+                std::cout << "fabs(d): " << fabs(d) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << '\n';
 #endif
                 break;
               }
@@ -246,8 +246,8 @@ namespace OpenMS
             else if (fabs(1.0 - (d / u)) > config.numpressErrorTolerance)
             {
 #ifdef NUMPRESS_DEBUG
-              std::cout << "d: " << d << " u: " << u << std::endl;
-              std::cout << "fabs(1.0 - (d / u)): " << fabs(1.0 - (d / u)) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << std::endl;
+              std::cout << "d: " << d << " u: " << u << '\n';
+              std::cout << "fabs(1.0 - (d / u)): " << fabs(1.0 - (d / u)) << " > config.numpressErrorTolerance: " << config.numpressErrorTolerance << '\n';
 #endif
               break;
             }
@@ -257,7 +257,7 @@ namespace OpenMS
       if (n >= 0)
       {
         //Comment: throw?
-        std::cerr << "Error occurred at position n = " << n << ". Enable NUMPRESS_DEBUG to get more info." << std::endl;
+        std::cerr << "Error occurred at position n = " << n << ". Enable NUMPRESS_DEBUG to get more info." << '\n';
       }
       else
       {
@@ -269,15 +269,15 @@ namespace OpenMS
     }
     catch (int e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
+      std::cerr << "MSNumpress encoder threw exception: " << e << '\n';
     }
     catch (char const * e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
+      std::cerr << "MSNumpress encoder threw exception: " << e << '\n';
     }
     catch (...)
     {
-      std::cerr << "Unknown exception while encoding " << dataSize << " doubles" << std::endl;
+      std::cerr << "Unknown exception while encoding " << dataSize << " doubles" << '\n';
     }
   }
 
@@ -294,10 +294,10 @@ namespace OpenMS
     size_t byteCount = in_size;
 
 #ifdef NUMPRESS_DEBUG
-    std::cout << "decodeNPInternal_: array input with length " << in_size << std::endl;
+    std::cout << "decodeNPInternal_: array input with length " << in_size << '\n';
     for (int i = 0; i < in_size; i++)
     {
-      std::cout << "array[" << i << "] : " << (int)in[i] << std::endl;
+      std::cout << "array[" << i << "] : " << (int)in[i] << '\n';
     }
 #endif
 
@@ -359,10 +359,10 @@ namespace OpenMS
     }
 
 #ifdef NUMPRESS_DEBUG
-    std::cout << "decodeNPInternal_: output size " << out.size() << std::endl;
+    std::cout << "decodeNPInternal_: output size " << out.size() << '\n';
     for (int i = 0; i < out.size(); i++)
     {
-      std::cout << "array[" << i << "] : " << out[i] << std::endl;
+      std::cout << "array[" << i << "] : " << out[i] << '\n';
     }
 #endif
 

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -257,7 +257,7 @@ namespace OpenMS
       if (n >= 0)
       {
         //Comment: throw?
-        std::cerr << "Error occurred at position n = " << n << ". Enable NUMPRESS_DEBUG to get more info." << '\n';
+        std::cerr << "Error occurred at position n = " << n << ". Enable NUMPRESS_DEBUG to get more info." << std::endl;
       }
       else
       {
@@ -269,15 +269,15 @@ namespace OpenMS
     }
     catch (int e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << '\n';
+      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
     }
     catch (char const * e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << '\n';
+      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
     }
     catch (...)
     {
-      std::cerr << "Unknown exception while encoding " << dataSize << " doubles" << '\n';
+      std::cerr << "Unknown exception while encoding " << dataSize << " doubles" << std::endl;
     }
   }
 

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -85,7 +85,7 @@ namespace OpenMS
       double upper = -1, lower = -1, center = -1;
       if (exp->empty())
       {
-        std::cerr << "WARNING: File " << file_list[i] << "\n does not have any scans - I will skip it" << '\n';
+        std::cerr << "WARNING: File " << file_list[i] << "\n does not have any scans - I will skip it" << std::endl;
         continue;
       }
       if (exp->getSpectra()[0].getPrecursors().empty())

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
 #pragma omp critical (OPENMS_SwathFile_loadSplit)
 #endif
       {
-        std::cout << "Loading file " << i << " with name " << file_list[i] << " using readoptions " << readoptions << std::endl;
+        std::cout << "Loading file " << i << " with name " << file_list[i] << " using readoptions " << readoptions << '\n';
       }
 
       String tmp_fname = "openswath_tmpfile_" + String(i) + ".mzML";
@@ -85,12 +85,12 @@ namespace OpenMS
       double upper = -1, lower = -1, center = -1;
       if (exp->empty())
       {
-        std::cerr << "WARNING: File " << file_list[i] << "\n does not have any scans - I will skip it" << std::endl;
+        std::cerr << "WARNING: File " << file_list[i] << "\n does not have any scans - I will skip it" << '\n';
         continue;
       }
       if (exp->getSpectra()[0].getPrecursors().empty())
       {
-        std::cout << "NOTE: File " << file_list[i] << "\n does not have any precursors - I will assume it is the MS1 scan." << std::endl;
+        std::cout << "NOTE: File " << file_list[i] << "\n does not have any precursors - I will assume it is the MS1 scan." << '\n';
         ms1 = true;
       }
       else
@@ -108,7 +108,7 @@ namespace OpenMS
 #pragma omp critical (OPENMS_SwathFile_loadSplit)
 #endif
       {
-        OPENMS_LOG_DEBUG << "Adding Swath file " << file_list[i] << " with " << swath_map.lower << " to " << swath_map.upper << std::endl;
+        OPENMS_LOG_DEBUG << "Adding Swath file " << file_list[i] << " with " << swath_map.lower << " to " << swath_map.upper << '\n';
         swath_maps[i] = swath_map;
         setProgress(progress++);
       }
@@ -124,7 +124,7 @@ namespace OpenMS
                                                        const String& readoptions,
                                                        Interfaces::IMSDataConsumer* plugin_consumer)
   {
-    std::cout << "Loading mzML file " << file << " using readoptions " << readoptions << std::endl;
+    std::cout << "Loading mzML file " << file << " using readoptions " << readoptions << '\n';
     String tmp_fname = tmp.hasSuffix('/') ? File::getUniqueName() : ""; // use tmp-filename if just a directory was given
 
     startProgress(0, 1, "Loading metadata file " + file);
@@ -132,14 +132,14 @@ namespace OpenMS
     exp_meta = exp_stripped;
 
     // First pass through the file -> get the meta data
-    std::cout << "Will analyze the metadata first to determine the number of SWATH windows and the window sizes." << std::endl;
+    std::cout << "Will analyze the metadata first to determine the number of SWATH windows and the window sizes." << '\n';
     std::vector<int> swath_counter;
     int nr_ms1_spectra;
     std::vector<OpenSwath::SwathMap> known_window_boundaries;
 
     countScansInSwath_(exp_stripped->getSpectra(), swath_counter, nr_ms1_spectra, known_window_boundaries);
     std::cout << "Determined there to be " << swath_counter.size()
-              << " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << std::endl;
+              << " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << '\n';
     endProgress();
 
     std::shared_ptr<FullSwathFileConsumer> dataConsumer;
@@ -180,7 +180,7 @@ namespace OpenMS
     MSDataChainingConsumer chaining_consumer(consumer_list);
     MzMLFile().transform(file, &chaining_consumer, false, true); // we do not need to reload metadata, it has already been loaded
 
-    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << std::endl;
+    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << '\n';
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
     endProgress();
@@ -193,7 +193,7 @@ namespace OpenMS
     std::shared_ptr<ExperimentalSettings>& exp_meta,
     const String& readoptions)
   {
-    std::cout << "Loading mzXML file " << file << " using readoptions " << readoptions << std::endl;
+    std::cout << "Loading mzXML file " << file << " using readoptions " << readoptions << '\n';
     String tmp_fname = "openswath_tmpfile";
 
     startProgress(0, 1, "Loading metadata file " + file);
@@ -205,13 +205,13 @@ namespace OpenMS
     exp_meta = experiment_metadata;
 
     // First pass through the file -> get the meta data
-    std::cout << "Will analyze the metadata first to determine the number of SWATH windows and the window sizes." << std::endl;
+    std::cout << "Will analyze the metadata first to determine the number of SWATH windows and the window sizes." << '\n';
     std::vector<int> swath_counter;
     int nr_ms1_spectra;
     std::vector<OpenSwath::SwathMap> known_window_boundaries;
     countScansInSwath_(experiment_metadata->getSpectra(), swath_counter, nr_ms1_spectra, known_window_boundaries);
     std::cout << "Determined there to be " << swath_counter.size() <<
-      " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << std::endl;
+      " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << '\n';
     endProgress();
 
     FullSwathFileConsumer* dataConsumer;
@@ -236,7 +236,7 @@ namespace OpenMS
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         "Unknown or unsupported option " + readoptions);
     }
-    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << std::endl;
+    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << '\n';
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
     delete dataConsumer;
@@ -271,7 +271,7 @@ namespace OpenMS
     endProgress();
 
     std::cout << "Determined there to be " << swath_maps.size() <<
-      " SWATH windows and in total " << indices.size() << " MS1 spectra" << std::endl;
+      " SWATH windows and in total " << indices.size() << " MS1 spectra" << '\n';
 
     return swath_maps;
   }
@@ -368,7 +368,7 @@ namespace OpenMS
 
             OPENMS_LOG_DEBUG << "Adding Swath centered at " << boundary.center
               << " m/z with an isolation window of " << boundary.lower << " to " << boundary.upper
-              << " m/z and IM start of " << boundary.imLower << " and IM end of " << boundary.imUpper << std::endl;
+              << " m/z and IM start of " << boundary.imLower << " and IM end of " << boundary.imUpper << '\n';
           }
         }
       }
@@ -376,6 +376,6 @@ namespace OpenMS
     nr_ms1_spectra = ms1_counter;
 
     std::cout << "Determined there to be " << swath_counter.size() <<
-      " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << std::endl;
+      " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra" << '\n';
   }
 }

--- a/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
+++ b/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
@@ -78,10 +78,10 @@ namespace OpenMS
   {
     // XML Header
     std::ofstream spec_xml_file;
-    std::cout << "Writing spec.xml to " << out_file << std::endl;
+    std::cout << "Writing spec.xml to " << out_file << '\n';
     spec_xml_file.open(out_file.c_str(), std::ios::trunc); // ios::app = append to file, ios::trunc = overwrites file
     // TODO write actual data
-    spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << std::endl;
+    spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << '\n';
 
     // collect indices of spectra, that need to be written out
     std::vector <std::pair <Size, Size> > spectrum_indices;
@@ -110,13 +110,13 @@ namespace OpenMS
       if (scan_index_light < spectra.size() && scan_index_heavy < spectra.size() && i < preprocessed_pair_spectra.spectra_linear_peaks.size() && i < preprocessed_pair_spectra.spectra_xlink_peaks.size())
       {
         // 4 Spectra resulting from a light/heavy spectra pair.  Write for each spectrum, that is written to xquest.xml (should be all considered pairs, or better only those with at least one sensible Hit, meaning a score was computed)
-        spec_xml_file << "<spectrum filename=\"" << spectrum_light_name << ".dta" << R"(" type="light">)" << std::endl;
+        spec_xml_file << "<spectrum filename=\"" << spectrum_light_name << ".dta" << R"(" type="light">)" << '\n';
         spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[scan_index_light], String(""), test_mode);
-        spec_xml_file << "</spectrum>" << std::endl;
+        spec_xml_file << "</spectrum>" << '\n';
 
-        spec_xml_file << "<spectrum filename=\"" << spectrum_heavy_name << ".dta" << R"(" type="heavy">)" << std::endl;
+        spec_xml_file << "<spectrum filename=\"" << spectrum_heavy_name << ".dta" << R"(" type="heavy">)" << '\n';
         spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[scan_index_heavy], String(""), test_mode);
-        spec_xml_file << "</spectrum>" << std::endl;
+        spec_xml_file << "</spectrum>" << '\n';
 
         // the preprocessed pair spectra are sorted by another index
         // because some pairs do not yield any hits worth reporting (e.g. no matching peaks), the index from the spectrum matches or spectrum_indices does not address the right pair anymore
@@ -125,18 +125,18 @@ namespace OpenMS
         Size pair_index = std::distance(spectrum_pairs.begin(), pair_it);
 
         String spectrum_common_name = spectrum_name + String("_common.txt");
-        spec_xml_file << "<spectrum filename=\"" << spectrum_common_name << R"(" type="common">)" << std::endl;
+        spec_xml_file << "<spectrum filename=\"" << spectrum_common_name << R"(" type="common">)" << '\n';
         spec_xml_file << getxQuestBase64EncodedSpectrum_(preprocessed_pair_spectra.spectra_linear_peaks[pair_index], spectrum_light_name + ".dta," + spectrum_heavy_name + ".dta", test_mode);
-        spec_xml_file << "</spectrum>" << std::endl;
+        spec_xml_file << "</spectrum>" << '\n';
 
         String spectrum_xlink_name = spectrum_name + String("_xlinker.txt");
-        spec_xml_file << "<spectrum filename=\"" << spectrum_xlink_name << R"(" type="xlinker">)" << std::endl;
+        spec_xml_file << "<spectrum filename=\"" << spectrum_xlink_name << R"(" type="xlinker">)" << '\n';
         spec_xml_file << getxQuestBase64EncodedSpectrum_(preprocessed_pair_spectra.spectra_xlink_peaks[pair_index], spectrum_light_name + ".dta," + spectrum_heavy_name + ".dta", test_mode);
-        spec_xml_file << "</spectrum>" << std::endl;
+        spec_xml_file << "</spectrum>" << '\n';
       }
     }
 
-    spec_xml_file << "</xquest_spectra>" << std::endl;
+    spec_xml_file << "</xquest_spectra>" << '\n';
     spec_xml_file.close();
 
     return;
@@ -148,10 +148,10 @@ namespace OpenMS
     // String spec_xml_filename = base_name + "_matched.spec.xml";
     // XML Header
     std::ofstream spec_xml_file;
-    std::cout << "Writing spec.xml to " << out_file << std::endl;
+    std::cout << "Writing spec.xml to " << out_file << '\n';
     spec_xml_file.open(out_file.c_str(), std::ios::trunc); // ios::app = append to file, ios::trunc = overwrites file
     // TODO write actual data
-    spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << std::endl;
+    spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << '\n';
 
     // collect indices of spectra, that need to be written out
     std::vector <Size> spectrum_indices;
@@ -176,26 +176,26 @@ namespace OpenMS
       String spectrum_name = spectrum_light_name + String("_") + spectrum_heavy_name;
 
       // 4 Spectra resulting from a light/heavy spectra pair.  Write for each spectrum, that is written to xquest.xml (should be all considered pairs, or better only those with at least one sensible Hit, meaning a score was computed)
-      spec_xml_file << "<spectrum filename=\"" << spectrum_light_name << ".dta" << R"(" type="light">)" << std::endl;
+      spec_xml_file << "<spectrum filename=\"" << spectrum_light_name << ".dta" << R"(" type="light">)" << '\n';
       spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[spectrum_indices[i]], String(""), test_mode);
-      spec_xml_file << "</spectrum>" << std::endl;
+      spec_xml_file << "</spectrum>" << '\n';
 
-      spec_xml_file << "<spectrum filename=\"" << spectrum_heavy_name << ".dta" << R"(" type="heavy">)" << std::endl;
+      spec_xml_file << "<spectrum filename=\"" << spectrum_heavy_name << ".dta" << R"(" type="heavy">)" << '\n';
       spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[spectrum_indices[i]], String(""), test_mode);
-      spec_xml_file << "</spectrum>" << std::endl;
+      spec_xml_file << "</spectrum>" << '\n';
 
       String spectrum_common_name = spectrum_name + String("_common.txt");
-      spec_xml_file << "<spectrum filename=\"" << spectrum_common_name << R"(" type="common">)" << std::endl;
+      spec_xml_file << "<spectrum filename=\"" << spectrum_common_name << R"(" type="common">)" << '\n';
       spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[spectrum_indices[i]], spectrum_light_name + ".dta," + spectrum_heavy_name + ".dta", test_mode);
-      spec_xml_file << "</spectrum>" << std::endl;
+      spec_xml_file << "</spectrum>" << '\n';
 
       String spectrum_xlink_name = spectrum_name + String("_xlinker.txt");
-      spec_xml_file << "<spectrum filename=\"" << spectrum_xlink_name << R"(" type="xlinker">)" << std::endl;
+      spec_xml_file << "<spectrum filename=\"" << spectrum_xlink_name << R"(" type="xlinker">)" << '\n';
       spec_xml_file << getxQuestBase64EncodedSpectrum_(spectra[spectrum_indices[i]], spectrum_light_name + ".dta," + spectrum_heavy_name + ".dta", test_mode);
-      spec_xml_file << "</spectrum>" << std::endl;
+      spec_xml_file << "</spectrum>" << '\n';
     }
 
-    spec_xml_file << "</xquest_spectra>" << std::endl;
+    spec_xml_file << "</xquest_spectra>" << '\n';
     spec_xml_file.close();
 
     return;

--- a/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
+++ b/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h>
 #include <OpenMS/FORMAT/Base64.h>
 #include <OpenMS/MATH/MathFunctions.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <fstream>
 #include <OpenMS/ANALYSIS/XLMS/OPXLHelper.h>
 
@@ -78,7 +79,7 @@ namespace OpenMS
   {
     // XML Header
     std::ofstream spec_xml_file;
-    std::cout << "Writing spec.xml to " << out_file << '\n';
+    OPENMS_LOG_INFO << "Writing spec.xml to " << out_file << std::endl;
     spec_xml_file.open(out_file.c_str(), std::ios::trunc); // ios::app = append to file, ios::trunc = overwrites file
     // TODO write actual data
     spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << '\n';
@@ -148,7 +149,7 @@ namespace OpenMS
     // String spec_xml_filename = base_name + "_matched.spec.xml";
     // XML Header
     std::ofstream spec_xml_file;
-    std::cout << "Writing spec.xml to " << out_file << '\n';
+    OPENMS_LOG_INFO << "Writing spec.xml to " << out_file << std::endl;
     spec_xml_file.open(out_file.c_str(), std::ios::trunc); // ios::app = append to file, ios::trunc = overwrites file
     // TODO write actual data
     spec_xml_file << R"(<?xml version="1.0" encoding="UTF-8"?><xquest_spectra author="Eugen Netz" deffile="xquest.def" >)" << '\n';

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -389,10 +389,10 @@ namespace OpenMS
   std::ostream& operator<<(std::ostream& os, const ConsensusFeature& cons)
   {
     os << "---------- CONSENSUS ELEMENT BEGIN -----------------\n";
-    os << "Position: " << cons.getPosition() << std::endl;
-    os << "Intensity " << precisionWrapper(cons.getIntensity()) << std::endl;
-    os << "Quality " << precisionWrapper(cons.getQuality()) << std::endl;
-    os << "Grouped features: " << std::endl;
+    os << "Position: " << cons.getPosition() << '\n';
+    os << "Intensity " << precisionWrapper(cons.getIntensity()) << '\n';
+    os << "Quality " << precisionWrapper(cons.getQuality()) << '\n';
+    os << "Grouped features: " << '\n';
 
     for (ConsensusFeature::HandleSetType::const_iterator it = cons.begin(); it != cons.end(); ++it)
     {
@@ -400,17 +400,17 @@ namespace OpenMS
          << "   Feature id: " << it->getUniqueId() << std::endl
          << "   RT: " << precisionWrapper(it->getRT()) << std::endl
          << "   m/z: " << precisionWrapper(it->getMZ()) << std::endl
-         << "   Intensity: " << precisionWrapper(it->getIntensity()) << std::endl;
+         << "   Intensity: " << precisionWrapper(it->getIntensity()) << '\n';
     }
 
-    os << "Meta information: " << std::endl;
+    os << "Meta information: " << '\n';
     std::vector<String> keys;
     cons.getKeys(keys);
     for (const String& it : keys)
     {
-      os << "   " << (it) << ": " << cons.getMetaValue(it) << std::endl;
+      os << "   " << (it) << ": " << cons.getMetaValue(it) << '\n';
     }
-    os << "---------- CONSENSUS ELEMENT END ----------------- " << std::endl;
+    os << "---------- CONSENSUS ELEMENT END ----------------- " << '\n';
 
     return os;
   }

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -396,10 +396,10 @@ namespace OpenMS
 
     for (ConsensusFeature::HandleSetType::const_iterator it = cons.begin(); it != cons.end(); ++it)
     {
-      os << " - Map index: " << it->getMapIndex() << std::endl
-         << "   Feature id: " << it->getUniqueId() << std::endl
-         << "   RT: " << precisionWrapper(it->getRT()) << std::endl
-         << "   m/z: " << precisionWrapper(it->getMZ()) << std::endl
+      os << " - Map index: " << it->getMapIndex() << '\n'
+         << "   Feature id: " << it->getUniqueId() << '\n'
+         << "   RT: " << precisionWrapper(it->getRT()) << '\n'
+         << "   m/z: " << precisionWrapper(it->getMZ()) << '\n'
          << "   Intensity: " << precisionWrapper(it->getIntensity()) << '\n';
     }
 

--- a/src/openms/source/ML/CLUSTERING/ClusterAnalyzer.cpp
+++ b/src/openms/source/ML/CLUSTERING/ClusterAnalyzer.cpp
@@ -90,7 +90,7 @@ namespace OpenMS
     /* to manually retrace
     for (Size i = 0; i < original.dimensionsize(); ++i)
     {
-        std::cout << interdist_i[i] << " | " << cluster_with_interdist[i] << " | " << intradist_i[i] << std::endl;
+        std::cout << interdist_i[i] << " | " << cluster_with_interdist[i] << " | " << intradist_i[i] << '\n';
     }
     */
 
@@ -263,15 +263,15 @@ namespace OpenMS
           }
           std::cout << " | ";
       }
-      std::cout << std::endl;
-      std::cout << "---------" << std::endl;
+      std::cout << '\n';
+      std::cout << "---------" << '\n';
       for (Size z = 0; z < original.dimensionsize(); ++z)
       {
           std::cout << interdist_i[z] << " , " << intradist_i[z] << " , " << cluster_with_interdist[z] << " , ";
-          std::cout << ((interdist_i[z] - intradist_i[z]) / std::max(interdist_i[z],intradist_i[z])) << std::endl;
+          std::cout << ((interdist_i[z] - intradist_i[z]) / std::max(interdist_i[z],intradist_i[z])) << '\n';
 
       }
-      std::cout << "---------" << std::endl;
+      std::cout << "---------" << '\n';
       */
 
       //calculate average silhouette width for clusters and then overall average silhouette width for cluster step
@@ -299,9 +299,9 @@ namespace OpenMS
       /* to manually retrace
           for (Size i = 0; i < silhouettes.size(); ++i)
           {
-              std::cout << "s(" <<  (i) << ") = " << silhouettes[i] << std::endl;
+              std::cout << "s(" <<  (i) << ") = " << silhouettes[i] << '\n';
           }
-          std::cout << "---------" << std::endl;
+          std::cout << "---------" << '\n';
       */
       average_silhouette_widths.push_back(average_overall_silhouette / (float)(tree.size() + 1));
     }
@@ -488,9 +488,9 @@ namespace OpenMS
       }
 
       /* to manually retrace
-          std::cout << min_intercluster_distance << std::endl;
-          std::cout << clusters_with_min_intercluster_dist.first << " , " << clusters_with_min_intercluster_dist.second << std::endl;
-          std::cout << max_intracluster_distance << std::endl;
+          std::cout << min_intercluster_distance << '\n';
+          std::cout << clusters_with_min_intercluster_dist.first << " , " << clusters_with_min_intercluster_dist.second << '\n';
+          std::cout << max_intracluster_distance << '\n';
       */
 
     }
@@ -678,7 +678,7 @@ namespace OpenMS
       {
         av_c_dist = av_dist;
       }
-      //~ std::cout << " av clu i " << av_c_dist << std::endl;
+      //~ std::cout << " av clu i " << av_c_dist << '\n';
       cohesions.push_back(av_c_dist);
     }
     return cohesions;

--- a/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/PROCESSING/CALIBRATION/InternalCalibration.cpp
@@ -154,7 +154,7 @@ namespace OpenMS
     {
       OPENMS_LOG_INFO << "  " << its->first << " [of " << ref_masses.size() << "] lock masses: " << its->second << "x\n";
     }
-    OPENMS_LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << '\n';
 
     // sort CalData by RT
     cal_data_.sortByRT();
@@ -186,7 +186,7 @@ namespace OpenMS
     // unassigned peptide IDs
     fillIDs_(fm.getUnassignedPeptideIdentifications(), tol_ppm, stats);
 
-    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants (incl. unassigned) in FeatureMap." << std::endl;
+    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants (incl. unassigned) in FeatureMap." << '\n';
     stats.print();
 
     // sort CalData by RT
@@ -261,7 +261,7 @@ namespace OpenMS
     CalibrantStats_ stats(tol_ppm);
     stats.cnt_total = pep_ids.size();
     fillIDs_(pep_ids, tol_ppm, stats);
-    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << std::endl;
+    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << '\n';
     stats.print();
 
     // sort CalData by RT
@@ -304,7 +304,7 @@ namespace OpenMS
     bool global_model = (rt_chunk < 0);
     if (global_model)
     { // build one global modal
-      OPENMS_LOG_INFO << "Building a global model..." << std::endl;
+      OPENMS_LOG_INFO << "Building a global model..." << '\n';
       tms.emplace_back();
       tms[0].train(cal_data_, model_type, use_RANSAC);
       if (MZTrafoModel::isValidModel(tms[0]))
@@ -356,7 +356,7 @@ namespace OpenMS
         // 2nd attempt to calibrate spectra using neighboring models
         // (will not be entered for global model since could_not_cal is empty)
         OPENMS_LOG_INFO << "\nCalibration failed on " << invalid_models.size() << "/" << tms.size() << " [" <<  invalid_models.size() * 100 / tms.size() << " %] spectra. "
-          << "Using the closest successful model on these." << std::endl;
+          << "Using the closest successful model on these." << '\n';
 
         std::vector<MZTrafoModel> tms_new = tms; // will contain corrected models (this wastes a bit of memory)
         for (std::map<Size, Size>::const_iterator it = invalid_models.begin(); it != invalid_models.end(); ++it)
@@ -406,7 +406,7 @@ namespace OpenMS
     {
       if (!RWrapper::findR(rscript_executable, true))
       {
-        OPENMS_LOG_ERROR << "The R interpreter is required to create PNG plot files. To avoid the error, either do not request 'quality_control:*_plot' (not recommended) or fix your R installation." << std::endl;
+        OPENMS_LOG_ERROR << "The R interpreter is required to create PNG plot files. To avoid the error, either do not request 'quality_control:*_plot' (not recommended) or fix your R installation." << '\n';
         return false;
       }
     }
@@ -446,7 +446,7 @@ namespace OpenMS
       {
         if (!RWrapper::runScript("InternalCalibration_Models.R", QStringList() << out_table.toQString() << file_models_plot.toQString(), rscript_executable))
         {
-          OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:models_plot' (not recommended) or fix your R installation." << std::endl;
+          OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:models_plot' (not recommended) or fix your R installation." << '\n';
           return false;
         }
       }
@@ -509,7 +509,7 @@ namespace OpenMS
     {
       if (!RWrapper::runScript("InternalCalibration_Residuals.R", QStringList() << out_table_residuals.toQString() << file_residuals_plot.toQString(), rscript_executable))
       {
-        OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:residuals_plot' (not recommended) or fix your R installation." << std::endl;
+        OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:residuals_plot' (not recommended) or fix your R installation." << '\n';
         return false;
       }
     }
@@ -517,10 +517,10 @@ namespace OpenMS
 
     if (!hasValidModels)
     { // QC tables are done; quit
-      OPENMS_LOG_ERROR << "Error: Could not build a single local calibration model! Check your calibrants and/or extend the search window!" << std::endl;
+      OPENMS_LOG_ERROR << "Error: Could not build a single local calibration model! Check your calibrants and/or extend the search window!" << '\n';
       if (use_RANSAC)
       {
-        OPENMS_LOG_ERROR << "       Since you are using RANSAC, check the parameters as well and test different setups." << std::endl;
+        OPENMS_LOG_ERROR << "       Since you are using RANSAC, check the parameters as well and test different setups." << '\n';
       }
       return false;
     }
@@ -537,12 +537,12 @@ namespace OpenMS
     // check desired limits
     if (post_ppm_median < fabs(median_ppm_after))
     {
-      OPENMS_LOG_INFO << "Post calibration median threshold (" << post_ppm_median << " ppm) not reached (median = |" << median_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
+      OPENMS_LOG_INFO << "Post calibration median threshold (" << post_ppm_median << " ppm) not reached (median = |" << median_ppm_after << "| ppm). Failed to calibrate!" << '\n';
       return false;
     }
     if (post_ppm_MAD < fabs(MAD_ppm_after))
     {
-      OPENMS_LOG_INFO << "Post calibration MAD threshold (" << post_ppm_MAD << " ppm) not reached (MAD = |" << MAD_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
+      OPENMS_LOG_INFO << "Post calibration MAD threshold (" << post_ppm_MAD << " ppm) not reached (MAD = |" << MAD_ppm_after << "| ppm). Failed to calibrate!" << '\n';
       return false;
     }
 

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
         {
 #ifdef DEBUG_PICKER
           OPENMS_LOG_DEBUG << "Skipping trace " << s << " because it has too few points ("
-                    << summed_trace.size() << ")." << std::endl;
+                    << summed_trace.size() << ")." << '\n';
 #endif
           continue; // skip this spectrum
         }
@@ -77,7 +77,7 @@ namespace OpenMS
       if (mz_diffs.empty())
       {
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Warning: No valid m/z differences found in any spectra. Using default sampling rate of 0.01" << std::endl;
+        OPENMS_LOG_DEBUG << "Warning: No valid m/z differences found in any spectra. Using default sampling rate of 0.01" << '\n';
 #endif
         return 0.01; // Fallback value
       }
@@ -91,7 +91,7 @@ namespace OpenMS
       double threshold = mz_diffs[percentile_index];
 
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "75th percentile of position differences is: " << threshold << std::endl;
+      OPENMS_LOG_DEBUG << "75th percentile of position differences is: " << threshold << '\n';
 #endif
 
       // Filter out large differences (keep diffs <= threshold)
@@ -106,7 +106,7 @@ namespace OpenMS
 
       if (small_mz_diffs.empty())
       {
-        OPENMS_LOG_WARN << "Warning: No valid small m/z differences found after filtering. Using default sampling rate of 0.01" << std::endl;
+        OPENMS_LOG_WARN << "Warning: No valid small m/z differences found after filtering. Using default sampling rate of 0.01" << '\n';
         return 0.01;
       }
 
@@ -130,7 +130,7 @@ namespace OpenMS
       }
 
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Computed optimal sampling rate: " << mode_sampling_rate << std::endl;
+      OPENMS_LOG_DEBUG << "Computed optimal sampling rate: " << mode_sampling_rate << '\n';
 #endif
 
       return mode_sampling_rate;
@@ -217,19 +217,19 @@ namespace OpenMS
 
       if (!fwhm_array)
       {
-        OPENMS_LOG_WARN << "FWHM data array not found!" << std::endl;
+        OPENMS_LOG_WARN << "FWHM data array not found!" << '\n';
         return {};
       }
 
       if (fwhm_array->size() != picked_spectrum.size())
       {
-        OPENMS_LOG_WARN << "Size mismatch between FWHM array and picked peaks!" << std::endl;
+        OPENMS_LOG_WARN << "Size mismatch between FWHM array and picked peaks!" << '\n';
         return {};
       }
       // Get the Ion Mobility array index from raw_spectrum
       if (!raw_spectrum.containsIMData())
       {
-        OPENMS_LOG_WARN << "No ion mobility data found in raw_spectrum." << std::endl;
+        OPENMS_LOG_WARN << "No ion mobility data found in raw_spectrum." << '\n';
         return {};
       }
       const auto [im_data_index, im_unit] = raw_spectrum.getIMData();
@@ -250,7 +250,7 @@ namespace OpenMS
 
         if (center_idx == -1)
         {
-          OPENMS_LOG_WARN << "No raw peaks found near picked m/z: " << picked_mz << std::endl;
+          OPENMS_LOG_WARN << "No raw peaks found near picked m/z: " << picked_mz << '\n';
           mobility_traces.emplace_back();
           continue;
         }
@@ -315,12 +315,12 @@ namespace OpenMS
       mz_fwhm_array.setName("MZ FWHM");
 
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "picked_traces.size(): " << picked_traces.size() << std::endl;
+      OPENMS_LOG_DEBUG << "picked_traces.size(): " << picked_traces.size() << '\n';
 #endif
       // Loop over picked traces and their corresponding raw mobilogram traces
       for (size_t i = 0; i < picked_traces.size(); ++i)
       {
-        // std::cout << "Looping through picked_trace that has .. " << picked_traces[i].size() << std::endl;
+        // std::cout << "Looping through picked_trace that has .. " << picked_traces[i].size() << '\n';
         const MSSpectrum& picked_trace = picked_traces[i];
         const MSSpectrum& raw_trace = mobilogram_traces[i];
 
@@ -328,7 +328,7 @@ namespace OpenMS
 
         if (picked_float_arrays.empty())
         {
-          OPENMS_LOG_WARN << "No IM FWHM array found for picked_trace " << i << "!" << std::endl;
+          OPENMS_LOG_WARN << "No IM FWHM array found for picked_trace " << i << "!" << '\n';
           continue;
         }
 
@@ -337,7 +337,7 @@ namespace OpenMS
 
         if (fwhm_array.size() != picked_trace.size())
         {
-          OPENMS_LOG_WARN << "FWHM array size mismatch with picked_trace size!" << std::endl;
+          OPENMS_LOG_WARN << "FWHM array size mismatch with picked_trace size!" << '\n';
           continue;
         }
 
@@ -346,7 +346,7 @@ namespace OpenMS
 
         if (raw_float_arrays.empty())
         {
-          OPENMS_LOG_WARN << "No raw m/z peaks found for raw_trace " << i << "!" << std::endl;
+          OPENMS_LOG_WARN << "No raw m/z peaks found for raw_trace " << i << "!" << '\n';
           continue;
         }
 
@@ -355,7 +355,7 @@ namespace OpenMS
 
         if (raw_mz_values.size() != raw_trace.size())
         {
-          OPENMS_LOG_WARN << "raw_mz_values size mismatch with raw_trace size!" << std::endl;
+          OPENMS_LOG_WARN << "raw_mz_values size mismatch with raw_trace size!" << '\n';
           continue;
         }
 
@@ -384,14 +384,14 @@ namespace OpenMS
 #ifdef DEBUG_PICKER
           OPENMS_LOG_DEBUG << "Picked peak " << j << " IM centroid: " << centroid_im
                     << " ion mobility FWHM: " << fwhm
-                    << " --> IM bounds: [" << im_lower << ", " << im_upper << "]" << std::endl;
+                    << " --> IM bounds: [" << im_lower << ", " << im_upper << "]" << '\n';
 #endif
           // Use findNearest() to get the index of the closest peak in the raw mobilogram trace
           SignedSize center_idx = raw_trace.findNearest(centroid_im);
 
           if (center_idx == -1)
           {
-            OPENMS_LOG_WARN << "Could not find nearest peak to centroid_im in raw_trace!" << std::endl;
+            OPENMS_LOG_WARN << "Could not find nearest peak to centroid_im in raw_trace!" << '\n';
             continue;
           }
 
@@ -425,7 +425,7 @@ namespace OpenMS
 
 #ifdef DEBUG_PICKER
           OPENMS_LOG_DEBUG << "Picked IM peak " << j << ": collected " << raw_peaks_within_bounds.size()
-                    << " raw m/z points between IM [" << im_lower << ", " << im_upper << "]" << std::endl;
+                    << " raw m/z points between IM [" << im_lower << ", " << im_upper << "]" << '\n';
 #endif
 
           // If we only retrieved one raw peak, pass it over to centroided_frame as is
@@ -445,7 +445,7 @@ namespace OpenMS
 
 #ifdef DEBUG_PICKER
             OPENMS_LOG_DEBUG << "[INFO] Only one raw peak found. Added directly to centroided_frame. m/z: "
-                      << single_peak.getMZ() << " intensity: " << single_peak.getIntensity() << std::endl;
+                      << single_peak.getMZ() << " intensity: " << single_peak.getIntensity() << '\n';
 #endif
             // Skip the rest of the loop and move on to the next picked_trace peak
             continue;
@@ -461,7 +461,7 @@ namespace OpenMS
           sumFrame_(raw_peaks_within_bounds, raw_mz_peaks, 0.1, true);
           if (raw_mz_peaks.empty())
           {
-            OPENMS_LOG_DEBUG << "No data in raw_mz_peaks for picked IM peak " << j << "!" << std::endl;
+            OPENMS_LOG_DEBUG << "No data in raw_mz_peaks for picked IM peak " << j << "!" << '\n';
             continue;
           }
 
@@ -477,7 +477,7 @@ namespace OpenMS
 #ifdef DEBUG_PICKER
             const Peak1D& single_peak = raw_mz_peaks[0];
             OPENMS_LOG_DEBUG << "[INFO] sumFrame_ reduced peaks to a single entry. Added directly to centroided_frame. m/z: " << single_peak.getMZ()
-                      << " intensity: " << single_peak.getIntensity() << std::endl;
+                      << " intensity: " << single_peak.getIntensity() << '\n';
 #endif
             continue;
           }
@@ -558,8 +558,8 @@ namespace OpenMS
           Math::spline_bisection(spline, left_bound, right_bound, apex_mz, apex_intensity, max_search_threshold);
 
 #ifdef DEBUG_PICKER
-          OPENMS_LOG_DEBUG << "Apex m/z: " << apex_mz << std::endl;
-          OPENMS_LOG_DEBUG << "Apex intensity: " << apex_intensity << std::endl;
+          OPENMS_LOG_DEBUG << "Apex m/z: " << apex_mz << '\n';
+          OPENMS_LOG_DEBUG << "Apex intensity: " << apex_intensity << '\n';
 #endif
 
           // FWHM calculation (same binary search as before)
@@ -627,9 +627,9 @@ namespace OpenMS
           double mz_fwhm = fwhm_right_mz - fwhm_left_mz;
 
 #ifdef DEBUG_PICKER
-          OPENMS_LOG_DEBUG << "Left m/z at half height: " << fwhm_left_mz << std::endl;
-          OPENMS_LOG_DEBUG << "Right m/z at half height: " << fwhm_right_mz << std::endl;
-          OPENMS_LOG_DEBUG << "m/z FWHM: " << mz_fwhm << std::endl;
+          OPENMS_LOG_DEBUG << "Left m/z at half height: " << fwhm_left_mz << '\n';
+          OPENMS_LOG_DEBUG << "Right m/z at half height: " << fwhm_right_mz << '\n';
+          OPENMS_LOG_DEBUG << "m/z FWHM: " << mz_fwhm << '\n';
 #endif
 
           centroided_frame.emplace_back(apex_mz, apex_intensity);
@@ -650,11 +650,11 @@ namespace OpenMS
       centroided_frame.sortByPosition();
 
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Peaks in centroided frame: " << centroided_frame.size() << std::endl;
-      OPENMS_LOG_DEBUG << "Printing centroided_frame inside ComputerCenters function " << std::endl;
+      OPENMS_LOG_DEBUG << "Peaks in centroided frame: " << centroided_frame.size() << '\n';
+      OPENMS_LOG_DEBUG << "Printing centroided_frame inside ComputerCenters function " << '\n';
       for (const auto& peak : centroided_frame)
       {
-        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << '\n';
       }
 #endif
       return centroided_frame;
@@ -734,7 +734,7 @@ namespace OpenMS
                     "IMFormat set to UNKNOWN after determineIMFormat. This should never happen.",
                     String(NamesOfIMFormat[(size_t)format]));
             case IMFormat::CONCATENATED:
-                OPENMS_LOG_DEBUG << "Processing concatenated IM data." << std::endl;
+                OPENMS_LOG_DEBUG << "Processing concatenated IM data." << '\n';
                 return true; // continue processing
             default:
                 throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -764,14 +764,14 @@ namespace OpenMS
       MSSpectrum summed_spectrum;
       sumFrame_(spectrum, summed_spectrum, sum_tolerance_mz_, true);
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Spectrum after sumFrame_ has " << summed_spectrum.size() << " peaks." << std::endl;
+      OPENMS_LOG_DEBUG << "Spectrum after sumFrame_ has " << summed_spectrum.size() << " peaks." << '\n';
 #endif
 
       // ------------------------------------------ step 2a: smooth ------------------------------------------
       // Apply gaussian smoothing to the peaks projected into the m/z axis. This facilitates peak picking
       // in the m/z dimension and subseqent mobilogram extraction for each picked m/z peak.
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Applying Gaussian smoothing..." << std::endl;
+      OPENMS_LOG_DEBUG << "Applying Gaussian smoothing..." << '\n';
 #endif
       GaussFilter gauss_filter;
       Param gauss_params;
@@ -780,10 +780,10 @@ namespace OpenMS
       gauss_filter.setParameters(gauss_params);
       gauss_filter.filter(summed_spectrum);
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Spectrum after Gaussian smoothing has " << summed_spectrum.size() << " peaks." << std::endl;
+      OPENMS_LOG_DEBUG << "Spectrum after Gaussian smoothing has " << summed_spectrum.size() << " peaks." << '\n';
       for (const auto& peak : summed_spectrum)
       {
-        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << '\n';
       }
 #endif
 
@@ -799,11 +799,11 @@ namespace OpenMS
       MSSpectrum picked_spectrum;
       picker_mz.pick(summed_spectrum, picked_spectrum);
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Size of picked spectrum: " << picked_spectrum.size() << std::endl;
+      OPENMS_LOG_DEBUG << "Size of picked spectrum: " << picked_spectrum.size() << '\n';
 #endif
       if (picked_spectrum.empty())
       {
-        OPENMS_LOG_WARN << "No m/z peaks picked. Returning empty spectrum." << std::endl;
+        OPENMS_LOG_WARN << "No m/z peaks picked. Returning empty spectrum." << '\n';
         spectrum.clear(true);
         return;
       }
@@ -824,13 +824,13 @@ namespace OpenMS
       resampler_param.setValue("ppm", "false");
 
 #ifdef DEBUG_PICKER
-      OPENMS_LOG_DEBUG << "Using sampling rate... : " << sampling_rate << std::endl;
+      OPENMS_LOG_DEBUG << "Using sampling rate... : " << sampling_rate << '\n';
 #endif
 
 #ifdef DEBUG_PICKER
       for (size_t i = 0; i < mobilogram_traces.size(); ++i)
       {
-        OPENMS_LOG_DEBUG << "Trace " << i << " contains " << mobilogram_traces[i].size() << " points in ion mobility space." << std::endl;
+        OPENMS_LOG_DEBUG << "Trace " << i << " contains " << mobilogram_traces[i].size() << " points in ion mobility space." << '\n';
       }
 #endif
       // ************************************************* PART II *****************************************************
@@ -857,14 +857,14 @@ namespace OpenMS
 
 #ifdef DEBUG_PICKER
         OPENMS_LOG_DEBUG << "\n--- Processing Trace " << i << " ---\n";
-        OPENMS_LOG_DEBUG << "Original trace has " << trace.size() << " peaks." << std::endl;
+        OPENMS_LOG_DEBUG << "Original trace has " << trace.size() << " peaks." << '\n';
 #endif
         MSSpectrum summed_trace;
         summed_trace.reserve(trace.size() + 1);
         summed_trace.emplace_back(-1.0, -1.0);
         sumFrame_(trace, summed_trace, sum_tolerance_im_, false);
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Trace after sumFrame_ has " << summed_trace.size() << " peaks." << std::endl;
+        OPENMS_LOG_DEBUG << "Trace after sumFrame_ has " << summed_trace.size() << " peaks." << '\n';
 #endif
         // ------------------------------------------ part 2b: smooth and resample --------------------------------
         // Prepare mobilograms for SGolay smoothing.
@@ -873,7 +873,7 @@ namespace OpenMS
         double im_end = summed_trace.back().getMZ();
 
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Original summed trace ion mobility range: [" << im_start << ", " << im_end << "]" << std::endl;
+        OPENMS_LOG_DEBUG << "Original summed trace ion mobility range: [" << im_start << ", " << im_end << "]" << '\n';
 #endif
         int padding_points = static_cast<int>(std::ceil((sgolay_frame_length_ - 1) / 2.0));
 
@@ -888,7 +888,7 @@ namespace OpenMS
         summed_trace.push_back(back_padding);
 
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Padded summed trace im range: [" << summed_trace.front().getMZ() << ", " << summed_trace.back().getMZ() << "]" << std::endl;
+        OPENMS_LOG_DEBUG << "Padded summed trace im range: [" << summed_trace.front().getMZ() << ", " << summed_trace.back().getMZ() << "]" << '\n';
 #endif
 
         // linear resample to rescue weak signal
@@ -896,10 +896,10 @@ namespace OpenMS
         lin_resampler.setParameters(resampler_param);
         lin_resampler.raster(summed_trace);
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Size of resampled trace: " << summed_trace.size() << " peaks." << std::endl;
+        OPENMS_LOG_DEBUG << "Size of resampled trace: " << summed_trace.size() << " peaks." << '\n';
         for (const auto& peak : summed_trace)
         {
-          OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+          OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << '\n';
         }
 #endif
         // SGolay smooth prior to peak picking
@@ -911,10 +911,10 @@ namespace OpenMS
         sgolay_filter.filter(summed_trace);
 
 #ifdef DEBUG_PICKER
-        OPENMS_LOG_DEBUG << "Trace after Savitzky-Golay smoothing has " << summed_trace.size() << " peaks." << std::endl;
+        OPENMS_LOG_DEBUG << "Trace after Savitzky-Golay smoothing has " << summed_trace.size() << " peaks." << '\n';
         for (const auto& peak : summed_trace)
         {
-          OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+          OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << '\n';
         }
 #endif
 
@@ -964,7 +964,7 @@ namespace OpenMS
       OPENMS_LOG_DEBUG << "--- Spectrum final output object has ..  " << spectrum.size() << " --- peaks.\n";
       for (const auto& peak : spectrum)
       {
-        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << std::endl;
+        OPENMS_LOG_DEBUG << "m/z: " << peak.getMZ() << ", intensity: " << peak.getIntensity() << '\n';
       }
 #endif
     }
@@ -982,7 +982,7 @@ namespace OpenMS
       // Get IM data array
       if (!spectrum.containsIMData())
       {
-        OPENMS_LOG_WARN << "No ion mobility data found in spectrum." << std::endl;
+        OPENMS_LOG_WARN << "No ion mobility data found in spectrum." << '\n';
         return;
       }
       const auto [im_data_index, im_unit] = spectrum.getIMData();
@@ -1210,7 +1210,7 @@ namespace OpenMS
       // Get IM data array
       if (!input.containsIMData())
       {
-        OPENMS_LOG_WARN << "No ion mobility data found in spectrum." << std::endl;
+        OPENMS_LOG_WARN << "No ion mobility data found in spectrum." << '\n';
         return;
       }
       const auto [im_data_index, im_unit] = input.getIMData();

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -323,7 +323,7 @@ namespace OpenMS
     {
       if (!parent_dir.rmdir(path))
       {
-        std::cerr << "Could not remove directory " << String(dir.dirName()) << "!" << '\n';
+        std::cerr << "Could not remove directory " << String(dir.dirName()) << "!" << std::endl;
         fail = true;
       }
     }
@@ -845,7 +845,7 @@ namespace OpenMS
     {
       if (File::exists(filenames_[i]) && !File::remove(filenames_[i]))
       {
-        std::cerr << "Warning: unable to remove temporary file '" << filenames_[i] << "'" << '\n';
+        std::cerr << "Warning: unable to remove temporary file '" << filenames_[i] << "'" << std::endl;
       }
     }
   }

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -62,7 +62,7 @@ namespace OpenMS
     : keep_dir_(keep_dir)
   {
     temp_dir_ = File::getTempDirectory() + "/" + File::getUniqueName() + "/";
-    OPENMS_LOG_DEBUG << "Creating temporary directory '" << temp_dir_ << "'" << std::endl;
+    OPENMS_LOG_DEBUG << "Creating temporary directory '" << temp_dir_ << "'" << '\n';
     QDir d;
     d.mkpath(temp_dir_.toQString());
   };
@@ -71,7 +71,7 @@ namespace OpenMS
   {
     if (keep_dir_)
     {
-      OPENMS_LOG_DEBUG << "Keeping temporary files in directory '" << temp_dir_ << std::endl;
+      OPENMS_LOG_DEBUG << "Keeping temporary files in directory '" << temp_dir_ << '\n';
       return;
     }
 
@@ -195,7 +195,7 @@ namespace OpenMS
     // check canonical path
     if (canonical_source_dir == canonical_target_dir)
     {
-      OPENMS_LOG_ERROR << "Error: Could not copy  " << from_dir.toStdString() << " to " << to_dir.toStdString() << ". Same path given." << std::endl;
+      OPENMS_LOG_ERROR << "Error: Could not copy  " << from_dir.toStdString() << " to " << to_dir.toStdString() << ". Same path given." << '\n';
       return false;
     }
 
@@ -229,7 +229,7 @@ namespace OpenMS
               case CopyOptions::CANCEL:
                 return false;
               case CopyOptions::SKIP:
-                OPENMS_LOG_WARN << "The file " << entry.fileName().toStdString() << " was skipped." << std::endl;
+                OPENMS_LOG_WARN << "The file " << entry.fileName().toStdString() << " was skipped." << '\n';
                 continue;
               case CopyOptions::OVERWRITE:
                 target_dir.remove(entry.fileName());
@@ -305,7 +305,7 @@ namespace OpenMS
     {
       if (!dir.remove(file_name))
       {
-        OPENMS_LOG_WARN << "Could not remove file " << String(file_name) << "!" << std::endl;
+        OPENMS_LOG_WARN << "Could not remove file " << String(file_name) << "!" << '\n';
         fail = true;
       }
     }
@@ -323,7 +323,7 @@ namespace OpenMS
     {
       if (!parent_dir.rmdir(path))
       {
-        std::cerr << "Could not remove directory " << String(dir.dirName()) << "!" << std::endl;
+        std::cerr << "Could not remove directory " << String(dir.dirName()) << "!" << '\n';
         fail = true;
       }
     }
@@ -631,11 +631,11 @@ namespace OpenMS
     try
     {
       full_db_name = find(db_name, ListUtils::toStringList<std::string>(sys_p.getValue("id_db_dir")));
-      OPENMS_LOG_INFO << "Augmenting database name '" << db_name << "' with path given in 'OpenMS.ini:id_db_dir'. Full name is now: '" << full_db_name << "'" << std::endl;
+      OPENMS_LOG_INFO << "Augmenting database name '" << db_name << "' with path given in 'OpenMS.ini:id_db_dir'. Full name is now: '" << full_db_name << "'" << '\n';
     }
     catch (Exception::FileNotFound& e)
     {
-      OPENMS_LOG_ERROR << "Input database '" + db_name + "' not found (" << e.what() << "). Make sure it exists (and check 'OpenMS.ini:id_db_dir' if you used relative paths. Aborting!" << std::endl;
+      OPENMS_LOG_ERROR << "Input database '" + db_name + "' not found (" << e.what() << "). Make sure it exists (and check 'OpenMS.ini:id_db_dir' if you used relative paths. Aborting!" << '\n';
       throw;
     }
 
@@ -690,13 +690,13 @@ namespace OpenMS
       {
         if (!p.exists("version"))
         {
-          OPENMS_LOG_WARN << "Broken file '" << filename << "' discovered. The 'version' tag is missing." << std::endl;
+          OPENMS_LOG_WARN << "Broken file '" << filename << "' discovered. The 'version' tag is missing." << '\n';
         }
         else // old version
         {
-          OPENMS_LOG_WARN << "File '" << filename << "' is deprecated." << std::endl;
+          OPENMS_LOG_WARN << "File '" << filename << "' is deprecated." << '\n';
         }
-        OPENMS_LOG_WARN << "Updating missing/wrong entries in '" << filename << "' with defaults!" << std::endl;
+        OPENMS_LOG_WARN << "Updating missing/wrong entries in '" << filename << "' with defaults!" << '\n';
         Param p_new = getSystemParameterDefaults_();
         p.setValue("version", VersionInfo::getVersion()); // update old version, such that p_new:version does not get overwritten during update()
         p_new.update(p);
@@ -845,7 +845,7 @@ namespace OpenMS
     {
       if (File::exists(filenames_[i]) && !File::remove(filenames_[i]))
       {
-        std::cerr << "Warning: unable to remove temporary file '" << filenames_[i] << "'" << std::endl;
+        std::cerr << "Warning: unable to remove temporary file '" << filenames_[i] << "'" << '\n';
       }
     }
   }


### PR DESCRIPTION
Replace ~705 occurrences of std::endl with '\n' in 35 high-impact source files.

std::endl flushes the stream buffer after each newline, which is particularly
expensive on Windows console I/O. This change addresses issue #4854 by
reducing unnecessary stream flushing in logging and debug output paths.

Key files updated:
- FeatureFinderAlgorithmPicked.cpp (68 occurrences)
- PeakPickerIM.cpp (49 occurrences)
- Param.cpp (41 occurrences)
- TransitionTSVFile.cpp (38 occurrences)
- ClassTest.cpp (30 occurrences)
- Plus 30 additional high-impact files

This optimization should improve test execution times, especially in
debug mode on Windows where console I/O is significantly slower.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ion-mobility peak clustering to ensure correct cluster boundaries and more reliable peak grouping.

* **Performance Improvements**
  * Reduced automatic log flushing across many modules to improve runtime output performance and reduce I/O overhead.

* **Chores**
  * Standardized newline/log formatting across the codebase for more consistent console and file output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->