### PR TITLE
Feature/wrap qc classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,3 +125,4 @@ the authors tag in the respective file header.
  - Witold Wolski
  - Xiao Liang
  - Yasset Perez-Riverol
+ - Uzma Nayab 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3126,3 +3126,21 @@ Detailed list of changes to specific OpenMS classes:
   - Added InternalCalibration - Calibration of peak m/z using reference masses
   - Added ExternalCalibration - Conversion of flight times into m/z using external
                                 calibrant spectra
+
+
+#Added Python bindings for QC classes (issue #6102)
+- Contaminants.pxd
+- FWHM.pxd
+- DBSuitability.pxd
+- FeatureSummary.pxd
+- FragmentMassError.pxd
+- IdentificationSummary.pxd
+- MissedCleavages.pxd
+- Ms2IdentificationRate.pxd
+- Ms2SpectrumStats.pxd
+- MzCalibration.pxd
+- PSMExplainedIonCurrent.pxd
+- PeptideMass.pxd
+- RTAlignment.pxd
+- SpectrumCount.pxd
+- TIC.pxd

--- a/src/pyOpenMS/pxds/Contaminants.pxd
+++ b/src/pyOpenMS/pxds/Contaminants.pxd
@@ -1,6 +1,5 @@
 from libcpp.vector cimport vector
 from libcpp.utility cimport pair
-
 from QCBase cimport QCBase
 from FeatureMap cimport FeatureMap
 from FASTAFile cimport FASTAFile

--- a/src/pyOpenMS/pxds/Contaminants.pxd
+++ b/src/pyOpenMS/pxds/Contaminants.pxd
@@ -1,0 +1,33 @@
+from libcpp.vector cimport vector
+from libcpp.utility cimport pair
+
+from QCBase cimport QCBase
+from FeatureMap cimport FeatureMap
+from FASTAFile cimport FASTAFile
+from String cimport String
+from Types cimport Int64
+from PeptideHit cimport PeptideHit
+
+
+cdef extern from "<OpenMS/QC/Contaminants.h>" namespace "OpenMS":
+
+    cdef cppclass Contaminants(QCBase):
+
+        # nested struct
+        cdef cppclass ContaminantsSummary:
+            double assigned_contaminants_ratio
+            double unassigned_contaminants_ratio
+            double all_contaminants_ratio
+            double assigned_contaminants_intensity_ratio
+            pair[Int64, Int64] empty_features
+
+        Contaminants() except +
+
+        void compute(FeatureMap& features,
+                     const vector[FASTAFile.FASTAEntry]& contaminants) except +
+
+        const String& getName() const except +
+
+        const vector[ContaminantsSummary]& getResults() except +
+
+        QCBase.Status requirements() const except +

--- a/src/pyOpenMS/pxds/Contaminants.pxd
+++ b/src/pyOpenMS/pxds/Contaminants.pxd
@@ -25,8 +25,8 @@ cdef extern from "<OpenMS/QC/Contaminants.h>" namespace "OpenMS":
         void compute(FeatureMap& features,
                      const vector[FASTAFile.FASTAEntry]& contaminants) except +
 
-        const String& getName() const except +
+        const String& getName() except + const
 
         const vector[ContaminantsSummary]& getResults() except +
 
-        QCBase.Status requirements() const except +
+        QCBase.Status requirements() except + const

--- a/src/pyOpenMS/pxds/Contaminants.pxd
+++ b/src/pyOpenMS/pxds/Contaminants.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/QC/Contaminants.h>" namespace "OpenMS":
     cdef cppclass Contaminants(QCBase):
 
         # nested struct
-        cdef cppclass ContaminantsSummary:
+        cppclass ContaminantsSummary:
             double assigned_contaminants_ratio
             double unassigned_contaminants_ratio
             double all_contaminants_ratio

--- a/src/pyOpenMS/pxds/DBSuitability.pxd
+++ b/src/pyOpenMS/pxds/DBSuitability.pxd
@@ -1,0 +1,34 @@
+from libcpp.vector cimport vector
+
+from DefaultParamHandler cimport DefaultParamHandler
+from PeptideIdentificationList cimport PeptideIdentificationList
+from MSExperiment cimport MSExperiment
+from FASTAFile cimport FASTAFile
+from ProteinIdentification cimport ProteinIdentification
+from Types cimport Size, UInt
+from String cimport String
+
+
+cdef extern from "<OpenMS/QC/DBSuitability.h>" namespace "OpenMS":
+
+    cdef cppclass DBSuitability(DefaultParamHandler):
+
+        cdef cppclass SuitabilityData:
+            Size num_top_novo
+            Size num_top_db
+            Size num_interest
+            Size num_re_ranked
+            double cut_off
+            double suitability
+            double suitability_no_rerank
+            double suitability_corr_no_rerank
+
+        DBSuitability() except +
+
+        void compute(PeptideIdentificationList&& pep_ids,
+                     const MSExperiment& exp,
+                     const vector[FASTAFile.FASTAEntry]& original_fasta,
+                     const vector[FASTAFile.FASTAEntry]& novo_fasta,
+                     const ProteinIdentification.SearchParameters& search_params) except +
+
+        const vector[SuitabilityData]& getResults() const except +

