### PR TITLE
FileInfo: Add sequence length stats and nucleic acid support for FASTA

### DIFF
--- a/src/tests/topp/FileInfo_17_output.txt
+++ b/src/tests/topp/FileInfo_17_output.txt
@@ -8,12 +8,18 @@ Warning: Duplicate header, #10, ID: crab_squac = #9, ID: crab_squac
 Warning: Duplicate sequence, #10, ID: crab_squac == #9, ID: crab_squac
 
 Number of sequences   : 11
+Sequence length distribution:
+  Minimum : 174
+  25%ile  : 175
+  Median  : 176
+  75%ile  : 177
+  Maximum : 177
 Number of sequences with ambiguous amino acids: 0 (0%)
 # duplicated headers  : 2 (18.18%)
 # duplicated sequences: 1 (9.09%) [by exact string matching]
 Total amino acids     : 1933
 
-Amino acid counts: 
+Amino acid counts:
   *:	2
   -:	5
   A:	87

--- a/src/tests/topp/FileInfo_18_output.txt
+++ b/src/tests/topp/FileInfo_18_output.txt
@@ -5,12 +5,18 @@ File name: C:/dev/openms/src/tests/topp/FileInfo_18_input.fasta
 File type: fasta
 
 Number of sequences   : 5
+Sequence length distribution:
+  Minimum : 267
+  25%ile  : 296
+  Median  : 433
+  75%ile  : 533.5
+  Maximum : 538
 Number of sequences with ambiguous amino acids: 3 (60%)
 # duplicated headers  : 0 (0%)
 # duplicated sequences: 0 (0%) [by exact string matching]
 Total amino acids     : 2092
 
-Amino acid counts: 
+Amino acid counts:
   A:	175
   C:	15
   D:	159

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -855,8 +855,8 @@ protected:
       file.load(in, entries);
       std::cout << "\n\n" << mu.delta("loading FASTA") << std::endl;
 
-      std::map<char, int> aacids;// required for default construction of non-existing keys
-      size_t number_of_aacids = 0;
+      std::map<char, int> residue_counts; // required for default construction of non-existing keys
+      size_t number_of_residues = 0;
 
       Size dup_header(0);
       Size dup_seq(0);
@@ -865,21 +865,47 @@ protected:
       SHashmap m_headers;
       SHashmap m_seqs;
 
-      // lambda to count ambiguous amino acids in frequency table
-      auto count_AAAs = [](const auto& aacids, std::string_view which) {
+      // Collect sequence lengths for statistics
+      std::vector<size_t> sequence_lengths;
+      sequence_lengths.reserve(entries.size());
+
+      // lambda to count residues matching given characters in frequency table
+      auto count_residues = [](const auto& residue_counts, std::string_view which) {
         size_t count = 0;
         for (char a : which)
         {
-          auto it = aacids.find(a);
-          if (it != aacids.end()) { count += it->second; }
+          auto it = residue_counts.find(a);
+          if (it != residue_counts.end()) { count += it->second; }
         }
         return count;
       };
 
-      size_t protein_has_ambiguous_aas = 0;
-      
-      const std::string_view& AAA_BXZJ = "BZXbzxJj"; // ambiguous amino acids
-      const std::string_view& AAA_BXZ = "BZXbzx"; // ambiguous amino acids
+      size_t seq_has_ambiguous = 0;
+
+      // Ambiguity codes for amino acids
+      const std::string_view AA_AMBIGUOUS_BXZJ = "BZXbzxJj"; // B=Asx, Z=Glx, X=unknown, J=Leu/Ile
+      const std::string_view AA_AMBIGUOUS_BXZ = "BZXbzx";
+
+      // IUPAC nucleotide codes (standard + ambiguity codes)
+      // Standard: A, C, G, T, U; Ambiguity: N (any), R, Y, S, W, K, M, B, D, H, V
+      const std::string_view NUCLEOTIDE_CHARS = "ACGTUNacgtunRYSWKMBDHVryswkmbdhv";
+      const std::string_view NA_AMBIGUOUS = "NRYSWKMBDHVnryswkmbdhv";
+
+      // Detect if sequences are nucleic acid (vs amino acid)
+      // If ANY character is not a valid nucleotide code, it's an amino acid sequence
+      bool is_nucleic_acid = true;
+      for (const auto& entry : entries)
+      {
+        for (char c : entry.sequence)
+        {
+          if (NUCLEOTIDE_CHARS.find(c) == std::string_view::npos)
+          {
+            is_nucleic_acid = false;
+            break;
+          }
+        }
+        if (!is_nucleic_acid) break;
+      }
 
       std::hash<string> s_hash;
       for (auto loopiter = entries.begin(); loopiter != entries.end(); ++loopiter)
@@ -918,38 +944,84 @@ protected:
           m_seqs[id_seq] = { std::distance(entries.begin(), loopiter) };
         }
 
