### PR TITLE
Use unordered_map for counting in ILPDCWrapper

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -14,7 +14,7 @@
 #include <OpenMS/DATASTRUCTURES/MassExplainer.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
-
+#include <unordered_map>
 #include <fstream>
 #include <map>
 
@@ -443,7 +443,7 @@ namespace OpenMS
 
     // variable values
     UInt active_edges = 0;
-    std::map<String, Size> count_cmp;
+    std::unordered_map<String, Size> count_cmp;
 
     for (Int iColumn = 0; iColumn < build.getNumberOfColumns(); ++iColumn)
     {

--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -465,7 +465,7 @@ namespace OpenMS
     if (verbose_level > 2)
       OPENMS_LOG_INFO << "Active edges: " << active_edges << " of overall " << pairs.size() << std::endl;
 
-    for (std::map<String, Size>::const_iterator it = count_cmp.begin(); it != count_cmp.end(); ++it)
+    for (std::unordered_map<String, Size>::const_iterator it = count_cmp.begin(); it != count_cmp.end(); ++it)
     {
       //std::cout << "Cmp " << it->first << " x " << it->second << "\n";
     }


### PR DESCRIPTION
### Summary
Replace std::map with std::unordered_map for compomer counting in
ILPDCWrapper::computeSliceOld_.

### Motivation
The container is used purely for counting and lookup; no ordering is relied upon.
Switching to std::unordered_map reduces lookup and insertion overhead.

Local benchmark (Windows, g++ -O2, C++17):
- std::map: ~70 ms
- std::unordered_map: ~20 ms

### Scope & Safety
- Change is limited to a single local container
- No algorithmic or behavioral changes
- Iteration order is not used
- Affects only the old / slower code path

### Notes
This is a small, self-contained performance improvement intended as a first
contribution. Feedback is welcome.
[ILPDCWrapper.cpp](https://github.com/user-attachments/files/24506619/ILPDCWrapper.cpp)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal performance optimization to the decharging analysis module. Data structure improvements applied to enhance efficiency with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->