### PR TITLE
refactor: replace Qt Network with libcurl in core library

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -347,6 +347,23 @@ jobs:
           rm contrib_build-Windows.tar.gz
           ls -la
 
+    - name: Build libcurl from source (Windows)
+      if: startsWith(matrix.os, 'windows')
+      shell: bash
+      run: |
+          curl -L -o curl-src.tar.gz https://curl.se/download/curl-8.12.1.tar.gz
+          tar xzf curl-src.tar.gz
+          cd curl-8.12.1
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/OpenMS/contrib" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCURL_USE_SCHANNEL=ON \
+            -DBUILD_CURL_EXE=OFF \
+            -DBUILD_TESTING=OFF
+          cmake --build build
+          cmake --install build
+
     - name: Setup ccache cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -360,7 +360,9 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DCURL_USE_SCHANNEL=ON \
             -DBUILD_CURL_EXE=OFF \
-            -DBUILD_TESTING=OFF
+            -DBUILD_TESTING=OFF \
+            -DCURL_DISABLE_LDAP=ON \
+            -DCURL_USE_LIBPSL=OFF
           cmake --build build
           cmake --install build
 

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -120,7 +120,7 @@ jobs:
             -w /project \
             ghcr.io/openms/contrib_manylinux_2_34:latest-amd64 \
             bash -c '
-              yum install -y cmake ninja-build
+              yum install -y cmake ninja-build libcurl-devel
               mkdir build && cd build
               cmake .. \
                 -G Ninja \
@@ -199,7 +199,7 @@ jobs:
             -w /project \
             ghcr.io/openms/contrib_manylinux_2_34:latest-arm64 \
             bash -c '
-              yum install -y cmake ninja-build
+              yum install -y cmake ninja-build libcurl-devel
               mkdir build && cd build
               cmake .. \
                 -G Ninja \
@@ -350,6 +350,22 @@ jobs:
         uses: egor-tensin/vs-shell@v2
         with:
           arch: x64
+
+      - name: Build libcurl from source
+        shell: bash
+        run: |
+          curl -L -o curl-src.tar.gz https://curl.se/download/curl-8.12.1.tar.gz
+          tar xzf curl-src.tar.gz
+          cd curl-8.12.1
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/contrib" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCURL_USE_SCHANNEL=ON \
+            -DBUILD_CURL_EXE=OFF \
+            -DBUILD_TESTING=OFF
+          cmake --build build
+          cmake --install build
 
       - name: Build and install OpenMS
         shell: bash

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -159,6 +159,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ needs.setup.outputs.cibw-build-linux-x64 }}
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/openms/contrib_manylinux_2_34:latest-amd64
+          CIBW_BEFORE_ALL: yum install -y libcurl-devel
           # Use install directory with stripped libraries
           CIBW_ENVIRONMENT: >-
             OpenMS_ROOT=/project/install
@@ -238,6 +239,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ needs.setup.outputs.cibw-build-linux-arm64 }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/openms/contrib_manylinux_2_34:latest-arm64
+          CIBW_BEFORE_ALL: yum install -y libcurl-devel
           CIBW_ENVIRONMENT: >-
             OpenMS_ROOT=/project/install
             CMAKE_PREFIX_PATH=/contrib-build:/project/install

--- a/.github/workflows/pyopenms-wheels-cibuildwheel.yml
+++ b/.github/workflows/pyopenms-wheels-cibuildwheel.yml
@@ -363,7 +363,9 @@ jobs:
             -DBUILD_SHARED_LIBS=ON \
             -DCURL_USE_SCHANNEL=ON \
             -DBUILD_CURL_EXE=OFF \
-            -DBUILD_TESTING=OFF
+            -DBUILD_TESTING=OFF \
+            -DCURL_DISABLE_LDAP=ON \
+            -DCURL_USE_LIBPSL=OFF
           cmake --build build
           cmake --install build
 

--- a/cmake/OpenMSConfig.cmake.in
+++ b/cmake/OpenMSConfig.cmake.in
@@ -23,6 +23,7 @@ endif()
 
 #TODO somehow add the same/compatible versions that were found by OpenMS? And what about static vs dynamic? E.g. if we link to static zlib in OpenMS(.dll) what (if at all) can/should the consumer link against?
 find_dependency(Qt6 @QT_MIN_VERSION@ COMPONENTS @OpenMS_QT_COMPONENTS@)
+find_dependency(CURL)
 find_dependency(XercesC)
 # Find Eigen
 # Try the version range first (CMake 3.19+ with compatible Eigen config)

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -171,11 +171,12 @@ endif()
 
 
 #------------------------------------------------------------------------------
+# libcurl (used for HTTP in OpenMS core; also needed by Apache Arrow 23+)
+find_package(CURL REQUIRED)
+
+#------------------------------------------------------------------------------
  # Apache Arrow and Parquet
  if (WITH_PARQUET)
-   # Workaround for Arrow 23+ CMake configuration issue where CURL dependency
-   # is not properly exported. See: https://github.com/apache/arrow/issues/48885
-   find_package(CURL QUIET)
    # Arrow 23+ required for parquet file format compatibility
    find_package(Arrow 23 CONFIG REQUIRED)
    find_package(Parquet 23 CONFIG REQUIRED)
@@ -275,7 +276,7 @@ endif()
 SET(QT_MIN_VERSION "6.1.0")
 
 # find qt
-set(OpenMS_QT_COMPONENTS Core Network CACHE INTERNAL "QT components for core lib")
+set(OpenMS_QT_COMPONENTS Core CACHE INTERNAL "QT components for core lib")
 find_package(Qt6 ${QT_MIN_VERSION} COMPONENTS ${OpenMS_QT_COMPONENTS} REQUIRED)
 
 IF (NOT Qt6Core_FOUND)
@@ -300,7 +301,7 @@ if (WITH_GUI)
   # --------------------------------------------------------------------------
   # Find additional Qt libs
   #---------------------------------------------------------------------------
-  set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Svg OpenGLWidgets)
+  set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Svg OpenGLWidgets Network)
 
   # On macOS the platform plugin of QT requires PrintSupport. We link
   # so it's packaged via the bundling/dependency tools/scripts

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -301,7 +301,7 @@ if (WITH_GUI)
   # --------------------------------------------------------------------------
   # Find additional Qt libs
   #---------------------------------------------------------------------------
-  set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Svg OpenGLWidgets Network)
+  set (TEMP_OpenMS_GUI_QT_COMPONENTS Gui Widgets Svg OpenGLWidgets)
 
   # On macOS the platform plugin of QT requires PrintSupport. We link
   # so it's packaged via the bundling/dependency tools/scripts

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
     zlib1g \
     libxerces-c-dev \
     libbz2-dev \
+    libcurl4-openssl-dev \
     libomp-dev \
     libhdf5-dev\
     coinor-libcoinmp-dev \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -167,6 +167,7 @@ RUN apt-get update \
     libzip4 \
     zlib1g \
     libbz2-1.0 \
+    libcurl4 \
     libgomp1 \
     libqt6svg6 \
     libxerces-c3.2 \

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -59,7 +59,7 @@ set(OPENMS_DEP_LIBRARIES
   LibSVM::LibSVM
   XercesC::XercesC
   Qt6::Core
-  Qt6::Network
+  CURL::libcurl
 )
 
 ## setup the arguments to 'target_link_libraries(OpenMS PRIVATE ${OPENMS_DEP_PRIVATE_LIBRARIES})'

--- a/src/openms/include/OpenMS/FORMAT/MascotRemoteQuery.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotRemoteQuery.h
@@ -9,12 +9,11 @@
 #pragma once
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
-#include <QtCore/QObject>
-#include <QtCore/QString>
-#include <QtCore/QTimer>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkReply>
 
+#include <string>
+#include <vector>
+
+typedef void CURL;
 
 namespace OpenMS
 {
@@ -28,18 +27,15 @@ namespace OpenMS
 
   */
   class MascotRemoteQuery :
-    public QObject,
     public DefaultParamHandler
   {
-    Q_OBJECT
-
 public:
 
     /** @name Constructors and destructors
     */
     //@{
     /// default constructor
-    OPENMS_DLLAPI MascotRemoteQuery(QObject* parent = 0);
+    OPENMS_DLLAPI MascotRemoteQuery();
 
     /// assignment operator
     OPENMS_DLLAPI MascotRemoteQuery& operator=(const MascotRemoteQuery& rhs) = delete;
@@ -55,10 +51,10 @@ public:
     OPENMS_DLLAPI void setQuerySpectra(const String& exp);
 
     /// returns the Mascot XML response which contains the identifications
-    OPENMS_DLLAPI const QByteArray& getMascotXMLResponse() const;
+    OPENMS_DLLAPI const std::string& getMascotXMLResponse() const;
 
     /// returns the Mascot XML response which contains the decoy identifications (note: setExportDecoys must be set to true, otherwise result will be empty)
-    OPENMS_DLLAPI const QByteArray& getMascotXMLDecoyResponse() const;
+    OPENMS_DLLAPI const std::string& getMascotXMLDecoyResponse() const;
 
     /// predicate which returns true if an error occurred during the query
     OPENMS_DLLAPI bool hasError() const;
@@ -72,85 +68,46 @@ public:
     /// request export of decoy summary and decoys (note: internal decoy search must be enabled in the MGF file passed to mascot)
     OPENMS_DLLAPI void setExportDecoys(const bool b);
 
+    /// Execute the full Mascot workflow synchronously (login -> query -> export results).
+    OPENMS_DLLAPI void run();
+
 protected:
 
     OPENMS_DLLAPI void updateMembers_() override;
 
-public slots:
-
-    OPENMS_DLLAPI void run();
-
-private slots:
-
-    /// slot connected to QTimer (timeout_)
-    OPENMS_DLLAPI void timedOut() const;
-
-    /// slot connected to the QNetworkAccessManager::finished signal
-    OPENMS_DLLAPI void readResponse(QNetworkReply* reply);
-
-    /// slot connected to signal downloadProgress
-    OPENMS_DLLAPI void downloadProgress(qint64 bytes_read, qint64 bytes_total);
-
-    /// slot connected to signal uploadProgress
-    OPENMS_DLLAPI void uploadProgress(qint64 bytes_read, qint64 bytes_total);
-
-    /// slot connected to signal gotRedirect
-    OPENMS_DLLAPI void followRedirect(QNetworkReply * reply);
-
-signals:
-
-    /// signal when class got a redirect
-    OPENMS_DLLAPI void gotRedirect(QNetworkReply * reply);
-
-    /// signal when class is done and results can be collected
-    OPENMS_DLLAPI void done();
-
 private:
 
     /// login to Mascot server
-    void login();
+    void login(CURL* curl);
 
     /// execute query (upload file)
-    void execQuery();
+    void execQuery(CURL* curl);
 
-    /// download result file
-    void getResults(const QString& results_path);
+    /// download result file and process response
+    std::string getResults(CURL* curl, const std::string& results_path);
 
-    /// finish a run and emit "done"
-    OPENMS_DLLAPI void endRun_();
+    /// perform an HTTP GET and return the response body
+    std::string httpGet(CURL* curl, const std::string& path);
 
-    /**
-      @brief Remove host name information from an url, e.g., "http://www.google.de/search" -> "search"
+    /// perform an HTTP POST with the given body and content type, return the response body
+    std::string httpPost(CURL* curl, const std::string& path, const std::string& body, const std::string& content_type);
 
-      @param[in] url The url that will be manipulated.
-    */
-    void removeHostName_(QString& url);
+    /// build full URL from a path
+    std::string buildUrl(const std::string& path) const;
 
-    /// helper function to build URL
-    QUrl buildUrl_(const std::string& path);
-
-    /// Write HTTP header to error stream (for debugging)
-    OPENMS_DLLAPI void logHeader_(const QNetworkRequest& header, const String& what);
-
-    /// Write HTTP header to error stream (for debugging)
-    OPENMS_DLLAPI void logHeader_(const QNetworkReply* header, const String& what);
-
+    /// Extract search identifier from .dat file path
     OPENMS_DLLAPI String getSearchIdentifierFromFilePath(const String& path) const;
 
-    /// parse new response header
-    OPENMS_DLLAPI void readResponseHeader(const QNetworkReply* reply);
-
-    QNetworkAccessManager* manager_;
+    /// Remove host name information from a url
+    std::string removeHostName(const std::string& url) const;
 
     // Input / Output data
     String query_spectra_;
-    QByteArray mascot_xml_;
-    QByteArray mascot_decoy_xml_;
+    std::string mascot_xml_;
+    std::string mascot_decoy_xml_;
 
     // Internal data structures
-    QString cookie_;
     String error_message_;
-    QTimer timeout_;
     String search_identifier_;
 
     /// Path on mascot server
@@ -158,16 +115,15 @@ private:
     /// Hostname of the mascot server
     String host_name_;
     /// Login required
-    bool requires_login_;
+    bool requires_login_ = false;
     /// Use SSL connection
-    bool use_ssl_;
+    bool use_ssl_ = false;
     /// boundary string that will be embedded into the HTTP requests
     String boundary_;
     /// Timeout after these many seconds
-    Int to_;
+    Int to_ = 1500;
 
     bool export_decoys_ = false;
   };
 
 }
-

--- a/src/openms/include/OpenMS/FORMAT/sources.cmake
+++ b/src/openms/include/OpenMS/FORMAT/sources.cmake
@@ -3,7 +3,6 @@ set(directory include/OpenMS/FORMAT)
 
 ### list all MOC filenames of the directory here
 set(sources_list
-MascotRemoteQuery.h
 )
 
 ### add path to the filenames

--- a/src/openms/include/OpenMS/SYSTEM/CurlInit.h
+++ b/src/openms/include/OpenMS/SYSTEM/CurlInit.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+namespace OpenMS
+{
+  /// Thread-safe RAII guard for curl_global_init / curl_global_cleanup.
+  /// Call CurlInit::ensure() before using any curl API.
+  class CurlInit
+  {
+  public:
+    OPENMS_DLLAPI static void ensure();
+
+  private:
+    CurlInit();
+    ~CurlInit();
+    CurlInit(const CurlInit&) = delete;
+    CurlInit& operator=(const CurlInit&) = delete;
+  };
+}

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -311,15 +311,6 @@ public:
                                                        bool basename = true, 
                                                        bool ignore_extension = true);
 
-    /**
-      @brief Download file from given URL into a download folder. Returns when done.
-      
-      If a file with same filename already exists, continues download and appends '.\#number' to basename.
-      
-      @throw FileNotFound exception if download failed. 
-    */
-    static void download(const std::string& url, const std::string& download_folder);
-
 private:
 
     /// get defaults for the system's Temp-path, user home directory etc.

