### PR TITLE
perf(OpenSwathScoring): cache parameter lookups in DIA scoring

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
@@ -131,9 +131,8 @@ namespace OpenMS
     std::vector<OpenSwath::SpectrumPtr> spectra = fetchSpectrumSwath(swath_maps, imrmfeature->getRT(), n_merge_spectra, im_range);
 
     // set the DIA parameters
-    // TODO Cache these parameters
-    double dia_extract_window_ = (double)diascoring.getParameters().getValue("dia_extraction_window");
-    bool dia_extraction_ppm_ = diascoring.getParameters().getValue("dia_extraction_unit") == "ppm";
+    const double dia_extract_window_ = (double)diascoring.getParameters().getValue("dia_extraction_window");
+    const bool dia_extraction_ppm_ = diascoring.getParameters().getValue("dia_extraction_unit") == "ppm";
 
     // score drift time dimension
     if ( su_.use_im_scores)
@@ -197,8 +196,6 @@ namespace OpenMS
 
     if ( (ms1_map && ms1_map->getNrSpectra() > 0) && ( su_.use_im_scores) )  // IM MS1 scores
     {
-        double dia_extract_window_ = (double)diascoring.getParameters().getValue("dia_extraction_window");
-        bool dia_extraction_ppm_ = diascoring.getParameters().getValue("dia_extraction_unit") == "ppm";
         double rt = imrmfeature->getRT();
 
         std::vector<OpenSwath::SpectrumPtr> ms1_spectrum = fetchSpectrumSwath(ms1_map, rt, n_merge_spectra, im_range_ms1);
@@ -343,8 +340,8 @@ namespace OpenMS
       // Add the existing transition to the vector
       transitionVector.push_back(transition);
 
-      double dia_extract_window_ = (double)diascoring.getParameters().getValue("dia_extraction_window");
-      bool dia_extraction_ppm_ = diascoring.getParameters().getValue("dia_extraction_unit") == "ppm";
+      const double dia_extract_window_ = (double)diascoring.getParameters().getValue("dia_extraction_window");
+      const bool dia_extraction_ppm_ = diascoring.getParameters().getValue("dia_extraction_unit") == "ppm";
 
       IonMobilityScoring::driftIdScoring(spectrum, transitionVector, trgr_detect, scores,
                                        drift_target, im_range,


### PR DESCRIPTION
## Description

Fixes #[8772]

Addressed an existing `TODO` in `OpenSwathScoring::calculateDIAScores` to cache repetitive parameter lookups. Extracted `dia_extraction_window` and `dia_extraction_unit` parameter lookups and stored them as local `const` variables before the inner loops, rather than repeatedly querying them via `diascoring.getParameters().getValue()`. This prevents redundant dictionary lookups during hot iterations over precursor/fragment chromatograms.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number. 
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>

- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds

</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

@hroest @JoshuaCharkow PTAL! 😊


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency by enforcing immutability constraints on parameter variables in scoring algorithms. This internal refactoring maintains existing functionality while enhancing code maintainability and reducing redundant declarations across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->