### PR TITLE
feat: implement zero-copy numpy structured array for MSSpectrum (AoS)

### DIFF
--- a/src/pyOpenMS/bindings/bind_spectrum.cpp
+++ b/src/pyOpenMS/bindings/bind_spectrum.cpp
@@ -162,6 +162,24 @@ Usage:
             return nb::make_tuple((int)result.first, (int)result.second);
         }, "Returns (index, drift_time_unit) for ion mobility data")
 
+        .def("get_peaks_view", [](OpenMS::MSSpectrum& self) {
+            // Cast to a raw byte pointer
+            uint8_t* data_ptr = reinterpret_cast<uint8_t*>(self.data());
+
+            // Shape is total number of peaks * size of one peak (16 bytes)
+            size_t shape[1] = { self.size() * sizeof(OpenMS::Peak1D) };
+
+            // Return as a 1D NumPy array of unsigned 8-bit integers (bytes)
+            return nb::ndarray<nb::numpy, uint8_t, nb::c_contig>(
+                data_ptr,
+                1,
+                shape,
+                nb::handle()
+            );
+        },
+        nb::rv_policy::reference_internal,
+        "Returns a raw byte view of the underlying Peak1D array (AoS layout).")
+
         .def("get_peaks", [](const OpenMS::MSSpectrum& self) {
             // Return (mz_array, intensity_array) as numpy arrays
             // mz as float64 (double), intensity as float32 (float) matching C++ storage

--- a/src/pyOpenMS/pyopenms/addons/msspectrum.py
+++ b/src/pyOpenMS/pyopenms/addons/msspectrum.py
@@ -280,3 +280,23 @@ def get_base_peak(self) -> Tuple[float, float]:
     mz, intensity = self.get_peaks()
     idx = np.argmax(intensity)
     return (mz[idx], intensity[idx])
+
+@addon("MSSpectrum")
+def get_peaks_struct(self):
+    """
+    Returns a zero-copy numpy structured array of the spectrum's peaks (AoS layout).
+    """
+    # Get the raw 1D byte array from C++
+    raw_view = self.get_peaks_view()
+
+    # Define the exact 16-byte memory layout of OpenMS::Peak1D
+    # mz (double) is at offset 0, intensity (float) is at offset 8
+    peak_dtype = np.dtype({
+        'names': ['mz', 'intensity'],
+        'formats': [np.float64, np.float32],
+        'offsets': [0, 8],
+        'itemsize': 16
+    })
+
+    # Cast the byte array directly into our structured array
+    return raw_view.view(peak_dtype)

--- a/src/pyOpenMS/tests/unittests/test_spectrum_zerocopy.py
+++ b/src/pyOpenMS/tests/unittests/test_spectrum_zerocopy.py
@@ -1,0 +1,40 @@
+import gc
+import numpy as np
+import pytest
+import pyopenms as poms
+
+def test_spectrum_zero_copy_modification():
+    spec = poms.MSSpectrum()
+    
+    # Populate with some dummy data
+    spec.push_back(poms.Peak1D(100.0, 50.0))
+    spec.push_back(poms.Peak1D(200.0, 75.0))
+    
+    # Get the zero-copy structured array view
+    peaks_array = spec.get_peaks_struct()
+    
+    # 1. Check if values match
+    assert np.isclose(peaks_array['mz'][0], 100.0)
+    assert np.isclose(peaks_array['intensity'][1], 75.0)
+    
+    # 2. PROVE ZERO-COPY: Modify the numpy array and check the C++ object
+    peaks_array['intensity'][0] = 999.0
+    assert np.isclose(spec[0].getIntensity(), 999.0), "Zero-copy modification failed!"
+
+def test_spectrum_memory_safety():
+    # Create the spectrum and get the view inside a local scope
+    def get_view():
+        spec = poms.MSSpectrum()
+        spec.push_back(poms.Peak1D(300.0, 10.0))
+        return spec.get_peaks_struct()
+    
+    # 'spec' goes out of scope here and would normally be destroyed, 
+    # but the numpy array view should keep the C++ memory alive.
+    peaks_array = get_view()
+    
+    # Force Python's garbage collection
+    gc.collect()
+    
+    # If nanobind's reference_internal policy failed, this next line will segfault (crash).
+    # If it passes, the memory was safely kept alive by the view.
+    assert np.isclose(peaks_array['mz'][0], 300.0), "Memory safety/lifetime sharing failed!"


### PR DESCRIPTION
Summary
This PR introduces get_peaks_struct(), a zero-copy NumPy structured array view for MSSpectrum peaks. This addresses the performance bottleneck of existing peak extraction methods by allowing direct, high-speed access to the underlying C++ memory without data duplication.

Technical Implementation
The implementation maps the C++ memory layout of OpenMS::Peak1D directly to a Python structured array (Array of Structures - AoS):

C++ Binding (bind_spectrum.cpp):

Exposes the std::vector<Peak1D> data as a raw 1D uint8_t (byte) nanobind::ndarray.
Employs nb::rv_policy::reference_internal to ensure the MSSpectrum object's lifetime is tied to the NumPy view, preventing memory corruption if the C++ object is deleted while Python still holds the view.

Python Addon (msspectrum.py):

Defines a structured np.dtype that mirrors the Peak1D memory layout.
Memory Alignment: Specifically handles the 16-byte alignment of Peak1D on modern architectures (8 bytes for double mz, 4 bytes for float intensity, and 4 bytes of padding).

Key Advantages
Performance: Drastically reduces latency for data-intensive tasks like plotting and signal processing.
Memory Efficiency: Zero data copying; uses the same memory buffer as the C++ kernel.

In-Place Modification: Modifications made to the NumPy array are instantly reflected in the C++ object, enabling efficient data cleaning and normalization.

Verification Results
Verified on macOS (AppleClang 17) with the following success:

Plaintext
Original C++ Peak 0: mz=123.45, intensity=67.89
Modifying NumPy array...
New C++ Peak 0:      mz=123.45, intensity=999.9
 RESULT: ZERO-COPY SUCCESS!

Testing
A new unit test test_spectrum_zerocopy.py has been added to cover:
Data Integrity: Validating that m/z and intensity values map correctly.
Zero-Copy Verification: Proving that NumPy updates affect the C++ state.