-        const auto count_AAA_before = count_AAAs(aacids, AAA_BXZJ);
-        // count AAs
+        // Collect sequence length for statistics
+        sequence_lengths.push_back(loopiter->sequence.size());
+
+        // Count before to detect if this sequence has ambiguous residues
+        const auto count_ambig_before = is_nucleic_acid
+          ? count_residues(residue_counts, NA_AMBIGUOUS)
+          : count_residues(residue_counts, AA_AMBIGUOUS_BXZJ);
+
+        // count residues
         for (char a : loopiter->sequence)
         {
-          ++aacids[a];
-        }
-        // did this protein contain ambiguous amino acids?
-        if (count_AAA_before != count_AAAs(aacids, AAA_BXZJ))
-        {
-          ++protein_has_ambiguous_aas;
+          ++residue_counts[a];
         }
 
-        number_of_aacids += loopiter->sequence.size();
+        // did this sequence contain ambiguous residues?
+        const auto count_ambig_after = is_nucleic_acid
+          ? count_residues(residue_counts, NA_AMBIGUOUS)
+          : count_residues(residue_counts, AA_AMBIGUOUS_BXZJ);
+        if (count_ambig_before != count_ambig_after)
+        {
+          ++seq_has_ambiguous;
+        }
+
+        number_of_residues += loopiter->sequence.size();
       }
+
+      // Labels depend on sequence type
+      const char* residue_type = is_nucleic_acid ? "nucleotide" : "amino acid";
+      const char* residue_type_cap = is_nucleic_acid ? "Nucleotide" : "Amino acid";
 
       os << '\n';
       os << "Number of sequences   : " << entries.size() << '\n';
-      os << "Number of sequences with ambiguous amino acids: " << protein_has_ambiguous_aas << " ("
-         << Math::percentOf(protein_has_ambiguous_aas, entries.size(), 2) << "%)\n";
+
+      // Sequence length distribution statistics
+      if (!sequence_lengths.empty())
+      {
+        std::sort(sequence_lengths.begin(), sequence_lengths.end());
+        size_t len_min = sequence_lengths.front();
+        size_t len_max = sequence_lengths.back();
+        double len_median = Math::median(sequence_lengths.begin(), sequence_lengths.end(), true);
+        double len_q1 = Math::quantile1st(sequence_lengths.begin(), sequence_lengths.end(), true);
+        double len_q3 = Math::quantile3rd(sequence_lengths.begin(), sequence_lengths.end(), true);
+
+        os << "Sequence length distribution:\n";
+        os << "  Minimum : " << len_min << '\n';
+        os << "  25%ile  : " << len_q1 << '\n';
+        os << "  Median  : " << len_median << '\n';
+        os << "  75%ile  : " << len_q3 << '\n';
+        os << "  Maximum : " << len_max << '\n';
+      }
+
+      os << "Number of sequences with ambiguous " << residue_type << "s: " << seq_has_ambiguous << " ("
+         << Math::percentOf(seq_has_ambiguous, entries.size(), 2) << "%)\n";
       os << "# duplicated headers  : " << dup_header << " (" << Math::percentOf(dup_header, entries.size(), 2) << "%)\n";
       os << "# duplicated sequences: " << dup_seq << " (" << Math::percentOf(dup_seq, entries.size(), 2) << "%) [by exact string matching]\n";
