### PR TITLE
[CI] Fix anaconda-client upgrade in Bioconda deploy

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Conda packages
         run: |
-          conda install "anaconda-client>=1.14" -y  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
+          pip install "anaconda-client>=1.14"  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
           ls -l $GITHUB_WORKSPACE/output
           if ls $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2 1>/dev/null 2>&1; then
             anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2


### PR DESCRIPTION
## Summary
Follow-up to #8814 — `conda install "anaconda-client>=1.14"` fails due to solver conflicts with bioconda-utils' dependency tree on Python 3.12. Switch to `pip install` which bypasses the conda solver.

The underlying issue: bioconda-utils pulls anaconda-client 1.13.x which imports the removed `pkg_resources`. Version 1.14+ has dropped that dependency.

## Test plan
- [ ] After merge, trigger nightly update and verify Bioconda deploy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized deployment workflow package installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->