### PR TITLE
Remove Arrow 22 version pin and use CURL workaround for Arrow 23+

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -164,6 +164,9 @@ endif()
 #------------------------------------------------------------------------------
  # Apache Arrow and Parquet
  if (WITH_PARQUET)
+   # Workaround for Arrow 23+ CMake configuration issue where CURL dependency
+   # is not properly exported. See: https://github.com/apache/arrow/issues/48885
+   find_package(CURL QUIET)
    find_package(Arrow CONFIG REQUIRED)
    find_package(Parquet CONFIG REQUIRED)
    

--- a/tools/ci/deps-macos.sh
+++ b/tools/ci/deps-macos.sh
@@ -69,6 +69,7 @@ brew install \
   cgl \
   clp \
   qtbase \
+  curl \
   apache-arrow \
   zstd \
   bash

--- a/tools/ci/deps-ubuntu.sh
+++ b/tools/ci/deps-ubuntu.sh
@@ -45,19 +45,19 @@ sudo apt-get -qq install -y \
   nlohmann-json3-dev \
   libsimde-dev
 
-  # Install Apache Arrow (pinned to version 22 due to CMake issues with Arrow 23.0.0)
-  sudo apt update
-  sudo apt-get install -y -V ca-certificates lsb-release wget
-  wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-  sudo apt update
-  sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-  sudo apt update
-  # Pin to Arrow 22.x to avoid CMake configuration issues with Arrow 23.0.0
-  sudo apt-get install -y --no-install-recommends \
-        libarrow-dev=22.0.0-1 \
-        libparquet-dev=22.0.0-1 \
-        libarrow2200=22.0.0-1 \
-        libparquet2200=22.0.0-1 \
+# Install Apache Arrow
+sudo apt update
+sudo apt-get install -y -V ca-certificates lsb-release wget
+wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt update
+sudo apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt update
+# Install libcurl-dev as a workaround for Arrow CMake config issue
+# See: https://github.com/apache/arrow/issues/48885
+sudo apt-get install -y --no-install-recommends \
+      libcurl4-openssl-dev \
+      libarrow-dev \
+      libparquet-dev
 
 # Optional dependencies:
 sudo apt-get -qq install -y \

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,7 @@
     "coinutils",
     "eigen3",
     "bzip2",
+    "curl",
     "arrow"
   ]
 }


### PR DESCRIPTION
Arrow 23+ has a CMake configuration issue where the CURL dependency is not
properly exported via find_dependency(). This caused build failures when
using static libarrow.

Instead of pinning to Arrow 22.x, apply the recommended workaround:
- Add find_package(CURL) before find_package(Arrow) in CMake
- Install libcurl-dev in CI dependencies

See: https://github.com/apache/arrow/issues/48885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with Arrow 23+ by enhancing CURL dependency resolution in the build configuration.
  * Streamlined Ubuntu CI dependency installation by simplifying library setup and removing Arrow version-specific constraints.
  * Added curl to macOS CI install list.
  * Added curl to the vcpkg dependency manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->