### PR TITLE
[CI] Fix --pkg_dir flag in Bioconda deploy

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -55,13 +55,13 @@ jobs:
         run: |
           cd bioconda-recipes
           bioconda-utils lint --packages pyopenms openms-meta
-          bioconda-utils build --docker --pkg_dir $GITHUB_WORKSPACE/output --packages openms-meta || true
+          bioconda-utils build --docker --pkg-dir $GITHUB_WORKSPACE/output --packages openms-meta || true
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Build pyopenms package
         run: |
           cd bioconda-recipes
-          bioconda-utils build --docker --mulled-test --pkg_dir $GITHUB_WORKSPACE/output --packages pyopenms || true
+          bioconda-utils build --docker --mulled-test --pkg-dir $GITHUB_WORKSPACE/output --packages pyopenms || true
           python -m conda_index $GITHUB_WORKSPACE/output
 
       - name: Upload Conda packages

--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Conda packages
         run: |
-          conda install "anaconda-client>=1.14" -y  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
+          pip install "anaconda-client>=1.14"  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
           ls -l $GITHUB_WORKSPACE/output
           if ls $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2 1>/dev/null 2>&1; then
             anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2


### PR DESCRIPTION
## Summary
bioconda-utils 4.0.0 (installed with Python 3.12) no longer accepts `--pkg_dir` with underscores. The `argh` library now requires the standard hyphenated form `--pkg-dir`. This caused both build commands to silently fail (masked by `|| true`), producing no packages.

## Test plan
- [ ] After merge, trigger nightly update and verify packages are built

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved conda package deployment workflow with enhanced error handling to detect and report missing packages during upload.
  * Updated package installation process in deployment pipeline for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->