### PR TITLE
Fix XICParquetFile Windows exports and API consistency

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/XICParquetFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XICParquetFile.h
@@ -62,7 +62,7 @@ namespace OpenMS
     /**
       @brief Lightweight chromatogram container for XIC parquet rows.
     */
-    struct XICChromatogram
+    struct OPENMS_DLLAPI XICChromatogram
     {
       Int64 run_id{0};
       String source_file;
@@ -95,7 +95,7 @@ namespace OpenMS
     /**
       @brief Unique run information (run_id, source_file).
     */
-    struct XICRunInfo
+    struct OPENMS_DLLAPI XICRunInfo
     {
       Int64 run_id{0};
       String source_file;
@@ -110,7 +110,7 @@ namespace OpenMS
       vector members (transition_ids, product_charges, etc.), with one entry
       per unique transition belonging to the precursor.
     */
-    struct XICAnalyte
+    struct OPENMS_DLLAPI XICAnalyte
     {
       bool has_precursor_id{false};
       Int64 precursor_id{0};
@@ -247,7 +247,7 @@ namespace OpenMS
       @param[in] nest_transitions Aggregate transition fields per precursor
     */
     void getAnalytes(std::vector<XICAnalyte>& output,
-                     const std::vector<String>& columns,
+                     const std::vector<String>& columns = {},
                      bool nest_transitions = true) const;
 
     /**

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -1679,6 +1679,10 @@ protected:
         }
 
         ofstream outstr(out.c_str());
+        if (!outstr)
+        {
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, out);
+        }
         SVOutStream output(outstr, sep, replacement, quoting_method);
         output.modifyStrings(false);
 


### PR DESCRIPTION
## Summary
- Add `OPENMS_DLLAPI` to `XICChromatogram`, `XICRunInfo`, and `XICAnalyte` structs for proper symbol/typeinfo export on Windows
- Add default empty vector for `columns` parameter in `getAnalytes()` to match the documentation stating it is optional
- Add missing file open validation in TextExporter CHROMPARQUET branch, consistent with other branches (throws `UnableToCreateFile` on failure)

## Test plan
- [ ] Verify Windows build exports symbols correctly
- [ ] Test `getAnalytes()` can be called without columns argument
- [ ] Test TextExporter with invalid output path throws appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in export operations to detect and report failures when output files cannot be created, ensuring users receive clear notifications of export issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->