### PR TITLE
feat: Arrow/Parquet IO for ProteinIdentification, FeatureMap, and ConsensusMap

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -140,6 +140,15 @@ if (OPENMS_ARROW_DATASET_TARGET)
   target_compile_definitions(OpenMS PRIVATE WITH_ARROW_DATASET)
 endif()
 
+# When Arrow is statically linked, hide its bundled third-party symbols from
+# libOpenMS.so's dynamic symbol table to avoid conflicts with system libraries.
+# NOTE: We intentionally do NOT hide libarrow.a or libparquet.a symbols because
+# the OpenMS public API exposes arrow::Table etc., and downstream consumers
+# (including test executables) need to resolve those symbols from libOpenMS.so.
+if(WITH_PARQUET AND ARROW_USE_STATIC AND NOT MSVC AND NOT APPLE)
+  target_link_options(OpenMS PRIVATE "LINKER:--exclude-libs,libarrow_bundled_dependencies.a")
+endif()
+
 if (MSVC)
   ## treat warning of unused function parameter as error, similar to -Werror=unused-variable on GCC
   target_compile_options(OpenMS PRIVATE "/we4100")

--- a/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusMapArrowIO.h
@@ -1,0 +1,141 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+#ifdef WITH_PARQUET
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/FORMAT/MSExperimentArrowExport.h>
+
+#include <memory>
+
+// Forward declarations
+namespace arrow
+{
+  class Table;
+}
+
+namespace OpenMS
+{
+
+/**
+  @brief Import and export ConsensusMap data to/from Apache Arrow format
+
+  This class provides static methods to export and import ConsensusMap
+  data to/from Apache Arrow Tables and Parquet files. Separate tables are
+  provided for consensus features (with their handles and metadata) and for
+  peptide spectrum matches (PSMs) associated with features.
+
+  @experimental This API is experimental and may change in future versions.
+
+  @ingroup FileIO
+*/
+class OPENMS_DLLAPI ConsensusMapArrowIO
+{
+public:
+  // ==================== Export methods ====================
+
+  /**
+    @brief Export consensus features to Apache Arrow Table
+
+    Each ConsensusFeature becomes one row with RT, MZ, intensity, charge,
+    quality, width, nested FeatureHandles, and metadata columns.
+
+    @param[in] cmap The ConsensusMap to export
+    @return Shared pointer to Arrow Table, or nullptr on error
+  */
+  static std::shared_ptr<arrow::Table> exportFeaturesToArrow(
+    const ConsensusMap& cmap);
+
+  /**
+    @brief Export peptide spectrum matches (PSMs) associated with consensus features to Apache Arrow Table
+
+    Each PeptideHit from each PeptideIdentification (both feature-level
+    and unassigned) becomes one row.
+
+    @param[in] cmap The ConsensusMap whose identifications to export
+    @return Shared pointer to Arrow Table, or nullptr on error
+  */
+  static std::shared_ptr<arrow::Table> exportPSMsToArrow(
+    const ConsensusMap& cmap);
+
+  /**
+    @brief Export ConsensusMap to a directory of Parquet files
+
+    Writes five Parquet files: consensus_features.parquet, psms.parquet,
+    proteins.parquet, protein_groups.parquet, and search_params.parquet
+    into the specified directory. Protein-level data is delegated to
+    ProteinIdentificationArrowIO. ConsensusMap-level metadata
+    (column headers, experiment type, DocumentIdentifier, DataProcessing)
+    is stored as file-level key-value metadata in consensus_features.parquet.
+
+    @param[in] cmap The ConsensusMap to export
+    @param[in] directory Output directory path
+    @param[in] config Parquet writing options
+    @return true on success, false on error
+  */
+  static bool exportToParquet(
+    const ConsensusMap& cmap,
+    const String& directory,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  // ==================== Import methods ====================
+
+  /**
+    @brief Import consensus features from Apache Arrow Table
+
+    Each row becomes a ConsensusFeature with RT, MZ, intensity, charge,
+    quality, width, FeatureHandles, and metadata populated.
+
+    @param[in] table Arrow Table with consensus feature data
+    @param[out] cmap ConsensusMap to populate
+    @return true on success, false on error
+  */
+  static bool importFeaturesFromArrow(
+    const std::shared_ptr<arrow::Table>& table,
+    ConsensusMap& cmap);
+
+  /**
+    @brief Import PSMs from Apache Arrow Table
+
+    Reconstructs PeptideIdentifications and PeptideHits from the table
+    and assigns them to the appropriate consensus features or as unassigned.
+
+    @param[in] table Arrow Table with PSM data
+    @param[out] cmap ConsensusMap to populate
+    @return true on success, false on error
+  */
+  static bool importPSMsFromArrow(
+    const std::shared_ptr<arrow::Table>& table,
+    ConsensusMap& cmap);
+
+  /**
+    @brief Import ConsensusMap from a directory of Parquet files
+
+    Reads five Parquet files (consensus_features.parquet, psms.parquet,
+    proteins.parquet, protein_groups.parquet, search_params.parquet)
+    from the specified directory and reconstructs a complete ConsensusMap
+    including FeatureHandles, PSM linkage, protein identifications,
+    and ConsensusMap-level metadata.
+
+    @param[in] directory Input directory path containing Parquet files
+    @param[out] cmap ConsensusMap to populate
+    @return true on success, false on error
+  */
+  static bool importFromParquet(
+    const String& directory,
+    ConsensusMap& cmap);
+};
+
+} // namespace OpenMS
+
+#endif // WITH_PARQUET

--- a/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinIdentificationArrowIO.h
@@ -121,8 +121,8 @@ public:
   /**
     @brief Import all three Parquet files and reconstruct ProteinIdentifications
 
-    Reads search_params, proteins, and protein_groups files in order,
-    combining them into a single vector of ProteinIdentification objects.
+    Reads the three Parquet files and reconstructs a vector of
+    ProteinIdentification objects with hits, groups, and search parameters.
 
     @param[in] proteins_filename Path to proteins Parquet file
     @param[in] protein_groups_filename Path to protein groups Parquet file

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -128,6 +128,7 @@ if (WITH_PARQUET)
   list(APPEND sources_list_h QPXFile.h)
   list(APPEND sources_list_h ProteinIdentificationArrowIO.h)
   list(APPEND sources_list_h FeatureMapArrowIO.h)
+  list(APPEND sources_list_h ConsensusMapArrowIO.h)
 endif()
 
 ### add path to the filenames

--- a/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
@@ -6,7 +6,7 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/FeatureMapArrowIO.h>
+#include <OpenMS/FORMAT/ConsensusMapArrowIO.h>
 
 #ifdef WITH_PARQUET
 
@@ -25,6 +25,7 @@
 #include <parquet/arrow/reader.h>
 #include <parquet/properties.h>
 
+#include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
@@ -122,7 +123,7 @@ namespace // anonymous
             if (i + 4 < s.size())
             {
               unsigned int cp = 0;
-              for (int j = 0; j < 4; ++j) // parse 4 hex digits
+              for (int j = 0; j < 4; ++j)
               {
                 char ch = s[i + 1 + j];
                 cp <<= 4;
@@ -130,7 +131,6 @@ namespace // anonymous
                 else if (ch >= 'a' && ch <= 'f') cp |= (ch - 'a' + 10);
                 else if (ch >= 'A' && ch <= 'F') cp |= (ch - 'A' + 10);
               }
-              // Encode as UTF-8
               if (cp < 0x80)
               {
                 result += static_cast<char>(cp);
@@ -170,13 +170,9 @@ namespace // anonymous
       if (i > 0) json += ",";
       json += "{";
 
-      // software_name
       json += "\"software_name\":\"" + escapeJsonString_(dp.getSoftware().getName()) + "\"";
-
-      // software_version
       json += ",\"software_version\":\"" + escapeJsonString_(dp.getSoftware().getVersion()) + "\"";
 
-      // completion_time
       std::string time_str;
       if (dp.getCompletionTime().isValid())
       {
@@ -184,7 +180,6 @@ namespace // anonymous
       }
       json += ",\"completion_time\":\"" + escapeJsonString_(time_str) + "\"";
 
-      // actions
       json += ",\"actions\":[";
       const auto& actions = dp.getProcessingActions();
       bool first_action = true;
@@ -196,7 +191,6 @@ namespace // anonymous
       }
       json += "]";
 
-      // metavalues
       json += ",\"metavalues\":[";
       std::vector<String> keys;
       dp.getKeys(keys);
@@ -239,11 +233,10 @@ namespace // anonymous
   }
 
   /// Parse a JSON string value starting at position pos (must point to opening quote).
-  /// Returns the unescaped string value and advances pos past the closing quote.
   std::string parseJsonString_(const std::string& s, size_t& pos)
   {
     if (pos >= s.size() || s[pos] != '"') return "";
-    ++pos; // skip opening quote
+    ++pos;
     std::string raw;
     while (pos < s.size() && s[pos] != '"')
     {
@@ -267,7 +260,7 @@ namespace // anonymous
         ++pos;
       }
     }
-    if (pos < s.size()) ++pos; // skip closing quote
+    if (pos < s.size()) ++pos;
     return unescapeJsonString_(raw);
   }
 
@@ -280,7 +273,7 @@ namespace // anonymous
     size_t pos = 0;
     skipWhitespace_(json, pos);
     if (pos >= json.size() || json[pos] != '[') return result;
-    ++pos; // skip '['
+    ++pos;
 
     while (pos < json.size())
     {
@@ -288,23 +281,21 @@ namespace // anonymous
       if (pos >= json.size() || json[pos] == ']') break;
       if (json[pos] == ',') { ++pos; continue; }
       if (json[pos] != '{') break;
-      ++pos; // skip '{'
+      ++pos;
 
       DataProcessing dp;
       std::string software_name, software_version, completion_time;
       std::vector<std::string> action_names;
 
-      // Parse key-value pairs in the object
       while (pos < json.size())
       {
         skipWhitespace_(json, pos);
         if (pos >= json.size() || json[pos] == '}') { ++pos; break; }
         if (json[pos] == ',') { ++pos; continue; }
 
-        // Parse key
         std::string key = parseJsonString_(json, pos);
         skipWhitespace_(json, pos);
-        if (pos < json.size() && json[pos] == ':') ++pos; // skip ':'
+        if (pos < json.size() && json[pos] == ':') ++pos;
         skipWhitespace_(json, pos);
 
         if (key == "software_name")
@@ -321,10 +312,9 @@ namespace // anonymous
         }
         else if (key == "actions")
         {
-          // Parse array of strings
           if (pos < json.size() && json[pos] == '[')
           {
-            ++pos; // skip '['
+            ++pos;
             while (pos < json.size())
             {
               skipWhitespace_(json, pos);
@@ -336,17 +326,16 @@ namespace // anonymous
         }
         else if (key == "metavalues")
         {
-          // Parse array of {name, value, type} objects
           if (pos < json.size() && json[pos] == '[')
           {
-            ++pos; // skip '['
+            ++pos;
             while (pos < json.size())
             {
               skipWhitespace_(json, pos);
               if (pos >= json.size() || json[pos] == ']') { ++pos; break; }
               if (json[pos] == ',') { ++pos; continue; }
               if (json[pos] != '{') break;
-              ++pos; // skip '{'
+              ++pos;
 
               std::string mv_name, mv_value, mv_type;
               while (pos < json.size())
@@ -363,7 +352,7 @@ namespace // anonymous
                 if (mk == "name") mv_name = parseJsonString_(json, pos);
                 else if (mk == "value") mv_value = parseJsonString_(json, pos);
                 else if (mk == "type") mv_type = parseJsonString_(json, pos);
-                else parseJsonString_(json, pos); // skip unknown value
+                else parseJsonString_(json, pos);
               }
 
               if (!mv_name.empty())
@@ -420,12 +409,10 @@ namespace // anonymous
         }
         else
         {
-          // Skip unknown value (string)
           parseJsonString_(json, pos);
         }
       }
 
-      // Apply parsed fields to DataProcessing
       dp.getSoftware().setName(software_name);
       dp.getSoftware().setVersion(software_version);
       if (!completion_time.empty())
@@ -440,7 +427,7 @@ namespace // anonymous
         }
         catch (...)
         {
-          OPENMS_LOG_WARN << "FeatureMapArrowIO: Unknown processing action: " << action_name << std::endl;
+          OPENMS_LOG_WARN << "ConsensusMapArrowIO: Unknown processing action: " << action_name << std::endl;
         }
       }
 
@@ -449,6 +436,226 @@ namespace // anonymous
 
     return result;
   }
+
+  // ==================== MetaInfoInterface JSON helpers ====================
+
+  /// Serialize MetaInfoInterface metavalues to a JSON array string.
+  std::string serializeMetaValues_(const MetaInfoInterface& mii)
+  {
+    std::string json = "[";
+    std::vector<String> keys;
+    mii.getKeys(keys);
+    bool first = true;
+    for (const auto& key : keys)
+    {
+      if (!first) json += ",";
+      const DataValue& val = mii.getMetaValue(key);
+      std::string type_str;
+      switch (val.valueType())
+      {
+        case DataValue::INT_VALUE: type_str = "int"; break;
+        case DataValue::DOUBLE_VALUE: type_str = "double"; break;
+        case DataValue::STRING_VALUE: type_str = "string"; break;
+        case DataValue::INT_LIST: type_str = "int_list"; break;
+        case DataValue::DOUBLE_LIST: type_str = "double_list"; break;
+        case DataValue::STRING_LIST: type_str = "string_list"; break;
+        default: type_str = "string"; break;
+      }
+      json += "{\"name\":\"" + escapeJsonString_(std::string(key))
+            + "\",\"value\":\"" + escapeJsonString_(val.toString())
+            + "\",\"type\":\"" + type_str + "\"}";
+      first = false;
+    }
+    json += "]";
+    return json;
+  }
+
+  /// Deserialize a JSON array of {name, value, type} objects into a MetaInfoInterface.
+  void deserializeMetaValues_(const std::string& json, MetaInfoInterface& target)
+  {
+    if (json.empty()) return;
+
+    size_t pos = 0;
+    skipWhitespace_(json, pos);
+    if (pos >= json.size() || json[pos] != '[') return;
+    ++pos;
+
+    while (pos < json.size())
+    {
+      skipWhitespace_(json, pos);
+      if (pos >= json.size() || json[pos] == ']') break;
+      if (json[pos] == ',') { ++pos; continue; }
+      if (json[pos] != '{') break;
+      ++pos;
+
+      std::string mv_name, mv_value, mv_type;
+      while (pos < json.size())
+      {
+        skipWhitespace_(json, pos);
+        if (pos >= json.size() || json[pos] == '}') { ++pos; break; }
+        if (json[pos] == ',') { ++pos; continue; }
+
+        std::string mk = parseJsonString_(json, pos);
+        skipWhitespace_(json, pos);
+        if (pos < json.size() && json[pos] == ':') ++pos;
+        skipWhitespace_(json, pos);
+
+        if (mk == "name") mv_name = parseJsonString_(json, pos);
+        else if (mk == "value") mv_value = parseJsonString_(json, pos);
+        else if (mk == "type") mv_type = parseJsonString_(json, pos);
+        else parseJsonString_(json, pos);
+      }
+
+      if (!mv_name.empty())
+      {
+        if (mv_type == "int")
+        {
+          try { target.setMetaValue(mv_name, DataValue(std::stoi(mv_value))); }
+          catch (...) { target.setMetaValue(mv_name, DataValue(mv_value)); }
+        }
+        else if (mv_type == "double" || mv_type == "float")
+        {
+          try { target.setMetaValue(mv_name, DataValue(std::stod(mv_value))); }
+          catch (...) { target.setMetaValue(mv_name, DataValue(mv_value)); }
+        }
+        else if (mv_type == "int_list")
+        {
+          try
+          {
+            String s(mv_value);
+            if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+            target.setMetaValue(mv_name, DataValue(ListUtils::create<Int>(s)));
+          }
+          catch (...) { target.setMetaValue(mv_name, DataValue(mv_value)); }
+        }
+        else if (mv_type == "double_list")
+        {
+          try
+          {
+            String s(mv_value);
+            if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+            target.setMetaValue(mv_name, DataValue(ListUtils::create<double>(s)));
+          }
+          catch (...) { target.setMetaValue(mv_name, DataValue(mv_value)); }
+        }
+        else if (mv_type == "string_list")
+        {
+          try
+          {
+            String s(mv_value);
+            if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+            auto sl = ListUtils::create<String>(s);
+            for (auto& e : sl) { e = e.trim(); }
+            target.setMetaValue(mv_name, DataValue(sl));
+          }
+          catch (...) { target.setMetaValue(mv_name, DataValue(mv_value)); }
+        }
+        else
+        {
+          target.setMetaValue(mv_name, DataValue(mv_value));
+        }
+      }
+    }
+  }
+
+  // ==================== Column header JSON helpers ====================
+
+  /// Serialize ConsensusMap column headers to a JSON string (including metavalues).
+  std::string serializeColumnHeaders_(const ConsensusMap::ColumnHeaders& headers)
+  {
+    std::string json = "[";
+    bool first = true;
+    for (const auto& [map_index, header] : headers)
+    {
+      if (!first) json += ",";
+      json += "{\"map_index\":" + std::to_string(map_index)
+            + ",\"filename\":\"" + escapeJsonString_(header.filename) + "\""
+            + ",\"label\":\"" + escapeJsonString_(header.label) + "\""
+            + ",\"size\":" + std::to_string(header.size)
+            + ",\"unique_id\":" + std::to_string(header.unique_id)
+            + ",\"metavalues\":" + serializeMetaValues_(header)
+            + "}";
+      first = false;
+    }
+    json += "]";
+    return json;
+  }
+
+  /// Deserialize a JSON string into ConsensusMap column headers.
+  ConsensusMap::ColumnHeaders deserializeColumnHeaders_(const std::string& json)
+  {
+    ConsensusMap::ColumnHeaders result;
+    if (json.empty()) return result;
+
+    size_t pos = 0;
+    skipWhitespace_(json, pos);
+    if (pos >= json.size() || json[pos] != '[') return result;
+    ++pos;
+
+    while (pos < json.size())
+    {
+      skipWhitespace_(json, pos);
+      if (pos >= json.size() || json[pos] == ']') break;
+      if (json[pos] == ',') { ++pos; continue; }
+      if (json[pos] != '{') break;
+      ++pos;
+
+      ConsensusMap::ColumnHeader header;
+      UInt64 map_index = 0;
+
+      while (pos < json.size())
+      {
+        skipWhitespace_(json, pos);
+        if (pos >= json.size() || json[pos] == '}') { ++pos; break; }
+        if (json[pos] == ',') { ++pos; continue; }
+
+        std::string key = parseJsonString_(json, pos);
+        skipWhitespace_(json, pos);
+        if (pos < json.size() && json[pos] == ':') ++pos;
+        skipWhitespace_(json, pos);
+
+        if (key == "map_index" || key == "size" || key == "unique_id")
+        {
+          std::string num_str;
+          while (pos < json.size() && (std::isdigit(json[pos]) || json[pos] == '-'))
+          {
+            num_str += json[pos++];
+          }
+          if (key == "map_index") map_index = std::stoull(num_str);
+          else if (key == "size") header.size = std::stoull(num_str);
+          else if (key == "unique_id") header.unique_id = std::stoull(num_str);
+        }
+        else if (key == "metavalues")
+        {
+          // Parse the nested metavalues array inline
+          // Find the matching ']' to extract the substring for deserializeMetaValues_
+          if (pos < json.size() && json[pos] == '[')
+          {
+            size_t start = pos;
+            int depth = 0;
+            while (pos < json.size())
+            {
+              if (json[pos] == '[') ++depth;
+              else if (json[pos] == ']') { --depth; if (depth == 0) { ++pos; break; } }
+              else if (json[pos] == '"') { ++pos; while (pos < json.size() && json[pos] != '"') { if (json[pos] == '\\') ++pos; ++pos; } }
+              ++pos;
+            }
+            deserializeMetaValues_(json.substr(start, pos - start), header);
+          }
+        }
+        else
+        {
+          std::string val = parseJsonString_(json, pos);
+          if (key == "filename") header.filename = val;
+          else if (key == "label") header.label = val;
+        }
+      }
+      result[map_index] = header;
+    }
+    return result;
+  }
+
+  // ==================== Parquet I/O helpers ====================
 
   /// Write an Arrow table to a Parquet file with QPX-style metadata.
   bool writeArrowTableToParquet_(
@@ -460,7 +667,7 @@ namespace // anonymous
   {
     if (!table)
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: null table passed to writeArrowTableToParquet_" << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: null table passed to writeArrowTableToParquet_" << std::endl;
       return false;
     }
 
@@ -474,8 +681,8 @@ namespace // anonymous
       uint32_t r = dist(gen);
       std::memcpy(bytes + i * 4, &r, 4);
     }
-    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
-    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
+    bytes[6] = (bytes[6] & 0x0F) | 0x40;
+    bytes[8] = (bytes[8] & 0x3F) | 0x80;
     char buf[37];
     std::snprintf(buf, sizeof(buf),
       "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
@@ -504,16 +711,14 @@ namespace // anonymous
     }
     table = table->ReplaceSchemaMetadata(metadata);
 
-    // Open output file
     auto result = arrow::io::FileOutputStream::Open(filename);
     if (!result.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to open file: " << filename << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to open file: " << filename << std::endl;
       return false;
     }
     auto outfile = *result;
 
-    // Configure Parquet writer
     auto builder = parquet::WriterProperties::Builder();
 
     switch (config.compression)
@@ -551,31 +756,18 @@ namespace // anonymous
     auto writer_props = builder.build();
     auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
 
-    // Write
     auto write_status = parquet::arrow::WriteTable(
       *table, arrow::default_memory_pool(), outfile,
       config.row_group_size, writer_props, arrow_props);
 
     if (!write_status.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to write Parquet: "
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to write Parquet: "
                        << write_status.ToString() << std::endl;
       return false;
     }
 
     return true;
-  }
-
-  /// Count total features recursively (top-level + all subordinates).
-  Size countFeaturesRecursive_(const std::vector<Feature>& features)
-  {
-    Size count = 0;
-    for (const auto& f : features)
-    {
-      ++count;
-      count += countFeaturesRecursive_(f.getSubordinates());
-    }
-    return count;
   }
 
   // ==================== Import helpers ====================
@@ -586,7 +778,7 @@ namespace // anonymous
     auto infile_result = arrow::io::ReadableFile::Open(std::string(filename));
     if (!infile_result.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to open file: " << filename << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to open file: " << filename << std::endl;
       return nullptr;
     }
     auto infile = *infile_result;
@@ -594,7 +786,7 @@ namespace // anonymous
     auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
     if (!reader_result.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to create Parquet reader for: " << filename << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to create Parquet reader for: " << filename << std::endl;
       return nullptr;
     }
     auto reader = std::move(reader_result.ValueOrDie());
@@ -603,14 +795,14 @@ namespace // anonymous
     auto read_status = reader->ReadTable(&table);
     if (!read_status.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to read table: " << read_status.ToString() << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to read table: " << read_status.ToString() << std::endl;
       return nullptr;
     }
 
     auto combined = table->CombineChunks(arrow::default_memory_pool());
     if (!combined.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks" << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks" << std::endl;
       return nullptr;
     }
 
@@ -618,7 +810,6 @@ namespace // anonymous
   }
 
   /// Fetch a named column from a table, combining chunks if needed.
-  /// Returns nullptr if column not found (logs error if required).
   std::shared_ptr<arrow::Array> getColumn_(
     const std::shared_ptr<arrow::Table>& table,
     const std::string& name,
@@ -629,13 +820,13 @@ namespace // anonymous
     {
       if (required)
       {
-        OPENMS_LOG_ERROR << "FeatureMapArrowIO: Missing required column '" << name << "'" << std::endl;
+        OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Missing required column '" << name << "'" << std::endl;
       }
       return nullptr;
     }
     if (column->num_chunks() == 0)
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Column '" << name << "' has no chunks" << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Column '" << name << "' has no chunks" << std::endl;
       return nullptr;
     }
     if (column->num_chunks() == 1)
@@ -645,62 +836,54 @@ namespace // anonymous
     auto combined = arrow::Concatenate(column->chunks(), arrow::default_memory_pool());
     if (!combined.ok())
     {
-      OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks for column '" << name << "'" << std::endl;
+      OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks for column '" << name << "'" << std::endl;
       return nullptr;
     }
     return *combined;
   }
 
-  /// Get string value at a row, returning empty string if null.
   String getStringValue_(const std::shared_ptr<arrow::Array>& array, int64_t row)
   {
     if (!array || array->IsNull(row)) return "";
     return std::static_pointer_cast<arrow::StringArray>(array)->GetString(row);
   }
 
-  /// Get double value at a row, returning default_val if null.
   double getDoubleValue_(const std::shared_ptr<arrow::Array>& array, int64_t row, double default_val = 0.0)
   {
     if (!array || array->IsNull(row)) return default_val;
     return std::static_pointer_cast<arrow::DoubleArray>(array)->Value(row);
   }
 
-  /// Get float value at a row, returning default_val if null.
   float getFloatValue_(const std::shared_ptr<arrow::Array>& array, int64_t row, float default_val = 0.0f)
   {
     if (!array || array->IsNull(row)) return default_val;
     return std::static_pointer_cast<arrow::FloatArray>(array)->Value(row);
   }
 
-  /// Get int64 value at a row, returning default_val if null.
   int64_t getInt64Value_(const std::shared_ptr<arrow::Array>& array, int64_t row, int64_t default_val = 0)
   {
     if (!array || array->IsNull(row)) return default_val;
     return std::static_pointer_cast<arrow::Int64Array>(array)->Value(row);
   }
 
-  /// Get int32 value at a row, returning default_val if null.
   int32_t getInt32Value_(const std::shared_ptr<arrow::Array>& array, int64_t row, int32_t default_val = 0)
   {
     if (!array || array->IsNull(row)) return default_val;
     return std::static_pointer_cast<arrow::Int32Array>(array)->Value(row);
   }
 
-  /// Get boolean value at a row, returning default_val if null.
   bool getBoolValue_(const std::shared_ptr<arrow::Array>& array, int64_t row, bool default_val = false)
   {
     if (!array || array->IsNull(row)) return default_val;
     return std::static_pointer_cast<arrow::BooleanArray>(array)->Value(row);
   }
 
-  /// Check if value at row is null.
   bool isNull_(const std::shared_ptr<arrow::Array>& array, int64_t row)
   {
     return !array || array->IsNull(row);
   }
 
   /// Read metavalues from a list<struct{name,value,value_type}> column at a given row.
-  /// Sets them on the target MetaInfoInterface, excluding specified keys.
   void readMetaValues_(
     const std::shared_ptr<arrow::Array>& array,
     int64_t row,
@@ -773,82 +956,82 @@ namespace // anonymous
     }
   }
 
-  /// Read convex hulls from a list<struct{hull_index, points: list<struct{x, y}>}> column at a given row.
-  void readConvexHulls_(
+  /// Read FeatureHandles from a list<struct{...}> column at a given row into a ConsensusFeature.
+  void readHandles_(
     const std::shared_ptr<arrow::Array>& array,
     int64_t row,
-    Feature& feature)
+    ConsensusFeature& cf)
   {
     if (!array || array->IsNull(row)) return;
     auto list_arr = std::static_pointer_cast<arrow::ListArray>(array);
-    auto hull_struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->value_slice(row));
-    if (!hull_struct_arr || hull_struct_arr->length() == 0) return;
+    auto struct_arr = std::static_pointer_cast<arrow::StructArray>(list_arr->value_slice(row));
+    if (!struct_arr || struct_arr->length() == 0) return;
 
-    auto points_list_arr = std::static_pointer_cast<arrow::ListArray>(hull_struct_arr->field(1));
+    auto map_index_arr = std::static_pointer_cast<arrow::Int64Array>(struct_arr->field(0));
+    auto unique_id_arr = std::static_pointer_cast<arrow::Int64Array>(struct_arr->field(1));
+    auto rt_arr = std::static_pointer_cast<arrow::DoubleArray>(struct_arr->field(2));
+    auto mz_arr = std::static_pointer_cast<arrow::DoubleArray>(struct_arr->field(3));
+    auto intensity_arr = std::static_pointer_cast<arrow::FloatArray>(struct_arr->field(4));
+    auto charge_arr = std::static_pointer_cast<arrow::Int32Array>(struct_arr->field(5));
+    auto width_arr = std::static_pointer_cast<arrow::FloatArray>(struct_arr->field(6));
 
-    for (int64_t h = 0; h < hull_struct_arr->length(); ++h)
+    for (int64_t i = 0; i < struct_arr->length(); ++i)
     {
-      ConvexHull2D hull;
-      ConvexHull2D::PointArrayType hull_points;
-
-      auto point_struct_arr = std::static_pointer_cast<arrow::StructArray>(points_list_arr->value_slice(h));
-      if (point_struct_arr && point_struct_arr->length() > 0)
-      {
-        auto x_arr = std::static_pointer_cast<arrow::DoubleArray>(point_struct_arr->field(0));
-        auto y_arr = std::static_pointer_cast<arrow::DoubleArray>(point_struct_arr->field(1));
-
-        hull_points.reserve(point_struct_arr->length());
-        for (int64_t p = 0; p < point_struct_arr->length(); ++p)
-        {
-          hull_points.emplace_back(x_arr->Value(p), y_arr->Value(p));
-        }
-      }
-
-      hull.setHullPoints(hull_points);
-      feature.getConvexHulls().push_back(hull);
+      FeatureHandle handle;
+      handle.setMapIndex(static_cast<UInt64>(map_index_arr->Value(i)));
+      handle.setUniqueId(static_cast<UInt64>(unique_id_arr->Value(i)));
+      handle.setRT(rt_arr->Value(i));
+      handle.setMZ(mz_arr->Value(i));
+      handle.setIntensity(intensity_arr->Value(i));
+      handle.setCharge(static_cast<Int>(charge_arr->Value(i)));
+      handle.setWidth(width_arr->Value(i));
+      cf.insert(handle);
     }
   }
 
 } // anonymous namespace
 
 
-std::shared_ptr<arrow::Table> FeatureMapArrowIO::exportFeaturesToArrow(
-  const FeatureMap& feature_map)
+// ==================== Export methods ====================
+
+std::shared_ptr<arrow::Table> ConsensusMapArrowIO::exportFeaturesToArrow(
+  const ConsensusMap& cmap)
 {
   // -- Scalar column builders --
   arrow::Int64Builder unique_id_builder;
-  arrow::Int64Builder parent_feature_id_builder;
-  arrow::Int32Builder depth_builder;
   arrow::DoubleBuilder rt_builder, mz_builder;
   arrow::FloatBuilder intensity_builder;
   arrow::Int32Builder charge_builder;
-  arrow::FloatBuilder overall_quality_builder, quality_rt_builder, quality_mz_builder;
+  arrow::FloatBuilder quality_builder;
   arrow::FloatBuilder width_builder;
-  arrow::DoubleBuilder rt_bb_min_builder, rt_bb_max_builder, mz_bb_min_builder, mz_bb_max_builder;
 
-  // -- convex_hulls: list<struct{hull_index: int32, points: list<struct{x: float64, y: float64}>}> --
-  auto point_x_b = std::make_shared<arrow::DoubleBuilder>();
-  auto point_y_b = std::make_shared<arrow::DoubleBuilder>();
-  auto point_struct_type = arrow::struct_({
-    arrow::field("x", arrow::float64()),
-    arrow::field("y", arrow::float64())
+  // -- handles: list<struct{map_index, unique_id, rt, mz, intensity, charge, width}> --
+  auto handle_map_index_b = std::make_shared<arrow::Int64Builder>();
+  auto handle_unique_id_b = std::make_shared<arrow::Int64Builder>();
+  auto handle_rt_b = std::make_shared<arrow::DoubleBuilder>();
+  auto handle_mz_b = std::make_shared<arrow::DoubleBuilder>();
+  auto handle_intensity_b = std::make_shared<arrow::FloatBuilder>();
+  auto handle_charge_b = std::make_shared<arrow::Int32Builder>();
+  auto handle_width_b = std::make_shared<arrow::FloatBuilder>();
+
+  auto handle_struct_type = arrow::struct_({
+    arrow::field("map_index", arrow::int64()),
+    arrow::field("unique_id", arrow::int64()),
+    arrow::field("rt", arrow::float64()),
+    arrow::field("mz", arrow::float64()),
+    arrow::field("intensity", arrow::float32()),
+    arrow::field("charge", arrow::int32()),
+    arrow::field("width", arrow::float32())
   });
-  auto point_struct_b = std::make_shared<arrow::StructBuilder>(
-    point_struct_type, arrow::default_memory_pool(),
-    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{point_x_b, point_y_b});
-  auto points_list_b = std::make_shared<arrow::ListBuilder>(arrow::default_memory_pool(), point_struct_b);
 
-  auto hull_index_b = std::make_shared<arrow::Int32Builder>();
-  auto hull_struct_type = arrow::struct_({
-    arrow::field("hull_index", arrow::int32()),
-    arrow::field("points", arrow::list(point_struct_type))
-  });
-  auto hull_struct_b = std::make_shared<arrow::StructBuilder>(
-    hull_struct_type, arrow::default_memory_pool(),
-    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{hull_index_b, points_list_b});
-  arrow::ListBuilder convex_hulls_builder(arrow::default_memory_pool(), hull_struct_b);
+  auto handle_struct_b = std::make_shared<arrow::StructBuilder>(
+    handle_struct_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{
+      handle_map_index_b, handle_unique_id_b, handle_rt_b, handle_mz_b,
+      handle_intensity_b, handle_charge_b, handle_width_b});
+  arrow::ListBuilder handles_builder(arrow::default_memory_pool(), handle_struct_b);
 
-  // -- metavalues: list<struct{name: utf8, value: utf8, value_type: utf8}> --
+  // -- metavalues: list<struct{name, value, value_type}> --
   auto mv_name_b = std::make_shared<arrow::StringBuilder>();
   auto mv_value_b = std::make_shared<arrow::StringBuilder>();
   auto mv_type_b = std::make_shared<arrow::StringBuilder>();
@@ -862,80 +1045,39 @@ std::shared_ptr<arrow::Table> FeatureMapArrowIO::exportFeaturesToArrow(
     std::vector<std::shared_ptr<arrow::ArrayBuilder>>{mv_name_b, mv_value_b, mv_type_b});
   arrow::ListBuilder metavalues_builder(arrow::default_memory_pool(), mv_struct_b);
 
-  // Count total features (top-level + subordinates) for capacity reservation
-  Size num_rows = countFeaturesRecursive_(feature_map.getData());
+  Size num_rows = cmap.size();
 
-  // Reserve capacity for scalar builders
   arrow::Status status;
 
   #define RESERVE_OR_RETURN(builder_name) \
     status = builder_name.Reserve(num_rows); \
-    if (!status.ok()) { OPENMS_LOG_ERROR << "FeatureMapArrowIO: " #builder_name " Reserve failed: " << status.ToString() << std::endl; return nullptr; }
+    if (!status.ok()) { OPENMS_LOG_ERROR << "ConsensusMapArrowIO: " #builder_name " Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
   RESERVE_OR_RETURN(unique_id_builder)
-  RESERVE_OR_RETURN(parent_feature_id_builder)
-  RESERVE_OR_RETURN(depth_builder)
   RESERVE_OR_RETURN(rt_builder)
   RESERVE_OR_RETURN(mz_builder)
   RESERVE_OR_RETURN(intensity_builder)
   RESERVE_OR_RETURN(charge_builder)
-  RESERVE_OR_RETURN(overall_quality_builder)
-  RESERVE_OR_RETURN(quality_rt_builder)
-  RESERVE_OR_RETURN(quality_mz_builder)
+  RESERVE_OR_RETURN(quality_builder)
   RESERVE_OR_RETURN(width_builder)
-  RESERVE_OR_RETURN(rt_bb_min_builder)
-  RESERVE_OR_RETURN(rt_bb_max_builder)
-  RESERVE_OR_RETURN(mz_bb_min_builder)
-  RESERVE_OR_RETURN(mz_bb_max_builder)
 
   #undef RESERVE_OR_RETURN
 
-  // Exclude FWHM from metavalues (it is already stored as a dedicated column or derived from convex hulls)
+  // Exclude FWHM from metavalues (it is already stored as the dedicated 'width' column)
   static const std::unordered_set<std::string> excluded_mvs = {"FWHM"};
 
-  // Recursive lambda to flatten features depth-first
-  std::function<void(const Feature&, int64_t, int32_t)> appendFeature =
-    [&](const Feature& feature, int64_t parent_id, int32_t depth)
+  for (const auto& cf : cmap)
   {
-    // === unique_id (not nullable) ===
-    (void)unique_id_builder.Append(static_cast<int64_t>(feature.getUniqueId()));
+    (void)unique_id_builder.Append(static_cast<int64_t>(cf.getUniqueId()));
+    (void)rt_builder.Append(cf.getRT());
+    (void)mz_builder.Append(cf.getMZ());
+    (void)intensity_builder.Append(cf.getIntensity());
+    (void)charge_builder.Append(static_cast<int32_t>(cf.getCharge()));
+    (void)quality_builder.Append(cf.getQuality());
 
-    // === parent_feature_id (nullable: null for top-level) ===
-    if (depth == 0)
-    {
-      (void)parent_feature_id_builder.AppendNull();
-    }
-    else
-    {
-      (void)parent_feature_id_builder.Append(parent_id);
-    }
-
-    // === depth (not nullable) ===
-    (void)depth_builder.Append(depth);
-
-    // === rt (not nullable) ===
-    (void)rt_builder.Append(feature.getRT());
-
-    // === mz (not nullable) ===
-    (void)mz_builder.Append(feature.getMZ());
-
-    // === intensity (not nullable) ===
-    (void)intensity_builder.Append(feature.getIntensity());
-
-    // === charge (not nullable) ===
-    (void)charge_builder.Append(static_cast<int32_t>(feature.getCharge()));
-
-    // === overall_quality (not nullable) ===
-    (void)overall_quality_builder.Append(feature.getOverallQuality());
-
-    // === quality_rt (not nullable) ===
-    (void)quality_rt_builder.Append(feature.getQuality(0));
-
-    // === quality_mz (not nullable) ===
-    (void)quality_mz_builder.Append(feature.getQuality(1));
-
-    // === width (nullable: null if 0.0, since 0.0 is the unset default; round-trip correct) ===
-    float w = feature.getWidth();
+    // Width: 0.0 is the unset default, stored as null to distinguish from explicitly set values.
+    // On import, null is left as default (0.0), so round-trip is numerically correct.
+    float w = cf.getWidth();
     if (w == 0.0f)
     {
       (void)width_builder.AppendNull();
@@ -945,182 +1087,104 @@ std::shared_ptr<arrow::Table> FeatureMapArrowIO::exportFeaturesToArrow(
       (void)width_builder.Append(w);
     }
 
-    // === bounding box (nullable: null if no convex hulls) ===
-    const auto& hulls = feature.getConvexHulls();
-    if (hulls.empty())
+    // handles
+    (void)handles_builder.Append();
+    for (const auto& handle : cf.getFeatures())
     {
-      (void)rt_bb_min_builder.AppendNull();
-      (void)rt_bb_max_builder.AppendNull();
-      (void)mz_bb_min_builder.AppendNull();
-      (void)mz_bb_max_builder.AppendNull();
-    }
-    else
-    {
-      auto bb = feature.getConvexHull().getBoundingBox();
-      (void)rt_bb_min_builder.Append(bb.minPosition()[0]);
-      (void)rt_bb_max_builder.Append(bb.maxPosition()[0]);
-      (void)mz_bb_min_builder.Append(bb.minPosition()[1]);
-      (void)mz_bb_max_builder.Append(bb.maxPosition()[1]);
+      (void)handle_struct_b->Append();
+      (void)handle_map_index_b->Append(static_cast<int64_t>(handle.getMapIndex()));
+      (void)handle_unique_id_b->Append(static_cast<int64_t>(handle.getUniqueId()));
+      (void)handle_rt_b->Append(handle.getRT());
+      (void)handle_mz_b->Append(handle.getMZ());
+      (void)handle_intensity_b->Append(handle.getIntensity());
+      (void)handle_charge_b->Append(static_cast<int32_t>(handle.getCharge()));
+      (void)handle_width_b->Append(handle.getWidth());
     }
 
-    // === convex_hulls (not nullable) ===
-    (void)convex_hulls_builder.Append(); // begin list for this feature
-    for (int32_t hull_idx = 0; hull_idx < static_cast<int32_t>(hulls.size()); ++hull_idx)
-    {
-      const auto& hull = hulls[hull_idx];
-      const auto& points = hull.getHullPoints();
-
-      (void)hull_struct_b->Append(); // begin struct for this hull
-      (void)hull_index_b->Append(hull_idx);
-      (void)points_list_b->Append(); // begin list of points
-      for (const auto& pt : points)
-      {
-        (void)point_struct_b->Append();
-        (void)point_x_b->Append(pt[0]); // RT
-        (void)point_y_b->Append(pt[1]); // MZ
-      }
-    }
-
-    // === metavalues (not nullable) ===
+    // metavalues
     (void)metavalues_builder.Append();
-    appendMetaValues_(feature, mv_name_b, mv_value_b, mv_type_b, mv_struct_b, excluded_mvs);
-
-    // Recurse into subordinates
-    int64_t this_id = static_cast<int64_t>(feature.getUniqueId());
-    for (const auto& sub : feature.getSubordinates())
-    {
-      appendFeature(sub, this_id, depth + 1);
-    }
-  };
-
-  // Walk all top-level features
-  for (const auto& feature : feature_map)
-  {
-    appendFeature(feature, 0, 0);
+    appendMetaValues_(cf, mv_name_b, mv_value_b, mv_type_b, mv_struct_b, excluded_mvs);
   }
 
-  // Finalize all arrays
-  std::shared_ptr<arrow::Array> arr_unique_id, arr_parent_id, arr_depth;
-  std::shared_ptr<arrow::Array> arr_rt, arr_mz, arr_intensity;
-  std::shared_ptr<arrow::Array> arr_charge, arr_overall_quality;
-  std::shared_ptr<arrow::Array> arr_quality_rt, arr_quality_mz;
-  std::shared_ptr<arrow::Array> arr_width;
-  std::shared_ptr<arrow::Array> arr_rt_bb_min, arr_rt_bb_max, arr_mz_bb_min, arr_mz_bb_max;
-  std::shared_ptr<arrow::Array> arr_convex_hulls, arr_metavalues;
+  // Finalize arrays
+  std::shared_ptr<arrow::Array> arr_unique_id, arr_rt, arr_mz, arr_intensity;
+  std::shared_ptr<arrow::Array> arr_charge, arr_quality, arr_width;
+  std::shared_ptr<arrow::Array> arr_handles, arr_metavalues;
 
   #define FINISH_OR_RETURN(builder_name, arr_name) \
     status = builder_name.Finish(&arr_name); \
-    if (!status.ok()) { OPENMS_LOG_ERROR << "FeatureMapArrowIO: " #builder_name " Finish failed: " << status.ToString() << std::endl; return nullptr; }
+    if (!status.ok()) { OPENMS_LOG_ERROR << "ConsensusMapArrowIO: " #builder_name " Finish failed: " << status.ToString() << std::endl; return nullptr; }
 
   FINISH_OR_RETURN(unique_id_builder, arr_unique_id)
-  FINISH_OR_RETURN(parent_feature_id_builder, arr_parent_id)
-  FINISH_OR_RETURN(depth_builder, arr_depth)
   FINISH_OR_RETURN(rt_builder, arr_rt)
   FINISH_OR_RETURN(mz_builder, arr_mz)
   FINISH_OR_RETURN(intensity_builder, arr_intensity)
   FINISH_OR_RETURN(charge_builder, arr_charge)
-  FINISH_OR_RETURN(overall_quality_builder, arr_overall_quality)
-  FINISH_OR_RETURN(quality_rt_builder, arr_quality_rt)
-  FINISH_OR_RETURN(quality_mz_builder, arr_quality_mz)
+  FINISH_OR_RETURN(quality_builder, arr_quality)
   FINISH_OR_RETURN(width_builder, arr_width)
-  FINISH_OR_RETURN(rt_bb_min_builder, arr_rt_bb_min)
-  FINISH_OR_RETURN(rt_bb_max_builder, arr_rt_bb_max)
-  FINISH_OR_RETURN(mz_bb_min_builder, arr_mz_bb_min)
-  FINISH_OR_RETURN(mz_bb_max_builder, arr_mz_bb_max)
-  FINISH_OR_RETURN(convex_hulls_builder, arr_convex_hulls)
+  FINISH_OR_RETURN(handles_builder, arr_handles)
   FINISH_OR_RETURN(metavalues_builder, arr_metavalues)
 
   #undef FINISH_OR_RETURN
 
-  // Build schema (17 columns)
   auto schema = arrow::schema({
-    arrow::field("unique_id", arrow::int64(), /*nullable=*/false),
-    arrow::field("parent_feature_id", arrow::int64(), /*nullable=*/true),
-    arrow::field("depth", arrow::int32(), /*nullable=*/false),
-    arrow::field("rt", arrow::float64(), /*nullable=*/false),
-    arrow::field("mz", arrow::float64(), /*nullable=*/false),
-    arrow::field("intensity", arrow::float32(), /*nullable=*/false),
-    arrow::field("charge", arrow::int32(), /*nullable=*/false),
-    arrow::field("quality", arrow::float32(), /*nullable=*/false),
-    arrow::field("quality_rt", arrow::float32(), /*nullable=*/false),
-    arrow::field("quality_mz", arrow::float32(), /*nullable=*/false),
-    arrow::field("width", arrow::float32(), /*nullable=*/true),
-    arrow::field("rt_bb_min", arrow::float64(), /*nullable=*/true),
-    arrow::field("rt_bb_max", arrow::float64(), /*nullable=*/true),
-    arrow::field("mz_bb_min", arrow::float64(), /*nullable=*/true),
-    arrow::field("mz_bb_max", arrow::float64(), /*nullable=*/true),
-    arrow::field("convex_hulls", convex_hulls_builder.type(), /*nullable=*/false),
-    arrow::field("metavalues", metavalues_builder.type(), /*nullable=*/false),
+    arrow::field("unique_id", arrow::int64()),
+    arrow::field("rt", arrow::float64()),
+    arrow::field("mz", arrow::float64()),
+    arrow::field("intensity", arrow::float32()),
+    arrow::field("charge", arrow::int32()),
+    arrow::field("quality", arrow::float32()),
+    arrow::field("width", arrow::float32()),
+    arrow::field("handles", arrow::list(handle_struct_type)),
+    arrow::field("metavalues", arrow::list(mv_struct_type))
   });
 
