### PR TITLE
Use unordered_map in PrecursorPurity and PeptideProteinResolution

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideProteinResolution.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideProteinResolution.h
@@ -15,6 +15,7 @@
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <vector>
 #include <set>
+#include <unordered_map>
 
 namespace OpenMS
 {
@@ -73,7 +74,7 @@ namespace OpenMS
     /** represents the middle layer of an implicit tripartite graph:
     consists of single protein accessions and their mapping to the (indist.)
     group's indices */
-    std::map<String, Size> prot_acc_to_indist_prot_grp_;
+    std::unordered_map<String, Size> prot_acc_to_indist_prot_grp_;
     
     /// log debug information?
     bool statistics_;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PrecursorPurity.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PrecursorPurity.h
@@ -11,6 +11,7 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <unordered_map>
 #include <vector>
 
 
@@ -54,7 +55,7 @@ namespace OpenMS
      * @param[in] precursor_mass_tolerance_unit_ppm The unit of the precursor tolerance
      * @param[in] ignore_missing_precursor_spectra Allow MS2 spectra without a MS1 precursor spectrum (PurityScores for these spectra will be 0).
     */
-    static std::map<String, PurityScores> computePrecursorPurities(const PeakMap& spectra, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, bool ignore_missing_precursor_spectra = false);
+    static std::unordered_map<String, PurityScores> computePrecursorPurities(const PeakMap& spectra, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, bool ignore_missing_precursor_spectra = false);
 
     /** @brief compute precursor purity metrics for one MS2 precursor
 

--- a/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
+++ b/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
@@ -345,10 +345,10 @@ namespace OpenMS
     return score;
   }
 
-  std::map<String, PrecursorPurity::PurityScores> PrecursorPurity::computePrecursorPurities(const PeakMap& spectra, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, bool ignore_missing_precursor_spectra)
+  std::unordered_map<String, PrecursorPurity::PurityScores> PrecursorPurity::computePrecursorPurities(const PeakMap& spectra, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, bool ignore_missing_precursor_spectra)
   {
-    std::map<String, PrecursorPurity::PurityScores> purityscores;
-    std::pair<std::map<String, PrecursorPurity::PurityScores>::iterator, bool> insert_return_value;
+    std::unordered_map<String, PrecursorPurity::PurityScores> purityscores;
+    std::pair<std::unordered_map<String, PrecursorPurity::PurityScores>::iterator, bool> insert_return_value;
     int spectra_size = static_cast<int>(spectra.size());
 
     if (spectra[0].getMSLevel() != 1 && !ignore_missing_precursor_spectra)
@@ -365,12 +365,12 @@ namespace OpenMS
         if (parent_spectrum_it == spectra.end() && !ignore_missing_precursor_spectra)
         {
           OPENMS_LOG_WARN << "Warning: Input data not suitable for Precursor Purity computation. An MS2 spectrum without parent spectrum detected. Precursor Purity info will not be calculated!\n";
-          return std::map<String, PrecursorPurity::PurityScores>();
+          return std::unordered_map<String, PrecursorPurity::PurityScores>();
         }
         if (spectra[i].getNativeID().empty())
         {
           OPENMS_LOG_WARN << "Warning: Input data not suitable for Precursor Purity computation. Spectrum without an ID. Precursor Purity info will not be calculated!\n";
-          return std::map<String, PrecursorPurity::PurityScores>();
+          return std::unordered_map<String, PrecursorPurity::PurityScores>();
         }
 
         // check for uniqueness of IDs by inserting initialized (0-value) scores into map
@@ -378,7 +378,7 @@ namespace OpenMS
         if (!insert_return_value.second)
         {
           OPENMS_LOG_WARN << "Warning: Input data not suitable for Precursor Purity computation. Duplicate Spectrum IDs. Precursor Purity info will not be calculated!\n";
-          return std::map<String, PrecursorPurity::PurityScores>();
+          return std::unordered_map<String, PrecursorPurity::PurityScores>();
         }
       }
     }

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -220,7 +220,7 @@ using namespace OpenMS;
     unprocessed_spectra.clear(true);
 
     // Precursor Purity precalculation
-    map<String, PrecursorPurity::PurityScores> precursor_purities = PrecursorPurity::computePrecursorPurities(picked_spectra, precursor_mass_tolerance_, precursor_mass_tolerance_unit_ppm_);
+    unordered_map<String, PrecursorPurity::PurityScores> precursor_purities = PrecursorPurity::computePrecursorPurities(picked_spectra, precursor_mass_tolerance_, precursor_mass_tolerance_unit_ppm_);
 
     // preprocess spectra (filter out 0 values, sort by position)
     progresslogger.startProgress(0, 1, "Filtering spectra...");

--- a/src/tests/class_tests/openms/source/PrecursorPurity_test.cpp
+++ b/src/tests/class_tests/openms/source/PrecursorPurity_test.cpp
@@ -56,7 +56,7 @@ END_SECTION
 
 START_SECTION(static computePrecursorPurities(const PeakMap& spectra, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm))
 
-  map<String, PrecursorPurity::PurityScores> purityscores = PrecursorPurity::computePrecursorPurities(spectra, 0.1, false);
+  unordered_map<String, PrecursorPurity::PurityScores> purityscores = PrecursorPurity::computePrecursorPurities(spectra, 0.1, false);
 
   TEST_EQUAL(purityscores.size(), 5)
 

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -1067,9 +1067,9 @@ protected:
     return (plss_Morph < MIN_SHIFTED_IONS && plss_im_MIC < 0.03);
   }
 
-  map<String, PrecursorPurity::PurityScores> calculatePrecursorPurities_(const String& in_mzml, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm) const
+  unordered_map<String, PrecursorPurity::PurityScores> calculatePrecursorPurities_(const String& in_mzml, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm) const
   {
-    map<String, PrecursorPurity::PurityScores> purities;
+    unordered_map<String, PrecursorPurity::PurityScores> purities;
     PeakMap tmp_spectra;
     // Important: load both MS1 and MS2 for precursor purity annotation
     MzMLFile().load(in_mzml, tmp_spectra);
@@ -3068,7 +3068,7 @@ static void scoreXLIons_(
     bool annotate_charge,
     double window_size,
     size_t peakcount,
-    const std::map<String, PrecursorPurity::PurityScores>& purities)
+    const std::unordered_map<String, PrecursorPurity::PurityScores>& purities)
   {
     // filter MS2 map
     // remove 0 intensities
@@ -3507,7 +3507,7 @@ static void scoreXLIons_(
     const Size max_variable_mods_per_peptide,
     const Size scan_index, 
     const MSSpectrum& spec,
-    const map<String, PrecursorPurity::PurityScores>& purities,
+    const unordered_map<String, PrecursorPurity::PurityScores>& purities,
     const vector<size_t>& nr_candidates,
     const vector<size_t>& matched_peaks
     /*,
@@ -3734,7 +3734,7 @@ static void scoreXLIons_(
     const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
     const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
     Size max_variable_mods_per_peptide,
-    const map<String, PrecursorPurity::PurityScores>& purities,
+    const unordered_map<String, PrecursorPurity::PurityScores>& purities,
     const vector<size_t>& nr_candidates,
     const vector<size_t>& matched_peaks
     /*,
@@ -4609,7 +4609,7 @@ static void scoreXLIons_(
     }
   }
 
-  void filterPeakInterference_(PeakMap& spectra, const map<String, PrecursorPurity::PurityScores>& purities, double fragment_mass_tolerance = 20.0, bool fragment_mass_tolerance_unit_ppm = true)
+  void filterPeakInterference_(PeakMap& spectra, const unordered_map<String, PrecursorPurity::PurityScores>& purities, double fragment_mass_tolerance = 20.0, bool fragment_mass_tolerance_unit_ppm = true)
   {
     double filtered_peaks_count{0};
     size_t filtered_spectra{0};
@@ -5173,7 +5173,7 @@ static void scoreXLIons_(
     MzMLFile f;
     f.setLogType(log_type_);
 
-    map<String, PrecursorPurity::PurityScores> purities = calculatePrecursorPurities_(in_mzml, precursor_mass_tolerance, precursor_mass_tolerance_unit_ppm);
+    unordered_map<String, PrecursorPurity::PurityScores> purities = calculatePrecursorPurities_(in_mzml, precursor_mass_tolerance, precursor_mass_tolerance_unit_ppm);
 
     // define percolator feature set
     StringList data_dependent_features; // percolator features that only exist e.g., if MS1 spectra were present


### PR DESCRIPTION
## Description

Related to #6295 
Replaces map with Unordered_map in `PrecursorPurity` and `PeptideProteinResolution` where the order of the elements does not matter. the maps i changed were only being used for lookups and hence can be changed without a problem. I benchmarked many other maps in the ID data algorithm folder but did not find any more maps that were giving performance boost without breaking things

## Benchmark Results

**PrecursorPurity — downstream lookups** (5× `operator[]` + `find` per MS2, simulating OpenPepXL/OpenNuXL caller patterns):

| Scale | Before | After | Improvement |
|-------|--------|-------|-------------|
| 20K spectra | 8.4 ms | 6.2 ms | ~25% |
| 50K spectra | 28.0 ms | 19.4 ms | ~31% |

**PeptideProteinResolution — `buildGraph()`**:

| Scale | Before | After | Improvement |
|-------|--------|-------|-------------|
| 10K proteins | 46.0 ms | 38.9 ms | ~15% |
| 50K proteins | 347.8 ms | 315.3 ms | ~9% |

No memory regression in either case. All existing tests pass.

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structures used in precursor purity calculations to improve lookup performance and efficiency during mass spectrometry analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->