-      os << "Total amino acids     : " << number_of_aacids << "\n\n";
-      os << "Amino acid counts: \n";
+      os << "Total " << residue_type << "s     : " << number_of_residues << "\n\n";
+      os << residue_type_cap << " counts:\n";
 
-      for (const auto& [AA, count] : aacids)
+      for (const auto& [residue, count] : residue_counts)
       {
-        os << "  " << AA << ":\t" << count << '\n';
+        os << "  " << residue << ":\t" << count << '\n';
       }
-      size_t amb = count_AAAs(aacids, AAA_BXZ);
-      size_t amb_J = count_AAAs(aacids, AAA_BXZJ);
-      os << "Ambiguous amino acids (B/Z/X)  : " << amb   << " (" << Math::percentOf(amb  , number_of_aacids, 2) << "%)\n";
-      os << "                      (B/Z/X/J): " << amb_J << " (" << Math::percentOf(amb_J, number_of_aacids, 2) << "%)\n\n";
+
+      // Ambiguous residue counts
+      if (is_nucleic_acid)
+      {
+        size_t amb_N = residue_counts['N'] + residue_counts['n'];
+        size_t amb_all = count_residues(residue_counts, NA_AMBIGUOUS);
+        os << "Ambiguous nucleotides (N)      : " << amb_N << " (" << Math::percentOf(amb_N, number_of_residues, 2) << "%)\n";
+        os << "All IUPAC ambiguity codes      : " << amb_all << " (" << Math::percentOf(amb_all, number_of_residues, 2) << "%)\n\n";
+      }
+      else
+      {
+        size_t amb = count_residues(residue_counts, AA_AMBIGUOUS_BXZ);
+        size_t amb_J = count_residues(residue_counts, AA_AMBIGUOUS_BXZJ);
+        os << "Ambiguous amino acids (B/Z/X)  : " << amb << " (" << Math::percentOf(amb, number_of_residues, 2) << "%)\n";
+        os << "                      (B/Z/X/J): " << amb_J << " (" << Math::percentOf(amb_J, number_of_residues, 2) << "%)\n\n";
+      }
     }
     else if (in_type == FileTypes::FEATUREXML) //features
     {


### PR DESCRIPTION
## Summary
- Add sequence length distribution reporting (Min, 25%ile, Median, 75%ile, Max)
- Detect nucleic acid vs amino acid sequences automatically based on IUPAC character set
- Use appropriate labels ("nucleotide" vs "amino acid") based on detected sequence type
- Report IUPAC ambiguity codes for nucleic acid files (N count and all ambiguity codes)

Closes #8638

## Example Output

**Amino acid FASTA:**
```
Number of sequences   : 11
Sequence length distribution:
  Minimum : 174
  25%ile  : 175
  Median  : 176
  75%ile  : 177
  Maximum : 177
Number of sequences with ambiguous amino acids: 0 (0%)
...
Total amino acids     : 1933
Amino acid counts:
...
Ambiguous amino acids (B/Z/X)  : 0 (0%)
                      (B/Z/X/J): 0 (0%)
```

**Nucleic acid FASTA:**
```
Number of sequences   : 3
Sequence length distribution:
  Minimum : 16
  25%ile  : 16
  Median  : 17
  75%ile  : 48
  Maximum : 48
Number of sequences with ambiguous nucleotides: 1 (33.33%)
...
Total nucleotides     : 81
Nucleotide counts:
...
Ambiguous nucleotides (N)      : 9 (11.11%)
All IUPAC ambiguity codes      : 9 (11.11%)
```

## Test plan
- [x] Build FileInfo target
- [x] Test with amino acid FASTA (existing test file)
- [x] Test with nucleic acid FASTA (created test file with N ambiguity codes)
- [x] Verify correct detection and labeling for both sequence types

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sequence type detection (nucleotide vs amino acid)
  * Unified analysis for both nucleotide and amino acid sequences
  * Expanded per-residue counts to report all standard residues
  * Improved ambiguity reporting with type-specific metrics
  * Added sequence length distribution statistics (min, max, median, 25th/75th percentiles)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->