### PR TITLE
Add development guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@
 - **CMAKE_PREFIX_PATH**: Use `;` separator with `-D` flag, `:` with env var on Unix
 - **delocate-wheel `-L`**: Destination subdir inside wheel, NOT library search path. Use `delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}`
 
+## Guidelines
+
+- When CI tests fail, always investigate the root cause first before patching reference files or test expectations. Never bulk-replace expected values or regenerate test outputs as a first approach.
+- Never dismiss a test failure as "acceptable behavior" or "pre-existing/unrelated" without explicit user confirmation. Always investigate fully before concluding a failure is not actionable.
+- When asked to fix something, prefer using existing APIs/utilities in the codebase over heuristic approaches. Search for existing helper functions, conversion utilities, or detection APIs before implementing custom logic.
+- Before implementing non-trivial changes, first explore the codebase for existing patterns and utilities, then explain the planned approach before writing code.
+- For multi-file changes or unfamiliar areas, use plan mode or explore the relevant code first. Do not dive into implementation without understanding the existing architecture.
+
 ## pyOpenMS
 
 See `src/pyOpenMS/CLAUDE.md` for Python binding development.


### PR DESCRIPTION
## Summary
- Add a Guidelines section to CLAUDE.md with 5 rules for Claude Code to follow during development:
  - Investigate root causes before patching reference files or test expectations
  - Never dismiss test failures without user confirmation
  - Prefer existing APIs over heuristic approaches
  - Explore codebase and explain approach before non-trivial changes
  - Use plan mode for multi-file changes or unfamiliar areas

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Guidelines section covering CI/test failure handling and test expectations under Build Gotchas.
  * Added a Quick commands block with build and test commands for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->