--- a/src/openms/include/OpenMS/SYSTEM/Network.h
+++ b/src/openms/include/OpenMS/SYSTEM/Network.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+#include <string>
+
+namespace OpenMS
+{
+  /// Utility class for network operations (HTTP downloads)
+  class OPENMS_DLLAPI Network
+  {
+  public:
+    /**
+      @brief Download file from given URL into a download folder. Returns when done.
+
+      If a file with same filename already exists, continues download and appends '.\#number' to basename.
+
+      @throw IOException if download failed.
+    */
+    static void downloadFile(const std::string& url, const std::string& download_folder);
+  };
+}

--- a/src/openms/include/OpenMS/SYSTEM/Network.h
+++ b/src/openms/include/OpenMS/SYSTEM/Network.h
@@ -20,7 +20,7 @@ namespace OpenMS
     /**
       @brief Download file from given URL into a download folder. Returns when done.
 
-      If a file with same filename already exists, continues download and appends '.\#number' to basename.
+      If a file with same filename already exists, creates a new file with '.number' appended to the basename.
 
       @throw IOException if download failed.
     */

--- a/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
+++ b/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
@@ -16,32 +16,32 @@
 namespace OpenMS
 {
   /// Synchronous HTTP GET request using libcurl.
-  class NetworkGetRequest
+  class OPENMS_DLLAPI NetworkGetRequest
   {
   public:
-    OPENMS_DLLAPI NetworkGetRequest();
-    OPENMS_DLLAPI ~NetworkGetRequest();
+    NetworkGetRequest();
+    ~NetworkGetRequest();
 
     /// set the URL to request
-    OPENMS_DLLAPI void setUrl(const std::string& url);
+    void setUrl(const std::string& url);
 
     /// set the timeout in seconds (0 = no timeout)
-    OPENMS_DLLAPI void setTimeout(int seconds);
+    void setTimeout(int seconds);
 
     /// execute the GET request (blocks until complete or timeout)
-    OPENMS_DLLAPI void run();
+    void run();
 
     /// returns the response as a string
-    OPENMS_DLLAPI std::string getResponse() const;
+    std::string getResponse() const;
 
     /// returns the raw response bytes
-    OPENMS_DLLAPI const std::vector<char>& getResponseBinary() const;
+    const std::vector<char>& getResponseBinary() const;
 
     /// returns true if an error occurred during the query
-    OPENMS_DLLAPI bool hasError() const;
+    bool hasError() const;
 
     /// returns the error message
-    OPENMS_DLLAPI std::string getErrorString() const;
+    std::string getErrorString() const;
 
   private:
     NetworkGetRequest(const NetworkGetRequest&) = delete;

--- a/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
+++ b/src/openms/include/OpenMS/SYSTEM/NetworkGetRequest.h
@@ -10,74 +10,47 @@
 
 #include <OpenMS/config.h>
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
-#include <QtCore/QUrl>
-#include <QtNetwork/QNetworkReply>
+#include <string>
+#include <vector>
 
 namespace OpenMS
 {
-
-  class NetworkGetRequest :
-    public QObject
+  /// Synchronous HTTP GET request using libcurl.
+  class NetworkGetRequest
   {
-    Q_OBJECT
-
   public:
+    OPENMS_DLLAPI NetworkGetRequest();
+    OPENMS_DLLAPI ~NetworkGetRequest();
 
-    /** @name Constructors and destructors
-    */
-    //@{
-    /// default constructor
-    OPENMS_DLLAPI NetworkGetRequest(QObject* parent = nullptr);
+    /// set the URL to request
+    OPENMS_DLLAPI void setUrl(const std::string& url);
 
-    /// destructor
-    OPENMS_DLLAPI ~NetworkGetRequest() override;
-    //@}
+    /// set the timeout in seconds (0 = no timeout)
+    OPENMS_DLLAPI void setTimeout(int seconds);
 
-    // set request parameters
-    OPENMS_DLLAPI void setUrl(const QUrl& url);
+    /// execute the GET request (blocks until complete or timeout)
+    OPENMS_DLLAPI void run();
 
-    /// returns the response
-    OPENMS_DLLAPI QString getResponse() const;
+    /// returns the response as a string
+    OPENMS_DLLAPI std::string getResponse() const;
 
-    /// returns the response
-    OPENMS_DLLAPI const QByteArray& getResponseBinary() const;
+    /// returns the raw response bytes
+    OPENMS_DLLAPI const std::vector<char>& getResponseBinary() const;
 
     /// returns true if an error occurred during the query
     OPENMS_DLLAPI bool hasError() const;
 
-    /// returns the error message, if hasError can be used to check whether an error has occurred
-    OPENMS_DLLAPI QString getErrorString() const;
-
-  protected:
-
-    public slots:
-
-    OPENMS_DLLAPI void run();
-
-    OPENMS_DLLAPI void timeOut();
-
-    private slots:
-
-    OPENMS_DLLAPI void replyFinished(QNetworkReply*);
-
-  signals:
-
-    OPENMS_DLLAPI void done();
+    /// returns the error message
+    OPENMS_DLLAPI std::string getErrorString() const;
 
   private:
-    /// assignment operator
-    OPENMS_DLLAPI NetworkGetRequest& operator=(const NetworkGetRequest& rhs);
-    /// copy constructor
-    OPENMS_DLLAPI NetworkGetRequest(const NetworkGetRequest& rhs);
+    NetworkGetRequest(const NetworkGetRequest&) = delete;
+    NetworkGetRequest& operator=(const NetworkGetRequest&) = delete;
 
-    QByteArray response_bytes_;
-    QUrl url_;
-    QNetworkAccessManager* manager_;
-    QNetworkReply* reply_;
-    QNetworkReply::NetworkError error_;
-    QString error_string_;
+    std::vector<char> response_bytes_;
+    std::string url_;
+    int timeout_ = 0;
+    bool has_error_ = false;
+    std::string error_string_;
   };
 }
-

--- a/src/openms/include/OpenMS/SYSTEM/sources.cmake
+++ b/src/openms/include/OpenMS/SYSTEM/sources.cmake
@@ -22,6 +22,7 @@ CurlInit.h
 ExternalProcess.h
 File.h
 JavaInfo.h
+Network.h
 NetworkGetRequest.h
 PythonInfo.h
 RWrapper.h

--- a/src/openms/include/OpenMS/SYSTEM/sources.cmake
+++ b/src/openms/include/OpenMS/SYSTEM/sources.cmake
@@ -3,7 +3,6 @@ set(directory include/OpenMS/SYSTEM)
 
 ### list all MOC filenames of the directory here
 set(sources_list
-NetworkGetRequest.h
 )
 
 ### add path to the filenames
@@ -19,6 +18,7 @@ source_group("Source Files\\OpenMS\\SYSTEM" FILES ${sources})
 ### list all header files of the directory here
 set(sources_list_h
 BuildInfo.h
+CurlInit.h
 ExternalProcess.h
 File.h
 JavaInfo.h

--- a/src/openms/source/CHEMISTRY/ModomicsJSONDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/ModomicsJSONDataProvider.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 
@@ -231,8 +232,8 @@ namespace OpenMS
 
     String full_path = File::find(filename_);
 
-    // Data files are UTF-8 encoded (verified). std::ifstream reads UTF-8 correctly.
-    std::ifstream file(full_path);
+    // Use std::filesystem::path to support non-ASCII paths on Windows (wide-string open)
+    std::ifstream file{std::filesystem::path{std::string(full_path)}};
     if (!file.is_open())
     {
       throw Exception::FileNotReadable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, full_path);

--- a/src/openms/source/CHEMISTRY/MonosaccharideDB.cpp
+++ b/src/openms/source/CHEMISTRY/MonosaccharideDB.cpp
@@ -13,6 +13,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 
@@ -39,8 +40,8 @@ namespace OpenMS
 
     OPENMS_LOG_DEBUG << "Loading monosaccharide data from " << full_path << "\n";
 
-    // Data files are UTF-8 encoded (verified). std::ifstream reads UTF-8 correctly.
-    std::ifstream file(full_path);
+    // Use std::filesystem::path to support non-ASCII paths on Windows (wide-string open)
+    std::ifstream file{std::filesystem::path{std::string(full_path)}};
     if (!file.is_open())
     {
       throw Exception::FileNotReadable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, full_path);

--- a/src/openms/source/CHEMISTRY/RibonucleotideTSVDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideTSVDataProvider.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/CHEMISTRY/RibonucleotideTSVDataProvider.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace std;
@@ -131,8 +132,8 @@ namespace OpenMS
 
     String header = "name\tshort_name\tnew_nomenclature\toriginating_base\trnamods_abbrev\thtml_abbrev\tformula\tmonoisotopic_mass\taverage_mass";
 
-    // Data files are UTF-8 encoded (verified). std::ifstream reads UTF-8 correctly.
-    std::ifstream file(full_path);
+    // Use std::filesystem::path to support non-ASCII paths on Windows (wide-string open)
+    std::ifstream file{std::filesystem::path{std::string(full_path)}};
     if (!file.is_open())
     {
       throw Exception::FileNotReadable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, full_path);

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -53,6 +53,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
@@ -677,7 +678,7 @@ namespace OpenMS
 
   String FileHandler::computeFileHash(const String& filename)
   {
-    std::ifstream file(filename, std::ios::binary);
+    std::ifstream file{std::filesystem::path{std::string(filename)}, std::ios::binary};
     if (!file.is_open())
     {
       return "";

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -261,7 +261,7 @@ namespace OpenMS
     addField("onerrdisplay", "login_prompt");
     body += "--" + boundary + "--\r\n";
 
-    string content_type = "multipart/form-data, boundary=" + boundary;
+    string content_type = "multipart/form-data; boundary=" + boundary;
     string response = httpPost(curl, server_path_ + "/cgi/login.pl", body, content_type);
 
     if (hasError()) return;
@@ -305,7 +305,7 @@ namespace OpenMS
          << "<<<< Query (end)." << endl;
 #endif
 
-    string content_type = "multipart/form-data, boundary=" + boundary;
+    string content_type = "multipart/form-data; boundary=" + boundary;
     string response = httpPost(curl, server_path_ + "/cgi/nph-mascot.exe?1", body, content_type);
 
     if (hasError()) return;
@@ -521,6 +521,7 @@ namespace OpenMS
     mascot_xml_.clear();
     mascot_decoy_xml_.clear();
     error_message_.clear();
+    search_identifier_.clear();
 
     to_ = param_.getValue("timeout");
     requires_login_ = param_.getValue("login").toBool();

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -8,13 +8,11 @@
 
 #include <OpenMS/FORMAT/MascotRemoteQuery.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/SYSTEM/CurlInit.h>
 
-#include <QtGui/QTextDocument>
-#include <QtNetwork/QNetworkReply>
-#include <QtNetwork/QNetworkProxy>
-#include <QtNetwork/QSslSocket>
+#include <curl/curl.h>
 
-#include <QRegularExpression>
+#include <regex>
 
 // #define MASCOTREMOTEQUERY_DEBUG
 // #define MASCOTREMOTEQUERY_DEBUG_FULL_QUERY
@@ -23,11 +21,18 @@ using namespace std;
 
 namespace OpenMS
 {
+  namespace
+  {
+    size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata)
+    {
+      auto* buf = static_cast<string*>(userdata);
+      buf->append(ptr, size * nmemb);
+      return size * nmemb;
+    }
+  }
 
-  MascotRemoteQuery::MascotRemoteQuery(QObject* parent) :
-    QObject(parent),
-    DefaultParamHandler("MascotRemoteQuery"),
-    manager_(nullptr)
+  MascotRemoteQuery::MascotRemoteQuery() :
+    DefaultParamHandler("MascotRemoteQuery")
   {
     // server specifications
     defaults_.setValue("hostname", "", "Address of the host where Mascot listens, e.g. 'mascot-server' or '127.0.0.1'");
@@ -69,584 +74,397 @@ namespace OpenMS
   MascotRemoteQuery::~MascotRemoteQuery()
   {
 #ifdef MASCOTREMOTEQUERY_DEBUG
-      std::cerr << "MascotRemoteQuery::~MascotRemoteQuery()\n";
+    std::cerr << "MascotRemoteQuery::~MascotRemoteQuery()\n";
 #endif
-    if (manager_) {delete manager_;}
-  }
-
-  void MascotRemoteQuery::timedOut() const
-  {
-    OPENMS_LOG_FATAL_ERROR << "Mascot request timed out after " << to_ << " seconds! See 'timeout' parameter for details!" << std::endl;
   }
 
   void MascotRemoteQuery::run()
   {
-    // Due to the asynchronous nature of Qt network requests (and the resulting use
-    // of signals and slots), the information flow in this class is not very
-    // clear. After the initial call to "run", the steps are roughly as follows:
-    //
-    // 1. optional: log into Mascot server (function "login")
-    // 2. send query (function "execQuery")
-    // 3. read query result, prepare exporting (function "readResponse")
-    // 4. send export request (function "getResults")
-    // 5. Mascot 2.4: read result, check for redirect (function "readResponse")
-    // 6. Mascot 2.4: request redirected (caching) page (function "getResults")
-    // (5. and 6. can happen multiple times - keep following redirects)
-    // 7. Mascot 2.4: read result, check if caching is done (function "readResponse")
-    // 8. Mascot 2.4: request results again (function "getResults")
-    // 9. read results, which should now contain the XML (function "readResponse")
-    //
-
     updateMembers_();
+    CurlInit::ensure();
 
-    // Make sure we do not mess with the asynchronous nature of the call and
-    // start a second one while the first one is still running.
-    if (manager_)
+    CURL* curl = curl_easy_init();
+    if (!curl)
     {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Error: Please call run() only once per MascotRemoteQuery.");
-    }
-    manager_ = new QNetworkAccessManager(this);
-
-    if (!use_ssl_)
-    {
-      manager_->connectToHost(host_name_.c_str(), (UInt)param_.getValue("host_port"));
-    }
-    else
-    {
-#ifndef QT_NO_SSL
-      manager_->connectToHostEncrypted(host_name_.c_str(), (UInt)param_.getValue("host_port"));
-#else
-      // should not happen since it is checked during parameter reading. Kept for safety.
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Error: Usage of SSL encryption requested but the linked QT library was not compiled with SSL support. Please recompile QT.");
-#endif
+      error_message_ = "Failed to initialize libcurl";
+      return;
     }
 
-    connect(this, SIGNAL(gotRedirect(QNetworkReply *)), this, SLOT(followRedirect(QNetworkReply *)));
-    connect(&timeout_, SIGNAL(timeout()), this, SLOT(timedOut()));
-    connect(manager_, SIGNAL(finished(QNetworkReply*)), this, SLOT(readResponse(QNetworkReply*)));
+    // Enable cookie engine (automatic cookie management)
+    curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+    // Thread-safe DNS timeout (avoids signal handler issues with OpenMP)
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    // Follow HTTP redirects automatically
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    // SSL verification
+    if (use_ssl_)
+    {
+      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+      curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    }
+    // Timeout
+    if (to_ > 0)
+    {
+      curl_easy_setopt(curl, CURLOPT_TIMEOUT, static_cast<long>(to_));
+    }
 
-    if (param_.getValue("login").toBool())
+    // Proxy
+    bool use_proxy(param_.getValue("use_proxy").toBool());
+    if (use_proxy)
     {
-      login();
+      String proxy_host(param_.getValue("proxy_host").toString());
+      Int proxy_port(param_.getValue("proxy_port"));
+      string proxy_url = proxy_host + ":" + String(proxy_port);
+      curl_easy_setopt(curl, CURLOPT_PROXY, proxy_url.c_str());
+      // SOCKS5 matches the original Qt implementation (QNetworkProxy::Socks5Proxy)
+      curl_easy_setopt(curl, CURLOPT_PROXYTYPE, static_cast<long>(CURLPROXY_SOCKS5));
+
+      String proxy_username(param_.getValue("proxy_username").toString());
+      if (!proxy_username.empty())
+      {
+        curl_easy_setopt(curl, CURLOPT_PROXYUSERNAME, proxy_username.c_str());
+        String proxy_password(param_.getValue("proxy_password").toString());
+        curl_easy_setopt(curl, CURLOPT_PROXYPASSWORD, proxy_password.c_str());
+      }
     }
-    else
+
+    // Step 1: Optional login
+    if (requires_login_)
     {
-      execQuery();
+      login(curl);
+      if (hasError())
+      {
+        curl_easy_cleanup(curl);
+        return;
+      }
     }
+
+    // Step 2: Execute query
+    execQuery(curl);
+    if (hasError())
+    {
+      curl_easy_cleanup(curl);
+      return;
+    }
+
+    curl_easy_cleanup(curl);
   }
 
-  void MascotRemoteQuery::login()
+  string MascotRemoteQuery::buildUrl(const string& path) const
+  {
+    string protocol = use_ssl_ ? "https" : "http";
+    Int port = param_.getValue("host_port");
+    return protocol + "://" + string(host_name_.c_str()) + ":" + to_string(port) + path;
+  }
+
+  string MascotRemoteQuery::httpGet(CURL* curl, const string& path)
+  {
+    string url = buildUrl(path);
+    string response;
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+#ifdef MASCOTREMOTEQUERY_DEBUG
+    cerr << "\nhttpGet URL: " << url << "\n";
+#endif
+
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK)
+    {
+      error_message_ = String("Mascot HTTP GET failed: ") + curl_easy_strerror(res);
+      return {};
+    }
+
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    if (http_code >= 400)
+    {
+      error_message_ = String("Mascot server returned HTTP error ") + String(http_code) + "\nTry accessing the server\n  " + host_name_ + server_path_ + "\n from your browser and check if it works fine.";
+      return {};
+    }
+
+    return response;
+  }
+
+  string MascotRemoteQuery::httpPost(CURL* curl, const string& path, const string& body, const string& content_type)
+  {
+    string url = buildUrl(path);
+    string response;
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    struct curl_slist* headers = nullptr;
+    string ct_header = "Content-Type: " + content_type;
+    headers = curl_slist_append(headers, ct_header.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+#ifdef MASCOTREMOTEQUERY_DEBUG
+    cerr << "\nhttpPost URL: " << url << "\n";
+#endif
+
+    CURLcode res = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
+    // Reset custom headers
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, nullptr);
+
+    if (res != CURLE_OK)
+    {
+      error_message_ = String("Mascot HTTP POST failed: ") + curl_easy_strerror(res);
+      return {};
+    }
+
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    if (http_code >= 400)
+    {
+      error_message_ = String("Mascot server returned HTTP error ") + String(http_code) + "\nTry accessing the server\n  " + host_name_ + server_path_ + "\n from your browser and check if it works fine.";
+      return {};
+    }
+
+    return response;
+  }
+
+  void MascotRemoteQuery::login(CURL* curl)
   {
 #ifdef MASCOTREMOTEQUERY_DEBUG
     cerr << "\nvoid MascotRemoteQuery::login()" << "\n";
 #endif
 
-    QUrl url = buildUrl_(server_path_ + "/cgi/login.pl");
-    QNetworkRequest request(url);
+    string boundary = string(boundary_.c_str());
+    string body;
+    string boundary_line = "--" + boundary + "\r\n";
 
-    QByteArray boundary = boundary_.toQString().toUtf8();
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "multipart/form-data, boundary=" + boundary);
-
-    // header
-    request.setRawHeader("Host", host_name_.c_str());
-    request.setRawHeader("Cache-Control", "no-cache");
-    request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-
-    // content
-    QByteArray loginbytes;
-    QByteArray boundary_string("--" + boundary + "\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"username\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append(String(param_.getValue("username").toString()).toQString().toUtf8());
-    loginbytes.append("\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"password\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append(String(param_.getValue("password").toString()).toQString().toUtf8());
-    loginbytes.append("\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"submit\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("Login\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"referer\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"display\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("nothing\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"savecookie\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("1\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"action\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("login\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"userid\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append(boundary_string);
-    loginbytes.append("Content-Disposition: ");
-    loginbytes.append("form-data; name=\"onerrdisplay\"\r\n");
-    loginbytes.append("\r\n");
-    loginbytes.append("login_prompt\r\n");
-    loginbytes.append("--" + boundary + "--\r\n");
-
-    request.setHeader(QNetworkRequest::ContentLengthHeader, loginbytes.length());
-    QNetworkReply* pReply = manager_->post(request, loginbytes);
-    connect(pReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(uploadProgress(qint64, qint64)));
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    logHeader_(request, "send");
-    cerr << "  login sent reply " << pReply << std::endl;
-#endif
-
-  }
-
-  void MascotRemoteQuery::getResults(const QString& results_path)
-  {
-    // Tidy up again and run another request...
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "\nvoid MascotRemoteQuery::getResults()" << "\n";
-    cerr << " from path " << results_path.toStdString() << "\n";
-#endif
-
-    QUrl url = buildUrl_(results_path.toStdString());
-    QNetworkRequest request(url);
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << " server_path_ " << server_path_ << std::endl;
-    cerr << " URL : " << url.toDisplayString().toStdString() << std::endl;
-#endif
-
-    // header
-    request.setRawHeader("Host", host_name_.c_str());
-    // request.setRawHeader("Host", String("http://www.chuchitisch.ch").c_str());
-    request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-    request.setRawHeader("Keep-Alive", "300");
-    request.setRawHeader("Connection", "keep-alive");
-    if (cookie_ != "")
+    auto addField = [&](const string& name, const string& value)
     {
-      request.setRawHeader(QByteArray::fromStdString("Cookie"), QByteArray::fromStdString(cookie_.toStdString()));
-    }
+      body += boundary_line;
+      body += "Content-Disposition: form-data; name=\"" + name + "\"\r\n";
+      body += "\r\n";
+      body += value + "\r\n";
+    };
 
-    QNetworkReply* pReply = manager_->get(request);
-    connect(pReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(uploadProgress(qint64, qint64)));
+    addField("username", string(param_.getValue("username").toString()));
+    addField("password", string(param_.getValue("password").toString()));
+    addField("submit", "Login");
+    addField("referer", "");
+    addField("display", "nothing");
+    addField("savecookie", "1");
+    addField("action", "login");
+    addField("userid", "");
+    addField("onerrdisplay", "login_prompt");
+    body += "--" + boundary + "--\r\n";
 
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    logHeader_(request, "request results");
-    cerr << "  getResults expects reply " << pReply << std::endl;
-#endif
+    string content_type = "multipart/form-data, boundary=" + boundary;
+    string response = httpPost(curl, server_path_ + "/cgi/login.pl", body, content_type);
 
-  }
+    if (hasError()) return;
 
-  void MascotRemoteQuery::followRedirect(QNetworkReply * r)
-  {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "\nvoid MascotRemoteQuery::followRedirect(QNetworkReply *)" << "\n";
-    logHeader_(r, "follow redirect");
-
-    // print full response
-#ifdef MASCOTREMOTEQUERY_DEBUG_FULL_QUERY
-    QByteArray new_bytes = r->readAll();
-    QString str = QString::fromUtf8(new_bytes.data(), new_bytes.size());
-
-    cerr << "Response of query: " << "\n";
-    cerr << "-----------------------------------" << "\n";
-    cerr << QString(new_bytes.constData()).toStdString() << "\n";
-    cerr << "-----------------------------------" << "\n";
-    cerr << str.toStdString() << "\n";
-#endif
-#endif
-
-    // parse the location mascot wants us to go
-    QString location = r->header(QNetworkRequest::LocationHeader).toString();
-    removeHostName_(location);
-
-    QUrl url = buildUrl_(location.toStdString());
-    QNetworkRequest request(url);
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "Location: " << location.toStdString() << "\n";
-#endif
-
-    // header
-    request.setRawHeader("Host", host_name_.c_str());
-    request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-    request.setRawHeader("Keep-Alive", "300");
-    request.setRawHeader("Connection", "keep-alive");
-    if (cookie_ != "")
+    if (response.find("Logged in successfu") != string::npos)
     {
-      request.setRawHeader(QByteArray::fromStdString("Cookie"), QByteArray::fromStdString(cookie_.toStdString()));
+      OPENMS_LOG_INFO << "Login successful!" << std::endl;
     }
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    QNetworkReply* pReply = manager_->get(request);
-    logHeader_(request, "following redirect");
-    cerr << "  followRedirect expects reply " << pReply << std::endl;
-#else
-    manager_->get(request);
-#endif
+    else if (response.find("Error: You have entered an invalid password") != string::npos)
+    {
+      error_message_ = "Error: You have entered an invalid password";
+    }
+    else if (response.find("is not a valid user") != string::npos)
+    {
+      error_message_ = "Error: Username is not valid";
+    }
+    else
+    {
+      error_message_ = "Login failed with unexpected response from Mascot server";
+    }
   }
 
-  void MascotRemoteQuery::execQuery()
+  void MascotRemoteQuery::execQuery(CURL* curl)
   {
 #ifdef MASCOTREMOTEQUERY_DEBUG
     cerr << "\nvoid MascotRemoteQuery::execQuery()" << "\n";
 #endif
 
-    QUrl url = buildUrl_(server_path_ + "/cgi/nph-mascot.exe?1");
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << " server_path_ " << server_path_ << std::endl;
-    cerr << " URL : " << url.toDisplayString().toStdString() << std::endl;
-#endif
-    QNetworkRequest request(url);
+    string boundary = string(boundary_.c_str());
+    string body;
+    body += "--" + boundary + "\r\n";
+    body += "Content-Disposition: form-data; name=\"QUE\"\r\n";
+    body += "\r\n";
+    body += string(query_spectra_.c_str());
+    body += "--" + boundary + "--\r\n";
 
-    QByteArray boundary = boundary_.toQString().toUtf8();
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "multipart/form-data, boundary=" + boundary);
-
-    // header
-    request.setRawHeader("Host", host_name_.c_str());
-    request.setRawHeader("Cache-Control", "no-cache");
-    request.setRawHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-    request.setRawHeader("Accept", "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*");
-
-    if (cookie_ != "")
-    {
-      request.setRawHeader(QByteArray::fromStdString("Cookie"), QByteArray::fromStdString(cookie_.toStdString()));
-    }
-
-    QByteArray querybytes;
-    querybytes.append("--" + boundary + "--\n");
-    querybytes.append("Content-Disposition: ");
-    querybytes.append("form-data; name=\"QUE\"\n");
-    querybytes.append("\n");
-    querybytes.append(query_spectra_.c_str());
-    querybytes.append("--" + boundary + "--\n");
-
-    querybytes.replace("\n", "\r\n");
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    logHeader_(request, "request");
 #ifdef MASCOTREMOTEQUERY_DEBUG_FULL_QUERY
     cerr << ">>>> Query (begin):" << "\n"
-         << querybytes.constData() << "\n"
+         << body << "\n"
          << "<<<< Query (end)." << endl;
 #endif
-#endif
 
-    if (to_ > 0)
+    string content_type = "multipart/form-data, boundary=" + boundary;
+    string response = httpPost(curl, server_path_ + "/cgi/nph-mascot.exe?1", body, content_type);
+
+    if (hasError()) return;
+
+    // Check for "Click here to see Search Report"
+    if (response.find("Click here to see Search Report") == string::npos)
     {
-      timeout_.start();
-    }
-
-    request.setHeader(QNetworkRequest::ContentLengthHeader, querybytes.length());
-    QNetworkReply* pReply = manager_->post(request, querybytes);
-    connect(pReply, SIGNAL(uploadProgress(qint64, qint64)), this, SLOT(uploadProgress(qint64, qint64)));
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "  execQuery expects reply " << pReply << std::endl;
-#endif
-  }
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-  void MascotRemoteQuery::downloadProgress(qint64 bytes_read, qint64 bytes_total)
-#else
-  void MascotRemoteQuery::downloadProgress(qint64 /*bytes_read*/, qint64 /*bytes_total*/)
-#endif
-  {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "void MascotRemoteQuery::downloadProgress(): " << bytes_read << " bytes of " << bytes_total << " read." << "\n";
-    /*
-    if (http_->state() == QHttp::Reading)
-    {
-      QByteArray new_bytes = http_->readAll();
-      cerr << "Current response: " << "\n";
-      cerr << QString(new_bytes.constData()).toStdString() << "\n";
-    }
-     */
-#endif
-  }
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-  void MascotRemoteQuery::uploadProgress(qint64 bytes_read, qint64 bytes_total)
-#else
-  void MascotRemoteQuery::uploadProgress(qint64 /* bytes_read */, qint64 /* bytes_total */)
-#endif
-  {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "void MascotRemoteQuery::uploadProgress(): " << bytes_read << " bytes of " << bytes_total << " sent." << "\n";
-#endif
-  }
-
-  void MascotRemoteQuery::readResponseHeader(const QNetworkReply* reply)
-  {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "void MascotRemoteQuery::readResponseHeader(const QNetworkReply* reply)" << "\n";
-    logHeader_(reply, "read");
-#endif
-
-    int status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-
-    if (status >= 400)
-    {
-      error_message_ = String("MascotRemoteQuery: The server returned an error status code '") + status + "': " + reply->attribute( QNetworkRequest::HttpReasonPhraseAttribute ).toString() + "\nTry accessing the server\n  " + host_name_ + server_path_ + "\n from your browser and check if it works fine.";
-      endRun_();
-    }
-
-    // Get session and username and so on...
-    if (reply->header(QNetworkRequest::SetCookieHeader).isValid())
-    {
-      // QVariant qcookie_ = reply->header(QNetworkRequest::SetCookieHeader);
-
-      QByteArray tmp = QByteArray::fromStdString(String("Set-Cookie"));
-      QString response = reply->rawHeader(tmp);
-
-      QRegularExpression rx("MASCOT_SESSION=(\\w+);\\spath");
-      QString mascot_session(rx.match(response).captured(1));
-
-      rx.setPattern("MASCOT_USERNAME=(\\w+);\\spath");
-      QString mascot_username(rx.match(response).captured(1));
-
-      rx.setPattern("MASCOT_USERID=(\\d+);\\spath");
-      QString mascot_user_ID(rx.match(response).captured(1));
-
-      //Put the cookie together...
-      cookie_ = "userName=; userEmail=; MASCOT_SESSION=";
-      cookie_.append(mascot_session);
-      cookie_.append("; MASCOT_USERNAME=");
-      cookie_.append(mascot_username);
-      cookie_.append("; MASCOT_USERID=");
-      cookie_.append(mascot_user_ID);
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-      cerr << "Cookie created: " << cookie_.toStdString() << "\n";
-      cerr << "Cookie created from: " << response.toStdString() << "\n";
-#endif
-    }
-  }
-
-  void MascotRemoteQuery::endRun_()
-  {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-      cerr << "void MascotRemoteQuery::endRun_()" << std::endl;
-#endif
-
-    // for consumers of this class
-    emit done();
-  }
-
-  void MascotRemoteQuery::readResponse(QNetworkReply* reply)
-  {
-    static QString dat_file_path_;
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "\nvoid MascotRemoteQuery::readResponse(const QNetworkReply* reply): ";
-    if (reply->error())
-    {
-      cerr << "'" << reply->errorString().toStdString() << "'" << "\n";
-    }
-    else
-    {
-      cerr << "\n";
-    }
-    cerr << "  -- got query " << reply << endl;
-#endif
-
-    readResponseHeader(reply); // first read and parse the header (also log)
-
-    timeout_.stop();
-
-    if (reply->error())
-    {
-      error_message_ = String("Mascot Server replied: '") + String(reply->errorString().toStdString()) + "'";
-      cerr << "   ending run with " + String("Mascot Server replied: '") + String(reply->errorString().toStdString()) + "'\n";
-      endRun_();
-      return;
-    }
-
-    QByteArray new_bytes = reply->readAll();
-#ifdef MASCOTREMOTEQUERY_DEBUG_FULL_QUERY
-    QString str = QString::fromUtf8(new_bytes.data(), new_bytes.size());
-
-    cerr << "Response of query: " << "\n";
-    cerr << "-----------------------------------" << "\n";
-    cerr << QString(new_bytes.constData()).toStdString() << "\n";
-    cerr << "-----------------------------------" << "\n";
-    cerr << str.toStdString() << "\n";
-#endif
-
-
-    int status = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-#ifdef MASCOTREMOTEQUERY_DEBUG
-    cerr << "HTTP status: " << status << "\n";
-    cerr << "Response size: " << QString(new_bytes).trimmed().size() << "\n";
-#endif
-
-    // Catch "ghost queries": strange responses that are completely empty and
-    // have a HTTP status of zero (and we never actually sent out)
-    if (QString(new_bytes).trimmed().size() == 0 && status == 0)
-    {
-      return;
-    }
-
-    if (QString(new_bytes).trimmed().size() == 0 && status != 303) // status != 303: no redirect
-    {
-      error_message_ = "Error: Reply from mascot server is empty! Possible server overload - see the Mascot Admin!";
-      endRun_();
-      return;
-    }
-
-    // Successful login? fire off the search
-    if (new_bytes.contains("Logged in successfu")) // Do not use the whole string. Currently Mascot writes 'successfully', but that might change...
-    {
-      OPENMS_LOG_INFO << "Login successful!" << std::endl;
-      execQuery();
-    }
-    else if (new_bytes.contains("Error: You have entered an invalid password"))
-    {
-      error_message_ = "Error: You have entered an invalid password";
-      endRun_();
-    }
-    else if (new_bytes.contains("is not a valid user"))
-    {
-      error_message_ = "Error: Username is not valid";
-      endRun_();
-    }
-    else if (new_bytes.contains("Click here to see Search Report"))
-    {
-      //Extract filename from this...
-      //e.g. data might look like
-      // <A HREF="../cgi/master_results.pl?file=../data/20100728/F018032.dat">Click here to see Search Report</A>
-      QString response(new_bytes);
-
-      QRegularExpression rx(R"(file=(.+/\d+/\w+\.dat))");
-      rx.setPatternOptions(QRegularExpression::InvertedGreedinessOption);
-      dat_file_path_ = rx.match(response).captured(1);
-      search_identifier_ = getSearchIdentifierFromFilePath(dat_file_path_);
-
-      if (param_.exists("skip_export") &&
-          (param_.getValue("skip_export") == "true"))
-      {
-        endRun_();
-        return;
-      }
-
-      QString results_path("");
-      results_path.append(server_path_.toQString());
-      results_path.append("/cgi/export_dat_2.pl?file=");
-      results_path.append(dat_file_path_);
-
-#ifdef MASCOTREMOTEQUERY_DEBUG
-      cerr << "Results path to export: " << results_path.toStdString() << "\n";
-#endif
-
-      // see http://www.matrixscience.com/help/export_help.html for parameter documentation
-      String required_params = "&do_export=1&export_format=XML&generate_file=1&group_family=1&peptide_master=1&protein_master=1&search_master=1&show_unassigned=1&show_mods=1&show_header=1&show_params=1&prot_score=1&pep_exp_z=1&pep_score=1&pep_seq=1&pep_homol=1&pep_ident=1&pep_expect=1&pep_var_mod=1&pep_scan_title=1&query_qualifiers=1&query_peaks=1&query_raw=1&query_title=1";
-    // TODO: check that export_params don't contain _show_decoy_report=1. This would add <decoy> at the top of the XML document and we can't easily distinguish the two files (target/decoy) from the search results later.
-      String adjustable_params = param_.getValue("export_params").toString();
-
-      results_path.append(required_params.toQString() + "&" +
-                          adjustable_params.toQString());
-      // results_path.append("&show_same_sets=1&show_unassigned=1&show_queries=1&do_export=1&export_format=XML&pep_rank=1&_sigthreshold=0.99&_showsubsets=1&show_header=1&prot_score=1&pep_exp_z=1&pep_score=1&pep_seq=1&pep_homol=1&pep_ident=1&show_mods=1&pep_var_mod=1&protein_master=1&search_master=1&show_params=1&pep_scan_title=1&query_qualifiers=1&query_peaks=1&query_raw=1&query_title=1&pep_expect=1&peptide_master=1&generate_file=1&group_family=1");
-
-      // Finished search, fire off results retrieval
-      getResults(results_path);
-    }
-    else if (status == 303)
-    {
-#ifdef MASCOTREMOTEQUERY_DEBUG
-      cerr << "Retrieved redirect \n";
-#endif
-      emit gotRedirect(reply);
-    }
-    // mascot 2.4 export page done
-    else if (new_bytes.contains("Finished after") &&  new_bytes.contains("<a id=\"continuation-link\""))
-    {
-      // parsing mascot 2.4 continuation download link
-      // <p>Finished after 0 s. <a id="continuation-link" ..
-      QString response(new_bytes);
-      QRegularExpression rx("<a id=\"continuation-link\" href=\"(.*)\"");
-      rx.setPatternOptions(QRegularExpression::InvertedGreedinessOption);
-      QString results_path = rx.match(response).captured(1);
-
-      // fill result link again and download
-      removeHostName_(results_path);
-      //Finished search, fire off results retrieval
-      getResults(results_path);
-    }
-    else
-    {
-      // check whether Mascot responded using an error code e.g. [M00440], pipe through results else
-      QString response_text = new_bytes;
-      QRegularExpression mascot_error_regex(R"(\[M[0-9][0-9][0-9][0-9][0-9]\])");
-      QRegularExpressionMatch match;
-      if (response_text.contains(mascot_error_regex, &match))
+      // Check for Mascot error codes
+      regex mascot_error_regex(R"(\[M[0-9]{5}\])");
+      smatch match;
+      if (regex_search(response, match, mascot_error_regex))
       {
         OPENMS_LOG_ERROR << "Received response with Mascot error message!" << std::endl;
-        if (match.captured() == "[M00380]")
+        if (match[0].str() == "[M00380]")
         {
-          // we know this error, so we give a much shorter and readable error message for the user
           error_message_ = "You must enter an email address and user name when using the Matrix Science public web site [M00380].";
-          OPENMS_LOG_ERROR << error_message_ << std::endl;
         }
         else
         {
-          OPENMS_LOG_ERROR << "Error code: " << match.captured().toStdString() << std::endl;
-          error_message_ = response_text;
+          OPENMS_LOG_ERROR << "Error code: " << match[0].str() << std::endl;
+          error_message_ = response;
         }
-        endRun_();
       }
       else
       {
-        // seems to be fine so grab the xml
-#ifdef MASCOTREMOTEQUERY_DEBUG
-        cerr << "Get the XML File" << "\n";
-#endif
-        if (new_bytes.contains("<decoy>"))
-        {
-          mascot_decoy_xml_ = new_bytes;          
-          endRun_();
-        }
-        else
-        {
-          mascot_xml_ = new_bytes;
-
-          // now retrieve decos
-          if (export_decoys_)
-          {
-            QString results_path("");
-            results_path.append(server_path_.toQString());
-            results_path.append("/cgi/export_dat_2.pl?file=");
-            results_path.append(dat_file_path_); // export again from dat file (now decoys)        
-            // see http://www.matrixscience.com/help/export_help.html for parameter documentation
-            String required_params = "&do_export=1&export_format=XML&generate_file=1&group_family=1&peptide_master=1&protein_master=1&search_master=1&show_unassigned=1&show_mods=1&show_header=1&show_params=1&prot_score=1&pep_exp_z=1&pep_score=1&pep_seq=1&pep_homol=1&pep_ident=1&pep_expect=1&pep_var_mod=1&pep_scan_title=1&query_qualifiers=1&query_peaks=1&query_raw=1&query_title=1";
-            // TODO: check that export_params don't contain _show_decoy_report=1. This would add <decoy> at the top of the XML document and we can't easily distinguish the two files (target/decoy) from the search results later.
-            String adjustable_params = param_.getValue("export_params").toString();
-            results_path.append(required_params.toQString() + "&" +
-                            adjustable_params.toQString() + "&_show_decoy_report=1&show_decoy=1"); // request 
-
-            getResults(results_path); 
-          }
-          else
-          {
-            endRun_();
-          }
-        }
+        error_message_ = "Error: Unexpected response from Mascot server after query submission";
       }
+      return;
     }
+
+    // Extract .dat file path
+    regex rx(R"(file=(.+/\d+/\w+\.dat))");
+    smatch dat_match;
+    if (!regex_search(response, dat_match, rx))
+    {
+      error_message_ = "Error: Could not extract .dat file path from Mascot response";
+      return;
+    }
+    string dat_file_path = dat_match[1].str();
+    search_identifier_ = getSearchIdentifierFromFilePath(dat_file_path);
+
+    if (param_.exists("skip_export") && (param_.getValue("skip_export") == "true"))
+    {
+      return;
+    }
+
+    // Build export URL path
+    string required_params = "&do_export=1&export_format=XML&generate_file=1&group_family=1&peptide_master=1&protein_master=1&search_master=1&show_unassigned=1&show_mods=1&show_header=1&show_params=1&prot_score=1&pep_exp_z=1&pep_score=1&pep_seq=1&pep_homol=1&pep_ident=1&pep_expect=1&pep_var_mod=1&pep_scan_title=1&query_qualifiers=1&query_peaks=1&query_raw=1&query_title=1";
+    string adjustable_params = string(param_.getValue("export_params").toString());
+
+    string results_path = string(server_path_.c_str()) + "/cgi/export_dat_2.pl?file=" + dat_file_path + required_params + "&" + adjustable_params;
+
+    // Get results (with continuation link handling for Mascot 2.4)
+    string xml_response = getResults(curl, results_path);
+    if (hasError()) return;
+
+    // Check if this is a decoy response
+    if (xml_response.find("<decoy>") != string::npos)
+    {
+      mascot_decoy_xml_ = std::move(xml_response);
+      return;
+    }
+
+    mascot_xml_ = std::move(xml_response);
+
+    // Now retrieve decoys if requested
+    if (export_decoys_)
+    {
+      string decoy_path = string(server_path_.c_str()) + "/cgi/export_dat_2.pl?file=" + dat_file_path + required_params + "&" + adjustable_params + "&_show_decoy_report=1&show_decoy=1";
+
+      string decoy_response = getResults(curl, decoy_path);
+      if (hasError()) return;
+      mascot_decoy_xml_ = std::move(decoy_response);
+    }
+  }
+
+  string MascotRemoteQuery::getResults(CURL* curl, const string& results_path)
+  {
+#ifdef MASCOTREMOTEQUERY_DEBUG
+    cerr << "\nvoid MascotRemoteQuery::getResults()" << "\n";
+    cerr << " from path " << results_path << "\n";
+#endif
+
+    string response = httpGet(curl, results_path);
+    if (hasError()) return {};
+
+    // Handle Mascot 2.4 continuation links (these are in-body HTML, NOT HTTP redirects)
+    while (response.find("Finished after") != string::npos &&
+           response.find("<a id=\"continuation-link\"") != string::npos)
+    {
+      regex rx(R"xx(<a id="continuation-link" href="(.*?)")xx");
+      smatch match;
+      if (!regex_search(response, match, rx))
+      {
+        break;
+      }
+      string continuation_path = removeHostName(match[1].str());
+
+#ifdef MASCOTREMOTEQUERY_DEBUG
+      cerr << "Following continuation link: " << continuation_path << "\n";
+#endif
+
+      response = httpGet(curl, continuation_path);
+      if (hasError()) return {};
+    }
+
+    // Check for empty response
+    if (response.empty())
+    {
+      error_message_ = "Error: Reply from mascot server is empty! Possible server overload - see the Mascot Admin!";
+      return {};
+    }
+
+    // Check for Mascot error codes in final response
+    regex mascot_error_regex(R"(\[M[0-9]{5}\])");
+    smatch error_match;
+    if (regex_search(response, error_match, mascot_error_regex))
+    {
+      OPENMS_LOG_ERROR << "Received response with Mascot error message!" << std::endl;
+      if (error_match[0].str() == "[M00380]")
+      {
+        error_message_ = "You must enter an email address and user name when using the Matrix Science public web site [M00380].";
+      }
+      else
+      {
+        OPENMS_LOG_ERROR << "Error code: " << error_match[0].str() << std::endl;
+        error_message_ = response;
+      }
+      return {};
+    }
+
+    return response;
+  }
+
+  string MascotRemoteQuery::removeHostName(const string& url) const
+  {
+    string result = url;
+    if (result.substr(0, 7) == "http://")
+      result = result.substr(7);
+    else if (result.substr(0, 8) == "https://")
+      result = result.substr(8);
+
+    string hostname = string(host_name_.c_str());
+    if (result.substr(0, hostname.size()) == hostname)
+    {
+      result = result.substr(hostname.size());
+    }
+
+    // Check for port suffix
+    Int port = param_.getValue("host_port");
+    string port_suffix = ":" + to_string(port);
+    if (result.substr(0, port_suffix.size()) == port_suffix)
+    {
+      result = result.substr(port_suffix.size());
+    }
+
+    // ensure path starts with /
+    if (result.empty() || result[0] != '/') result = "/" + result;
+
+    return result;
   }
 
   void MascotRemoteQuery::setQuerySpectra(const String& exp)
@@ -654,12 +472,12 @@ namespace OpenMS
     query_spectra_ = exp;
   }
 
-  const QByteArray& MascotRemoteQuery::getMascotXMLResponse() const
+  const string& MascotRemoteQuery::getMascotXMLResponse() const
   {
     return mascot_xml_;
   }
 
-  const QByteArray& MascotRemoteQuery::getMascotXMLDecoyResponse() const
+  const string& MascotRemoteQuery::getMascotXMLDecoyResponse() const
   {
     return mascot_decoy_xml_;
   }
@@ -690,120 +508,21 @@ namespace OpenMS
     cerr << "MascotRemoteQuery::updateMembers_()" << "\n";
 #endif
     server_path_ = param_.getValue("server_path").toString();
-    //MascotRemoteQuery_test
     if (!server_path_.empty())
     {
       server_path_ = "/" + server_path_;
     }
     host_name_ = param_.getValue("hostname").toString();
-    
+
     use_ssl_ = param_.getValue("use_ssl").toBool();
-#ifndef QT_NO_SSL
-    if (use_ssl_ && !QSslSocket::supportsSsl())
-    {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Error: Usage of SSL encryption requested but the OpenSSL library was not found at runtime. Please install OpenSSL system-wide.");
-    }
-#else
-    if (use_ssl_)
-    {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Error: Usage of SSL encryption requested but the linked QT library was not compiled with SSL support. Please recompile QT.");
-    }
-#endif
-    
+
     boundary_ = param_.getValue("boundary").toString();
-    cookie_ = "";
-    mascot_xml_ = "";
-    mascot_decoy_xml_ = "";
+    mascot_xml_.clear();
+    mascot_decoy_xml_.clear();
+    error_message_.clear();
 
     to_ = param_.getValue("timeout");
-    timeout_.setInterval(1000 * to_);
     requires_login_ = param_.getValue("login").toBool();
-
-    bool use_proxy(param_.getValue("use_proxy").toBool());
-    if (use_proxy)
-    {
-      QNetworkProxy proxy;
-      proxy.setType(QNetworkProxy::Socks5Proxy);
-      String proxy_host(param_.getValue("proxy_host").toString());
-      proxy.setHostName(proxy_host.toQString());
-      String proxy_port(param_.getValue("proxy_port").toString());
-      proxy.setPort(proxy_port.toInt());
-
-      String proxy_password(param_.getValue("proxy_password").toString());
-      proxy.setPassword(proxy_password.toQString());
-
-      String proxy_username(param_.getValue("proxy_username").toString());
-      if (!proxy_username.empty())
-      {
-        proxy.setUser(proxy_username.toQString());
-      }
-
-      QNetworkProxy::setApplicationProxy(proxy);
-    }
-
-
-    return;
-  }
-
-  void MascotRemoteQuery::removeHostName_(QString& url)
-  {
-    if (url.startsWith("http://"))
-      url.remove("http://");
-    else if (url.startsWith("https://"))
-      url.remove("https://");
-
-    if (!url.startsWith(host_name_.toQString()))
-    {
-      OPENMS_LOG_ERROR << "Invalid location returned by mascot! Abort." << std::endl;
-      endRun_();
-      return;
-    }
-    
-    // makes sure that only the first occurrence in the String is replaced,
-    // in case of an equal server_name_
-    url.replace(url.indexOf(host_name_.toQString()),
-                          host_name_.toQString().size(), QString(""));
-
-    // ensure path starts with /
-    if (url[0] != '/') url.prepend('/');
-  }
-
-  QUrl MascotRemoteQuery::buildUrl_(const std::string& path)
-  {
-    String protocol;
-    if (use_ssl_)
-    {
-      protocol = "https";
-    }
-    else
-    {
-      protocol = "http";
-    }
-    return QUrl(String(protocol + "://" + host_name_ + path).c_str());
-  }
-
-  void MascotRemoteQuery::logHeader_(const QNetworkReply* header, const String& what)
-  {
-    QList<QByteArray> header_list = header->rawHeaderList();
-    cerr << ">>>> Header to " << what << " (begin):\n";
-    foreach (QByteArray rawHeader, header_list)
-    {
-      cerr << "    " << rawHeader.toStdString() << " : " << header->rawHeader(rawHeader).toStdString() << std::endl;
-    }
-    cerr << "<<<< Header to " << what << " (end)." << endl;
-  }
-
-  void MascotRemoteQuery::logHeader_(const QNetworkRequest& header, const String& what)
-  {
-    QList<QByteArray> header_list = header.rawHeaderList();
-    cerr << ">>>> Header to " << what << " (begin):\n";
-    foreach (QByteArray rawHeader, header_list)
-    {
-      cerr << "    " << rawHeader.toStdString() << " : " << header.rawHeader(rawHeader).toStdString() << std::endl;
-    }
-    cerr << "<<<< Header to " << what << " (end)." << endl;
   }
 
   String MascotRemoteQuery::getSearchIdentifierFromFilePath(const String& path) const
@@ -821,4 +540,3 @@ namespace OpenMS
     return tmp;
   }
 }
-

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -296,6 +296,7 @@ namespace OpenMS
     body += "Content-Disposition: form-data; name=\"QUE\"\r\n";
     body += "\r\n";
     body += string(query_spectra_.c_str());
+    body += "\r\n";
     body += "--" + boundary + "--\r\n";
 
 #ifdef MASCOTREMOTEQUERY_DEBUG_FULL_QUERY

--- a/src/openms/source/SYSTEM/CurlInit.cpp
+++ b/src/openms/source/SYSTEM/CurlInit.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/SYSTEM/CurlInit.h>
+
+#include <curl/curl.h>
+
+namespace OpenMS
+{
+  void CurlInit::ensure()
+  {
+    static CurlInit instance;
+    (void)instance;
+  }
+
+  CurlInit::CurlInit()
+  {
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+  }
+
+  CurlInit::~CurlInit()
+  {
+    curl_global_cleanup();
+  }
+}

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -23,6 +23,7 @@
 #include <QtCore/QFileInfo>
 
 #include <atomic>
+#include <cerrno>
 #include <filesystem>
 #include <fstream>
 
@@ -477,11 +478,22 @@ namespace OpenMS
       char hbuf[256] = {};
 #ifdef OPENMS_WINDOWSPLATFORM
       DWORD sz = sizeof(hbuf);
-      GetComputerNameA(hbuf, &sz);
+      if (!GetComputerNameA(hbuf, &sz))
+      {
+        OPENMS_LOG_WARN << "Warning: GetComputerNameA failed (error " << GetLastError() << ")" << std::endl;
+        hbuf[0] = '\0';
+      }
 #else
-      gethostname(hbuf, sizeof(hbuf));
+      if (gethostname(hbuf, sizeof(hbuf)) != 0)
+      {
+        OPENMS_LOG_WARN << "Warning: gethostname failed (errno " << errno << ")" << std::endl;
+        hbuf[0] = '\0';
+      }
 #endif
-      hostname_str = String(hbuf) + "_";
+      if (hbuf[0] != '\0')
+      {
+        hostname_str = String(hbuf) + "_";
+      }
     }
     return now.getDate().remove('-') + "_" + now.getTime().remove(':') + "_" + hostname_str + pid + "_" + (++number);
   }

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -18,8 +18,6 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
-#include <OpenMS/SYSTEM/NetworkGetRequest.h>
-
 #include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
