### PR TITLE
Fix Python wrapping of FileTypes

### DIFF
--- a/src/pyOpenMS/addons/Peptidoform.pyx
+++ b/src/pyOpenMS/addons/Peptidoform.pyx
@@ -250,10 +250,7 @@
         Args:
             min_charge: Minimum fragment ion charge state (default: 1)
             max_charge: Maximum fragment ion charge state (default: 1)
-            ion_types: String specifying which ion types to generate (default: "by"):
-                       'a','b','c','x','y','z' for ion series,
-                       'M' for precursor peaks, 'I' for immonium ions.
-                       Example: "by" for b/y ions, "abyM" for a/b/y + precursor
+            ion_types: Ion types to generate, e.g. "by" (default) or "abyM". Use a/b/c/x/y/z for ion series, M for precursor, I for immonium.
             add_losses: If True, include neutral loss peaks (H2O, NH3) (default: False)
             add_metainfo: If True, include ion annotations in spectrum (default: True)
 

--- a/src/pyOpenMS/addons/PeptidoformIon.pyx
+++ b/src/pyOpenMS/addons/PeptidoformIon.pyx
@@ -156,10 +156,7 @@
         Args:
             min_charge: Minimum fragment ion charge state (default: 1)
             max_charge: Maximum fragment ion charge state (default: 1)
-            ion_types: String specifying which ion types to generate (default: "by"):
-                       'a','b','c','x','y','z' for ion series,
-                       'M' for precursor peaks, 'I' for immonium ions.
-                       Example: "by" for b/y ions, "abyM" for a/b/y + precursor
+            ion_types: Ion types to generate, e.g. "by" (default) or "abyM". Use a/b/c/x/y/z for ion series, M for precursor, I for immonium.
             add_losses: If True, include neutral loss peaks (H2O, NH3) (default: False)
             add_metainfo: If True, include ion annotations in spectrum (default: True)
 

--- a/src/pyOpenMS/pxds/FileTypes.pxd
+++ b/src/pyOpenMS/pxds/FileTypes.pxd
@@ -9,13 +9,19 @@ cdef extern from "<OpenMS/FORMAT/FileTypes.h>" namespace "OpenMS":
         FileTypes() except + nogil  # wrap-doc:Centralizes the file types recognized by FileHandler
         FileTypes(FileTypes &) except + nogil  # compiler
 
+        @staticmethod
         String typeToName(FileType t) except + nogil  # wrap-doc:Returns the name/extension of the type
 
+        @staticmethod
+        String typeToDescription(FileType t) except + nogil  # wrap-doc:Returns the human-readable explanation of the type
+
+        @staticmethod
         String typeToMZML(FileType t) except + nogil  # wrap-doc:Returns the mzML name
 
-        FileType nameToType(String name) except + nogil  
+        @staticmethod
+        FileType nameToType(String name) except + nogil
             # wrap-doc:
-                #  Converts a file type name into a Type 
+                #  Converts a file type name into a Type
                 #  
                 #  
                 #  :param name: A case-insensitive name (e.g. FASTA or Fasta, etc.)
@@ -23,51 +29,65 @@ cdef extern from "<OpenMS/FORMAT/FileTypes.h>" namespace "OpenMS":
 cdef extern from "<OpenMS/FORMAT/FileTypes.h>" namespace "OpenMS::FileTypes":
 
     cdef enum FileType "OpenMS::FileTypes::Type":
