### PR TITLE
Add Gaussian smoothing option to PeakPickerMobilogram

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
@@ -165,7 +165,7 @@ namespace OpenMS
                                 size_t right_index);
 
         /**
-           @brief Helper function yo convert OpenMS FloatDataArray to a vector of doubles
+           @brief Helper function to convert OpenMS FloatDataArray to a vector of doubles
           
            @param[in] floatDataArray A const reference to a FloatDataArray object
            @return A vector of doubles containing the values from the FloatDataArray
@@ -173,10 +173,10 @@ namespace OpenMS
         static std::vector<double> extractFloatValues_(const OpenMS::DataArrays::FloatDataArray& floatDataArray);
 
         /**
-           @brief Helper function to convert OpenMS IntegerDataArray to a vector of std::size
+           @brief Helper function to convert OpenMS FloatDataArray to a vector of size_t
 
             @param[in] floatDataArray A const reference to an FloatDataArray object
-            @return A vector of std::size containing the values from the IntegerDataArray
+            @return A vector of size_t containing the values from the FloastDataArray
         */
         static std::vector<std::size_t> extractIntValues_(const OpenMS::DataArrays::FloatDataArray& floatDataArray);
 
@@ -207,7 +207,7 @@ namespace OpenMS
         /// Width of the Gaussian smoothing
         double gauss_width_;
         /// Whether to use Gaussian smoothing
-        bool use_gauss_;
+        String use_gauss_;
         /// Whether to resolve overlapping peaks
         bool remove_overlapping_;
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
@@ -176,7 +176,7 @@ namespace OpenMS
            @brief Helper function to convert OpenMS FloatDataArray to a vector of size_t
 
             @param[in] floatDataArray A const reference to an FloatDataArray object
-            @return A vector of size_t containing the values from the FloastDataArray
+            @return A vector of size_t containing the values from the FloatDataArray
         */
         static std::vector<std::size_t> extractIntValues_(const OpenMS::DataArrays::FloatDataArray& floatDataArray);
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakPickerMobilogram.h
@@ -207,7 +207,7 @@ namespace OpenMS
         /// Width of the Gaussian smoothing
         double gauss_width_;
         /// Whether to use Gaussian smoothing
