### PR TITLE
Add explanatory section to generated INI HTML documentation

### DIFF
--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -1,3 +1,7 @@
+:root {
+  --item-advanced-foreground-color: var(--nav-menu-foreground-color);
+}
+
 div.ini_global {
 	padding-left:10px;
 	border: 2px solid;
@@ -45,7 +49,7 @@ div.ini_global > div.item {
 .item_advanced {
 	/* we are kind of abusing an unrelated variable here */
 	/* TODO maybe redefine? */
-	color: var(--nav-menu-foreground-color)
+	color: var(--item-advanced-foreground-color);
 }
 
 div.item span.item_name {

--- a/doc/doxygen/parameters/TOPPDocumenter.cpp
+++ b/doc/doxygen/parameters/TOPPDocumenter.cpp
@@ -24,9 +24,21 @@ using namespace Internal;
 
 void convertINI2HTML(const Param& p, ostream& os)
 {
-  // the .css file is included via the Header.html (see doc/doxygen/common/Header.html)
-  // TODO add some general description on how to handle subsections, what each column means, what the tags mean, etc.
   os << "<div class=\"ini_global\">\n";
+  os << "<div class=\"ini_explanation\">\n";
+  os << "<h3>Parameter Documentation</h3>\n";
+  os << "<p>This page lists all parameters grouped into subsections.</p>\n";
+  os << "<ul>\n";
+  os << "<li><b>Subsections</b> represent logical groupings of parameters.</li>\n";
+  os << "<li><b>Name</b> is the parameter identifier used in the INI file.</li>\n";
+  os << "<li><b>Value</b> shows the default value.</li>\n";
+  os << "<li><b>Description</b> explains the purpose of the parameter.</li>\n";
+  os << "<li><b>Restrictions</b> indicate valid ranges or allowed values.</li>\n";
+  os << "<li><b>Tags</b> provide additional information about the parameter.</li>\n";
+  os << "</ul>\n";
+  os << "<p>Parameters marked as <span class=\"item_required\">required</span> must be provided. ";
+  os << "Parameters marked as <span class=\"item_advanced\">advanced</span> are intended for experienced users.</p>\n";
+  os << "</div>\n";
   os << "<div class=\"legend\">\n";
   os << "<b>Legend:</b><br>\n";
   os << " <div class=\"item item_required\">required parameter</div>\n";


### PR DESCRIPTION
This PR adds an explanatory section at the top of the generated INI HTML documentation created by TOPPDocumenter.

The new section provides a structured overview explaining:

The purpose of subsections

The meaning of each column (Name, Value, Description, Restrictions, Tags)

The difference between required and advanced parameters

This improves clarity and usability of the generated parameter documentation without changing any functional behavior of the tools.

The changes were implemented in:

doc/doxygen/parameters/TOPPDocumenter.cpp

The generated HTML output was rebuilt and verified locally to ensure the new section appears correctly.

Checklist

 Make sure that you are listed in the AUTHORS file

 Add relevant changes and new features to the CHANGELOG file

 I have commented my code, particularly in hard-to-understand areas

 New and existing unit tests pass locally with my changes

 Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<img width="1801" height="941" alt="Screenshot from 2026-02-24 23-08-46" src="https://github.com/user-attachments/assets/c43ce365-f61c-4d10-85f2-4abdb0e1bb85" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color property management with a new dedicated custom property for improved consistency.

* **Documentation**
  * Added explanatory content to parameter documentation output, detailing documentation scope, subsections, and field descriptions (Name, Value, Description, Restrictions, Tags).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->