-    
-          UNKNOWN,            # < Unknown file extension
-          DTA,                # < DTA file (.dta)
-          DTA2D,              # < DTA2D file (.dta2d)
-          MZDATA,             # < MzData file (.mzData)
-          MZXML,              # < MzXML file (.mzXML)
-          FEATUREXML,         # < %OpenMS feature file (.featureXML)
-          IDXML,              # < %OpenMS identification format (.idXML)
-          CONSENSUSXML,       # < %OpenMS consensus map format (.consensusXML)
-          MGF,                # < Mascot Generic Format (.mgf)
-          INI,                # < %OpenMS parameters file (.ini)
-          TOPPAS,             # < %OpenMS parameters file with workflow information (.toppas)
-          TRANSFORMATIONXML,  # < Transformation description file (.trafoXML)
-          MZML,               # < MzML file (.mzML)
-          CACHEDMZML,         # < CachedMzML file (.cachedmzML)
-          MS2,                # < MS2 file (.ms2)
-          PEPXML,             # < TPP pepXML file (.pepXML)
-          PROTXML,            # < TPP protXML file (.protXML)
-          MZIDENTML,          # < mzIdentML (HUPO PSI AnalysisXML followup format) (.mzid)
-          QCML,               # < qcML (will undergo standardisation maybe) (.qcml)
-          GELML,              # < GelML (HUPO PSI format) (.gelML)
-          TRAML,              # < TraML (HUPO PSI format) for transitions (.traML)
-          MSP,                # < NIST spectra library file format (.msp)
-          OMSSAXML,           # < OMSSA XML file format for peptide identifications (.xml)
-          MASCOTXML,          # < Mascot XML file format for peptide identifications (.xml)
-          PNG,                # < Portable Network Graphics (.png)
-          XMASS,              # < XMass Analysis file (fid)
-          TSV,                # < msInspect file (.tsv)
-          PEPLIST,            # < specArray file (.peplist)
-          HARDKLOER,          # < hardkloer file (.hardkloer)
-          KROENIK,            # < kroenik file (.kroenik)
-          FASTA,              # < FASTA file (.fasta)
-          EDTA,               # < enhanced comma separated files (RT, m/z, Intensity, [meta])
-          CSV,                # < general comma separated files format (might also be tab or space separated!!!), data should be regular, i.e. matrix form
-          TXT,                # < any text format, which has only loose definition of what it actually contains -- thus it is usually hard to say where the file actually came from (e.g. PepNovo).
-          OBO,                # < Controlled Vocabulary format
-          HTML,               # < any HTML format
-          XML,                # < any XML format
-          ANALYSISXML,        # < analysisXML format
-          XSD,                # < XSD schema format
-          PSQ,                # < NCBI binary blast db
-          MRM,                # < SpectraST MRM List
-          SQMASS,             # < SqLite format for mass and chromatograms
-          PQP,                # < OpenSWATH Peptide Query Parameter (PQP) SQLite DB
-          OSW,                # < OpenSWATH OpenSWATH report (OSW) SQLite DB
-          PSMS,               # < Percolator tab-delimited output (PSM level)
-          PARAMXML,           # < internal format for writing and reading parameters (also used as part of CTD)
-          SIZE_OF_TYPE        # < No file type. Simply stores the number of types
+        UNKNOWN,            # Unknown file extension
+        DTA,                # DTA file (.dta)
+        DTA2D,              # DTA2D file (.dta2d)
+        MZDATA,             # MzData file (.mzData)
+        MZXML,              # MzXML file (.mzXML)
+        FEATUREXML,         # OpenMS feature file (.featureXML)
+        IDXML,              # OpenMS identification format (.idXML)
+        CONSENSUSXML,       # OpenMS consensus map format (.consensusXML)
+        MGF,                # Mascot Generic Format (.mgf)
+        INI,                # OpenMS parameters file (.ini)
+        TOPPAS,             # OpenMS parameters file with workflow information (.toppas)
+        TRANSFORMATIONXML,  # Transformation description file (.trafoXML)
+        MZML,               # MzML file (.mzML)
+        CACHEDMZML,         # CachedMzML file (.cachedmzML)
+        MS2,                # MS2 file (.ms2)
+        PEPXML,             # TPP pepXML file (.pepXML)
+        PROTXML,            # TPP protXML file (.protXML)
+        MZIDENTML,          # mzIdentML (HUPO PSI AnalysisXML followup format) (.mzid)
+        QCML,               # qcML (will undergo standardisation maybe) (.qcml)
+        MZQC,               # mzQC (HUPO PSI format) (.mzQC)
+        GELML,              # GelML (HUPO PSI format) (.gelML)
+        TRAML,              # TraML (HUPO PSI format) for transitions (.traML)
+        MSP,                # NIST spectra library file format (.msp)
+        OMSSAXML,           # OMSSA XML file format for peptide identifications (.xml)
+        MASCOTXML,          # Mascot XML file format for peptide identifications (.xml)
+        PNG,                # Portable Network Graphics (.png)
+        XMASS,              # XMass Analysis file (fid)
+        TSV,                # any TSV file
+        MZTAB,              # mzTab file (.mzTab)
+        PEPLIST,            # specArray file (.peplist)
+        HARDKLOER,          # hardkloer file (.hardkloer)
+        KROENIK,            # kroenik file (.kroenik)
+        FASTA,              # FASTA file (.fasta)
+        EDTA,               # enhanced comma separated files (RT, m/z, Intensity, [meta])
+        CSV,                # general comma separated files format
+        TXT,                # any text format
+        OBO,                # Controlled Vocabulary format
+        HTML,               # any HTML format
+        ANALYSISXML,        # analysisXML format
+        XSD,                # XSD schema format
+        PSQ,                # NCBI binary blast db
+        MRM,                # SpectraST MRM List
+        SQMASS,             # SqLite format for mass and chromatograms
+        PQP,                # OpenSWATH Peptide Query Parameter (PQP) SQLite DB
+        MS,                 # SIRIUS file format (.ms)
+        OSW,                # OpenSWATH OpenSWATH report (OSW) SQLite DB
+        PSMS,               # Percolator tab-delimited output (PSM level)
+        PIN,                # Percolator tab-delimited input (PSM level)
+        PARAMXML,           # internal format for writing and reading parameters
+        SPLIB,              # SpectraST binary spectral library file
+        NOVOR,              # Novor custom parameter file
+        XQUESTXML,          # xQuest XML file format for cross-link identifications
+        SPECXML,            # xQuest XML file format for matched spectra
+        JSON,               # JavaScript Object Notation file (.json)
+        RAW,                # Thermo Raw File (.raw)
+        OMS,                # OpenMS database file
+        EXE,                # Executable (.exe)
+        XML,                # any XML format
+        BZ2,                # any BZ2 compressed file
+        GZ,                 # any Gzipped file
+        PARQUET,            # Apache Parquet file format (.parquet, .pqt)
+        SIZE_OF_TYPE        # No file type. Simply stores the number of types