--- a/src/pyOpenMS/pxds/DBSuitability.pxd
+++ b/src/pyOpenMS/pxds/DBSuitability.pxd
@@ -24,6 +24,7 @@ cdef extern from "<OpenMS/QC/DBSuitability.h>" namespace "OpenMS":
             double suitability_corr_no_rerank
 
         DBSuitability() except +
+        DBSuitability(DBSuitability &) except +
 
         void compute(PeptideIdentificationList&& pep_ids,
                      const MSExperiment& exp,

--- a/src/pyOpenMS/pxds/DBSuitability.pxd
+++ b/src/pyOpenMS/pxds/DBSuitability.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/QC/DBSuitability.h>" namespace "OpenMS":
 
     cdef cppclass DBSuitability(DefaultParamHandler):
 
-        cdef cppclass SuitabilityData:
+        cppclass SuitabilityData:
             Size num_top_novo
             Size num_top_db
             Size num_interest

--- a/src/pyOpenMS/pxds/DBSuitability.pxd
+++ b/src/pyOpenMS/pxds/DBSuitability.pxd
@@ -13,6 +13,8 @@ cdef extern from "<OpenMS/QC/DBSuitability.h>" namespace "OpenMS":
 
     cdef cppclass DBSuitability(DefaultParamHandler):
 
+        # wrap-inherits:
+        #    DefaultParamHandler
         cppclass SuitabilityData:
             Size num_top_novo
             Size num_top_db

--- a/src/pyOpenMS/pxds/DBSuitability.pxd
+++ b/src/pyOpenMS/pxds/DBSuitability.pxd
@@ -31,4 +31,4 @@ cdef extern from "<OpenMS/QC/DBSuitability.h>" namespace "OpenMS":
                      const vector[FASTAFile.FASTAEntry]& novo_fasta,
                      const ProteinIdentification.SearchParameters& search_params) except +
 
-        const vector[SuitabilityData]& getResults() const except +
+        const vector[SuitabilityData]& getResults() except + const

--- a/src/pyOpenMS/pxds/FWHM.pxd
+++ b/src/pyOpenMS/pxds/FWHM.pxd
@@ -1,0 +1,16 @@
+from QCBase cimport QCBase
+from FeatureMap cimport FeatureMap
+from String cimport String
+
+
+cdef extern from "<OpenMS/QC/FWHM.h>" namespace "OpenMS":
+
+    cdef cppclass FWHM(QCBase):
+
+        FWHM() except +
+
+        void compute(FeatureMap& features) except +
+
+        const String& getName() const except +
+
+        QCBase.Status requirements() const except +

--- a/src/pyOpenMS/pxds/FeatureSummary.pxd
+++ b/src/pyOpenMS/pxds/FeatureSummary.pxd
@@ -10,7 +10,7 @@ cdef extern from "<OpenMS/QC/FeatureSummary.h>" namespace "OpenMS":
 
     cdef cppclass FeatureSummary(QCBase):
 
-        cdef cppclass Result:
+        cppclass Result:
             UInt feature_count
             float rt_shift_mean
 

--- a/src/pyOpenMS/pxds/FeatureSummary.pxd
+++ b/src/pyOpenMS/pxds/FeatureSummary.pxd
@@ -1,0 +1,23 @@
+from libcpp.vector cimport vector
+
+from QCBase cimport QCBase
+from FeatureMap cimport FeatureMap
+from Types cimport UInt
+from String cimport String
+
+
+cdef extern from "<OpenMS/QC/FeatureSummary.h>" namespace "OpenMS":
+
+    cdef cppclass FeatureSummary(QCBase):
+
+        cdef cppclass Result:
+            UInt feature_count
+            float rt_shift_mean
+
+        FeatureSummary() except +
+
+        Result compute(const FeatureMap& feature_map) except +
+
+        const String& getName() const except +
+
+        QCBase.Status requirements() const except +

