### PR TITLE
Fix typos and duplicated words in documentation comments

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/StablePairFinder.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/StablePairFinder.h
@@ -137,7 +137,7 @@ protected:
     bool use_IDs_;
 
     /**
-      @brief Returns the highest scoring peptide hit in the the given peptide identification.
+      @brief Returns the highest scoring peptide hit in the given peptide identification.
 
       @param[in] peptideIdentification The peptideIdentification to scan.
     */

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
@@ -29,7 +29,7 @@ namespace OpenMS
 
     - two-point-linear: Uses a line through the first and last point to extrapolate 
     - four-point-linear: Uses a line through the first and second point to
-                         extrapolate in front and and a line through the last
+                         extrapolate in front and a line through the last
                          and second-to-last point in the end. If the data is
                          non-linear, this may yield better approximations for
                          extrapolation.

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -70,7 +70,7 @@ public:
      * @param[in] mz_extraction_window Extracts a window of this size in m/z
      * dimension (e.g. a window of 50 ppm means an extraction of 25 ppm on
      * either side)
-     * @param[in] ppm Whether mz windows in in ppm
+     * @param[in] ppm Whether mz windows in ppm
      * @param[in] filter Which filter to use (bartlett or tophat)
      *
      *
@@ -97,7 +97,7 @@ public:
      * @param[in] mz_extraction_window Extracts a window of this size in m/z
      * dimension (e.g. a window of 50 ppm means an extraction of 25 ppm on
      * either side)
-     * @param[in] ppm Whether mz windows in in ppm
+     * @param[in] ppm Whether mz windows in ppm
      * @param[in] im_extraction_window Extracts a window of this size in ion mobility
      * @param[in] filter Which filter to use (bartlett or tophat)
      *

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureSelector.h
@@ -102,7 +102,7 @@ public:
       bool   locality_weight         = false; ///< Weight compounds with a nearer Tr greater than compounds with a further Tr
       bool   select_transition_group = true; ///< Use components groups instead of components for retention time optimization
       Int    segment_window_length   = 8; ///< Number of components or component groups to include in the network
-      Int    segment_step_length     = 4; ///< Number of of components or component groups to shift the `segment_window_length` at each loop
+      Int    segment_step_length     = 4; ///< Number of components or component groups to shift the `segment_window_length` at each loop
       MRMFeatureSelector::VariableType variable_type = MRMFeatureSelector::VariableType::CONTINUOUS; ///< INTEGER or CONTINUOUS
       double optimal_threshold       = 0.5; ///< Value above which the transition group or transition is considered optimal (0 < x < 1)
       std::map<String, MRMFeatureSelector::LambdaScore> score_weights; ///< Weights for the scores

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
@@ -201,7 +201,7 @@ public:
       @param[in] transformation_model_params parameters used by the transformation_model
       @param[out] optimized_params optimized parameters
 
-      @returns true if a a fit was found, false otherwise
+      @returns true if a fit was found, false otherwise
 
       @exception Exception::UnableToFit
     */

--- a/src/openms/include/OpenMS/DATASTRUCTURES/ParamValue.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ParamValue.h
@@ -99,28 +99,28 @@ public:
     /**
       @brief conversion operator to string
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator std::string() const;
 
     /**
       @brief conversion operator to string vector
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator std::vector<std::string>() const;
 
     /**
       @brief conversion operator to integer vector
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator std::vector<int>() const;
 
     /**
       @brief conversion operator to double vector
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator std::vector<double>() const;
 
@@ -129,7 +129,7 @@ public:
 
       Note: The implementation uses typedef double (as opposed to float, double, long double.)
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator long double() const;
 
@@ -138,7 +138,7 @@ public:
 
       Note: The implementation uses typedef double (as opposed to float, double, long double.)
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator double() const;
 
@@ -147,7 +147,7 @@ public:
 
       Note: The implementation uses typedef double (as opposed to float, double, long double.)
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator float() const;
 
@@ -156,7 +156,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator short int() const;
 
@@ -165,7 +165,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator unsigned short int() const;
 
@@ -174,7 +174,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
 
     operator int() const;
@@ -184,7 +184,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator unsigned int() const;
 
@@ -193,7 +193,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator long int() const;
 
@@ -202,7 +202,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator unsigned long int() const;
 
@@ -211,7 +211,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator long long() const;
 
@@ -220,7 +220,7 @@ public:
 
       Note: The implementation uses typedef ptrdiff_t.
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     operator unsigned long long() const;
 
@@ -252,21 +252,21 @@ public:
     /**
       @brief Explicitly convert ParamValue to string vector
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     std::vector<std::string> toStringVector() const;
 
     /**
       @brief Explicitly convert ParamValue to IntList
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     std::vector<int> toIntVector() const;
 
     /**
       @brief Explicitly convert ParamValue to DoubleList
 
-      @exception Exception::ConversionError is thrown if a cast from the the wrong type is requested
+      @exception Exception::ConversionError is thrown if a cast from the wrong type is requested
     */
     std::vector<double> toDoubleVector() const;
     //@}


### PR DESCRIPTION
## Description

Fixed duplicated words (e.g. "the the", "and and", "of of") in doxygen comments across several headers. 

Files touched:
- TransformationModelInterpolated.h
- StablePairFinder.h
- AbsoluteQuantitation.h
- ChromatogramExtractor.h
- MRMFeatureSelector.h
- ParamValue.h

Pure documentation cleanup; no logic changes.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed documentation comments throughout the codebase by removing duplicate words and correcting phrasing for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->