### PR TITLE
Remove leftover traces of doc_internal target (#2256)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -66,6 +66,7 @@ the authors tag in the respective file header.
  - Katharina Albers
  - Khue Nguyen
  - Knut Reinert
+ - Krrish Verma
  - Kyowon Jeong
  - Lars Nilse
  - Lenny Kovac

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ General:
   - Ubuntu CI runners updated to 24.04
   - macOS code signing and notarization integrated directly into CI (#8486, #8494, #8527)
   - Parquet support enabled across all platforms (#8370, #8422)
+  - Removed leftover traces of removed doc_internal target (#2256)
 
 Dependencies:
   - PyOpenMS now depends on Autowrap >= 0.26.0 (#8580, #8616)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -251,7 +251,7 @@ if(ENABLE_DOCS)
                       VERBATIM)
 
     #------------------------------------------------------------------------------
-    # doc_internal target
+    # doc_xml target
     add_custom_target(doc_xml
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/doc/doxygen/install/install-win.doxygen
+++ b/doc/doxygen/install/install-win.doxygen
@@ -154,7 +154,7 @@
 
   This section is optional. If you can live with the online documentation, you do not need to build your own.
 
-  In order to build the class documentation (<tt>doc</tt> & <tt>doc_internal</tt> targets), TOPP tutorials (<tt>doc_tutorials</tt> target) and more,
+  In order to build the class documentation (<tt>doc</tt> target), TOPP tutorials (<tt>doc_tutorials</tt> target) and more,
   you will need to install three programs:
 
   <ol>

--- a/doc/doxygen/public/ExternalCode.doxygen
+++ b/doc/doxygen/public/ExternalCode.doxygen
@@ -48,8 +48,8 @@ cmake -G "<generator>" .
 
 @section development_external_ship Shipping your external code to a new machine
 
-  If you've modified %OpenMS itself and not used an external project you can just use our installer scripts,
-	to build your own %OpenMS installer for your platform (see our internal FAQ which is built using "make doc_internal") and ship that to a client machine.
+  If you've modified %OpenMS itself and not used an external project you can just use our installer scripts
+	to build your own %OpenMS installer for your platform and ship that to a client machine.
 	
 	If you've used an external project and have a new executable (+ an optional new library), you can use the 
 	installer approach as well, and manually copy the new executable to the TOPP binary directory (e.g. on

--- a/tools/checker.php
+++ b/tools/checker.php
@@ -16,7 +16,6 @@ function printUsage() {
   print "Usage: checker.php <OpenMS src path> <OpenMS build path> [-u \"user name\"] [-t test] [options]\n";
   print "\n";
   print "This script works only if an OpenMS copy is used, where\n";
-  print "- the internal documentation was built (doc_internal),\n";
   print "- the XML documentation was built (doc_xml),\n";
   print "- all tests were executed.\n";
   print "\n";
@@ -261,7 +260,7 @@ if (in_array("doxygen_errors", $tests))
   if (!file_exists("$bin_path/doc/doxygen/doxygen-error.log"))
   {
     print "Error: For the 'doxygen_errors' test, the file '$bin_path/doc/doxygen/doxygen-error.log' is needed!\n";
-    print "       Please execute 'make doc_internal' first!'.\n";
+    print "       Please execute 'make doc' first!.\n";
     $abort = true;
   }
 }


### PR DESCRIPTION
## Description

Closes #2256

Removes all remaining traces of the removed `doc_internal` build target from the codebase.

### Changes

| File | Change |
|------|--------|
| `doc/CMakeLists.txt` | Fixed misleading comment: `# doc_internal target` → `# doc_xml target` (the actual target below is `doc_xml`) |
| `doc/doxygen/install/install-win.doxygen` | Removed `doc_internal` from the list of documentation targets |
| `doc/doxygen/public/ExternalCode.doxygen` | Removed reference to `make doc_internal` |
| `tools/checker.php` | Removed `doc_internal` from usage text, updated error message to reference `make doc` instead |

Confirmed zero remaining occurrences via `git grep doc_internal`.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed references to the internal documentation target and simplified class-doc and installer guidance; clarified Doxygen and usage messages to direct users to the standard doc build.

* **Chores**
  * Added a new contributor to the project authors list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->