-  auto table = arrow::Table::Make(schema, {
-    arr_unique_id, arr_parent_id, arr_depth,
-    arr_rt, arr_mz, arr_intensity,
-    arr_charge, arr_overall_quality,
-    arr_quality_rt, arr_quality_mz,
-    arr_width,
-    arr_rt_bb_min, arr_rt_bb_max, arr_mz_bb_min, arr_mz_bb_max,
-    arr_convex_hulls, arr_metavalues
+  return arrow::Table::Make(schema, {
+    arr_unique_id, arr_rt, arr_mz, arr_intensity,
+    arr_charge, arr_quality, arr_width,
+    arr_handles, arr_metavalues
   });
-
-  return table;
 }
 
-std::shared_ptr<arrow::Table> FeatureMapArrowIO::exportPSMsToArrow(
-  const FeatureMap& feature_map)
+std::shared_ptr<arrow::Table> ConsensusMapArrowIO::exportPSMsToArrow(
+  const ConsensusMap& cmap)
 {
-  // 1. Collect all PeptideIdentifications with their associated feature_ids.
-  //    For each PeptideIdentification we store (feature_unique_id, is_null).
+  // Collect all PeptideIdentifications with their associated consensus_feature_unique_ids.
   PeptideIdentificationList all_pep_ids;
-  std::vector<std::pair<int64_t, bool>> feature_ids_per_pep_id; // (feature_id, is_null)
+  std::vector<std::pair<int64_t, bool>> feature_ids_per_pep_id; // (id, is_null)
 
-  // Helper: recursively collect PeptideIdentifications from a Feature and its subordinates.
-  std::function<void(const Feature&)> collectFromFeature = [&](const Feature& f)
+  // Collect from consensus features (flat - no subordinates)
+  for (const auto& cf : cmap)
   {
-    for (const auto& pep_id : f.getPeptideIdentifications())
+    for (const auto& pep_id : cf.getPeptideIdentifications())
     {
       all_pep_ids.push_back(pep_id);
-      feature_ids_per_pep_id.push_back({static_cast<int64_t>(f.getUniqueId()), false});
+      feature_ids_per_pep_id.push_back({static_cast<int64_t>(cf.getUniqueId()), false});
     }
-    for (const auto& sub : f.getSubordinates())
-    {
-      collectFromFeature(sub);
-    }
-  };
-
-  for (const auto& feature : feature_map)
-  {
-    collectFromFeature(feature);
   }
 
-  // Unassigned peptide identifications get feature_id = null
-  for (const auto& pep_id : feature_map.getUnassignedPeptideIdentifications())
+  // Unassigned peptide identifications get consensus_feature_unique_id = null
+  for (const auto& pep_id : cmap.getUnassignedPeptideIdentifications())
   {
     all_pep_ids.push_back(pep_id);
-    feature_ids_per_pep_id.push_back({0, true}); // null
+    feature_ids_per_pep_id.push_back({0, true});
   }
 
-  // 2. Call QPXFile::exportToArrow to produce the base PSM table.
-  //    We use export_all_psms=true so all hits per PeptideIdentification are exported.
+  // Delegate to QPXFile to produce the base PSM table
   auto base_table = QPXFile::exportToArrow(
-    feature_map.getProteinIdentifications(), all_pep_ids, true);
+    cmap.getProteinIdentifications(), all_pep_ids, true);
   if (!base_table) { return nullptr; }
 
-  // 3. Build the feature_id column.
-  //    QPXFile::exportToArrow (with export_all_psms=true) produces one row per
-  //    PeptideHit across all PeptideIdentifications. PeptideIdentifications
-  //    with empty hits are skipped. We emit one feature_id per PeptideHit.
+  // Build the consensus_feature_unique_id column (one value per PeptideHit)
   arrow::Int64Builder feature_id_builder;
 
   for (size_t i = 0; i < all_pep_ids.size(); ++i)
   {
-    // Skip PeptideIdentifications with no hits (QPXFile skips them too)
     if (all_pep_ids[i].getHits().empty())
     {
       continue;
     }
 
-    // Emit one feature_id per PeptideHit in this PeptideIdentification
     for (size_t j = 0; j < all_pep_ids[i].getHits().size(); ++j)
     {
       if (feature_ids_per_pep_id[i].second) // is_null
@@ -1138,31 +1202,29 @@ std::shared_ptr<arrow::Table> FeatureMapArrowIO::exportPSMsToArrow(
   auto status = feature_id_builder.Finish(&feature_id_array);
   if (!status.ok())
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: feature_id_builder Finish failed: " << status.ToString() << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: feature_id_builder Finish failed: " << status.ToString() << std::endl;
     return nullptr;
   }
 
-  // Verify row count matches
   if (feature_id_array->length() != base_table->num_rows())
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: feature_id column length (" << feature_id_array->length()
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: consensus_feature_unique_id column length (" << feature_id_array->length()
                      << ") does not match table row count (" << base_table->num_rows() << ")" << std::endl;
     return nullptr;
   }
 
-  // 4. Add feature_id as the first column in the table.
   auto chunked_feature_id = std::make_shared<arrow::ChunkedArray>(feature_id_array);
-  auto result = base_table->AddColumn(0, arrow::field("feature_unique_id", arrow::int64()), chunked_feature_id);
+  auto result = base_table->AddColumn(0, arrow::field("consensus_feature_unique_id", arrow::int64()), chunked_feature_id);
   if (!result.ok())
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: AddColumn failed: " << result.status().ToString() << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: AddColumn failed: " << result.status().ToString() << std::endl;
     return nullptr;
   }
   return *result;
 }
 
-bool FeatureMapArrowIO::exportToParquet(
-  const FeatureMap& feature_map,
+bool ConsensusMapArrowIO::exportToParquet(
+  const ConsensusMap& cmap,
   const String& directory,
   const ParquetWriteConfig& config)
 {
@@ -1173,35 +1235,39 @@ bool FeatureMapArrowIO::exportToParquet(
   }
   catch (const std::filesystem::filesystem_error& e)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to create directory: " << e.what() << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to create directory: " << e.what() << std::endl;
     return false;
   }
 
-  // 2. Export features table (with FeatureMap-level metadata)
-  auto features_table = exportFeaturesToArrow(feature_map);
+  // 2. Export consensus features table (with ConsensusMap-level metadata)
+  auto features_table = exportFeaturesToArrow(cmap);
   if (!features_table)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to create features Arrow table" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to create consensus features Arrow table" << std::endl;
     return false;
   }
 
-  // Collect FeatureMap-level metadata (DocumentIdentifier + DataProcessing)
-  std::unordered_map<std::string, std::string> feature_map_metadata;
-  feature_map_metadata["document_id"] = feature_map.getIdentifier();
-  feature_map_metadata["loaded_file_path"] = feature_map.getLoadedFilePath();
-  feature_map_metadata["loaded_file_type"] = FileTypes::typeToName(feature_map.getLoadedFileType());
-  feature_map_metadata["data_processing"] = serializeDataProcessing_(feature_map.getDataProcessing());
+  std::unordered_map<std::string, std::string> cmap_metadata;
+  cmap_metadata["column_headers"] = serializeColumnHeaders_(cmap.getColumnHeaders());
+  cmap_metadata["experiment_type"] = cmap.getExperimentType();
+  cmap_metadata["document_id"] = cmap.getIdentifier();
+  cmap_metadata["loaded_file_path"] = cmap.getLoadedFilePath();
+  cmap_metadata["loaded_file_type"] = FileTypes::typeToName(cmap.getLoadedFileType());
+  cmap_metadata["data_processing"] = serializeDataProcessing_(cmap.getDataProcessing());
+  cmap_metadata["unique_id"] = std::to_string(cmap.getUniqueId());
+  cmap_metadata["cmap_metavalues"] = serializeMetaValues_(cmap);
 
-  if (!writeArrowTableToParquet_(features_table, directory + "/features.parquet", "features", config, feature_map_metadata))
+  if (!writeArrowTableToParquet_(features_table, directory + "/consensus_features.parquet",
+                                  "consensus_features", config, cmap_metadata))
   {
     return false;
   }
 
   // 3. Export PSMs table
-  auto psms_table = exportPSMsToArrow(feature_map);
+  auto psms_table = exportPSMsToArrow(cmap);
   if (!psms_table)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to create PSMs Arrow table" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to create PSMs Arrow table" << std::endl;
     return false;
   }
   if (!writeArrowTableToParquet_(psms_table, directory + "/psms.parquet", "psms", config))
@@ -1210,7 +1276,7 @@ bool FeatureMapArrowIO::exportToParquet(
   }
 
   // 4. Delegate protein data to ProteinIdentificationArrowIO
-  const auto& prot_ids = feature_map.getProteinIdentifications();
+  const auto& prot_ids = cmap.getProteinIdentifications();
   if (!ProteinIdentificationArrowIO::exportProteinsToParquet(
           prot_ids, directory + "/proteins.parquet", config))
   {
@@ -1230,21 +1296,22 @@ bool FeatureMapArrowIO::exportToParquet(
   return true;
 }
 
-bool FeatureMapArrowIO::importFeaturesFromArrow(
+// ==================== Import methods ====================
+
+bool ConsensusMapArrowIO::importFeaturesFromArrow(
   const std::shared_ptr<arrow::Table>& table,
-  FeatureMap& feature_map)
+  ConsensusMap& cmap)
 {
   if (!table)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: null table passed to importFeaturesFromArrow" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: null table passed to importFeaturesFromArrow" << std::endl;
     return false;
   }
 
-  // Combine chunks for reliable single-chunk access
   auto combined_result = table->CombineChunks(arrow::default_memory_pool());
   if (!combined_result.ok())
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks" << std::endl;
     return false;
   }
   auto tbl = *combined_result;
@@ -1255,174 +1322,78 @@ bool FeatureMapArrowIO::importFeaturesFromArrow(
     return true;
   }
 
-  // Get all columns
   auto col_unique_id = getColumn_(tbl, "unique_id");
-  auto col_parent_id = getColumn_(tbl, "parent_feature_id");
-  auto col_depth = getColumn_(tbl, "depth");
   auto col_rt = getColumn_(tbl, "rt");
   auto col_mz = getColumn_(tbl, "mz");
   auto col_intensity = getColumn_(tbl, "intensity");
   auto col_charge = getColumn_(tbl, "charge");
-  auto col_overall_quality = getColumn_(tbl, "quality");
-  auto col_quality_rt = getColumn_(tbl, "quality_rt");
-  auto col_quality_mz = getColumn_(tbl, "quality_mz");
-  auto col_width = getColumn_(tbl, "width");
-  auto col_convex_hulls = getColumn_(tbl, "convex_hulls", /*required=*/false);
+  auto col_quality = getColumn_(tbl, "quality");
+  auto col_width = getColumn_(tbl, "width", /*required=*/false);
+  auto col_handles = getColumn_(tbl, "handles", /*required=*/false);
   auto col_metavalues = getColumn_(tbl, "metavalues", /*required=*/false);
 
-  if (!col_unique_id || !col_parent_id || !col_depth || !col_rt || !col_mz ||
-      !col_intensity || !col_charge || !col_overall_quality ||
-      !col_quality_rt || !col_quality_mz)
+  if (!col_unique_id || !col_rt || !col_mz || !col_intensity || !col_charge || !col_quality)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Missing one or more required columns" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Missing one or more required columns" << std::endl;
     return false;
   }
 
