### PR TITLE
Add zero-copy NumPy view for MSChromatogram.get_peaks_struct()

### DIFF
--- a/src/pyOpenMS/bindings/bind_chromatogram.cpp
+++ b/src/pyOpenMS/bindings/bind_chromatogram.cpp
@@ -139,7 +139,43 @@ The chromatogram is sorted with respect to position. Meta data arrays will be so
             auto int_arr = nb::ndarray<nb::numpy, double, nb::ndim<1>>(int_data, {n}, owner);
             return nb::make_tuple(rt_arr, int_arr);
         }, "Returns a tuple of (rt_array, intensity_array) as numpy arrays")
+    
+    
+    
+        .def("get_peaks_struct",
+            [](OpenMS::MSChromatogram& self)
+                -> nb::ndarray<nb::numpy, double, nb::ndim<2>>
+            {
+                const size_t n = self.size();
 
+                if (n == 0)
+                {
+                    size_t shape[2] = { 0, 2 };
+
+                        return nb::ndarray<nb::numpy, double, nb::ndim<2>>(
+                            nullptr,
+                            2,
+                            shape,
+                            nb::handle()
+                        );
+                }
+
+                OpenMS::ChromatogramPeak* first = &self[0];
+                double* raw_ptr = reinterpret_cast<double*>(first);
+
+                size_t shape[2] = { n, 2 };
+
+                return nb::ndarray<nb::numpy, double, nb::ndim<2>>(
+                    raw_ptr,
+                    2,
+                    shape,
+                    nb::find(self)
+                );
+            },
+            nb::rv_policy::reference_internal,
+            "Returns zero-copy (n,2) float64 array: [RT, intensity]"
+        )
+    
         .def("set_peaks", [](OpenMS::MSChromatogram& self, nb::object rt_obj, nb::object int_obj) {
             auto rt_arr = as_numpy_array<double>(rt_obj);
             auto int_arr = as_numpy_array<double>(int_obj);

--- a/src/pyOpenMS/tests/unittests/test_mschromatogram_struct_view.py
+++ b/src/pyOpenMS/tests/unittests/test_mschromatogram_struct_view.py
@@ -1,0 +1,60 @@
+import gc
+import numpy as np
+import pytest
+import pyopenms as poms
+
+
+def test_chromatogram_zero_copy_modification():
+    chrom = poms.MSChromatogram()
+
+    chrom.set_peaks([[1.0, 2.0], [10.0, 20.0]])
+
+    arr = chrom.get_peaks_struct()
+
+    # Value correctness
+    assert np.isclose(arr[0, 0], 1.0)   # RT
+    assert np.isclose(arr[1, 1], 20.0)  # intensity
+
+    # PROVE ZERO-COPY
+    arr[0, 1] = 999.0
+
+    rt_copy, int_copy = chrom.get_peaks()
+    assert np.isclose(int_copy[0], 999.0), "Zero-copy modification failed!"
+
+
+def test_chromatogram_memory_safety():
+    def get_view():
+        chrom = poms.MSChromatogram()
+        chrom.set_peaks([[5.0], [42.0]])
+        return chrom.get_peaks_struct()
+
+    arr = get_view()
+
+    # Force garbage collection
+    gc.collect()
+
+    # If lifetime policy is broken, this will segfault
+    assert np.isclose(arr[0, 1], 42.0), "Memory safety/lifetime sharing failed!"
+
+
+def test_empty_chromatogram():
+    chrom = poms.MSChromatogram()
+    arr = chrom.get_peaks_struct()
+
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (0, 2)
+    assert arr.dtype == np.float64
+
+
+def test_consistency_with_get_peaks():
+    rts = [0.5, 1.5, 2.5]
+    ints = [100.0, 200.0, 300.0]
+
+    chrom = poms.MSChromatogram()
+    chrom.set_peaks([rts, ints])
+
+    arr = chrom.get_peaks_struct()
+    rt_copy, int_copy = chrom.get_peaks()
+
+    np.testing.assert_array_equal(arr[:, 0], rt_copy)
+    np.testing.assert_array_equal(arr[:, 1], int_copy)


### PR DESCRIPTION
**Summary**

This PR adds a zero-copy NumPy accessor for chromatogram peak data:

MSChromatogram.get_peaks_struct()

Instead of allocating and copying RT and intensity arrays (as done by get_peaks()), this method exposes a direct NumPy view over the underlying std::vector<ChromatogramPeak> memory using nanobind.

This eliminates the O(n) copy cost when accessing large chromatograms from Python.

**Motivation**

For large chromatograms (e.g. SWATH / DIA data), copying peak data into separate NumPy arrays introduces measurable overhead.

The new method:
	•	Avoids memory allocation
	•	Avoids copying
	•	Returns immediately with a view
	•	Preserves lifetime safety using reference_internal

The existing get_peaks() remains unchanged for backward compatibility.

Benchmark performed on macOS (Apple Silicon), Python 3.14, Release build.
for n in [100, 10_000, 100_000, 1_000_000]:
    benchmark(n)
    
Peaks: 100
get_peaks (copy): 0.000002 s
get_peaks_struct (zero-copy): 0.000001 s

Peaks: 10,000
get_peaks (copy): 0.000009 s
get_peaks_struct (zero-copy): 0.000001 s

Peaks: 100,000
get_peaks (copy): 0.000117 s
get_peaks_struct (zero-copy): 0.000001 s

Peaks: 1,000,000
get_peaks (copy): 0.002011 s
get_peaks_struct (zero-copy): 0.000001 s

**Memory**

For 1M peaks:
Copy arrays memory:      16,000,000 bytes
Zero-copy array memory:  16,000,000 bytes

**Safety**

Uses nb::rv_policy::reference_internal
Lifetime safety verified via dedicated test
No segfaults under forced GC
Full pyopenms_tests suite passes

100% tests passed, 0 tests failed

**Backward Compatibility**

No changes to existing API
get_peaks() remains unchanged
This is an additive improvement

**Notes**

This implementation mirrors the zero-copy approach already used for peak containers and keeps the Python binding minimal while preserving performance.
