### PR TITLE
(fix,osw): disable auto_irt when linear iRT file is provided

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -214,6 +214,7 @@ Fixes:
   - Fix PeptideIndexer AhoCorasick segfault for short peptides (#8685)
   - Fix redundant PRAGMA foreign_keys execution in OMSFileStore
   - Fix potential memory leak in SwathFile::loadMzXML on exception by using std::unique_ptr
+  - Fix: disable auto_irt and ignore tr_irt_priority_sampling when linear_irt_file is provided in OpenSwathWorkflow (#8830)
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -567,6 +567,19 @@ protected:
     // Extract parameters needed for OpenSwathWorkflow validation logic
     UInt irt_bins_lin = irt_calibration_params.getValue("auto_irt:irt_bins");
     UInt irt_pep_lin  = irt_calibration_params.getValue("auto_irt:irt_peptides_per_bin");
+
+    // If a linear iRT file is explicitly provided, auto_irt must be disabled
+    // and any priority sampling iRT file should be ignored.
+    if (!irt_tr_file.empty())
+    {
+      if (auto_irt)
+      {
+        OPENMS_LOG_WARN << "Calibration:files:linear_irt_file provided -> disabling auto_irt and ignoring tr_irt_priority_sampling." << std::endl;
+      }
+      auto_irt = false;
+      // clear the priority sampling file so downstream logic won't attempt to use/validate it
+      priority_sampling_irt_tr_file.clear();
+    }
     
     String swath_windows_file = getStringOption_("swath_windows_file");
 
@@ -652,21 +665,29 @@ protected:
       }
     }
     
-    // Validate priority iRT sampling file format if provided
+    // Validate priority iRT sampling file format if provided and if auto_irt is enabled
     if (!priority_sampling_irt_tr_file.empty())
     {
-      if (!File::exists(priority_sampling_irt_tr_file))
+      if (!auto_irt)
       {
-        writeLogError_("Parameter error: Priority iRT file does not exist: " + priority_sampling_irt_tr_file);
-        return PARSE_ERROR;
+        // auto_irt disabled (possibly due to explicit linear iRT file); ignore provided priority sampling file
+        OPENMS_LOG_WARN << "Priority iRT sampling file provided but auto_irt is disabled; ignoring: " << priority_sampling_irt_tr_file << std::endl;
       }
-      
-      FileTypes::Type priority_file_type = FileHandler::getType(priority_sampling_irt_tr_file);
-      if (priority_file_type != FileTypes::TSV)
+      else
       {
-        writeLogError_("Parameter error: Priority iRT file must be in TSV format. Provided: " + 
-                       FileTypes::typeToName(priority_file_type));
-        return PARSE_ERROR;
+        if (!File::exists(priority_sampling_irt_tr_file))
+        {
+          writeLogError_("Parameter error: Priority iRT file does not exist: " + priority_sampling_irt_tr_file);
+          return PARSE_ERROR;
+        }
+        
+        FileTypes::Type priority_file_type = FileHandler::getType(priority_sampling_irt_tr_file);
+        if (priority_file_type != FileTypes::TSV)
+        {
+          writeLogError_("Parameter error: Priority iRT file must be in TSV format. Provided: " + 
+                         FileTypes::typeToName(priority_file_type));
+          return PARSE_ERROR;
+        }
       }
     }
 

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -572,13 +572,15 @@ protected:
     // and any priority sampling iRT file should be ignored.
     if (!irt_tr_file.empty())
     {
-      if (auto_irt)
+      if (auto_irt || !priority_sampling_irt_tr_file.empty())
       {
         OPENMS_LOG_WARN << "Calibration:files:linear_irt_file provided -> disabling auto_irt and ignoring tr_irt_priority_sampling." << std::endl;
       }
       auto_irt = false;
+      irt_calibration_params.setValue("auto_irt:enabled", "false");
       // clear the priority sampling file so downstream logic won't attempt to use/validate it
       priority_sampling_irt_tr_file.clear();
+      irt_calibration_params.setValue("tr_irt_priority_sampling", "");
     }
     
     String swath_windows_file = getStringOption_("swath_windows_file");


### PR DESCRIPTION
## Description

This PR fixes the case when iRT files are provided, auto_irt should be disabled and priority irt loading should also be disabled.

Calibration file handling improvements:

* If an explicit linear iRT file (`irt_tr_file`) is provided, the workflow now disables `auto_irt` and clears any priority sampling iRT file (`priority_sampling_irt_tr_file`) to prevent downstream logic from using it. A warning is logged to inform the user of this behavior.
* The validation of the priority iRT sampling file now only occurs if `auto_irt` is enabled. If `auto_irt` is disabled (e.g., due to an explicit linear iRT file), a warning is logged and the priority sampling file is ignored. [[1]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6L655-R676) [[2]](diffhunk://#diff-a3a2201361d0fa1b7f08d6e8a3789ff1513cac308c34029aad8435081eed34c6R692)

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When an explicit linear iRT file is provided, auto iRT is now automatically disabled and any downstream priority sampling iRT file is ignored; a warning is logged to inform users.
  * Improved validation for priority iRT sampling files: clearer warnings/errors and stricter checks for presence and TSV format to prevent misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->