### PR TITLE
Use unordered_map for O(1) lookups in OpenSWATH code

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h
@@ -11,6 +11,8 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 
+#include <unordered_map>
+
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h>
@@ -146,7 +148,7 @@ private:
     /// Subfunction of dia_isotope_scores
     void diaIsotopeScoresSub_(const std::vector<TransitionType>& transitions,
                               const SpectrumSequence& spectrum,
-                              std::map<std::string, double>& intensities,
+                              std::unordered_map<std::string, double>& intensities,
                               const RangeMobility& im_range,
                               double& isotope_corr,
                               double& isotope_overlap) const;
@@ -155,7 +157,7 @@ private:
     /// computes a vector of relative intensities for each feature (output to intensities)
     void getFirstIsotopeRelativeIntensities_(const std::vector<TransitionType>& transitions,
                                             OpenSwath::IMRMFeature* mrmfeature,
-                                            std::map<std::string, double>& intensities //experimental intensities of transitions
+                                            std::unordered_map<std::string, double>& intensities //experimental intensities of transitions
                                             ) const;
 
 private:

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -290,7 +290,6 @@ private:
 
     double im_extra_drift_;
 
-    // members (unordered_map for O(1) lookup performance)
     std::unordered_map<OpenMS::String, const PeptideType*> PeptideRefMap_;
     OpenSwath_Scores_Usage su_;
     OpenMS::DIAScoring diascoring_;

--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h
@@ -17,6 +17,7 @@
 #include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>
 
+#include <unordered_map>
 #include <vector>
 
 namespace OpenMS
@@ -63,9 +64,9 @@ public:
     typedef ReactionMonitoringTransition Transition;
     typedef Residue IonType; // IonType enum of Interpretation class
 
-    typedef std::map<String, const Protein *> ProteinReferenceMapType;
-    typedef std::map<String, const Peptide *> PeptideReferenceMapType;
-    typedef std::map<String, const Compound *> CompoundReferenceMapType;
+    typedef std::unordered_map<String, const Protein *> ProteinReferenceMapType;
+    typedef std::unordered_map<String, const Peptide *> PeptideReferenceMapType;
+    typedef std::unordered_map<String, const Compound *> CompoundReferenceMapType;
 
     /** @name Constructors and destructors
     */

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -12,6 +12,8 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
+#include <unordered_map>
+
 #define IMPLIES(a, b) !(a) || (b)
 
 namespace OpenMS