--- a/src/pyOpenMS/pxds/FeatureSummary.pxd
+++ b/src/pyOpenMS/pxds/FeatureSummary.pxd
@@ -18,6 +18,6 @@ cdef extern from "<OpenMS/QC/FeatureSummary.h>" namespace "OpenMS":
 
         Result compute(const FeatureMap& feature_map) except +
 
-        const String& getName() const except +
+        const String& getName() except + const
 
-        QCBase.Status requirements() const except +
+        QCBase.Status requirements() except + const

--- a/src/pyOpenMS/pxds/FragmentMassError.pxd
+++ b/src/pyOpenMS/pxds/FragmentMassError.pxd
@@ -13,16 +13,16 @@ cdef extern from "<OpenMS/QC/FragmentMassError.h>" namespace "OpenMS":
 
     cdef cppclass FragmentMassError(QCBase):
 
-        # -------------------------
+        
         # Nested struct Statistics
-        # -------------------------
-        cdef cppclass Statistics:
+        
+        cppclass Statistics:
             double average_ppm
             double variance_ppm
 
-        # -------------------------
+        
         # Enum ToleranceUnit
-        # -------------------------
+        
         cdef enum ToleranceUnit:
             AUTO
             PPM
@@ -30,18 +30,18 @@ cdef extern from "<OpenMS/QC/FragmentMassError.h>" namespace "OpenMS":
 
         FragmentMassError() except +
 
-        # -------------------------
+        
         # compute overload 1
-        # -------------------------
+        
         void compute(FeatureMap& fmap,
                      const MSExperiment& exp,
                      const QCBase.SpectraMap& map_to_spectrum,
                      ToleranceUnit tolerance_unit = AUTO,
                      double tolerance = 20) except +
 
-        # -------------------------
+       
         # compute overload 2
-        # -------------------------
+        
         void compute(PeptideIdentificationList& pep_ids,
                      const ProteinIdentification.SearchParameters& search_params,
                      const MSExperiment& exp,

--- a/src/pyOpenMS/pxds/FragmentMassError.pxd
+++ b/src/pyOpenMS/pxds/FragmentMassError.pxd
@@ -46,8 +46,8 @@ cdef extern from "<OpenMS/QC/FragmentMassError.h>" namespace "OpenMS":
                      ToleranceUnit tolerance_unit = AUTO,
                      double tolerance = 20) except +
 
-        const String& getName() const except +
+        const String& getName() except + const
 
-        const vector[Statistics]& getResults() const except +
+        const vector[Statistics]& getResults() except + const
 
-        QCBase.Status requirements() const except +
+        QCBase.Status requirements() except + const

--- a/src/pyOpenMS/pxds/FragmentMassError.pxd
+++ b/src/pyOpenMS/pxds/FragmentMassError.pxd
@@ -1,0 +1,56 @@
+from libcpp.vector cimport vector
+
+from QCBase cimport QCBase
+from FeatureMap cimport FeatureMap
+from MSExperiment cimport MSExperiment
+from PeptideIdentificationList cimport PeptideIdentificationList
+from ProteinIdentification cimport ProteinIdentification
+from Types cimport UInt32
+from String cimport String
+
+
+cdef extern from "<OpenMS/QC/FragmentMassError.h>" namespace "OpenMS":
+
+    cdef cppclass FragmentMassError(QCBase):
+
+        # -------------------------
+        # Nested struct Statistics
+        # -------------------------
+        cdef cppclass Statistics:
+            double average_ppm
+            double variance_ppm
+
+        # -------------------------
+        # Enum ToleranceUnit
+        # -------------------------
+        cdef enum ToleranceUnit:
+            AUTO
+            PPM
+            DA
+
+        FragmentMassError() except +
+
+        # -------------------------
+        # compute overload 1
+        # -------------------------
+        void compute(FeatureMap& fmap,
+                     const MSExperiment& exp,
+                     const QCBase.SpectraMap& map_to_spectrum,
+                     ToleranceUnit tolerance_unit = AUTO,
+                     double tolerance = 20) except +
+
+        # -------------------------
+        # compute overload 2
+        # -------------------------
+        void compute(PeptideIdentificationList& pep_ids,
+                     const ProteinIdentification.SearchParameters& search_params,
+                     const MSExperiment& exp,
+                     const QCBase.SpectraMap& map_to_spectrum,
+                     ToleranceUnit tolerance_unit = AUTO,
+                     double tolerance = 20) except +
+
+        const String& getName() const except +
+
+        const vector[Statistics]& getResults() const except +
+
+        QCBase.Status requirements() const except +

