### PR TITLE
[FIX] Correct defaultArrayLength in MzMLFile_negative_offsets.mzML test file

### DIFF
--- a/src/tests/class_tests/openms/data/MzMLFile_negative_offsets.mzML
+++ b/src/tests/class_tests/openms/data/MzMLFile_negative_offsets.mzML
@@ -28,7 +28,7 @@
   </dataProcessingList>
   <run id="test_run" defaultInstrumentConfigurationRef="IC1">
     <spectrumList count="2" defaultDataProcessingRef="DP1">
-      <spectrum index="0" id="spectrum=0" defaultArrayLength="5">
+      <spectrum index="0" id="spectrum=0" defaultArrayLength="0">
         <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum"/>
         <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan"/>
@@ -53,7 +53,7 @@
           </binaryDataArray>
         </binaryDataArrayList>
       </spectrum>
-      <spectrum index="1" id="spectrum=1" defaultArrayLength="5">
+      <spectrum index="1" id="spectrum=1" defaultArrayLength="0">
         <cvParam cvRef="MS" accession="MS:1000580" name="MSn spectrum"/>
         <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2"/>
         <cvParam cvRef="MS" accession="MS:1000130" name="positive scan"/>


### PR DESCRIPTION
## Summary
- Fixed incorrect `defaultArrayLength="5"` in test file that had empty binary arrays
- Both spectra now correctly declare `defaultArrayLength="0"` to match actual content
- Eliminates spurious warnings and potential Windows segfaults during MzMLFile tests

## Problem
The test file `MzMLFile_negative_offsets.mzML` declared `defaultArrayLength="5"` for both spectra but had empty `<binary>` tags. This caused:
- Warning: `Float binary data array 'm/z array' has length 0, but should have length 5`
- Potential segfaults on Windows due to array size mismatches

## Root Cause
The file was created in commit 7f9e926781 to test negative isolation window offset handling. It was likely copied from another test file and the binary data was emptied, but `defaultArrayLength` was not updated to match.

## Test plan
- [x] `MzMLFile_test` passes (100% pass rate)
- [x] No warnings about array length mismatches
- [x] Test "negative isolation window offsets are skipped" works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data to validate spectrum array handling with modified data length parameters in mass spectrometry file formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->