-  // Build a vector of {depth, row_index, unique_id, parent_id, Feature} entries
-  struct FeatureEntry
-  {
-    int32_t depth;
-    int64_t row_index;
-    int64_t unique_id;
-    int64_t parent_id;  // -1 if top-level
-    Feature feature;
-  };
-
-  std::vector<FeatureEntry> entries;
-  entries.reserve(num_rows);
-
-  // No metavalue keys to exclude for features
-  static const std::unordered_set<std::string> excluded_mvs = {};
-
   for (int64_t i = 0; i < num_rows; ++i)
   {
-    FeatureEntry entry;
-    entry.row_index = i;
-    entry.depth = getInt32Value_(col_depth, i, 0);
-    entry.unique_id = getInt64Value_(col_unique_id, i, 0);
-    entry.parent_id = isNull_(col_parent_id, i) ? -1 : getInt64Value_(col_parent_id, i, 0);
+    ConsensusFeature cf;
+    cf.setUniqueId(static_cast<UInt64>(getInt64Value_(col_unique_id, i, 0)));
+    cf.setRT(getDoubleValue_(col_rt, i));
+    cf.setMZ(getDoubleValue_(col_mz, i));
+    cf.setIntensity(getFloatValue_(col_intensity, i));
+    cf.setCharge(static_cast<Int>(getInt32Value_(col_charge, i)));
+    cf.setQuality(getFloatValue_(col_quality, i));
 
-    Feature& f = entry.feature;
-    f.setUniqueId(static_cast<UInt64>(entry.unique_id));
-    f.setRT(getDoubleValue_(col_rt, i));
-    f.setMZ(getDoubleValue_(col_mz, i));
-    f.setIntensity(getFloatValue_(col_intensity, i));
-    f.setCharge(static_cast<int>(getInt32Value_(col_charge, i)));
-    f.setOverallQuality(getFloatValue_(col_overall_quality, i));
-    f.setQuality(0, getFloatValue_(col_quality_rt, i));
-    f.setQuality(1, getFloatValue_(col_quality_mz, i));
-
-    // width: null means unset (default 0.0); only set if non-null and non-zero
-    float w = getFloatValue_(col_width, i, 0.0f);
-    if (w != 0.0f)
+    // Width: null means unset (default 0.0), so we only call setWidth for non-null values.
+    if (col_width && !isNull_(col_width, i))
     {
-      f.setWidth(w);
+      cf.setWidth(getFloatValue_(col_width, i));
     }
 
-    // Read convex hulls
-    if (col_convex_hulls)
+    if (col_handles)
     {
-      readConvexHulls_(col_convex_hulls, i, f);
+      readHandles_(col_handles, i, cf);
     }
 
-    // Read metavalues
     if (col_metavalues)
     {
-      readMetaValues_(col_metavalues, i, f, excluded_mvs);
+      readMetaValues_(col_metavalues, i, cf);
     }
 
-    entries.push_back(std::move(entry));
-  }
-
-  // Sort by depth descending so children are processed before parents.
-  // This allows us to build the tree bottom-up: attach children to parents
-  // in the entries vector first, then add fully assembled top-level features
-  // to the FeatureMap.
-  std::stable_sort(entries.begin(), entries.end(),
-    [](const FeatureEntry& a, const FeatureEntry& b) { return a.depth > b.depth; });
-
-  // Build unique_id -> index-in-entries lookup map
-  std::unordered_map<int64_t, size_t> id_to_index;
-  for (size_t i = 0; i < entries.size(); ++i)
-  {
-    id_to_index[entries[i].unique_id] = i;
-  }
-
-  // Bottom-up assembly: for each entry (deepest first), attach it to its parent
-  for (auto& entry : entries)
-  {
-    if (entry.parent_id != -1)
-    {
-      auto it = id_to_index.find(entry.parent_id);
-      if (it != id_to_index.end())
-      {
-        entries[it->second].feature.getSubordinates().push_back(std::move(entry.feature));
-      }
-      else
-      {
-        OPENMS_LOG_WARN << "FeatureMapArrowIO: Could not find parent feature with id "
-                        << entry.parent_id << " for feature " << entry.unique_id
-                        << ". Will be added as top-level." << std::endl;
-        // Mark as top-level by clearing parent_id
-        entry.parent_id = -1;
-      }
-    }
-  }
-
-  // Add top-level features to the FeatureMap (preserving original order by row_index)
-  // First, collect top-level entries sorted by row_index
-  std::vector<size_t> top_level_indices;
-  for (size_t i = 0; i < entries.size(); ++i)
-  {
-    if (entries[i].parent_id == -1)
-    {
-      top_level_indices.push_back(i);
-    }
-  }
-  std::sort(top_level_indices.begin(), top_level_indices.end(),
-    [&](size_t a, size_t b) { return entries[a].row_index < entries[b].row_index; });
-
-  for (size_t idx : top_level_indices)
-  {
-    feature_map.push_back(std::move(entries[idx].feature));
+    cmap.push_back(std::move(cf));
   }
 
   return true;
 }
 
-bool FeatureMapArrowIO::importPSMsFromArrow(
+bool ConsensusMapArrowIO::importPSMsFromArrow(
   const std::shared_ptr<arrow::Table>& table,
-  FeatureMap& feature_map)
+  ConsensusMap& cmap)
 {
   if (!table || table->num_rows() == 0) { return true; }
 
-  // Combine chunks for reliable single-chunk access
   auto combined_result = table->CombineChunks(arrow::default_memory_pool());
   if (!combined_result.ok())
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks in importPSMsFromArrow" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks in importPSMsFromArrow" << std::endl;
     return false;
   }
   auto tbl = *combined_result;
   int64_t num_rows = tbl->num_rows();
 
-  // Build feature lookup: unique_id -> Feature* (recursively includes subordinates)
-  std::unordered_map<int64_t, Feature*> feature_lookup;
-  std::function<void(Feature&)> buildLookup = [&](Feature& f)
+  // Build consensus feature lookup: unique_id -> ConsensusFeature*
+  std::unordered_map<int64_t, ConsensusFeature*> feature_lookup;
+  for (auto& cf : cmap)
   {
-    feature_lookup[static_cast<int64_t>(f.getUniqueId())] = &f;
-    for (auto& sub : f.getSubordinates())
-    {
-      buildLookup(sub);
-    }
-  };
-  for (auto& f : feature_map)
-  {
-    buildLookup(f);
+    feature_lookup[static_cast<int64_t>(cf.getUniqueId())] = &cf;
   }
 
   // Read columns
-  auto col_feature_id = getColumn_(tbl, "feature_unique_id");
+  auto col_feature_id = getColumn_(tbl, "consensus_feature_unique_id");
   auto col_p_id = getColumn_(tbl, "peptide_identification_index");
   auto col_peptidoform = getColumn_(tbl, "peptidoform", /*required=*/false);
   auto col_sequence = getColumn_(tbl, "sequence", /*required=*/false);
@@ -1447,26 +1418,17 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
 
   if (!col_feature_id || !col_p_id || !col_charge || !col_score || !col_score_type)
   {
-    OPENMS_LOG_ERROR << "FeatureMapArrowIO: Missing required columns for PSM import" << std::endl;
+    OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Missing required columns for PSM import" << std::endl;
     return false;
   }
 
-  // Group rows by P_ID to reconstruct PeptideIdentifications.
-  // Each unique P_ID value corresponds to one PeptideIdentification.
-  // Rows with the same P_ID share the same PeptideIdentification-level data
-  // (rt, mz, score_type, spectrum_reference, run_identifier).
-  //
-  // We also track the feature_id for each group so we know where to attach it.
-  // All rows in the same P_ID group should have the same feature_id.
-
   // Build a lookup for higher_score_better from ProteinIdentifications
   std::unordered_map<std::string, bool> higher_score_better_lookup;
-  for (const auto& prot_id : feature_map.getProteinIdentifications())
+  for (const auto& prot_id : cmap.getProteinIdentifications())
   {
     higher_score_better_lookup[prot_id.getIdentifier()] = prot_id.isHigherScoreBetter();
   }
 
