### PR TITLE
fix: replace U100/U1000 dtypes with object in DataFrame exports

### DIFF
--- a/src/pyOpenMS/addons/ConsensusMap.pyx
+++ b/src/pyOpenMS/addons/ConsensusMap.pyx
@@ -332,7 +332,7 @@ from collections import defaultdict as _defaultdict
 
         cnt = self.size()
 
-        mddtypes = [('id', np.dtype('uint64')), ('sequence', 'U200'), ('charge', 'i4'),
+        mddtypes = [('id', np.dtype('uint64')), ('sequence', 'object'), ('charge', 'i4'),
                     ('rt', np.dtype('double')), ('mz', np.dtype('double')), ('quality', 'f')]
 
         mdarr = np.fromiter(iter=gen(self, extract_meta_data), dtype=mddtypes, count=cnt)

--- a/src/pyOpenMS/addons/FeatureMap.pyx
+++ b/src/pyOpenMS/addons/FeatureMap.pyx
@@ -196,7 +196,7 @@ import numpy as np
             b'score_fit': 'f',
             b'score_correlation': 'f',
             b'FWHM': 'f',
-            b'spectrum_native_id': 'U100',
+            b'spectrum_native_id': 'object',
             b'max_height': 'f',
             b'num_of_masstraces': 'i',
             b'masstrace_intensity': 'f',
@@ -205,7 +205,7 @@ import numpy as np
             b'leftWidth': 'f',
             b'rightWidth': 'f',
             b'total_xic': 'f',
-            b'PeptideRef': 'U100',
+            b'PeptideRef': 'object',
             b'peak_apices_sum': 'f'
         }
 
@@ -274,9 +274,9 @@ import numpy as np
 
         cnt = self.size()
 
-        mddtypes = [('feature_id', 'U100')]
+        mddtypes = [('feature_id', 'object')]
         if need_pep_ids:
-            mddtypes += [('peptide_sequence', 'U200'), ('peptide_score', 'f'), ('ID_filename', 'U100'), ('ID_native_id', 'U100')]
+            mddtypes += [('peptide_sequence', 'object'), ('peptide_score', 'f'), ('ID_filename', 'object'), ('ID_native_id', 'object')]
         mddtypes += [('charge', 'i4'), ('rt', np.dtype('double')), ('mz', np.dtype('double')), ('rt_start', np.dtype('double')), ('rt_end', np.dtype('double')),
                     ('mz_start', np.dtype('double')), ('mz_end', np.dtype('double')), ('quality', 'f'), ('intensity', 'f')]
 

--- a/src/pyOpenMS/addons/MRMTransitionGroupCP.pyx
+++ b/src/pyOpenMS/addons/MRMTransitionGroupCP.pyx
@@ -134,7 +134,7 @@ import numpy as np
             b'score_fit': 'f',
             b'score_correlation': 'f',
             b'FWHM': 'f',
-            b'spectrum_native_id': 'U100',
+            b'spectrum_native_id': 'object',
             b'max_height': 'f',
             b'num_of_masstraces': 'i',
             b'masstrace_intensity': 'f',
@@ -143,7 +143,7 @@ import numpy as np
             b'leftWidth': 'f',
             b'rightWidth': 'f',
             b'total_xic': 'f',
-            b'PeptideRef': 'U100',
+            b'PeptideRef': 'object',
             b'peak_apices_sum': 'f'
         }
 

--- a/src/pyOpenMS/addons/MSChromatogram.pyx
+++ b/src/pyOpenMS/addons/MSChromatogram.pyx
@@ -134,7 +134,7 @@ import numpy as np
 
         # Identifier
         if want('native_id'):
-            data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='U100')
+            data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='object')
 
         # Non-default columns (only if explicitly requested)
         if want_explicit('chromatogram_type'):
@@ -152,10 +152,10 @@ import numpy as np
                 8: 'EMISSION_CHROMATOGRAM'
             }
             type_name = type_names.get(chrom_type, f'UNKNOWN_{chrom_type}')
-            data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype='U100')
+            data_dict['chromatogram_type'] = np.full(cnt, type_name, dtype='object')
 
         if want_explicit('comment'):
-            data_dict['comment'] = np.full(cnt, self.getComment(), dtype='U100')
+            data_dict['comment'] = np.full(cnt, self.getComment(), dtype='object')
 
         # Meta values handling
         if requested is None and export_meta_values:

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -163,7 +163,7 @@ import numpy as np
         if want('ms_level'):
             data_dict['ms_level'] = np.full(cnt, self.getMSLevel(), dtype=np.uint16)
         if want('native_id'):
-            data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='U100')
+            data_dict['native_id'] = np.full(cnt, self.getNativeID(), dtype='object')
 
         # Ion mobility handling - only compute if requested
         if want('ion_mobility') or want('ion_mobility_unit'):

--- a/src/pyOpenMS/addons/PeptideIdentificationList.pyx
+++ b/src/pyOpenMS/addons/PeptideIdentificationList.pyx
@@ -126,7 +126,7 @@ import numpy as np
             # Use type() to get Python types since 'bool' conflicts with C bool in Cython
             default_missing_values = {type(True): False, type(1): -9999, type(1.0): np.nan, type(''): ''}
 
-        switchDict = {type(True): '?', type(1): 'i', type(1.0): 'f', type(''): 'U100'}
+        switchDict = {type(True): '?', type(1): 'i', type(1.0): 'f', type(''): 'object'}
 
         # filter out PeptideIdentifications without PeptideHits if export_unidentified == False
         count = self.size()
@@ -176,7 +176,7 @@ import numpy as np
             clearMVs = decodedMVs
 
         clearcols = ["id", "rt", "mz", mainscorename, "charge", "protein_accession", "start", "end", "P_ID", "PSM_ID"] + clearMVs
-        coltypes = ['U100', 'f', 'f', 'f', 'i','U1000', 'U1000', 'U1000', 'i', 'i'] + types
+        coltypes = ['object', 'f', 'f', 'f', 'i','object', 'object', 'object', 'i', 'i'] + types
         dt = list(zip(clearcols, coltypes))
 
         def extract(pep, pep_idx):


### PR DESCRIPTION
Fixes #8583

## Changes Made
- Replaced fixed-width Unicode dtypes (U100, U200, U1000) with object dtype
- Updated PeptideIdentificationList, MRMTransitionGroupCP, FeatureMap, MSChromatogram, MSSpectrum, and ConsensusMap

## Rationale
- object dtype uses Python string objects for memory efficiency and safety
- avoids unnecessary large allocations like U1000
- consistent with other dataframe exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data type handling across multiple modules for more flexible storage of metadata fields and identifiers, enhancing compatibility and performance of data export operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->