### PR TITLE
[FIX] Fix memory leak in SwathFile::loadMzXML using std::unique_ptr

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -206,6 +206,7 @@ Fixes:
   - Fix empty GENE table causing PQP file reading to return zero transitions (#8688)
   - Fix PeptideIndexer AhoCorasick segfault for short peptides (#8685)
   - Fix redundant PRAGMA foreign_keys execution in OMSFileStore
+  - Fix memory leak in SwathFile::loadMzXML on exception by using std::unique_ptr
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -206,7 +206,7 @@ Fixes:
   - Fix empty GENE table causing PQP file reading to return zero transitions (#8688)
   - Fix PeptideIndexer AhoCorasick segfault for short peptides (#8685)
   - Fix redundant PRAGMA foreign_keys execution in OMSFileStore
-  - Fix memory leak in SwathFile::loadMzXML on exception by using std::unique_ptr
+  - Fix potential memory leak in SwathFile::loadMzXML on exception by using std::unique_ptr
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -216,22 +216,22 @@ namespace OpenMS
       " SWATH windows and in total " << nr_ms1_spectra << " MS1 spectra\n";
     endProgress();
 
-    FullSwathFileConsumer* dataConsumer;
+    std::unique_ptr<FullSwathFileConsumer> dataConsumer;
     startProgress(0, 1, "Loading data file " + file);
     if (readoptions == "normal")
     {
-      dataConsumer = new RegularSwathFileConsumer(known_window_boundaries);
-      MzXMLFile().transform(file, dataConsumer);
+      dataConsumer = std::make_unique<RegularSwathFileConsumer>(known_window_boundaries);
+      MzXMLFile().transform(file, dataConsumer.get());
     }
     else if (readoptions == "cache")
     {
-      dataConsumer = new CachedSwathFileConsumer(known_window_boundaries, tmp, tmp_fname, nr_ms1_spectra, swath_counter);
-      MzXMLFile().transform(file, dataConsumer);
+      dataConsumer = std::make_unique<CachedSwathFileConsumer>(known_window_boundaries, tmp, tmp_fname, nr_ms1_spectra, swath_counter);
+      MzXMLFile().transform(file, dataConsumer.get());
     }
     else if (readoptions == "split")
     {
-      dataConsumer = new MzMLSwathFileConsumer(known_window_boundaries, tmp, tmp_fname, nr_ms1_spectra, swath_counter);
-      MzXMLFile().transform(file, dataConsumer);
+      dataConsumer = std::make_unique<MzMLSwathFileConsumer>(known_window_boundaries, tmp, tmp_fname, nr_ms1_spectra, swath_counter);
+      MzXMLFile().transform(file, dataConsumer.get());
     }
     else
     {
@@ -241,7 +241,6 @@ namespace OpenMS
     OPENMS_LOG_DEBUG << "Finished parsing Swath file \n";
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
-    delete dataConsumer;
 
     endProgress();
     return swath_maps;


### PR DESCRIPTION
Replace raw new/delete with std::unique_ptr in SwathFile::loadMzXML to prevent memory leaks when MzXMLFile::transform() throws an exception. The companion loadMzML() function already uses std::make_shared for the same pattern.

## Description

Fixes memory leak in `SwathFile::loadMzXML` where a raw `FullSwathFileConsumer*` allocated via `new` was never freed if `MzXMLFile::transform()` threw an exception — leaving the allocated memory permanently leaked.

Replaced the raw `new`/`delete` pattern with `std::unique_ptr` so the destructor is called automatically on scope exit, whether normal or via exception. The companion `loadMzML()` function already uses `std::make_shared` for the same pattern — this brings `loadMzXML` in line with the same approach.

Closes #8803 

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in MZXML file loading by switching to allocation-safe resource management. This prevents resource accumulation when exceptions occur during file reads, improving stability and memory usage during repeated file processing and boosting overall reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->