### PR TITLE
OPENMS_LOG_WARN writes to std::cerr now

### DIFF
--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -294,6 +294,7 @@ namespace OpenMS
       else if (out_chrom_type == FileTypes::CHROMPARQUET)
       {
 #ifndef WITH_PARQUET
+        (void*)&source_file; // to suppress unused variable warning
         throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
 #else
         auto * chromConsumer = new MSChromatogramParquetConsumer(out_chrom, run_id, source_file, transition_exp);

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -609,7 +609,7 @@ namespace OpenMS
   {
     Logger::LogStream g_log_fatal(new Logger::LogStreamBuf("FATAL_ERROR", &red), true, &cerr);
     Logger::LogStream g_log_error(new Logger::LogStreamBuf("ERROR", &red), true, &cerr);
-    Logger::LogStream g_log_warn(new Logger::LogStreamBuf("WARNING", &yellow), true, &cout);
+    Logger::LogStream g_log_warn(new Logger::LogStreamBuf("WARNING", &yellow), true, &cerr);
     Logger::LogStream g_log_info(new Logger::LogStreamBuf("INFO", nullptr), true, &cout);
     // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
     Logger::LogStream g_log_debug(new Logger::LogStreamBuf("DEBUG", &magenta), false); // last param should be 'true', but segfaults...

--- a/src/tests/topp/FileInfo_17_output.txt
+++ b/src/tests/topp/FileInfo_17_output.txt
@@ -3,9 +3,6 @@
 
 File name: C:/dev/openms/src/tests/topp/FileInfo_17_input.fasta
 File type: fasta
-Warning: Duplicate header, #7, ID: crab_chick = #2, ID: crab_chick
-Warning: Duplicate header, #10, ID: crab_squac = #9, ID: crab_squac
-Warning: Duplicate sequence, #10, ID: crab_squac == #9, ID: crab_squac
 
 Number of sequences   : 11
 Sequence length distribution:

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -918,7 +918,7 @@ protected:
             vector<ptrdiff_t>::const_iterator iter = find_if(it_id->second.begin(), it_id->second.end(), [&loopiter, &entries](const ptrdiff_t& idx) { return entries[idx].headerMatches(*loopiter); });
             if (iter != it_id->second.end())
             {
-              os << "Warning: Duplicate header, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " = #" << *iter << ", ID: " << entries[*iter].identifier << '\n';
+              OPENMS_LOG_WARN << "Warning: Duplicate header, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " = #" << *iter << ", ID: " << entries[*iter].identifier << '\n';
               ++dup_header;
             }
 
@@ -935,7 +935,8 @@ protected:
             vector<ptrdiff_t>::const_iterator iter = find_if(it_id->second.begin(), it_id->second.end(), [&loopiter, &entries](const ptrdiff_t& idx) { return entries[idx].sequenceMatches(*loopiter); });
             if (iter != it_id->second.end())
             {
-              os << "Warning: Duplicate sequence, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " == #" << *iter << ", ID: " << entries[*iter].identifier << '\n';
+              OPENMS_LOG_WARN << "Warning: Duplicate sequence, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier
+                              << " == #" << *iter << ", ID: " << entries[*iter].identifier << '\n';
               ++dup_seq;
             }
 

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -814,27 +814,16 @@ protected:
         return ILLEGAL_PARAMETERS;
       }
 
-      std::cout << "Checking mzML file for valid indices ... " << std::endl;
+      os << "Checking mzML file for valid indices ... " << std::endl;
       Internal::IndexedMzMLHandler ifile;
       ifile.openFile(in);
       if (ifile.getParsingSuccess())
       {
-        // Validate that we can access each single spectrum and chromatogram
-        for (int i = 0; i < (int)ifile.getNrSpectra(); i++)
-        {
-          OpenMS::Interfaces::SpectrumPtr p = ifile.getSpectrumById(i);
-        }
-        for (int i = 0; i < (int)ifile.getNrChromatograms(); i++)
-        {
-          OpenMS::Interfaces::ChromatogramPtr p = ifile.getChromatogramById(i);
-        }
-
-        std::cout << "Found a valid indexed mzML XML File with " << ifile.getNrSpectra() << " spectra and " << ifile.getNrChromatograms() << " chromatograms." << std::endl
-                  << std::endl;
+        os << "Found a valid indexed mzML XML File with " << ifile.getNrSpectra() << " spectra and " << ifile.getNrChromatograms() << " chromatograms.\n";
       }
       else
       {
-        std::cout << "Could not detect a valid index for the mzML file " << in << "\nEither the index is not present or is not correct." << std::endl;
+        os << "Could not detect a valid index for the mzML file " << in << "\nEither the index is not present or is not correct.\n";
         return ILLEGAL_PARAMETERS;
       }
     }
@@ -861,7 +850,7 @@ protected:
       Size dup_header(0);
       Size dup_seq(0);
 
-      typedef std::unordered_map<size_t, vector<ptrdiff_t> > SHashmap;
+      using SHashmap = std::unordered_map<size_t, vector<ptrdiff_t> >;
       SHashmap m_headers;
       SHashmap m_seqs;
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->


### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved warning suppression for unused variable handling in specific build configurations.

* **Refactor**
  * Updated FileInfo tool to route output messages through appropriate streams for better consistency.
  * Migrated warning messages to standardized logging system, improving message organization and visibility.
  * Warning log output now directed to standard error stream for better separation from regular output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->