### PR TITLE
fix: handle empty GENE table in PQP file reading

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -54,6 +54,17 @@ namespace OpenMS
     info.gene_exists = SqliteConnector::tableExists(db, "GENE");
     if (info.gene_exists)
     {
+      // Check if the GENE table actually has any data (issue #8687)
+      // An empty GENE table with INNER JOIN would return zero rows
+      sqlite3_stmt* gene_count_stmt;
+      SqliteConnector::prepareStatement(db, &gene_count_stmt, "SELECT COUNT(*) FROM GENE;");
+      sqlite3_step(gene_count_stmt);
+      int gene_count = sqlite3_column_int(gene_count_stmt, 0);
+      sqlite3_finalize(gene_count_stmt);
+      info.gene_exists = (gene_count > 0);
+    }
+    if (info.gene_exists)
+    {
       select_gene = ", GENE_AGGREGATED.GENE_NAME AS gene_name ";
       select_gene_null = ", 'NA' AS gene_name ";
       join_gene = "INNER JOIN PEPTIDE_GENE_MAPPING ON PEPTIDE.ID = PEPTIDE_GENE_MAPPING.PEPTIDE_ID " \

--- a/src/tests/class_tests/openms/source/TransitionPQPFile_test.cpp
+++ b/src/tests/class_tests/openms/source/TransitionPQPFile_test.cpp
@@ -9,6 +9,8 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/FORMAT/SqliteConnector.h>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <boost/assign/std/vector.hpp>
 
@@ -57,6 +59,86 @@ END_SECTION
 START_SECTION( void validateTargetedExperiment(OpenMS::TargetedExperiment & targeted_exp))
 {
   NOT_TESTABLE
+}
+END_SECTION
+
+START_SECTION([EXTRA] test reading PQP with empty GENE table (issue #8687))
+{
+  // Create a minimal PQP file with an empty GENE table
+  // This tests the fix for issue #8687 where an empty GENE table caused
+  // INNER JOIN to return zero rows
+  String temp_file = File::getTemporaryFile();
+
+  // Create the PQP database structure with empty GENE table
+  {
+    SqliteConnector conn(temp_file);
+
+    // Create all required tables (based on PQP schema)
+    const char* create_sql =
+      "CREATE TABLE VERSION(ID INT NOT NULL);"
+      "CREATE TABLE GENE(ID INT PRIMARY KEY NOT NULL, GENE_NAME TEXT NOT NULL, DECOY INT NOT NULL);"
+      "CREATE TABLE PEPTIDE_GENE_MAPPING(PEPTIDE_ID INT NOT NULL, GENE_ID INT NOT NULL);"
+      "CREATE TABLE PROTEIN(ID INT PRIMARY KEY NOT NULL, PROTEIN_ACCESSION TEXT NOT NULL, DECOY INT NOT NULL);"
+      "CREATE TABLE PEPTIDE_PROTEIN_MAPPING(PEPTIDE_ID INT NOT NULL, PROTEIN_ID INT NOT NULL);"
+      "CREATE TABLE PEPTIDE(ID INT PRIMARY KEY NOT NULL, UNMODIFIED_SEQUENCE TEXT NOT NULL, MODIFIED_SEQUENCE TEXT NOT NULL, DECOY INT NOT NULL);"
+      "CREATE TABLE PRECURSOR_PEPTIDE_MAPPING(PRECURSOR_ID INT NOT NULL, PEPTIDE_ID INT NOT NULL);"
+      "CREATE TABLE COMPOUND(ID INT PRIMARY KEY NOT NULL, COMPOUND_NAME TEXT NOT NULL, SUM_FORMULA TEXT NOT NULL, SMILES TEXT NOT NULL, ADDUCTS TEXT NOT NULL, DECOY INT NOT NULL);"
+      "CREATE TABLE PRECURSOR_COMPOUND_MAPPING(PRECURSOR_ID INT NOT NULL, COMPOUND_ID INT NOT NULL);"
+      "CREATE TABLE PRECURSOR(ID INT PRIMARY KEY NOT NULL, TRAML_ID TEXT NULL, GROUP_LABEL TEXT NULL, PRECURSOR_MZ REAL NOT NULL, CHARGE INT NULL, LIBRARY_INTENSITY REAL NULL, LIBRARY_RT REAL NULL, LIBRARY_DRIFT_TIME REAL NULL, DECOY INT NOT NULL);"
+      "CREATE TABLE TRANSITION_PRECURSOR_MAPPING(TRANSITION_ID INT NOT NULL, PRECURSOR_ID INT NOT NULL);"
+      "CREATE TABLE TRANSITION_PEPTIDE_MAPPING(TRANSITION_ID INT NOT NULL, PEPTIDE_ID INT NOT NULL);"
+      "CREATE TABLE TRANSITION(ID INT PRIMARY KEY NOT NULL, TRAML_ID TEXT NULL, PRODUCT_MZ REAL NOT NULL, CHARGE INT NULL, TYPE CHAR(1) NULL, ANNOTATION TEXT NULL, ORDINAL INT NULL, DETECTING INT NOT NULL, IDENTIFYING INT NOT NULL, QUANTIFYING INT NOT NULL, LIBRARY_INTENSITY REAL NULL, DECOY INT NOT NULL);";
+
+    conn.executeStatement(create_sql);
+
+    // Insert version
+    conn.executeStatement("INSERT INTO VERSION (ID) VALUES (3);");
+
+    // Insert a protein
+    conn.executeStatement("INSERT INTO PROTEIN (ID, PROTEIN_ACCESSION, DECOY) VALUES (0, 'TestProtein', 0);");
+
+    // Insert a peptide
+    conn.executeStatement("INSERT INTO PEPTIDE (ID, UNMODIFIED_SEQUENCE, MODIFIED_SEQUENCE, DECOY) VALUES (0, 'PEPTIDE', 'PEPTIDE', 0);");
+
+    // Insert peptide-protein mapping
+    conn.executeStatement("INSERT INTO PEPTIDE_PROTEIN_MAPPING (PEPTIDE_ID, PROTEIN_ID) VALUES (0, 0);");
+
+    // Insert a precursor
+    conn.executeStatement("INSERT INTO PRECURSOR (ID, TRAML_ID, GROUP_LABEL, PRECURSOR_MZ, CHARGE, LIBRARY_RT, LIBRARY_DRIFT_TIME, DECOY) VALUES (0, 'precursor_1', 'group1', 500.0, 2, 100.0, -1, 0);");
+
+    // Insert precursor-peptide mapping
+    conn.executeStatement("INSERT INTO PRECURSOR_PEPTIDE_MAPPING (PRECURSOR_ID, PEPTIDE_ID) VALUES (0, 0);");
+
+    // Insert a transition
+    conn.executeStatement("INSERT INTO TRANSITION (ID, TRAML_ID, PRODUCT_MZ, CHARGE, TYPE, ORDINAL, DETECTING, IDENTIFYING, QUANTIFYING, LIBRARY_INTENSITY, DECOY) VALUES (0, 'transition_1', 300.0, 1, 'y', 3, 1, 0, 1, 1000.0, 0);");
+
+    // Insert transition-precursor mapping
+    conn.executeStatement("INSERT INTO TRANSITION_PRECURSOR_MAPPING (TRANSITION_ID, PRECURSOR_ID) VALUES (0, 0);");
+
+    // NOTE: GENE table and PEPTIDE_GENE_MAPPING are intentionally left empty!
+  }
+
+  // Now try to read the PQP file - this should NOT fail even with empty GENE table
+  TransitionPQPFile pqp_reader;
+  TargetedExperiment targeted_exp;
+
+  pqp_reader.convertPQPToTargetedExperiment(temp_file.c_str(), targeted_exp, true);
+
+  // Verify we got the transition data
+  TEST_EQUAL(targeted_exp.getTransitions().size(), 1)
+  TEST_EQUAL(targeted_exp.getPeptides().size(), 1)
+  TEST_EQUAL(targeted_exp.getProteins().size(), 1)
+
+  // Test with LightTargetedExperiment as well
+  OpenSwath::LightTargetedExperiment light_exp;
+  pqp_reader.convertPQPToTargetedExperiment(temp_file.c_str(), light_exp, true);
+
+  TEST_EQUAL(light_exp.transitions.size(), 1)
+  TEST_EQUAL(light_exp.compounds.size(), 1)
+  TEST_EQUAL(light_exp.proteins.size(), 1)
+
+  // Clean up
+  File::remove(temp_file);
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary

- Fixes an issue where PQP files with an empty GENE table would fail to parse, returning zero transitions
- Adds a row count check after verifying table existence, treating an empty GENE table the same as a non-existent one
- Adds comprehensive test case for the empty GENE table scenario

## Background

When reading PQP files, the code checked if the GENE table exists but not if it contained any rows. An empty GENE table combined with INNER JOINs would return zero rows, causing all peptide/transition data to be lost.

This is a common scenario when users create their own PQP files without gene information.

## Test plan

- [x] New unit test `TransitionPQPFile_test` covers empty GENE table scenario
- [x] Tests both `TargetedExperiment` and `LightTargetedExperiment` conversion paths
- [x] All existing tests pass

Fixes #8687
Related to #8683

🤖 Generated with [Claude Code](https://claude.ai/code)