### PR TITLE
Expose SpectrumRangeManager::byMSLevel() in pyOpenMS bindings

### DIFF
--- a/src/pyOpenMS/pxds/SpectrumRangeManager.pxd
+++ b/src/pyOpenMS/pxds/SpectrumRangeManager.pxd
@@ -31,6 +31,8 @@ cdef extern from "<OpenMS/KERNEL/SpectrumRangeManager.h>" namespace "OpenMS":
         void extendRT(double rt, UInt ms_level) except + nogil
         void extendMZ(double mz, UInt ms_level) except + nogil
         void extendUnsafe(const MSSpectrum& spectrum, UInt ms_level) except + nogil
+
+        RangeManager byMSLevel(int ms_level) except + nogil
         
         # Range accessors
         double getMinRT() except + nogil


### PR DESCRIPTION
Summary: This pull request addresses issue #8751 by exposing the byMSLevel() method in the SpectrumRangeManager Cython bindings.

Changes:

Added RangeManager byMSLevel(int ms_level) except + nogil to SpectrumRangeManager.pxd.

This allows Python users to access per-MS-level range information (RT, m/z, etc.), which was previously inaccessible in pyOpenMS despite being available in the C++ core.

Use Case: Essential for tools like peak map viewers where axis ranges need to be calculated based on specific MS levels (e.g., displaying only MS1 data without interference from MS2 ranges).

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability to retrieve spectrum ranges by MS level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->