### PR TITLE
[CI] Support .conda format in Bioconda deploy upload

### DIFF
--- a/.github/workflows/bioconda_deploy.yaml
+++ b/.github/workflows/bioconda_deploy.yaml
@@ -68,8 +68,10 @@ jobs:
         run: |
           pip install "anaconda-client>=1.14"  # bioconda-utils pulls 1.13.x which still uses removed pkg_resources
           ls -l $GITHUB_WORKSPACE/output
-          if ls $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2 1>/dev/null 2>&1; then
-            anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force $GITHUB_WORKSPACE/output/linux-64/*.tar.bz2
+          shopt -s nullglob
+          pkgs=($GITHUB_WORKSPACE/output/linux-64/*.tar.bz2 $GITHUB_WORKSPACE/output/linux-64/*.conda)
+          if [ ${#pkgs[@]} -gt 0 ]; then
+            anaconda -v -t ${{ secrets.ANACONDA_TOKEN }} upload -u openms --no-progress --force "${pkgs[@]}"
           else
             echo "No packages found to upload!"
             exit 1


### PR DESCRIPTION
## Summary
Newer conda-build produces `.conda` packages instead of `.tar.bz2`. The upload step only looked for `*.tar.bz2`, so built packages were never uploaded. Update the glob to handle both formats.

## Test plan
- [ ] After merge, verify nightly Bioconda deploy uploads packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in deployment process to prevent false positives and ensure accurate error reporting when packages cannot be located.

* **Chores**
  * Enhanced deployment workflow to support multiple package formats with more robust detection and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->