### PR TITLE
Use unordered_map for counting in ILPDCWrapper

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -14,7 +14,7 @@
 #include <OpenMS/DATASTRUCTURES/MassExplainer.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
-
+#include <unordered_map>
 #include <fstream>
 #include <map>
 
@@ -443,7 +443,7 @@ namespace OpenMS
 
     // variable values
     UInt active_edges = 0;
-    std::map<String, Size> count_cmp;
+    std::unordered_map<String, Size> count_cmp;
 
     for (Int iColumn = 0; iColumn < build.getNumberOfColumns(); ++iColumn)
     {


### PR DESCRIPTION
### What changed
Replaced std::map with std::unordered_map for `count_cmp` in
ILPDCWrapper.cpp, where the container is used only for counting/lookups.

### Why
Standalone benchmark (Windows, g++ -O2, C++17):

- std::map: ~70 ms
- std::unordered_map: ~20 ms

~3.5× speedup for insert + lookup heavy workloads.

### Safety
- No ordering is relied upon
- Logic unchanged
- Minimal, localized change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structure handling for improved performance in decharging analysis computations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->