### PR TITLE
Refactor FileHandler: prefer empty() over size() checks

### DIFF
--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -606,7 +606,7 @@ namespace OpenMS
     // determine file type
     FileTypes::Type type = getType(filename);
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {    
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -642,7 +642,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -679,7 +679,7 @@ namespace OpenMS
     // determine file type
     FileTypes::Type type = getType(filename);
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -821,7 +821,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -927,7 +927,7 @@ namespace OpenMS
   {
     // determine file type
     FileTypes::Type type = getType(filename);
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -989,7 +989,7 @@ namespace OpenMS
     }
 
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1055,7 +1055,7 @@ namespace OpenMS
     //determine file type
     FileTypes::Type type = getType(filename);
 
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1104,7 +1104,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1148,7 +1148,7 @@ namespace OpenMS
     
     //determine file type
     FileTypes::Type type = getType(filename);
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1228,7 +1228,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1283,7 +1283,7 @@ namespace OpenMS
   {
     //determine file type
     FileTypes::Type type = getType(filename);
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1316,7 +1316,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1344,7 +1344,7 @@ namespace OpenMS
   {
     //determine file type
     FileTypes::Type type = getType(filename);
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1374,7 +1374,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {
@@ -1418,7 +1418,7 @@ namespace OpenMS
       type = allowed_types[0];
     }
     // If we have a restricted set of file types check that we match them
-    if (allowed_types.size() != 0)
+    if (!allowed_types.empty())
     {
       if (!FileTypeList(allowed_types).contains(type))
       {


### PR DESCRIPTION
## Description

Replaces checks like `size() == 0`, `size() != 0`, and `size() > 0` with `empty()` and `!empty()` in `FileHandler.cpp`.
This is more idiomatic C++ and provides O(1) performance guarantee regardless of container implementation.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality by modernizing syntax conventions across file handling operations. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->