--- a/src/pyOpenMS/tests/unittests/test_FileTypes.py
+++ b/src/pyOpenMS/tests/unittests/test_FileTypes.py
@@ -1,0 +1,80 @@
+import pyopenms
+
+
+def test_enum_values_accessible():
+    """Test that all FileType enum values are accessible."""
+    expected = [
+        "UNKNOWN", "DTA", "DTA2D", "MZDATA", "MZXML", "FEATUREXML", "IDXML",
+        "CONSENSUSXML", "MGF", "INI", "TOPPAS", "TRANSFORMATIONXML", "MZML",
+        "CACHEDMZML", "MS2", "PEPXML", "PROTXML", "MZIDENTML", "QCML", "MZQC",
+        "GELML", "TRAML", "MSP", "OMSSAXML", "MASCOTXML", "PNG", "XMASS",
+        "TSV", "MZTAB", "PEPLIST", "HARDKLOER", "KROENIK", "FASTA", "EDTA",
+        "CSV", "TXT", "OBO", "HTML", "ANALYSISXML", "XSD", "PSQ", "MRM",
+        "SQMASS", "PQP", "MS", "OSW", "PSMS", "PIN", "PARAMXML", "SPLIB",
+        "NOVOR", "XQUESTXML", "SPECXML", "JSON", "RAW", "OMS", "EXE", "XML",
+        "BZ2", "GZ", "PARQUET", "SIZE_OF_TYPE",
+    ]
+    for name in expected:
+        val = getattr(pyopenms.FileType, name)
+        assert val is not None
+
+
+def test_typeToName():
+    """Test typeToName returns correct strings for known types."""
+    ft = pyopenms.FileTypes()
+    assert ft.typeToName(pyopenms.FileType.MZML) == "mzML"
+    assert ft.typeToName(pyopenms.FileType.FASTA) == "fasta"
+    assert ft.typeToName(pyopenms.FileType.IDXML) == "idXML"
+    assert ft.typeToName(pyopenms.FileType.FEATUREXML) == "featureXML"
+
+
+def test_typeToDescription():
+    """Test typeToDescription returns non-empty strings."""
+    ft = pyopenms.FileTypes()
+    desc = ft.typeToDescription(pyopenms.FileType.MZML)
+    assert isinstance(desc, str)
+    assert len(desc) > 0
+
+    desc2 = ft.typeToDescription(pyopenms.FileType.FASTA)
+    assert isinstance(desc2, str)
+    assert len(desc2) > 0
+
+
+def test_nameToType():
+    """Test nameToType converts names back to types."""
+    ft = pyopenms.FileTypes()
+    assert ft.nameToType("mzML") == pyopenms.FileType.MZML
+    assert ft.nameToType("fasta") == pyopenms.FileType.FASTA
+    assert ft.nameToType("idXML") == pyopenms.FileType.IDXML
+
+
+def test_nameToType_roundtrip():
+    """Test that typeToName and nameToType round-trip correctly."""
+    ft = pyopenms.FileTypes()
+    for t in [pyopenms.FileType.MZML, pyopenms.FileType.FASTA,
+              pyopenms.FileType.TRAML, pyopenms.FileType.FEATUREXML]:
+        name = ft.typeToName(t)
+        assert ft.nameToType(name) == t
+
+
+def test_typeToMZML():
+    """Test typeToMZML for known types."""
+    ft = pyopenms.FileTypes()
+    result = ft.typeToMZML(pyopenms.FileType.MZML)
+    assert isinstance(result, str)
+
+
+def test_static_methods_callable_on_class():
+    """Test that static methods are callable without an instance."""
+    # These should work as static methods on the class
+    name = pyopenms.FileTypes.typeToName(pyopenms.FileType.MZML)
+    assert name == "mzML"
+
+    desc = pyopenms.FileTypes.typeToDescription(pyopenms.FileType.MZML)
+    assert len(desc) > 0
+
+    t = pyopenms.FileTypes.nameToType("mzML")
+    assert t == pyopenms.FileType.MZML
+
+    mzml_name = pyopenms.FileTypes.typeToMZML(pyopenms.FileType.MZML)
+    assert isinstance(mzml_name, str)