@@ -908,65 +906,5 @@ namespace OpenMS
   }
 
   File::TemporaryFiles_ File::temporary_files_;
-
-  // construct a filename from URL. Add number suffix if already exists.
-  static std::string saveFileName_(const std::string& url)
-  {
-    namespace fs = std::filesystem;
-    // extract filename from URL path
-    std::string path_part = url;
-    auto query_pos = path_part.find('?');
-    if (query_pos != std::string::npos) path_part = path_part.substr(0, query_pos);
-    auto frag_pos = path_part.find('#');
-    if (frag_pos != std::string::npos) path_part = path_part.substr(0, frag_pos);
-
-    std::string basename = fs::path(path_part).filename().string();
-    if (basename.empty()) basename = "download";
-
-    if (!fs::exists(basename)) return basename;
-
-    // already exists, don't overwrite
-    int i = 0;
-    while (fs::exists(basename + "." + std::to_string(i)))
-      ++i;
-    return basename + "." + std::to_string(i);
-  }
-
-// static
-void File::download(const std::string& url, const std::string& download_folder)
-{
-  NetworkGetRequest query;
-  query.setUrl(url);
-  query.setTimeout(600); // 10 minutes timeout
-  query.run();
-
-  if (!query.hasError())
-  {
-    std::string folder = download_folder.empty() ? "./" : download_folder;
-    std::string filename = folder + "/" + saveFileName_(url);
-    std::ofstream ofs(filename, std::ios::binary);
-    if (!ofs)
-    {
-      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "Failed to open output file: " + filename);
-    }
-    const auto& data = query.getResponseBinary();
-    ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
-    if (!ofs)
-    {
-      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "Failed to write downloaded data to: " + filename);
-    }
-    ofs.close();
-    OPENMS_LOG_INFO << "Download of '" << url << "' successful." << endl;
-    OPENMS_LOG_INFO << "Stored as '" << filename << "'." << endl;
-  }
-  else
-  {
-    String error = "Download of '" + url + "' failed!. Error: " + query.getErrorString() + '\n';
-    throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error);
-  }
-}
-
 
 } // namespace OpenMS

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -18,14 +18,20 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
-#include <QtCore/QFileInfo>
+#include <OpenMS/SYSTEM/NetworkGetRequest.h>
+
 #include <QtCore/QDir>