--- a/src/pyOpenMS/pxds/FragmentMassError.pxd
+++ b/src/pyOpenMS/pxds/FragmentMassError.pxd
@@ -12,10 +12,7 @@ from String cimport String
 cdef extern from "<OpenMS/QC/FragmentMassError.h>" namespace "OpenMS":
 
     cdef cppclass FragmentMassError(QCBase):
-
-        
         # Nested struct Statistics
-        
         cppclass Statistics:
             double average_ppm
             double variance_ppm

--- a/src/pyOpenMS/pxds/IdentificationSummary.pxd
+++ b/src/pyOpenMS/pxds/IdentificationSummary.pxd
@@ -1,6 +1,3 @@
-
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from OpenMS cimport *
 from QCBase cimport *

--- a/src/pyOpenMS/pxds/IdentificationSummary.pxd
+++ b/src/pyOpenMS/pxds/IdentificationSummary.pxd
@@ -1,0 +1,33 @@
+
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from OpenMS cimport *
+from QCBase cimport *
+
+cdef extern from "<OpenMS/QC/IdentificationSummary.h>" namespace "OpenMS":
+
+    cdef cppclass IdentificationSummary(QCBase):
+
+        IdentificationSummary() except +
+
+        # Nested classes
+        cppclass UniqueID:
+            unsigned int count
+            float fdr_threshold
+
+        cppclass Result:
+            unsigned int peptide_spectrum_matches
+            UniqueID unique_peptides
+            UniqueID unique_proteins
+            float missed_cleavages_mean
+            double protein_hit_scores_mean
+            double peptide_length_mean
+
+        # Methods
+        Result compute(vector[ProteinIdentification]& prot_ids,
+                       PeptideIdentificationList& pep_ids) except +
+
+        String getName() const
+
+        QCBase.Status requirements() const

--- a/src/pyOpenMS/pxds/MissedCleavages.pxd
+++ b/src/pyOpenMS/pxds/MissedCleavages.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/MissedCleavages.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.map cimport map as cppmap
 from libc.stdint cimport uint32_t

--- a/src/pyOpenMS/pxds/MissedCleavages.pxd
+++ b/src/pyOpenMS/pxds/MissedCleavages.pxd
@@ -1,0 +1,32 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/MissedCleavages.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.map cimport map as cppmap
+from libc.stdint cimport uint32_t
+from OpenMS cimport *
+from QCBase cimport *
+from ProteaseDigestion cimport *
+from FeatureMap cimport *
+from PeptideIdentification cimport *
+from ProteinIdentification cimport *
+
+cdef extern from "<OpenMS/QC/MissedCleavages.h>" namespace "OpenMS":
+
+    cdef cppclass MissedCleavages(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        MissedCleavages() except +
+        MissedCleavages(MissedCleavages &) except +
+
+        void compute(FeatureMap& fmap) except +
+        void compute(vector[ProteinIdentification]& prot_ids, 
+                     PeptideIdentificationList& pep_ids) except +
+
+        const vector[cppmap[uint32_t, uint32_t]]& getResults() const
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/MissedCleavages.pxd
+++ b/src/pyOpenMS/pxds/MissedCleavages.pxd
@@ -26,4 +26,3 @@ cdef extern from "<OpenMS/QC/MissedCleavages.h>" namespace "OpenMS":
         String getName() const
 
         QCBase.Status requirements() const
-EOF

--- a/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
+++ b/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/Ms2IdentificationRate.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t, int64_t
@@ -10,6 +7,7 @@ from FeatureMap cimport *
 from MSExperiment cimport *
 from MzTabMetaData cimport *
 from PeptideIdentification cimport *
+from PeptideIdentificationList cimport *
 
 cdef extern from "<OpenMS/QC/Ms2IdentificationRate.h>" namespace "OpenMS":
 
@@ -34,11 +32,11 @@ cdef extern from "<OpenMS/QC/Ms2IdentificationRate.h>" namespace "OpenMS":
                      const MSExperiment& exp, 
                      bool assume_all_target) except +
 
-        const vector[IdentificationRateData]& getResults() const
+        const vector[IdentificationRateData]& getResults() except + const
 
-        String getName() const
+        String getName() except + const
 
-        QCBase.Status requirements() const
+        QCBase.Status requirements() except + const
 
-        void addMetaDataMetricsToMzTab(MzTabMetaData& meta) const
+        void addMetaDataMetricsToMzTab(MzTabMetaData& meta) except + const
 EOF