-  // Process rows in order, grouping consecutive rows with the same P_ID.
   struct PepIdGroup
   {
     int64_t feature_id;
@@ -1481,18 +1443,12 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
   {
     int32_t p_id = getInt32Value_(col_p_id, row, -1);
 
-    // Start a new group if P_ID changes.
-    // Note: This assumes rows with the same P_ID are contiguous in the table,
-    // which is guaranteed by QPXFile::exportToArrow. If the Parquet file has been
-    // externally sorted/filtered, non-contiguous rows with the same P_ID will be
-    // split into separate PeptideIdentification objects.
     if (groups.empty() || p_id != current_p_id)
     {
       PepIdGroup group;
       group.feature_id_is_null = isNull_(col_feature_id, row);
       group.feature_id = group.feature_id_is_null ? 0 : getInt64Value_(col_feature_id, row, 0);
 
-      // Set PeptideIdentification-level fields
       PeptideIdentification& pid = group.pep_id;
       pid.setScoreType(getStringValue_(col_score_type, row));
       // Run identifier (links to ProteinIdentification)
@@ -1523,25 +1479,21 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
         pid.setHigherScoreBetter(true);
       }
 
-      // RT
       if (col_rt && !isNull_(col_rt, row))
       {
         pid.setRT(getDoubleValue_(col_rt, row));
       }
 
-      // MZ
       if (col_mz && !isNull_(col_mz, row))
       {
         pid.setMZ(getDoubleValue_(col_mz, row));
       }
 
-      // Spectrum reference
       if (col_spec_ref && !isNull_(col_spec_ref, row))
       {
         pid.setSpectrumReference(getStringValue_(col_spec_ref, row));
       }
 
-      // spectrum_metavalues -> PeptideIdentification metavalues
       if (col_spectrum_metavalues)
       {
         readMetaValues_(col_spectrum_metavalues, row, pid);
@@ -1554,7 +1506,6 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
     // Add a PeptideHit to the current group
     PeptideHit hit;
 
-    // Reconstruct sequence from peptidoform (ProForma) if available, else from sequence column
     if (col_peptidoform && !isNull_(col_peptidoform, row))
     {
       String peptidoform_str = getStringValue_(col_peptidoform, row);
@@ -1567,7 +1518,6 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
         }
         catch (...)
         {
-          // Fallback: try unmodified sequence
           if (col_sequence && !isNull_(col_sequence, row))
           {
             hit.setSequence(AASequence::fromString(getStringValue_(col_sequence, row)));
@@ -1588,14 +1538,12 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
       hit.setRank(static_cast<UInt>(getInt32Value_(col_rank, row, 0)));
     }
 
-    // is_decoy -> target_decoy metavalue
     if (col_is_decoy && !isNull_(col_is_decoy, row))
     {
       bool is_decoy = getBoolValue_(col_is_decoy, row, false);
       hit.setMetaValue("target_decoy", is_decoy ? "decoy" : "target");
     }
 
-    // protein_accessions -> PeptideEvidence
     if (col_protein_accs && !isNull_(col_protein_accs, row))
     {
       auto list_arr = std::static_pointer_cast<arrow::ListArray>(col_protein_accs);
@@ -1610,7 +1558,6 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
       }
     }
 
-    // additional_scores -> metavalues on PeptideHit
     if (col_additional_scores && !isNull_(col_additional_scores, row))
     {
       auto list_arr = std::static_pointer_cast<arrow::ListArray>(col_additional_scores);
@@ -1628,13 +1575,11 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
       }
     }
 
-    // predicted_rt -> PeptideHit metavalue
     if (col_predicted_rt && !isNull_(col_predicted_rt, row))
     {
       hit.setMetaValue("predicted_RT", getDoubleValue_(col_predicted_rt, row));
     }
 
-    // ion_mobility -> PeptideHit metavalue
     if (col_ion_mobility && !isNull_(col_ion_mobility, row))
     {
       hit.setMetaValue("ion_mobility", getDoubleValue_(col_ion_mobility, row));
@@ -1652,7 +1597,6 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
       hit.setMetaValue("reference_file_name", getStringValue_(col_ref_file, row));
     }
 
-    // psm_metavalues -> PeptideHit metavalues (exclude keys that have dedicated columns)
     if (col_psm_metavalues)
     {
       static const std::unordered_set<std::string> psm_excluded_mvs =
@@ -1664,13 +1608,12 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
     groups.back().pep_id.getHits().push_back(std::move(hit));
   }
 
-  // Assign PeptideIdentifications to features or as unassigned
+  // Assign PeptideIdentifications to consensus features or as unassigned
   for (auto& group : groups)
   {
     if (group.feature_id_is_null)
     {
-      // Unassigned
-      feature_map.getUnassignedPeptideIdentifications().push_back(std::move(group.pep_id));
+      cmap.getUnassignedPeptideIdentifications().push_back(std::move(group.pep_id));
     }
     else
     {
@@ -1681,9 +1624,9 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
       }
       else
       {
-        OPENMS_LOG_WARN << "FeatureMapArrowIO: Could not find feature with id "
+        OPENMS_LOG_WARN << "ConsensusMapArrowIO: Could not find consensus feature with id "
                         << group.feature_id << " for PSM. Adding as unassigned." << std::endl;
-        feature_map.getUnassignedPeptideIdentifications().push_back(std::move(group.pep_id));
+        cmap.getUnassignedPeptideIdentifications().push_back(std::move(group.pep_id));
       }
     }
   }
@@ -1691,11 +1634,11 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
   return true;
 }
 
-bool FeatureMapArrowIO::importFromParquet(
+bool ConsensusMapArrowIO::importFromParquet(
   const String& directory,
-  FeatureMap& feature_map)
+  ConsensusMap& cmap)
 {
-  feature_map = FeatureMap{};
+  cmap = ConsensusMap{};
 
   // 1. Import protein identification data
   std::vector<ProteinIdentification> prot_ids;
@@ -1707,45 +1650,57 @@ bool FeatureMapArrowIO::importFromParquet(
   {
     return false;
   }
-  feature_map.setProteinIdentifications(prot_ids);
+  cmap.setProteinIdentifications(prot_ids);
 
-  // 2. Import features and FeatureMap-level metadata
-  auto features_table = readParquetTable_(directory + "/features.parquet");
+  // 2. Import consensus features and ConsensusMap-level metadata
+  auto features_table = readParquetTable_(directory + "/consensus_features.parquet");
   if (!features_table) { return false; }
 
-  // Extract FeatureMap-level metadata from file-level key-value metadata
+  // Extract ConsensusMap-level metadata from file-level key-value metadata
   auto schema_md = features_table->schema()->metadata();
   if (schema_md)
   {
-    // DocumentIdentifier fields
-    int idx = schema_md->FindKey("document_id");
-    if (idx >= 0) feature_map.setIdentifier(schema_md->value(idx));
+    int idx = schema_md->FindKey("column_headers");
+    if (idx >= 0) cmap.setColumnHeaders(deserializeColumnHeaders_(schema_md->value(idx)));
+
+    idx = schema_md->FindKey("experiment_type");
+    if (idx >= 0) cmap.setExperimentType(schema_md->value(idx));
+
+    idx = schema_md->FindKey("document_id");
+    if (idx >= 0) cmap.setIdentifier(schema_md->value(idx));
 
     idx = schema_md->FindKey("loaded_file_path");
-    if (idx >= 0) feature_map.setLoadedFilePath(schema_md->value(idx));
+    if (idx >= 0) cmap.setLoadedFilePath(schema_md->value(idx));
 
-    // loaded_file_type: stored as type name string (e.g. "featureXML").
-    // Note: DocumentIdentifier::setLoadedFileType(String) expects a file path and
-    // determines type by content/extension, so we cannot directly restore the type
-    // from a type name. The type can be re-derived from loaded_file_path if needed.
-
-    // DataProcessing
     idx = schema_md->FindKey("data_processing");
     if (idx >= 0)
     {
-      feature_map.setDataProcessing(deserializeDataProcessing_(schema_md->value(idx)));
+      cmap.setDataProcessing(deserializeDataProcessing_(schema_md->value(idx)));
+    }
+
+    idx = schema_md->FindKey("unique_id");
+    if (idx >= 0)
+    {
+      try { cmap.setUniqueId(std::stoull(schema_md->value(idx))); }
+      catch (...) {}
+    }
+
+    idx = schema_md->FindKey("cmap_metavalues");
+    if (idx >= 0)
+    {
+      deserializeMetaValues_(schema_md->value(idx), cmap);
     }
   }
 
-  if (!importFeaturesFromArrow(features_table, feature_map))
+  if (!importFeaturesFromArrow(features_table, cmap))
   {
     return false;
   }
 
-  // 3. Import PSMs (links to features already in the map)
+  // 3. Import PSMs (links to consensus features already in the map)
   auto psms_table = readParquetTable_(directory + "/psms.parquet");
   if (!psms_table) { return false; }
-  if (!importPSMsFromArrow(psms_table, feature_map))
+  if (!importPSMsFromArrow(psms_table, cmap))
   {
     return false;
   }

--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -64,9 +64,12 @@ namespace // anonymous
       switch (val.valueType())
       {
         case DataValue::INT_VALUE: (void)type_b->Append("int"); break;
-        case DataValue::DOUBLE_VALUE: (void)type_b->Append("float"); break;
-        case DataValue::STRING_VALUE: (void)type_b->Append("str"); break;
-        default: (void)type_b->Append("str"); break;
+        case DataValue::DOUBLE_VALUE: (void)type_b->Append("double"); break;
+        case DataValue::STRING_VALUE: (void)type_b->Append("string"); break;
+        case DataValue::INT_LIST: (void)type_b->Append("int_list"); break;
+        case DataValue::DOUBLE_LIST: (void)type_b->Append("double_list"); break;
+        case DataValue::STRING_LIST: (void)type_b->Append("string_list"); break;
+        default: (void)type_b->Append("string"); break;
       }
     }
   }
@@ -334,9 +337,41 @@ namespace // anonymous
         try { target.setMetaValue(name, static_cast<int>(std::stol(value_str))); }
         catch (...) { target.setMetaValue(name, value_str); }
       }
-      else if (type_str == "float")
+      else if (type_str == "double" || type_str == "float")
       {
         try { target.setMetaValue(name, std::stod(value_str)); }
+        catch (...) { target.setMetaValue(name, value_str); }
+      }
+      else if (type_str == "int_list")
+      {
+        try
+        {
+          String s(value_str);
+          if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+          target.setMetaValue(name, DataValue(ListUtils::create<Int>(s)));
+        }
+        catch (...) { target.setMetaValue(name, value_str); }
+      }
+      else if (type_str == "double_list")
+      {
+        try
+        {
+          String s(value_str);
+          if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+          target.setMetaValue(name, DataValue(ListUtils::create<double>(s)));
+        }
+        catch (...) { target.setMetaValue(name, value_str); }
+      }
+      else if (type_str == "string_list")
+      {
+        try
+        {
+          String s(value_str);
+          if (s.hasPrefix("[") && s.hasSuffix("]")) { s = s.substr(1, s.size() - 2); }
+          auto sl = ListUtils::create<String>(s);
+          for (auto& e : sl) { e = e.trim(); }
+          target.setMetaValue(name, DataValue(sl));
+        }
         catch (...) { target.setMetaValue(name, value_str); }
       }
       else
