### PR TITLE
Add CCS (collisional cross section) support for ion mobility data

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/CommonEnums.h
+++ b/src/openms/include/OpenMS/CONCEPT/CommonEnums.h
@@ -24,10 +24,11 @@ namespace OpenMS
     IM_MS,    ///< ion mobility milliseconds
     IM_VSSC,  ///< volt-second per square centimeter (i.e. 1/K_0)
     FAIMS_CV, ///< FAIMS compensation voltage
+    IM_CCS,   ///< collisional cross section (square angstrom)
     SIZE_OF_DIM_UNITS
   };
-  inline std::string_view DIM_NAMES[(int)DIM_UNIT::SIZE_OF_DIM_UNITS] = {"RT [s]", "m/z [Th]", "intensity", "IM [milliseconds]", "IM [vs / cm2]", "FAIMS CV"};
-  inline std::string_view DIM_NAMES_SHORT[(int)DIM_UNIT::SIZE_OF_DIM_UNITS] = {"RT", "m/z", "int", "IM", "IM", "FCV"};
+  inline std::string_view DIM_NAMES[(int)DIM_UNIT::SIZE_OF_DIM_UNITS] = {"RT [s]", "m/z [Th]", "intensity", "IM [milliseconds]", "IM [vs / cm2]", "FAIMS CV", "CCS [angstrom^2]"};
+  inline std::string_view DIM_NAMES_SHORT[(int)DIM_UNIT::SIZE_OF_DIM_UNITS] = {"RT", "m/z", "int", "IM", "IM", "FCV", "CCS"};
 
 
   enum class MZ_UNITS

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -250,6 +250,11 @@ namespace OpenMS
        */
       inline const std::string ION_MOBILITY = "Ion Mobility";
 
