### PR TITLE
Fix conda activation race condition on Windows CI

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -253,6 +253,12 @@ jobs:
         # Some output for debugging:
         echo "CONDA_ENV_PREFIX=$CONDA_ENV_PREFIX"
 
+        # Disable conda auto-activation to prevent race conditions during parallel
+        # CMake builds. See https://github.com/conda/conda/issues/8733
+        # The paths are already added to GITHUB_PATH above, so conda activation
+        # is no longer needed for subsequent steps.
+        conda init --reverse bash
+
     - name: Install Qt (Windows)
       if: startsWith(matrix.os, 'windows')
       uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
## Summary
- Fixes conda environment activation errors during Windows CI builds
- Adds `conda init --reverse bash` to remove shell hooks after conda packages are installed

## Problem
During the CMake linking phase on Windows, the build process spawns multiple parallel subprocesses (via Ninja). Each subprocess triggers conda's shell hooks, causing simultaneous `conda activate` calls that race over temporary files:

- "The process cannot access the file because it is being used by another process"
- "The system cannot find the file C:\Users\...\Temp\__conda_tmp_*.txt"
- "Failed to run 'conda activate base/ci'"

This is a known conda bug:
- https://github.com/conda/conda/issues/8733
- https://github.com/conda/conda/issues/9911

## Solution
Run `conda init --reverse bash` after installing conda packages. This removes conda's shell integration hooks from the bash profile. The conda-installed packages (libarrow, libparquet) remain accessible via `$GITHUB_PATH` which is already set earlier in the step.

## Test plan
- [ ] Windows CI build completes without conda activation errors

Fixes #8611

🤖 Generated with [Claude Code](https://claude.com/claude-code)