-#include <QtNetwork/QHostInfo>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 
 #include <atomic>
+#include <filesystem>
+#include <fstream>
 
 #ifdef OPENMS_WINDOWSPLATFORM
-#include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName()
+#include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName() && GetComputerNameA()
+#else
+#include <unistd.h> // for gethostname()
 #endif
 
 #ifdef OPENMS_HAS_UNISTD_H
@@ -35,21 +41,6 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
-
-
-#include <QtCore/QObject>
-#include <QtNetwork/QNetworkAccessManager>
-#include <QtNetwork/QNetworkRequest>
-#include <QtNetwork/QNetworkReply>
-#include <QtCore/QUrl>
-#include <QtCore/QDateTime>
-#include <QtCore/QFile>
-
-#include <OpenMS/SYSTEM/NetworkGetRequest.h>
-#include <QtCore/QDir>
-#include <QtCore/QCoreApplication>
-#include <QtCore/QDateTime>
-#include <QtCore/QTimer>
 
 
 using namespace std;
@@ -482,7 +473,19 @@ namespace OpenMS
     pid = (String)getpid();
 #endif
     static std::atomic_int number = 0;
-    return now.getDate().remove('-') + "_" + now.getTime().remove(':') + "_" + (include_hostname ? String(QHostInfo::localHostName()) + "_" : "")  + pid + "_" + (++number);
+    String hostname_str;
+    if (include_hostname)
+    {
+      char hbuf[256] = {};
+#ifdef OPENMS_WINDOWSPLATFORM
+      DWORD sz = sizeof(hbuf);
+      GetComputerNameA(hbuf, &sz);
+#else
+      gethostname(hbuf, sizeof(hbuf));
+#endif
+      hostname_str = String(hbuf) + "_";
+    }
+    return now.getDate().remove('-') + "_" + now.getTime().remove(':') + "_" + hostname_str + pid + "_" + (++number);
   }
 
   String File::getOpenMSDataPath()
