### PR TITLE
perf: Hot-loop cleanup in OpenSWATH scoring pipeline

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -278,7 +278,7 @@ namespace OpenMS
      * @return Vector of spectra to be used
      *
     */
-    SpectrumSequence fetchSpectrumSwath(std::vector<OpenSwath::SwathMap> swath_maps, double RT, int nr_spectra_to_add, const RangeMobility& im_range);
+    SpectrumSequence fetchSpectrumSwath(const std::vector<OpenSwath::SwathMap>& swath_maps, double RT, int nr_spectra_to_add, const RangeMobility& im_range);
 
 
    /** @brief Prepares a spectrum for DIA analysis (multiple map)

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -595,6 +595,23 @@ namespace OpenMS
 
     auto& mrmfeatures = transition_group_detection.getFeaturesMuteable();
 
+    // Pre-compute group-invariant values (constant across all features)
+    const bool swath_present = (!swath_maps.empty() && swath_maps[0].sptr->getNrSpectra() > 0);
+
+    std::vector<double> normalized_library_intensity;
+    transition_group_detection.getLibraryIntensity(normalized_library_intensity);
+    OpenSwath::Scoring::normalize_sum(normalized_library_intensity.data(), static_cast<unsigned int>(normalized_library_intensity.size()));
+
+    const auto& transitions = transition_group_detection.getTransitions();
+    std::vector<std::string> native_ids_detection(transitions.size());
+    std::transform(transitions.begin(), transitions.end(), native_ids_detection.begin(),
+                   [](const auto& tr) { return tr.getNativeID(); });
+
+    const auto& precursor_chroms = transition_group_detection.getPrecursorChromatograms();
+    std::vector<std::string> precursor_ids(precursor_chroms.size());
+    std::transform(precursor_chroms.begin(), precursor_chroms.end(), precursor_ids.begin(),
+                   [](const auto& ch) { return ch.getNativeID(); });
+
     // Go through all peak groups (found MRM features) and score them
     #ifdef _OPENMP
     int in_parallel = omp_in_parallel();
@@ -619,7 +636,6 @@ namespace OpenMS
                                          "Error: Transition group " + transition_group_detection.getTransitionGroupID() +
                                          " has no chromatograms.");
       }
-      bool swath_present = (!swath_maps.empty() && swath_maps[0].sptr->getNrSpectra() > 0);
       double xx_lda_prescore;
       double precursor_mz(-1);
 
@@ -703,24 +719,6 @@ namespace OpenMS
         ///////////////////////////////////
         // Call the scoring for fragment ions
         ///////////////////////////////////
-
-        std::vector<double> normalized_library_intensity;
-        transition_group_detection.getLibraryIntensity(normalized_library_intensity);
-        OpenSwath::Scoring::normalize_sum(&normalized_library_intensity[0], boost::numeric_cast<int>(normalized_library_intensity.size()));
-
-        std::vector<std::string> native_ids_detection;
-        for (Size i = 0; i < transition_group_detection.size(); i++)
-        {
-          std::string native_id = transition_group_detection.getTransitions()[i].getNativeID();
-          native_ids_detection.push_back(native_id);
-        }
-
-        std::vector<std::string> precursor_ids;
-        for (Size i = 0; i < transition_group_detection.getPrecursorChromatograms().size(); i++)
-        {
-          std::string precursor_id = transition_group_detection.getPrecursorChromatograms()[i].getNativeID();
-          precursor_ids.push_back(precursor_id);
-        }
 
         ///////////////////////////////////
         // Library and chromatographic scores

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathScoring.cpp
@@ -490,15 +490,6 @@ namespace OpenMS
         OpenSwath_Scores & scores)
   {
     OPENMS_PRECONDITION(imrmfeature != nullptr, "Feature to be scored cannot be null");
-    std::vector<double> normalized_library_intensity;
-    getNormalized_library_intensities_(transitions, normalized_library_intensity);
-
-    std::vector<std::string> native_ids;
-    native_ids.reserve(transitions.size());
-    for (const auto& trans : transitions)
-    {
-      native_ids.push_back(trans.getNativeID());
-    }
 
     if (su_.use_library_score_)
     {
@@ -553,7 +544,7 @@ namespace OpenMS
     }
   }
 
-  SpectrumSequence OpenSwathScoring::fetchSpectrumSwath(std::vector<OpenSwath::SwathMap> swath_maps, double RT, int nr_spectra_to_add, const RangeMobility& im_range)
+  SpectrumSequence OpenSwathScoring::fetchSpectrumSwath(const std::vector<OpenSwath::SwathMap>& swath_maps, double RT, int nr_spectra_to_add, const RangeMobility& im_range)
   {
     OPENMS_PRECONDITION(nr_spectra_to_add >= 1, "nr_spectra_to_add must be at least 1.")
     OPENMS_PRECONDITION(!swath_maps.empty(), "swath_maps vector cannot be empty")


### PR DESCRIPTION
## Summary

- **Pass `swath_maps` by `const&`** in `fetchSpectrumSwath` — avoids copying the entire `SwathMap` vector on every call
- **Hoist group-invariant computations** out of the OpenMP parallel loop in `scorePeakgroups()` — `swath_present`, `normalized_library_intensity`, `native_ids_detection`, and `precursor_ids` only depend on `transition_group_detection` and `swath_maps`, which are constant across all features
- **Remove dead code** in `calculateLibraryScores` — `normalized_library_intensity` and `native_ids` vectors were computed but never read

All changes are behavior-preserving (no scoring logic modified).

## Test plan

- [x] `OpenSwathScoring_test` — passed
- [x] `MRMFeatureFinderScoring_test` — passed
- [x] `TOPP_OpenSwathWorkflow` (76 tests) — 100% passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal spectrum scoring computation by pre-calculating repeated values and eliminating redundant recalculations during batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->