### PR TITLE
Add Python bindings for QCBase and TIC QC classes

### DIFF
--- a/src/pyOpenMS/pxds/QCBase.pxd
+++ b/src/pyOpenMS/pxds/QCBase.pxd
@@ -1,0 +1,19 @@
+from libcpp cimport bool
+from Types cimport *
+from String cimport *
+from MSExperiment cimport *
+
+cdef extern from "<OpenMS/QC/QCBase.h>" namespace "OpenMS":
+
+    cdef cppclass QCBase:
+        QCBase() nogil except +
+        String getName() nogil except +
+        bool isRunnable(QCBase.Status) nogil except +
+
+        cdef cppclass SpectraMap:
+            SpectraMap() nogil except +
+            void calculateMap(MSExperiment) nogil except +
+            UInt64 at(String) nogil except +
+            void clear() nogil except +
+            bool empty() nogil except +
+            Size size() nogil except +

--- a/src/pyOpenMS/pxds/TIC.pxd
+++ b/src/pyOpenMS/pxds/TIC.pxd
@@ -1,0 +1,26 @@
+from libcpp cimport bool
+from libcpp.vector cimport vector
+from Types cimport *
+from String cimport *
+from MSExperiment cimport *
+from MSChromatogram cimport *
+from QCBase cimport *
+
+cdef extern from "<OpenMS/QC/TIC.h>" namespace "OpenMS":
+
+    cdef cppclass TIC(QCBase):
+        TIC() nogil except +
+
+        cdef cppclass Result:
+            Result() nogil except +
+            vector[UInt] intensities
+            vector[float] relative_intensities
+            vector[float] retention_times
+            UInt area
+            UInt fall
+            UInt jump
+            bool operator==(Result) nogil except +
+
+        Result compute(MSExperiment, float, UInt) nogil except +
+        String getName() nogil except +
+        vector[MSChromatogram] getResults() nogil except +


### PR DESCRIPTION
```
## Description
Add Python bindings for QCBase and TIC QC classes

Closes #6102

## Changes
- Added QCBase.pxd wrapping the QCBase abstract base class
  including SpectraMap inner class
- Added TIC.pxd wrapping the TIC class including:
  - Result struct (intensities, retention_times, area, jump, fall)
  - compute() method
  - getName() method
  - getResults() method

## Notes
- Partial implementation of #6102
- More QC classes can be wrapped in follow-up PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python API now includes Quality Control functionality for mass spectrometry data validation and quality assessment within Python workflows
  * Python API now includes Total Ion Chromatogram functionality supporting intensity computation, retention time analysis, and comparative assessment of mass spectrometry results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->