@@ -367,15 +402,11 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
   const std::vector<ProteinIdentification>& protein_identifications)
 {
   // -- Simple column builders --
-  arrow::StringBuilder accession_builder, score_type_builder, sequence_builder;
+  arrow::StringBuilder accession_builder, sequence_builder;
   arrow::StringBuilder description_builder, run_identifier_builder;
-  arrow::StringBuilder reference_file_builder, search_engine_builder;
-  arrow::StringBuilder search_engine_version_builder;
-  arrow::StringBuilder inference_engine_builder, inference_engine_version_builder;
-  arrow::StringBuilder date_builder;
-  arrow::DoubleBuilder score_builder, coverage_builder, significance_threshold_builder;
-  arrow::BooleanBuilder higher_score_better_builder;
-  arrow::Int32Builder rank_builder, is_decoy_builder;
+  arrow::DoubleBuilder score_builder, coverage_builder;
+  arrow::Int32Builder rank_builder;
+  arrow::BooleanBuilder is_decoy_builder;
 
   // -- modifications list<struct{position: int32, modification: utf8}> --
   auto mod_position_b = std::make_shared<arrow::Int32Builder>();
@@ -417,10 +448,6 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: accession_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = score_builder.Reserve(num_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: score_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = score_type_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: score_type_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = higher_score_better_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: higher_score_better_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = rank_builder.Reserve(num_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: rank_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = coverage_builder.Reserve(num_rows);
@@ -433,20 +460,6 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: is_decoy_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = run_identifier_builder.Reserve(num_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: run_identifier_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = reference_file_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: reference_file_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = search_engine_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: search_engine_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = search_engine_version_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: search_engine_version_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = inference_engine_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: inference_engine_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = inference_engine_version_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: inference_engine_version_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = significance_threshold_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: significance_threshold_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
-  status = date_builder.Reserve(num_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: date_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
   // Metavalue keys excluded from metavalues column (they have dedicated columns)
   static const std::unordered_set<std::string> excluded_hit_mvs = {
@@ -455,21 +468,7 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
 
   for (const auto& prot_id : protein_identifications)
   {
-    // Get shared per-run values
-    const String& score_type = prot_id.getScoreType();
-    bool higher_better = prot_id.isHigherScoreBetter();
     const String& run_id = prot_id.getIdentifier();
-    const String& search_engine = prot_id.getSearchEngine();
-    const String& search_engine_version = prot_id.getSearchEngineVersion();
-    const String inference_engine = prot_id.getInferenceEngine();
-    const String inference_engine_version = prot_id.getInferenceEngineVersion();
-    double sig_threshold = prot_id.getSignificanceThreshold();
-    String date_str = prot_id.getDateTime().toString("yyyy-MM-ddThh:mm:ss");
-
-    // Get primary MS run path
-    StringList ms_runs;
-    prot_id.getPrimaryMSRunPath(ms_runs);
-    String ref_file = ms_runs.empty() ? "" : ms_runs[0];
 
     for (const auto& hit : prot_id.getHits())
     {
@@ -478,12 +477,6 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
 
       // === score (not nullable) ===
       (void)score_builder.Append(hit.getScore());
-
-      // === score_type (not nullable) ===
-      (void)score_type_builder.Append(score_type);
-
-      // === higher_score_better (not nullable) ===
-      (void)higher_score_better_builder.Append(higher_better);
 
       // === rank (nullable) ===
       (void)rank_builder.Append(static_cast<int32_t>(hit.getRank()));
@@ -537,68 +530,12 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
         }
         else
         {
-          (void)is_decoy_builder.Append(td_type == ProteinHit::TargetDecoyType::DECOY ? 1 : 0);
+          (void)is_decoy_builder.Append(td_type == ProteinHit::TargetDecoyType::DECOY);
         }
       }
 
       // === run_identifier (not nullable) ===
       (void)run_identifier_builder.Append(run_id);
-
-      // === reference_file_name (nullable) ===
-      if (ref_file.empty())
-      {
-        (void)reference_file_builder.AppendNull();
-      }
-      else
-      {
-        (void)reference_file_builder.Append(ref_file);
-      }
-
-      // === search_engine (not nullable) ===
-      (void)search_engine_builder.Append(search_engine);
-
-      // === search_engine_version (nullable, null if empty) ===
-      if (search_engine_version.empty())
-      {
-        (void)search_engine_version_builder.AppendNull();
-      }
-      else
-      {
-        (void)search_engine_version_builder.Append(search_engine_version);
-      }
-
-      // === inference_engine (nullable, null if empty) ===
-      if (inference_engine.empty())
-      {
-        (void)inference_engine_builder.AppendNull();
-      }
-      else
-      {
-        (void)inference_engine_builder.Append(inference_engine);
-      }
-
-      // === inference_engine_version (nullable, null if empty) ===
-      if (inference_engine_version.empty())
-      {
-        (void)inference_engine_version_builder.AppendNull();
-      }
-      else
-      {
-        (void)inference_engine_version_builder.Append(inference_engine_version);
-      }
-
-      // === significance_threshold (nullable) ===
-      (void)significance_threshold_builder.Append(sig_threshold);
-
-      // === date (nullable, null if empty) ===
-      if (date_str.empty())
-      {
-        (void)date_builder.AppendNull();
-      }
-      else
-      {
-        (void)date_builder.Append(date_str);
-      }
 
       // === modifications (nullable) ===
       const auto& mods = hit.getModifications();
@@ -625,22 +562,16 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
   } // end protein identification loop
 
   // Finalize all arrays
-  std::shared_ptr<arrow::Array> arr_accession, arr_score, arr_score_type;
-  std::shared_ptr<arrow::Array> arr_higher_better, arr_rank, arr_coverage;
+  std::shared_ptr<arrow::Array> arr_accession, arr_score;
+  std::shared_ptr<arrow::Array> arr_rank, arr_coverage;
   std::shared_ptr<arrow::Array> arr_sequence, arr_description, arr_is_decoy;
-  std::shared_ptr<arrow::Array> arr_run_id, arr_ref_file, arr_search_engine;
-  std::shared_ptr<arrow::Array> arr_se_version, arr_inf_engine, arr_inf_version;
-  std::shared_ptr<arrow::Array> arr_sig_threshold, arr_date;
+  std::shared_ptr<arrow::Array> arr_run_id;
   std::shared_ptr<arrow::Array> arr_modifications, arr_metavalues;
 
   status = accession_builder.Finish(&arr_accession);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: accession_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = score_builder.Finish(&arr_score);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: score_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = score_type_builder.Finish(&arr_score_type);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: score_type_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = higher_score_better_builder.Finish(&arr_higher_better);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: higher_score_better_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = rank_builder.Finish(&arr_rank);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: rank_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = coverage_builder.Finish(&arr_coverage);
@@ -653,55 +584,30 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportProteinsToArro
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: is_decoy_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = run_identifier_builder.Finish(&arr_run_id);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: run_identifier_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = reference_file_builder.Finish(&arr_ref_file);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: reference_file_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = search_engine_builder.Finish(&arr_search_engine);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: search_engine_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = search_engine_version_builder.Finish(&arr_se_version);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: search_engine_version_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = inference_engine_builder.Finish(&arr_inf_engine);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: inference_engine_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = inference_engine_version_builder.Finish(&arr_inf_version);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: inference_engine_version_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = significance_threshold_builder.Finish(&arr_sig_threshold);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: significance_threshold_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
-  status = date_builder.Finish(&arr_date);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: date_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = modifications_builder.Finish(&arr_modifications);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: modifications_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = metavalues_builder.Finish(&arr_metavalues);
   if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: metavalues_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
 
-  // Build schema (19 columns)
+  // Build schema (10 columns)
   auto schema = arrow::schema({
     arrow::field("accession", arrow::utf8(), /*nullable=*/false),
     arrow::field("score", arrow::float64(), /*nullable=*/false),
-    arrow::field("score_type", arrow::utf8(), /*nullable=*/false),
-    arrow::field("higher_score_better", arrow::boolean(), /*nullable=*/false),
     arrow::field("rank", arrow::int32(), /*nullable=*/true),
     arrow::field("coverage", arrow::float64(), /*nullable=*/true),
     arrow::field("sequence", arrow::utf8(), /*nullable=*/true),
     arrow::field("description", arrow::utf8(), /*nullable=*/true),
-    arrow::field("is_decoy", arrow::int32(), /*nullable=*/true),
+    arrow::field("is_decoy", arrow::boolean(), /*nullable=*/true),
     arrow::field("run_identifier", arrow::utf8(), /*nullable=*/false),
-    arrow::field("reference_file_name", arrow::utf8(), /*nullable=*/true),
-    arrow::field("search_engine", arrow::utf8(), /*nullable=*/false),
-    arrow::field("search_engine_version", arrow::utf8(), /*nullable=*/true),
-    arrow::field("inference_engine", arrow::utf8(), /*nullable=*/true),
-    arrow::field("inference_engine_version", arrow::utf8(), /*nullable=*/true),
-    arrow::field("significance_threshold", arrow::float64(), /*nullable=*/true),
-    arrow::field("date", arrow::utf8(), /*nullable=*/true),
     arrow::field("modifications", arrow::list(mod_struct_type), /*nullable=*/true),
     arrow::field("metavalues", metavalues_builder.type(), /*nullable=*/false),
   });
 
   auto table = arrow::Table::Make(schema, {
-    arr_accession, arr_score, arr_score_type,
-    arr_higher_better, arr_rank, arr_coverage,
+    arr_accession, arr_score,
+    arr_rank, arr_coverage,
     arr_sequence, arr_description, arr_is_decoy,
-    arr_run_id, arr_ref_file, arr_search_engine,
-    arr_se_version, arr_inf_engine, arr_inf_version,
-    arr_sig_threshold, arr_date,
+    arr_run_id,
     arr_modifications, arr_metavalues
   });
 
@@ -953,7 +859,8 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsTo
   arrow::StringBuilder run_identifier_builder, search_engine_builder;
   arrow::StringBuilder search_engine_version_builder;
   arrow::StringBuilder inference_engine_builder, inference_engine_version_builder;
-  arrow::StringBuilder date_builder, score_type_builder;
+  arrow::StringBuilder score_type_builder;
+  arrow::TimestampBuilder date_builder(arrow::timestamp(arrow::TimeUnit::SECOND), arrow::default_memory_pool());
   arrow::BooleanBuilder higher_score_better_builder;
   arrow::DoubleBuilder significance_threshold_builder;
   arrow::StringBuilder db_builder, db_version_builder, taxonomy_builder, charges_builder;
@@ -1091,15 +998,39 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsTo
       (void)inference_engine_version_builder.Append(inference_engine_version);
     }
 
-    // === date (nullable, null if empty) ===
-    String date_str = prot_id.getDateTime().toString("yyyy-MM-ddThh:mm:ss");
-    if (date_str.empty())
+    // === date (nullable, null if unset) ===
     {
-      (void)date_builder.AppendNull();
-    }
-    else
-    {
-      (void)date_builder.Append(date_str);
+      const DateTime& dt = prot_id.getDateTime();
+      String date_str = dt.toString("yyyy-MM-ddThh:mm:ss");
+      if (date_str.empty())
+      {
+        (void)date_builder.AppendNull();
+      }
+      else
+      {
+        UInt month, day, year, hour, minute, second;
+        dt.get(month, day, year, hour, minute, second);
+        std::tm tm{};
+        tm.tm_year = static_cast<int>(year) - 1900;
+        tm.tm_mon = static_cast<int>(month) - 1;
+        tm.tm_mday = static_cast<int>(day);
+        tm.tm_hour = static_cast<int>(hour);
+        tm.tm_min = static_cast<int>(minute);
+        tm.tm_sec = static_cast<int>(second);
+#ifdef _WIN32
+        int64_t epoch = static_cast<int64_t>(_mkgmtime(&tm));
+#else
+        int64_t epoch = static_cast<int64_t>(timegm(&tm));
+#endif
+        if (epoch < 0)
+        {
+          (void)date_builder.AppendNull(); // invalid date (e.g. default-constructed DateTime)
+        }
+        else
+        {
+          (void)date_builder.Append(epoch);
+        }
+      }
     }
 
     // === score_type (not nullable) ===
@@ -1313,7 +1244,7 @@ std::shared_ptr<arrow::Table> ProteinIdentificationArrowIO::exportSearchParamsTo
     arrow::field("search_engine_version", arrow::utf8(), /*nullable=*/true),
     arrow::field("inference_engine", arrow::utf8(), /*nullable=*/true),
     arrow::field("inference_engine_version", arrow::utf8(), /*nullable=*/true),
-    arrow::field("date", arrow::utf8(), /*nullable=*/true),
+    arrow::field("date", arrow::timestamp(arrow::TimeUnit::SECOND), /*nullable=*/true),
     arrow::field("score_type", arrow::utf8(), /*nullable=*/false),
     arrow::field("higher_score_better", arrow::boolean(), /*nullable=*/false),
     arrow::field("significance_threshold", arrow::float64(), /*nullable=*/true),
@@ -1427,14 +1358,32 @@ bool ProteinIdentificationArrowIO::importSearchParamsFromArrow(
     prot_id.setHigherScoreBetter(getBoolValue_(col_higher_better, row));
     prot_id.setSignificanceThreshold(getDoubleValue_(col_sig_threshold, row));
 
-    // Date
-    String date_str = getStringValue_(col_date, row);
-    if (!date_str.empty())
+    // Date (timestamp seconds since epoch)
+    if (!isNull_(col_date, row))
     {
-      DateTime dt;
-      // Format: yyyy-MM-ddThh:mm:ss
-      dt.set(date_str.substitute('T', ' '));
-      prot_id.setDateTime(dt);
+      auto ts_arr = std::static_pointer_cast<arrow::TimestampArray>(col_date);
+      int64_t epoch_secs = ts_arr->Value(row);
+      if (epoch_secs >= 0) // negative epochs are invalid on Windows
+      {
+        time_t t = static_cast<time_t>(epoch_secs);
+        std::tm tm{};
+#ifdef _WIN32
+        errno_t err = gmtime_s(&tm, &t);
+        if (err == 0)
+#else
+        if (gmtime_r(&t, &tm) != nullptr)
+#endif
+        {
+          DateTime dt;
+          dt.set(static_cast<UInt>(tm.tm_mon + 1),
+                 static_cast<UInt>(tm.tm_mday),
+                 static_cast<UInt>(tm.tm_year + 1900),
+                 static_cast<UInt>(tm.tm_hour),
+                 static_cast<UInt>(tm.tm_min),
+                 static_cast<UInt>(tm.tm_sec));
+          prot_id.setDateTime(dt);
+        }
+      }
     }
 
     // Primary MS run paths
@@ -1534,26 +1483,16 @@ bool ProteinIdentificationArrowIO::importProteinsFromArrow(
   // Get all columns
   auto col_accession = getColumn_(table, "accession");
   auto col_score = getColumn_(table, "score");
-  auto col_score_type = getColumn_(table, "score_type");
-  auto col_higher_better = getColumn_(table, "higher_score_better");
   auto col_rank = getColumn_(table, "rank", false);
   auto col_coverage = getColumn_(table, "coverage", false);
   auto col_sequence = getColumn_(table, "sequence", false);
   auto col_description = getColumn_(table, "description", false);
   auto col_is_decoy = getColumn_(table, "is_decoy", false);
   auto col_run_id = getColumn_(table, "run_identifier");
-  auto col_ref_file = getColumn_(table, "reference_file_name", false);
-  auto col_search_engine = getColumn_(table, "search_engine");
-  auto col_se_version = getColumn_(table, "search_engine_version", false);
-  auto col_inf_engine = getColumn_(table, "inference_engine", false);
-  auto col_inf_version = getColumn_(table, "inference_engine_version", false);
-  auto col_sig_threshold = getColumn_(table, "significance_threshold", false);
-  auto col_date = getColumn_(table, "date", false);
   auto col_modifications = getColumn_(table, "modifications", false);
   auto col_metavalues = getColumn_(table, "metavalues", false);
 
-  if (!col_accession || !col_score || !col_score_type || !col_higher_better ||
-      !col_run_id || !col_search_engine)
+  if (!col_accession || !col_score || !col_run_id)
   {
     OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: Missing required columns in proteins table" << std::endl;
     return false;
@@ -1580,39 +1519,11 @@ bool ProteinIdentificationArrowIO::importProteinsFromArrow(
     }
     else
     {
-      // Create new ProteinIdentification from run-level data in this row
+      // Create minimal ProteinIdentification with just run_identifier
+      OPENMS_LOG_WARN << "ProteinIdentificationArrowIO: run_identifier '" << run_id
+                      << "' not found in search_params; creating minimal ProteinIdentification" << std::endl;
       ProteinIdentification new_prot_id;
       new_prot_id.setIdentifier(run_id);
-      new_prot_id.setSearchEngine(getStringValue_(col_search_engine, row));
-      new_prot_id.setSearchEngineVersion(getStringValue_(col_se_version, row));
-      new_prot_id.setScoreType(getStringValue_(col_score_type, row));
-      new_prot_id.setHigherScoreBetter(getBoolValue_(col_higher_better, row));
-      new_prot_id.setSignificanceThreshold(getDoubleValue_(col_sig_threshold, row));
-
-      String date_str = getStringValue_(col_date, row);
-      if (!date_str.empty())
-      {
-        DateTime dt;
-        dt.set(date_str.substitute('T', ' '));
-        new_prot_id.setDateTime(dt);
-      }
-
-      String ref_file = getStringValue_(col_ref_file, row);
-      if (!ref_file.empty())
-      {
-        new_prot_id.setPrimaryMSRunPath(StringList{ref_file});
-      }
-
-      String inf_engine = getStringValue_(col_inf_engine, row);
-      if (!inf_engine.empty())
-      {
-        new_prot_id.setInferenceEngine(inf_engine);
-        String inf_version = getStringValue_(col_inf_version, row);
-        if (!inf_version.empty())
-        {
-          new_prot_id.setInferenceEngineVersion(inf_version);
-        }
-      }
 
       prot_id_idx = protein_identifications.size();
       protein_identifications.push_back(std::move(new_prot_id));
@@ -1647,8 +1558,8 @@ bool ProteinIdentificationArrowIO::importProteinsFromArrow(
     // is_decoy -> target_decoy metavalue
     if (!isNull_(col_is_decoy, row))
     {
-      int32_t is_decoy = getInt32Value_(col_is_decoy, row);
-      hit.setMetaValue("target_decoy", is_decoy == 1 ? "decoy" : "target");
+      bool is_decoy = getBoolValue_(col_is_decoy, row);
+      hit.setMetaValue("target_decoy", is_decoy ? "decoy" : "target");
     }
 
     // Modifications

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -58,10 +58,12 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
 {
   // -- Simple column builders --
   arrow::StringBuilder sequence_builder, peptidoform_builder;
-  arrow::StringBuilder reference_file_builder, scan_builder, score_type_builder;
+  arrow::StringBuilder reference_file_builder, score_type_builder;
   arrow::StringBuilder spectrum_reference_builder, cv_params_builder;
   arrow::StringBuilder run_identifier_builder;
-  arrow::Int32Builder precursor_charge_builder, is_decoy_builder, rank_builder, p_id_builder;
+  arrow::Int32Builder precursor_charge_builder, rank_builder, p_id_builder;
+  arrow::BooleanBuilder is_decoy_builder, higher_score_better_builder;
+  arrow::Int32Builder scan_builder;
   arrow::DoubleBuilder pep_builder, calculated_mz_builder, observed_mz_builder;
   arrow::DoubleBuilder rt_builder, ion_mobility_builder, predicted_rt_builder, score_builder;
 
@@ -156,6 +158,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: pep_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = is_decoy_builder.Reserve(num_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: is_decoy_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
+  status = higher_score_better_builder.Reserve(num_rows);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: higher_score_better_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = calculated_mz_builder.Reserve(num_rows);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: calculated_mz_builder Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = observed_mz_builder.Reserve(num_rows);
@@ -199,7 +203,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
 
   // Metavalue keys excluded from psm_metavalues (they have dedicated columns)
   static const std::unordered_set<std::string> excluded_hit_mvs = {
-    "target_decoy", "predicted_RT", "predicted_rt", "ion_mobility", "IM"
+    "target_decoy", "predicted_RT", "predicted_rt", "ion_mobility", "IM",
+    "scan", "reference_file_name"
   };
 
   IDScoreSwitcherAlgorithm idsa;
@@ -349,7 +354,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
       if (hit.metaValueExists("target_decoy"))
       {
         std::string td = hit.getMetaValue("target_decoy").toString();
-        (void)is_decoy_builder.Append(td.substr(0, 5) == "decoy" ? 1 : 0);
+        (void)is_decoy_builder.Append(td.substr(0, 5) == "decoy");
       }
       else
       {
@@ -453,7 +458,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         Int scan_num = extractScan(spec_ref);
         if (scan_num >= 0)
         {
-          (void)scan_builder.Append(std::to_string(scan_num));
+          (void)scan_builder.Append(scan_num);
         }
         else
         {
@@ -494,9 +499,10 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         (void)ion_mobility_builder.AppendNull();
       }
 
-      // === score / score_type ===
+      // === score / score_type / higher_score_better ===
       (void)score_builder.Append(hit.getScore());
       (void)score_type_builder.Append(pep_id.getScoreType());
+      (void)higher_score_better_builder.Append(pep_id.isHigherScoreBetter());
 
       // === rank (0-based) ===
       (void)rank_builder.Append(static_cast<int32_t>(hit_idx));
@@ -529,9 +535,12 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
           switch (val.valueType())
           {
             case DataValue::INT_VALUE: (void)pmv_type_b->Append("int"); break;
-            case DataValue::DOUBLE_VALUE: (void)pmv_type_b->Append("float"); break;
-            case DataValue::STRING_VALUE: (void)pmv_type_b->Append("str"); break;
-            default: (void)pmv_type_b->Append("str"); break;
+            case DataValue::DOUBLE_VALUE: (void)pmv_type_b->Append("double"); break;
+            case DataValue::STRING_VALUE: (void)pmv_type_b->Append("string"); break;
+            case DataValue::INT_LIST: (void)pmv_type_b->Append("int_list"); break;
+            case DataValue::DOUBLE_LIST: (void)pmv_type_b->Append("double_list"); break;
+            case DataValue::STRING_LIST: (void)pmv_type_b->Append("string_list"); break;
+            default: (void)pmv_type_b->Append("string"); break;
           }
         }
       }
@@ -553,9 +562,12 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
           switch (val.valueType())
           {
             case DataValue::INT_VALUE: (void)smv_type_b->Append("int"); break;
-            case DataValue::DOUBLE_VALUE: (void)smv_type_b->Append("float"); break;
-            case DataValue::STRING_VALUE: (void)smv_type_b->Append("str"); break;
-            default: (void)smv_type_b->Append("str"); break;
+            case DataValue::DOUBLE_VALUE: (void)smv_type_b->Append("double"); break;
+            case DataValue::STRING_VALUE: (void)smv_type_b->Append("string"); break;
+            case DataValue::INT_LIST: (void)smv_type_b->Append("int_list"); break;
+            case DataValue::DOUBLE_LIST: (void)smv_type_b->Append("double_list"); break;
+            case DataValue::STRING_LIST: (void)smv_type_b->Append("string_list"); break;
+            default: (void)smv_type_b->Append("string"); break;
           }
         }
       }
@@ -571,6 +583,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
   std::shared_ptr<arrow::Array> arr_protein_acc, arr_predicted_rt, arr_ref_file;
   std::shared_ptr<arrow::Array> arr_cv_params, arr_scan, arr_rt, arr_ion_mobility;
   std::shared_ptr<arrow::Array> arr_spectrum_ref, arr_score, arr_score_type;
+  std::shared_ptr<arrow::Array> arr_higher_score_better;
   std::shared_ptr<arrow::Array> arr_rank, arr_p_id;
   std::shared_ptr<arrow::Array> arr_psm_mvs, arr_spectrum_mvs;
 
@@ -612,6 +625,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: score_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = score_type_builder.Finish(&arr_score_type);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: score_type_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = higher_score_better_builder.Finish(&arr_higher_score_better);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: higher_score_better_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = rank_builder.Finish(&arr_rank);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: rank_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = p_id_builder.Finish(&arr_p_id);
@@ -632,7 +647,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
     arrow::field("modifications", modifications_builder.type()),
     arrow::field("precursor_charge", arrow::int32()),
     arrow::field("posterior_error_probability", arrow::float64()),
-    arrow::field("is_decoy", arrow::int32()),
+    arrow::field("is_decoy", arrow::boolean()),
     arrow::field("calculated_mz", arrow::float64()),
     arrow::field("observed_mz", arrow::float64()),
     arrow::field("additional_scores", additional_scores_builder.type()),
@@ -640,15 +655,16 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
     arrow::field("predicted_rt", arrow::float64()),
     arrow::field("reference_file_name", arrow::utf8()),
     arrow::field("cv_params", arrow::utf8()),
-    arrow::field("scan", arrow::utf8()),
+    arrow::field("scan", arrow::int32()),
     arrow::field("rt", arrow::float64()),
     arrow::field("ion_mobility", arrow::float64()),
     // OpenMS-specific columns
     arrow::field("spectrum_reference", arrow::utf8()),
     arrow::field("score", arrow::float64()),
     arrow::field("score_type", arrow::utf8()),
+    arrow::field("higher_score_better", arrow::boolean()),
     arrow::field("rank", arrow::int32()),
-    arrow::field("P_ID", arrow::int32()),
+    arrow::field("peptide_identification_index", arrow::int32()),
     arrow::field("psm_metavalues", psm_metavalues_builder.type()),
     arrow::field("spectrum_metavalues", spectrum_metavalues_builder.type()),
     arrow::field("run_identifier", arrow::utf8()),
@@ -660,7 +676,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
     arr_calc_mz, arr_obs_mz, arr_additional_scores,
     arr_protein_acc, arr_predicted_rt, arr_ref_file,
     arr_cv_params, arr_scan, arr_rt, arr_ion_mobility,
-    arr_spectrum_ref, arr_score, arr_score_type,
+    arr_spectrum_ref, arr_score, arr_score_type, arr_higher_score_better,
     arr_rank, arr_p_id, arr_psm_mvs, arr_spectrum_mvs,
     arr_run_identifier
   });

--- a/src/openms/source/FORMAT/sources.cmake
+++ b/src/openms/source/FORMAT/sources.cmake
@@ -114,6 +114,7 @@ if (WITH_PARQUET)
   list(APPEND sources_list XICParquetFile.cpp)
   list(APPEND sources_list ProteinIdentificationArrowIO.cpp)
   list(APPEND sources_list FeatureMapArrowIO.cpp)
+  list(APPEND sources_list ConsensusMapArrowIO.cpp)
 endif()
 
 ### add path to the filenames

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -444,7 +444,11 @@ WITH_PARQUET = ${_PY_WITH_PARQUET}
       ${PYOPENMS_BUILD_DIR}/pyopenms/_arrow_zerocopy.cpp
       WITH_SOABI
     )
-    target_link_libraries(arrow_zerocopy PRIVATE OpenMS ${OPENMS_ARROW_TARGET} Python::NumPy)
+    # Link only against OpenMS (not Arrow directly). The _arrow_zerocopy module
+    # uses only the Arrow C Data Interface (arrow/c/abi.h — header-only C structs)
+    # and OpenMS C++ functions. Linking Arrow here would re-export Arrow symbols,
+    # conflicting with pyarrow's own Arrow runtime at Python import time.
+    target_link_libraries(arrow_zerocopy PRIVATE OpenMS Python::NumPy)
     target_compile_definitions(arrow_zerocopy PRIVATE
       NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION
       WITH_PARQUET=1

--- a/src/pyOpenMS/pxds/ConsensusMapArrowIO.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapArrowIO.pxd
@@ -1,0 +1,44 @@
+# Part of pyOpenMS. Copyright 2002-present, OpenMS Inc.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from Types cimport *
+from ConsensusMap cimport *
+from MSExperimentArrowExport cimport *
+from libcpp cimport bool
+
+# OpenMS ConsensusMapArrowIO declarations (only available when WITH_PARQUET is enabled)
+cdef extern from "<OpenMS/FORMAT/ConsensusMapArrowIO.h>" namespace "OpenMS":
+
+    cdef cppclass ConsensusMapArrowIO:
+        # wrap-doc:
+        #  Import and export ConsensusMap data to/from Apache Arrow/Parquet format.
+        #
+        #  Stores data as a directory of Parquet files (consensus features, PSMs,
+        #  proteins, protein groups, search parameters). Enables full round-trip
+        #  serialization as a replacement for ConsensusXML.
+        #
+        #  EXPERIMENTAL: This API is experimental and may change in future versions.
+        ConsensusMapArrowIO() except + nogil
+        ConsensusMapArrowIO(const ConsensusMapArrowIO&) except + nogil
+
+        bool exportToParquet(
+            const ConsensusMap& cmap,
+            const String& directory,
+            const ParquetWriteConfig& config
+        ) except + nogil
+        # wrap-doc:
+        #  Export ConsensusMap to a directory of Parquet files.
+        #  Creates consensus_features.parquet, psms.parquet, proteins.parquet,
+        #  protein_groups.parquet, and search_params.parquet.
+        #  Returns true on success, false on error.
+
+        bool importFromParquet(
+            const String& directory,
+            ConsensusMap& cmap
+        ) except + nogil
+        # wrap-doc:
+        #  Import ConsensusMap from a directory of Parquet files.
+        #  Reads all five Parquet files and reconstructs the complete ConsensusMap.
+        #  Returns true on success, false on error.

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -100,6 +100,10 @@ if (WITH_PARQUET)
   ${OPENMS_ARROW_TARGET}
   ${OPENMS_PARQUET_TARGET}
   )
+  target_link_libraries(ConsensusMapArrowIO_test
+  ${OPENMS_ARROW_TARGET}
+  ${OPENMS_PARQUET_TARGET}
+  )
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -291,7 +291,8 @@ if(WITH_PARQUET)
     MSChromatogramParquetConsumer_test
     XICParquetFile_test
     ProteinIdentificationArrowIO_test
-    FeatureMapArrowIO_test)
+    FeatureMapArrowIO_test
+    ConsensusMapArrowIO_test)
 endif()
 
 set(math_executables_list

--- a/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapArrowIO_test.cpp
@@ -1,0 +1,900 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/FORMAT/ConsensusMapArrowIO.h>
+///////////////////////////
+
+#include <OpenMS/config.h>
+
+#ifdef WITH_PARQUET
+
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
+#include <OpenMS/KERNEL/FeatureHandle.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <OpenMS/FORMAT/FileTypes.h>
+#include <OpenMS/METADATA/DataProcessing.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/ProteinHit.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
+
+#include <arrow/api.h>
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(ConsensusMapArrowIO, "$Id$")
+
+/////////////////////////////////////////////////////////////
+// Export tests
+/////////////////////////////////////////////////////////////
+
+START_SECTION(exportFeaturesToArrow - empty ConsensusMap)
+{
+  ConsensusMap cmap;
+  auto table = ConsensusMapArrowIO::exportFeaturesToArrow(cmap);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+  TEST_EQUAL(table->num_columns(), 9)
+}
+END_SECTION
+
+START_SECTION(exportFeaturesToArrow - single feature with handles and metavalues)
+{
+  ConsensusMap cmap;
+
+  // Set up column headers
+  ConsensusMap::ColumnHeader ch0;
+  ch0.filename = "file0.mzML";
+  ch0.label = "light";
+  ch0.size = 100;
+  ch0.unique_id = 111;
+  cmap.getColumnHeaders()[0] = ch0;
+
+  ConsensusMap::ColumnHeader ch1;
+  ch1.filename = "file1.mzML";
+  ch1.label = "heavy";
+  ch1.size = 200;
+  ch1.unique_id = 222;
+  cmap.getColumnHeaders()[1] = ch1;
+
+  ConsensusFeature cf;
+  cf.setRT(100.5);
+  cf.setMZ(500.25);
+  cf.setIntensity(1000.0f);
+  cf.setCharge(2);
+  cf.setQuality(0.95f);
+  cf.setWidth(1.5f);
+  cf.setUniqueId(12345);
+
+  // Add 2 FeatureHandles
+  FeatureHandle h0;
+  h0.setMapIndex(0);
+  h0.setUniqueId(100);
+  h0.setRT(100.0);
+  h0.setMZ(500.2);
+  h0.setIntensity(800.0f);
+  h0.setCharge(2);
+  h0.setWidth(1.2f);
+  cf.insert(h0);
+
+  FeatureHandle h1;
+  h1.setMapIndex(1);
+  h1.setUniqueId(200);
+  h1.setRT(101.0);
+  h1.setMZ(500.3);
+  h1.setIntensity(1200.0f);
+  h1.setCharge(2);
+  h1.setWidth(1.8f);
+  cf.insert(h1);
+
+  // Add metavalues
+  cf.setMetaValue("my_int", 42);
+  cf.setMetaValue("my_float", 3.14);
+  cf.setMetaValue("my_string", String("hello"));
+
+  cmap.push_back(cf);
+
+  auto table = ConsensusMapArrowIO::exportFeaturesToArrow(cmap);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 1)
+  TEST_EQUAL(table->num_columns(), 9)
+
+  // Verify scalar columns
+  auto col_unique_id = std::static_pointer_cast<arrow::Int64Array>(table->GetColumnByName("unique_id")->chunk(0));
+  TEST_EQUAL(col_unique_id->Value(0), 12345)
+
+  auto col_rt = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("rt")->chunk(0));
+  TEST_REAL_SIMILAR(col_rt->Value(0), 100.5)
+
+  auto col_mz = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("mz")->chunk(0));
+  TEST_REAL_SIMILAR(col_mz->Value(0), 500.25)
+
+  auto col_intensity = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("intensity")->chunk(0));
+  TEST_REAL_SIMILAR(col_intensity->Value(0), 1000.0)
+
+  auto col_charge = std::static_pointer_cast<arrow::Int32Array>(table->GetColumnByName("charge")->chunk(0));
+  TEST_EQUAL(col_charge->Value(0), 2)
+
+  auto col_quality = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("quality")->chunk(0));
+  TEST_REAL_SIMILAR(col_quality->Value(0), 0.95)
+
+  auto col_width = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("width")->chunk(0));
+  TEST_EQUAL(col_width->IsNull(0), false)
+  TEST_REAL_SIMILAR(col_width->Value(0), 1.5)
+
+  // Verify handles column (list of structs)
+  auto handles_chunked = table->GetColumnByName("handles");
+  TEST_NOT_EQUAL(handles_chunked, nullptr)
+  auto handles_list = std::static_pointer_cast<arrow::ListArray>(handles_chunked->chunk(0));
+  TEST_EQUAL(handles_list->value_length(0), 2)
+
+  auto handle_structs = std::static_pointer_cast<arrow::StructArray>(handles_list->value_slice(0));
+  auto h_map_idx = std::static_pointer_cast<arrow::Int64Array>(handle_structs->field(0));
+  auto h_uid = std::static_pointer_cast<arrow::Int64Array>(handle_structs->field(1));
+  auto h_rt = std::static_pointer_cast<arrow::DoubleArray>(handle_structs->field(2));
+  auto h_intensity = std::static_pointer_cast<arrow::FloatArray>(handle_structs->field(4));
+
+  // Handles are stored sorted by (map_index, unique_id)
+  TEST_EQUAL(h_map_idx->Value(0), 0)
+  TEST_EQUAL(h_uid->Value(0), 100)
+  TEST_REAL_SIMILAR(h_rt->Value(0), 100.0)
+  TEST_REAL_SIMILAR(h_intensity->Value(0), 800.0)
+
+  TEST_EQUAL(h_map_idx->Value(1), 1)
+  TEST_EQUAL(h_uid->Value(1), 200)
+  TEST_REAL_SIMILAR(h_rt->Value(1), 101.0)
+  TEST_REAL_SIMILAR(h_intensity->Value(1), 1200.0)
+
+  // Verify metavalues column
+  auto mv_chunked = table->GetColumnByName("metavalues");
+  TEST_NOT_EQUAL(mv_chunked, nullptr)
+  auto mv_list = std::static_pointer_cast<arrow::ListArray>(mv_chunked->chunk(0));
+  TEST_EQUAL(mv_list->value_length(0), 3)
+}
+END_SECTION
+
+START_SECTION(exportPSMsToArrow - empty ConsensusMap)
+{
+  ConsensusMap cmap;
+  // Need at least an empty ProteinIdentification for QPXFile
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_1");
+  cmap.setProteinIdentifications({prot_id});
+
+  auto table = ConsensusMapArrowIO::exportPSMsToArrow(cmap);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+}
+END_SECTION
+
+START_SECTION(exportPSMsToArrow - feature and unassigned PSMs)
+{
+  ConsensusMap cmap;
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_1");
+  prot_id.setSearchEngine("TestEngine");
+  prot_id.setScoreType("TestScore");
+  cmap.setProteinIdentifications({prot_id});
+
+  // ConsensusFeature (uid=1000) with 1 PeptideIdentification
+  ConsensusFeature cf;
+  cf.setRT(100.0);
+  cf.setMZ(500.0);
+  cf.setIntensity(1000.0f);
+  cf.setCharge(2);
+  cf.setUniqueId(1000);
+
+  PeptideIdentification pep_id1;
+  pep_id1.setIdentifier("run_1");
+  pep_id1.setScoreType("TestScore");
+  pep_id1.setHigherScoreBetter(true);
+  pep_id1.setRT(100.0);
+  pep_id1.setMZ(500.0);
+  PeptideHit hit1;
+  hit1.setSequence(AASequence::fromString("PEPTIDER"));
+  hit1.setScore(0.95);
+  hit1.setCharge(2);
+  pep_id1.getHits().push_back(hit1);
+  cf.getPeptideIdentifications().push_back(pep_id1);
+
+  cmap.push_back(cf);
+
+  // 1 unassigned PeptideIdentification
+  PeptideIdentification pep_id2;
+  pep_id2.setIdentifier("run_1");
+  pep_id2.setScoreType("TestScore");
+  pep_id2.setHigherScoreBetter(true);
+  pep_id2.setRT(200.0);
+  pep_id2.setMZ(600.0);
+  PeptideHit hit2;
+  hit2.setSequence(AASequence::fromString("ACDEFGHIK"));
+  hit2.setScore(0.80);
+  hit2.setCharge(3);
+  pep_id2.getHits().push_back(hit2);
+  cmap.getUnassignedPeptideIdentifications().push_back(pep_id2);
+
+  auto table = ConsensusMapArrowIO::exportPSMsToArrow(cmap);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 2)
+
+  // Verify consensus_feature_unique_id column
+  auto cf_id_chunked = table->GetColumnByName("consensus_feature_unique_id");
+  TEST_NOT_EQUAL(cf_id_chunked, nullptr)
+  auto cf_id_arr = std::static_pointer_cast<arrow::Int64Array>(cf_id_chunked->chunk(0));
+
+  // Row 0: feature PSM -> consensus_feature_unique_id = 1000
+  TEST_EQUAL(cf_id_arr->IsNull(0), false)
+  TEST_EQUAL(cf_id_arr->Value(0), 1000)
+
+  // Row 1: unassigned PSM -> consensus_feature_unique_id = null
+  TEST_EQUAL(cf_id_arr->IsNull(1), true)
+
+  // Verify sequence column
+  auto seq_col = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("sequence")->chunk(0));
+  TEST_EQUAL(seq_col->GetString(0), "PEPTIDER")
+  TEST_EQUAL(seq_col->GetString(1), "ACDEFGHIK")
+
+  // Verify score column
+  auto score_col = std::static_pointer_cast<arrow::DoubleArray>(table->GetColumnByName("score")->chunk(0));
+  TEST_REAL_SIMILAR(score_col->Value(0), 0.95)
+  TEST_REAL_SIMILAR(score_col->Value(1), 0.80)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// Feature round-trip tests
+/////////////////////////////////////////////////////////////
+
+START_SECTION(importFeaturesFromArrow - feature round-trip with handles and metavalues)
+{
+  ConsensusMap cmap_in;
+
+  // Feature 1: with handles and metavalues
+  ConsensusFeature cf1;
+  cf1.setRT(100.5);
+  cf1.setMZ(500.25);
+  cf1.setIntensity(1000.0f);
+  cf1.setCharge(2);
+  cf1.setQuality(0.95f);
+  cf1.setWidth(1.5f);
+  cf1.setUniqueId(1001);
+  cf1.setMetaValue("my_int", 42);
+  cf1.setMetaValue("my_float", 3.14);
+  cf1.setMetaValue("my_string", String("hello"));
+  cf1.setMetaValue("test_int_list", DataValue(IntList{1, 2, 3}));
+  cf1.setMetaValue("test_double_list", DataValue(DoubleList{1.5, 2.5}));
+  cf1.setMetaValue("test_string_list", DataValue(StringList{"a", "b", "c"}));
+
+  FeatureHandle h0;
+  h0.setMapIndex(0);
+  h0.setUniqueId(100);
+  h0.setRT(100.0);
+  h0.setMZ(500.2);
+  h0.setIntensity(800.0f);
+  h0.setCharge(2);
+  h0.setWidth(1.2f);
+  cf1.insert(h0);
+
+  FeatureHandle h1;
+  h1.setMapIndex(1);
+  h1.setUniqueId(200);
+  h1.setRT(101.0);
+  h1.setMZ(500.3);
+  h1.setIntensity(1200.0f);
+  h1.setCharge(3);
+  h1.setWidth(1.8f);
+  cf1.insert(h1);
+
+  cmap_in.push_back(cf1);
+
+  // Feature 2: minimal, no handles, no metavalues
+  ConsensusFeature cf2;
+  cf2.setRT(200.0);
+  cf2.setMZ(600.0);
+  cf2.setIntensity(2000.0f);
+  cf2.setCharge(3);
+  cf2.setQuality(0.5f);
+  cf2.setUniqueId(2001);
+  cmap_in.push_back(cf2);
+
+  // Export
+  auto table = ConsensusMapArrowIO::exportFeaturesToArrow(cmap_in);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 2)
+
+  // Import
+  ConsensusMap cmap_out;
+  bool ok = ConsensusMapArrowIO::importFeaturesFromArrow(table, cmap_out);
+  TEST_EQUAL(ok, true)
+  TEST_EQUAL(cmap_out.size(), 2)
+
+  // Verify feature 1
+  const auto& out1 = cmap_out[0];
+  TEST_REAL_SIMILAR(out1.getRT(), 100.5)
+  TEST_REAL_SIMILAR(out1.getMZ(), 500.25)
+  TEST_REAL_SIMILAR(out1.getIntensity(), 1000.0)
+  TEST_EQUAL(out1.getCharge(), 2)
+  TEST_REAL_SIMILAR(out1.getQuality(), 0.95)
+  TEST_REAL_SIMILAR(out1.getWidth(), 1.5)
+  TEST_EQUAL(out1.getUniqueId(), 1001)
+
+  // Verify handles
+  const auto& handles = out1.getFeatures();
+  TEST_EQUAL(handles.size(), 2)
+
+  auto it = handles.begin();
+  TEST_EQUAL(it->getMapIndex(), 0)
+  TEST_EQUAL(it->getUniqueId(), 100)
+  TEST_REAL_SIMILAR(it->getRT(), 100.0)
+  TEST_REAL_SIMILAR(it->getMZ(), 500.2)
+  TEST_REAL_SIMILAR(it->getIntensity(), 800.0)
+  TEST_EQUAL(it->getCharge(), 2)
+  TEST_REAL_SIMILAR(it->getWidth(), 1.2)
+
+  ++it;
+  TEST_EQUAL(it->getMapIndex(), 1)
+  TEST_EQUAL(it->getUniqueId(), 200)
+  TEST_REAL_SIMILAR(it->getRT(), 101.0)
+  TEST_REAL_SIMILAR(it->getMZ(), 500.3)
+  TEST_REAL_SIMILAR(it->getIntensity(), 1200.0)
+  TEST_EQUAL(it->getCharge(), 3)
+  TEST_REAL_SIMILAR(it->getWidth(), 1.8)
+
+  // Verify metavalues
+  TEST_EQUAL(int(out1.getMetaValue("my_int")), 42)
+  TEST_REAL_SIMILAR(double(out1.getMetaValue("my_float")), 3.14)
+  TEST_EQUAL(String(out1.getMetaValue("my_string")), "hello")
+
+  // Check list metavalue types are preserved
+  TEST_EQUAL(out1.getMetaValue("test_int_list").valueType(), DataValue::INT_LIST)
+  TEST_EQUAL(out1.getMetaValue("test_int_list") == DataValue(IntList{1, 2, 3}), true)
+  TEST_EQUAL(out1.getMetaValue("test_double_list").valueType(), DataValue::DOUBLE_LIST)
+  TEST_EQUAL(out1.getMetaValue("test_double_list") == DataValue(DoubleList{1.5, 2.5}), true)
+  TEST_EQUAL(out1.getMetaValue("test_string_list").valueType(), DataValue::STRING_LIST)
+  TEST_EQUAL(out1.getMetaValue("test_string_list") == DataValue(StringList{"a", "b", "c"}), true)
+
+  // Verify feature 2
+  const auto& out2 = cmap_out[1];
+  TEST_REAL_SIMILAR(out2.getRT(), 200.0)
+  TEST_REAL_SIMILAR(out2.getMZ(), 600.0)
+  TEST_REAL_SIMILAR(out2.getIntensity(), 2000.0)
+  TEST_EQUAL(out2.getCharge(), 3)
+  TEST_REAL_SIMILAR(out2.getQuality(), 0.5)
+  TEST_EQUAL(out2.getUniqueId(), 2001)
+  TEST_EQUAL(out2.getFeatures().size(), 0)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// PSM round-trip tests
+/////////////////////////////////////////////////////////////
+
+START_SECTION(importPSMsFromArrow - PSM round-trip)
+{
+  ConsensusMap cmap_in;
+
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_1");
+  prot_id.setSearchEngine("TestEngine");
+  prot_id.setScoreType("TestScore");
+  cmap_in.setProteinIdentifications({prot_id});
+
+  // ConsensusFeature (uid=1000) with 1 PeptideIdentification
+  ConsensusFeature cf;
+  cf.setRT(100.0);
+  cf.setMZ(500.0);
+  cf.setIntensity(1000.0f);
+  cf.setCharge(2);
+  cf.setUniqueId(1000);
+
+  PeptideIdentification pep_id1;
+  pep_id1.setIdentifier("run_1");
+  pep_id1.setScoreType("TestScore");
+  pep_id1.setHigherScoreBetter(true);
+  pep_id1.setRT(100.0);
+  pep_id1.setMZ(500.0);
+  PeptideHit hit1;
+  hit1.setSequence(AASequence::fromString("PEPTIDER"));
+  hit1.setScore(0.95);
+  hit1.setCharge(2);
+  pep_id1.getHits().push_back(hit1);
+  cf.getPeptideIdentifications().push_back(pep_id1);
+
+  cmap_in.push_back(cf);
+
+  // Unassigned PeptideIdentification
+  PeptideIdentification pep_id2;
+  pep_id2.setIdentifier("run_1");
+  pep_id2.setScoreType("TestScore");
+  pep_id2.setHigherScoreBetter(true);
+  pep_id2.setRT(200.0);
+  pep_id2.setMZ(600.0);
+  PeptideHit hit2;
+  hit2.setSequence(AASequence::fromString("ACDEFGHIK"));
+  hit2.setScore(0.80);
+  hit2.setCharge(3);
+  pep_id2.getHits().push_back(hit2);
+  cmap_in.getUnassignedPeptideIdentifications().push_back(pep_id2);
+
+  // Export features and PSMs
+  auto features_table = ConsensusMapArrowIO::exportFeaturesToArrow(cmap_in);
+  TEST_NOT_EQUAL(features_table, nullptr)
+
+  auto psm_table = ConsensusMapArrowIO::exportPSMsToArrow(cmap_in);
+  TEST_NOT_EQUAL(psm_table, nullptr)
+  TEST_EQUAL(psm_table->num_rows(), 2)
+
+  // Import: first features, then PSMs
+  ConsensusMap cmap_out;
+  cmap_out.setProteinIdentifications(cmap_in.getProteinIdentifications());
+
+  bool ok = ConsensusMapArrowIO::importFeaturesFromArrow(features_table, cmap_out);
+  TEST_EQUAL(ok, true)
+  TEST_EQUAL(cmap_out.size(), 1)
+
+  ok = ConsensusMapArrowIO::importPSMsFromArrow(psm_table, cmap_out);
+  TEST_EQUAL(ok, true)
+
+  // Verify feature PSMs
+  TEST_EQUAL(cmap_out[0].getPeptideIdentifications().size(), 1)
+  const auto& out_pid1 = cmap_out[0].getPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid1.getHits().size(), 1)
+  TEST_EQUAL(out_pid1.getHits()[0].getSequence().toString(), "PEPTIDER")
+  TEST_REAL_SIMILAR(out_pid1.getHits()[0].getScore(), 0.95)
+  TEST_EQUAL(out_pid1.getHits()[0].getCharge(), 2)
+
+  // Verify unassigned PSMs
+  TEST_EQUAL(cmap_out.getUnassignedPeptideIdentifications().size(), 1)
+  const auto& out_pid2 = cmap_out.getUnassignedPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid2.getHits().size(), 1)
+  TEST_EQUAL(out_pid2.getHits()[0].getSequence().toString(), "ACDEFGHIK")
+  TEST_REAL_SIMILAR(out_pid2.getHits()[0].getScore(), 0.80)
+  TEST_EQUAL(out_pid2.getHits()[0].getCharge(), 3)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// PSM per-PSM higher_score_better + scan/reference_file_name round-trip
+/////////////////////////////////////////////////////////////
+
+START_SECTION(exportToParquet / importFromParquet - per-PSM higher_score_better independent from ProteinIdentification)
+{
+  ConsensusMap cmap;
+
+  // ProteinIdentification with higher_score_better=false (run-level)
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_hsb_test");
+  prot_id.setSearchEngine("Comet");
+  prot_id.setScoreType("expect");
+  prot_id.setHigherScoreBetter(false);
+  cmap.setProteinIdentifications({prot_id});
+
+  // ConsensusFeature with PeptideIdentification where higher_score_better=true (differs from run-level)
+  ConsensusFeature cf;
+  cf.setRT(100.0);
+  cf.setMZ(500.0);
+  cf.setIntensity(1000.0f);
+  cf.setCharge(2);
+  cf.setUniqueId(7001);
+
+  PeptideIdentification pep_id1;
+  pep_id1.setIdentifier("run_hsb_test");
+  pep_id1.setScoreType("xcorr");
+  pep_id1.setHigherScoreBetter(true); // different from run-level false
+  pep_id1.setRT(100.0);
+  pep_id1.setMZ(500.25);
+  pep_id1.setSpectrumReference("spectrum=99");
+
+  PeptideHit hit1;
+  hit1.setSequence(AASequence::fromString("PEPTIDER"));
+  hit1.setScore(2.5);
+  hit1.setCharge(2);
+  hit1.setRank(1);
+  hit1.setMetaValue("target_decoy", "target");
+  pep_id1.insertHit(hit1);
+  cf.setPeptideIdentifications({pep_id1});
+  cmap.push_back(cf);
+
+  // Unassigned PeptideIdentification with higher_score_better=false (same as run-level)
+  PeptideIdentification pep_id2;
+  pep_id2.setIdentifier("run_hsb_test");
+  pep_id2.setScoreType("expect");
+  pep_id2.setHigherScoreBetter(false);
+  pep_id2.setRT(200.0);
+  pep_id2.setMZ(600.0);
+
+  PeptideHit hit2;
+  hit2.setSequence(AASequence::fromString("ACDEFGHIK"));
+  hit2.setScore(0.05);
+  hit2.setCharge(3);
+  hit2.setRank(1);
+  hit2.setMetaValue("target_decoy", "target");
+  pep_id2.insertHit(hit2);
+  cmap.getUnassignedPeptideIdentifications().push_back(pep_id2);
+
+  // --- Export and import ---
+  String tmp_dir;
+  NEW_TMP_FILE(tmp_dir)
+  tmp_dir += ".cmd";
+
+  TEST_EQUAL(ConsensusMapArrowIO::exportToParquet(cmap, tmp_dir), true)
+
+  ConsensusMap imported;
+  TEST_EQUAL(ConsensusMapArrowIO::importFromParquet(tmp_dir, imported), true)
+
+  // Verify per-PSM higher_score_better: pep_id1 should be true (not run-level false)
+  TEST_EQUAL(imported[0].getPeptideIdentifications().size(), 1)
+  const PeptideIdentification& out_pid1 = imported[0].getPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid1.isHigherScoreBetter(), true)  // per-PSM value, NOT run-level false
+  TEST_EQUAL(out_pid1.getScoreType(), "xcorr")
+
+  // Verify unassigned PSM: higher_score_better should be false
+  TEST_EQUAL(imported.getUnassignedPeptideIdentifications().size(), 1)
+  const PeptideIdentification& out_pid2 = imported.getUnassignedPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid2.isHigherScoreBetter(), false)
+  TEST_EQUAL(out_pid2.getScoreType(), "expect")
+
+  // Verify scan survives round-trip via metavalue
+  const PeptideHit& out_hit1 = out_pid1.getHits()[0];
+  TEST_EQUAL(out_hit1.metaValueExists("scan"), true)
+  TEST_EQUAL(static_cast<int>(out_hit1.getMetaValue("scan")), 99)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// Full Parquet directory round-trip test
+/////////////////////////////////////////////////////////////
+
+START_SECTION(exportToParquet / importFromParquet - full round-trip)
+{
+  ConsensusMap cmap;
+
+  // --- Column headers ---
+  ConsensusMap::ColumnHeader ch0;
+  ch0.filename = "sample1.mzML";
+  ch0.label = "light";
+  ch0.size = 100;
+  ch0.unique_id = 111;
+  cmap.getColumnHeaders()[0] = ch0;
+
+  ConsensusMap::ColumnHeader ch1;
+  ch1.filename = "sample2.mzML";
+  ch1.label = "heavy";
+  ch1.size = 200;
+  ch1.unique_id = 222;
+  cmap.getColumnHeaders()[1] = ch1;
+
+  cmap.setExperimentType("label-free");
+
+  // --- Set ConsensusMap-level UniqueId ---
+  cmap.setUniqueId(55555);
+
+  // --- ProteinIdentification ---
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_full_1");
+  prot_id.setSearchEngine("Comet");
+  prot_id.setSearchEngineVersion("2023.01");
+  prot_id.setScoreType("expect");
+  prot_id.setHigherScoreBetter(false);
+
+  ProteinIdentification::SearchParameters sp;
+  sp.db = "uniprot_human";
+  sp.mass_type = ProteinIdentification::PeakMassType::MONOISOTOPIC;
+  sp.precursor_mass_tolerance = 10.0;
+  sp.precursor_mass_tolerance_ppm = true;
+  sp.fragment_mass_tolerance = 0.02;
+  sp.fragment_mass_tolerance_ppm = false;
+  sp.digestion_enzyme = *ProteaseDB::getInstance()->getEnzyme("Trypsin");
+  sp.missed_cleavages = 2;
+  prot_id.setSearchParameters(sp);
+
+  ProteinHit ph;
+  ph.setAccession("P12345");
+  ph.setScore(0.001);
+  prot_id.insertHit(ph);
+
+  ProteinIdentification::ProteinGroup pg;
+  pg.probability = 0.99;
+  pg.accessions = {"P12345"};
+  prot_id.insertProteinGroup(pg);
+
+  cmap.setProteinIdentifications({prot_id});
+
+  // --- ConsensusFeature 1: with handles, metavalues, and PSM ---
+  ConsensusFeature cf1;
+  cf1.setRT(100.0);
+  cf1.setMZ(500.0);
+  cf1.setIntensity(1000.0f);
+  cf1.setCharge(2);
+  cf1.setQuality(0.9f);
+  cf1.setWidth(1.5f);
+  cf1.setUniqueId(1001);
+  cf1.setMetaValue("custom_val", 42);
+
+  FeatureHandle fh0;
+  fh0.setMapIndex(0);
+  fh0.setUniqueId(100);
+  fh0.setRT(99.5);
+  fh0.setMZ(500.0);
+  fh0.setIntensity(800.0f);
+  fh0.setCharge(2);
+  cf1.insert(fh0);
+
+  FeatureHandle fh1;
+  fh1.setMapIndex(1);
+  fh1.setUniqueId(200);
+  fh1.setRT(100.5);
+  fh1.setMZ(500.1);
+  fh1.setIntensity(1200.0f);
+  fh1.setCharge(2);
+  cf1.insert(fh1);
+
+  PeptideIdentification pep_id1;
+  pep_id1.setScoreType("expect");
+  pep_id1.setHigherScoreBetter(false);
+  pep_id1.setIdentifier("run_full_1");
+  PeptideHit pep_hit1;
+  pep_hit1.setSequence(AASequence::fromString("PEPTIDER"));
+  pep_hit1.setScore(0.001);
+  pep_hit1.setCharge(2);
+  pep_id1.insertHit(pep_hit1);
+  cf1.setPeptideIdentifications({pep_id1});
+
+  cmap.push_back(cf1);
+
+  // --- ConsensusFeature 2: simple, no PSMs ---
+  ConsensusFeature cf2;
+  cf2.setRT(200.0);
+  cf2.setMZ(600.0);
+  cf2.setIntensity(2000.0f);
+  cf2.setCharge(3);
+  cf2.setUniqueId(2001);
+  cmap.push_back(cf2);
+
+  // --- Unassigned PeptideIdentification ---
+  PeptideIdentification unassigned;
+  unassigned.setScoreType("expect");
+  unassigned.setHigherScoreBetter(false);
+  unassigned.setIdentifier("run_full_1");
+  PeptideHit unassigned_hit;
+  unassigned_hit.setSequence(AASequence::fromString("ACDEFGHIK"));
+  unassigned_hit.setScore(0.5);
+  unassigned_hit.setCharge(3);
+  unassigned.insertHit(unassigned_hit);
+  cmap.setUnassignedPeptideIdentifications({unassigned});
+
+  // --- Export to temp directory ---
+  String tmp_dir;
+  NEW_TMP_FILE(tmp_dir)
+  tmp_dir += ".cmd";
+
+  TEST_EQUAL(ConsensusMapArrowIO::exportToParquet(cmap, tmp_dir), true)
+
+  // --- Import back ---
+  ConsensusMap imported;
+  TEST_EQUAL(ConsensusMapArrowIO::importFromParquet(tmp_dir, imported), true)
+
+  // --- Verify column headers ---
+  TEST_EQUAL(imported.getColumnHeaders().size(), 2)
+  TEST_EQUAL(imported.getColumnHeaders().at(0).filename, "sample1.mzML")
+  TEST_EQUAL(imported.getColumnHeaders().at(0).label, "light")
+  TEST_EQUAL(imported.getColumnHeaders().at(0).size, 100)
+  TEST_EQUAL(imported.getColumnHeaders().at(0).unique_id, 111)
+  TEST_EQUAL(imported.getColumnHeaders().at(1).filename, "sample2.mzML")
+  TEST_EQUAL(imported.getColumnHeaders().at(1).label, "heavy")
+
+  // --- Verify experiment type ---
+  TEST_EQUAL(imported.getExperimentType(), "label-free")
+
+  // --- Verify ConsensusMap-level UniqueId ---
+  TEST_EQUAL(imported.getUniqueId(), 55555)
+
+  // --- Verify features ---
+  TEST_EQUAL(imported.size(), 2)
+
+  // Feature 1
+  TEST_REAL_SIMILAR(imported[0].getRT(), 100.0)
+  TEST_REAL_SIMILAR(imported[0].getMZ(), 500.0)
+  TEST_REAL_SIMILAR(imported[0].getIntensity(), 1000.0)
+  TEST_EQUAL(imported[0].getCharge(), 2)
+  TEST_REAL_SIMILAR(imported[0].getQuality(), 0.9)
+  TEST_REAL_SIMILAR(imported[0].getWidth(), 1.5)
+  TEST_EQUAL(imported[0].getUniqueId(), 1001)
+  TEST_EQUAL(int(imported[0].getMetaValue("custom_val")), 42)
+
+  // Feature 1 handles
+  TEST_EQUAL(imported[0].getFeatures().size(), 2)
+  auto hit = imported[0].getFeatures().begin();
+  TEST_EQUAL(hit->getMapIndex(), 0)
+  TEST_EQUAL(hit->getUniqueId(), 100)
+  TEST_REAL_SIMILAR(hit->getIntensity(), 800.0)
+  ++hit;
+  TEST_EQUAL(hit->getMapIndex(), 1)
+  TEST_EQUAL(hit->getUniqueId(), 200)
+  TEST_REAL_SIMILAR(hit->getIntensity(), 1200.0)
+
+  // Feature 2
+  TEST_REAL_SIMILAR(imported[1].getRT(), 200.0)
+  TEST_EQUAL(imported[1].getCharge(), 3)
+  TEST_EQUAL(imported[1].getUniqueId(), 2001)
+  TEST_EQUAL(imported[1].getFeatures().size(), 0)
+
+  // --- Verify PSMs ---
+  TEST_EQUAL(imported[0].getPeptideIdentifications().size(), 1)
+  TEST_EQUAL(imported[0].getPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "PEPTIDER")
+  TEST_REAL_SIMILAR(imported[0].getPeptideIdentifications()[0].getHits()[0].getScore(), 0.001)
+
+  TEST_EQUAL(imported.getUnassignedPeptideIdentifications().size(), 1)
+  TEST_EQUAL(imported.getUnassignedPeptideIdentifications()[0].getHits()[0].getSequence().toString(), "ACDEFGHIK")
+
+  // --- Verify protein identifications ---
+  TEST_EQUAL(imported.getProteinIdentifications().size(), 1)
+  TEST_EQUAL(imported.getProteinIdentifications()[0].getIdentifier(), "run_full_1")
+  TEST_EQUAL(imported.getProteinIdentifications()[0].getSearchEngine(), "Comet")
+  TEST_EQUAL(imported.getProteinIdentifications()[0].getHits().size(), 1)
+  TEST_EQUAL(imported.getProteinIdentifications()[0].getHits()[0].getAccession(), "P12345")
+  TEST_EQUAL(imported.getProteinIdentifications()[0].getProteinGroups().size(), 1)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// ConsensusMap metadata round-trip tests
+/////////////////////////////////////////////////////////////
+
+START_SECTION(exportToParquet / importFromParquet - metadata round-trip (DocumentIdentifier + DataProcessing + ColumnHeaders + UniqueId + MetaValues))
+{
+  ConsensusMap cmap;
+
+  // --- Set DocumentIdentifier fields ---
+  cmap.setIdentifier("test_cmap_lsid_456");
+  cmap.setLoadedFilePath("/data/experiments/test_run.consensusXML");
+
+  // --- Set ConsensusMap-level UniqueId ---
+  cmap.setUniqueId(77777);
+
+  // --- Set ConsensusMap-level MetaValues ---
+  cmap.setMetaValue("analysis_type", String("differential"));
+  cmap.setMetaValue("num_runs", 5);
+  cmap.setMetaValue("threshold", 0.01);
+
+  // --- Set column headers with metavalues ---
+  ConsensusMap::ColumnHeader ch0;
+  ch0.filename = "run_A.mzML";
+  ch0.label = "sample_A";
+  ch0.size = 500;
+  ch0.unique_id = 1111;
+  ch0.setMetaValue("injection_order", 1);
+  ch0.setMetaValue("sample_group", String("control"));
+  cmap.getColumnHeaders()[0] = ch0;
+
+  ConsensusMap::ColumnHeader ch1;
+  ch1.filename = "run_B.mzML";
+  ch1.label = "sample_B";
+  ch1.size = 600;
+  ch1.unique_id = 2222;
+  ch1.setMetaValue("injection_order", 2);
+  ch1.setMetaValue("sample_group", String("treatment"));
+  cmap.getColumnHeaders()[1] = ch1;
+
+  ConsensusMap::ColumnHeader ch2;
+  ch2.filename = "run_C.mzML";
+  ch2.label = "sample_C";
+  ch2.size = 700;
+  ch2.unique_id = 3333;
+  // ch2 intentionally has no metavalues
+  cmap.getColumnHeaders()[2] = ch2;
+
+  cmap.setExperimentType("labeled_MS1");
+
+  // --- Set DataProcessing ---
+  DataProcessing dp1;
+  dp1.getSoftware().setName("FeatureFinderCentroided");
+  dp1.getSoftware().setVersion("3.2.0");
+  dp1.setCompletionTime(DateTime::fromString("2025-06-15T14:30:00", "yyyy-MM-ddThh:mm:ss"));
+  dp1.getProcessingActions().insert(DataProcessing::PEAK_PICKING);
+  dp1.getProcessingActions().insert(DataProcessing::FILTERING);
+  dp1.setMetaValue("parameter_file", String("params.ini"));
+  dp1.setMetaValue("num_threads", 8);
+
+  DataProcessing dp2;
+  dp2.getSoftware().setName("FeatureLinkerUnlabeledQT");
+  dp2.getSoftware().setVersion("3.2.0");
+  dp2.setCompletionTime(DateTime::fromString("2025-06-15T15:00:00", "yyyy-MM-ddThh:mm:ss"));
+  dp2.getProcessingActions().insert(DataProcessing::FEATURE_GROUPING);
+  dp2.setMetaValue("max_rt_shift", 300.5);
+
+  cmap.setDataProcessing({dp1, dp2});
+
+  // --- Add a simple consensus feature so the map is non-empty ---
+  ConsensusFeature cf;
+  cf.setRT(100.0);
+  cf.setMZ(500.0);
+  cf.setIntensity(1000.0f);
+  cf.setCharge(2);
+  cf.setUniqueId(9999);
+  cmap.push_back(cf);
+
+  // Need ProteinIdentification for export
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_meta_test");
+  cmap.setProteinIdentifications({prot_id});
+
+  // --- Export ---
+  String tmp_dir;
+  NEW_TMP_FILE(tmp_dir)
+  tmp_dir += ".cmd";
+
+  TEST_EQUAL(ConsensusMapArrowIO::exportToParquet(cmap, tmp_dir), true)
+
+  // --- Import ---
+  ConsensusMap imported;
+  TEST_EQUAL(ConsensusMapArrowIO::importFromParquet(tmp_dir, imported), true)
+
+  // --- Verify DocumentIdentifier ---
+  TEST_EQUAL(imported.getIdentifier(), "test_cmap_lsid_456")
+  TEST_EQUAL(imported.getLoadedFilePath(), "/data/experiments/test_run.consensusXML")
+
+  // --- Verify ConsensusMap-level UniqueId ---
+  TEST_EQUAL(imported.getUniqueId(), 77777)
+
+  // --- Verify ConsensusMap-level MetaValues ---
+  TEST_EQUAL(String(imported.getMetaValue("analysis_type")), "differential")
+  TEST_EQUAL(int(imported.getMetaValue("num_runs")), 5)
+  TEST_REAL_SIMILAR(double(imported.getMetaValue("threshold")), 0.01)
+
+  // --- Verify experiment type ---
+  TEST_EQUAL(imported.getExperimentType(), "labeled_MS1")
+
+  // --- Verify column headers ---
+  TEST_EQUAL(imported.getColumnHeaders().size(), 3)
+  TEST_EQUAL(imported.getColumnHeaders().at(0).filename, "run_A.mzML")
+  TEST_EQUAL(imported.getColumnHeaders().at(0).label, "sample_A")
+  TEST_EQUAL(imported.getColumnHeaders().at(0).size, 500)
+  TEST_EQUAL(imported.getColumnHeaders().at(0).unique_id, 1111)
+  TEST_EQUAL(imported.getColumnHeaders().at(1).filename, "run_B.mzML")
+  TEST_EQUAL(imported.getColumnHeaders().at(1).label, "sample_B")
+  TEST_EQUAL(imported.getColumnHeaders().at(2).filename, "run_C.mzML")
+  TEST_EQUAL(imported.getColumnHeaders().at(2).label, "sample_C")
+
+  // --- Verify column header metavalues ---
+  TEST_EQUAL(int(imported.getColumnHeaders().at(0).getMetaValue("injection_order")), 1)
+  TEST_EQUAL(String(imported.getColumnHeaders().at(0).getMetaValue("sample_group")), "control")
+  TEST_EQUAL(int(imported.getColumnHeaders().at(1).getMetaValue("injection_order")), 2)
+  TEST_EQUAL(String(imported.getColumnHeaders().at(1).getMetaValue("sample_group")), "treatment")
+
+  // --- Verify DataProcessing ---
+  TEST_EQUAL(imported.getDataProcessing().size(), 2)
+
+  const auto& out_dp1 = imported.getDataProcessing()[0];
+  TEST_EQUAL(out_dp1.getSoftware().getName(), "FeatureFinderCentroided")
+  TEST_EQUAL(out_dp1.getSoftware().getVersion(), "3.2.0")
+  TEST_EQUAL(out_dp1.getCompletionTime().toString("yyyy-MM-ddThh:mm:ss"), "2025-06-15T14:30:00")
+  TEST_EQUAL(out_dp1.getProcessingActions().count(DataProcessing::PEAK_PICKING), 1)
+  TEST_EQUAL(out_dp1.getProcessingActions().count(DataProcessing::FILTERING), 1)
+  TEST_EQUAL(String(out_dp1.getMetaValue("parameter_file")), "params.ini")
+  TEST_EQUAL(int(out_dp1.getMetaValue("num_threads")), 8)
+
+  const auto& out_dp2 = imported.getDataProcessing()[1];
+  TEST_EQUAL(out_dp2.getSoftware().getName(), "FeatureLinkerUnlabeledQT")
+  TEST_EQUAL(out_dp2.getProcessingActions().count(DataProcessing::FEATURE_GROUPING), 1)
+  TEST_REAL_SIMILAR(double(out_dp2.getMetaValue("max_rt_shift")), 300.5)
+}
+END_SECTION
+
+#endif // WITH_PARQUET
+
+END_TEST

--- a/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMapArrowIO_test.cpp
@@ -109,7 +109,7 @@ START_SECTION(exportFeaturesToArrow - single feature with convex hulls and metav
   auto col_charge = std::static_pointer_cast<arrow::Int32Array>(table->GetColumnByName("charge")->chunk(0));
   TEST_EQUAL(col_charge->Value(0), 2)
 
-  auto col_oq = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("overall_quality")->chunk(0));
+  auto col_oq = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("quality")->chunk(0));
   TEST_REAL_SIMILAR(col_oq->Value(0), 0.95f)
 
   auto col_qrt = std::static_pointer_cast<arrow::FloatArray>(table->GetColumnByName("quality_rt")->chunk(0));