@@ -906,62 +909,63 @@ namespace OpenMS
 
   File::TemporaryFiles_ File::temporary_files_;
 
-  // construct a filename. Add number if already exists.
-  QString saveFileName_(const QUrl &url)
+  // construct a filename from URL. Add number suffix if already exists.
+  static std::string saveFileName_(const std::string& url)
   {
-    QString path = url.path();
-    QString basename = QFileInfo(path).fileName();
+    namespace fs = std::filesystem;
+    // extract filename from URL path
+    std::string path_part = url;
+    auto query_pos = path_part.find('?');
+    if (query_pos != std::string::npos) path_part = path_part.substr(0, query_pos);
+    auto frag_pos = path_part.find('#');
+    if (frag_pos != std::string::npos) path_part = path_part.substr(0, frag_pos);
 
-    if (basename.isEmpty())
-        basename = "download";
+    std::string basename = fs::path(path_part).filename().string();
+    if (basename.empty()) basename = "download";
 
-    if (QFile::exists(basename)) {
-        // already exists, don't overwrite
-        int i = 0;
-        basename += '.';
-        while (QFile::exists(basename + QString::number(i)))
-            ++i;
+    if (!fs::exists(basename)) return basename;
 
-        basename += QString::number(i);
-    }
-
-    return basename;
+    // already exists, don't overwrite
+    int i = 0;
+    while (fs::exists(basename + "." + std::to_string(i)))
+      ++i;
+    return basename + "." + std::to_string(i);
   }
 
 // static
 void File::download(const std::string& url, const std::string& download_folder)
 {
-  // We need to use a QCoreApplication to fire up the  QEventLoop to process the signals and slots.
-  char const * argv2[] = { "dummyname", nullptr };
-  int argc = 1;
-  QCoreApplication event_loop(argc, const_cast<char**>(argv2));
-  NetworkGetRequest* query = new NetworkGetRequest(&event_loop);
-  auto qURL = QUrl(QString::fromUtf8(url.c_str()));
-  query->setUrl(qURL);
-  QObject::connect(query, SIGNAL(done()), &event_loop, SLOT(quit()));
-  QTimer::singleShot(1000, query, SLOT(run()));          
-  QTimer::singleShot(600000, query, SLOT(timeOut())); // 10 minutes timeout
-  event_loop.exec();
+  NetworkGetRequest query;
+  query.setUrl(url);
+  query.setTimeout(600); // 10 minutes timeout
+  query.run();
 
-  if (!query->hasError())
+  if (!query.hasError())
   {
-    QString folder = download_folder.empty() ? QString("./") : QString(download_folder.c_str());
-    QString filename = QString(folder) + "/" + saveFileName_(qURL); 
-    QFile file(filename);
-    file.open(QIODevice::ReadWrite);
-    file.write(query->getResponseBinary().data(), query->getResponseBinary().size());
-    file.close();
+    std::string folder = download_folder.empty() ? "./" : download_folder;
+    std::string filename = folder + "/" + saveFileName_(url);
+    std::ofstream ofs(filename, std::ios::binary);
+    if (!ofs)
+    {
+      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Failed to open output file: " + filename);
+    }
+    const auto& data = query.getResponseBinary();
+    ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (!ofs)
+    {
+      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Failed to write downloaded data to: " + filename);
+    }
+    ofs.close();
     OPENMS_LOG_INFO << "Download of '" << url << "' successful." << endl;
-    OPENMS_LOG_INFO << "Stored as '" << filename.toStdString() << "'." << endl;
+    OPENMS_LOG_INFO << "Stored as '" << filename << "'." << endl;
   }
   else
   {
-    String error = "Download of '" + url + "' failed!. Error: " + String(query->getErrorString()) + '\n';
+    String error = "Download of '" + url + "' failed!. Error: " + query.getErrorString() + '\n';
     throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error);
   }