--- a/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
+++ b/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
@@ -39,4 +39,3 @@ cdef extern from "<OpenMS/QC/Ms2IdentificationRate.h>" namespace "OpenMS":
         QCBase.Status requirements() except + const
 
         void addMetaDataMetricsToMzTab(MzTabMetaData& meta) except + const
-EOF

--- a/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
+++ b/src/pyOpenMS/pxds/Ms2IdentificationRate.pxd
@@ -1,0 +1,44 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/Ms2IdentificationRate.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libc.stdint cimport uint32_t, uint64_t, int64_t
+from OpenMS cimport *
+from QCBase cimport *
+from FeatureMap cimport *
+from MSExperiment cimport *
+from MzTabMetaData cimport *
+from PeptideIdentification cimport *
+
+cdef extern from "<OpenMS/QC/Ms2IdentificationRate.h>" namespace "OpenMS":
+
+    cdef cppclass Ms2IdentificationRate(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        # Nested struct for results
+        cppclass IdentificationRateData:
+            uint64_t num_peptide_identification
+            uint64_t num_ms2_spectra
+            double identification_rate
+
+        Ms2IdentificationRate() except +
+        Ms2IdentificationRate(Ms2IdentificationRate &) except +
+
+        void compute(const FeatureMap& feature_map, 
+                     const MSExperiment& exp, 
+                     bool assume_all_target) except +
+        
+        void compute(const PeptideIdentificationList& pep_ids, 
+                     const MSExperiment& exp, 
+                     bool assume_all_target) except +
+
+        const vector[IdentificationRateData]& getResults() const
+
+        String getName() const
+
+        QCBase.Status requirements() const
+
+        void addMetaDataMetricsToMzTab(MzTabMetaData& meta) const
+EOF

--- a/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
+++ b/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
@@ -1,0 +1,37 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/Ms2SpectrumStats.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libc.stdint cimport uint32_t, uint64_t, int64_t
+from OpenMS cimport *
+from QCBase cimport *
+from FeatureMap cimport *
+from MSExperiment cimport *
+from MSSpectrum cimport *
+from PeptideIdentification cimport *
+from TransformationDescription cimport *
+
+cdef extern from "<OpenMS/QC/Ms2SpectrumStats.h>" namespace "OpenMS":
+
+    cdef cppclass Ms2SpectrumStats(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        # Nested struct
+        cppclass ScanEvent:
+            ScanEvent(uint32_t sem, bool ms2) except +
+            uint32_t scan_event_number
+            bool ms2_presence
+
+        Ms2SpectrumStats() except +
+        Ms2SpectrumStats(Ms2SpectrumStats &) except +
+
+        PeptideIdentificationList compute(const MSExperiment& exp, 
+                                         FeatureMap& features, 
+                                         const QCBase.SpectraMap& map_to_spectrum) except +
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
+++ b/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
@@ -31,4 +31,3 @@ cdef extern from "<OpenMS/QC/Ms2SpectrumStats.h>" namespace "OpenMS":
         String getName() const
 
         QCBase.Status requirements() const
-EOF

--- a/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
+++ b/src/pyOpenMS/pxds/Ms2SpectrumStats.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/Ms2SpectrumStats.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t, int64_t

--- a/src/pyOpenMS/pxds/MzCalibration.pxd
+++ b/src/pyOpenMS/pxds/MzCalibration.pxd
@@ -1,0 +1,29 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/MzCalibration.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libc.stdint cimport uint32_t, uint64_t, int64_t
+from OpenMS cimport *
+from QCBase cimport *
+from FeatureMap cimport *
+from MSExperiment cimport *
+from PeptideIdentification cimport *
+
+cdef extern from "<OpenMS/QC/MzCalibration.h>" namespace "OpenMS":
+
+    cdef cppclass MzCalibration(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        MzCalibration() except +
+        MzCalibration(MzCalibration &) except +
+
+        void compute(FeatureMap& features, 
+                     const MSExperiment& exp, 
+                     const QCBase.SpectraMap& map_to_spectrum) except +
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/MzCalibration.pxd
+++ b/src/pyOpenMS/pxds/MzCalibration.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/MzCalibration.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t, int64_t

--- a/src/pyOpenMS/pxds/MzCalibration.pxd
+++ b/src/pyOpenMS/pxds/MzCalibration.pxd
@@ -20,7 +20,7 @@ cdef extern from "<OpenMS/QC/MzCalibration.h>" namespace "OpenMS":
                      const MSExperiment& exp, 
                      const QCBase.SpectraMap& map_to_spectrum) except +
 
-        String getName() const
+        String getName() except + const 
 
-        QCBase.Status requirements() const
+        QCBase.Status requirements() except + const
 EOF

--- a/src/pyOpenMS/pxds/MzCalibration.pxd
+++ b/src/pyOpenMS/pxds/MzCalibration.pxd
@@ -23,4 +23,3 @@ cdef extern from "<OpenMS/QC/MzCalibration.h>" namespace "OpenMS":
         String getName() except + const 
 
         QCBase.Status requirements() except + const
-EOF

--- a/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
+++ b/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
@@ -19,6 +19,13 @@ cdef extern from "<OpenMS/QC/PSMExplainedIonCurrent.h>" namespace "OpenMS":
         cppclass Statistics:
             double average_correctness
             double variance_correctness
+        
+         # Enum ToleranceUnit
+        
+        cdef enum ToleranceUnit:
+            AUTO
+            PPM
+            DA
 
         PSMExplainedIonCurrent() except +
         PSMExplainedIonCurrent(PSMExplainedIonCurrent &) except +
@@ -38,7 +45,7 @@ cdef extern from "<OpenMS/QC/PSMExplainedIonCurrent.h>" namespace "OpenMS":
 
         const vector[Statistics]& getResults() const
 
-        String getName() const
+        String getName() except + const
 
-        QCBase.Status requirements() const
+        QCBase.Status requirements() except + const
 EOF

--- a/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
+++ b/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t, int64_t

--- a/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
+++ b/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
@@ -1,0 +1,47 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libc.stdint cimport uint32_t, uint64_t, int64_t
+from OpenMS cimport *
+from QCBase cimport *
+from FeatureMap cimport *
+from MSExperiment cimport *
+from PeptideIdentification cimport *
+from ProteinIdentification cimport *
+from WindowMower cimport *
+
+cdef extern from "<OpenMS/QC/PSMExplainedIonCurrent.h>" namespace "OpenMS":
+
+    cdef cppclass PSMExplainedIonCurrent(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        # Nested struct for results
+        cppclass Statistics:
+            double average_correctness
+            double variance_correctness
+
+        PSMExplainedIonCurrent() except +
+        PSMExplainedIonCurrent(PSMExplainedIonCurrent &) except +
+
+        void compute(FeatureMap& fmap, 
+                     const MSExperiment& exp, 
+                     const QCBase.SpectraMap& map_to_spectrum,
+                     ToleranceUnit tolerance_unit,
+                     double tolerance) except +
+        
+        void compute(PeptideIdentificationList& pep_ids, 
+                     const ProteinIdentification.SearchParameters& search_params,
+                     const MSExperiment& exp, 
+                     const QCBase.SpectraMap& map_to_spectrum,
+                     ToleranceUnit tolerance_unit,
+                     double tolerance) except +
+
+        const vector[Statistics]& getResults() const
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
+++ b/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
@@ -22,7 +22,7 @@ cdef extern from "<OpenMS/QC/PSMExplainedIonCurrent.h>" namespace "OpenMS":
         
          # Enum ToleranceUnit
         
-        cdef enum ToleranceUnit:
+        cdef enum class ToleranceUnit:
             AUTO
             PPM
             DA

--- a/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
+++ b/src/pyOpenMS/pxds/PSMExplainedIonCurrent.pxd
@@ -48,4 +48,3 @@ cdef extern from "<OpenMS/QC/PSMExplainedIonCurrent.h>" namespace "OpenMS":
         String getName() except + const
 
         QCBase.Status requirements() except + const
-EOF

--- a/src/pyOpenMS/pxds/PeptideMass.pxd
+++ b/src/pyOpenMS/pxds/PeptideMass.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/PeptideMass.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from OpenMS cimport *

--- a/src/pyOpenMS/pxds/PeptideMass.pxd
+++ b/src/pyOpenMS/pxds/PeptideMass.pxd
@@ -15,7 +15,7 @@ cdef extern from "<OpenMS/QC/PeptideMass.h>" namespace "OpenMS":
 
         void compute(FeatureMap& features) except +
 
-        String getName() const
+        String getName() except + const
 
-        QCBase.Status requirements() const
+        QCBase.Status requirements() except + const
 EOF

--- a/src/pyOpenMS/pxds/PeptideMass.pxd
+++ b/src/pyOpenMS/pxds/PeptideMass.pxd
@@ -1,0 +1,24 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/PeptideMass.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from OpenMS cimport *
+from QCBase cimport *
+from FeatureMap cimport *
+
+cdef extern from "<OpenMS/QC/PeptideMass.h>" namespace "OpenMS":
+
+    cdef cppclass PeptideMass(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        PeptideMass() except +
+        PeptideMass(PeptideMass &) except +
+
+        void compute(FeatureMap& features) except +
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/PeptideMass.pxd
+++ b/src/pyOpenMS/pxds/PeptideMass.pxd
@@ -18,4 +18,3 @@ cdef extern from "<OpenMS/QC/PeptideMass.h>" namespace "OpenMS":
         String getName() except + const
 
         QCBase.Status requirements() except + const
-EOF

--- a/src/pyOpenMS/pxds/RTAlignment.pxd
+++ b/src/pyOpenMS/pxds/RTAlignment.pxd
@@ -12,11 +12,11 @@ cdef extern from "<OpenMS/QC/RTAlignment.h>" namespace "OpenMS":
         RTAlignment() except +
 
         void compute(FeatureMap& fm,
-                     const TransformationDescription& trafo) const except +
+                     const TransformationDescription& trafo) except + const 
 
         void compute(PeptideIdentificationList& ids,
-                     const TransformationDescription& trafo) const except +
+                     const TransformationDescription& trafo)  except + const
 
-        const String& getName() const except +
+        const String& getName() except + const
 
-        QCBase.Status requirements() const except +
+        QCBase.Status requirements() except + const

--- a/src/pyOpenMS/pxds/RTAlignment.pxd
+++ b/src/pyOpenMS/pxds/RTAlignment.pxd
@@ -1,0 +1,22 @@
+from QCBase cimport QCBase
+from FeatureMap cimport FeatureMap
+from PeptideIdentificationList cimport PeptideIdentificationList
+from TransformationDescription cimport TransformationDescription
+from String cimport String
+
+
+cdef extern from "<OpenMS/QC/RTAlignment.h>" namespace "OpenMS":
+
+    cdef cppclass RTAlignment(QCBase):
+
+        RTAlignment() except +
+
+        void compute(FeatureMap& fm,
+                     const TransformationDescription& trafo) const except +
+
+        void compute(PeptideIdentificationList& ids,
+                     const TransformationDescription& trafo) const except +
+
+        const String& getName() const except +
+
+        QCBase.Status requirements() const except +

--- a/src/pyOpenMS/pxds/SpectrumCount.pxd
+++ b/src/pyOpenMS/pxds/SpectrumCount.pxd
@@ -1,0 +1,26 @@
+cat > /workspaces/OpenMS/pyOpenMS/pxds/SpectrumCount.pxd << 'EOF'
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libcpp.map cimport map as cppmap
+from libc.stdint cimport uint32_t, uint64_t, int64_t
+from OpenMS cimport *
+from QCBase cimport *
+from MSExperiment cimport *
+
+cdef extern from "<OpenMS/QC/SpectrumCount.h>" namespace "OpenMS":
+
+    cdef cppclass SpectrumCount(QCBase):
+        # wrap-inherits:
+        #    QCBase
+
+        SpectrumCount() except +
+        SpectrumCount(SpectrumCount &) except +
+
+        cppmap[uint32_t, uint32_t] compute(const MSExperiment& exp) except +
+
+        String getName() const
+
+        QCBase.Status requirements() const
+EOF

--- a/src/pyOpenMS/pxds/SpectrumCount.pxd
+++ b/src/pyOpenMS/pxds/SpectrumCount.pxd
@@ -1,6 +1,3 @@
-cat > /workspaces/OpenMS/pyOpenMS/pxds/SpectrumCount.pxd << 'EOF'
-# distutils: language = c++
-
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp.map cimport map as cppmap

--- a/src/pyOpenMS/pxds/SpectrumCount.pxd
+++ b/src/pyOpenMS/pxds/SpectrumCount.pxd
@@ -20,4 +20,3 @@ cdef extern from "<OpenMS/QC/SpectrumCount.h>" namespace "OpenMS":
         String getName() const
 
         QCBase.Status requirements() const
-EOF

--- a/src/pyOpenMS/pxds/TIC.pxd
+++ b/src/pyOpenMS/pxds/TIC.pxd
@@ -1,0 +1,37 @@
+from libcpp.vector cimport vector
+
+from QCBase cimport QCBase
+from MSExperiment cimport MSExperiment
+from MSChromatogram cimport MSChromatogram
+from MzTabMetaData cimport MzTabMetaData
+from String cimport String
+from Types cimport UInt
+
+
+cdef extern from "<OpenMS/QC/TIC.h>" namespace "OpenMS":
+
+    cdef cppclass TIC(QCBase):
+
+        # nested struct
+        cdef cppclass Result:
+            vector[UInt] intensities
+            vector[float] relative_intensities
+            vector[float] retention_times
+            UInt area
+            UInt fall
+            UInt jump
+
+        TIC() except +
+
+        Result compute(const MSExperiment& exp,
+                       float bin_size = 0,
+                       UInt ms_level = 1) except +
+
+        const String& getName() const except +
+
+        const vector[MSChromatogram]& getResults() const except +
+
+        QCBase.Status requirements() const except +
+
+        void addMetaDataMetricsToMzTab(MzTabMetaData& meta,
+                                       vector[Result]& tics) except +

--- a/src/pyOpenMS/pxds/TIC.pxd
+++ b/src/pyOpenMS/pxds/TIC.pxd
@@ -10,30 +10,30 @@ from Types cimport UInt
 
 cdef extern from "<OpenMS/QC/TIC.h>" namespace "OpenMS":
 
-    cdef cppclass TIC(QCBase):
-        TIC() except +
-        TIC_Result compute(MSExperiment& exp, float bin_size, unsigned int ms_level) except +
-        const String& getName() const
-
+    #  Nested struct first 
     cdef cppclass TIC_Result "OpenMS::TIC::Result":
-        vector[unsigned int] intensities
+        vector[UInt] intensities
         vector[float] relative_intensities
         vector[float] retention_times
-        unsigned int area
-        unsigned int fall
-        unsigned int jump
+        UInt area
+        UInt fall
+        UInt jump
+
+
+    
+    cdef cppclass TIC(QCBase):
 
         TIC() except +
 
-        Result compute(const MSExperiment& exp,
-                       float bin_size = 0,
-                       UInt ms_level = 1) except +
+        TIC_Result compute(const MSExperiment& exp,
+                           float bin_size = 0,
+                           UInt ms_level = 1) except +
 
-        const String& getName() const except +
+        const String& getName() const
 
-        const vector[MSChromatogram]& getResults() const except +
+        const vector[MSChromatogram]& getResults() except + const
 
-        QCBase.Status requirements() const except +
+        QCBase.Status requirements() except + const
 
         void addMetaDataMetricsToMzTab(MzTabMetaData& meta,
-                                       vector[Result]& tics) except +
+                                       vector[TIC_Result]& tics) except +

--- a/src/pyOpenMS/pxds/TIC.pxd
+++ b/src/pyOpenMS/pxds/TIC.pxd
@@ -11,15 +11,17 @@ from Types cimport UInt
 cdef extern from "<OpenMS/QC/TIC.h>" namespace "OpenMS":
 
     cdef cppclass TIC(QCBase):
+        TIC() except +
+        TIC_Result compute(MSExperiment& exp, float bin_size, unsigned int ms_level) except +
+        const String& getName() const
 
-        # nested struct
-        cdef cppclass Result:
-            vector[UInt] intensities
-            vector[float] relative_intensities
-            vector[float] retention_times
-            UInt area
-            UInt fall
-            UInt jump
+    cdef cppclass TIC_Result "OpenMS::TIC::Result":
+        vector[unsigned int] intensities
+        vector[float] relative_intensities
+        vector[float] retention_times
+        unsigned int area
+        unsigned int fall
+        unsigned int jump
 
         TIC() except +
 


### PR DESCRIPTION
I added Cython .pxd bindings for multiple QC classes in OpenMS to make them available in pyOpenMS.

Checklist
✅ Make sure that you are listed in the AUTHORS file
✅ Add relevant changes and new features to the CHANGELOG file
✅ I have commented my code, particularly in hard-to-understand areas
✅ New and existing unit tests pass locally with my changes
✅ Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)
Detail:
I wrapped the following QC classes :

Ms2IdentificationRate
TIC
RTAlignment
FWHM
Contaminants
DBSuitability
FeatureSummary
FragmentMassError
IdentificationSummary
MissedCleavages
Ms2SpectrumStats
MzCalibration
PSMExplainedIonCurrent
PeptideMass
SpectrumCount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Python access to many QC metrics: contaminants, FWHM, database suitability, feature summary, fragment mass error, identification summary, missed cleavages, MS2 identification rate, MS2 spectrum stats, m/z calibration, PSM explained ion current, peptide mass, RT alignment, spectrum counting, and TIC — including result retrieval and mzTab metadata hooks where available.

- **Documentation**
  - Added Uzma Nayab to the authors list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->