### PR TITLE
minor fix to PeptideIndexer's AC

### DIFF
--- a/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
+++ b/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
@@ -284,8 +284,8 @@ namespace OpenMS
   Index ACTrie::add_(const Index index, const AA label)
   {
     if (vec_index2children_naive_.size() <= index())
-    { // double...
-      vec_index2children_naive_.resize(vec_index2children_naive_.size() * 2);
+    { // doubling is not enough
+      vec_index2children_naive_.resize(std::bit_ceil(index() + 1));  // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
     }
     Index ch = findChildNaive_(index, label);
     if (ch.isInvalid())


### PR DESCRIPTION
## Description

This bug can effectively not occur in TOPP, since we feed peptides with a minimal length of 5 (usually).
However, an internal vector in the AhoCorasickAmbiguous class would cause a segfault for peptides of length < 2. When building a trie for a 1-AA peptide and then adding a 2-AA peptide, it needs to access index 2 (i.e., element 3), and prior doubling capacity from 1 to 2 is insufficient.

Fix: Instead of doubling, we use the next power of 2.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated submodule dependencies.

* **Refactor**
  * Improved memory allocation efficiency in analysis components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->