### PR TITLE
Fix/remove duplicate pragma omsfilestore

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,6 +102,7 @@ the authors tag in the respective file header.
  - Ruben Grünberg
  - Samuel Wein
  - Sandro Andreotti
+ - Santhil
  - Simon Gene Gottlieb
  - Steffen Sass
  - Stephan Aiche

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -205,6 +205,7 @@ Fixes:
   - Fix SIMD type mismatch and unaligned memory access in Base64 decoding (ARM64 crash) (#8689)
   - Fix empty GENE table causing PQP file reading to return zero transitions (#8688)
   - Fix PeptideIndexer AhoCorasick segfault for short peptides (#8685)
+  - Fix redundant PRAGMA foreign_keys execution in OMSFileStore
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)

--- a/src/openms/source/FORMAT/OMSFileStore.cpp
+++ b/src/openms/source/FORMAT/OMSFileStore.cpp
@@ -63,8 +63,6 @@ namespace OpenMS::Internal
     // we don't have to worry about database consistency:
     db_->exec("PRAGMA synchronous = OFF");
     db_->exec("PRAGMA journal_mode = OFF");
-    db_->exec("PRAGMA foreign_keys = ON");
-    db_->exec("PRAGMA foreign_keys = ON");
   }
 
   OMSFileStore::~OMSFileStore() = default;


### PR DESCRIPTION
## Description

This PR fixes a minor code quality issue in the [OMSFileStore](cci:1://file:///Users/santhil/OpenMS/src/openms/source/FORMAT/OMSFileStore.cpp:52:2-65:3) constructor where `PRAGMA foreign_keys = ON` was executed redundantly.

In [src/openms/source/FORMAT/OMSFileStore.cpp](cci:7://file:///Users/santhil/OpenMS/src/openms/source/FORMAT/OMSFileStore.cpp:0:0-0:0) around line 60, the PRAGMA was correctly executed once. However, due to a likely copy-paste error, it was executed two more times consecutively on lines 66 and 67 (below the synchronous and journal_mode pragmas). This PR removes the two duplicate lines, maintaining the expected behavior while removing the redundant database operations.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
Closes #8781 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a performance issue in the file storage system by eliminating redundant database foreign key initialization operations. These operations were unnecessarily executed multiple times during system startup, which has now been optimized for improved initialization speed.

* **Chores**
  * Updated project contributors list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->