### PR TITLE
Let the build environment select the builder

### DIFF
--- a/src/pyOpenMS/pyproject.toml
+++ b/src/pyOpenMS/pyproject.toml
@@ -134,7 +134,6 @@ include = [
 
 [tool.py-build-cmake.cmake]
 # CMake build configuration
-generator = "Ninja"
 build_type = "Release"
 source_path = "."
 install_args = ["--strip"]


### PR DESCRIPTION
The `generator` setting forces wheel building to be done with Ninja even if another builder was previously selected with `cmake -G`.  This change removes that setting.

Probably unintentional AI slop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use default build settings instead of explicit generator specification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->