### PR TITLE
Add explanatory section to generated INI HTML documentation

### DIFF
--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -47,8 +47,7 @@ div.ini_global > div.item {
 }
 
 .item_advanced {
-	/* we are kind of abusing an unrelated variable here */
-	/* TODO maybe redefine? */
+
 	color: var(--item-advanced-foreground-color);
 }
 

--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -47,7 +47,6 @@ div.ini_global > div.item {
 }
 
 .item_advanced {
-
 	color: var(--item-advanced-foreground-color);
 }
 

--- a/doc/doxygen/common/style_ini.css
+++ b/doc/doxygen/common/style_ini.css
@@ -1,3 +1,7 @@
+:root {
+  --item-advanced-foreground-color: var(--nav-menu-foreground-color);
+}
+
 div.ini_global {
 	padding-left:10px;
 	border: 2px solid;
@@ -45,7 +49,7 @@ div.ini_global > div.item {
 .item_advanced {
 	/* we are kind of abusing an unrelated variable here */
 	/* TODO maybe redefine? */
-	color: var(--nav-menu-foreground-color)
+	color: var(--item-advanced-foreground-color);
 }
 
 div.item span.item_name {

--- a/doc/doxygen/parameters/TOPPDocumenter.cpp
+++ b/doc/doxygen/parameters/TOPPDocumenter.cpp
@@ -24,8 +24,20 @@ using namespace Internal;
 
 void convertINI2HTML(const Param& p, ostream& os)
 {
-  // the .css file is included via the Header.html (see doc/doxygen/common/Header.html)
-  // TODO add some general description on how to handle subsections, what each column means, what the tags mean, etc.
+  os << "<div class=\"ini_explanation\">\n";
+  os << "<h3>Parameter Documentation</h3>\n";
+  os << "<p>This page lists all parameters grouped into subsections.</p>\n";
+  os << "<ul>\n";
+  os << "<li><b>Subsections</b> represent logical groupings of parameters.</li>\n";
+  os << "<li><b>Name</b> is the parameter identifier used in the INI file.</li>\n";
+  os << "<li><b>Value</b> shows the default value.</li>\n";
+  os << "<li><b>Description</b> explains the purpose of the parameter.</li>\n";
+  os << "<li><b>Restrictions</b> indicate valid ranges or allowed values.</li>\n";
+  os << "<li><b>Tags</b> provide additional information about the parameter.</li>\n";
+  os << "</ul>\n";
+  os << "<p>Parameters marked as <span class=\"item_required\">required</span> must be provided. ";
+  os << "Parameters marked as <span class=\"item_advanced\">advanced</span> are intended for experienced users.</p>\n";
+  os << "</div>\n";
   os << "<div class=\"ini_global\">\n";
   os << "<div class=\"legend\">\n";
   os << "<b>Legend:</b><br>\n";


### PR DESCRIPTION
This PR adds an explanatory section at the top of the generated INI HTML documentation created by TOPPDocumenter.

The new section provides a structured overview explaining:

The purpose of subsections

The meaning of each column (Name, Value, Description, Restrictions, Tags)

The difference between required and advanced parameters

This improves clarity and usability of the generated parameter documentation without changing any functional behavior of the tools.

The changes were implemented in:

doc/doxygen/parameters/TOPPDocumenter.cpp

The generated HTML output was rebuilt and verified locally to ensure the new section appears correctly.

Checklist

 Make sure that you are listed in the AUTHORS file

 Add relevant changes and new features to the CHANGELOG file

 I have commented my code, particularly in hard-to-understand areas

 New and existing unit tests pass locally with my changes

 Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Generated documentation now features enhanced HTML explanation blocks with improved formatting for parameter information, including well-organized sections for names, values, descriptions, restrictions, and tags.

* **Style**
  * Introduced new CSS variable aliases for streamlined color management and refactored styling rules for better visual consistency across documentation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->