### PR DESCRIPTION
## Summary

- Add `@staticmethod` to `typeToName`, `typeToMZML`, `nameToType` in `FileTypes.pxd`
- Add missing `typeToDescription()` static method
- Add 16 missing `FileType` enum values (`MZQC`, `MZTAB`, `MS`, `PIN`, `SPLIB`, `NOVOR`, `XQUESTXML`, `SPECXML`, `JSON`, `RAW`, `OMS`, `EXE`, `XML`, `BZ2`, `GZ`, `PARQUET`) to align with C++ header
- Fix RST indentation errors in `generateSpectrum` docstrings in `Peptidoform.pyx` and `PeptidoformIon.pyx` addons
- Add `test_FileTypes.py` covering enum access, static methods, and round-trip conversions

Closes #8707

## Test plan

- [x] All 7 new `test_FileTypes.py` tests pass
- [x] `test_docstring_format.py::test_generated_docstrings_valid_rst` now passes (was failing due to RST indentation)
- [x] Full pyOpenMS test suite: 597 passed, 9 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified and clarified ion-type descriptions for spectrum generation.

* **New Features**
  * Expanded supported file formats with several additional types.
  * Added a file-type description method to the API.

* **Tests**
  * Added comprehensive unit tests for file-type values, name/type conversions, descriptions, and mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->