### PR TITLE
Fix macOS Homebrew LLVM build by linking against bundled libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,19 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose the type of build,
 # see OpenMS/cmake/OpenMSConfig.cmake.in to see how its configured and used (i.e. as OPENMS_ADDCXX_FLAGS)
 include(cmake/compiler_flags.cmake)
 
+# macOS builds with Homebrew LLVM need the toolchain's bundled libc++ (under
+# lib/c++); the system libc++ can lack newer symbols. Add that directory to the
+# link search path so we consistently link against the intended runtime.
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  get_filename_component(_clang_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+  get_filename_component(_toolchain_root "${_clang_bin_dir}/.." ABSOLUTE)
+  set(_llvm_libcxx_dir "${_toolchain_root}/lib/c++")
+  if(EXISTS "${_llvm_libcxx_dir}/libc++.dylib")
+    message(STATUS "Adding ${_llvm_libcxx_dir} to the libc++ link search path")
+    add_link_options("-L${_llvm_libcxx_dir}")
+  endif()
+endif()
+
 # Visibility settings
 if (NOT CMAKE_CXX_VISIBILITY_PRESET)
   set(CMAKE_CXX_VISIBILITY_PRESET "hidden")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,13 +191,23 @@ include(cmake/compiler_flags.cmake)
 # macOS builds with Homebrew LLVM need the toolchain's bundled libc++ (under
 # lib/c++); the system libc++ can lack newer symbols. Add that directory to the
 # link search path so we consistently link against the intended runtime.
-if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  get_filename_component(_clang_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
-  get_filename_component(_toolchain_root "${_clang_bin_dir}/.." ABSOLUTE)
+# Note: STREQUAL "Clang" is intentional — "AppleClang" (Xcode) is a distinct
+# compiler ID and must NOT enter this block.
+if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  # Resolve symlinks before deriving the toolchain root.
+  # get_filename_component(ABSOLUTE) does NOT follow symlinks; Homebrew often
+  # installs clang as a symlink (e.g. via brew link --force), so without
+  # REAL_PATH the derived _toolchain_root points to the wrong prefix and the
+  # EXISTS check below silently fails — reproducing the original link error.
+  file(REAL_PATH "${CMAKE_CXX_COMPILER}" _clang_real)
+  cmake_path(GET _clang_real PARENT_PATH _clang_bin_dir)
+  cmake_path(GET _clang_bin_dir PARENT_PATH _toolchain_root)
   set(_llvm_libcxx_dir "${_toolchain_root}/lib/c++")
   if(EXISTS "${_llvm_libcxx_dir}/libc++.dylib")
-    message(STATUS "Adding ${_llvm_libcxx_dir} to the libc++ link search path")
+    message(STATUS "Homebrew LLVM libc++ found at ${_llvm_libcxx_dir} — injecting -L")
     add_link_options("-L${_llvm_libcxx_dir}")
+  else()
+    message(STATUS "Homebrew LLVM libc++ not found at ${_llvm_libcxx_dir}; skipping -L injection")
   endif()
 endif()
 


### PR DESCRIPTION
## PR description
## fixes #8776 
- Add a **macOS/Clang** block in `CMakeLists.txt` that derives the Homebrew LLVM root from `CMAKE_CXX_COMPILER`, checks for `libc++.dylib` in `<toolchain>/lib/c++`, and injects `-L` for that directory via `add_link_options`.
- This ensures `clang++` links against Homebrew's bundled `libc++`, which contains `std::__1::__hash_memory`, preventing the **Undefined Symbol** errors seen when building `libOpenMS.dylib` on **macOS arm64**.
- Help of AI tool was taken for resolving the issues raised by coderabbit.
---

### Testing
Tested by re-running `cmake ../OpenMS` and `cmake --build . --target OpenMS -j8` on **macOS/arm64** with **Homebrew LLVM 21.1.8**; build now completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved macOS build behavior: when using Clang and Homebrew LLVM libc++ is present, the build detects it and adds the appropriate linker path; otherwise it skips gracefully.
  * Build now emits informative messages during detection.
  * No changes to other platforms or toolchains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->