### PR TITLE
Refactor(style_ini): use dedicated variable for .item_advanced color

### DIFF
--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -47,8 +47,7 @@ div.ini_global > div.item {
 }
 
 .item_advanced {
-	/* we are kind of abusing an unrelated variable here */
-	/* TODO maybe redefine? */
+
 	color: var(--item-advanced-foreground-color);
 }
 

--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -47,7 +47,6 @@ div.ini_global > div.item {
 }
 
 .item_advanced {
-
 	color: var(--item-advanced-foreground-color);
 }
 

--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -1,3 +1,7 @@
+:root {
+  --item-advanced-foreground-color: var(--nav-menu-foreground-color);
+}
+
 div.ini_global {
 	padding-left:10px;
 	border: 2px solid;
@@ -45,7 +49,7 @@ div.ini_global > div.item {
 .item_advanced {
 	/* we are kind of abusing an unrelated variable here */
 	/* TODO maybe redefine? */
-	color: var(--nav-menu-foreground-color)
+	color: var(--item-advanced-foreground-color);
 }
 
 div.item span.item_name {


### PR DESCRIPTION
This PR resolves a TODO comment in doc/doxygen/common/style_ini.css.

Previously, the .item_advanced CSS class reused the unrelated variable --nav-menu-foreground-color, creating an implicit dependency between navigation styling and advanced item styling.

Changes

Introduced a dedicated CSS variable: --item-advanced-foreground-color

Updated .item_advanced to use the new variable

This change improves maintainability and avoids unintended coupling between UI components.
It is purely cosmetic and does not affect functionality.

Checklist

 Make sure that you are listed in the AUTHORS file

 Add relevant changes and new features to the CHANGELOG file

 I have commented my code, particularly in hard-to-understand areas

 New and existing unit tests pass locally with my changes

 Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a dedicated CSS variable for the advanced-item foreground color and updated advanced-item styling to use it, improving theme consistency and maintainability; removed obsolete inline comments and applied minor formatting cleanup for clearer, more consistent styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->