@@ -250,6 +250,9 @@ START_SECTION(importFeaturesFromArrow - round-trip with subordinates and hulls a
   f1.setMetaValue("my_int", 42);
   f1.setMetaValue("my_float", 3.14);
   f1.setMetaValue("my_string", String("hello"));
+  f1.setMetaValue("test_int_list", DataValue(IntList{1, 2, 3}));
+  f1.setMetaValue("test_double_list", DataValue(DoubleList{1.5, 2.5}));
+  f1.setMetaValue("test_string_list", DataValue(StringList{"a", "b", "c"}));
 
   // Subordinate A (uid=101)
   Feature subA;
@@ -340,6 +343,14 @@ START_SECTION(importFeaturesFromArrow - round-trip with subordinates and hulls a
   TEST_EQUAL(out_f1.getMetaValue("my_float").valueType(), DataValue::DOUBLE_VALUE)
   TEST_EQUAL(out_f1.getMetaValue("my_string").valueType(), DataValue::STRING_VALUE)
 
+  // Check list metavalue types are preserved
+  TEST_EQUAL(out_f1.getMetaValue("test_int_list").valueType(), DataValue::INT_LIST)
+  TEST_EQUAL(out_f1.getMetaValue("test_int_list") == DataValue(IntList{1, 2, 3}), true)
+  TEST_EQUAL(out_f1.getMetaValue("test_double_list").valueType(), DataValue::DOUBLE_LIST)
+  TEST_EQUAL(out_f1.getMetaValue("test_double_list") == DataValue(DoubleList{1.5, 2.5}), true)
+  TEST_EQUAL(out_f1.getMetaValue("test_string_list").valueType(), DataValue::STRING_LIST)
+  TEST_EQUAL(out_f1.getMetaValue("test_string_list") == DataValue(StringList{"a", "b", "c"}), true)
+
   // Check subordinates of feature 1
   TEST_EQUAL(out_f1.getSubordinates().size(), 2)
 
@@ -390,8 +401,8 @@ START_SECTION(exportPSMsToArrow - empty FeatureMap)
   auto table = FeatureMapArrowIO::exportPSMsToArrow(fm);
   TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 0)
-  // Should have feature_id column + all QPX PSM columns
-  auto feature_id_col = table->GetColumnByName("feature_id");
+  // Should have feature_unique_id column + all QPX PSM columns
+  auto feature_id_col = table->GetColumnByName("feature_unique_id");
   TEST_NOT_EQUAL(feature_id_col, nullptr)
 }
 END_SECTION
