### PR TITLE
Add model load/save and value-only prediction to SimpleSVM

### DIFF
--- a/src/openms/include/OpenMS/ML/SVM/SimpleSVM.h
+++ b/src/openms/include/OpenMS/ML/SVM/SimpleSVM.h
@@ -132,6 +132,42 @@ namespace OpenMS
     /// Get data range of predictors before scaling to [0, 1]
     const ScaleMap& getScaling() const;
 
+    /**
+       @brief Predict class labels or regression values for specific observations.
+
+       Returns only the predicted values without probability estimates.
+
+       @param[in] indexes Vector of observation indexes for which predictions are desired.
+       @return Vector of predicted values (same order as @p indexes).
+
+       @throw Exception::Precondition if no model has been trained
+       @throw Exception::InvalidValue if an invalid index is used in @p indexes
+    */
+    std::vector<double> predictValues(const std::vector<Size>& indexes) const;
+
+    /**
+       @brief Check if a model has been trained or loaded.
+       @return true if a model exists, false otherwise
+    */
+    bool hasModel() const;
+
+    /**
+       @brief Save the trained model to a file.
+
+       @param[in] path Path to save the model to.
+       @throw Exception::Precondition if no model has been trained
+       @throw Exception::IOException if the file cannot be written
+    */
+    void saveModel(const String& path) const;
+
+    /**
+       @brief Load a pre-trained model from a file.
+
+       @param[in] path Path to load the model from.
+       @throw Exception::IOException if the file cannot be read or is invalid
+    */
+    void loadModel(const String& path);
+
   protected:
     // Forward declaration of implementation class
     class Impl;

--- a/src/openms/source/ML/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ML/SVM/SimpleSVM.cpp
@@ -542,6 +542,51 @@ void SimpleSVM::predict(vector<Prediction>& predictions, vector<Size> indexes) c
   }
 }
 
+// predict values only (without probabilities) on (subset) of training data
+std::vector<double> SimpleSVM::predictValues(const std::vector<Size>& indexes) const
+{
+  if (pimpl_->model_ == nullptr)
+  {
+    throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  "SVM model has not been trained (use the "
+                                  "'setup' method)");
+  }
+
+  Size n_obs = pimpl_->nodes_.size();
+
+  // Make a local copy we can modify
+  std::vector<Size> indices = indexes;
+
+  if (indices.empty())
+  {
+    indices.reserve(n_obs);
+    for (Size i = 0; i < n_obs; ++i)
+    {
+      indices.push_back(i);
+    }
+  }
+
+  std::vector<double> results;
+  results.reserve(indices.size());
+
+  for (Size idx : indices)
+  {
+    if (idx >= pimpl_->nodes_.size())
+    {
+      String msg = "Invalid index for prediction; there are only " +
+                   String(n_obs) + " observations.";
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                    msg, String(idx));
+    }
+
+    results.push_back(
+      svm_predict(pimpl_->model_, &(pimpl_->nodes_[idx][0]))
+    );
+  }
+
+  return results;
+}
+
 void scaleDataUsingTrainingRanges(SimpleSVM::PredictorMap& predictors, const map<String, pair<double, double>>& scaling)
 {
   // scale each feature dimension to the min-max-range
@@ -668,5 +713,37 @@ void SimpleSVM::writeXvalResults(const String& path) const
                << pimpl_->performance_[g_index][c_index][p_index] << nl;
       }
     }
+  }
+}
+
+bool SimpleSVM::hasModel() const
+{
+  return pimpl_->model_ != nullptr;
+}
+
+void SimpleSVM::saveModel(const String& path) const
+{
+  if (pimpl_->model_ == nullptr)
+  {
+    throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  "No model to save.");
+  }
+
+  if (svm_save_model(path.c_str(), pimpl_->model_) != 0)
+  {
+    throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                 "Failed to save SVM model to file." + path);
+  }
+}
+
+void SimpleSVM::loadModel(const String& path)
+{
+  pimpl_->clear_();
+
+  pimpl_->model_ = svm_load_model(path.c_str());
+  if (pimpl_->model_ == nullptr)
+  {
+    throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                 "Failed to load SVM model from file." + path);
   }
 }


### PR DESCRIPTION
## Description

This PR extends `SimpleSVM` with minimal functionality required to fully encapsulate libSVM and prepare for making it a private dependency.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### Summary of changes
- Add support for saving and loading trained SVM models via `SimpleSVM`
- Add prediction of values without probability estimates
- Add a helper to check whether a model is present
- Keep all libSVM usage confined to the implementation file (`.cpp`)

### Motivation
These changes are a prerequisite for refactoring `FeatureFindingMetabo` away from direct libSVM types, as discussed in #8558 and the previously closed PR #8557.

### Scope
- No behavioral changes to existing workflows
- No refactor of `FeatureFindingMetabo` yet (to be handled in a follow-up PR)
- No changes to public headers exposing libSVM types

### Build
- Successfully built locally (Windows, MSVC)