-
-  delete query;
-  event_loop.quit();
 }
 
 

--- a/src/openms/source/SYSTEM/Network.cpp
+++ b/src/openms/source/SYSTEM/Network.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/SYSTEM/Network.h>
+
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/SYSTEM/NetworkGetRequest.h>
+
+#include <filesystem>
+#include <fstream>
+
+using namespace std;
+
+namespace OpenMS
+{
+
+namespace
+{
+  // construct a filename from URL. Add number suffix if already exists.
+  std::string saveFileName_(const std::string& url)
+  {
+    namespace fs = std::filesystem;
+    // extract filename from URL path
+    std::string path_part = url;
+    auto query_pos = path_part.find('?');
+    if (query_pos != std::string::npos) path_part = path_part.substr(0, query_pos);
+    auto frag_pos = path_part.find('#');
+    if (frag_pos != std::string::npos) path_part = path_part.substr(0, frag_pos);
+
+    std::string basename = fs::path(path_part).filename().string();
+    if (basename.empty()) basename = "download";
+
+    if (!fs::exists(basename)) return basename;
+
+    // already exists, don't overwrite
+    int i = 0;
+    while (fs::exists(basename + "." + std::to_string(i)))
+      ++i;
+    return basename + "." + std::to_string(i);
+  }
+} // anonymous namespace
+
+void Network::downloadFile(const std::string& url, const std::string& download_folder)
+{
+  NetworkGetRequest query;
+  query.setUrl(url);
+  query.setTimeout(600); // 10 minutes timeout
+  query.run();
+
+  if (!query.hasError())
+  {
+    std::string folder = download_folder.empty() ? "./" : download_folder;
+    std::string filename = folder + "/" + saveFileName_(url);
+    std::ofstream ofs(filename, std::ios::binary);
+    if (!ofs)
+    {
+      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Failed to open output file: " + filename);
+    }
+    const auto& data = query.getResponseBinary();
+    ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (!ofs)
+    {
+      throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Failed to write downloaded data to: " + filename);
+    }
+    ofs.close();
+    OPENMS_LOG_INFO << "Download of '" << url << "' successful." << endl;
+    OPENMS_LOG_INFO << "Stored as '" << filename << "'." << endl;
+  }
+  else
+  {
+    String error = "Download of '" + url + "' failed!. Error: " + query.getErrorString() + '\n';
+    throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, error);
+  }
+}
+
+} // namespace OpenMS