@@ -449,16 +460,16 @@ START_SECTION(exportPSMsToArrow - feature and unassigned PSMs)
   TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 2)
 
-  // Verify feature_id column
-  auto feature_id_chunked = table->GetColumnByName("feature_id");
+  // Verify feature_unique_id column
+  auto feature_id_chunked = table->GetColumnByName("feature_unique_id");
   TEST_NOT_EQUAL(feature_id_chunked, nullptr)
   auto feature_id_arr = std::static_pointer_cast<arrow::Int64Array>(feature_id_chunked->chunk(0));
 
-  // Row 0: feature PSM -> feature_id = 1000
+  // Row 0: feature PSM -> feature_unique_id = 1000
   TEST_EQUAL(feature_id_arr->IsNull(0), false)
   TEST_EQUAL(feature_id_arr->Value(0), 1000)
 
-  // Row 1: unassigned PSM -> feature_id = null
+  // Row 1: unassigned PSM -> feature_unique_id = null
   TEST_EQUAL(feature_id_arr->IsNull(1), true)
 
   // Verify sequence column
@@ -988,6 +999,95 @@ START_SECTION(exportToParquet / importFromParquet - PSM completeness round-trip 
   TEST_EQUAL(out_pid2.getHits()[0].getSequence().toString(), "ACDEFGHIK")
   TEST_REAL_SIMILAR(out_pid2.getHits()[0].getScore(), 0.1)
   TEST_EQUAL(out_pid2.getHits()[0].getCharge(), 3)
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+// PSM per-PSM higher_score_better + scan/reference_file_name round-trip
+/////////////////////////////////////////////////////////////
+
+START_SECTION(exportToParquet / importFromParquet - per-PSM higher_score_better independent from ProteinIdentification)
+{
+  FeatureMap fm;
+
+  // ProteinIdentification with higher_score_better=false (run-level)
+  ProteinIdentification prot_id;
+  prot_id.setIdentifier("run_hsb_test");
+  prot_id.setSearchEngine("Comet");
+  prot_id.setScoreType("expect");
+  prot_id.setHigherScoreBetter(false);
+  fm.setProteinIdentifications({prot_id});
+
+  // Feature with PeptideIdentification where higher_score_better=true (differs from run-level)
+  Feature f1;
+  f1.setRT(100.0);
+  f1.setMZ(500.0);
+  f1.setIntensity(1000.0f);
+  f1.setCharge(2);
+  f1.setUniqueId(6001);
+
+  PeptideIdentification pep_id1;
+  pep_id1.setIdentifier("run_hsb_test");
+  pep_id1.setScoreType("xcorr");
+  pep_id1.setHigherScoreBetter(true); // different from run-level false
+  pep_id1.setRT(100.0);
+  pep_id1.setMZ(500.25);
+  pep_id1.setSpectrumReference("spectrum=99");
+
+  PeptideHit hit1;
+  hit1.setSequence(AASequence::fromString("PEPTIDER"));
+  hit1.setScore(2.5);
+  hit1.setCharge(2);
+  hit1.setRank(1);
+  hit1.setMetaValue("target_decoy", "target");
+  pep_id1.insertHit(hit1);
+  f1.setPeptideIdentifications({pep_id1});
+  fm.push_back(f1);
+
+  // Unassigned PeptideIdentification with higher_score_better=false (same as run-level)
+  PeptideIdentification pep_id2;
+  pep_id2.setIdentifier("run_hsb_test");
+  pep_id2.setScoreType("expect");
+  pep_id2.setHigherScoreBetter(false);
+  pep_id2.setRT(200.0);
+  pep_id2.setMZ(600.0);
+
+  PeptideHit hit2;
+  hit2.setSequence(AASequence::fromString("ACDEFGHIK"));
+  hit2.setScore(0.05);
+  hit2.setCharge(3);
+  hit2.setRank(1);
+  hit2.setMetaValue("target_decoy", "target");
+  pep_id2.insertHit(hit2);
+  fm.setUnassignedPeptideIdentifications({pep_id2});
+
+  // --- Export and import ---
+  String tmp_dir;
+  NEW_TMP_FILE(tmp_dir)
+  tmp_dir += ".fmd";
+
+  TEST_EQUAL(FeatureMapArrowIO::exportToParquet(fm, tmp_dir), true)
+
+  FeatureMap imported;
+  TEST_EQUAL(FeatureMapArrowIO::importFromParquet(tmp_dir, imported), true)
+
+  // Verify per-PSM higher_score_better: pep_id1 should be true (not run-level false)
+  TEST_EQUAL(imported[0].getPeptideIdentifications().size(), 1)
+  const PeptideIdentification& out_pid1 = imported[0].getPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid1.isHigherScoreBetter(), true)  // per-PSM value, NOT run-level false
+  TEST_EQUAL(out_pid1.getScoreType(), "xcorr")
+
+  // Verify unassigned PSM: higher_score_better should be false
+  TEST_EQUAL(imported.getUnassignedPeptideIdentifications().size(), 1)
+  const PeptideIdentification& out_pid2 = imported.getUnassignedPeptideIdentifications()[0];
+  TEST_EQUAL(out_pid2.isHigherScoreBetter(), false)
+  TEST_EQUAL(out_pid2.getScoreType(), "expect")
+
+  // Verify scan and reference_file_name survive round-trip via metavalue
+  // (scan is derived from spectrum_reference on export, reference_file_name from ProteinIdentification)
+  const PeptideHit& out_hit1 = out_pid1.getHits()[0];
+  TEST_EQUAL(out_hit1.metaValueExists("scan"), true)
+  TEST_EQUAL(static_cast<int>(out_hit1.getMetaValue("scan")), 99)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ProteinIdentificationArrowIO_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteinIdentificationArrowIO_test.cpp
@@ -82,30 +82,21 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportProteinsToArrow(...))
   // Verify number of rows (2 hits)
   TEST_EQUAL(table->num_rows(), 2)
 
