### PR TITLE
Add Claude CI fix workflow

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -1,0 +1,176 @@
+# Fix CI failures when triggered by @claude fix ci comment on a PR
+name: Claude CI Fix
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  issues: write
+  id-token: write
+
+jobs:
+  fix-ci:
+    # Only run when someone comments "@claude fix ci" on a PR
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      contains(toLower(github.event.comment.body), 'fix ci')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return {
+              head_ref: pr.data.head.ref,
+              head_sha: pr.data.head.sha
+            };
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ fromJSON(steps.pr.outputs.result).head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup git identity
+        run: |
+          git config --global user.email "claude[bot]@users.noreply.github.com"
+          git config --global user.name "claude[bot]"
+
+      - name: Get CI failure details
+        id: failure_details
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the most recent workflow runs for this PR's head SHA
+            const runs = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: '${{ fromJSON(steps.pr.outputs.result).head_sha }}',
+              status: 'completed',
+              per_page: 10
+            });
+
+            // Find failed runs
+            const failedRuns = runs.data.workflow_runs.filter(r => r.conclusion === 'failure');
+
+            if (failedRuns.length === 0) {
+              return { noFailures: true };
+            }
+
+            // Get the most recent failed run
+            const failedRun = failedRuns[0];
+
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: failedRun.id
+            });
+
+            const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');
+
+            let errorLogs = [];
+            for (const job of failedJobs.slice(0, 3)) {
+              try {
+                const logs = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  job_id: job.id
+                });
+                // Extract last 500 lines to focus on errors
+                const logLines = logs.data.split('\n');
+                const relevantLogs = logLines.slice(-500).join('\n');
+                errorLogs.push({
+                  jobName: job.name,
+                  logs: relevantLogs
+                });
+              } catch (e) {
+                errorLogs.push({
+                  jobName: job.name,
+                  logs: `Failed to fetch logs: ${e.message}`
+                });
+              }
+            }
+
+            return {
+              noFailures: false,
+              runUrl: failedRun.html_url,
+              workflowName: failedRun.name,
+              failedJobs: failedJobs.map(j => j.name),
+              errorLogs: errorLogs
+            };
+
+      - name: Post comment if no failures
+        if: fromJSON(steps.failure_details.outputs.result).noFailures == true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'No CI failures found for the current commit. All workflows passed or are still running.'
+            });
+
+      - name: Fix CI failures with Claude
+        if: fromJSON(steps.failure_details.outputs.result).noFailures != true
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            ## CI Failure Fix Request
+
+            A user has requested help fixing CI failures on this PR.
+
+            **Failed CI Run:** ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}
+            **Workflow:** ${{ fromJSON(steps.failure_details.outputs.result).workflowName }}
+            **Failed Jobs:** ${{ join(fromJSON(steps.failure_details.outputs.result).failedJobs, ', ') }}
+            **PR Number:** ${{ github.event.issue.number }}
+            **Branch:** ${{ fromJSON(steps.pr.outputs.result).head_ref }}
+
+            ## Error Logs
+
+            ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
+
+            ## Instructions
+
+            1. **Analyze the error logs** to identify the root cause
+
+            2. **Common OpenMS CI failures:**
+               - C++ compilation errors (missing includes, type mismatches, undefined symbols)
+               - CMake configuration issues
+               - Test failures (check expected vs actual in assertions)
+               - Doxygen warnings treated as errors
+               - pyOpenMS binding build failures
+
+            3. **Fix the code** by editing the source files
+
+            4. **After fixing**, commit and push directly to the PR branch:
+               ```bash
+               git add -A
+               git commit -m "fix: <description>
+
+               Co-Authored-By: Claude <noreply@anthropic.com>"
+               git push origin ${{ fromJSON(steps.pr.outputs.result).head_ref }}
+               ```
+
+            5. **Post a comment** on the PR summarizing what you fixed
+
+            6. **If unfixable** (infra issue, flaky test, needs human):
+               - Comment explaining the issue and what manual steps are needed
+               - Do NOT commit broken code
+
+          claude_args: |
+            --allowedTools "Edit,Write,Read,Glob,Grep,Bash(git:*),Bash(gh pr comment:*),Bash(gh issue comment:*)"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that allows users to trigger Claude to automatically analyze and fix CI failures
- Triggered by commenting `@claude fix ci` on a PR

## Features
- **Manual trigger only** - Won't spam PRs automatically
- **Fetches error logs** - Downloads logs from up to 3 failed CI jobs
- **Analyzes common OpenMS failures** - C++ compilation, CMake, tests, Doxygen warnings, pyOpenMS
- **Pushes fixes directly** - Commits and pushes to the PR branch
- **Posts summary** - Comments on the PR explaining what was fixed

## Usage
Comment on any PR with CI failures:
```
@claude fix ci
```

## Test plan
- [ ] Merge and test on a PR with failing CI
- [ ] Verify Claude can access error logs
- [ ] Verify fixes are pushed to the correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI failure detection and automated fix assistance. Developers can request analysis of failed checks through PR comments to receive guided remediation steps and error diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->