### PR TITLE
[pyOpenMS] Add Python bindings for XICParquetFile

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,6 +88,7 @@ PyOpenMS:
     - PEFFDatabaseMetadata for header information
     - Conversion methods: toFASTAEntry(), fromFASTAEntry(), toProForma()
     - Sequence accessors: getSequence(), getModifiedSequence(), getVariantSequences(), getProcessedSequence()
+  - XICParquetFile: Python bindings with multi-file support and filtering for reading XIC data from Parquet files (#8725)
 
 TOPP tools:
   Changes:

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -58,6 +58,11 @@ else()
   if(NOT TARGET OpenMS)
     # Standalone build - find installed/built OpenMS
     find_package(OpenMS REQUIRED)
+    # pyOpenMS builds its own Arrow-based modules (arrow_zerocopy, parquet_filter)
+    # when WITH_PARQUET is enabled, so it needs Arrow targets directly.
+    if(WITH_PARQUET)
+      find_package(Arrow QUIET)
+    endif()
     # TODO the following is just a fallback.
     # CF_OPENMS_PACKAGE_VERSION is what is written into pyopenms/_version.py
     # which is the old way of getting the version.
@@ -210,8 +215,11 @@ else()
   # Convert CMake boolean to Python boolean for env.py
   if(WITH_PARQUET)
     set(_PY_WITH_PARQUET "True")
+    message(STATUS "pyOpenMS: WITH_PARQUET=ON, including Parquet-related bindings")
+    message(STATUS "pyOpenMS: OPENMS_ARROW_TARGET=${OPENMS_ARROW_TARGET}")
   else()
     set(_PY_WITH_PARQUET "False")
+    message(STATUS "pyOpenMS: WITH_PARQUET=OFF, excluding Parquet-related bindings")
   endif()
 
   file(WRITE ${PYOPENMS_BUILD_DIR}/env.py
@@ -257,8 +265,11 @@ WITH_PARQUET = ${_PY_WITH_PARQUET}
   #------------------------------------------------------------------------------
   set(PYGEN_SENTINEL "${PYOPENMS_BUILD_DIR}/.cpp_extension_generated")
 
+  # Note: All generated outputs must be listed in a single add_custom_command.
+  # Using a separate add_custom_command with DEPENDS but no COMMAND breaks on
+  # Windows/MSBuild, which generates empty .rule files that never produce outputs.
   add_custom_command(
-    OUTPUT ${PYGEN_SENTINEL}
+    OUTPUT ${PYGEN_SENTINEL} ${PYCPPFILES} ${PYPYXFILES} ${PYGEN_EXTRA_FILES}
     # Fake dependency on OpenMS to trigger rebuild when headers change
     # TODO: Should depend on .pxd files instead for more accurate rebuilds
     DEPENDS OpenMS
@@ -267,12 +278,6 @@ WITH_PARQUET = ${_PY_WITH_PARQUET}
     COMMENT "Creating C++ extension with autowrap and Cython"
     WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
     USES_TERMINAL
-  )
-
-  add_custom_command(
-    OUTPUT ${PYCPPFILES} ${PYPYXFILES} ${PYGEN_EXTRA_FILES}
-    DEPENDS ${PYGEN_SENTINEL}
-    COMMENT "Generated files depend on successful code generation"
   )
 
   add_custom_target(compile_pxds DEPENDS ${PYCPPFILES} ${PYPYXFILES})
@@ -432,6 +437,73 @@ WITH_PARQUET = ${_PY_WITH_PARQUET}
       LIBRARY DESTINATION pyopenms
       RUNTIME DESTINATION pyopenms
     )
+
+    #------------------------------------------------------------------------------
+    # Parquet filter builder module (only when WITH_PARQUET is enabled)
+    #------------------------------------------------------------------------------
+    if(WITH_PARQUET)
+      message(STATUS "Building Parquet filter builder module for pyOpenMS")
+
+      configure_file(
+        ${PROJECT_SOURCE_DIR}/pyopenms/_parquet_filter.pyx
+        ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.pyx
+        COPYONLY
+      )
+      configure_file(
+        ${PROJECT_SOURCE_DIR}/pyopenms/_parquet_filter.pxd
+        ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.pxd
+        COPYONLY
+      )
+
+      add_custom_command(
+        OUTPUT ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.cpp
+        COMMAND ${Python_EXECUTABLE} -m cython --cplus
+          ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.pyx
+          -o ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.cpp
+        DEPENDS ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.pyx
+                ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.pxd
+        COMMENT "Cythonizing _parquet_filter.pyx"
+        WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
+      )
+
+      Python_add_library(parquet_filter MODULE
+        ${PYOPENMS_BUILD_DIR}/pyopenms/_parquet_filter.cpp
+        WITH_SOABI
+      )
+      target_link_libraries(parquet_filter PRIVATE OpenMS)
+      target_compile_definitions(parquet_filter PRIVATE
+        WITH_PARQUET=1
+      )
+      target_include_directories(parquet_filter SYSTEM PRIVATE
+        ${AUTOWRAP_INCLUDE_DIR}
+        ${PYOPENMS_BUILD_DIR}/extra_includes
+      )
+      target_compile_options(parquet_filter PRIVATE ${EXTRA_WARNINGS})
+      set_target_properties(parquet_filter PROPERTIES
+        OUTPUT_NAME _parquet_filter
+        LIBRARY_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms"
+        RUNTIME_OUTPUT_DIRECTORY "${PYOPENMS_BUILD_DIR}/pyopenms"
+      )
+      if(NOT PYOPENMS_PREPARE_WHEEL_REPAIR)
+        set_target_properties(parquet_filter PROPERTIES
+          INSTALL_RPATH "${PY_RPATH}"
+          BUILD_WITH_INSTALL_RPATH 1
+          BUILD_WITH_INSTALL_NAME_DIR 1
+        )
+      else()
+        set_target_properties(parquet_filter PROPERTIES
+          INSTALL_RPATH_USE_LINK_PATH TRUE
+          INSTALL_NAME_DIR ""
+        )
+      endif()
+      add_dependencies(parquet_filter compile_pxds)
+
+      install(TARGETS parquet_filter
+        COMPONENT python_modules
+        LIBRARY DESTINATION pyopenms
+        RUNTIME DESTINATION pyopenms
+      )
+    endif()
   endif()
 
   #------------------------------------------------------------------------------

--- a/src/pyOpenMS/addons/XICParquetFile.pyx
+++ b/src/pyOpenMS/addons/XICParquetFile.pyx
@@ -1,0 +1,604 @@
+from libcpp.vector cimport vector as libcpp_vector
+from libc.stdint cimport int64_t
+from cython.operator cimport dereference as deref
+from String cimport String
+from StringList cimport StringList
+from XICParquetFile cimport XICChromatogram as _XICChromatogram
+from XICParquetFile cimport XICAnalyte as _XICAnalyte
+from XICParquetFile cimport XICRunInfo as _XICRunInfo
+from ParquetFilter cimport ParquetFilterBuilder as _CppParquetFilterBuilder
+from pyopenms._parquet_filter cimport ParquetFilterBuilder as _PyParquetFilterBuilder
+from ._pyopenms_1 cimport convString, convOutputString
+import numpy as np
+
+
+    def __init__(self, filename):
+        """
+        __init__(self, filename: Union[str, bytes, String, List[Union[str, bytes, String]]]) -> None
+
+        Initialize from a single filename or a list/tuple of filenames.
+
+        :param filename: Path to a .xic file or a list/tuple of paths.
+        :type filename: Union[str, bytes, String, List[Union[str, bytes, String]]]
+
+        Example::
+
+            xic = XICParquetFile("file.xic")
+            xic_multi = XICParquetFile(["file1.xic", "file2.xic"])
+        """
+        filenames = None
+        if isinstance(filename, (str, bytes, String)):
+            self._init_0(filename)
+            return
+        if isinstance(filename, (list, tuple)):
+            filenames = []
+            for entry in filename:
+                if isinstance(entry, bytes):
+                    filenames.append(entry)
+                elif isinstance(entry, str):
+                    filenames.append(entry.encode())
+                elif isinstance(entry, String):
+                    filenames.append(str(entry).encode())
+                else:
+                    raise TypeError("filenames must be str/bytes/String")
+            self._init_1(filenames)
+            return
+        raise TypeError("filename must be str/bytes/String or a list/tuple of those")
+
+    def __len__(self):
+        """
+        __len__(self: XICParquetFile) -> int
+
+        Return the number of files associated with this instance.
+        """
+        try:
+            return len(self.getFilenames())
+        except Exception:
+            return 0
+
+    def __repr__(self):
+        """
+        __repr__(self: XICParquetFile) -> str
+
+        Return a detailed string representation.
+        """
+        try:
+            files = self.getFilenames()
+            files = [f.decode() if isinstance(f, (bytes, bytearray)) else str(f) for f in files]
+            return "XICParquetFile(n_files=%d, files=%r)" % (len(files), files)
+        except Exception:
+            return "XICParquetFile(<unavailable>)"
+
+    def __str__(self):
+        """
+        __str__(self: XICParquetFile) -> str
+        
+        Return a concise string representation.
+        """
+        try:
+            return "XICParquetFile(n_files=%d)" % len(self.getFilenames())
+        except Exception:
+            return "XICParquetFile(n_files=?)"
+
+    def get_data_dict(self, explode=False, precursor_id=-1, transition_id=-1, modified_sequence="", precursor_charge=-1,
+                      product_charge=-1, ms_level=-1, run_id=-1, filter=""):
+        """
+        get_data_dict(self, explode: bool = False, precursor_id: int = -1, transition_id: int = -1,
+                      modified_sequence: str = "", precursor_charge: int = -1, product_charge: int = -1,
+                      ms_level: int = -1, run_id: int = -1, filter: str = "") -> Dict[str, np.ndarray]
+
+        Return chromatogram data as a dict of numpy arrays.
+
+        If explode=True, returns long format with rt/intensity rows.
+        Otherwise, rt and intensity are stored as object arrays of lists.
+
+        :param explode: If True, return long format with one row per RT/intensity.
+        :type explode: bool
+        :param precursor_id: Optional precursor id (-1 to ignore).
+        :type precursor_id: int
+        :param transition_id: Optional transition id (-1 to ignore).
+        :type transition_id: int
+        :param modified_sequence: Optional modified sequence filter (empty to ignore).
+        :type modified_sequence: str
+        :param precursor_charge: Optional precursor charge filter (-1 to ignore).
+        :type precursor_charge: int
+        :param product_charge: Optional product charge filter (-1 to ignore).
+        :type product_charge: int
+        :param ms_level: Optional MS level filter (-1 to ignore).
+        :type ms_level: int
+        :param run_id: Optional run id filter (-1 to ignore).
+        :type run_id: int
+        :param filter: Optional filter expression string.
+        :type filter: str
+
+        :return: Dict of numpy arrays keyed by column name.
+        :rtype: Dict[str, np.ndarray]
+
+        Example::
+
+            data = xic.get_data_dict(precursor_id=1318, explode=True)
+        """
+        cdef libcpp_vector[_XICChromatogram] chroms
+        self.inst.get().getChromatograms(chroms,
+                                         <int64_t>precursor_id,
+                                         <int64_t>transition_id,
+                                         deref((convString(modified_sequence)).get()),
+                                         <int64_t>precursor_charge,
+                                         <int64_t>product_charge,
+                                         <int64_t>ms_level,
+                                         <int64_t>run_id,
+                                         deref((convString(filter)).get()))
+
+        cdef list run_id_list = []
+        cdef list source_file_list = []
+        cdef list ms_level_list = []
+        cdef list precursor_id_list = []
+        cdef list transition_id_list = []
+        cdef list modified_sequence_list = []
+        cdef list precursor_charge_list = []
+        cdef list product_charge_list = []
+        cdef list detecting_transition_list = []
+        cdef list precursor_decoy_list = []
+        cdef list product_decoy_list = []
+        cdef list transition_ordinal_list = []
+        cdef list transition_type_list = []
+        cdef list annotation_list = []
+        cdef list rt_list = []
+        cdef list intensity_list = []
+
+        cdef size_t i, j
+        cdef _XICChromatogram chrom
+        for i in range(chroms.size()):
+            chrom = chroms[i]
+            if explode:
+                if chrom.rt.size() == 0:
+                    continue
+                for j in range(chrom.rt.size()):
+                    run_id_list.append(chrom.run_id)
+                    source_file_list.append(convOutputString(chrom.source_file))
+                    ms_level_list.append(chrom.ms_level)
+                    precursor_id_list.append(chrom.precursor_id if chrom.has_precursor_id else None)
+                    transition_id_list.append(chrom.transition_id if chrom.has_transition_id else None)
+                    modified_sequence_list.append(convOutputString(chrom.modified_sequence))
+                    precursor_charge_list.append(chrom.precursor_charge if chrom.has_precursor_charge else None)
+                    product_charge_list.append(chrom.product_charge if chrom.has_product_charge else None)
+                    detecting_transition_list.append(chrom.detecting_transition if chrom.has_detecting_transition else None)
+                    precursor_decoy_list.append(chrom.precursor_decoy if chrom.has_precursor_decoy else None)
+                    product_decoy_list.append(chrom.product_decoy if chrom.has_product_decoy else None)
+                    transition_ordinal_list.append(chrom.transition_ordinal if chrom.has_transition_ordinal else None)
+                    transition_type_list.append(convOutputString(chrom.transition_type))
+                    annotation_list.append(convOutputString(chrom.annotation))
+                    rt_list.append(chrom.rt[j])
+                    intensity_list.append(chrom.intensity[j])
+            else:
+                run_id_list.append(chrom.run_id)
+                source_file_list.append(convOutputString(chrom.source_file))
+                ms_level_list.append(chrom.ms_level)
+                precursor_id_list.append(chrom.precursor_id if chrom.has_precursor_id else None)
+                transition_id_list.append(chrom.transition_id if chrom.has_transition_id else None)
+                modified_sequence_list.append(convOutputString(chrom.modified_sequence))
+                precursor_charge_list.append(chrom.precursor_charge if chrom.has_precursor_charge else None)
+                product_charge_list.append(chrom.product_charge if chrom.has_product_charge else None)
+                detecting_transition_list.append(chrom.detecting_transition if chrom.has_detecting_transition else None)
+                precursor_decoy_list.append(chrom.precursor_decoy if chrom.has_precursor_decoy else None)
+                product_decoy_list.append(chrom.product_decoy if chrom.has_product_decoy else None)
+                transition_ordinal_list.append(chrom.transition_ordinal if chrom.has_transition_ordinal else None)
+                transition_type_list.append(convOutputString(chrom.transition_type))
+                annotation_list.append(convOutputString(chrom.annotation))
+                rt_list.append([chrom.rt[k] for k in range(chrom.rt.size())])
+                intensity_list.append([chrom.intensity[k] for k in range(chrom.intensity.size())])
+
+        return {
+            "run_id": np.array(run_id_list, dtype=np.int64),
+            "source_file": np.array(source_file_list, dtype=object),
+            "ms_level": np.array(ms_level_list, dtype=np.int64),
+            "precursor_id": np.array(precursor_id_list, dtype=object),
+            "transition_id": np.array(transition_id_list, dtype=object),
+            "modified_sequence": np.array(modified_sequence_list, dtype=object),
+            "precursor_charge": np.array(precursor_charge_list, dtype=object),
+            "product_charge": np.array(product_charge_list, dtype=object),
+            "detecting_transition": np.array(detecting_transition_list, dtype=object),
+            "precursor_decoy": np.array(precursor_decoy_list, dtype=object),
+            "product_decoy": np.array(product_decoy_list, dtype=object),
+            "transition_ordinal": np.array(transition_ordinal_list, dtype=object),
+            "transition_type": np.array(transition_type_list, dtype=object),
+            "annotation": np.array(annotation_list, dtype=object),
+            "rt": np.array(rt_list, dtype=object),
+            "intensity": np.array(intensity_list, dtype=object),
+        }
+
+    def _get_data_dict_from_parquet_filter(self, parquet_filter, explode=False):
+        """
+        Internal helper to fetch chromatograms using a typed ParquetFilter.
+        """
+        if parquet_filter is None:
+            return self.get_data_dict(explode=explode)
+        cdef libcpp_vector[_XICChromatogram] chroms
+        # Cast the pointer from the standalone module's type to the pxd-declared type
+        # Both refer to the same C++ class (OpenMS::ParquetFilterBuilder)
+        cdef _CppParquetFilterBuilder* cpp_filter = <_CppParquetFilterBuilder*>(
+            (<_PyParquetFilterBuilder>parquet_filter).inst.get()
+        )
+        self.inst.get().getChromatograms(chroms, deref(cpp_filter))
+
+        cdef list run_id_list = []
+        cdef list source_file_list = []
+        cdef list ms_level_list = []
+        cdef list precursor_id_list = []
+        cdef list transition_id_list = []
+        cdef list modified_sequence_list = []
+        cdef list precursor_charge_list = []
+        cdef list product_charge_list = []
+        cdef list detecting_transition_list = []
+        cdef list precursor_decoy_list = []
+        cdef list product_decoy_list = []
+        cdef list transition_ordinal_list = []
+        cdef list transition_type_list = []
+        cdef list annotation_list = []
+        cdef list rt_list = []
+        cdef list intensity_list = []
+
+        cdef size_t i, j
+        cdef _XICChromatogram chrom
+        for i in range(chroms.size()):
+            chrom = chroms[i]
+            if explode:
+                if chrom.rt.size() == 0:
+                    continue
+                for j in range(chrom.rt.size()):
+                    run_id_list.append(chrom.run_id)
+                    source_file_list.append(convOutputString(chrom.source_file))
+                    ms_level_list.append(chrom.ms_level)
+                    precursor_id_list.append(chrom.precursor_id if chrom.has_precursor_id else None)
+                    transition_id_list.append(chrom.transition_id if chrom.has_transition_id else None)
+                    modified_sequence_list.append(convOutputString(chrom.modified_sequence))
+                    precursor_charge_list.append(chrom.precursor_charge if chrom.has_precursor_charge else None)
+                    product_charge_list.append(chrom.product_charge if chrom.has_product_charge else None)
+                    detecting_transition_list.append(chrom.detecting_transition if chrom.has_detecting_transition else None)
+                    precursor_decoy_list.append(chrom.precursor_decoy if chrom.has_precursor_decoy else None)
+                    product_decoy_list.append(chrom.product_decoy if chrom.has_product_decoy else None)
+                    transition_ordinal_list.append(chrom.transition_ordinal if chrom.has_transition_ordinal else None)
+                    transition_type_list.append(convOutputString(chrom.transition_type))
+                    annotation_list.append(convOutputString(chrom.annotation))
+                    rt_list.append(chrom.rt[j])
+                    intensity_list.append(chrom.intensity[j])
+            else:
+                run_id_list.append(chrom.run_id)
+                source_file_list.append(convOutputString(chrom.source_file))
+                ms_level_list.append(chrom.ms_level)
+                precursor_id_list.append(chrom.precursor_id if chrom.has_precursor_id else None)
+                transition_id_list.append(chrom.transition_id if chrom.has_transition_id else None)
+                modified_sequence_list.append(convOutputString(chrom.modified_sequence))
+                precursor_charge_list.append(chrom.precursor_charge if chrom.has_precursor_charge else None)
+                product_charge_list.append(chrom.product_charge if chrom.has_product_charge else None)
+                detecting_transition_list.append(chrom.detecting_transition if chrom.has_detecting_transition else None)
+                precursor_decoy_list.append(chrom.precursor_decoy if chrom.has_precursor_decoy else None)
+                product_decoy_list.append(chrom.product_decoy if chrom.has_product_decoy else None)
+                transition_ordinal_list.append(chrom.transition_ordinal if chrom.has_transition_ordinal else None)
+                transition_type_list.append(convOutputString(chrom.transition_type))
+                annotation_list.append(convOutputString(chrom.annotation))
+                rt_list.append([chrom.rt[k] for k in range(chrom.rt.size())])
+                intensity_list.append([chrom.intensity[k] for k in range(chrom.intensity.size())])
+
+        return {
+            "run_id": np.array(run_id_list, dtype=np.int64),
+            "source_file": np.array(source_file_list, dtype=object),
+            "ms_level": np.array(ms_level_list, dtype=np.int64),
+            "precursor_id": np.array(precursor_id_list, dtype=object),
+            "transition_id": np.array(transition_id_list, dtype=object),
+            "modified_sequence": np.array(modified_sequence_list, dtype=object),
+            "precursor_charge": np.array(precursor_charge_list, dtype=object),
+            "product_charge": np.array(product_charge_list, dtype=object),
+            "detecting_transition": np.array(detecting_transition_list, dtype=object),
+            "precursor_decoy": np.array(precursor_decoy_list, dtype=object),
+            "product_decoy": np.array(product_decoy_list, dtype=object),
+            "transition_ordinal": np.array(transition_ordinal_list, dtype=object),
+            "transition_type": np.array(transition_type_list, dtype=object),
+            "annotation": np.array(annotation_list, dtype=object),
+            "rt": np.array(rt_list, dtype=object),
+            "intensity": np.array(intensity_list, dtype=object),
+        }
+
+    def to_df(self, explode=False):
+        """
+        to_df(self, explode: bool = False) -> pandas.DataFrame
+
+        Return chromatogram data as a pandas DataFrame.
+
+        If explode=True, returns long format with rt/intensity rows.
+
+        :param explode: If True, return long format with one row per RT/intensity.
+        :type explode: bool
+
+        :return: DataFrame with chromatogram data.
+        :rtype: pandas.DataFrame
+
+        :raises ImportError: If pandas is not installed
+
+        Example::
+
+            df = xic.to_df()
+            df_long = xic.to_df(explode=True)
+        """
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise ImportError("pandas is required for this method. Install with `pip install pandas`.") from e
+        data = self.get_data_dict(explode=explode)
+        if explode:
+            return pd.DataFrame(data)
+        # Convert to plain Python lists to avoid pandas inferring 2D arrays.
+        clean = {}
+        for k, v in data.items():
+            if hasattr(v, "ndim") and v.ndim > 1:
+                clean[k] = [row for row in v]
+            else:
+                clean[k] = list(v)
+        return pd.DataFrame(clean)
+
+    def get_analyte_dict(self, nest_transitions=True, columns=None):
+        """
+        get_analyte_dict(self, nest_transitions: bool = True,
+                         columns: Optional[List[str]] = None) -> Dict[str, np.ndarray]
+
+        Return unique analyte metadata as a dict of numpy arrays.
+
+        If nest_transitions=False, each row represents a unique precursor-transition
+        pair with scalar transition fields. If nest_transitions=True, each row
+        represents a unique precursor and transition fields are lists.
+
+        :param nest_transitions: Aggregate transition fields per precursor.
+        :type nest_transitions: bool
+        :param columns: Optional list of column names to return. If None,
+                        uses the default analyte columns.
+        :type columns: Optional[List[str]]
+
+        :return: Dict of numpy arrays keyed by column name.
+        :rtype: Dict[str, np.ndarray]
+
+        Example::
+
+            analytes = xic.get_analyte_dict()
+            analytes_nested = xic.get_analyte_dict(nest_transitions=True)
+            analytes_subset = xic.get_analyte_dict(columns=["precursor_id", "modified_sequence"])
+        """
+        cdef libcpp_vector[_XICAnalyte] analytes
+        cdef StringList cols_cpp
+        cdef list cols_norm = []
+        cdef object s
+        if columns is not None:
+            if not isinstance(columns, (list, tuple)):
+                raise TypeError("columns must be a list/tuple of str/bytes/String")
+            for entry in columns:
+                if isinstance(entry, bytes):
+                    s = entry.decode()
+                    cols_norm.append(s.lower())
+                elif isinstance(entry, str):
+                    s = entry
+                    cols_norm.append(s.lower())
+                elif isinstance(entry, String):
+                    s = str(entry)
+                    cols_norm.append(s.lower())
+                else:
+                    raise TypeError("columns must be str/bytes/String")
+                cols_cpp.push_back(deref((convString(s)).get()))
+        self.inst.get().getAnalytes(analytes, cols_cpp, <bint>nest_transitions)
+
+        cdef list precursor_id_list = []
+        cdef list modified_sequence_list = []
+        cdef list precursor_charge_list = []
+        cdef list precursor_decoy_list = []
+        cdef list transition_id_list = []
+        cdef list product_charge_list = []
+        cdef list transition_ordinal_list = []
+        cdef list detecting_transition_list = []
+        cdef list product_decoy_list = []
+        cdef list transition_type_list = []
+        cdef list annotation_list = []
+
+        cdef size_t i, j
+        cdef list t_ids = []
+        cdef list p_charges = []
+        cdef list t_ordinals = []
+        cdef list d_transitions = []
+        cdef list p_decoys = []
+        cdef list t_types = []
+        cdef list annots = []
+        cdef _XICAnalyte analyte
+        for i in range(analytes.size()):
+            analyte = analytes[i]
+            precursor_id_list.append(analyte.precursor_id if analyte.has_precursor_id else None)
+            modified_sequence_list.append(convOutputString(analyte.modified_sequence))
+            precursor_charge_list.append(analyte.precursor_charge if analyte.has_precursor_charge else None)
+            precursor_decoy_list.append(analyte.precursor_decoy if analyte.has_precursor_decoy else None)
+
+            if not nest_transitions:
+                transition_id_list.append(analyte.transition_id if analyte.has_transition_id else None)
+                product_charge_list.append(analyte.product_charge if analyte.has_product_charge else None)
+                transition_ordinal_list.append(analyte.transition_ordinal if analyte.has_transition_ordinal else None)
+                detecting_transition_list.append(analyte.detecting_transition if analyte.has_detecting_transition else None)
+                product_decoy_list.append(analyte.product_decoy if analyte.has_product_decoy else None)
+                transition_type_list.append(convOutputString(analyte.transition_type))
+                annotation_list.append(convOutputString(analyte.annotation))
+            else:
+                t_ids = []
+                p_charges = []
+                t_ordinals = []
+                d_transitions = []
+                p_decoys = []
+                t_types = []
+                annots = []
+                for j in range(analyte.transition_ids.size()):
+                    t_ids.append(analyte.transition_ids[j] if analyte.transition_ids[j] >= 0 else None)
+                for j in range(analyte.product_charges.size()):
+                    p_charges.append(analyte.product_charges[j] if analyte.product_charges[j] >= 0 else None)
+                for j in range(analyte.transition_ordinals.size()):
+                    t_ordinals.append(analyte.transition_ordinals[j] if analyte.transition_ordinals[j] >= 0 else None)
+                for j in range(analyte.detecting_transitions.size()):
+                    d_transitions.append(analyte.detecting_transitions[j] if analyte.detecting_transitions[j] >= 0 else None)
+                for j in range(analyte.product_decoys.size()):
+                    p_decoys.append(analyte.product_decoys[j] if analyte.product_decoys[j] >= 0 else None)
+                for j in range(analyte.transition_types.size()):
+                    t_types.append(convOutputString(analyte.transition_types[j]))
+                for j in range(analyte.annotations.size()):
+                    annots.append(convOutputString(analyte.annotations[j]))
+
+                transition_id_list.append(t_ids)
+                product_charge_list.append(p_charges)
+                transition_ordinal_list.append(t_ordinals)
+                detecting_transition_list.append(d_transitions)
+                product_decoy_list.append(p_decoys)
+                transition_type_list.append(t_types)
+                annotation_list.append(annots)
+
+        data = {
+            "precursor_id": np.array(precursor_id_list, dtype=object),
+            "modified_sequence": np.array(modified_sequence_list, dtype=object),
+            "precursor_charge": np.array(precursor_charge_list, dtype=object),
+            "precursor_decoy": np.array(precursor_decoy_list, dtype=object),
+            "transition_id": np.array(transition_id_list, dtype=object),
+            "product_charge": np.array(product_charge_list, dtype=object),
+            "transition_ordinal": np.array(transition_ordinal_list, dtype=object),
+            "detecting_transition": np.array(detecting_transition_list, dtype=object),
+            "product_decoy": np.array(product_decoy_list, dtype=object),
+            "transition_type": np.array(transition_type_list, dtype=object),
+            "annotation": np.array(annotation_list, dtype=object),
+        }
+        if columns is not None:
+            return {k: v for k, v in data.items() if k in cols_norm}
+        return data
+
+    def get_analyte_df(self, nest_transitions=True, columns=None):
+        """
+        get_analyte_df(self, nest_transitions: bool = True,
+                       columns: Optional[List[str]] = None) -> pandas.DataFrame
+
+        Return unique analyte metadata as a pandas DataFrame.
+
+        :param nest_transitions: Aggregate transition fields per precursor.
+        :type nest_transitions: bool
+        :param columns: Optional list of column names to return.
+        :type columns: Optional[List[str]]
+
+        :return: DataFrame with analyte metadata.
+        :rtype: pandas.DataFrame
+
+        :raises ImportError: If pandas is not installed
+
+        Example::
+
+            df = xic.get_analyte_df()
+            df_nested = xic.get_analyte_df(nest_transitions=True)
+            df_subset = xic.get_analyte_df(columns=["precursor_id", "modified_sequence"])
+        """
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise ImportError("pandas is required for this method. Install with `pip install pandas`.") from e
+        data = self.get_analyte_dict(nest_transitions=nest_transitions, columns=columns)
+        return pd.DataFrame({k: list(v) for k, v in data.items()})
+
+    def get_run_dict(self):
+        """
+        get_run_dict(self) -> Dict[str, np.ndarray]
+
+        Return unique run metadata as a dict of numpy arrays.
+
+        :return: Dict with run_id and source_file arrays.
+        :rtype: Dict[str, np.ndarray]
+
+        Example::
+
+            runs = xic.get_run_dict()
+        """
+        cdef libcpp_vector[_XICRunInfo] runs
+        self.inst.get().getRuns(runs)
+
+        cdef list run_id_list = []
+        cdef list source_file_list = []
+        cdef size_t i
+        cdef _XICRunInfo run
+        for i in range(runs.size()):
+            run = runs[i]
+            run_id_list.append(run.run_id)
+            source_file_list.append(convOutputString(run.source_file))
+
+        return {
+            "run_id": np.array(run_id_list, dtype=np.int64),
+            "source_file": np.array(source_file_list, dtype=object),
+        }
+
+    def get_run_df(self):
+        """
+        get_run_df(self) -> pandas.DataFrame
+
+        Return unique run metadata as a pandas DataFrame.
+
+        :return: DataFrame with run_id and source_file.
+        :rtype: pandas.DataFrame
+
+        :raises ImportError: If pandas is not installed
+        """
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise ImportError("pandas is required for this method. Install with `pip install pandas`.") from e
+        data = self.get_run_dict()
+        return pd.DataFrame(data)
+
+    def df_columns(self):
+        """
+        df_columns(self) -> List[str]
+
+        Return the parquet schema column names.
+
+        :return: List of column names.
+        :rtype: List[str]
+        """
+        cdef StringList cols
+        self.inst.get().getColumns(cols)
+        return [convOutputString(cols[i]) for i in range(cols.size())]
+
+    def to_arrow(self, explode=False):
+        """
+        to_arrow(self: XICParquetFile, explode: bool = False) -> pa.Table
+
+        Returns an Apache Arrow Table representation of the chromatograms.
+
+        If explode=True, returns long format with rt/intensity rows.
+
+        :param explode: If True, return long format with one row per RT/intensity.
+        :type explode: bool
+
+        :return: Arrow Table with chromatogram data.
+        :rtype: pyarrow.Table
+
+        :raises ImportError: If pyarrow is not installed
+
+        Example::
+
+            table = xic.to_arrow()
+            table_long = xic.to_arrow(explode=True)
+        """
+        try:
+            import pyarrow as pa
+        except ImportError as e:
+            raise ImportError(
+                "pyarrow is required for to_arrow(). "
+                "Please install it with: pip install pyarrow"
+            ) from e
+        return pa.Table.from_pydict(self.get_data_dict(explode=explode))
+
+    def query_chromatograms(self):
+        """
+        query_chromatograms(self) -> XICParquetFile._ChromatogramQuery
+
+        Return a chainable chromatogram query builder.
+
+        Example::
+
+            q = xic.query_chromatograms()
+            df = q.filter_precursor_id(1381).filter_annotation("y3^1").to_df(explode=False)
+        """
+        from ._parquet_query import ChromatogramQuery
+        return ChromatogramQuery(self)

--- a/src/pyOpenMS/addons/XICParquetFile.pyx
+++ b/src/pyOpenMS/addons/XICParquetFile.pyx
@@ -1,7 +1,6 @@
 from libcpp.vector cimport vector as libcpp_vector
 from libc.stdint cimport int64_t
 from cython.operator cimport dereference as deref
-from String cimport String
 from StringList cimport StringList
 from XICParquetFile cimport XICChromatogram as _XICChromatogram
 from XICParquetFile cimport XICAnalyte as _XICAnalyte

--- a/src/pyOpenMS/converters/special_autowrap_conversionproviders.py
+++ b/src/pyOpenMS/converters/special_autowrap_conversionproviders.py
@@ -402,7 +402,7 @@ class StdVectorStringConverter(TypeConverterBase):
 
     def type_check_expression(self, cpp_type, arg_var):
         return Code().add("""
-          |isinstance($arg_var, list) and all(isinstance(i, bytes) for i in
+          |isinstance($arg_var, list) and all(isinstance(i, (bytes, str)) for i in
           + $arg_var)
           """, locals()).render()
 
@@ -410,11 +410,17 @@ class StdVectorStringConverter(TypeConverterBase):
         temp_var = "v%d" % arg_num
         temp_it = "it_%d" % arg_num
         item = "item%d" % arg_num
+        bytes_var = "_b%d" % arg_num
         code = Code().add("""
             |cdef libcpp_vector[_String] * $temp_var = new libcpp_vector[_String]()
-            |cdef bytes $item
+            |cdef object $item
+            |cdef bytes $bytes_var
             |for $item in $argument_var:
-            |   $temp_var.push_back(_String(<char *>$item))
+            |   if isinstance($item, bytes):
+            |       $bytes_var = <bytes>$item
+            |   else:
+            |       $bytes_var = (<str>$item).encode()
+            |   $temp_var.push_back(_String(<char *>$bytes_var))
             """, locals())
         if cpp_type.is_ref:
             cleanup_code = Code().add("""
@@ -663,5 +669,3 @@ class CVTermMapConverter(TypeConverterBase):
             """, locals())
 
         return code
-
-

--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -83,10 +83,19 @@ if __name__ == '__main__':
 
   # Filter out Arrow/Parquet-dependent pxd files when WITH_PARQUET is disabled
   if not WITH_PARQUET:
-    pxd_files = [f for f in pxd_files if not os.path.basename(f).startswith('Arrow')]
-    print("WITH_PARQUET is disabled, excluding Arrow*.pxd files from wrapping")
+    def _is_parquet_related(name):
+      return name.startswith('Arrow') or ('Parquet' in name)
+
+    pxd_files = [f for f in pxd_files if not _is_parquet_related(os.path.basename(f))]
+    print("WITH_PARQUET is disabled, excluding Arrow*/Parquet* pxds from wrapping")
 
   addons = glob.glob(PYOPENMS_SRC_DIR + "/addons/*.pyx")
+  if not WITH_PARQUET:
+    def _is_parquet_addon(name):
+      return 'Parquet' in name
+
+    addons = [a for a in addons if not _is_parquet_addon(os.path.basename(a))]
+    print("WITH_PARQUET is disabled, excluding Parquet* addons from wrapping")
   converters = [j(PYOPENMS_SRC_DIR, "converters")]
 
   persisted_data_path = "include_dir.bin"

--- a/src/pyOpenMS/pxds/ParquetFilter.pxd
+++ b/src/pyOpenMS/pxds/ParquetFilter.pxd
@@ -1,0 +1,55 @@
+from libcpp.vector cimport vector as libcpp_vector
+from libc.stdint cimport int64_t
+from String cimport String
+
+cdef extern from "<OpenMS/FORMAT/ParquetFilter.h>" namespace "OpenMS":
+    cdef cppclass ParquetFilter:
+        ParquetFilter() except +
+        ParquetFilter(const ParquetFilter&) except +
+
+        ParquetFilter& andNext()
+        ParquetFilter& orNext()
+
+        ParquetFilter& eq(const String& column, int64_t value)
+        ParquetFilter& ne(const String& column, int64_t value)
+        ParquetFilter& lt(const String& column, int64_t value)
+        ParquetFilter& le(const String& column, int64_t value)
+        ParquetFilter& gt(const String& column, int64_t value)
+        ParquetFilter& ge(const String& column, int64_t value)
+        ParquetFilter& in_ "in"(const String& column, const libcpp_vector[int64_t]& values)
+
+        ParquetFilter& eq(const String& column, const String& value)
+        ParquetFilter& ne(const String& column, const String& value)
+        ParquetFilter& lt(const String& column, const String& value)
+        ParquetFilter& le(const String& column, const String& value)
+        ParquetFilter& gt(const String& column, const String& value)
+        ParquetFilter& ge(const String& column, const String& value)
+        ParquetFilter& in_ "in"(const String& column, const libcpp_vector[String]& values)
+
+        bint empty() const
+
+    cdef cppclass ParquetFilterBuilder:
+        ParquetFilterBuilder() except +
+        ParquetFilterBuilder(const ParquetFilterBuilder&) except +
+
+        ParquetFilterBuilder& andNext()
+        ParquetFilterBuilder& orNext()
+
+        ParquetFilterBuilder& eq(const String& column, int64_t value)
+        ParquetFilterBuilder& ne(const String& column, int64_t value)
+        ParquetFilterBuilder& lt(const String& column, int64_t value)
+        ParquetFilterBuilder& le(const String& column, int64_t value)
+        ParquetFilterBuilder& gt(const String& column, int64_t value)
+        ParquetFilterBuilder& ge(const String& column, int64_t value)
+        ParquetFilterBuilder& in_ "in"(const String& column, const libcpp_vector[int64_t]& values)
+
+        ParquetFilterBuilder& eq(const String& column, const String& value)
+        ParquetFilterBuilder& ne(const String& column, const String& value)
+        ParquetFilterBuilder& lt(const String& column, const String& value)
+        ParquetFilterBuilder& le(const String& column, const String& value)
+        ParquetFilterBuilder& gt(const String& column, const String& value)
+        ParquetFilterBuilder& ge(const String& column, const String& value)
+        ParquetFilterBuilder& in_ "in"(const String& column, const libcpp_vector[String]& values)
+
+        const ParquetFilter& filter() const
+        bint empty() const

--- a/src/pyOpenMS/pxds/XICParquetFile.pxd
+++ b/src/pyOpenMS/pxds/XICParquetFile.pxd
@@ -1,0 +1,135 @@
+from libcpp.vector cimport vector
+from libcpp cimport bool
+
+from String cimport String
+from StringList cimport StringList
+from Types cimport Int64
+from ParquetFilter cimport ParquetFilter, ParquetFilterBuilder
+
+ctypedef vector[double] DoubleVector
+
+cdef extern from "<OpenMS/FORMAT/XICParquetFile.h>" namespace "OpenMS":
+    cdef cppclass XICChromatogram:
+        # wrap-ignore
+        Int64 run_id
+        String source_file
+        Int64 ms_level
+
+        bool has_precursor_id
+        Int64 precursor_id
+        bool has_transition_id
+        Int64 transition_id
+        String modified_sequence
+        bool has_precursor_charge
+        Int64 precursor_charge
+        bool has_product_charge
+        Int64 product_charge
+        bool has_detecting_transition
+        Int64 detecting_transition
+        bool has_precursor_decoy
+        Int64 precursor_decoy
+        bool has_product_decoy
+        Int64 product_decoy
+        bool has_transition_ordinal
+        Int64 transition_ordinal
+        String transition_type
+        String annotation
+
+        DoubleVector rt  # wrap-ignore
+        DoubleVector intensity  # wrap-ignore
+
+    cdef cppclass XICRunInfo:
+        # wrap-ignore
+        Int64 run_id
+        String source_file
+
+    cdef cppclass XICAnalyte:
+        # wrap-ignore
+        bool has_precursor_id
+        Int64 precursor_id
+        String modified_sequence
+        bool has_precursor_charge
+        Int64 precursor_charge
+        bool has_precursor_decoy
+        Int64 precursor_decoy
+
+        bool has_transition_id
+        Int64 transition_id
+        bool has_product_charge
+        Int64 product_charge
+        bool has_transition_ordinal
+        Int64 transition_ordinal
+        bool has_detecting_transition
+        Int64 detecting_transition
+        bool has_product_decoy
+        Int64 product_decoy
+        String transition_type
+        String annotation
+
+        vector[Int64] transition_ids
+        vector[Int64] product_charges
+        vector[Int64] transition_ordinals
+        vector[Int64] detecting_transitions
+        vector[Int64] product_decoys
+        vector[String] transition_types
+        vector[String] annotations
+
+    cdef cppclass XICParquetFile:
+        XICParquetFile(String filename) except + nogil
+            # wrap-doc:
+            #  Reader for OpenSWATH chromatogram Parquet files (.xic).
+        XICParquetFile(const StringList& filenames) except + nogil
+            # wrap-doc:
+            #  Reader for multiple OpenSWATH chromatogram Parquet files (.xic).
+
+        const String& getFilename() const
+        const StringList& getFilenames() const
+
+        void load(vector[XICChromatogram]& output) const  # wrap-ignore
+            # wrap-doc:
+            #  Load all chromatograms from the file.
+
+        void getChromatograms(vector[XICChromatogram]& output,
+                              Int64 precursor_id,
+                              Int64 transition_id,
+                              const String& modified_sequence,
+                              Int64 precursor_charge,
+                              Int64 product_charge,
+                              Int64 ms_level,
+                              Int64 run_id,
+                              const String& filter) const  # wrap-ignore
+            # wrap-doc:
+            #  Load chromatograms with optional filtering.
+            #  
+            #  :param precursor_id: Optional precursor id (-1 to ignore)
+            #  :param transition_id: Optional transition id (-1 to ignore)
+            #  :param modified_sequence: Optional modified sequence (empty to ignore)
+            #  :param precursor_charge: Optional precursor charge (-1 to ignore)
+            #  :param product_charge: Optional product charge (-1 to ignore)
+            #  :param ms_level: Optional MS level (-1 to ignore)
+            #  :param run_id: Optional run id (-1 to ignore)
+            #  :param filter: Optional filter expression string
+
+        void getChromatograms(vector[XICChromatogram]& output,
+                              const ParquetFilter& filter) const  # wrap-ignore
+            # wrap-doc:
+            #  Load chromatograms using a typed parquet filter.
+
+        void getChromatograms(vector[XICChromatogram]& output,
+                              const ParquetFilterBuilder& filter) const  # wrap-ignore
+            # wrap-doc:
+            #  Load chromatograms using a typed parquet filter builder.
+
+        void getRuns(vector[XICRunInfo]& output) except +  # wrap-ignore
+            # wrap-doc:
+            #  Return unique run metadata (run_id, source_file).
+
+        void getAnalytes(vector[XICAnalyte]& output,
+                         const StringList& columns,
+                         bool nest_transitions) except +  # wrap-ignore
+            # wrap-doc:
+            #  Return unique analyte metadata.
+
+        void getColumns(StringList& output) except +  # wrap-ignore
+            # wrap-doc:
+            #  Return parquet schema column names.

--- a/src/pyOpenMS/pyopenms/_parquet_filter.pxd
+++ b/src/pyOpenMS/pyopenms/_parquet_filter.pxd
@@ -1,0 +1,40 @@
+"""Cython declaration for the Parquet filter builder wrapper.
+
+This pxd exposes the cdef class for the standalone `_parquet_filter` module.
+It intentionally lives outside the autowrapped `_pyopenms_*` modules to provide
+stable cimports for addons and query helpers.
+"""
+
+from libc.stdint cimport int64_t
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp.memory cimport shared_ptr
+
+# Inline C++ declarations - must match the pyx file
+cdef extern from "<OpenMS/DATASTRUCTURES/String.h>" namespace "OpenMS":
+    cdef cppclass _String "OpenMS::String":
+        _String() except +
+        _String(const char*) except +
+
+cdef extern from "<OpenMS/FORMAT/ParquetFilter.h>" namespace "OpenMS":
+    cdef cppclass _ParquetFilterBuilder "OpenMS::ParquetFilterBuilder":
+        _ParquetFilterBuilder() except +
+        _ParquetFilterBuilder& andNext()
+        _ParquetFilterBuilder& orNext()
+        _ParquetFilterBuilder& eq(const _String& column, int64_t value)
+        _ParquetFilterBuilder& ne(const _String& column, int64_t value)
+        _ParquetFilterBuilder& lt(const _String& column, int64_t value)
+        _ParquetFilterBuilder& le(const _String& column, int64_t value)
+        _ParquetFilterBuilder& gt(const _String& column, int64_t value)
+        _ParquetFilterBuilder& ge(const _String& column, int64_t value)
+        _ParquetFilterBuilder& in_ "in"(const _String& column, const libcpp_vector[int64_t]& values)
+        _ParquetFilterBuilder& eq(const _String& column, const _String& value)
+        _ParquetFilterBuilder& ne(const _String& column, const _String& value)
+        _ParquetFilterBuilder& lt(const _String& column, const _String& value)
+        _ParquetFilterBuilder& le(const _String& column, const _String& value)
+        _ParquetFilterBuilder& gt(const _String& column, const _String& value)
+        _ParquetFilterBuilder& ge(const _String& column, const _String& value)
+        _ParquetFilterBuilder& in_ "in"(const _String& column, const libcpp_vector[_String]& values)
+        bint empty() const
+
+cdef class ParquetFilterBuilder:
+    cdef shared_ptr[_ParquetFilterBuilder] inst

--- a/src/pyOpenMS/pyopenms/_parquet_filter.pyx
+++ b/src/pyOpenMS/pyopenms/_parquet_filter.pyx
@@ -1,0 +1,125 @@
+# distutils: language = c++
+# cython: language_level=3
+"""Typed Parquet filter builder.
+
+This module provides a small, stable wrapper around the C++
+OpenMS::ParquetFilterBuilder for use in pyOpenMS query builders.
+
+Why this exists:
+  - The autowrapped pyOpenMS modules are split across `_pyopenms_*` files,
+    which makes importing a generated ParquetFilter wrapper by module index
+    brittle.
+  - This standalone module gives a stable import path
+    (`pyopenms._parquet_filter.ParquetFilterBuilder`) for predicate pushdown
+    builders.
+
+Usage:
+    from pyopenms._parquet_filter import ParquetFilterBuilder
+    f = ParquetFilterBuilder().eq("precursor_id", 1318).andNext().eq("annotation", "y3^1")
+
+The resulting builder can be passed to XICParquetFile query helpers or used
+internally by higher-level Python query classes.
+"""
+
+from cython.operator cimport dereference as deref
+
+# Import declarations from the pxd file
+from pyopenms._parquet_filter cimport (
+    _String, _ParquetFilterBuilder, ParquetFilterBuilder,
+    shared_ptr, libcpp_vector, int64_t
+)
+
+
+cdef inline _String _to_string(object value):
+    cdef bytes b
+    if isinstance(value, bytes):
+        b = value
+    elif hasattr(value, "toString"):
+        b = (<str>value.toString()).encode("utf-8")
+    else:
+        b = (<str>value).encode("utf-8")
+    return _String(<char *>b)
+
+
+cdef class ParquetFilterBuilder:
+    """Typed filter builder for Parquet-backed readers.
+
+    This class mirrors OpenMS::ParquetFilterBuilder and is intended to be used
+    by higher-level query helpers (e.g., ChromatogramQuery). It is not tied to
+    any specific `_pyopenms_*` split module.
+    """
+
+    def __cinit__(self):
+        self.inst = shared_ptr[_ParquetFilterBuilder](new _ParquetFilterBuilder())
+
+    def andNext(self):
+        """andNext(self) -> ParquetFilterBuilder"""
+        self.inst.get().andNext()
+        return self
+
+    def orNext(self):
+        """orNext(self) -> ParquetFilterBuilder"""
+        self.inst.get().orNext()
+        return self
+
+    def eq(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().eq(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().eq(_to_string(column), <int64_t>value)
+        return self
+
+    def ne(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().ne(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().ne(_to_string(column), <int64_t>value)
+        return self
+
+    def lt(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().lt(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().lt(_to_string(column), <int64_t>value)
+        return self
+
+    def le(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().le(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().le(_to_string(column), <int64_t>value)
+        return self
+
+    def gt(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().gt(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().gt(_to_string(column), <int64_t>value)
+        return self
+
+    def ge(self, column, value):
+        if isinstance(value, (str, bytes)):
+            self.inst.get().ge(_to_string(column), _to_string(value))
+        else:
+            self.inst.get().ge(_to_string(column), <int64_t>value)
+        return self
+
+    def in_(self, column, values):
+        cdef libcpp_vector[_String] v1
+        cdef libcpp_vector[int64_t] v2
+        if values is None:
+            raise TypeError("values must be a list or tuple")
+        if len(values) == 0:
+            raise ValueError("values must be non-empty")
+        if isinstance(values[0], (str, bytes)):
+            for item1 in values:
+                v1.push_back(_to_string(item1))
+            self.inst.get().in_(_to_string(column), v1)
+        else:
+            for item2 in values:
+                v2.push_back(<int64_t>item2)
+            self.inst.get().in_(_to_string(column), v2)
+        return self
+
+    def empty(self):
+        return self.inst.get().empty()

--- a/src/pyOpenMS/pyopenms/_parquet_query.py
+++ b/src/pyOpenMS/pyopenms/_parquet_query.py
@@ -1,0 +1,246 @@
+"""Typed query builders for Parquet-backed data access.
+
+This module defines a small abstract query interface and a concrete
+ChromatogramQuery for XICParquetFile. The builders are pure Python to
+avoid Cython class placement limitations while still using the C++
+ParquetFilter under the hood for predicate pushdown.
+
+Why this exists:
+  - Keeps a stable, Python-friendly chaining API (filter_* methods).
+  - Delegates predicate construction to the C++ ParquetFilterBuilder via
+    `pyopenms._parquet_filter`, enabling pushdown without string-encoded filters.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ParquetQuery(ABC):
+    """Abstract base class for Parquet query builders.
+
+    Shared query methods:
+      - and_(), or_()
+      - filter(column, value, op="=")
+      - to_dict(explode=False)
+      - to_df(explode=True)
+
+    Subclasses are expected to add domain-specific filter helpers and
+    implement the data access methods.
+    """
+
+    def __init__(self, typed_builder=None):
+        self._pending_connector = None
+        self._condition_count = 0
+        self._typed = typed_builder
+        self._typed_has_condition = False
+        if self._typed is None:
+            try:
+                from . import _parquet_filter
+                self._typed = _parquet_filter.ParquetFilterBuilder()
+            except Exception:
+                self._typed = None
+
+    def __repr__(self):
+        return "%s(conditions=%d)" % (self.__class__.__name__, self._condition_count)
+
+    def and_(self):
+        """Explicitly set the next connector to AND."""
+        self._pending_connector = "AND"
+        return self
+
+    def or_(self):
+        """Explicitly set the next connector to OR."""
+        self._pending_connector = "OR"
+        return self
+
+    def filter(self, column, value, op="="):
+        """Generic filter using a column name.
+
+        :param column: Column name (string)
+        :param value: Value to compare (int or str, or list for IN)
+        :param op: Operator, e.g. '=', '!=', '<', '<=', '>', '>=', 'IN'
+        """
+        if not isinstance(column, str):
+            column = str(column)
+        is_string = isinstance(value, (str, bytes)) or (
+            isinstance(value, (list, tuple)) and value and isinstance(value[0], (str, bytes))
+        )
+        return self._add_condition(column, op, value, is_string)
+
+    @abstractmethod
+    def to_dict(self, explode=False):
+        """Return results as a dict of numpy arrays."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_df(self, explode=True):
+        """Return results as a pandas.DataFrame."""
+        raise NotImplementedError
+
+    def _consume_connector(self):
+        if self._condition_count == 0:
+            return ""
+        if self._pending_connector is None:
+            return "AND"
+        connector = self._pending_connector
+        self._pending_connector = None
+        return connector
+
+    def _quote_string(self, value):
+        if value is None:
+            raise ValueError("String filter value cannot be None")
+        s = str(value)
+        has_single = "'" in s
+        has_double = '"' in s
+        if has_single and has_double:
+            raise ValueError("String filter value contains both quote types: %r" % s)
+        if has_double:
+            return "'%s'" % s
+        return '"%s"' % s
+
+    def _format_value(self, value, is_string):
+        if is_string:
+            return self._quote_string(value)
+        try:
+            return str(int(value))
+        except Exception as exc:
+            raise ValueError("Expected integer value, got %r" % (value,)) from exc
+
+    def _add_condition(self, column, op, value, is_string):
+        connector = self._consume_connector()
+        op_norm = op.upper()
+        is_list = isinstance(value, (list, tuple))
+        if op_norm != "IN" and is_list:
+            op_norm = "IN"
+        if op_norm == "IN":
+            if not is_list:
+                raise ValueError("IN operator expects a list/tuple of values")
+            if not value:
+                raise ValueError("IN operator expects a non-empty list of values")
+            if self._typed is not None:
+                if self._typed_has_condition:
+                    if connector == "OR":
+                        self._typed.orNext()
+                    else:
+                        self._typed.andNext()
+                if is_string:
+                    self._typed.in_(column, [str(v) for v in value])
+                else:
+                    self._typed.in_(column, [int(v) for v in value])
+                self._typed_has_condition = True
+        else:
+            if self._typed is not None:
+                if self._typed_has_condition:
+                    if connector == "OR":
+                        self._typed.orNext()
+                    else:
+                        self._typed.andNext()
+                if is_string:
+                    sval = str(value)
+                    if op_norm == "=":
+                        self._typed.eq(column, sval)
+                    elif op_norm == "!=":
+                        self._typed.ne(column, sval)
+                    elif op_norm == "<":
+                        self._typed.lt(column, sval)
+                    elif op_norm == "<=":
+                        self._typed.le(column, sval)
+                    elif op_norm == ">":
+                        self._typed.gt(column, sval)
+                    elif op_norm == ">=":
+                        self._typed.ge(column, sval)
+                    else:
+                        raise ValueError("Unsupported operator: %s" % op)
+                else:
+                    ival = int(value)
+                    if op_norm == "=":
+                        self._typed.eq(column, ival)
+                    elif op_norm == "!=":
+                        self._typed.ne(column, ival)
+                    elif op_norm == "<":
+                        self._typed.lt(column, ival)
+                    elif op_norm == "<=":
+                        self._typed.le(column, ival)
+                    elif op_norm == ">":
+                        self._typed.gt(column, ival)
+                    elif op_norm == ">=":
+                        self._typed.ge(column, ival)
+                    else:
+                        raise ValueError("Unsupported operator: %s" % op)
+                self._typed_has_condition = True
+        if self._typed is None:
+            raise RuntimeError("ParquetFilter is not available in this environment")
+        self._condition_count += 1
+        return self
+
+
+class ChromatogramQuery(ParquetQuery):
+    """Chainable query builder for XICParquetFile chromatograms.
+
+    Inherited methods:
+      - filter(column, value, op="=")
+      - filter_precursor_id(value, op="=")
+      - filter_transition_id(value, op="=")
+      - filter_ms_level(value, op="=")
+      - filter_run_id(value, op="=")
+      - filter_precursor_charge(value, op="=")
+      - filter_product_charge(value, op="=")
+      - filter_annotation(value, op="=")
+      - filter_modified_sequence(value, op="=")
+      - filter_transition_type(value, op="=")
+      - to_dict(explode=False)
+      - to_df(explode=True)
+
+    Example::
+
+        q = xic.query_chromatograms()
+        df = q.filter_precursor_id(1381).filter_annotation("y3^1").to_df()
+        df = q.filter_precursor_id([1381,2025]).filter_annotation(["y3^1", "y4^1", "b9^1"]).to_df()
+    """
+
+    def __init__(self, xic):
+        self._xic = xic
+        super().__init__()
+
+    def filter_precursor_id(self, value, op="="):
+        return self._add_condition("precursor_id", op, value, False)
+
+    def filter_transition_id(self, value, op="="):
+        return self._add_condition("transition_id", op, value, False)
+
+    def filter_ms_level(self, value, op="="):
+        return self._add_condition("ms_level", op, value, False)
+
+    def filter_run_id(self, value, op="="):
+        return self._add_condition("run_id", op, value, False)
+
+    def filter_precursor_charge(self, value, op="="):
+        return self._add_condition("precursor_charge", op, value, False)
+
+    def filter_product_charge(self, value, op="="):
+        return self._add_condition("product_charge", op, value, False)
+
+    def filter_annotation(self, value, op="="):
+        return self._add_condition("annotation", op, value, True)
+
+    def filter_modified_sequence(self, value, op="="):
+        return self._add_condition("modified_sequence", op, value, True)
+
+    def filter_transition_type(self, value, op="="):
+        return self._add_condition("transition_type", op, value, True)
+
+    def to_dict(self, explode=False):
+        """Return chromatogram data as dict of numpy arrays."""
+        if self._typed is None:
+            raise RuntimeError("ParquetFilter is not available in this environment")
+        if not self._typed_has_condition:
+            return self._xic.get_data_dict(explode=explode)
+        return self._xic._get_data_dict_from_parquet_filter(self._typed, explode=explode)
+
+    def to_df(self, explode=True):
+        """Return chromatogram data as pandas.DataFrame."""
+        try:
+            import pandas as pd
+        except ImportError as exc:
+            raise ImportError("pandas is required for to_df(). Install with `pip install pandas`.") from exc
+        data = self.to_dict(explode=explode)
+        return pd.DataFrame({k: list(v) for k, v in data.items()})

--- a/src/pyOpenMS/tests/unittests/test_XICParquetFile.py
+++ b/src/pyOpenMS/tests/unittests/test_XICParquetFile.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import pytest
+
+
+def _repo_root():
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    )
+
+
+def _xic_path():
+    return os.path.join(
+        _repo_root(),
+        "src",
+        "tests",
+        "class_tests",
+        "openms",
+        "data",
+        "XICParquetFile_1_input.xic",
+    )
+
+
+def _get_xic():
+    import pyopenms as poms
+
+    # Check if XICParquetFile class exists (may be excluded when WITH_PARQUET=False)
+    if not hasattr(poms, 'XICParquetFile'):
+        pytest.skip("pyopenms built without parquet support")
+
+    try:
+        return poms.XICParquetFile(_xic_path())
+    except RuntimeError as e:
+        if "Parquet support" in str(e):
+            pytest.skip("pyopenms built without parquet support")
+        raise
+
+
+def test_xic_df_columns():
+    xic = _get_xic()
+    cols = xic.df_columns()
+    assert "RUN_ID" in cols
+    assert "PRECURSOR_ID" in cols
+    assert "RT_DATA" in cols
+
+
+def test_xic_run_dict():
+    xic = _get_xic()
+    runs = xic.get_run_dict()
+    assert "run_id" in runs
+    assert "source_file" in runs
+    assert len(runs["run_id"]) > 0
+
+
+def test_xic_analyte_dict_default_nested():
+    xic = _get_xic()
+    nested = xic.get_analyte_dict()
+    exploded = xic.get_analyte_dict(nest_transitions=False)
+    assert len(nested["precursor_id"]) > 0
+    assert len(exploded["precursor_id"]) >= len(nested["precursor_id"])
+    # nested transition fields should be list-like (list or array)
+    assert hasattr(nested["transition_id"][0], "__iter__")
+
+
+def test_xic_analyte_columns_subset():
+    xic = _get_xic()
+    subset = xic.get_analyte_dict(columns=["PRECURSOR_ID", "MODIFIED_SEQUENCE"])
+    assert set(subset.keys()) == {"precursor_id", "modified_sequence"}
+
+
+def test_xic_analyte_columns_invalid():
+    xic = _get_xic()
+    with pytest.raises(RuntimeError):
+        xic.get_analyte_dict(columns=["PRECURSOR_CHARGE5"])
+
+
+def test_xic_to_df_summary_and_exploded():
+    xic = _get_xic()
+    df_summary = xic.to_df()
+    df_exploded = xic.to_df(explode=True)
+    assert len(df_summary) > 0
+    assert len(df_exploded) >= len(df_summary)
+    assert hasattr(df_summary.iloc[0]["rt"], "__iter__")
+    assert hasattr(df_summary.iloc[0]["intensity"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["rt"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["intensity"], "__iter__")
+
+
+def test_xic_query_builder_summary_and_exploded():
+    xic = _get_xic()
+    analytes = xic.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
+    precursor_id = analytes["precursor_id"][0]
+    df_summary = xic.query_chromatograms().filter_precursor_id(precursor_id).to_df(explode=False)
+    df_exploded = xic.query_chromatograms().filter_precursor_id(precursor_id).to_df(explode=True)
+    assert len(df_summary) > 0
+    assert len(df_exploded) >= len(df_summary)
+    assert hasattr(df_summary.iloc[0]["rt"], "__iter__")
+    assert hasattr(df_summary.iloc[0]["intensity"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["rt"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["intensity"], "__iter__")
+
+
+def test_xic_query_builder():
+    xic = _get_xic()
+    analytes = xic.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
+    precursor_id = analytes["precursor_id"][0]
+    df = xic.query_chromatograms().filter_precursor_id(precursor_id).to_df(explode=False)
+    assert len(df) > 0


### PR DESCRIPTION
## Description

This PR adds Python bindings for reading XIC data from Parquet files, enabling seamless integration with pandas, pyarrow, and pyopenms_viz.

> **Note**: This PR depends on #8737 (C++ core) and should be merged after it.

### pyOpenMS Bindings

Added bindings to load XICs from Parquet files using pyopenms, which includes using predicate pushdowns for filtering data prior to loading into memory. This also integrates nicely with pyopenms_viz.

```python
import pyopenms as poms
import pyopenms_viz
import pandas as pd
import glob
from matplotlib import pyplot as plt 
pd.options.plotting.backend = "ms_matplotlib"
 
files = glob.glob('*.xic')
xic_h = poms.XICParquetFile(files)
xic_h.get_chromatograms(filter="precursor_id=1318 & annotation=y3^1").plot(kind="chromatogram", x="rt", y="intensity", by="source_file")
```

### Additions

- **XICParquetFile** Python bindings with:
  - list-of-files constructor support
  - `get_data_dict`, `get_chromatograms`, `to_df`, `to_arrow`
  - `get_analyte_dict`, `get_analyte_df`, `get_run_dict`, `get_run_df`
  - `df_columns` for column discovery
  - Filter expressions with predicate pushdown support
- **ParquetFilter/ParquetFilterBuilder** Python bindings for typed filter construction
- **ParquetQuery/ChromatogramQuery** for chainable querying in Python
- **Unit tests** for Python bindings

Based on work by @singjc in PR #8725.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read XIC chromatogram data directly from Parquet files with support for multiple files.
  * Query and filter chromatogram data by precursor ID, transition ID, MS level, charge, and other criteria.
  * Convert XIC data to multiple formats including dictionaries, DataFrames, and Apache Arrow tables.
  * Access run metadata and analyte information with flexible structure options.

* **Tests**
  * Added comprehensive unit tests for XIC Parquet file functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->