### PR TITLE
feat(ProteomicsLFQ): Add -in_feat parameter to bypass internal feature finding

### DIFF
--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
 // SPDX-License-Identifier: BSD-3-Clause
-//  
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
 // $Authors: Timo Sachsenberg $
@@ -37,6 +37,7 @@
 #include <OpenMS/FORMAT/MzTabFile.h>
 #include <OpenMS/FORMAT/PeakTypeEstimator.h>
 #include <OpenMS/FORMAT/TriqlerFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/KERNEL/ConversionHelper.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/MassTrace.h>
@@ -75,7 +76,7 @@ Input: @n
     2. PSMFeatureExtractor to annotate percolator features.
     3. PercolatorAdapter tool (score_type = 'q-value', -post-processing-tdc)
     4. IDFilter (pep:score = 0.01) to filter PSMs at 1% FDR
-   
+
   - An experimental design file: @n
    (see @ref OpenMS::ExperimentalDesign "ExperimentalDesign" for details) @n
   - A protein database in with appended decoy sequences in FASTA format @n
@@ -129,12 +130,14 @@ public:
   {
   }
 
-protected:  
+protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFileList_("in", "<file list>", StringList(), "Input files");
     setValidFormats_("in", ListUtils::create<String>("mzML"));
-    registerInputFileList_("ids", "<file list>", StringList(), 
+    registerInputFileList_("in_feat", "<files>",StringList(), "Optional input featureXML files containing pre-computed features. Bypasses internal feature finding. Must match the number of '-in' files.", false, false);
+    setValidFormats_("in_feat", ListUtils::create<String>("featureXML"));
+    registerInputFileList_("ids", "<file list>", StringList(),
       "Identifications filtered at PSM level (e.g., q-value < 0.01)."
       "And annotated with PEP as main score.\n"
       "We suggest using:\n"
@@ -186,7 +189,7 @@ protected:
 
     //TODO expose all parameters of the inference algorithms (e.g. aggregation methods etc.)?
     registerStringOption_("protein_inference", "<option>", "aggregation",
-      "Infer proteins:\n" 
+      "Infer proteins:\n"
       "aggregation  = aggregates all peptide scores across a protein (using the best score) \n"
       "bayesian     = computes a posterior probability for every protein based on a Bayesian network.\n"
       "               Note: 'bayesian' only uses and reports the best PSM per peptide.",
@@ -200,13 +203,13 @@ protected:
       "strictly_unique_peptides = use peptides mapping to a unique single protein only.\n"
       "shared_peptides = use shared peptides only for its best group (by inference score)", false, true);
     setValidStrings_("protein_quantification", ListUtils::create<String>("unique_peptides,strictly_unique_peptides,shared_peptides"));
-    registerStringOption_("quantification_method", "<option>", 
-      "feature_intensity", 
+    registerStringOption_("quantification_method", "<option>",
+      "feature_intensity",
       "feature_intensity: MS1 signal.\n"
       "spectral_counting: PSM counts.", false, false);
     setValidStrings_("quantification_method", ListUtils::create<String>("feature_intensity,spectral_counting"));
 
-    registerStringOption_("targeted_only", "<option>", "false", 
+    registerStringOption_("targeted_only", "<option>", "false",
       "true: Only ID based quantification.\n"
       "false: include unidentified features so they can be linked to identified ones (=match between runs).", false, false);
     setValidStrings_("targeted_only", ListUtils::create<String>("true,false"));
@@ -223,7 +226,7 @@ protected:
     setValidStrings_("mass_recalibration", ListUtils::create<String>("true,false"));
 
     registerStringOption_("alignment_order", "<option>", "star", "If star, aligns all maps to the reference with most IDs.", false, true);
-    setValidStrings_("alignment_order", ListUtils::create<String>("star")); // TODO: fix and reenable tree guided 
+    setValidStrings_("alignment_order", ListUtils::create<String>("star")); // TODO: fix and reenable tree guided
 
     registerStringOption_("keep_feature_top_psm_only", "<option>", "true", "If false, also keeps lower ranked PSMs that have the top-scoring"
                                                                      " sequence as a candidate per feature in the same file.", false, true);
@@ -244,8 +247,8 @@ protected:
 
     Param ffi_defaults = FeatureFinderIdentificationAlgorithm().getDefaults();
     ffi_defaults.setValue("svm:samples", 10000); // restrict number of samples for training
-    ffi_defaults.setValue("svm:log2_C", DoubleList({-2.0, 5.0, 15.0})); 
-    ffi_defaults.setValue("svm:log2_gamma", DoubleList({-3.0, -1.0, 2.0})); 
+    ffi_defaults.setValue("svm:log2_C", DoubleList({-2.0, 5.0, 15.0}));
+    ffi_defaults.setValue("svm:log2_gamma", DoubleList({-3.0, -1.0, 2.0}));
     ffi_defaults.setValue("svm:min_prob", 0.9); // keep only feature candidates with > 0.9 probability of correctness
 
     // hide entries
@@ -273,8 +276,8 @@ protected:
     fl_defaults.setValue("distance_MZ:max_difference", 10.0);
     fl_defaults.setValue("distance_MZ:unit", "ppm");
     fl_defaults.setValue("distance_MZ:weight", 5.0);
-    fl_defaults.setValue("distance_intensity:weight", 0.1); 
-    fl_defaults.setValue("use_identifications", "true"); 
+    fl_defaults.setValue("distance_intensity:weight", 0.1);
+    fl_defaults.setValue("use_identifications", "true");
     fl_defaults.remove("distance_RT:max_difference"); // estimated from data
     for (const auto& s : {"distance_MZ:weight", "distance_intensity:weight", "use_identifications", "ignore_charge", "ignore_adduct"} )
     {
@@ -298,7 +301,7 @@ protected:
   }
 
   ExitCodes centroidAndCorrectPrecursors_(const String & mz_file, MSExperiment & ms_centroided)
-  { 
+  {
     Param pp_param = getParam_().copy("Centroiding:", true);
     writeDebug_("Parameters passed to PeakPickerHiRes algorithm", pp_param, 3);
 
@@ -338,19 +341,19 @@ protected:
     pp.setLogType(log_type_);
     pp.setParameters(pp_param);
     pp.pickExperiment(ms_raw, ms_centroided, true);
-      
+
     //-------------------------------------------------------------
     // HighRes Precursor Mass Correction
     //-------------------------------------------------------------
     std::vector<double> deltaMZs, mzs, rts;
     std::set<Size> corrected_to_highest_intensity_peak = PrecursorCorrection::correctToHighestIntensityMS1Peak(
-      ms_centroided, 
+      ms_centroided,
       0.01, // check if we can estimate this from data (here it is given in m/z not ppm)
       false, // is ppm = false
-      deltaMZs, 
-      mzs, 
+      deltaMZs,
+      mzs,
       rts
-      );      
+      );
     writeLogInfo_("Info: Corrected " + String(corrected_to_highest_intensity_peak.size()) + " precursors.");
     if (!deltaMZs.empty())
     {
@@ -367,15 +370,15 @@ protected:
       double MAD_abs = Math::MAD(deltaMZs_ppmabs.begin(), deltaMZs_ppmabs.end(), median_abs);
       writeLogInfo_("Precursor correction:\n  median        = "
         + String(median) + " ppm  MAD = " + String(MAD)
-        + "\n  median (abs.) = " + String(median_abs) 
+        + "\n  median (abs.) = " + String(median_abs)
         + " ppm  MAD = " + String(MAD_abs));
     }
     return EXECUTION_OK;
   }
 
-  // aligns the feature maps 
+  // aligns the feature maps
   double align_(
-    vector<FeatureMap> & feature_maps, 
+    vector<FeatureMap> & feature_maps,
     vector<TransformationDescription>& transformations
   )
   {
@@ -428,7 +431,7 @@ protected:
       vector<TransformationDescription::TransformationStatistics> alignment_stats;
       for (TransformationDescription & t : transformations)
       {
-        writeDebug_("Using " + String() + " points in fit.", 1); 
+        writeDebug_("Using " + String() + " points in fit.", 1);
         if (t.getDataPoints().size() > 10)
         {
           t.fitModel(model_type, model_params);
@@ -437,7 +440,7 @@ protected:
         alignment_stats.emplace_back(t.getStatistics());
       }
 
-      // determine maximum RT shift after transformation that includes all high confidence IDs 
+      // determine maximum RT shift after transformation that includes all high confidence IDs
       using TrafoStat = TransformationDescription::TransformationStatistics;
       for (auto & s : alignment_stats)
       {
@@ -459,7 +462,7 @@ protected:
       }
 
       double max_alignment_diff = std::max_element(alignment_stats.begin(), alignment_stats.end(),
-              [](TrafoStat a, TrafoStat b) 
+              [](TrafoStat a, TrafoStat b)
               { return a.percentiles_after[100] < b.percentiles_after[100]; })->percentiles_after[100];
       // sometimes, very good alignments might lead to bad overall performance. Choose 2 minutes as minimum.
       OPENMS_LOG_INFO << "Max alignment difference (seconds): " << max_alignment_diff << endl;
@@ -471,7 +474,7 @@ protected:
   }
 
   void transform_(
-    vector<FeatureMap>& feature_maps, 
+    vector<FeatureMap>& feature_maps,
     vector<TransformationDescription>& transformations
   )
   {
@@ -480,7 +483,7 @@ protected:
       // Apply transformations
       for (Size i = 0; i < feature_maps.size(); ++i)
       {
-        try 
+        try
         {
           MapAlignmentTransformer::transformRetentionTimes(feature_maps[i],
             transformations[i]);
@@ -488,7 +491,7 @@ protected:
         {
           OPENMS_LOG_WARN << e.what() << endl;
         }
-          
+
         if (debug_level_ > 666)
         {
           // plot with e.g.:
@@ -504,7 +507,7 @@ protected:
   //-------------------------------------------------------------
   /// this method will only be used during requantification.
   void link_(
-    vector<FeatureMap> & feature_maps, 
+    vector<FeatureMap> & feature_maps,
     double median_fwhm,
     double max_alignment_diff,
     ConsensusMap & consensus_fraction
@@ -521,14 +524,14 @@ protected:
     // grouping tolerance = max alignment error + median FWHM
     FeatureGroupingAlgorithmQT linker;
     fl_param.setValue("distance_RT:max_difference", 2.0 * max_alignment_diff + 2.0 * median_fwhm);
-    linker.setParameters(fl_param);      
+    linker.setParameters(fl_param);
 /*
     FeatureGroupingAlgorithmKD linker;
     fl_param.setValue("warp:rt_tol", 2.0 * max_alignment_diff + 2.0 * median_fwhm);
     fl_param.setValue("link:rt_tol", 2.0 * max_alignment_diff + 2.0 * median_fwhm);
     fl_param.setValue("link:mz_tol", 10.0);
     fl_param.setValue("mz_unit", "ppm");
-    linker.setParameters(fl_param);      
+    linker.setParameters(fl_param);
 */
     linker.group(feature_maps, consensus_fraction);
     OPENMS_LOG_INFO << "Size of consensus fraction: " << consensus_fraction.size() << endl;
@@ -537,7 +540,7 @@ protected:
 
   /// Align and link.
   void alignAndLink_(
-    vector<FeatureMap> & feature_maps, 
+    vector<FeatureMap> & feature_maps,
     ConsensusMap & consensus_fraction,
     vector<TransformationDescription>& transformations,
     const double median_fwhm)
@@ -551,13 +554,13 @@ protected:
       transform_(feature_maps, transformations);
 
       link_(feature_maps,
-        median_fwhm, 
-        max_alignment_diff, 
+        median_fwhm,
+        max_alignment_diff,
         consensus_fraction);
     }
     else // only one feature map
     {
-      MapConversion::convert(0, feature_maps.back(), consensus_fraction);                           
+      MapConversion::convert(0, feature_maps.back(), consensus_fraction);
     }
   }
 
@@ -620,7 +623,7 @@ protected:
     {
       OPENMS_LOG_WARN << "Warning: No mzML origin annotated in ID file. This can lead to errors or unexpected behaviour later: " << id_file_abs_path << endl;
     }
-    
+
     return EXECUTION_OK;
   }
 
@@ -647,7 +650,7 @@ protected:
     const String& in_db,
     const Size& fraction_group,
     const Size& fraction,
-    vector<ProteinIdentification>& protein_ids, 
+    vector<ProteinIdentification>& protein_ids,
     PeptideIdentificationList& peptide_ids,
     set<String>& fixed_modifications,  // adds to
     set<String>& variable_modifications) // adds to
@@ -695,15 +698,15 @@ protected:
 
     e = switchScoreType_(peptide_ids, id_file_abs_path);
     if (e != EXECUTION_OK) return e;
-  
+
     // TODO we could think about removing this limitation but it gets complicated quickly
     IDFilter::keepBestPeptideHits(peptide_ids, false); // strict = false
- 
+
     // add to the (global) set of fixed and variable modifications
     const vector<String>& var_mods = protein_ids[0].getSearchParameters().variable_modifications;
     const vector<String>& fixed_mods = protein_ids[0].getSearchParameters().fixed_modifications;
-    std::copy(var_mods.begin(), var_mods.end(), std::inserter(variable_modifications, variable_modifications.begin())); 
-    std::copy(fixed_mods.begin(), fixed_mods.end(), std::inserter(fixed_modifications, fixed_modifications.end())); 
+    std::copy(var_mods.begin(), var_mods.end(), std::inserter(variable_modifications, variable_modifications.begin()));
+    std::copy(fixed_mods.begin(), fixed_mods.end(), std::inserter(fixed_modifications, fixed_modifications.end()));
 
     // delete meta info to free some space
     for (PeptideIdentification & pid : peptide_ids)
@@ -718,11 +721,11 @@ protected:
         ph.getKeys(keys);
         for (const auto& k : keys)
         {
-          if (!(k.hasSubstring("_score") 
-            || k.hasSubstring("q-value") 
+          if (!(k.hasSubstring("_score")
+            || k.hasSubstring("q-value")
             || k.hasPrefix("Luciphor_global_flr")
             || k == "target_decoy") // keep target_decoy information for QC
-            )            
+            )
           {
             ph.removeMetaValue(k);
           }
@@ -789,7 +792,7 @@ protected:
     {
       if (!pid.metaValueExists(Constants::UserParam::SPECTRUM_REFERENCE)
         || pid.getMetaValue(Constants::UserParam::SPECTRUM_REFERENCE).toString().empty())
-      {          
+      {
         missing_spec_ref = true;
         break;
       }
@@ -801,24 +804,24 @@ protected:
                          "OpenMS will try to reannotate them by matching retention times between ID and spectra." << endl;
 
       SpectrumMetaDataLookup::addMissingSpectrumReferences(
-        peptide_ids, 
+        peptide_ids,
         mz_file_abs_path,
         true);
     }
 
     return EXECUTION_OK;
   }
- 
+
 
   void printMetaValues(const FeatureMap& tmp)
   {
     // extract meta value keys from the first element (which might be a normal or OffsetPeptide -> extract only the common ones)
     std::vector<String> keys;
     tmp[0].getKeys(keys);
-    if (auto it = std::find(keys.begin(), keys.end(), "OffsetPeptide"); it != keys.end()) 
+    if (auto it = std::find(keys.begin(), keys.end(), "OffsetPeptide"); it != keys.end())
     {
       keys.erase(it); // remove the string
-    }    
+    }
 
     for (const auto& k : keys) std::cout << k << '\t';
     std::cout << "OffsetPeptide" << std::endl;
@@ -826,7 +829,7 @@ protected:
     {
       for (const auto& k : keys)
       {
-        std::cout << f.getMetaValue(k) << '\t';           
+        std::cout << f.getMetaValue(k) << '\t';
       }
       if (f.metaValueExists("OffsetPeptide"))
       {
@@ -841,7 +844,7 @@ protected:
   }
 
   ExitCodes quantifyFraction_(
-    const pair<unsigned int, std::vector<String> > & ms_files, 
+    const pair<unsigned int, std::vector<String> > & ms_files,
     const map<String, String>& mzfile2idfile,
     const String& in_db,
     double median_fwhm,
@@ -853,29 +856,24 @@ protected:
     vector<FeatureMap> feature_maps;
     const Size fraction = ms_files.first;
 
-    // debug output
     writeDebug_("Processing fraction number: " + String(fraction) + "\nFiles: ",  1);
     for (String const & mz_file : ms_files.second) { writeDebug_(mz_file,  1); }
 
-    // for sanity checks we collect the primary MS run basenames as well as the ones stored in the ID files (below)
     StringList id_MS_run_ref;
     StringList in_MS_run = ms_files.second;
     const auto& path_label_to_fractiongroup = design_.getPathLabelToFractionGroupMapping(true);
 
-    // for each MS file of current fraction (e.g., all MS files that measured the n-th fraction) 
     for (String const & mz_file : ms_files.second)
     {
       const Size fraction_group = path_label_to_fractiongroup.at({File::basename(mz_file), 1});
       writeDebug_("Processing file: " + mz_file,  1);
-      // centroid spectra (if in profile mode) and correct precursor masses
-      MSExperiment ms_centroided;    
 
+      MSExperiment ms_centroided;
       {
         ExitCodes e = centroidAndCorrectPrecursors_(mz_file, ms_centroided);
         if (e != EXECUTION_OK) { return e; }
       }
 
-      // load and clean identification data associated with MS run
       vector<ProteinIdentification> protein_ids;
       PeptideIdentificationList peptide_ids;
       const String& mz_file_abs_path = File::absolutePath(mz_file);
@@ -886,36 +884,21 @@ protected:
         if (e != EXECUTION_OK) return e;
       }
 
-      // Annotate peptide IDs with FAIMS CV from spectrum data (required for proper per-CV filtering in FFI)
-      // Safe to call on non-FAIMS data - returns false and does nothing if no FAIMS data present
       SpectrumMetaDataLookup::addMissingFAIMSToPeptideIDs(peptide_ids, ms_centroided);
 
       StringList id_msfile_ref;
       protein_ids[0].getPrimaryMSRunPath(id_msfile_ref);
       id_MS_run_ref.push_back(id_msfile_ref[0]);
-     
-      //-------------------------------------------------------------
-      // Internal Calibration of spectra peaks and precursor peaks with high-confidence IDs
-      //-------------------------------------------------------------
+
       if (getStringOption_("mass_recalibration") == "true")
       {
         String debug_output_basename = (debug_level_ > 666) ? id_file_abs_path : "";
         DDAWorkflowCommons::recalibrateMS1(ms_centroided, peptide_ids, debug_output_basename);
       }
 
-      //////////////////////////////////////////
-      // Chromatographic parameter estimation
-      //////////////////////////////////////////
       median_fwhm = DDAWorkflowCommons::estimateMedianChromatographicFWHM(ms_centroided);
       OPENMS_LOG_INFO << "Median chromatographic FWHM: " << median_fwhm << std::endl;
 
-      //-------------------------------------------------------------
-      // Feature detection
-      //-------------------------------------------------------------
-
-      // Run MTD before FFM
-
-      // create empty feature map and annotate MS file
       FeatureMap seeds;
       seeds.setPrimaryMSRunPath({mz_file});
 
@@ -923,7 +906,6 @@ protected:
 
       if (!targeted_only)
       {
-        // TODO: infer min/max charge from ID data
         DDAWorkflowCommons::calculateSeeds(ms_centroided, getDoubleOption_("Seeding:intThreshold"), seeds, median_fwhm, 2, 5);
         if (debug_level_ > 666)
         {
@@ -932,266 +914,203 @@ protected:
       }
 
       /////////////////////////////////////////////////
-      // Run FeatureFinderIdentification
-      FeatureFinderIdentificationAlgorithm ffi;
-      ffi.getMSData().swap(ms_centroided);
-      ffi.getProgressLogger().setLogType(log_type_);
-
-      Param ffi_param = getParam_().copy("PeptideQuantification:", true);
-      ffi_param.setValue("detect:peak_width", 5.0 * median_fwhm);
-      ffi_param.setValue("debug", debug_level_); // pass down debug level
-
-      double feature_with_id_min_score = getDoubleOption_("feature_with_id_min_score");
-      double feature_without_id_min_score = getDoubleOption_("feature_without_id_min_score");
-      const bool filter_by_quant_scores = (feature_with_id_min_score > 0.0) && (targeted_only ||(feature_without_id_min_score > 0.0));
-      if (filter_by_quant_scores)
-      {
-        OPENMS_LOG_INFO << "Adding offset peptides as quant. decoys." << std::endl;
-        ffi_param.setValue("add_mass_offset_peptides", 10.005); // create mass offset peptides (aka quant. decoys). Uses same value as SAGE.
-      }
-
-      ffi.setParameters(ffi_param);
-      writeDebug_("Parameters passed to FeatureFinderIdentification algorithm", ffi_param, 3);
-
+      // Feature detection or loading pre-computed features
       FeatureMap fm;
+      StringList in_feat_list = getStringList_("in_feat");
 
+      if (!in_feat_list.empty())
       {
-        // These containers must be empty because we may be using
-        // seeds.  The variables are not used by this code but
-        // required by the `run` call.
-        vector<ProteinIdentification> ext_protein_ids;
-        PeptideIdentificationList ext_peptide_ids;
+        OPENMS_LOG_INFO << "Bypassing FeatureFinderIdentification. Loading pre-computed features..." << std::endl;
 
-        ffi.run(peptide_ids,
-                protein_ids,
-                ext_peptide_ids,
-                ext_protein_ids,
-                fm, // fills fm
-                seeds,
-                mz_file);
-      }
+        StringList in_list = getStringList_("in");
 
-      if (filter_by_quant_scores)
-      {
-        // SVM table for training
-        // We want to filter out wrongly quantified peptides and noise. Later we want to also filter out wrongly transfered ones.
-        SimpleSVM::PredictorMap predictors;
-        map<Size, double> labels;
-        size_t current_row = 0;
-  
-        size_t quant_target{}, quant_decoy{};
+        // Find the correct index for the current file
+        auto it = std::find(in_list.begin(), in_list.end(), mz_file);
+        size_t file_idx = std::distance(in_list.begin(), it);
 
-        // randomize selection
-        Math::RandomShuffler shuffler;
-        std::vector<size_t> randomized_indices(fm.size());
-        std::iota(randomized_indices.begin(), randomized_indices.end(), 0);
+        FeatureXMLFile f_file;
+        f_file.load(in_feat_list[file_idx], fm);
 
-        for (auto & i : randomized_indices)
+        StringList run_paths;
+        fm.getPrimaryMSRunPath(run_paths);
+        if (run_paths.empty())
         {
-          const auto& f = fm[i]; // select random feature
-          predictors["var_library_sangle"].push_back(f.getMetaValue("var_library_sangle"));
-          predictors["var_xcorr_shape"].push_back(f.getMetaValue("var_xcorr_shape"));
-          predictors["total_xic"].push_back(f.getMetaValue("total_xic"));
-          predictors["var_elution_model_fit_score"].push_back(f.getMetaValue("var_elution_model_fit_score"));
-
-          bool is_offset = f.metaValueExists("OffsetPeptide");
-          bool has_id = !f.getPeptideIdentifications().empty(); // offset peptides also have no id
-          if (is_offset)
-          {          
-            if (quant_decoy < 1000) // max 1000 for training
-            {
-              labels[current_row] = 0.0;
-              ++quant_decoy;
-            }
-          }
-          else
-          {
-            // only consider features with ID annotated
-            if (has_id && quant_target < 1000)
-            {
-              labels[current_row] = 1.0;
-              ++quant_target;
-            }
-          }
-          ++current_row;              
+            fm.setPrimaryMSRunPath({mz_file});
         }
-  
-        if (quant_decoy > 4 && quant_target > 4) // less than 4 will make the SVM to error out
+      }
+      else
+      {
+        // Run FeatureFinderIdentification
+        FeatureFinderIdentificationAlgorithm ffi;
+        ffi.getMSData().swap(ms_centroided);
+        ffi.getProgressLogger().setLogType(log_type_);
+
+        Param ffi_param = getParam_().copy("PeptideQuantification:", true);
+        ffi_param.setValue("detect:peak_width", 5.0 * median_fwhm);
+        ffi_param.setValue("debug", debug_level_); // pass down debug level
+
+        double feature_with_id_min_score = getDoubleOption_("feature_with_id_min_score");
+        double feature_without_id_min_score = getDoubleOption_("feature_without_id_min_score");
+        const bool filter_by_quant_scores = (feature_with_id_min_score > 0.0) && (targeted_only ||(feature_without_id_min_score > 0.0));
+
+        if (filter_by_quant_scores)
         {
-          SimpleSVM svm;
-          Param svm_param = svm.getParameters();        
-          svm_param.setValue("kernel", "linear");
-          svm_param.setValue("log2_C", ListUtils::create<double>("-5,-1,1,5,7,11,15"));
-          svm_param.setValue("log2_p", ListUtils::create<double>("-15,-9,-6,-3.32192809489,0,3.32192809489,6,9,15"));
-  
-          svm.setParameters(svm_param);
-          svm.setup(predictors, labels);
-          vector<SimpleSVM::Prediction> predictions;
-          OPENMS_LOG_INFO << "Predicting class probabilities:" << endl;
-          svm.predict(predictions);
-          std::map<String, double> feature_weights;
-          svm.getFeatureWeights(feature_weights);
-  
-          // assign quant probabilities to feature
-          size_t current_row{};
-          for (auto & i : randomized_indices) // traverse features in same order as before
+          OPENMS_LOG_INFO << "Adding offset peptides as quant. decoys." << std::endl;
+          ffi_param.setValue("add_mass_offset_peptides", 10.005);
+        }
+
+        ffi.setParameters(ffi_param);
+        writeDebug_("Parameters passed to FeatureFinderIdentification algorithm", ffi_param, 3);
+
+        {
+          vector<ProteinIdentification> ext_protein_ids;
+          PeptideIdentificationList ext_peptide_ids;
+
+          ffi.run(peptide_ids,
+                  protein_ids,
+                  ext_peptide_ids,
+                  ext_protein_ids,
+                  fm, // fills fm
+                  seeds,
+                  mz_file);
+        }
+
+        if (filter_by_quant_scores)
+        {
+          SimpleSVM::PredictorMap predictors;
+          map<Size, double> labels;
+          size_t current_row = 0;
+          size_t quant_target{}, quant_decoy{};
+
+          Math::RandomShuffler shuffler;
+          std::vector<size_t> randomized_indices(fm.size());
+          std::iota(randomized_indices.begin(), randomized_indices.end(), 0);
+
+          for (auto & i : randomized_indices)
           {
-            auto& f = fm[i];
-            f.setMetaValue("p_quant", (double)predictions[current_row].probabilities[1]); // set probability of being a peptide feature (not a MassOffset decoy)
+            const auto& f = fm[i];
+            predictors["var_library_sangle"].push_back(f.getMetaValue("var_library_sangle"));
+            predictors["var_xcorr_shape"].push_back(f.getMetaValue("var_xcorr_shape"));
+            predictors["total_xic"].push_back(f.getMetaValue("total_xic"));
+            predictors["var_elution_model_fit_score"].push_back(f.getMetaValue("var_elution_model_fit_score"));
+
+            bool is_offset = f.metaValueExists("OffsetPeptide");
+            bool has_id = !f.getPeptideIdentifications().empty();
+            if (is_offset)
+            {
+              if (quant_decoy < 1000)
+              {
+                labels[current_row] = 0.0;
+                ++quant_decoy;
+              }
+            }
+            else
+            {
+              if (has_id && quant_target < 1000)
+              {
+                labels[current_row] = 1.0;
+                ++quant_target;
+              }
+            }
             ++current_row;
           }
-  
-          OPENMS_LOG_DEBUG << "Feature weights:" << endl;
-          for (const auto& m : feature_weights)
+
+          if (quant_decoy > 4 && quant_target > 4)
           {
-            OPENMS_LOG_DEBUG << "weights: " << m.first << "\t" << m.second << endl;
-          }      
+            SimpleSVM svm;
+            Param svm_param = svm.getParameters();
+            svm_param.setValue("kernel", "linear");
+            svm_param.setValue("log2_C", ListUtils::create<double>("-5,-1,1,5,7,11,15"));
+            svm_param.setValue("log2_p", ListUtils::create<double>("-15,-9,-6,-3.32192809489,0,3.32192809489,6,9,15"));
+
+            svm.setParameters(svm_param);
+            svm.setup(predictors, labels);
+            vector<SimpleSVM::Prediction> predictions;
+            OPENMS_LOG_INFO << "Predicting class probabilities:" << endl;
+            svm.predict(predictions);
+            std::map<String, double> feature_weights;
+            svm.getFeatureWeights(feature_weights);
+
+            size_t current_row_pred{};
+            for (auto & i : randomized_indices)
+            {
+              auto& f = fm[i];
+              f.setMetaValue("p_quant", (double)predictions[current_row_pred].probabilities[1]);
+              ++current_row_pred;
+            }
+          }
+
+          if (quant_decoy > 4 && quant_target > 4)
+          {
+            fm.erase(std::remove_if(fm.begin(), fm.end(),
+              [&](const Feature& f)
+              {
+                double quant_score = f.getMetaValue("p_quant");
+                bool is_offset = f.metaValueExists("OffsetPeptide");
+                bool has_id = !f.getPeptideIdentifications().empty();
+                bool untargeted_feature = !is_offset && !has_id;
+                bool is_feature_with_id = !is_offset && has_id;
+
+                if (is_feature_with_id && quant_score < feature_with_id_min_score) return true;
+                if (untargeted_feature && quant_score < feature_without_id_min_score) return true;
+                if (is_offset && quant_score < feature_without_id_min_score) return true;
+                return false;
+              }),
+              fm.end());
+
+            fm.erase(std::remove_if(fm.begin(), fm.end(),
+              [](const Feature& f){return f.metaValueExists("OffsetPeptide");}),
+              fm.end());
+          }
         }
-  
-        // printMetaValues(tmp);
-  
-        if (quant_decoy > 4 && quant_target > 4)
-        {
-          // remove offset (peptides+untargeted), and non-offset peptides and untargeted features if they don't pass the score threshold
-          size_t removed_non_offset_with_id{}, removed_non_offset_without_id{}, removed_offset{}, total_offset{}, total_non_offset_with_id{}, total_non_offset_without_id{};
-          fm.erase(std::remove_if(fm.begin(), fm.end(),
-            [&](const Feature& f)
-            { 
-              double quant_score = f.getMetaValue("p_quant");
-  
-              bool is_offset = f.metaValueExists("OffsetPeptide");
-  
-              bool has_id = !f.getPeptideIdentifications().empty(); // offset peptides also have no id
-              bool untargeted_feature = !is_offset && !has_id;
-              bool is_feature_with_id = !is_offset && has_id;
-  
-              // count offset (peptides+untargeted), and non-offset peptides and untargeted features
-              // and remove if they don't pass the score threshold  
-              if (is_feature_with_id) // peptide but non-offset   
-              {
-                ++total_non_offset_with_id;
-                if (quant_score < feature_with_id_min_score)
-                {
-                  ++removed_non_offset_with_id;
-                  return true;
-                }
-              }
-              else if (untargeted_feature) // seed but non-offset
-              {
-                ++total_non_offset_without_id;
-                if (quant_score < feature_without_id_min_score)
-                {
-                  ++removed_non_offset_without_id;
-                  return true;
-                }
-              }
-              else // offset
-              {
-                ++total_offset;
-                if (quant_score < feature_without_id_min_score)
-                {
-                  ++removed_offset;
-                  return true;
-                }
-              }
+      } // <--- END OF ELSE BLOCK
 
-              return false;
-            }), 
-            fm.end());
-
-          // clean up by removing all OffsetPeptide features (TODO: maybe keep for transfer FDR)
-          fm.erase(std::remove_if(fm.begin(), fm.end(),
-            [](const Feature& f){return f.metaValueExists("OffsetPeptide");}), 
-            fm.end());
-      
-          std::cout << "Removed quant. targets with id (features with id) because of low quantification score: " 
-            << (double)removed_non_offset_with_id << " of " << total_non_offset_with_id << "\t ( " 
-            << (double)removed_non_offset_with_id/total_non_offset_with_id * 100.0 << "% )"
-            << std::endl;
- 
-          std::cout << "Removed quant. targets with id (features without id) because of low quantification score: " 
-            << (double)removed_non_offset_without_id << " of " << total_non_offset_without_id << "\t ( "
-            << (double)removed_non_offset_without_id/total_non_offset_without_id * 100.0 << "% )"
-            << std::endl;
-
-          std::cout << "Removed quant. decoys (offset features) because of low quantification score: " 
-            << (double)removed_offset << " of " << total_offset  << "\t ( " 
-            << (double)removed_offset/total_offset * 100.0 << "% )"
-            << std::endl;
-        }
-      }
-
-      // free parts of feature map not needed for further processing (e.g., subfeatures...)
-      unordered_set<String> keep_meta = {"OffsetPeptide"}; // meta values to keep (all others will be removed) TODO: keep FWHM etc. for QC
+      unordered_set<String> keep_meta = {"OffsetPeptide"};
       for (auto & f : fm)
       {
         std::vector<String> keys;
         f.getKeys(keys);
-        
         for (const auto& k : keys)
         {
-          if (auto it = keep_meta.find(k); it == keep_meta.end()) // not none of the meta value to keep? then delete
-          {
-            f.removeMetaValue(k);
-          }
+          if (auto it = keep_meta.find(k); it == keep_meta.end()) f.removeMetaValue(k);
         }
-
         f.setSubordinates({});
         f.setConvexHulls({});
       }
 
-      IDConflictResolverAlgorithm::resolve(fm,
-          getStringOption_("keep_feature_top_psm_only") == "false"); // keep only best peptide per feature per file
+      IDConflictResolverAlgorithm::resolve(fm, getStringOption_("keep_feature_top_psm_only") == "false");
 
       feature_maps.emplace_back(std::move(fm));
-      
+
       if (debug_level_ > 666)
       {
         FileHandler().storeFeatures("debug_fraction_" + String(ms_files.first) + "_" + String(fraction_group) + ".featureXML", feature_maps.back(), {FileTypes::FEATUREXML}, log_type_);
       }
+    } // <--- END OF FOR LOOP OVER MS FILES
 
-      if (debug_level_ > 10000)
-      {
-        FileHandler().storeExperiment("debug_fraction_" + String(ms_files.first) + "_" + String(fraction_group) + "_chroms.mzML", ffi.getChromatograms(), {FileTypes::MZML}, log_type_);
-      }
-    }
-
-    // validate file lists (use only basename and ignore extension)
     auto validation_result = File::validateMatchingFileNames(in_MS_run, id_MS_run_ref, true, true);
     switch(validation_result)
     {
       case File::MatchingFileListsStatus::SET_MISMATCH:
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "MS run path reference in ID files and spectra filenames differ.");
-        break;
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MS run path reference in ID files and spectra filenames differ.");
       case File::MatchingFileListsStatus::ORDER_MISMATCH:
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "MS run path reference in ID files and spectra filenames match but order differs.");
-        break;
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "MS run path reference in ID files and spectra filenames match but order differs.");
       case File::MatchingFileListsStatus::MATCH:
         writeLogInfo_("ID files reference same names as spectra files.");
         break;
-    }    
-
-    // Align all features of this fraction
-    alignAndLink_(feature_maps, consensus_fraction, transformations, median_fwhm);
-
-    // add dataprocessing
-    if (feature_maps.size() > 1)
-    {
-      addDataProcessing_(consensus_fraction,
-        getProcessingInfo_(DataProcessing::ALIGNMENT));
-      addDataProcessing_(consensus_fraction,
-        getProcessingInfo_(DataProcessing::FEATURE_GROUPING));
     }
 
-    ////////////////////////////////////////////////////////////
-    // Annotate experimental design in consensus map
-    ////////////////////////////////////////////////////////////
+    alignAndLink_(feature_maps, consensus_fraction, transformations, median_fwhm);
+
+    if (feature_maps.size() > 1)
+    {
+      addDataProcessing_(consensus_fraction, getProcessingInfo_(DataProcessing::ALIGNMENT));
+      addDataProcessing_(consensus_fraction, getProcessingInfo_(DataProcessing::FEATURE_GROUPING));
+    }
+
     Size j(0);
-    // for each MS file (as provided in the experimental design)
     const auto& path_label_to_sampleidx = design_.getPathLabelToSampleMapping(true);
-    for (String const & mz_file : ms_files.second) 
+    for (String const & mz_file : ms_files.second)
     {
       const Size curr_fraction_group = path_label_to_fractiongroup.at({File::basename(mz_file), 1});
       consensus_fraction.getColumnHeaders()[j].label = "label-free";
@@ -1205,40 +1124,13 @@ protected:
       ++j;
     }
 
-    // assign unique ids
     consensus_fraction.applyMemberFunction(&UniqueIdInterface::setUniqueId);
-
-    // sort list of peptide identifications in each consensus feature by map index
     consensus_fraction.sortPeptideIdentificationsByMapIndex();
-
-    if (debug_level_ >= 666)
-    {
-      FileHandler().storeConsensusFeatures("debug_fraction_" + String(ms_files.first) +  ".consensusXML", consensus_fraction, {FileTypes::CONSENSUSXML}, log_type_);
-      writeDebug_("to produce a consensus map with: " + String(consensus_fraction.getColumnHeaders().size()) + " columns.", 1);
-    }
-
-    //-------------------------------------------------------------
-    // ID conflict resolution
-    //-------------------------------------------------------------
     IDConflictResolverAlgorithm::resolve(consensus_fraction, true);
 
-    //-------------------------------------------------------------
-    // ConsensusMap normalization (basic median scaling)
-    //-------------------------------------------------------------
-    // Note: This normalization is applied automatically for feature-intensity-based quantification
-    // when multiple runs are provided. It uses simple median scaling to make sample medians equal.
-    // Normalization is DISABLED when MSstats or Triqler output is requested, as these tools
-    // perform their own normalization.
-    // This is independent of the -ProteinQuantification:consensus:normalize parameter, which
-    // controls an additional normalization step at the peptide quantification level (default: false).
-    if (getStringOption_("out_msstats").empty() 
-    && getStringOption_("out_triqler").empty())  // only normalize if no MSstats/Triqler output is generated
+    if (getStringOption_("out_msstats").empty() && getStringOption_("out_triqler").empty())
     {
-      ConsensusMapNormalizerAlgorithmMedian::normalizeMaps(
-        consensus_fraction, 
-        ConsensusMapNormalizerAlgorithmMedian::NM_SCALE, 
-        "", 
-        "");
+      ConsensusMapNormalizerAlgorithmMedian::normalizeMaps(consensus_fraction, ConsensusMapNormalizerAlgorithmMedian::NM_SCALE, "", "");
     }
 
     return EXECUTION_OK;
@@ -1420,7 +1312,7 @@ protected:
   {
     //-------------------------------------------------------------
     // Parameter handling
-    //-------------------------------------------------------------    
+    //-------------------------------------------------------------
 
     // Read tool parameters
     StringList in = getStringList_("in");
@@ -1430,11 +1322,17 @@ protected:
     StringList in_ids = getStringList_("ids");
     String design_file = getStringOption_("design");
     String in_db = getStringOption_("fasta");
+    StringList in_feat = getStringList_("in_feat");
 
     // Validate parameters
+    if (!in_feat.empty() && in_feat.size() != in.size())
+    {
+      OPENMS_LOG_ERROR << "Error: The number of input featureXML files (-in_feat) must exactly match the number of input mzML files (-in)." << std::endl;
+      return ILLEGAL_PARAMETERS;
+    }
     if (in.size() != in_ids.size())
     {
-      throw Exception::FileNotFound(__FILE__, __LINE__, 
+      throw Exception::FileNotFound(__FILE__, __LINE__,
         OPENMS_PRETTY_FUNCTION, "Number of spectra file (" + String(in.size()) + ") must match number of ID files (" + String(in_ids.size()) + ").");
     }
 
@@ -1442,12 +1340,12 @@ protected:
     {
       if (!out_msstats.empty())
       {
-        throw Exception::FileNotFound(__FILE__, __LINE__, 
+        throw Exception::FileNotFound(__FILE__, __LINE__,
           OPENMS_PRETTY_FUNCTION, "MSstats export for spectral counting data not supported. Please remove output file.");
       }
       if (!out_triqler.empty())
       {
-        throw Exception::FileNotFound(__FILE__, __LINE__, 
+        throw Exception::FileNotFound(__FILE__, __LINE__,
           OPENMS_PRETTY_FUNCTION, "Triqler export for spectral counting data not supported. Please remove output file.");
       }
     }
@@ -1473,7 +1371,7 @@ protected:
       {
         design_table.addLine(String(count) + "\t1\t" + s +"\t1\tSample" + String(count) + "\t" + String(count)+ "\t" + String(count));
         ++count;
-      }      
+      }
       design_ = ExperimentalDesignFile::load(design_table, "--no design file--", false);
     }
 
@@ -1508,14 +1406,14 @@ protected:
 
     if (design_.getNumberOfLabels() != 1)
     {
-      throw Exception::InvalidParameter(__FILE__, __LINE__, 
-        OPENMS_PRETTY_FUNCTION, "Experimental design is not label-free as it contains multiple labels.");          
+      throw Exception::InvalidParameter(__FILE__, __LINE__,
+        OPENMS_PRETTY_FUNCTION, "Experimental design is not label-free as it contains multiple labels.");
     }
     if (!design_.sameNrOfMSFilesPerFraction())
     {
       OPENMS_LOG_WARN << "WARNING: Different number of fractions for different samples provided. Support maybe limited in ProteomicsLFQ." << std::endl;
     }
-   
+
     std::map<unsigned int, std::vector<String> > frac2ms = design_.getFractionToMSFilesMapping();
 
     // experimental design file could contain URLs etc. that we want to overwrite with the actual input files
@@ -1525,7 +1423,7 @@ protected:
       { // for all ms files of current fraction number
         // if basename in experimental design matches to basename in input file
         // overwrite experimental design to point to existing file (and only if they were different)
-        if (auto it = std::find_if(in.begin(), in.end(), 
+        if (auto it = std::find_if(in.begin(), in.end(),
               [&s] (const String& in_filename) { return File::basename(in_filename) == File::basename(s); }); // basename matches?
                  it != in.end() && s != *it) // and differ?
         {
@@ -1534,8 +1432,8 @@ protected:
           s = *it; // overwrite filename in design with filename in input files
         }
       }
-      
-    } 
+
+    }
 
     for (auto & f : frac2ms)
     {
@@ -1553,7 +1451,7 @@ protected:
 
     // TODO maybe check if mzMLs in experimental design match to mzMLs passed as in parameter
     //  IF both are present
-    
+
 
     Param pep_param = getParam_().copy("Posterior Error Probability:", true);
     writeDebug_("Parameters passed to PEP algorithm", pep_param, 3);
@@ -1582,11 +1480,11 @@ protected:
       OPENMS_LOG_INFO << "Performing feature intensity-based quantification." << endl;
       double median_fwhm(0);
       for (auto const & ms_files : frac2ms) // for each fraction->ms file(s)
-      {      
+      {
         ConsensusMap consensus_fraction; // quantitative result for this fraction identifier
 
         ExitCodes e = quantifyFraction_(
-          ms_files, 
+          ms_files,
           mzfile2idfile,
           in_db,
           median_fwhm,
@@ -1595,7 +1493,7 @@ protected:
           variable_modifications);
 
         if (e != EXECUTION_OK) { return e; }
-        
+
         consensus.appendColumns(consensus_fraction);  // append consensus map calculated for this fraction number
       }  // end of scope of fraction related data
 
@@ -1619,7 +1517,7 @@ protected:
 
       Size run_index(0);
       for (auto const & ms_files : frac2ms) // for each fraction->ms file(s) e.g.: Fraction1->FileA,FileB,FileC
-      {      
+      {
         const Size& fraction = ms_files.first;
 
         // debug output
@@ -1631,9 +1529,9 @@ protected:
         StringList in_MS_run = ms_files.second;
         const auto& path_label_to_fractiongroup = design_.getPathLabelToFractionGroupMapping(true);
 
-        // for each MS file of current fraction (e.g., all MS files that measured the n-th fraction) 
+        // for each MS file of current fraction (e.g., all MS files that measured the n-th fraction)
         for (String const & mz_file : ms_files.second)
-        { 
+        {
           const Size fraction_group = path_label_to_fractiongroup.at({File::basename(mz_file), 1});
           // load and clean identification data associated with MS run
           vector<ProteinIdentification> protein_ids;
@@ -1652,8 +1550,8 @@ protected:
 
           // append the ProteinIdentification run (contains backlink to MS file) and the PeptideIdentifications (PSMs for this fraction and MS run) to the list of UnassignedPeptideIdentifications
           all_protein_ids.emplace_back(std::move(protein_ids[0]));
-          all_peptide_ids.insert(all_peptide_ids.end(), 
-            std::make_move_iterator(peptide_ids.begin()), 
+          all_peptide_ids.insert(all_peptide_ids.end(),
+            std::make_move_iterator(peptide_ids.begin()),
             std::make_move_iterator(peptide_ids.end()));
         }
 
@@ -1662,7 +1560,7 @@ protected:
         ////////////////////////////////////////////////////////////
         // for each MS file (as provided in the experimental design)
         const auto& path_label_to_sampleidx = design_.getPathLabelToSampleMapping(true);
-        for (String const & mz_file : ms_files.second) 
+        for (String const & mz_file : ms_files.second)
         {
           const Size curr_fraction_group = path_label_to_fractiongroup.at({File::basename(mz_file), 1});
           consensus.getColumnHeaders()[run_index].label = "label-free";
@@ -1685,7 +1583,7 @@ protected:
 
     // clean up references (assigned and unassigned)
     IDFilter::removeUnreferencedProteins(consensus, true);
-    
+
     // only keep best scoring ID for each consensus feature
     IDConflictResolverAlgorithm::resolve(consensus);
 
@@ -1741,16 +1639,16 @@ protected:
     if (inferred_proteins.getIndistinguishableProteins().empty())
     {
       throw Exception::MissingInformation(
-       __FILE__, 
-       __LINE__, 
-       OPENMS_PRETTY_FUNCTION, 
+       __FILE__,
+       __LINE__,
+       OPENMS_PRETTY_FUNCTION,
        "No information on indistinguishable protein groups found.");
     }
 
     quantifier.quantifyProteins(inferred_proteins);
     auto const & protein_quants = quantifier.getProteinResults();
     if (protein_quants.empty())
-    {        
+    {
      OPENMS_LOG_WARN << "Warning: No proteins were quantified." << endl;
     }
 
@@ -1767,7 +1665,7 @@ protected:
     // And probably make sure that peptides that correspond to filtered out proteins are not producing errors
     // e.g. by removing them with a Filter beforehand.
 
-    consensus.resolveUniqueIdConflicts(); // TODO: find out if this is still needed    
+    consensus.resolveUniqueIdConflicts(); // TODO: find out if this is still needed
 
     if (!getStringOption_("out_cxml").empty())
     {
@@ -1781,7 +1679,7 @@ protected:
     const bool report_unmapped(true); //TODO we should make a distinction from unassigned after conflict resolution and unassigned because unmappable
     const bool report_subfeatures(false);
     const bool report_unidentified_spectra(false);
-    const bool report_not_only_best_psm_per_spectrum(false); 
+    const bool report_not_only_best_psm_per_spectrum(false);
 
     MzTabFile().store(out,
                       consensus,
@@ -1795,7 +1693,7 @@ protected:
     if (!out_msstats.empty())
     {
       IDFilter::removeEmptyIdentifications(consensus); // MzTab stream exporter currently doesn't support IDs with empty hits.
-      
+
       MSstatsFile msstats;
       // TODO: add a helper method to quickly check if experimental design file contain the right columns
       //  (and put this at start of tool)
@@ -1804,13 +1702,13 @@ protected:
       consensus.getProteinIdentifications().resize(1);
 
       msstats.storeLFQ(
-        out_msstats, 
-        consensus, 
+        out_msstats,
+        consensus,
         design_,
-        StringList(), 
+        StringList(),
         false, //lfq
-        "MSstats_BioReplicate", 
-        "MSstats_Condition", 
+        "MSstats_BioReplicate",
+        "MSstats_Condition",
         "max");
     }
 
@@ -1827,13 +1725,13 @@ protected:
       switcher.switchToGeneralScoreType(consensus, IDScoreSwitcherAlgorithm::ScoreType::PEP, c);
 
       tf.storeLFQ(
-        out_triqler, 
-        consensus, 
+        out_triqler,
+        consensus,
         design_,
-        StringList(), 
+        StringList(),
         "MSstats_Condition" // TODO: choose something more generic like "Condition" for both MSstats and Triqler export
         );
-    }    
+    }
 
     return EXECUTION_OK;
   }


### PR DESCRIPTION
## Description

This PR introduces a new `-in_feat` parameter to the `ProteomicsLFQ` TOPP tool. 

**Summary of changes:**
* Registered the `-in_feat` parameter to accept a list of pre-computed `featureXML` files.
* Added validation to ensure the number of input feature files exactly matches the number of input `mzML` spectra files.
* Modified `quantifyFraction_` to include a conditional branch: if `-in_feat` is provided, the tool loads the external features directly into the `FeatureMap` (bypassing the internal `FeatureFinderIdentificationAlgorithm`) and aligns the `PrimaryMSRunPath` to the corresponding `mzML` file. If left empty, the tool proceeds with the default internal feature detection.

**Motivation:**
Previously, `ProteomicsLFQ` strictly relied on its internal feature detection step. This change allows users to leverage alternative or pre-computed feature detection methods while still utilizing the robust protein inference, quantification, alignment, and linking logic of the OpenMS pipeline.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading pre-computed features from input files as an alternative to feature detection.
  * Enhanced quantification workflow to better manage modification metadata throughout the analysis pipeline.

* **Improvements**
  * Improved parameter validation and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->