### PR TITLE
Fix UniqueIdGenerator seed collision in parallel pipelines

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/SysInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/SysInfo.h
@@ -42,10 +42,10 @@ namespace OpenMS
       /// @return True on success, false otherwise. If false is returned, then @p mem_virtual is set to 0.
       static bool getProcessPeakMemoryConsumption(size_t& mem_virtual);
 
-      /// Get the current process ID
-      /// @return The process ID of the current process
+      /// `@brief` Get the current process ID
+      ///
+      /// `@return` The process ID of the current process
       static Int64 getProcessId();
-
       /**
         @brief A convenience class to report either absolute or delta (between two timepoints) RAM usage
 

--- a/src/openms/include/OpenMS/SYSTEM/SysInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/SysInfo.h
@@ -42,6 +42,10 @@ namespace OpenMS
       /// @return True on success, false otherwise. If false is returned, then @p mem_virtual is set to 0.
       static bool getProcessPeakMemoryConsumption(size_t& mem_virtual);
 
+      /// Get the current process ID
+      /// @return The process ID of the current process
+      static Int64 getProcessId();
+
       /**
         @brief A convenience class to report either absolute or delta (between two timepoints) RAM usage
 

--- a/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
@@ -8,6 +8,8 @@
 
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 
+#include <OpenMS/SYSTEM/SysInfo.h>
+
 #include <boost/date_time/posix_time/posix_time_types.hpp> //no i/o just types
 
 namespace OpenMS
@@ -76,16 +78,21 @@ namespace OpenMS
 #ifdef _OPENMP
 #pragma omp critical (OPENMS_UniqueIdGenerator_init_)
 #endif
-    { 
+    {
       // find a seed:
       // get something with high resolution (around microseconds) -- its hard to do better on Windows --
-      // which has absolute system time (there is higher resolution available for the time since program startup, but 
+      // which has absolute system time (there is higher resolution available for the time since program startup, but
       // we do not want this here since this seed usually gets initialized at the same program uptime).
       // Reason for high-res: in pipelines, instances of TOPP tools can get initialized almost simultaneously (i.e., resolution in seconds is not enough),
       // leading to identical random numbers (e.g. feature-IDs) in two or more distinct files.
       // C++11 note: C++ build-in alternative once C++11 can be presumed: 'std::chrono::high_resolution_clock'
       boost::posix_time::ptime t(boost::posix_time::microsec_clock::local_time() );
       seed_ = t.time_of_day().ticks();  // independent of implementation; as opposed to nanoseconds(), which need not be available on every platform
+
+      // Mix in process ID to ensure different seeds for parallel processes started at the same microsecond.
+      // This prevents duplicate UniqueIds when multiple TOPP tools run simultaneously in a pipeline.
+      seed_ ^= static_cast<UInt64>(SysInfo::getProcessId()) << 32;
+
       rng_ = new boost::mt19937_64 (seed_);
       dist_ = new boost::uniform_int<UInt64> (0, std::numeric_limits<UInt64>::max());
     }

--- a/src/openms/source/SYSTEM/SysInfo.cpp
+++ b/src/openms/source/SYSTEM/SysInfo.cpp
@@ -17,9 +17,11 @@
 #ifdef OPENMS_WINDOWSPLATFORM
   #include "windows.h"
   #include "psapi.h"
+  #include <process.h>  // for _getpid()
 #elif __APPLE__
   #include <mach/mach.h>
   #include <mach/mach_init.h>
+  #include <unistd.h>   // for getpid()
 #else
   #define OMS_USELINUXMEMORYPLATFORM
   #include <cstdio>
@@ -161,6 +163,15 @@ namespace OpenMS
     }
     #endif
     return false;
+#endif
+  }
+
+  Int64 SysInfo::getProcessId()
+  {
+#ifdef OPENMS_WINDOWSPLATFORM
+    return static_cast<Int64>(_getpid());
+#else
+    return static_cast<Int64>(getpid());
 #endif
   }
 


### PR DESCRIPTION
## Summary
- Fix seed collision in `UniqueIdGenerator` when multiple TOPP tools start simultaneously
- Add `SysInfo::getProcessId()` as cross-platform wrapper for process ID retrieval

## Problem
When multiple TOPP tools run in parallel (e.g., in TOPPAS pipelines), they can initialize at the same microsecond, resulting in identical RNG seeds. This causes duplicate UniqueIds across different files, leading to errors like:
```
FeatureHandle exists twice in ConsensusMap!
```

## Solution
Mix the process ID into the seed using XOR with a 32-bit shift:
```cpp
seed_ ^= static_cast<UInt64>(SysInfo::getProcessId()) << 32;
```

This ensures parallel processes get different seeds even when started at the exact same microsecond.

## Test plan
- [ ] Existing tests pass
- [ ] QualityControl.toppas pipeline test no longer fails intermittently on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process ID retrieval to system information utilities, exposing a public method to obtain the current process ID.
  * Enhanced unique identifier generation to mix in the process ID, reducing the risk of ID collisions for concurrently started instances.
  * Implemented cross-platform support for the new process ID capability so it works on supported OSes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->