### PR TITLE
Simplify IDFilter by eliminating code duplication

### DIFF
--- a/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/PROCESSING/ID/IDFilter.h
@@ -256,24 +256,26 @@ namespace OpenMS
     /**
        @brief Given a list of protein accessions, do any occur in the annotation(s) of this hit?
 
+       Template implementation that works with any set-like container (std::set, std::unordered_set, etc.)
+       that provides a count() method.
+
        @note This predicate also works for peptide evidence (class PeptideEvidence).
     */
-    template<class HitType>
-    struct HasMatchingAccessionUnordered {
+    template<class HitType, class SetType>
+    struct HasMatchingAccessionImpl {
       typedef HitType argument_type; // for use as a predicate
 
-      const std::unordered_set<String>& accessions;
+      const SetType& accessions;
 
-      HasMatchingAccessionUnordered(const std::unordered_set<String>& accessions_) : 
-        accessions(accessions_)
+      explicit HasMatchingAccessionImpl(const SetType& accessions_) : accessions(accessions_)
       {
       }
 
       bool operator()(const PeptideHit& hit) const
       {
-        for (const auto& it : hit.extractProteinAccessionsSet())
+        for (const auto& acc : hit.extractProteinAccessionsSet())
         {
-          if (accessions.count(it) > 0)
+          if (accessions.count(acc) > 0)
             return true;
         }
         return false;
@@ -281,50 +283,22 @@ namespace OpenMS
 
       bool operator()(const ProteinHit& hit) const
       {
-        return (accessions.count(hit.getAccession()) > 0);
+        return accessions.count(hit.getAccession()) > 0;
       }
 
       bool operator()(const PeptideEvidence& evidence) const
       {
-        return (accessions.count(evidence.getProteinAccession()) > 0);
+        return accessions.count(evidence.getProteinAccession()) > 0;
       }
     };
 
-    /**
-       @brief Given a list of protein accessions, do any occur in the annotation(s) of this hit?
-
-       @note This predicate also works for peptide evidence (class PeptideEvidence).
-    */
+    /// Convenience alias for HasMatchingAccessionImpl with std::unordered_set (O(1) lookup)
     template<class HitType>
-    struct HasMatchingAccession {
-      typedef HitType argument_type; // for use as a predicate
+    using HasMatchingAccessionUnordered = HasMatchingAccessionImpl<HitType, std::unordered_set<String>>;
 
-      const std::set<String>& accessions;
-
-      HasMatchingAccession(const std::set<String>& accessions_) : accessions(accessions_)
-      {
-      }
-
-      bool operator()(const PeptideHit& hit) const
-      {
-        for (const auto& it : hit.extractProteinAccessionsSet())
-        {
-          if (accessions.count(it) > 0)
-            return true;
-        }
-        return false;
-      }
-
-      bool operator()(const ProteinHit& hit) const
-      {
-        return (accessions.count(hit.getAccession()) > 0);
-      }
-
-      bool operator()(const PeptideEvidence& evidence) const
-      {
-        return (accessions.count(evidence.getProteinAccession()) > 0);
-      }
-    };
+    /// Convenience alias for HasMatchingAccessionImpl with std::set (O(log n) lookup)
+    template<class HitType>
+    using HasMatchingAccession = HasMatchingAccessionImpl<HitType, std::set<String>>;
 
     /**
        @brief Builds a map index of data that have a String index to find matches and return the objects
@@ -1062,7 +1036,7 @@ namespace OpenMS
     template<class IdentificationType>
     static void removeHitsMatchingProteins(std::vector<IdentificationType>& ids, const std::set<String> accessions)
     {
-      struct HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
+      HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
       for (auto& id_it : ids)
       {
         removeMatchingItems(id_it.getHits(), acc_filter);
@@ -1079,7 +1053,7 @@ namespace OpenMS
     template<IsPeptideOrProteinIdentification IdentificationType>
     static void keepHitsMatchingProteins(IdentificationType& id, const std::set<String>& accessions)
     {
-      struct HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
+      HasMatchingAccession<typename IdentificationType::HitType> acc_filter(accessions);
       keepMatchingItems(id.getHits(), acc_filter);      
     }
 

--- a/src/openms/source/PROCESSING/ID/IDFilter.cpp
+++ b/src/openms/source/PROCESSING/ID/IDFilter.cpp
@@ -14,6 +14,66 @@ using namespace std;
 
 namespace OpenMS
 {
+  namespace // anonymous namespace for internal helpers
+  {
+    /// Collect protein accessions referenced by peptide hits, grouped by run identifier
+    std::map<String, std::unordered_set<String>> collectReferencedAccessions(const PeptideIdentificationList& peptides)
+    {
+      std::map<String, std::unordered_set<String>> run_to_accessions;
+      for (const PeptideIdentification& pep : peptides)
+      {
+        const String& run_id = pep.getIdentifier();
+        for (const PeptideHit& hit : pep.getHits())
+        {
+          const set<String>& current_accessions = hit.extractProteinAccessionsSet();
+          run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
+        }
+      }
+      return run_to_accessions;
+    }
+
+    /// Collect valid protein accessions from protein identifications, grouped by run identifier
+    std::map<String, std::unordered_set<String>> collectProteinAccessions(const std::vector<ProteinIdentification>& proteins)
+    {
+      std::map<String, std::unordered_set<String>> run_to_accessions;
+      for (const ProteinIdentification& prot : proteins)
+      {
+        const String& run_id = prot.getIdentifier();
+        for (const ProteinHit& hit : prot.getHits())
+        {
+          run_to_accessions[run_id].insert(hit.getAccession());
+        }
+      }
+      return run_to_accessions;
+    }
+
+    /// Filter peptide evidences to keep only those referencing proteins in the given accession set
+    void filterEvidencesByAccessions(PeptideHit& hit, const std::unordered_set<String>& accessions)
+    {
+      IDFilter::HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
+      vector<PeptideEvidence> evidences;
+      remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(),
+                     back_inserter(evidences), std::not_fn(acc_filter));
+      hit.setPeptideEvidences(evidences);
+    }
+
+    /// Process a PeptideIdentification to filter evidences and optionally remove hits without references
+    void filterPeptideReferences(PeptideIdentification& pep,
+                                 const std::unordered_set<String>& accessions,
+                                 bool remove_peptides_without_reference)
+    {
+      for (PeptideHit& hit : pep.getHits())
+      {
+        filterEvidencesByAccessions(hit, accessions);
+      }
+      if (remove_peptides_without_reference)
+      {
+        auto has_no_evidence = [](const PeptideHit& hit) { return hit.getPeptideEvidences().empty(); };
+        IDFilter::removeMatchingItems(pep.getHits(), has_no_evidence);
+      }
+    }
+  } // anonymous namespace
+
 
   struct IDFilter::HasMinPeptideLength {
     typedef PeptideHit argument_type; // for use as a predicate
@@ -220,7 +280,7 @@ namespace OpenMS
       const String& run_id = prot.getIdentifier();
       auto target = result.emplace(run_id, vector<ProteinHit> {});
       const unordered_set<String>& accessions = run_to_accessions[run_id];
-      struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
+      HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
       moveMatchingItems(prot.getHits(), std::not_fn(acc_filter), target.first->second);
     }
     return result;
@@ -248,159 +308,60 @@ namespace OpenMS
     {
       const String& run_id = prot.getIdentifier();
       const unordered_set<String>& accessions = run_to_accessions[run_id];
-      struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
+      HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
       keepMatchingItems(prot.getHits(), acc_filter);
     }
   }
 
   void IDFilter::removeUnreferencedProteins(ProteinIdentification& proteins, const PeptideIdentificationList& peptides)
   {
-    // collect accessions that are referenced by peptides for each ID run:
-    map<String, unordered_set<String>> run_to_accessions;
-    for (const PeptideIdentification& pep : peptides)
-    {
-      const String& run_id = pep.getIdentifier();
-      // extract protein accessions of each peptide hit:
-      for (const PeptideHit& hit : pep.getHits())
-      {
-        const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-        run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
-      }
-    }
-
-    const String& run_id = proteins.getIdentifier();
-    const unordered_set<String>& accessions = run_to_accessions[run_id];
-    struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
+    auto run_to_accessions = collectReferencedAccessions(peptides);
+    const unordered_set<String>& accessions = run_to_accessions[proteins.getIdentifier()];
+    HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
     keepMatchingItems(proteins.getHits(), acc_filter);
   }
 
   void IDFilter::removeUnreferencedProteins(vector<ProteinIdentification>& proteins, const PeptideIdentificationList& peptides)
   {
-    // collect accessions that are referenced by peptides for each ID run:
-    map<String, unordered_set<String>> run_to_accessions;
-    for (const PeptideIdentification& pep : peptides)
-    {
-      const String& run_id = pep.getIdentifier();
-      // extract protein accessions of each peptide hit:
-      for (const PeptideHit& hit : pep.getHits())
-      {
-        const set<String>& current_accessions = hit.extractProteinAccessionsSet();
-        run_to_accessions[run_id].insert(current_accessions.begin(), current_accessions.end());
-      }
-    }
-
+    auto run_to_accessions = collectReferencedAccessions(peptides);
     for (ProteinIdentification& prot : proteins)
     {
-      const String& run_id = prot.getIdentifier();
-      const unordered_set<String>& accessions = run_to_accessions[run_id];
-      struct HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
+      const unordered_set<String>& accessions = run_to_accessions[prot.getIdentifier()];
+      HasMatchingAccessionUnordered<ProteinHit> acc_filter(accessions);
       keepMatchingItems(prot.getHits(), acc_filter);
     }
   }
 
-  // TODO write version where you look up in a specific run (e.g. first inference run)
   void IDFilter::removeDanglingProteinReferences(ConsensusMap& cmap, bool remove_peptides_without_reference)
   {
-    vector<ProteinIdentification>& proteins = cmap.getProteinIdentifications();
-    // collect valid protein accessions for each ID run:
-    map<String, unordered_set<String>> run_to_accessions;
-    for (const ProteinIdentification& prot : proteins)
-    {
-      const String& run_id = prot.getIdentifier();
-      for (const ProteinHit& hit : prot.getHits())
-      {
-        run_to_accessions[run_id].insert(hit.getAccession());
-      }
-    }
+    auto run_to_accessions = collectProteinAccessions(cmap.getProteinIdentifications());
 
-    auto check_prots_avail = [&run_to_accessions, &remove_peptides_without_reference](PeptideIdentification& pep) -> void {
-      const String& run_id = pep.getIdentifier();
-      const unordered_set<String>& accessions = run_to_accessions[run_id];
-      struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
-      // check protein accessions of each peptide hit
-      for (PeptideHit& hit : pep.getHits())
-      {
-        // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
-        // can't use "keepMatchingItems":
-        vector<PeptideEvidence> evidences;
-        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
-        hit.setPeptideEvidences(evidences);
-      }
-
-      if (remove_peptides_without_reference)
-      {
-        removeMatchingItems(pep.getHits(), HasNoEvidence());
-      }
+    auto filter_func = [&run_to_accessions, remove_peptides_without_reference](PeptideIdentification& pep) {
+      filterPeptideReferences(pep, run_to_accessions[pep.getIdentifier()], remove_peptides_without_reference);
     };
-
-    cmap.applyFunctionOnPeptideIDs(check_prots_avail);
+    cmap.applyFunctionOnPeptideIDs(filter_func);
   }
 
   void IDFilter::removeDanglingProteinReferences(ConsensusMap& cmap, const ProteinIdentification& ref_run, bool remove_peptides_without_reference)
   {
-    // collect valid protein accessions for each ID run:
-    unordered_set<String> accessions_avail;
-
+    unordered_set<String> accessions;
     for (const ProteinHit& hit : ref_run.getHits())
     {
-      accessions_avail.insert(hit.getAccession());
+      accessions.insert(hit.getAccession());
     }
 
-    // TODO could be refactored and pulled out
-    auto check_prots_avail = [&accessions_avail, &remove_peptides_without_reference](PeptideIdentification& pep) -> void {
-      const unordered_set<String>& accessions = accessions_avail;
-      struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
-      // check protein accessions of each peptide hit
-      for (PeptideHit& hit : pep.getHits())
-      {
-        // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
-        // can't use "keepMatchingItems":
-        vector<PeptideEvidence> evidences;
-        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
-        hit.setPeptideEvidences(evidences);
-      }
-
-      if (remove_peptides_without_reference)
-      {
-        removeMatchingItems(pep.getHits(), HasNoEvidence());
-      }
+    auto filter_func = [&accessions, remove_peptides_without_reference](PeptideIdentification& pep) {
+      filterPeptideReferences(pep, accessions, remove_peptides_without_reference);
     };
-
-    cmap.applyFunctionOnPeptideIDs(check_prots_avail);
+    cmap.applyFunctionOnPeptideIDs(filter_func);
   }
 
   void IDFilter::removeDanglingProteinReferences(PeptideIdentificationList& peptides, const vector<ProteinIdentification>& proteins, bool remove_peptides_without_reference)
   {
-    // collect valid protein accessions for each ID run:
-    map<String, unordered_set<String>> run_to_accessions;
-    for (const ProteinIdentification& prot : proteins)
-    {
-      const String& run_id = prot.getIdentifier();
-      for (const ProteinHit& hit : prot.getHits())
-      {
-        run_to_accessions[run_id].insert(hit.getAccession());
-      }
-    }
-
+    auto run_to_accessions = collectProteinAccessions(proteins);
     for (PeptideIdentification& pep : peptides)
     {
-      const String& run_id = pep.getIdentifier();
-      const unordered_set<String>& accessions = run_to_accessions[run_id];
-      struct HasMatchingAccessionUnordered<PeptideEvidence> acc_filter(accessions);
-      // check protein accessions of each peptide hit
-      for (PeptideHit& hit : pep.getHits())
-      {
-        // no non-const "PeptideHit::getPeptideEvidences" implemented, so we
-        // can't use "keepMatchingItems":
-        vector<PeptideEvidence> evidences;
-        remove_copy_if(hit.getPeptideEvidences().begin(), hit.getPeptideEvidences().end(), back_inserter(evidences), std::not_fn(acc_filter));
-        hit.setPeptideEvidences(evidences);
-      }
-
-      if (remove_peptides_without_reference)
-      {
-        removeMatchingItems(pep.getHits(), HasNoEvidence());
-      }
+      filterPeptideReferences(pep, run_to_accessions[pep.getIdentifier()], remove_peptides_without_reference);
     }
   }
 


### PR DESCRIPTION
## Summary
- Unify `HasMatchingAccession` and `HasMatchingAccessionUnordered` predicates into a single template `HasMatchingAccessionImpl` with type aliases for backward API compatibility
- Extract duplicated accession collection logic into helper functions (`collectReferencedAccessions`, `collectProteinAccessions`)
- Extract duplicated evidence filtering into `filterPeptideReferences` helper
- Simplify `removeUnreferencedProteins` and `removeDanglingProteinReferences` overloads using the new helpers

Net reduction of ~65 lines while preserving the public API.

## Test plan
- [x] Unit tests pass (`IDFilter_test`)
- [x] TOPP integration tests pass (23 `TOPP_IDFilter_*` tests)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization in the identification filtering module to reduce duplication and enhance maintainability. Consolidated filtering logic into centralized helper functions, allowing for more flexible handling of protein accession matching across different container types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->