@@ -105,14 +107,15 @@ namespace OpenMS
                                                   const bool ms1,
                                                   const int ms1_isotopes)
   {
-    // hash of the peptide reference containing all transitions
-    std::map<String, std::vector<const OpenSwath::LightTransition*> > pep2tr;
+    // hash of the peptide reference containing all transitions (unordered for O(1) lookup)
+    std::unordered_map<String, std::vector<const OpenSwath::LightTransition*> > pep2tr;
     for (Size i = 0; i < transition_exp_used.getTransitions().size(); i++)
     {
       String ref = transition_exp_used.getTransitions()[i].getPeptideRef();
       pep2tr[ref].push_back(&transition_exp_used.getTransitions()[i]);
     }
-    std::map<String, const OpenSwath::LightCompound*> tr2pep;
+    std::unordered_map<String, const OpenSwath::LightCompound*> tr2pep;
+    tr2pep.reserve(transition_exp_used.getCompounds().size());
     for (const auto & p : transition_exp_used.getCompounds()) {tr2pep[p.id] = &p;}
 
     // Determine iteration size:
@@ -189,8 +192,8 @@ namespace OpenMS
                                                   const bool ms1,
                                                   const int ms1_isotopes)
   {
-    // hash of the peptide reference containing all transitions
-    typedef std::map<String, std::vector<const ReactionMonitoringTransition*> > PeptideTransitionMapType;
+    // hash of the peptide reference containing all transitions (unordered for O(1) lookup)
+    typedef std::unordered_map<String, std::vector<const ReactionMonitoringTransition*> > PeptideTransitionMapType;
     PeptideTransitionMapType pep2tr;
     for (Size i = 0; i < transition_exp_used.getTransitions().size(); i++)
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -107,7 +107,6 @@ namespace OpenMS
                                                   const bool ms1,
                                                   const int ms1_isotopes)
   {
-    // hash of the peptide reference containing all transitions (unordered for O(1) lookup)
     std::unordered_map<String, std::vector<const OpenSwath::LightTransition*> > pep2tr;
     for (Size i = 0; i < transition_exp_used.getTransitions().size(); i++)
     {
@@ -192,7 +191,6 @@ namespace OpenMS
                                                   const bool ms1,
                                                   const int ms1_isotopes)
   {
-    // hash of the peptide reference containing all transitions (unordered for O(1) lookup)
     typedef std::unordered_map<String, std::vector<const ReactionMonitoringTransition*> > PeptideTransitionMapType;
     PeptideTransitionMapType pep2tr;
     for (Size i = 0; i < transition_exp_used.getTransitions().size(); i++)

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAScoring.cpp
@@ -102,7 +102,7 @@ namespace OpenMS
   {
     isotope_corr = 0;
     isotope_overlap = 0;
-    // first compute a map of relative intensities from the feature, then compute the score (unordered for O(1) lookup)
+    // first compute a map of relative intensities from the feature, then compute the score
     std::unordered_map<std::string, double> intensities;
     intensities.reserve(transitions.size());
     getFirstIsotopeRelativeIntensities_(transitions, mrmfeature, intensities);

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAScoring.cpp
@@ -102,8 +102,9 @@ namespace OpenMS
   {
     isotope_corr = 0;
     isotope_overlap = 0;
-    // first compute a map of relative intensities from the feature, then compute the score
-    std::map<std::string, double> intensities;
+    // first compute a map of relative intensities from the feature, then compute the score (unordered for O(1) lookup)
+    std::unordered_map<std::string, double> intensities;
+    intensities.reserve(transitions.size());
     getFirstIsotopeRelativeIntensities_(transitions, mrmfeature, intensities);
     diaIsotopeScoresSub_(transitions, spectrum, intensities, im_range, isotope_corr, isotope_overlap);
   }
@@ -272,18 +273,18 @@ namespace OpenMS
   /// computes a vector of relative intensities for each feature (output to intensities)
   void DIAScoring::getFirstIsotopeRelativeIntensities_(
     const std::vector<TransitionType>& transitions,
-    OpenSwath::IMRMFeature* mrmfeature, std::map<std::string, double>& intensities) const
+    OpenSwath::IMRMFeature* mrmfeature, std::unordered_map<std::string, double>& intensities) const
   {
     for (Size k = 0; k < transitions.size(); k++)
     {
       std::string native_id = transitions[k].getNativeID();
       double rel_intensity = mrmfeature->getFeature(native_id)->getIntensity() / mrmfeature->getIntensity();
-      intensities.insert(std::pair<std::string, double>(native_id, rel_intensity));
+      intensities.emplace(native_id, rel_intensity);
     }
   }
 
   void DIAScoring::diaIsotopeScoresSub_(const std::vector<TransitionType>& transitions, const SpectrumSequence& spectrum,
-                                        std::map<std::string, double>& intensities, //relative intensities
+                                        std::unordered_map<std::string, double>& intensities, //relative intensities
                                         const RangeMobility& im_range,
                                         double& isotope_corr,
                                         double& isotope_overlap) const

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -903,13 +903,8 @@ namespace OpenMS
     // Generate a map of peptides to transitions for easy access
     for (Size i = 0; i < exp.getTransitions().size(); ++i)
     {
-      ReactionMonitoringTransition tr = exp.getTransitions()[i];
-
-      if (TransitionsMap.find(tr.getPeptideRef()) == TransitionsMap.end())
-      {
-        TransitionsMap[tr.getPeptideRef()];
-      }
-
+      const ReactionMonitoringTransition& tr = exp.getTransitions()[i];
+      // operator[] creates empty vector if key doesn't exist, avoiding redundant find() calls
       TransitionsMap[tr.getPeptideRef()].push_back(tr);
     }
 
@@ -1089,13 +1084,8 @@ namespace OpenMS
     // Generate a map of compounds to transitions for easy access
     for (Size i = 0; i < exp.getTransitions().size(); ++i)
     {
-      ReactionMonitoringTransition tr = exp.getTransitions()[i];
-
-      if (TransitionsMap.find(tr.getCompoundRef()) == TransitionsMap.end())
-      {
-        TransitionsMap[tr.getCompoundRef()];
-      }
-
+      const ReactionMonitoringTransition& tr = exp.getTransitions()[i];
+      // operator[] creates empty vector if key doesn't exist, avoiding redundant find() calls
       TransitionsMap[tr.getCompoundRef()].push_back(tr);
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -901,9 +901,8 @@ namespace OpenMS
     std::map<String, TransitionVectorType> TransitionsMap;
 
     // Generate a map of peptides to transitions for easy access
-    for (Size i = 0; i < exp.getTransitions().size(); ++i)
+    for (const auto& tr : exp.getTransitions())
     {
-      const ReactionMonitoringTransition& tr = exp.getTransitions()[i];
       // operator[] creates empty vector if key doesn't exist, avoiding redundant find() calls
       TransitionsMap[tr.getPeptideRef()].push_back(tr);
     }
@@ -1082,9 +1081,8 @@ namespace OpenMS
     std::map<String, TransitionVectorType> TransitionsMap;
 
     // Generate a map of compounds to transitions for easy access
-    for (Size i = 0; i < exp.getTransitions().size(); ++i)
+    for (const auto& tr : exp.getTransitions())
     {
-      const ReactionMonitoringTransition& tr = exp.getTransitions()[i];
       // operator[] creates empty vector if key doesn't exist, avoiding redundant find() calls
       TransitionsMap[tr.getCompoundRef()].push_back(tr);
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -24,6 +24,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <memory>
 #include <boost/foreach.hpp>
+#include <unordered_map>
 
 #define run_identifier "unique_run_identifier"
 
@@ -1096,9 +1097,10 @@ namespace OpenMS
     double rt_min, rt_max, expected_rt;
     trafo.invert();
 
-    std::map<String, int> chromatogram_map;
+    std::unordered_map<String, int> chromatogram_map;
     Size nr_chromatograms = input->getNrChromatograms();
-    for (Size i = 0; i < input->getNrChromatograms(); i++)
+    chromatogram_map.reserve(nr_chromatograms);
+    for (Size i = 0; i < nr_chromatograms; i++)
     {
       chromatogram_map[input->getChromatogramNativeID(i)] = boost::numeric_cast<int>(i);
     }
@@ -1111,7 +1113,8 @@ namespace OpenMS
     {
       // get the current transition and try to find the corresponding chromatogram
       const TransitionType* transition = &transition_exp.getTransitions()[i];
-      if (chromatogram_map.find(transition->getNativeID()) == chromatogram_map.end())
+      auto chrom_it = chromatogram_map.find(transition->getNativeID());
+      if (chrom_it == chromatogram_map.end())
       {
         OPENMS_LOG_DEBUG << "Error: Transition " + transition->getNativeID() + " from group " +
           transition->getPeptideRef() + " does not have a corresponding chromatogram" << std::endl;
@@ -1127,7 +1130,7 @@ namespace OpenMS
       //-----------------------------------
       // Retrieve chromatogram and filter it by the desired RT
       //-----------------------------------
-      OpenSwath::ChromatogramPtr cptr = input->getChromatogramById(chromatogram_map[transition->getNativeID()]);
+      OpenSwath::ChromatogramPtr cptr = input->getChromatogramById(chrom_it->second);
       MSChromatogram chromatogram;
 
       // Get the expected retention time, apply the RT-transformation

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -113,8 +113,9 @@ namespace OpenMS
     std::pair<double,double> RTRange = OpenSwathHelper::estimateRTRange(targeted_exp);
     OPENMS_LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << '\n';
 
-    // 2. Store the peptide retention times in an intermediate map
-    std::map<OpenMS::String, double> PeptideRTMap;
+    // 2. Store the peptide retention times in an intermediate map (unordered for O(1) lookup)
+    std::unordered_map<OpenMS::String, double> PeptideRTMap;
+    PeptideRTMap.reserve(targeted_exp.getCompounds().size());
     for (Size i = 0; i < targeted_exp.getCompounds().size(); i++)
     {
       PeptideRTMap[targeted_exp.getCompounds()[i].id] = targeted_exp.getCompounds()[i].rt;
@@ -172,9 +173,10 @@ namespace OpenMS
     for (std::map<std::string, double>::iterator it = best_features.begin(); it != best_features.end(); ++it)
     {
       pairs.emplace_back(it->second, PeptideRTMap[it->first]); // pair<exp_rt, theor_rt>
-      if (transition_group_map.find(it->first) != transition_group_map.end())
+      auto tg_it = transition_group_map.find(it->first);
+      if (tg_it != transition_group_map.end())
       {
-        trgrmap_allpeaks[ it->first ] = &transition_group_map[ it->first];
+        trgrmap_allpeaks[it->first] = &tg_it->second;
       }
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
     std::pair<double,double> RTRange = OpenSwathHelper::estimateRTRange(targeted_exp);
     OPENMS_LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << '\n';
 
-    // 2. Store the peptide retention times in an intermediate map (unordered for O(1) lookup)
+    // 2. Store the peptide retention times in an intermediate map
     std::unordered_map<OpenMS::String, double> PeptideRTMap;
     PeptideRTMap.reserve(targeted_exp.getCompounds().size());
     for (Size i = 0; i < targeted_exp.getCompounds().size(); i++)
@@ -952,7 +952,6 @@ namespace OpenMS
     featureFinder.setParameters(feature_finder_param);
     featureFinder.prepareProteinPeptideMaps_(transition_exp);
 
-    // Map ms1 chromatogram id to sequence number (unordered for O(1) lookup)
     std::unordered_map<String, int> ms1_chromatogram_map;
     ms1_chromatogram_map.reserve(ms1_chromatograms.size());
     for (Size i = 0; i < ms1_chromatograms.size(); i++)
@@ -960,14 +959,12 @@ namespace OpenMS
       ms1_chromatogram_map[ms1_chromatograms[i].getNativeID()] = boost::numeric_cast<int>(i);
     }
 
-    // Map chromatogram id to sequence number (unordered for O(1) lookup)
     std::unordered_map<String, int> chromatogram_map;
     chromatogram_map.reserve(ms2_chromatograms.size());
     for (Size i = 0; i < ms2_chromatograms.size(); i++)
     {
       chromatogram_map[ms2_chromatograms[i].getNativeID()] = boost::numeric_cast<int>(i);
     }
-    // Map peptide id to sequence number (unordered for O(1) lookup)
     std::unordered_map<String, int> assay_peptide_map;
     assay_peptide_map.reserve(transition_exp.getCompounds().size());
     for (Size i = 0; i < transition_exp.getCompounds().size(); i++)


### PR DESCRIPTION
## Summary
- Convert lookup-only `std::map` containers to `std::unordered_map` for O(1) average-case performance in hot paths
- Fix double-lookup anti-patterns (`find()` + `operator[]`) by using single iterator lookups
- Simplify redundant find-then-insert patterns in MRMAssay

## Changes
| File | Change | Impact |
|------|--------|--------|
| `MRMFeatureFinderScoring.cpp` | `chromatogram_map` → `unordered_map` + fixed double-lookup | O(1) lookups in transition mapping loop |
| `TargetedExperiment.h` | Reference maps → `unordered_map` | O(1) protein/peptide/compound lookups |
| `OpenSwathWorkflow.cpp` | `PeptideRTMap` → `unordered_map` + fixed double-lookup | O(1) RT normalization lookups |
| `ChromatogramExtractor.cpp` | `pep2tr`, `tr2pep` → `unordered_map` | O(1) coordinate preparation |
| `DIAScoring.cpp/.h` | `intensities` map → `unordered_map` | O(1) isotope scoring |
| `MRMAssay.cpp` | Fixed triple-lookup pattern (2 locations) | Reduced map operations by ~66% |

## Design Decisions
- Maps that are **iterated over** (e.g., `TransitionsMap` in MRMAssay, `transition_group_map`) are intentionally kept as `std::map` to preserve deterministic iteration order
- All maps converted are **lookup-only** (using `find()`, `operator[]`, or `at()`)
- Thread safety is preserved: all converted maps are built before parallel regions and accessed read-only

## Test plan
- [x] All 5 core C++ class tests pass (TargetedExperiment, MRMFeatureFinderScoring, DIAScoring, ChromatogramExtractor, MRMAssay)
- [x] All 160 OpenSWATH TOPP integration tests pass
- [x] All MRM-related tests pass (MRMDecoy, MRMFeatureFilter, MRMMapping, TransitionTSVFile, TransitionPQPFile)
- [x] SwathMapMassCorrection test passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimization**
  * Swapped ordered containers for hash-based maps and added preallocation across multiple analysis components for faster lookups and improved processing performance.
* **Refactor**
  * Simplified iteration and lookup logic to reduce overhead and clarify data population flows.
* **Chores**
  * Minor comment cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->