-        String use_gauss_;
+        String smoothing_;
         /// Whether to resolve overlapping peaks
         bool remove_overlapping_;
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
@@ -24,9 +24,9 @@ namespace OpenMS
     {
         defaults_.setValue("sgolay_frame_length", 9, "The number of subsequent data points used for smoothing.\nThis number has to be uneven. If it is not, 1 will be added.");
         defaults_.setValue("sgolay_polynomial_order", 3, "Order of the polynomial that is fitted.");
-        defaults_.setValue("gauss_width", 0.002, "Gaussian width in seconds, estimated peak size.");
-        defaults_.setValue("use_gauss", "sgolay","Smoothing method for mobilogram (sgolay or gauss).");        
-        defaults_.setValidStrings("use_gauss", {"sgolay","gauss"});
+        defaults_.setValue("gauss_width", 0.002, "Gaussian width in ion mobility units (1/k0).");
+        defaults_.setValue("smoothing", "sgolay","Smoothing method for mobilogram (sgolay or gauss).");        
+        defaults_.setValidStrings("smoothing", {"sgolay","gauss"});
 
         defaults_.setValue("peak_width", -1.0, "Force a certain minimal peak_width on the data (e.g. extend the peak at least by this amount on both sides) in seconds. -1 turns this feature off.");
         defaults_.setValue("signal_to_noise", 1.0, "Signal-to-noise threshold at which a peak will not be extended any more. Note that setting this too high (e.g. 1.0) can lead to peaks whose flanks are not fully captured.");
@@ -86,11 +86,11 @@ namespace OpenMS
 
       // Smooth the mobilogram
       smoothed_mobilogram = mobilogram;
-      if (use_gauss_ == "sgolay")
+      if (smoothing_ == "sgolay")
       {
           sgolay_.filter(smoothed_mobilogram);
       }
-      else if(use_gauss_ == "gauss")
+      else if(smoothing_ == "gauss")
       {
           gauss_.filter(smoothed_mobilogram);
       }
@@ -435,7 +435,7 @@ namespace OpenMS
         signal_to_noise_ = (double)param_.getValue("signal_to_noise");
         sn_win_len_ = (double)param_.getValue("sn_win_len");
         sn_bin_count_ = (UInt)param_.getValue("sn_bin_count");
-        use_gauss_ = param_.getValue("use_gauss").toString();
+        smoothing_ = param_.getValue("smoothing").toString();
         write_sn_log_messages_ = (bool)param_.getValue("write_sn_log_messages").toBool();
         method_ = (String)param_.getValue("method").toString();
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMobilogram.cpp
@@ -25,8 +25,8 @@ namespace OpenMS
         defaults_.setValue("sgolay_frame_length", 9, "The number of subsequent data points used for smoothing.\nThis number has to be uneven. If it is not, 1 will be added.");
         defaults_.setValue("sgolay_polynomial_order", 3, "Order of the polynomial that is fitted.");
         defaults_.setValue("gauss_width", 0.002, "Gaussian width in seconds, estimated peak size.");
-        defaults_.setValue("use_gauss", "false", "Use Gaussian filter for smoothing (alternative is Savitzky-Golay filter)");
-        defaults_.setValidStrings("use_gauss", {"false","true"});
+        defaults_.setValue("use_gauss", "sgolay","Smoothing method for mobilogram (sgolay or gauss).");        
+        defaults_.setValidStrings("use_gauss", {"sgolay","gauss"});
 
         defaults_.setValue("peak_width", -1.0, "Force a certain minimal peak_width on the data (e.g. extend the peak at least by this amount on both sides) in seconds. -1 turns this feature off.");
         defaults_.setValue("signal_to_noise", 1.0, "Signal-to-noise threshold at which a peak will not be extended any more. Note that setting this too high (e.g. 1.0) can lead to peaks whose flanks are not fully captured.");
@@ -86,11 +86,11 @@ namespace OpenMS
 
       // Smooth the mobilogram
       smoothed_mobilogram = mobilogram;
-      if (!use_gauss_)
+      if (use_gauss_ == "sgolay")
       {
           sgolay_.filter(smoothed_mobilogram);
       }
-      else
+      else if(use_gauss_ == "gauss")
       {
           gauss_.filter(smoothed_mobilogram);
       }
@@ -435,8 +435,7 @@ namespace OpenMS
         signal_to_noise_ = (double)param_.getValue("signal_to_noise");
         sn_win_len_ = (double)param_.getValue("sn_win_len");
         sn_bin_count_ = (UInt)param_.getValue("sn_bin_count");
-        // TODO make list, not boolean
-        use_gauss_ = (bool)param_.getValue("use_gauss").toBool();
+        use_gauss_ = param_.getValue("use_gauss").toString();
         write_sn_log_messages_ = (bool)param_.getValue("write_sn_log_messages").toBool();
         method_ = (String)param_.getValue("method").toString();
 

--- a/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
@@ -72,7 +72,7 @@ START_SECTION(void pickMobilogram(const RichPeakMobilogram& mobilogram, RichPeak
   PeakPickerMobilogram picker;
   Param picker_param = picker.getParameters();
   picker_param.setValue("method", "corrected");
-  picker_param.setValue("use_gauss", "gauss");
+  picker_param.setValue("smoothing", "gauss");
   picker.setParameters(picker_param);
   picker.pickMobilogram(mobilogram, picked_mobilogram, smoothed_mobilogram);
 

--- a/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerMobilogram_test.cpp
@@ -72,15 +72,15 @@ START_SECTION(void pickMobilogram(const RichPeakMobilogram& mobilogram, RichPeak
   PeakPickerMobilogram picker;
   Param picker_param = picker.getParameters();
   picker_param.setValue("method", "corrected");
-  picker_param.setValue("use_gauss", "false");
+  picker_param.setValue("use_gauss", "gauss");
   picker.setParameters(picker_param);
   picker.pickMobilogram(mobilogram, picked_mobilogram, smoothed_mobilogram);
 
-  TEST_REAL_SIMILAR(picked_mobilogram[0].getIntensity(), 58956.1);
-  TEST_REAL_SIMILAR(picked_mobilogram[0].getPos(), 0.978364);
-  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_ABUNDANCE][0], 884145); // IntegratedIntensity
-  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_LEFTBORDER][0], 0.948675); // leftWidth
-  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_RIGHTBORDER][0], 0.997081); // rightWidth
+  TEST_REAL_SIMILAR(picked_mobilogram[0].getIntensity(), 48356.6);
+  TEST_REAL_SIMILAR(picked_mobilogram[0].getPos(), 0.978028437487793);
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_ABUNDANCE][0], 889145);
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_LEFTBORDER][0], 0.93735);
+  TEST_REAL_SIMILAR(picked_mobilogram.getFloatDataArrays()[PeakPickerMobilogram::IDX_RIGHTBORDER][0], 0.998118);
 }
 END_SECTION
 


### PR DESCRIPTION
Description

This PR adds support for Gaussian smoothing in PeakPickerMobilogram.

Previously, mobilogram smoothing used only the Savitzky–Golay filter. This change introduces a configurable parameter (use_gauss) that allows selecting the smoothing method used during peak picking.

The available options are:

sgolay – applies Savitzky–Golay smoothing

gauss – applies Gaussian smoothing

The implementation checks the parameter value and applies the appropriate filter before peak detection. This provides additional flexibility for mobilogram processing and allows users to choose the smoothing approach best suited for their data.

Unit tests in PeakPickerMobilogram_test.cpp were updated to use the Gaussian smoothing option and verify the resulting peak properties.

All tests pass successfully after the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smoothing is now chosen by name via a single "smoothing" parameter ("sgolay" or "gauss"); default is "sgolay". Switching methods can change peak-picking results.

* **Documentation**
  * Corrected typos and aligned parameter/return descriptions in technical docstrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->