--- a/src/openms/source/SYSTEM/Network.cpp
+++ b/src/openms/source/SYSTEM/Network.cpp
@@ -22,8 +22,8 @@ namespace OpenMS
 
 namespace
 {
-  // construct a filename from URL. Add number suffix if already exists.
-  std::string saveFileName_(const std::string& url)
+  // construct a filename from URL. Add number suffix if file already exists in dest_folder.
+  std::string saveFileName_(const std::string& url, const std::string& dest_folder)
   {
     namespace fs = std::filesystem;
     // extract filename from URL path
@@ -36,11 +36,12 @@ namespace
     std::string basename = fs::path(path_part).filename().string();
     if (basename.empty()) basename = "download";
 
-    if (!fs::exists(basename)) return basename;
+    fs::path dest(dest_folder);
+    if (!fs::exists(dest / basename)) return basename;
 
     // already exists, don't overwrite
     int i = 0;
-    while (fs::exists(basename + "." + std::to_string(i)))
+    while (fs::exists(dest / (basename + "." + std::to_string(i))))
       ++i;
     return basename + "." + std::to_string(i);
   }
@@ -56,7 +57,7 @@ void Network::downloadFile(const std::string& url, const std::string& download_f
   if (!query.hasError())
   {
     std::string folder = download_folder.empty() ? "./" : download_folder;
-    std::string filename = folder + "/" + saveFileName_(url);
+    std::string filename = folder + "/" + saveFileName_(url, folder);
     std::ofstream ofs(filename, std::ios::binary);
     if (!ofs)
     {

--- a/src/openms/source/SYSTEM/NetworkGetRequest.cpp
+++ b/src/openms/source/SYSTEM/NetworkGetRequest.cpp
@@ -7,88 +7,101 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/SYSTEM/NetworkGetRequest.h>
+#include <OpenMS/SYSTEM/CurlInit.h>
 
-#include <OpenMS/CONCEPT/LogStream.h>
-
-#include <QtNetwork/QNetworkRequest>
-#include <QtGui/QTextDocument>
+#include <curl/curl.h>
 
 using namespace std;
 
 namespace OpenMS
 {
-
-  NetworkGetRequest::NetworkGetRequest(QObject* parent) :
-    QObject(parent), reply_(nullptr)
+  namespace
   {
-    manager_ = new QNetworkAccessManager(this);
+    size_t writeCallback(char* ptr, size_t size, size_t nmemb, void* userdata)
+    {
+      auto* buf = static_cast<vector<char>*>(userdata);
+      size_t total = size * nmemb;
+      buf->insert(buf->end(), ptr, ptr + total);
+      return total;
+    }
   }
 
+  NetworkGetRequest::NetworkGetRequest() = default;
   NetworkGetRequest::~NetworkGetRequest() = default;
 
-  void NetworkGetRequest::setUrl(const QUrl& url)
+  void NetworkGetRequest::setUrl(const string& url)
   {
     url_ = url;
   }
 
+  void NetworkGetRequest::setTimeout(int seconds)
+  {
+    timeout_ = seconds;
+  }
+
   void NetworkGetRequest::run()
   {
-    if (reply_ == nullptr)
+    CurlInit::ensure();
+
+    has_error_ = false;
+    error_string_.clear();
+    response_bytes_.clear();
+
+    CURL* curl = curl_easy_init();
+    if (!curl)
     {
-      error_ = QNetworkReply::NoError;
-      error_string_ = "";
-      QNetworkRequest request;
-      request.setUrl(url_);
-      request.setHeader(QNetworkRequest::ContentTypeHeader, "text/plain");
-      connect(manager_, SIGNAL(finished(QNetworkReply*)), this, SLOT(replyFinished(QNetworkReply*)));
-      reply_ = manager_->get(request);
+      has_error_ = true;
+      error_string_ = "Failed to initialize libcurl";
+      return;
     }
+
+    curl_easy_setopt(curl, CURLOPT_URL, url_.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_bytes_);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L); // thread-safe DNS timeout
+    if (timeout_ > 0)
+    {
+      curl_easy_setopt(curl, CURLOPT_TIMEOUT, static_cast<long>(timeout_));
+    }
+
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK)
+    {
+      has_error_ = true;
+      error_string_ = curl_easy_strerror(res);
+    }
+    else
+    {
+      long http_code = 0;
+      curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+      if (http_code >= 400)
+      {
+        has_error_ = true;
+        error_string_ = "HTTP error " + std::to_string(http_code);
+      }
+    }
+
+    curl_easy_cleanup(curl);
   }
 
-  void NetworkGetRequest::replyFinished(QNetworkReply* reply)
+  string NetworkGetRequest::getResponse() const
   {
-    if (reply_ != nullptr)
-    {
-      error_ = reply->error();
-      error_string_ = error_ != QNetworkReply::NoError ? reply->errorString() : "";
-      response_bytes_ = reply->readAll(); // in case of error this will just read the error html from the server
-      reply->close();
-      reply->deleteLater();;
-    }
-    emit done();
+    return string(response_bytes_.begin(), response_bytes_.end());
   }
 
-  void NetworkGetRequest::timeOut()
-  {
-    if (reply_ != nullptr)
-    {
-      error_ = QNetworkReply::TimeoutError;
-      error_string_ = "TimeoutError: the connection to the remote server timed out";
-      reply_->abort();
-      reply_->close();
-      reply_->deleteLater();
-    }
-    emit done();
-  }
-
-  const QByteArray& NetworkGetRequest::getResponseBinary() const
+  const vector<char>& NetworkGetRequest::getResponseBinary() const
   {
     return response_bytes_;
   }
 
-  QString NetworkGetRequest::getResponse() const
-  {
-    return QString(response_bytes_);
-  }  
-
   bool NetworkGetRequest::hasError() const
   {
-    return error_ != QNetworkReply::NoError;
+    return has_error_;
   }
 
-  QString NetworkGetRequest::getErrorString() const
+  string NetworkGetRequest::getErrorString() const
   {
     return error_string_;
   }
-
 }

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -108,11 +108,20 @@ namespace OpenMS
       {
         // update modification time stamp
         struct stat old_stat;
-        struct utimbuf new_times;
-        stat(version_file_name.c_str(), &old_stat);
-        new_times.actime = old_stat.st_atime; // keep accession time unchanged
-        new_times.modtime = time(nullptr);  // mod time to current time
-        utime(version_file_name.c_str(), &new_times);
+        if (stat(version_file_name.c_str(), &old_stat) != 0)
+        {
+          OPENMS_LOG_WARN << "Warning: stat() failed for '" << version_file_name << "' (errno " << errno << ")" << std::endl;
+        }
+        else
+        {
+          struct utimbuf new_times;
+          new_times.actime = old_stat.st_atime; // keep accession time unchanged
+          new_times.modtime = time(nullptr);  // mod time to current time
+          if (utime(version_file_name.c_str(), &new_times) != 0)
+          {
+            OPENMS_LOG_WARN << "Warning: utime() failed for '" << version_file_name << "' (errno " << errno << ")" << std::endl;
+          }
+        }
 
         if (debug_level > 0)
         {

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -22,14 +22,14 @@
 
 #include <OpenMS/SYSTEM/NetworkGetRequest.h>
 #include <QtCore/QDir>
-#include <QtCore/QCoreApplication>
 #include <QtCore/QDateTime>
-#include <QtCore/QTimer>
+#include <QtCore/QFileInfo>
+#include <QtCore/QSysInfo>
 
 #include <OpenMS/CONCEPT/VersionInfo.h>
 
 using namespace std;
-  
+
 namespace OpenMS
 {
   void UpdateCheck::run(const String& tool_name, const String& version, int debug_level)
@@ -110,9 +110,9 @@ namespace OpenMS
         struct stat old_stat;
         struct utimbuf new_times;
         stat(version_file_name.c_str(), &old_stat);
-        new_times.actime = old_stat.st_atime; // keep accession time unchanged 
+        new_times.actime = old_stat.st_atime; // keep accession time unchanged
         new_times.modtime = time(nullptr);  // mod time to current time
-        utime(version_file_name.c_str(), &new_times);          
+        utime(version_file_name.c_str(), &new_times);
 
         if (debug_level > 0)
         {
@@ -120,26 +120,20 @@ namespace OpenMS
           OPENMS_LOG_INFO << "We will never give out your personal data, but you may disable this functionality by " << endl;
           OPENMS_LOG_INFO << "setting the environmental variable OPENMS_DISABLE_UPDATE_CHECK to ON." << endl;
         }
-      
-        // We need to use a QCoreApplication to fire up the  QEventLoop to process the signals and slots.
-        char const * argv2[] = { "dummyname", nullptr };
-        int argc = 1;
-        QCoreApplication event_loop(argc, const_cast<char**>(argv2));
-        NetworkGetRequest* query = new NetworkGetRequest(&event_loop);
-        query->setUrl(QUrl(QString("http://openms-update.cs.uni-tuebingen.de/check/") + tool_version_string.toQString()));
-        QObject::connect(query, SIGNAL(done()), &event_loop, SLOT(quit()));
-        QTimer::singleShot(1000, query, SLOT(run()));          
-        QTimer::singleShot(5000, query, SLOT(timeOut()));
-        event_loop.exec();
 
-        if (!query->hasError())
+        NetworkGetRequest query;
+        query.setUrl("http://openms-update.cs.uni-tuebingen.de/check/" + tool_version_string);
+        query.setTimeout(5);
+        query.run();
+
+        if (!query.hasError())
         {
           if (debug_level > 0)
           {
             OPENMS_LOG_INFO << "Connecting to REST server successful. " << endl;
           }
 
-          QString response = query->getResponse();
+          String response = query.getResponse();
           VersionInfo::VersionDetails server_version = VersionInfo::VersionDetails::create(response);
           if (server_version != VersionInfo::VersionDetails::EMPTY)
           {
@@ -154,14 +148,11 @@ namespace OpenMS
           if (debug_level > 0)
           {
             OPENMS_LOG_INFO << "Connecting to REST server failed. Skipping update check." << endl;
-            OPENMS_LOG_INFO << "Error: " << String(query->getErrorString()) << endl;
+            OPENMS_LOG_INFO << "Error: " << query.getErrorString() << endl;
           }
         }
-        delete query;
-        event_loop.quit();
       }
     }
   }
 
 }
-

--- a/src/openms/source/SYSTEM/sources.cmake
+++ b/src/openms/source/SYSTEM/sources.cmake
@@ -8,6 +8,7 @@ CurlInit.cpp
 ExternalProcess.cpp
 File.cpp
 JavaInfo.cpp
+Network.cpp
 NetworkGetRequest.cpp
 PythonInfo.cpp
 RWrapper.cpp

--- a/src/openms/source/SYSTEM/sources.cmake
+++ b/src/openms/source/SYSTEM/sources.cmake
@@ -4,6 +4,7 @@ set(directory source/SYSTEM)
 ### list all filenames of the directory here
 set(sources_list
 BuildInfo.cpp
+CurlInit.cpp
 ExternalProcess.cpp
 File.cpp
 JavaInfo.cpp

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/FLASHDeconvWizardBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/FLASHDeconvWizardBase.h
@@ -16,7 +16,6 @@
 
 // QT
 #include <QtCore/QProcess>
-#include <QtNetwork/QNetworkReply>
 #include <QtWidgets/QButtonGroup>
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMdiArea>
@@ -30,8 +29,6 @@ class QLabel;
 class QWidget;
 class QTreeWidget;
 class QTreeWidgetItem;
-class QWebView;
-class QNetworkAccessManager;
 
 namespace Ui
 {

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/SwathWizardBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/SwathWizardBase.h
@@ -20,7 +20,6 @@
 #include <QtWidgets/QButtonGroup>
 #include <QtCore/QProcess>
 #include <QtWidgets/QSplashScreen>
-#include <QtNetwork/QNetworkReply>
 
 class QToolBar;
 class QListWidget;
@@ -30,8 +29,6 @@ class QLabel;
 class QWidget;
 class QTreeWidget;
 class QTreeWidgetItem;
-class QWebView;
-class QNetworkAccessManager;
 
 namespace Ui
 {

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPASBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPASBase.h
@@ -21,7 +21,6 @@
 #include <QtWidgets/QButtonGroup>
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMdiArea>
-#include <QtNetwork/QNetworkReply>
 #include <QtWidgets/QSplashScreen>
 
 class QToolBar;
@@ -33,8 +32,6 @@ class QPushButton;
 class QWidget;
 class QTreeWidget;
 class QTreeWidgetItem;
-class QWebView;
-class QNetworkAccessManager;
 
 
 namespace OpenMS
@@ -96,8 +93,6 @@ public slots:
     void loadPipelineResourceFile();
     /// shows a file dialog for selecting the resource file to write to
     void savePipelineResourceFile();
-    /// opens the OpenMS Homepage to download example workflows
-    void openOnlinePipelineRepository();
     /// shows the preferences dialog
     void preferencesDialog();
     /// changes the current path according to the currently active window/layer
@@ -169,13 +164,6 @@ protected slots:
     /// Inserts the @p item in the middle of the current window
     void insertNewVertexInCenter_(QTreeWidgetItem* item);
 
-    /// triggered when user clicks a link - if it ends in .TOPPAS we're done
-    void downloadTOPPASfromHomepage_(const QUrl& url);
-    /// triggered when download of .toppas file is finished, so we can store & open it
-    void toppasFileDownloaded_(QNetworkReply* r);
-    /// debug...
-    void TOPPASreadyRead();
-
     /// user edited the workflow description
     void descriptionUpdated_();
 
@@ -197,13 +185,6 @@ protected:
 
     /// Main workspace
     EnhancedWorkspace* ws_;
-
-    /// OpenMS homepage workflow browser
-    QWebView* webview_;
-    /// download .toppas files from homepage
-    QNetworkAccessManager* network_manager_;
-    /// the content of the network request
-    QNetworkReply* network_reply_;
 
     ///Tab bar. The address of the corresponding window to a tab is stored as an int in tabData()
     EnhancedTabBar* tab_bar_;

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/FLASHDeconvWizardBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/FLASHDeconvWizardBase.cpp
@@ -17,6 +17,7 @@
 // Qt
 #include <QDesktopServices>
 #include <QMessageBox>
+#include <QUrl>
 #include <QSettings>
 
 using namespace std;

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/SwathWizardBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/SwathWizardBase.cpp
@@ -18,6 +18,7 @@
 //Qt
 #include <QtCore/QDir>
 #include <QDesktopServices>
+#include <QUrl>
 #include <QMessageBox>
 #include <QSettings>
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -37,10 +37,6 @@
 #include <QApplication>
 #include <QCloseEvent>
 #include <QDesktopServices>
-#include <QNetworkAccessManager>
-#include <QNetworkProxy>
-#include <QNetworkProxyFactory>
-#include <QNetworkReply>
 #include <QSvgGenerator>
 #include <QTextStream>
 #include <QtCore/QDir>
@@ -263,9 +259,6 @@ namespace OpenMS
     connect((webview_->page()), SIGNAL(linkClicked(const QUrl &)), this, SLOT(downloadTOPPASfromHomepage_(const QUrl &)));
 */
 
-    network_manager_ = new QNetworkAccessManager(this);
-    connect(network_manager_, SIGNAL(finished(QNetworkReply*)), this, SLOT(toppasFileDownloaded_(QNetworkReply*)));
-
     // update the menu
     updateMenu(); 
 
@@ -299,134 +292,6 @@ namespace OpenMS
     //std::cerr << "changed to '" << String(desc_->toHtml()) << "'\n";
     activeSubWindow_()->getScene()->setChanged(true);
     activeSubWindow_()->getScene()->setDescription(desc_->toHtml());
-  }
-
-  void TOPPASBase::toppasFileDownloaded_(QNetworkReply* /* r */)
-  {
-/* QT5
-    r->deleteLater();
-    if (r->error() != QNetworkReply::NoError)
-    {
-      log_->appendNewHeader(LogWindow::LogState::CRITICAL, "Download failed", "Error '" + r->errorString() + "' while downloading TOPPAS file: '" + r->url().toString() + "'");
-      return;
-    }
-
-    QByteArray data = r->readAll();
-
-    QString proposed_filename;
-    if (r->url().hasQueryItem("file"))
-    {
-      proposed_filename = r->url().queryItemValue("file");
-    }
-    else
-    {
-      proposed_filename = "Workflow.toppas";
-      OPENMS_LOG_WARN << "The URL format of downloads from the TOPPAS Online-Repository has changed. Please notify developers!";
-    }
-    QString filename = QFileDialog::getSaveFileName(this, "Where to save the TOPPAS file?", this->current_path_.toQString() + "/" + proposed_filename, tr("TOPPAS (*.toppas)"));
-
-    // check if the user clicked cancel, to avoid saving .toppas somewhere
-    if (String(filename).trim().empty())
-    {
-      log_->appendNewHeader(LogWindow::LogState::NOTICE, "Download succeeded, but saving aborted by user!", "");
-      return;
-    }
-
-    if (!filename.endsWith(".toppas", Qt::CaseInsensitive))
-    {
-      filename += ".toppas";
-    }
-
-    QFile file(filename);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
-    {
-      log_->appendNewHeader(LogWindow::LogState::NOTICE, "Download succeeded. Cannot save the file. Try again with another filename and/or location!", "");
-      return;
-    }
-
-    QTextStream out(&file);
-    out << data;
-    file.close();
-
-    this->addTOPPASFile(filename);
-    log_->appendNewHeader(LogWindow::LogState::NOTICE, "File successfully saved to '" + filename + "'.", "");
-*/
-  }
-  
-  void TOPPASBase::TOPPASreadyRead()
-  {
-    QNetworkReply::NetworkError ne = network_reply_->error();
-    qint64 ba = network_reply_->bytesAvailable();
-    OPENMS_LOG_DEBUG << "Error code (QNetworkReply::NetworkError): " << ne << "  bytes available: " << ba << std::endl;
-    return;
-  }
-
-  void TOPPASBase::downloadTOPPASfromHomepage_(const QUrl& url)
-  {
-    if (url.toString().endsWith(QString(".toppas"), Qt::CaseInsensitive))
-    {
-      network_reply_ = network_manager_->get(QNetworkRequest(url));
-
-      // debug
-      connect(network_reply_, SIGNAL(readyRead()), this, SLOT(TOPPASreadyRead()));
-      connect(network_reply_, SIGNAL(error(QNetworkReply::NetworkError code)), this, SLOT(TOPPASreadyRead()));
-      connect(network_reply_, SIGNAL(finished()), this, SLOT(TOPPASreadyRead()));
-      connect(network_reply_, SIGNAL(metaDataChanged()), this, SLOT(TOPPASreadyRead()));
-      connect(network_reply_, SIGNAL(sslErrors(const QList<QSslError> & errors)), this, SLOT(TOPPASreadyRead()));
-      // .. end debug
-
-      log_->appendNewHeader(LogWindow::LogState::NOTICE, "Downloading file '" + url.toString() + "'. You will be notified once the download finished.", "");
-      // webview_->close(); QT5 replace with QWebEngine
-    }
-    else
-    {
-      QMessageBox::warning(this, tr("Error"), tr("You can only click '.toppas' files on this page. No navigation is allowed!\n"));
-      /* 
-      replace with QT5 webengine
-      webview_->setFocus(); 
-      webview_->activateWindow();
-      */
-    }
-  }
-
-  void TOPPASBase::openOnlinePipelineRepository()
-  {
-/* QT5
-    QUrl url = QUrl("http://www.OpenMS.de/TOPPASWorkflows/");
-
-    static bool proxy_settings_checked = false;
-    if (!proxy_settings_checked) // do only once because may take several seconds on windows
-    {
-      QNetworkProxy proxy;
-      QUrl tmp_proxy_url(QString(getenv("http_proxy")));
-      QUrl tmp_PROXY_url(QString(getenv("HTTP_PROXY")));
-      QUrl proxy_url = tmp_proxy_url.isValid() ? tmp_proxy_url : tmp_PROXY_url;
-      if (proxy_url.isValid())
-      {
-        QString hostname = proxy_url.host();
-        int port = proxy_url.port();
-        QString username = proxy_url.userName();
-        QString password = proxy_url.password();
-        proxy = QNetworkProxy(QNetworkProxy::HttpProxy, hostname, port, username, password);
-      }
-      else
-      {
-        QList<QNetworkProxy> proxies = QNetworkProxyFactory::systemProxyForQuery(url);
-        if (!proxies.empty())
-        {
-          proxy = proxies.first();
-        }
-      }
-      QNetworkProxy::setApplicationProxy(proxy); //no effect if proxy == QNetworkProxy()
-      proxy_settings_checked = true;
-    }
-
-    // show something immediately, so the user does not stare at white screen while the URL is fetched
-    webview_->setHtml("loading content ... ");
-    webview_->show();
-    // ... load the page in background
-    webview_->load(url);
-*/
   }
 
   //static

--- a/src/tests/class_tests/openms/data/Network_test_fixture.txt
+++ b/src/tests/class_tests/openms/data/Network_test_fixture.txt
@@ -1,0 +1,2 @@
+This is a test fixture for Network::downloadFile().
+It verifies that file:// URL downloads work correctly.

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -127,6 +127,7 @@ set(metadata_executables_list
 set(system_executables_list
   ExternalProcess_test
   File_test
+  Network_test
   JavaInfo_test
   PythonInfo_test
   StopWatch_test

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -235,7 +235,7 @@ TEST_STRING_EQUAL(exp.getSourceFiles()[0].getChecksum(), "d50d5144cc3805749b9e8d
 {
   namespace fs = std::filesystem;
   // Create a subdirectory with non-ASCII characters (German umlauts, Japanese)
-  fs::path utf8_dir = fs::path(File::getTempDirectory()) / u8"openms_t\u00e4st_\u30c6\u30b9\u30c8";
+  fs::path utf8_dir = fs::path(std::string(File::getTempDirectory())) / u8"openms_t\u00e4st_\u30c6\u30b9\u30c8";
   std::error_code ec;
   fs::create_directories(utf8_dir, ec);
   if (!ec)

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -17,6 +17,10 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <filesystem>
+#include <fstream>
 
 START_TEST(FileHandler, "$Id$")
 
@@ -226,6 +230,34 @@ FileHandler tmp;
 tmp.loadExperiment(OPENMS_GET_TEST_DATA_PATH("DTA2DFile_test_1.dta2d"), exp, {FileTypes::DTA2D}, ProgressLogger::NONE, true, true);
 // compute hash
 TEST_STRING_EQUAL(exp.getSourceFiles()[0].getChecksum(), "d50d5144cc3805749b9e8d16f3bc8994979d8142")
+
+// Regression test: computeFileHash must work with non-ASCII (UTF-8) paths
+{
+  namespace fs = std::filesystem;
+  // Create a subdirectory with non-ASCII characters (German umlauts, Japanese)
+  fs::path utf8_dir = fs::path(File::getTempDirectory()) / u8"openms_t\u00e4st_\u30c6\u30b9\u30c8";
+  std::error_code ec;
+  fs::create_directories(utf8_dir, ec);
+  if (!ec)
+  {
+    // Write a small test file
+    fs::path utf8_file = utf8_dir / "test.txt";
+    {
+      std::ofstream ofs{utf8_file, std::ios::binary};
+      ofs << "hello";
+    }
+    String hash = FileHandler::computeFileHash(utf8_file.string());
+    TEST_EQUAL(hash.empty(), false) // must succeed, not return ""
+    // Clean up
+    fs::remove(utf8_file, ec);
+    fs::remove(utf8_dir, ec);
+  }
+  else
+  {
+    // If the OS can't create non-ASCII dirs (unlikely), skip silently
+    STATUS("Skipping UTF-8 path test: could not create directory with non-ASCII name")
+  }
+}
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -231,31 +231,31 @@ tmp.loadExperiment(OPENMS_GET_TEST_DATA_PATH("DTA2DFile_test_1.dta2d"), exp, {Fi
 // compute hash
 TEST_STRING_EQUAL(exp.getSourceFiles()[0].getChecksum(), "d50d5144cc3805749b9e8d16f3bc8994979d8142")
 
-// Regression test: computeFileHash must work with non-ASCII (UTF-8) paths
+// Regression test: computeFileHash must work with non-ASCII paths
 {
   namespace fs = std::filesystem;
-  // Create a subdirectory with non-ASCII characters (German umlauts, Japanese)
-  fs::path utf8_dir = fs::path(std::string(File::getTempDirectory())) / u8"openms_t\u00e4st_\u30c6\u30b9\u30c8";
+  // Use u8"" for portable path construction. Only use Latin-1 characters (ä, ü) that are
+  // representable in Windows-1252 so that path::string() round-trips correctly on Windows.
+  // CJK characters would fail because Windows path::string() uses the Active Code Page.
+  fs::path nonascii_dir = fs::path(std::string(File::getTempDirectory())) / u8"openms_t\u00e4st_\u00fc";
   std::error_code ec;
-  fs::create_directories(utf8_dir, ec);
+  fs::create_directories(nonascii_dir, ec);
   if (!ec)
   {
-    // Write a small test file
-    fs::path utf8_file = utf8_dir / "test.txt";
+    fs::path nonascii_file = nonascii_dir / "test.txt";
     {
-      std::ofstream ofs{utf8_file, std::ios::binary};
+      std::ofstream ofs{nonascii_file, std::ios::binary};
       ofs << "hello";
     }
-    String hash = FileHandler::computeFileHash(utf8_file.string());
+    String hash = FileHandler::computeFileHash(nonascii_file.string());
     TEST_EQUAL(hash.empty(), false) // must succeed, not return ""
     // Clean up
-    fs::remove(utf8_file, ec);
-    fs::remove(utf8_dir, ec);
+    fs::remove(nonascii_file, ec);
+    fs::remove(nonascii_dir, ec);
   }
   else
   {
-    // If the OS can't create non-ASCII dirs (unlikely), skip silently
-    STATUS("Skipping UTF-8 path test: could not create directory with non-ASCII name")
+    STATUS("Skipping non-ASCII path test: could not create directory")
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -337,21 +337,6 @@ START_SECTION(File::~TempDir())
 END_SECTION
 
 
-START_SECTION(File::download(std::string url, std::string filename))
-{
-  std::string url = R"(http://raw.githubusercontent.com/OpenMS/OpenMS/refs/heads/develop/README.md)";
-  std::string folder = File::getTempDirectory();
-  File::download(url, folder);
-  std::string output_file_path = folder + "/README.md";
-
-  TEST_EQUAL(File::exists(output_file_path), 1);
-  if (File::exists(output_file_path))
-  {
-    File::removeDir(QString(output_file_path.c_str()));
-  }
-}
-END_SECTION
-
 START_SECTION(static File::MatchingFileListsStatus validateMatchingFileNames(const StringList& sl1, const StringList& sl2, bool basename, bool ignore_extension))
 {
   // Test exact match

--- a/src/tests/class_tests/openms/source/MascotRemoteQuery_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotRemoteQuery_test.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
 // SPDX-License-Identifier: BSD-3-Clause
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Chris Bielow $
 // $Authors: Andreas Bertsch, Daniel Jameson, Chris Bielow$
@@ -23,7 +23,7 @@ START_TEST(MascotRemoteQuery, "$Id$")
 
 MascotRemoteQuery* ptr = nullptr;
 MascotRemoteQuery* nullPointer = nullptr;
-START_SECTION(MascotRemoteQuery(QObject *parent=0))
+START_SECTION(MascotRemoteQuery())
 {
 	ptr = new MascotRemoteQuery();
 	TEST_NOT_EQUAL(ptr, nullPointer)
@@ -44,7 +44,7 @@ START_SECTION((void setQuerySpectra(const String &exp)))
 }
 END_SECTION
 
-START_SECTION((const QByteArray& getMascotXMLResponse() const ))
+START_SECTION((const std::string& getMascotXMLResponse() const ))
 {
   MascotRemoteQuery query;
 	TEST_EQUAL(query.getMascotXMLResponse().size(), 0)

--- a/src/tests/class_tests/openms/source/Network_test.cpp
+++ b/src/tests/class_tests/openms/source/Network_test.cpp
@@ -27,12 +27,19 @@ START_TEST(Network, "$Id$")
 
 START_SECTION(static void downloadFile(const std::string& url, const std::string& download_folder))
 {
-  std::string url = R"(http://raw.githubusercontent.com/OpenMS/OpenMS/refs/heads/develop/README.md)";
-  std::string folder = File::getTempDirectory();
-  Network::downloadFile(url, folder);
-  std::string output_file_path = folder + "/README.md";
+  // Use a local file:// URL to avoid external network dependency
+  std::string fixture_path = OPENMS_GET_TEST_DATA_PATH("Network_test_fixture.txt");
+  std::string url = "file://" + fixture_path;
 
-  TEST_EQUAL(File::exists(output_file_path), 1);
+  std::string tmp_file;
+  NEW_TMP_FILE(tmp_file);
+  // NEW_TMP_FILE gives a file path; we need the directory
+  std::string folder = std::filesystem::path(tmp_file).parent_path().string();
+
+  Network::downloadFile(url, folder);
+  std::string output_file_path = folder + "/Network_test_fixture.txt";
+
+  TEST_EQUAL(File::exists(output_file_path), true);
   if (File::exists(output_file_path))
   {
     std::filesystem::remove(output_file_path);

--- a/src/tests/class_tests/openms/source/Network_test.cpp
+++ b/src/tests/class_tests/openms/source/Network_test.cpp
@@ -31,10 +31,7 @@ START_SECTION(static void downloadFile(const std::string& url, const std::string
   std::string fixture_path = OPENMS_GET_TEST_DATA_PATH("Network_test_fixture.txt");
   std::string url = "file://" + fixture_path;
 
-  std::string tmp_file;
-  NEW_TMP_FILE(tmp_file);
-  // NEW_TMP_FILE gives a file path; we need the directory
-  std::string folder = std::filesystem::path(tmp_file).parent_path().string();
+  std::string folder = File::getTempDirectory();
 
   Network::downloadFile(url, folder);
   std::string output_file_path = folder + "/Network_test_fixture.txt";

--- a/src/tests/class_tests/openms/source/Network_test.cpp
+++ b/src/tests/class_tests/openms/source/Network_test.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+/////////////////////////////////////////////////////////////
+
+#include <OpenMS/SYSTEM/Network.h>
+#include <OpenMS/SYSTEM/File.h>
+
+#include <filesystem>
+
+using namespace OpenMS;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(Network, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+START_SECTION(static void downloadFile(const std::string& url, const std::string& download_folder))
+{
+  std::string url = R"(http://raw.githubusercontent.com/OpenMS/OpenMS/refs/heads/develop/README.md)";
+  std::string folder = File::getTempDirectory();
+  Network::downloadFile(url, folder);
+  std::string output_file_path = folder + "/README.md";
+
+  TEST_EQUAL(File::exists(output_file_path), 1);
+  if (File::exists(output_file_path))
+  {
+    std::filesystem::remove(output_file_path);
+  }
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+
+END_TEST

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -23,10 +23,8 @@
 #include <OpenMS/APPLICATIONS/SearchEngineBase.h>
 
 #include <sstream>
-
-#include <QtCore/QFile>
-#include <QtCore/QCoreApplication>
-#include <QtCore/QTimer>
+#include <fstream>
+#include <filesystem>
 
 using namespace OpenMS;
 using namespace std;
@@ -63,10 +61,6 @@ itself).
 The adapter supports Mascot security features as well as proxy connections.
 Mascot versions 2.2.x up to 2.4.1 are supported and have been successfully
 tested (to varying degrees).
-
-@bug Running the adapter on Mascot 2.4 (possibly also other versions) produces the following error messages, which should be ignored:\n
-MascotRemoteQuery: An error occurred (requestId=11): Request aborted (QT Error Code: 7)\n
-MascotRemoteQuery: An error occurred (requestId=12): Request aborted (QT Error Code: 7)
 
 @note Some Mascot server instances seem to fail without reporting back an
 error message. In such cases, try to run the search on another Mascot
@@ -141,20 +135,15 @@ protected:
   }
 
   void parseMascotResponse_(const PeakMap& exp, bool decoy, MascotRemoteQuery* mascot_query, ProteinIdentification& prot_id, PeptideIdentificationList& pep_ids)
-  {   
+  {
     String mascot_tmp_file_name = decoy ? (File::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_decoy_response") : (File::getTempDirectory() + "/" + File::getUniqueName() + "_Mascot_response");
-    QFile mascot_tmp_file(mascot_tmp_file_name.c_str());
-    mascot_tmp_file.open(QIODevice::WriteOnly);
-    if (decoy)
+
     {
-      mascot_tmp_file.write(mascot_query->getMascotXMLDecoyResponse());
+      const std::string& data = decoy ? mascot_query->getMascotXMLDecoyResponse() : mascot_query->getMascotXMLResponse();
+      std::ofstream ofs(mascot_tmp_file_name, std::ios::binary);
+      ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
     }
-    else
-    {
-      mascot_tmp_file.write(mascot_query->getMascotXMLResponse());
-    }
-    mascot_tmp_file.close();
-  
+
     writeDebug_(String("\nMascot Server Response file saved to: '") + mascot_tmp_file_name + "'. If an error occurs, send this file to the OpenMS team.\n", 100);
 
     // set up helper object for looking up spectrum meta data:
@@ -172,7 +161,7 @@ protected:
     }
     else
     {
-      mascot_tmp_file.remove(); // delete file
+      std::filesystem::remove(std::string(mascot_tmp_file_name));
     }
   }
 
@@ -304,15 +293,10 @@ protected:
       stringstream ss;
       mgf_file.store(ss, in, current_batch, true); // write in compact format
 
-      // Usage of a QCoreApplication is overkill here (and ugly too), but we just use the
-      // QEventLoop to process the signals and slots and grab the results afterwards from
-      // the MascotRemotQuery instance
-      char** argv2 = const_cast<char**>(argv);
-      QCoreApplication event_loop(argc, argv2);
-      MascotRemoteQuery* mascot_query = new MascotRemoteQuery(&event_loop);
+      MascotRemoteQuery* mascot_query = new MascotRemoteQuery();
       writeDebug_("Setting parameters for Mascot query", 1);
       mascot_query->setParameters(mascot_query_param);
-      
+
       bool internal_decoys = mascot_param.getValue("decoy") == "true";
       // We used internal decoy search. Set that we want to retrieve decoy search results during export.
       if (internal_decoys)
@@ -326,10 +310,8 @@ protected:
       // remove unnecessary spectra
       ss.clear();
 
-      QObject::connect(mascot_query, SIGNAL(done()), &event_loop, SLOT(quit()));
-      QTimer::singleShot(1000, mascot_query, SLOT(run()));
       writeLogInfo_("Submitting Mascot query (now: " + DateTime::now().get() + ")...");
-      event_loop.exec();
+      mascot_query->run();
       writeLogInfo_("Mascot query finished");
 
       if (mascot_query->hasError())

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <fstream>
 #include <filesystem>
+#include <memory>
 
 using namespace OpenMS;
 using namespace std;
@@ -170,7 +171,12 @@ protected:
     }
     else
     {
-      std::filesystem::remove(std::string(mascot_tmp_file_name));
+      std::error_code ec;
+      std::filesystem::remove(std::filesystem::path(std::string(mascot_tmp_file_name)), ec);
+      if (ec)
+      {
+        OPENMS_LOG_WARN << "Warning: Failed to remove temporary file '" << mascot_tmp_file_name << "': " << ec.message() << std::endl;
+      }
     }
   }
 
@@ -302,7 +308,7 @@ protected:
       stringstream ss;
       mgf_file.store(ss, in, current_batch, true); // write in compact format
 
-      MascotRemoteQuery* mascot_query = new MascotRemoteQuery();
+      auto mascot_query = std::make_unique<MascotRemoteQuery>();
       writeDebug_("Setting parameters for Mascot query", 1);
       mascot_query->setParameters(mascot_query_param);
 
@@ -326,7 +332,6 @@ protected:
       if (mascot_query->hasError())
       {
         writeLogError_("An error occurred during the query: " + mascot_query->getErrorMessage());
-        delete mascot_query;
         return EXTERNAL_PROGRAM_ERROR;
       }
 
@@ -337,7 +342,7 @@ protected:
           !mascot_query_param.getValue("skip_export").toBool())
       {
         // write Mascot response to file
-        parseMascotResponse_(current_batch, false, mascot_query, prot_id, pep_ids); // targets
+        parseMascotResponse_(current_batch, false, mascot_query.get(), prot_id, pep_ids); // targets
 
         // reannotate proper spectrum native id if missing
         for (auto& pep : pep_ids)
@@ -364,7 +369,7 @@ protected:
         {
           PeptideIdentificationList decoy_pep_ids;
           ProteinIdentification decoy_prot_id;
-          parseMascotResponse_(current_batch, true, mascot_query, decoy_prot_id, decoy_pep_ids);  // decoys
+          parseMascotResponse_(current_batch, true, mascot_query.get(), decoy_prot_id, decoy_pep_ids);  // decoys
 
           // reannotate proper spectrum native id if missing
           for (auto& pep : decoy_pep_ids)
@@ -406,7 +411,7 @@ protected:
       }
 
       // clean up
-      delete mascot_query;
+      mascot_query.reset();
       
       current_batch.clear(true); // clear meta data
 

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -141,7 +141,16 @@ protected:
     {
       const std::string& data = decoy ? mascot_query->getMascotXMLDecoyResponse() : mascot_query->getMascotXMLResponse();
       std::ofstream ofs(mascot_tmp_file_name, std::ios::binary);
+      if (!ofs)
+      {
+        throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, mascot_tmp_file_name);
+      }
       ofs.write(data.data(), static_cast<std::streamsize>(data.size()));
+      if (!ofs)
+      {
+        throw Exception::IOException(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Failed to write Mascot response to: " + mascot_tmp_file_name);
+      }
     }
 
     writeDebug_(String("\nMascot Server Response file saved to: '") + mascot_tmp_file_name + "'. If an error occurs, send this file to the OpenMS team.\n", 100);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,7 @@
     "libsvm",
     "qtsvg",
     "zlib",
+    "curl",
     "coin-or-cgl",
     "coin-or-clp",
     "coin-or-cbc",


### PR DESCRIPTION
## Summary

- Remove `Qt6::Network` dependency from the OpenMS core library (`libOpenMS`), replacing all HTTP operations with synchronous libcurl calls
- Also includes prior commit replacing miscellaneous Qt headers with STL/Boost equivalents across the core library
- GUI library (`TOPPASBase`, wizard classes) retains `Qt6::Network`

### Qt Network → libcurl changes

- **NetworkGetRequest**: rewritten as plain C++ class using `curl_easy_*` (no more `QObject`, signals/slots, `QNetworkAccessManager`)
- **MascotRemoteQuery**: async Qt state machine converted to sequential libcurl flow with automatic cookie management (`CURLOPT_COOKIEFILE`) and redirect following (`CURLOPT_FOLLOWLOCATION`)
- **File::download()**, **UpdateCheck::run()**: removed fake `QCoreApplication` event loops — now direct synchronous calls
- **MascotAdapterOnline**: removed Qt event loop, uses synchronous `MascotRemoteQuery::run()`
- New **CurlInit** RAII helper for `curl_global_init`/`curl_global_cleanup`

### Build system / packaging

- CMake: `find_package(CURL REQUIRED)` unconditionally; `Network` moved to GUI-only Qt components
- `OpenMSConfig.cmake.in`: added `find_dependency(CURL)` for downstream consumers
- `vcpkg.json`: added `curl` dependency
- Dockerfiles: added `libcurl4-openssl-dev` / `libcurl-devel`
- Removed `NetworkGetRequest.h` and `MascotRemoteQuery.h` from MOC lists

### Verification

- `libOpenMS.so` links `libcurl.so.4`, has zero `QNetwork` symbols, does not link `Qt6::Network`
- `MascotRemoteQuery_test` passes
- `File_test` passes
- `MascotAdapterOnline` TOPP tool builds successfully
- Works with both `WITH_PARQUET=ON` and `WITH_PARQUET=OFF`

## Notes

- The `contrib` submodule Dockerfiles also need `libcurl*-dev` added (changes prepared locally but need separate contrib repo commit)
- MascotRemoteQuery is the highest-risk change — complex multi-step Mascot protocol with server-version-specific quirks. All response parsing logic is preserved exactly.

## Test plan

- [ ] CI builds pass (Linux, macOS, Windows)
- [ ] `MascotRemoteQuery_test` passes
- [ ] `File_test` passes
- [ ] Build with `WITH_PARQUET=OFF` succeeds
- [ ] Build with `WITH_PARQUET=ON` succeeds
- [ ] GUI targets still build with `Qt6::Network` (requires `WITH_GUI=ON`)
- [ ] Verify no Qt Network symbols in `libOpenMS.so`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New file download utility with automatic duplicate-filename handling and configurable timeouts; libcurl support enabled across CI and builds.

* **Bug Fixes**
  * Improved handling of non-ASCII (UTF-8) file paths on Windows.
  * Updated Mascot query responses to use standard string types.

* **Improvements**
  * Network layer migrated to a curl-based backend; removed several legacy Qt network download flows (GUI online pipeline downloads disabled).

* **Tests**
  * Added unit tests and fixtures for download functionality and non-ASCII path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->