+      /** MetaValue key for inverse reduced ion mobility array (alternative name for 1/K0 from MSConvert).
+       * Uses the same CV term MS:1002815 as ION_MOBILITY.
+       */
+      inline const std::string INVERSE_REDUCED_ION_MOBILITY = "inverse reduced ion mobility";
+
       /** MetaValue key for centroided ion mobility data output by PeakPickerIM and MassTraceDetection.
        * PeakPickerIM outputs centroided peaks with this array name.
        * MassTraceDetection computes intensity-weighted ion mobility average of connected centroided peaks.

--- a/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
@@ -25,6 +25,7 @@ namespace OpenMS
     MILLISECOND,               ///< milliseconds
     VSSC,                      ///< volt-second per square centimeter (i.e. 1/K_0)
     FAIMS_COMPENSATION_VOLTAGE,///< compensation voltage
+    CCS,                       ///< collisional cross section (square angstrom)
     SIZE_OF_DRIFTTIMEUNIT
   };
 

--- a/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
+++ b/src/openms/include/OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h
@@ -143,5 +143,8 @@ namespace OpenMS
     double im_tolerance_cluster_{0.1};
 
     double ppm_tolerance_elution_{50.0};
+
+    /// Flag to track if CCS tolerance warning has been shown (mutable for const methods)
+    mutable bool ccs_warning_shown_{false};
   };
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
@@ -283,10 +283,12 @@ namespace OpenMS
       }
     }
 
-    double eps = 1e-5; // eps for two grid cells to be considered equal
-
     // extend IM range by drift_extra
     im_range.scaleBy(drift_extra * 2. + 1); // multiple by 2 because want drift extra to be extended by that amount on either side
+
+    // Compute eps as a fraction of the IM range to be scale-invariant across different IM units
+    // For VSSC (~0.8-1.5 range), this gives ~1e-5; for CCS (~300-500 range), this gives ~0.002
+    double eps = std::max(1e-8, im_range.getSpan() * 1e-5);
 
     // Step 1: MS2 extraction
     std::vector< Mobilogram > ms2_mobilograms;
@@ -425,9 +427,11 @@ namespace OpenMS
       }
     }
 
-    double eps = 1e-5; // eps for two grid cells to be considered equal
-
     im_range.scaleBy(drift_extra * 2. + 1); // multiple by 2 because want drift extra to be extended by that amount on either side
+
+    // Compute eps as a fraction of the IM range to be scale-invariant across different IM units
+    // For VSSC (~0.8-1.5 range), this gives ~1e-5; for CCS (~300-500 range), this gives ~0.002
+    double eps = std::max(1e-8, im_range.getSpan() * 1e-5);
 
     double delta_drift = 0;
     double delta_drift_abs = 0;
@@ -576,9 +580,11 @@ namespace OpenMS
         }
       }
 
-      double eps = 1e-5; // eps for two grid cells to be considered equal
-
       im_range.scaleBy(drift_extra * 2. + 1); // multiple by 2 because want drift extra to be extended by that amount on either side
+
+      // Compute eps as a fraction of the IM range to be scale-invariant across different IM units
+      // For VSSC (~0.8-1.5 range), this gives ~1e-5; for CCS (~300-500 range), this gives ~0.002
+      double eps = std::max(1e-8, im_range.getSpan() * 1e-5);
 
       Mobilogram res;
       double im(0), intensity(0);

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -27,6 +27,37 @@ using namespace std;
 
 namespace OpenMS
 {
+  // Helper function to check if ion mobility data is in CCS format
+  // CCS data is not directly compatible with OpenSwath which expects 1/K0 (inverse reduced ion mobility)
+  static void warnIfCCSData(const std::vector<OpenSwath::SwathMap>& swath_maps)
+  {
+    for (const auto& swath_map : swath_maps)
+    {
+      if (swath_map.sptr && swath_map.sptr->getNrSpectra() > 0)
+      {
+        // Get the first spectrum and check its data arrays for CCS indicators
+        auto spectrum = swath_map.sptr->getSpectrumById(0);
+        if (spectrum)
+        {
+          for (const auto& arr : spectrum->getDataArrays())
+          {
+            // Check for CCS CV term (MS:1002954) or square angstrom unit (UO:0000324)
+            if (arr->description.find("MS:1002954") != std::string::npos ||
+                arr->description.find("UO:0000324") != std::string::npos ||
+                arr->description.find("collision cross section") != std::string::npos)
+            {
+              OPENMS_LOG_WARN << "Warning: Ion mobility data appears to be in CCS (Collisional Cross Section) format. "
+                              << "OpenSwath expects ion mobility in 1/K0 (inverse reduced ion mobility) units. "
+                              << "Results may be incorrect if the spectral library also uses 1/K0 units. "
+                              << "Consider converting the data or using a CCS-based spectral library." << std::endl;
+              return; // Only warn once
+            }
+          }
+        }
+        return; // Only check first map with spectra
+      }
+    }
+  }
 
   TOPPOpenSwathBase::TOPPOpenSwathBase(String name, String description, bool official, const std::vector<Citation>& citations) :
     TOPPBase(name, description, official, citations)
@@ -235,6 +266,10 @@ namespace OpenMS
         }
       }
     }
+
+    // Check if ion mobility data is in CCS format and warn user
+    warnIfCCSData(swath_maps);
+
     return true;
   }
 

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -32,25 +32,6 @@ using namespace std;
 
 namespace OpenMS
 {
-  // Helper to warn once if CCS data is detected with small IM tolerance
-  static bool& getBiosaur2CCSWarningShown()
-  {
-    static bool shown = false;
-    return shown;
-  }
-
-  static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance)
-  {
-    if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getBiosaur2CCSWarningShown())
-    {
-      OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
-                      << "paseftol = " << im_tolerance
-                      << " appears to be set for 1/K0 data. "
-                      << "For CCS data, consider using larger values (e.g., 5-20)." << std::endl;
-      getBiosaur2CCSWarningShown() = true;
-    }
-  }
-
 
 Biosaur2Algorithm::Biosaur2Algorithm() :
   DefaultParamHandler("Biosaur2Algorithm")
@@ -252,6 +233,28 @@ void Biosaur2Algorithm::run(FeatureMap& feature_map,
   vector<FeatureMap> fmap_per_group(n_groups);
 
   const double original_paseftol = paseftol_;
+
+  // Check IM unit and warn if CCS data with small tolerance (single-threaded, before parallel loop)
+  for (const auto& group_pair : groups)
+  {
+    const MSExperiment& group_exp = group_pair.second;
+    for (const auto& spec : group_exp)
+    {
+      if (spec.containsIMData())
+      {
+        const auto [im_data_index, im_unit] = spec.getIMData();
+        if (im_unit == DriftTimeUnit::CCS && original_paseftol < 1.0)
+        {
+          OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                          << "paseftol = " << original_paseftol
+                          << " appears to be set for 1/K0 data. "
+                          << "For CCS data, consider using larger values (e.g., 5-20)." << '\n';
+        }
+        goto done_ccs_check; // Found IM data, no need to check further
+      }
+    }
+  }
+  done_ccs_check:
 
   // Parallelize processing across FAIMS groups. Each group is handled
   // independently using its own local hills/features containers.
@@ -944,11 +947,6 @@ void Biosaur2Algorithm::centroidPASEFData_(MSExperiment& exp, double mz_step, do
     }
 
     const double ion_mobility_step = (*it_max_im) * ion_mobility_accuracy;
-
-    // Check IM unit and warn if CCS data with small tolerance
-    DriftTimeUnit im_unit = DriftTimeUnit::NONE;
-    IMDataConverter::getIMUnit(im_array, im_unit);
-    warnIfCCSWithSmallTolerance(im_unit, ion_mobility_accuracy);
 
     if (ion_mobility_step <= 0.0)
     {

--- a/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/Biosaur2Algorithm.cpp
@@ -32,6 +32,25 @@ using namespace std;
 
 namespace OpenMS
 {
+  // Helper to warn once if CCS data is detected with small IM tolerance
+  static bool& getBiosaur2CCSWarningShown()
+  {
+    static bool shown = false;
+    return shown;
+  }
+
+  static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance)
+  {
+    if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getBiosaur2CCSWarningShown())
+    {
+      OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                      << "paseftol = " << im_tolerance
+                      << " appears to be set for 1/K0 data. "
+                      << "For CCS data, consider using larger values (e.g., 5-20)." << std::endl;
+      getBiosaur2CCSWarningShown() = true;
+    }
+  }
+
 
 Biosaur2Algorithm::Biosaur2Algorithm() :
   DefaultParamHandler("Biosaur2Algorithm")
@@ -84,7 +103,7 @@ Biosaur2Algorithm::Biosaur2Algorithm() :
   defaults_.setValue("profile", "false", "Enable profile mode processing (centroid spectra using PeakPickerHiRes)");
   defaults_.setValidStrings("profile", {"true", "false"});
 
-  defaults_.setValue("paseftol", 0.05, "Ion mobility accuracy (in the same units as the ion-mobility array) for linking peaks into hills and grouping isotopes (0 = disable IM-based gating).");
+  defaults_.setValue("paseftol", 0.05, "Ion mobility accuracy for linking peaks into hills and grouping isotopes (0 = disable IM-based gating). Default is for 1/K0 units (e.g., 0.03-0.08). For CCS data, use larger values (e.g., 5-20 square angstroms).");
   defaults_.setMinFloat("paseftol", 0.0);
 
   defaults_.setValue("use_hill_calib", "false", "Enable automatic hill mass tolerance calibration");
@@ -925,6 +944,12 @@ void Biosaur2Algorithm::centroidPASEFData_(MSExperiment& exp, double mz_step, do
     }
 
     const double ion_mobility_step = (*it_max_im) * ion_mobility_accuracy;
+
+    // Check IM unit and warn if CCS data with small tolerance
+    DriftTimeUnit im_unit = DriftTimeUnit::NONE;
+    IMDataConverter::getIMUnit(im_array, im_unit);
+    warnIfCCSWithSmallTolerance(im_unit, ion_mobility_accuracy);
+
     if (ion_mobility_step <= 0.0)
     {
       return;

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -47,6 +47,38 @@ using namespace OpenMS::Internal;
 
 namespace OpenMS
 {
+  // Helper to warn once if CCS data is detected with small IM window
+  static bool& getFFIDCCSWarningShown()
+  {
+    static bool shown = false;
+    return shown;
+  }
+
+  static void warnIfCCSWithSmallWindow(DriftTimeUnit unit, double im_window)
+  {
+    if (unit == DriftTimeUnit::CCS && im_window < 1.0 && !getFFIDCCSWarningShown())
+    {
+      OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                      << "IM_window = " << im_window
+                      << " appears to be set for 1/K0 data. "
+                      << "For CCS data, consider using larger values (e.g., 10-50)." << std::endl;
+      getFFIDCCSWarningShown() = true;
+    }
+  }
+
+  // Helper to get IM unit from first spectrum with IM data
+  static DriftTimeUnit getIMUnitFromExperiment(const PeakMap& exp)
+  {
+    for (const auto& spec : exp)
+    {
+      if (spec.containsIMData())
+      {
+        auto [idx, unit] = spec.getIMData();
+        return unit;
+      }
+    }
+    return DriftTimeUnit::NONE;
+  }
 
   FeatureFinderIdentificationAlgorithm::FeatureFinderIdentificationAlgorithm() :
     DefaultParamHandler("FeatureFinderIdentificationAlgorithm")
@@ -73,7 +105,7 @@ namespace OpenMS
       "This parameter is automatically ignored if the input data does not contain IM information "
       "(determined via IMTypes::determineIMFormat). "
       "Currently only concatenated IM format is supported. "
-      "Typical values: 0.05-0.10 for TIMS data (1/K0 units), 3-5 for FAIMS data (compensation voltage). "
+      "Typical values: 0.05-0.10 for TIMS data (1/K0 units), 10-50 for CCS data (square angstroms), 3-5 for FAIMS data (compensation voltage)."
       "Note: IM values are calculated per peptide/charge/RT-region, using the median of all identifications "
       "in that region for robustness. The median, min, and max IM values are propagated to output features "
       "as meta-values (IM_median, IM_min, IM_max) for quality control.");
@@ -681,6 +713,12 @@ namespace OpenMS
     if (im_format == IMFormat::CONCATENATED)
     {
       has_IM = true;
+      // Check IM unit and warn if CCS data with small window
+      if (IM_window > 0.0)
+      {
+        DriftTimeUnit im_unit = getIMUnitFromExperiment(ms_data_);
+        warnIfCCSWithSmallWindow(im_unit, IM_window);
+      }
     }
     else if (im_format != IMFormat::NONE) // has IM but wrong format
     {

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -47,25 +47,6 @@ using namespace OpenMS::Internal;
 
 namespace OpenMS
 {
-  // Helper to warn once if CCS data is detected with small IM window
-  static bool& getFFIDCCSWarningShown()
-  {
-    static bool shown = false;
-    return shown;
-  }
-
-  static void warnIfCCSWithSmallWindow(DriftTimeUnit unit, double im_window)
-  {
-    if (unit == DriftTimeUnit::CCS && im_window < 1.0 && !getFFIDCCSWarningShown())
-    {
-      OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
-                      << "IM_window = " << im_window
-                      << " appears to be set for 1/K0 data. "
-                      << "For CCS data, consider using larger values (e.g., 10-50)." << std::endl;
-      getFFIDCCSWarningShown() = true;
-    }
-  }
-
   // Helper to get IM unit from first spectrum with IM data
   static DriftTimeUnit getIMUnitFromExperiment(const PeakMap& exp)
   {
@@ -717,7 +698,13 @@ namespace OpenMS
       if (IM_window > 0.0)
       {
         DriftTimeUnit im_unit = getIMUnitFromExperiment(ms_data_);
-        warnIfCCSWithSmallWindow(im_unit, IM_window);
+        if (im_unit == DriftTimeUnit::CCS && IM_window < 1.0)
+        {
+          OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                          << "IM_window = " << IM_window
+                          << " appears to be set for 1/K0 data. "
+                          << "For CCS data, consider using larger values (e.g., 10-50)." << '\n';
+        }
       }
     }
     else if (im_format != IMFormat::NONE) // has IM but wrong format

--- a/src/openms/source/FEATUREFINDER/MassTraceDetection.cpp
+++ b/src/openms/source/FEATUREFINDER/MassTraceDetection.cpp
@@ -22,24 +22,6 @@
 
 namespace OpenMS
 {
-    // Helper to warn once if CCS data is detected with small IM tolerance
-    static bool& getMTDCCSWarningShown()
-    {
-      static bool shown = false;
-      return shown;
-    }
-
-    static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance)
-    {
-      if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getMTDCCSWarningShown())
-      {
-        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
-                        << "ion_mobility_tolerance = " << im_tolerance
-                        << " appears to be set for 1/K0 data. "
-                        << "For CCS data, consider using larger values (e.g., 2-10)." << std::endl;
-        getMTDCCSWarningShown() = true;
-      }
-    }
 
     MassTraceDetection::MassTraceDetection() :
             DefaultParamHandler("MassTraceDetection"), ProgressLogger()
@@ -213,6 +195,23 @@ namespace OpenMS
     {
       // make sure the output vector is empty
       found_masstraces.clear();
+
+      // Check IM unit and warn if CCS data with small tolerance (single-threaded check at algorithm start)
+      for (const auto& spec : input_exp)
+      {
+        if (spec.containsIMData())
+        {
+          const auto [im_data_index, im_unit] = spec.getIMData();
+          if (im_unit == DriftTimeUnit::CCS && ion_mobility_tolerance_ < 1.0)
+          {
+            OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                            << "ion_mobility_tolerance = " << ion_mobility_tolerance_
+                            << " appears to be set for 1/K0 data. "
+                            << "For CCS data, consider using larger values (e.g., 2-10)." << '\n';
+          }
+          break; // Found IM data, no need to check further spectra
+        }
+      }
 
       // gather all peaks that are potential chromatographic peak apices
       //   - use work_exp for actual work (remove peaks below noise threshold)
@@ -519,10 +518,6 @@ namespace OpenMS
         if (has_centroid_im_)
         {
           centroid_im = work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_][apex_peak_idx];
-          // Check IM unit and warn if CCS data with small tolerance
-          DriftTimeUnit im_unit = DriftTimeUnit::NONE;
-          IMDataConverter::getIMUnit(work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_], im_unit);
-          warnIfCCSWithSmallTolerance(im_unit, ion_mobility_tolerance_);
           prev_counter_im = apex_peak.getIntensity() * centroid_im;
           prev_denom_im = apex_peak.getIntensity();
           updateIterativeWeightedMean_(work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_][apex_peak_idx],

--- a/src/openms/source/FEATUREFINDER/MassTraceDetection.cpp
+++ b/src/openms/source/FEATUREFINDER/MassTraceDetection.cpp
@@ -16,16 +16,38 @@
 
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 
 namespace OpenMS
 {
+    // Helper to warn once if CCS data is detected with small IM tolerance
+    static bool& getMTDCCSWarningShown()
+    {
+      static bool shown = false;
+      return shown;
+    }
+
+    static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance)
+    {
+      if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getMTDCCSWarningShown())
+      {
+        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but "
+                        << "ion_mobility_tolerance = " << im_tolerance
+                        << " appears to be set for 1/K0 data. "
+                        << "For CCS data, consider using larger values (e.g., 2-10)." << std::endl;
+        getMTDCCSWarningShown() = true;
+      }
+    }
+
     MassTraceDetection::MassTraceDetection() :
             DefaultParamHandler("MassTraceDetection"), ProgressLogger()
     {
       defaults_.setValue("mass_error_ppm", 20.0, "Allowed mass deviation (in ppm).");
       defaults_.setValue("noise_threshold_int", 10.0, "Intensity threshold below which peaks are removed as noise.");
       defaults_.setValue("chrom_peak_snr", 3.0, "Minimum intensity above noise_threshold_int (signal-to-noise) a peak should have to be considered an apex.");
-      defaults_.setValue("ion_mobility_tolerance", 0.01, "Allowed ion mobility deviation (in 1/k0).");
+      defaults_.setValue("ion_mobility_tolerance", 0.01, "Allowed ion mobility deviation (in 1/K0 units, e.g., 0.01-0.05). For CCS data, use larger values (e.g., 2-10 square angstroms).");
 
       defaults_.setValue("reestimate_mt_sd", "true", "Enables dynamic re-estimation of m/z variance during mass trace collection stage.");
       defaults_.setValidStrings("reestimate_mt_sd", {"true","false"});
@@ -497,6 +519,10 @@ namespace OpenMS
         if (has_centroid_im_)
         {
           centroid_im = work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_][apex_peak_idx];
+          // Check IM unit and warn if CCS data with small tolerance
+          DriftTimeUnit im_unit = DriftTimeUnit::NONE;
+          IMDataConverter::getIMUnit(work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_], im_unit);
+          warnIfCCSWithSmallTolerance(im_unit, ion_mobility_tolerance_);
           prev_counter_im = apex_peak.getIntensity() * centroid_im;
           prev_denom_im = apex_peak.getIntensity();
           updateIterativeWeightedMean_(work_exp[apex_scan_idx].getFloatDataArrays()[ion_mobility_idx_][apex_peak_idx],

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1708,7 +1708,7 @@ namespace OpenMS::Internal
             chromatogram_.getPrecursor().getPossibleChargeStates().push_back(value.toInt());
           }
         }
-        else if (accession == "MS:1002476" || accession == "MS:1002815" || accession == "MS:1001581") //ion mobility drift time or FAIM compensation voltage
+        else if (accession == "MS:1002476" || accession == "MS:1002815" || accession == "MS:1001581" || accession == "MS:1002954") //ion mobility drift time, FAIMS CV, or CCS
         {
           // Drift time may be a property of the precursor (in case we are
           // acquiring a fragment ion spectrum) or of the spectrum itself.
@@ -1720,7 +1720,7 @@ namespace OpenMS::Internal
           // In most cases, there is a single precursor with a single drift
           // time.
           //
-          // Note that only milliseconds and VSSC are valid units
+          // Note that milliseconds, VSSC, FAIMS CV, and CCS are valid units
 
           auto unit = DriftTimeUnit::MILLISECOND;
           if (accession == "MS:1002476")
@@ -1729,11 +1729,15 @@ namespace OpenMS::Internal
           }
           else if (accession == "MS:1002815")
           {
-            unit = DriftTimeUnit::VSSC;          
+            unit = DriftTimeUnit::VSSC;
           }
           else if (accession == "MS:1001581")
           {
-            unit = DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE;          
+            unit = DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE;
+          }
+          else if (accession == "MS:1002954")
+          {
+            unit = DriftTimeUnit::CCS;
           }
 
           if (in_spectrum_list_)
@@ -2126,7 +2130,7 @@ namespace OpenMS::Internal
           //No member => meta data
           spec_.setMetaValue("dwell time", termValue);
         }
-        else if (accession == "MS:1002476" || accession == "MS:1002815" || accession == "MS:1001581") //ion mobility drift time or FAIMS compensation voltage
+        else if (accession == "MS:1002476" || accession == "MS:1002815" || accession == "MS:1001581" || accession == "MS:1002954") //ion mobility drift time, FAIMS CV, or CCS
         {
           // Drift time may be a property of the precursor (in case we are
           // acquiring a fragment ion spectrum) or of the spectrum itself.
@@ -2150,6 +2154,10 @@ namespace OpenMS::Internal
           else if (accession == "MS:1001581")
           {
             unit = DriftTimeUnit::FAIMS_COMPENSATION_VOLTAGE;
+          }
+          else if (accession == "MS:1002954")
+          {
+            unit = DriftTimeUnit::CCS;
           }
 
           spec_.setDriftTime(value.toDouble());
@@ -3873,6 +3881,10 @@ namespace OpenMS::Internal
               os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002815\" name=\"inverse reduced ion mobility\" value=\"" << precursor.getDriftTime()
                   << "\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\" unitCvRef=\"MS\" />\n";
               break;
+            case DriftTimeUnit::CCS:
+              os << "\t\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002954\" name=\"collisional cross sectional area\" value=\"" << precursor.getDriftTime()
+                  << "\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\" unitCvRef=\"UO\" />\n";
+              break;
           }
         }
         //userParam: no extra object for it => no user parameters
@@ -5212,6 +5224,11 @@ namespace OpenMS::Internal
             {
               os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002815\" name=\"inverse reduced ion mobility\" value=\"" << spec.getDriftTime()
                  << "\" unitAccession=\"MS:1002814\" unitName=\"volt-second per square centimeter\" unitCvRef=\"MS\" />\n";
+            }
+            else if (spec.getDriftTimeUnit() == DriftTimeUnit::CCS)
+            {
+              os << "\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002954\" name=\"collisional cross sectional area\" value=\"" << spec.getDriftTime()
+                 << "\" unitAccession=\"UO:0000324\" unitName=\"square angstrom\" unitCvRef=\"UO\" />\n";
             }
             else
             {

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -336,6 +336,10 @@ namespace OpenMS
       {
         unit = DriftTimeUnit::VSSC;
       }
+      else if (fda.getName().hasSubstring("MS:1002954"))
+      {
+        unit = DriftTimeUnit::CCS;
+      }
       else
       {
         unit = DriftTimeUnit::MILLISECOND;
@@ -355,6 +359,10 @@ namespace OpenMS
         else if (cv_term.units.find("UO:0000028") != cv_term.units.end())
         { // UO:0000028 ! millisecond
           unit = DriftTimeUnit::MILLISECOND;
+        }
+        else if (cv_term.units.find("UO:0000324") != cv_term.units.end())
+        { // UO:0000324 ! square angstrom (CCS)
+          unit = DriftTimeUnit::CCS;
         }
         else
         { // fallback

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -330,8 +330,9 @@ namespace OpenMS
   bool IMDataConverter::getIMUnit(const DataArrays::FloatDataArray& fda, DriftTimeUnit& unit)
   {
     const auto& cv = ControlledVocabulary::getPSIMSCV();
-    if (fda.getName().hasPrefix(Constants::UserParam::ION_MOBILITY))
-    { // fallback for non-standard IM arrays (as created by Mobi-DIK, or "Ion Mobility Centroid" from PeakPickerIM)
+    if (fda.getName().hasPrefix(Constants::UserParam::ION_MOBILITY) ||
+        fda.getName().hasPrefix(Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY))
+    { // fallback for non-standard IM arrays (as created by Mobi-DIK, "Ion Mobility Centroid" from PeakPickerIM, or "inverse reduced ion mobility" from MSConvert)
       if (fda.getName().hasSubstring("MS:1002815"))
       {
         unit = DriftTimeUnit::VSSC;

--- a/src/openms/source/IONMOBILITY/IMTypes.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypes.cpp
@@ -15,7 +15,7 @@
 namespace OpenMS
 {
 
-  const std::string NamesOfDriftTimeUnit[] = {"<NONE>", "ms", "1/K0", "FAIMS_CV"};
+  const std::string NamesOfDriftTimeUnit[] = {"<NONE>", "ms", "1/K0", "FAIMS_CV", "CCS"};
   const std::string NamesOfIMFormat[] = {"none", "concatenated", "multiple_spectra", "mixed", "centroided", "unknown"};
 
 
@@ -135,6 +135,8 @@ namespace OpenMS
         return DIM_UNIT::IM_MS;
       case DriftTimeUnit::VSSC:
         return DIM_UNIT::IM_VSSC;
+      case DriftTimeUnit::CCS:
+        return DIM_UNIT::IM_CCS;
       default:
         throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Cannot convert from " + driftTimeUnitToString(from) + " to a DIM_UNIT.");
     }

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -39,23 +39,6 @@ using namespace std;
 
 namespace OpenMS
 {
-    // Helper to warn once if CCS data is detected with small IM tolerances
-    static bool& getCCSWarningShown()
-    {
-      static bool shown = false;
-      return shown;
-    }
-
-    static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance, const String& param_name)
-    {
-      if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getCCSWarningShown())
-      {
-        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but " << param_name
-                        << " = " << im_tolerance << " appears to be set for 1/K0 data. "
-                        << "For CCS data, consider using larger values (e.g., 10-20 for clustering, 1.0 for summing)." << std::endl;
-        getCCSWarningShown() = true;
-      }
-    }
 
     double PeakPickerIM::computeOptimalSamplingRate(const vector<MSSpectrum>& spectra)
     {
@@ -254,8 +237,14 @@ namespace OpenMS
       const auto [im_data_index, im_unit] = raw_spectrum.getIMData();
       const auto& ion_mobility_array = raw_spectrum.getFloatDataArrays()[im_data_index];
 
-      // Warn if CCS data with small tolerance
-      warnIfCCSWithSmallTolerance(im_unit, sum_tolerance_im_, "sum_tolerance_im");
+      // Warn if CCS data with small tolerance (only once per PeakPickerIM instance)
+      if (im_unit == DriftTimeUnit::CCS && sum_tolerance_im_ < 1.0 && !ccs_warning_shown_)
+      {
+        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but sum_tolerance_im"
+                        << " = " << sum_tolerance_im_ << " appears to be set for 1/K0 data. "
+                        << "For CCS data, consider using larger values (e.g., 10-20 for clustering, 1.0 for summing)." << '\n';
+        ccs_warning_shown_ = true;
+      }
 
       // Vector of MSSpectra for each picked m/z peak (each spectrum is a mobilogram trace)
       vector<MSSpectrum> mobility_traces;
@@ -1011,8 +1000,14 @@ namespace OpenMS
       const auto [im_data_index, im_unit] = spectrum.getIMData();
       auto& im_data = spectrum.getFloatDataArrays()[im_data_index];
 
-      // Warn if CCS data with small tolerance
-      warnIfCCSWithSmallTolerance(im_unit, im_tolerance_cluster_, "im_tolerance_cluster");
+      // Warn if CCS data with small tolerance (only once per PeakPickerIM instance)
+      if (im_unit == DriftTimeUnit::CCS && im_tolerance_cluster_ < 1.0 && !ccs_warning_shown_)
+      {
+        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but im_tolerance_cluster"
+                        << " = " << im_tolerance_cluster_ << " appears to be set for 1/K0 data. "
+                        << "For CCS data, consider using larger values (e.g., 10-20 for clustering, 1.0 for summing)." << '\n';
+        ccs_warning_shown_ = true;
+      }
 
       struct Point {
         double mz;

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -679,13 +679,13 @@ namespace OpenMS
     {
       // --- PickIMTraces parameters ---
       defaults_.setValue("pickIMTraces:sum_tolerance_mz",        1.0,   "Tolerance for summing adjacent m/z peaks (ppm)");
-      defaults_.setValue("pickIMTraces:sum_tolerance_im",        0.0006,"Tolerance for summing adjacent ion mobility peaks (1/k0)");
+      defaults_.setValue("pickIMTraces:sum_tolerance_im",        0.0006,"Tolerance for summing adjacent ion mobility peaks (in 1/K0 units). For CCS data, use larger values (e.g., 1.0).");
       defaults_.setValue("pickIMTraces:gauss_ppm_tolerance",     5.0,   "Gaussian smoothing m/z tolerance in ppm");
       defaults_.setValue("pickIMTraces:sgolay_frame_length",     5,     "Savitzky-Golay smoothing frame length");
       defaults_.setValue("pickIMTraces:sgolay_polynomial_order", 3,     "Savitzky-Golay smoothing polynomial order");
       // --- PickIMCluster parameters ---
       defaults_.setValue("pickIMCluster:ppm_tolerance_cluster", 50.0, "m/z tolerance in ppm for clustering");
-      defaults_.setValue("pickIMCluster:im_tolerance_cluster", 0.1, "Ion mobility tolerance in 1/k for clustering");
+      defaults_.setValue("pickIMCluster:im_tolerance_cluster", 0.1, "Ion mobility tolerance for clustering (in 1/K0 units). For CCS data, use larger values (e.g., 10-20).");
       // --- PickIMElutionProfiles parameters ---
       defaults_.setValue("pickIMElutionProfiles:ppm_tolerance_elution", 50.0, "Mass trace m/z tolerance in ppm");
 

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/MATH/MISC/CubicSpline2d.h>
 #include <OpenMS/MATH/MISC/SplineBisection.h>
 #include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FEATUREFINDER/MassTraceDetection.h>
 #include <OpenMS/FEATUREFINDER/ElutionPeakDetection.h>
@@ -38,6 +39,24 @@ using namespace std;
 
 namespace OpenMS
 {
+    // Helper to warn once if CCS data is detected with small IM tolerances
+    static bool& getCCSWarningShown()
+    {
+      static bool shown = false;
+      return shown;
+    }
+
+    static void warnIfCCSWithSmallTolerance(DriftTimeUnit unit, double im_tolerance, const String& param_name)
+    {
+      if (unit == DriftTimeUnit::CCS && im_tolerance < 1.0 && !getCCSWarningShown())
+      {
+        OPENMS_LOG_WARN << "Warning: Ion mobility data is in CCS units (square angstroms), but " << param_name
+                        << " = " << im_tolerance << " appears to be set for 1/K0 data. "
+                        << "For CCS data, consider using larger values (e.g., 10-20 for clustering, 1.0 for summing)." << std::endl;
+        getCCSWarningShown() = true;
+      }
+    }
+
     double PeakPickerIM::computeOptimalSamplingRate(const vector<MSSpectrum>& spectra)
     {
       vector<double> mz_diffs;
@@ -234,6 +253,10 @@ namespace OpenMS
       }
       const auto [im_data_index, im_unit] = raw_spectrum.getIMData();
       const auto& ion_mobility_array = raw_spectrum.getFloatDataArrays()[im_data_index];
+
+      // Warn if CCS data with small tolerance
+      warnIfCCSWithSmallTolerance(im_unit, sum_tolerance_im_, "sum_tolerance_im");
+
       // Vector of MSSpectra for each picked m/z peak (each spectrum is a mobilogram trace)
       vector<MSSpectrum> mobility_traces;
 
@@ -988,6 +1011,8 @@ namespace OpenMS
       const auto [im_data_index, im_unit] = spectrum.getIMData();
       auto& im_data = spectrum.getFloatDataArrays()[im_data_index];
 
+      // Warn if CCS data with small tolerance
+      warnIfCCSWithSmallTolerance(im_unit, im_tolerance_cluster_, "im_tolerance_cluster");
 
       struct Point {
         double mz;

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -753,12 +753,12 @@ import numpy as np
     def get_drift_time_unit(self):
         """
         get_drift_time_unit(self: MSSpectrum) -> Optional[int]
-        
+
         Get the drift time unit for ion mobility data.
 
         Returns:
             int or None: The DriftTimeUnit enum value, or None if no IM data present.
-                        Values: 0=NONE, 1=MILLISECOND, 2=VSSC, 3=FAIMS_COMPENSATION_VOLTAGE
+                        Values: 0=NONE, 1=MILLISECOND, 2=VSSC, 3=FAIMS_COMPENSATION_VOLTAGE, 4=CCS
 
         Example:
             >>> unit = spectrum.get_drift_time_unit()

--- a/src/pyOpenMS/pxds/IMTypes.pxd
+++ b/src/pyOpenMS/pxds/IMTypes.pxd
@@ -16,10 +16,11 @@ cdef extern from "<OpenMS/IONMOBILITY/IMTypes.h>" namespace "OpenMS":
 cdef extern from "<OpenMS/IONMOBILITY/IMTypes.h>" namespace "OpenMS":
 
     cdef enum DriftTimeUnit:
-        NONE,                      
-        MILLISECOND,               
-        VSSC,                      
+        NONE,
+        MILLISECOND,
+        VSSC,
         FAIMS_COMPENSATION_VOLTAGE,
+        CCS,
         SIZE_OF_DRIFTTIMEUNIT
 
     cdef enum IMFormat:

--- a/src/tests/topp/MassTraceExtractor_3_expected.ini
+++ b/src/tests/topp/MassTraceExtractor_3_expected.ini
@@ -20,7 +20,7 @@
         </NODE>
         <NODE name="mtd" description="">
           <ITEM name="mass_error_ppm" value="20.0" type="double" description="Allowed mass deviation (in ppm)." required="false" advanced="false" />
-          <ITEM name="ion_mobility_tolerance" value="0.01" type="double" description="Allowed ion mobility deviation (in 1/k0)." required="false" advanced="false" />
+          <ITEM name="ion_mobility_tolerance" value="0.01" type="double" description="Allowed ion mobility deviation (in 1/K0 units, e.g., 0.01-0.05). For CCS data, use larger values (e.g., 2-10 square angstroms)." required="false" advanced="false" />
           <ITEM name="reestimate_mt_sd" value="true" type="string" description="Enables dynamic re-estimation of m/z variance during mass trace collection stage." required="false" advanced="false" restrictions="true,false" />
           <ITEM name="quant_method" value="area" type="string" description="Method of quantification for mass traces. For LC data &apos;area&apos; is recommended, &apos;median&apos; for direct injection data. &apos;max_height&apos; simply uses the most intense peak in the trace." required="false" advanced="false" restrictions="area,median,max_height" />
           <ITEM name="trace_termination_criterion" value="outlier" type="string" description="Termination criterion for the extension of mass traces. In &apos;outlier&apos; mode, trace extension cancels if a predefined number of consecutive outliers are found (see trace_termination_outliers parameter). In &apos;sample_rate&apos; mode, trace extension in both directions stops if ratio of found peaks versus visited spectra falls below the &apos;min_sample_rate&apos; threshold." required="false" advanced="true" restrictions="outlier,sample_rate" />

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -5193,10 +5193,14 @@ static void scoreXLIons_(
       data_dependent_features << "IM";
     }
 
-    // convert 1/k0 to CCS
+    // convert 1/k0 to CCS (skip if already CCS from newer MSConvert)
     if (IM_unit == DriftTimeUnit::VSSC)
-    {      
+    {
       convertVSSCToCCS(spectra);
+    }
+    else if (IM_unit == DriftTimeUnit::CCS)
+    {
+      OPENMS_LOG_INFO << "Ion Mobility already in CCS format, no conversion needed." << std::endl;
     }
 
     // all data dependent features (IM available or not, precursor intensities from MS1 available etc.) are known. We can define percolator features.
@@ -5955,14 +5959,15 @@ static void scoreXLIons_(
     // reload spectra from disc with same settings as before (important to keep same spectrum indices)
     spectra.clear(true);
     f.load(in_mzml, spectra);
-    spectra.sortSpectra(true);    
+    spectra.sortSpectra(true);
     //auto [IM_format, IM_unit] = getMS2IMType(spectra);
 
-    // convert 1/k0 to CCS
+    // convert 1/k0 to CCS (skip if already CCS from newer MSConvert)
     if (IM_unit == DriftTimeUnit::VSSC)
-    {      
+    {
       convertVSSCToCCS(spectra);
     }
+    // Note: if IM_unit == DriftTimeUnit::CCS, data is already in correct format
 
     preprocessSpectra_(spectra, 
     //                   fragment_mass_tolerance, 

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -4602,6 +4602,7 @@ static void scoreXLIons_(
       const double reduced_mass = mass * IM_N2_gas_mass / (mass + IM_N2_gas_mass);
       const double CCS = IM * charge * bruker_CCS_coef / std::sqrt(reduced_mass); // Mason-Schamp equation
       s.setDriftTime(CCS);
+      s.setDriftTimeUnit(DriftTimeUnit::CCS);
     }
   }
 

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -265,7 +265,7 @@ protected:
     registerDoubleOption_("rt_extraction_window", "<double>", 600.0, "Only extract RT around this value (-1 means extract over the whole range, a value of 600 means to extract around +/- 300 s of the expected elution).", false);
     registerDoubleOption_("extra_rt_extraction_window", "<double>", 0.0, "Output an XIC with a RT-window by this much larger (e.g. to visually inspect a larger area of the chromatogram)", false, true);
     setMinFloat_("extra_rt_extraction_window", 0.0);
-    registerDoubleOption_("ion_mobility_window", "<double>", -1, "Extraction window in ion mobility dimension (in 1/k0 or milliseconds depending on library). This is the full window size, e.g. a value of 10 milliseconds would extract 5 milliseconds on either side. -1 means extract over the whole range or ion mobility is not present. (Default for diaPASEF data: 0.06 1/k0)", false);
+    registerDoubleOption_("ion_mobility_window", "<double>", -1, "Extraction window in ion mobility dimension (in 1/K0, milliseconds, or CCS depending on library). This is the full window size, e.g. a value of 10 milliseconds would extract 5 milliseconds on either side. -1 means extract over the whole range or ion mobility is not present. (Default for diaPASEF data: 0.06 1/K0, or ~10 CCS)", false);
     registerDoubleOption_("mz_extraction_window", "<double>", 50, "Extraction window in Thomson or ppm (see mz_extraction_window_unit)", false);
     setMinFloat_("mz_extraction_window", 0.0);
     registerStringOption_("mz_extraction_window_unit", "<name>", "ppm", "Unit for mz extraction", false, true);
@@ -276,7 +276,7 @@ protected:
     setMinFloat_("mz_extraction_window_ms1", 0.0);
     registerStringOption_("mz_extraction_window_ms1_unit", "<name>", "ppm", "Unit of the MS1 m/z extraction window", false, true);
     setValidStrings_("mz_extraction_window_ms1_unit", ListUtils::create<String>("ppm,Th"));
-    registerDoubleOption_("im_extraction_window_ms1", "<double>", -1, "Extraction window in ion mobility dimension for MS1 (in 1/k0 or milliseconds depending on library). -1 means this is not ion mobility data.", false);
+    registerDoubleOption_("im_extraction_window_ms1", "<double>", -1, "Extraction window in ion mobility dimension for MS1 (in 1/K0, milliseconds, or CCS depending on library). -1 means this is not ion mobility data.", false);
 
     registerStringOption_("use_ms1_ion_mobility", "<name>", "true", "Also perform precursor extraction using the same ion mobility window as for fragment ion extraction", false, true);
     setValidStrings_("use_ms1_ion_mobility", ListUtils::create<String>("true,false"));
@@ -289,7 +289,7 @@ protected:
     setMinFloat_("irt_mz_extraction_window", 0.0);
     registerStringOption_("irt_mz_extraction_window_unit", "<name>", "ppm", "Unit for mz extraction", false, true);
     setValidStrings_("irt_mz_extraction_window_unit", ListUtils::create<String>("Th,ppm"));
-    registerDoubleOption_("irt_im_extraction_window", "<double>", -1, "Ion mobility extraction window used for iRT (in 1/K0 or milliseconds depending on library). -1 means do not perform ion mobility calibration", false, true);
+    registerDoubleOption_("irt_im_extraction_window", "<double>", -1, "Ion mobility extraction window used for iRT (in 1/K0, milliseconds, or CCS depending on library). -1 means do not perform ion mobility calibration", false, true);
     registerDoubleOption_("irt_nonlinear_rt_extraction_window", "<double>", 600.0, "Only extract RT around this value for non linear iRT calibration (-1 means extract over the whole range, a value of 600 means to extract around +/- 300 s of the expected elution).", false, true);
     setMinFloat_("irt_nonlinear_rt_extraction_window", -1.0); // means extract over the whole range
 


### PR DESCRIPTION
ProteoWizard/MSConvert v3.0.26007+ changed ion mobility representation
from 1/K0 (MS:1002815) to CCS (MS:1002954). This breaks NuXL and other
tools that rely on ion mobility data from mzML files.

Changes:
- Add CCS to DriftTimeUnit enum (IMTypes.h)
- Add IM_CCS to DIM_UNIT enum (CommonEnums.h)
- Parse MS:1002954 (CCS) in mzML reader (MzMLHandler.cpp)
- Write CCS values back to mzML with correct CV terms
- Update IMDataConverter to recognize CCS from CV terms
- Skip CCS conversion in NuXL when data is already CCS
- Make IonMobilityScoring epsilon scale-invariant for CCS compatibility
- Update parameter documentation to mention CCS units
- Add CCS to Python bindings (IMTypes.pxd, MSSpectrum.pyx)

Fixes: #8732

(cherry picked from commit 757e57b16f84eb1b7a527479f24c8091e2398945)

https://claude.ai/code/session_01MiYNbe4sAxvwNYk4eoPLKu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Collisional Cross Section (CCS) as a recognized ion-mobility/drift-time unit (read, store, write, convert).

* **User-facing behavior**
  * One-time warnings now alert when CCS data is used with unusually small IM tolerances to avoid misconfiguration.
  * Ion-mobility scoring now uses a scale-aware threshold, which may affect IM matching behavior.

* **Documentation**
  * Updated parameter/help text and examples to describe CCS units and recommended tolerances.

* **Chores**
  * Added a user parameter key for inverse reduced ion mobility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->