-  // Verify 19 columns
-  TEST_EQUAL(table->num_columns(), 19)
+  // Verify 10 columns
+  TEST_EQUAL(table->num_columns(), 10)
 
   // Verify column names
   auto schema = table->schema();
   TEST_EQUAL(schema->field(0)->name(), "accession")
   TEST_EQUAL(schema->field(1)->name(), "score")
-  TEST_EQUAL(schema->field(2)->name(), "score_type")
-  TEST_EQUAL(schema->field(3)->name(), "higher_score_better")
-  TEST_EQUAL(schema->field(4)->name(), "rank")
-  TEST_EQUAL(schema->field(5)->name(), "coverage")
-  TEST_EQUAL(schema->field(6)->name(), "sequence")
-  TEST_EQUAL(schema->field(7)->name(), "description")
-  TEST_EQUAL(schema->field(8)->name(), "is_decoy")
-  TEST_EQUAL(schema->field(9)->name(), "run_identifier")
-  TEST_EQUAL(schema->field(10)->name(), "reference_file_name")
-  TEST_EQUAL(schema->field(11)->name(), "search_engine")
-  TEST_EQUAL(schema->field(12)->name(), "search_engine_version")
-  TEST_EQUAL(schema->field(13)->name(), "inference_engine")
-  TEST_EQUAL(schema->field(14)->name(), "inference_engine_version")
-  TEST_EQUAL(schema->field(15)->name(), "significance_threshold")
-  TEST_EQUAL(schema->field(16)->name(), "date")
-  TEST_EQUAL(schema->field(17)->name(), "modifications")
-  TEST_EQUAL(schema->field(18)->name(), "metavalues")
+  TEST_EQUAL(schema->field(2)->name(), "rank")
+  TEST_EQUAL(schema->field(3)->name(), "coverage")
+  TEST_EQUAL(schema->field(4)->name(), "sequence")
+  TEST_EQUAL(schema->field(5)->name(), "description")
+  TEST_EQUAL(schema->field(6)->name(), "is_decoy")
+  TEST_EQUAL(schema->field(7)->name(), "run_identifier")
+  TEST_EQUAL(schema->field(8)->name(), "modifications")
+  TEST_EQUAL(schema->field(9)->name(), "metavalues")
 
   // Verify accession values
   auto acc_col = table->GetColumnByName("accession");
@@ -118,18 +109,6 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportProteinsToArrow(...))
   auto score_arr = std::static_pointer_cast<arrow::DoubleArray>(score_col->chunk(0));
   TEST_REAL_SIMILAR(score_arr->Value(0), 150.5)
   TEST_REAL_SIMILAR(score_arr->Value(1), 25.3)
-
-  // Verify score_type values
-  auto st_col = table->GetColumnByName("score_type");
-  auto st_arr = std::static_pointer_cast<arrow::StringArray>(st_col->chunk(0));
-  TEST_EQUAL(st_arr->GetString(0), "Mascot")
-  TEST_EQUAL(st_arr->GetString(1), "Mascot")
-
-  // Verify higher_score_better values
-  auto hsb_col = table->GetColumnByName("higher_score_better");
-  auto hsb_arr = std::static_pointer_cast<arrow::BooleanArray>(hsb_col->chunk(0));
-  TEST_EQUAL(hsb_arr->Value(0), true)
-  TEST_EQUAL(hsb_arr->Value(1), true)
 
   // Verify rank values
   auto rank_col = table->GetColumnByName("rank");
@@ -150,11 +129,11 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportProteinsToArrow(...))
   TEST_EQUAL(rid_arr->GetString(0), "run_1")
   TEST_EQUAL(rid_arr->GetString(1), "run_1")
 
-  // Verify is_decoy: first is target (0), second is decoy (1)
+  // Verify is_decoy: first is target (false), second is decoy (true)
   auto decoy_col = table->GetColumnByName("is_decoy");
-  auto decoy_arr = std::static_pointer_cast<arrow::Int32Array>(decoy_col->chunk(0));
-  TEST_EQUAL(decoy_arr->Value(0), 0)
-  TEST_EQUAL(decoy_arr->Value(1), 1)
+  auto decoy_arr = std::static_pointer_cast<arrow::BooleanArray>(decoy_col->chunk(0));
+  TEST_EQUAL(decoy_arr->Value(0), false)
+  TEST_EQUAL(decoy_arr->Value(1), true)
 
   // Verify description: first has value, second is null
   auto desc_col = table->GetColumnByName("description");
@@ -169,27 +148,6 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportProteinsToArrow(...))
   TEST_EQUAL(seq_arr->IsNull(0), false)
   TEST_EQUAL(seq_arr->GetString(0), "MKWVTFISLLLLFSSAYS")
   TEST_EQUAL(seq_arr->IsNull(1), true)
-
-  // Verify reference_file_name
-  auto ref_col = table->GetColumnByName("reference_file_name");
-  auto ref_arr = std::static_pointer_cast<arrow::StringArray>(ref_col->chunk(0));
-  TEST_EQUAL(ref_arr->GetString(0), "sample_1.mzML")
-  TEST_EQUAL(ref_arr->GetString(1), "sample_1.mzML")
-
-  // Verify search_engine
-  auto se_col = table->GetColumnByName("search_engine");
-  auto se_arr = std::static_pointer_cast<arrow::StringArray>(se_col->chunk(0));
-  TEST_EQUAL(se_arr->GetString(0), "Mascot")
-
-  // Verify search_engine_version
-  auto sev_col = table->GetColumnByName("search_engine_version");
-  auto sev_arr = std::static_pointer_cast<arrow::StringArray>(sev_col->chunk(0));
-  TEST_EQUAL(sev_arr->GetString(0), "2.7")
-
-  // Verify inference_engine is null (not set)
-  auto ie_col = table->GetColumnByName("inference_engine");
-  auto ie_arr = std::static_pointer_cast<arrow::StringArray>(ie_col->chunk(0));
-  TEST_EQUAL(ie_arr->IsNull(0), true)
 
   // Verify modifications: both should be null (no protein modifications set)
   auto mod_col = table->GetColumnByName("modifications");
@@ -208,12 +166,11 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportProteinsToArrow(...))
   // Verify data types
   TEST_EQUAL(schema->field(0)->type()->id(), arrow::Type::STRING)    // accession
   TEST_EQUAL(schema->field(1)->type()->id(), arrow::Type::DOUBLE)    // score
-  TEST_EQUAL(schema->field(3)->type()->id(), arrow::Type::BOOL)      // higher_score_better
-  TEST_EQUAL(schema->field(4)->type()->id(), arrow::Type::INT32)     // rank
-  TEST_EQUAL(schema->field(5)->type()->id(), arrow::Type::DOUBLE)    // coverage
-  TEST_EQUAL(schema->field(8)->type()->id(), arrow::Type::INT32)     // is_decoy
-  TEST_EQUAL(schema->field(17)->type()->id(), arrow::Type::LIST)     // modifications
-  TEST_EQUAL(schema->field(18)->type()->id(), arrow::Type::LIST)     // metavalues
+  TEST_EQUAL(schema->field(2)->type()->id(), arrow::Type::INT32)     // rank
+  TEST_EQUAL(schema->field(3)->type()->id(), arrow::Type::DOUBLE)    // coverage
+  TEST_EQUAL(schema->field(6)->type()->id(), arrow::Type::BOOL)      // is_decoy
+  TEST_EQUAL(schema->field(8)->type()->id(), arrow::Type::LIST)      // modifications
+  TEST_EQUAL(schema->field(9)->type()->id(), arrow::Type::LIST)      // metavalues
 }
 END_SECTION
 
@@ -224,7 +181,7 @@ START_SECTION(Test empty protein identifications)
   auto table = ProteinIdentificationArrowIO::exportProteinsToArrow(empty_ids);
   TEST_NOT_EQUAL(table, nullptr)
   TEST_EQUAL(table->num_rows(), 0)
-  TEST_EQUAL(table->num_columns(), 19)
+  TEST_EQUAL(table->num_columns(), 10)
 }
 END_SECTION
 
@@ -249,7 +206,7 @@ START_SECTION(Test is_decoy null when target_decoy not set)
   TEST_NOT_EQUAL(table, nullptr)
 
   auto decoy_col = table->GetColumnByName("is_decoy");
-  auto decoy_arr = std::static_pointer_cast<arrow::Int32Array>(decoy_col->chunk(0));
+  auto decoy_arr = std::static_pointer_cast<arrow::BooleanArray>(decoy_col->chunk(0));
   TEST_EQUAL(decoy_arr->IsNull(0), true)
 }
 END_SECTION
@@ -544,6 +501,7 @@ START_SECTION(exportSearchParamsToArrow())
   TEST_EQUAL(msrp_values->GetString(1), "sample_2.mzML")
 
   // Verify data types
+  TEST_EQUAL(schema->field(5)->type()->id(), arrow::Type::TIMESTAMP) // date
   TEST_EQUAL(schema->field(0)->type()->id(), arrow::Type::STRING)    // run_identifier
   TEST_EQUAL(schema->field(1)->type()->id(), arrow::Type::STRING)    // search_engine
   TEST_EQUAL(schema->field(7)->type()->id(), arrow::Type::BOOL)      // higher_score_better
@@ -596,7 +554,7 @@ START_SECTION(exportProteinsToParquet())
   auto read_status = reader->ReadTable(&table);
   TEST_EQUAL(read_status.ok(), true)
   TEST_EQUAL(table->num_rows(), 1)
-  TEST_EQUAL(table->num_columns(), 19)
+  TEST_EQUAL(table->num_columns(), 10)
 
   // Check file metadata
   auto metadata = table->schema()->metadata();
@@ -863,8 +821,13 @@ START_SECTION(importProteinsFromArrow - round trip)
   auto table = ProteinIdentificationArrowIO::exportProteinsToArrow(orig_ids);
   TEST_NOT_EQUAL(table, nullptr)
 
-  // Import back (starting from scratch - no pre-existing shells)
+  // Import back - first create shell via search params export/import (proper workflow)
+  auto sp_table = ProteinIdentificationArrowIO::exportSearchParamsToArrow(orig_ids);
   vector<ProteinIdentification> imported_ids;
+  TEST_EQUAL(ProteinIdentificationArrowIO::importSearchParamsFromArrow(sp_table, imported_ids), true)
+  TEST_EQUAL(imported_ids.size(), 1)
+
+  // Then import proteins into the shells
   TEST_EQUAL(ProteinIdentificationArrowIO::importProteinsFromArrow(table, imported_ids), true)
   TEST_EQUAL(imported_ids.size(), 1)
 
@@ -1286,6 +1249,9 @@ START_SECTION(metavalue type preservation round trip)
   hit.setMetaValue("my_int", 42);
   hit.setMetaValue("my_float", 3.14);
   hit.setMetaValue("my_string", "hello_world");
+  hit.setMetaValue("test_int_list", DataValue(IntList{1, 2, 3}));
+  hit.setMetaValue("test_double_list", DataValue(DoubleList{1.5, 2.5}));
+  hit.setMetaValue("test_string_list", DataValue(StringList{"a", "b", "c"}));
   prot_id.insertHit(hit);
   orig_ids.push_back(prot_id);
 
@@ -1300,6 +1266,14 @@ START_SECTION(metavalue type preservation round trip)
   TEST_EQUAL(int(imp_hit.getMetaValue("my_int")), 42)
   TEST_REAL_SIMILAR(double(imp_hit.getMetaValue("my_float")), 3.14)
   TEST_EQUAL(String(imp_hit.getMetaValue("my_string")), "hello_world")
+
+  // Check list metavalue types are preserved
+  TEST_EQUAL(imp_hit.getMetaValue("test_int_list").valueType(), DataValue::INT_LIST)
+  TEST_EQUAL(imp_hit.getMetaValue("test_int_list") == DataValue(IntList{1, 2, 3}), true)
+  TEST_EQUAL(imp_hit.getMetaValue("test_double_list").valueType(), DataValue::DOUBLE_LIST)
+  TEST_EQUAL(imp_hit.getMetaValue("test_double_list") == DataValue(DoubleList{1.5, 2.5}), true)
+  TEST_EQUAL(imp_hit.getMetaValue("test_string_list").valueType(), DataValue::STRING_LIST)
+  TEST_EQUAL(imp_hit.getMetaValue("test_string_list") == DataValue(StringList{"a", "b", "c"}), true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -94,9 +94,9 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...))
   // Verify number of rows (should equal number of peptide identifications, not hits)
   TEST_EQUAL(table->num_rows(), 3)
 
-  // Verify schema column names and count (24 columns in new QPX schema)
+  // Verify schema column names and count (25 columns in QPX schema)
   auto schema = table->schema();
-  TEST_EQUAL(table->num_columns(), 24)
+  TEST_EQUAL(table->num_columns(), 25)
 
   TEST_EQUAL(schema->field(0)->name(), "sequence")
   TEST_EQUAL(schema->field(1)->name(), "peptidoform")
@@ -117,11 +117,12 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...))
   TEST_EQUAL(schema->field(16)->name(), "spectrum_reference")
   TEST_EQUAL(schema->field(17)->name(), "score")
   TEST_EQUAL(schema->field(18)->name(), "score_type")
-  TEST_EQUAL(schema->field(19)->name(), "rank")
-  TEST_EQUAL(schema->field(20)->name(), "P_ID")
-  TEST_EQUAL(schema->field(21)->name(), "psm_metavalues")
-  TEST_EQUAL(schema->field(22)->name(), "spectrum_metavalues")
-  TEST_EQUAL(schema->field(23)->name(), "run_identifier")
+  TEST_EQUAL(schema->field(19)->name(), "higher_score_better")
+  TEST_EQUAL(schema->field(20)->name(), "rank")
+  TEST_EQUAL(schema->field(21)->name(), "peptide_identification_index")
+  TEST_EQUAL(schema->field(22)->name(), "psm_metavalues")
+  TEST_EQUAL(schema->field(23)->name(), "spectrum_metavalues")
+  TEST_EQUAL(schema->field(24)->name(), "run_identifier")
 
   // Verify data types for key columns
   TEST_EQUAL(schema->field(4)->type()->id(), arrow::Type::DOUBLE) // PEP is float64
@@ -148,10 +149,10 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...))
 
   // Verify is_decoy nullable behavior
   auto decoy_col = table->GetColumnByName("is_decoy");
-  auto decoy_arr = std::static_pointer_cast<arrow::Int32Array>(decoy_col->chunk(0));
-  TEST_EQUAL(decoy_arr->Value(0), 0) // target
-  TEST_EQUAL(decoy_arr->Value(1), 1) // decoy
-  TEST_EQUAL(decoy_arr->Value(2), 0) // target
+  auto decoy_arr = std::static_pointer_cast<arrow::BooleanArray>(decoy_col->chunk(0));
+  TEST_EQUAL(decoy_arr->Value(0), false) // target
+  TEST_EQUAL(decoy_arr->Value(1), true) // decoy
+  TEST_EQUAL(decoy_arr->Value(2), false) // target
 
   // Verify rank is always present and 0-based
   auto rank_col = table->GetColumnByName("rank");
@@ -160,8 +161,8 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...))
   TEST_EQUAL(rank_arr->Value(1), 0)
   TEST_EQUAL(rank_arr->Value(2), 0)
 
-  // Verify P_ID values
-  auto pid_col = table->GetColumnByName("P_ID");
+  // Verify peptide_identification_index values
+  auto pid_col = table->GetColumnByName("peptide_identification_index");
   auto pid_arr = std::static_pointer_cast<arrow::Int32Array>(pid_col->chunk(0));
   TEST_EQUAL(pid_arr->Value(0), 0)
   TEST_EQUAL(pid_arr->Value(1), 1)
@@ -169,10 +170,10 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...))
 
   // Verify scan extraction from native ID
   auto scan_col = table->GetColumnByName("scan");
-  auto scan_arr = std::static_pointer_cast<arrow::StringArray>(scan_col->chunk(0));
-  TEST_EQUAL(scan_arr->GetString(0), "1000")
-  TEST_EQUAL(scan_arr->GetString(1), "1001")
-  TEST_EQUAL(scan_arr->GetString(2), "1002")
+  auto scan_arr = std::static_pointer_cast<arrow::Int32Array>(scan_col->chunk(0));
+  TEST_EQUAL(scan_arr->Value(0), 1000)
+  TEST_EQUAL(scan_arr->Value(1), 1001)
+  TEST_EQUAL(scan_arr->Value(2), 1002)
 
   // Verify spectrum_reference stores full native ID
   auto sr_col = table->GetColumnByName("spectrum_reference");
@@ -234,8 +235,8 @@ START_SECTION(static std::shared_ptr<arrow::Table> exportToArrow(...) with expor
   TEST_EQUAL(rank_arr->Value(1), 1)
   TEST_EQUAL(rank_arr->Value(2), 2)
 
-  // All rows should have the same P_ID (same parent identification)
-  auto pid_col = table->GetColumnByName("P_ID");
+  // All rows should have the same peptide_identification_index (same parent identification)
+  auto pid_col = table->GetColumnByName("peptide_identification_index");
   auto pid_arr = std::static_pointer_cast<arrow::Int32Array>(pid_col->chunk(0));
   TEST_EQUAL(pid_arr->Value(0), 0)
   TEST_EQUAL(pid_arr->Value(1), 0)
@@ -300,7 +301,7 @@ START_SECTION(static bool exportToParquet(...))
   TEST_EQUAL(read_status.ok(), true)
 
   TEST_EQUAL(table->num_rows(), 1)
-  TEST_EQUAL(table->num_columns(), 24)
+  TEST_EQUAL(table->num_columns(), 25)
 
   // Verify modifications column has structured data for modified peptide
   auto mod_col = table->GetColumnByName("modifications");


### PR DESCRIPTION
## Summary

Adds full round-trip Arrow/Parquet IO for **ProteinIdentification**, **FeatureMap**, and **ConsensusMap**. Each map type exports to a `.cmd` directory containing multiple Parquet files.

### New classes
- **ProteinIdentificationArrowIO** — export/import protein hits, groups, and search parameters
- **FeatureMapArrowIO** — export/import features with convex hulls, nested subordinates, bounding boxes, and PSM linkage
- **ConsensusMapArrowIO** — export/import consensus features with feature handles, column headers, and PSM linkage

### Key design decisions
- Reuses **QPXFile** for PSM export/import (shared across all map types)
- Reuses **ProteinIdentificationArrowIO** for protein data (shared across FeatureMap and ConsensusMap)
- Normalized schema: run-level metadata lives in \`search_params.parquet\`, linked by \`run_identifier\`
- MetaValue list types (\`INT_LIST\`, \`DOUBLE_LIST\`, \`STRING_LIST\`) fully round-tripped
- Per-PSM \`higher_score_better\` column for correct score orientation independent of run-level setting
- Hide Arrow bundled dependency symbols on Linux (\`--exclude-libs\`) to prevent conflicts with pyarrow

### Directory layout

\`\`\`
experiment.cmd/
├── consensus_features.parquet   (or features.parquet)
├── psms.parquet
├── proteins.parquet
├── protein_groups.parquet
└── search_params.parquet
\`\`\`

### Files changed (21 files, +9426 lines)

| Category | Files |
|----------|-------|
| Headers | \`ConsensusMapArrowIO.h\`, \`FeatureMapArrowIO.h\`, \`ProteinIdentificationArrowIO.h\` |
| Sources | \`ConsensusMapArrowIO.cpp\`, \`FeatureMapArrowIO.cpp\`, \`ProteinIdentificationArrowIO.cpp\`, \`QPXFile.cpp\` |
| pyOpenMS bindings | \`ConsensusMapArrowIO.pxd\`, \`FeatureMapArrowIO.pxd\`, \`ProteinIdentificationArrowIO.pxd\` |
| Build config | \`sources.cmake\` (x2), \`CMakeLists.txt\` (x2), \`executables.cmake\`, \`create_cpp_extension.py\` |
| Tests | \`ConsensusMapArrowIO_test.cpp\`, \`FeatureMapArrowIO_test.cpp\`, \`ProteinIdentificationArrowIO_test.cpp\`, \`QPXFile_test.cpp\` |

## Test plan

- [x] \`QPXFile_test\` — PSM export with higher_score_better, scan, reference_file_name
- [x] \`ProteinIdentificationArrowIO_test\` — proteins, groups, search params round-trip
- [x] \`FeatureMapArrowIO_test\` — features, convex hulls, subordinates, PSMs, metavalues
- [x] \`ConsensusMapArrowIO_test\` — consensus features, handles, column headers, PSMs, metavalues
- [x] CI green on all 5 build platforms (Linux g++/clang++/ARM, macOS, Windows)
- [x] CI green on all 20 wheel test combinations (Python 3.10-3.14 x 4 OS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)