### PR TITLE
docs: update CHANGELOG with 19 recent merged PRs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ TOPP tools:
     ProteomicsLFQ:
       - Removed unnecessary group reindexing, added stricter validation (#8752)
       - Arrow/DataFrame/Parquet export for ConsensusMap (#8729)
+      - Added -in_feat parameter to accept pre-computed featureXML files, bypassing internal feature finding (#8796)
     MetaProSIP:
       - Added detailed documentation of CSV output column formats (#4400)
         Flags with trailing arguments now produce clearer warnings instead of cryptic "trailing text arguments" errors.
@@ -110,6 +111,8 @@ PyOpenMS:
   - Param to_dict quality-of-life improvements: dict-like API for parameter access (#8631)
   - Fix: FileTypes wrapping updated with missing enum values and static methods (#8720)
   - XICParquetFile: Python bindings with multi-file support and filtering for reading XIC data from Parquet files (#8737, #8738)
+  - Zero-copy get_peaks_struct() accessor for MSChromatogram and Mobilogram (#8825, #8842)
+  - Complete FileHandler wrapper: 14 new load/store methods for FeatureMap, ConsensusMap, identifications, and transformations (#8762)
 
 TOPP tools:
   Changes:
@@ -137,12 +140,6 @@ TOPP tools:
       - Documented input/output file type combinations (#8615)
     TextExporter:
       - Added support for XIC Parquet files (#8737, #8738)
-    ProteomicsLFQ:
-      - Added -in_feat parameter to accept pre-computed featureXML files, bypassing internal feature finding (#8796)
-
-PyOpenMS:
-  - Zero-copy get_peaks_struct() accessor for MSChromatogram and Mobilogram (#8825, #8842)
-  - Complete FileHandler wrapper: 14 new load/store methods for FeatureMap, ConsensusMap, identifications, and transformations (#8762)
 
 OpenMS Library:
   Added:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,8 @@ General:
 Dependencies:
   - PyOpenMS: Autowrap/Cython replaced with nanobind; nanobind 2.10.0+ fetched automatically (#8699)
   - Eigen minimum version updated from 3.3.4 to 3.4.0 (#8366)
+  - Qt6::Network replaced with libcurl for all HTTP operations in the core library (#8841)
+  - minizip-ng replaced with libzip for ZIP64 archive support (#8808)
 
 TOPP tools:
   Changes:
@@ -135,6 +137,12 @@ TOPP tools:
       - Documented input/output file type combinations (#8615)
     TextExporter:
       - Added support for XIC Parquet files (#8737, #8738)
+    ProteomicsLFQ:
+      - Added -in_feat parameter to accept pre-computed featureXML files, bypassing internal feature finding (#8796)
+
+PyOpenMS:
+  - Zero-copy get_peaks_struct() accessor for MSChromatogram and Mobilogram (#8825, #8842)
+  - Complete FileHandler wrapper: 14 new load/store methods for FeatureMap, ConsensusMap, identifications, and transformations (#8762)
 
 OpenMS Library:
   Added:
@@ -177,6 +185,8 @@ OpenMS Library:
       - pyOpenMS bindings included
     - OpenSwathWorkflow:
       - Added Parquet-based archive (.oswpq) to store spectral library information and multi-run feature scores. (#8813)
+    - FeatureFindingMetabo: Added ion mobility support with local_im_range parameter for coeluting mass trace filtering (#8758)
+    - IDMapper: Preserve upstream identification data processing metadata when annotating featureXML/consensusXML (#8852)
   Changes:
     - BREAKING: Matrix<T> no longer inherits from Eigen; uses std::vector<T> for storage (#8511)
     - BREAKING: Eigen moved from PUBLIC to PRIVATE linking - downstream users no longer need Eigen headers (#8511)
@@ -199,6 +209,11 @@ OpenMS Library:
     - Date class refactored from QDate inheritance to composition (#8710)
     - Thread-safe logging with OPENMS_LOG_* macro optimizations (#8620)
     - MetaInfo: Iterator support and merge optimizations (#8621)
+    - BREAKING: QuantmsIO renamed to QPXFile; PSM Parquet export rewritten using QPX pattern (#8756)
+    - Vectorized dotprodScoring and manhattanScoring in StatsHelpers using Eigen (#8848)
+    - Data provider pattern extracted for ModificationsDB, RibonucleotideDB, ProteaseDB, and RNaseDB (#8775, #8779)
+    - Use unordered_map in PrecursorPurity, PeptideProteinResolution, and PeptideIndexing for faster lookups (#8806, #8763)
+    - OpenSwath scoring speedups: cap XCorr maxdelay, vectorize DIAScoring, hoist loop-invariant computations, pass SwathMap by const& (#8787, #8785)
 
 Fixes:
   - Fix inverted use_all_hits logic causing NucleicAcidSearchEngine crash with multiple hits per spectrum (#8542)
@@ -217,6 +232,10 @@ Fixes:
   - Fix redundant PRAGMA foreign_keys execution in OMSFileStore
   - Fix potential memory leak in SwathFile::loadMzXML on exception by using std::unique_ptr
   - Fix: disable auto_irt and ignore tr_irt_priority_sampling when linear_irt_file is provided in OpenSwathWorkflow (#8830)
+  - Fix MSstatsConverter to allow subset of experimental design files (#8846, fixes #7314)
+  - Fix massdev_score denominator to count only observed transitions instead of total (#8831)
+  - Fix OpenSwathWorkflow run_id mismatch between Parquet/mzML XIC files and OSW/sqMass output (#8833)
+  - Fix OpenSwathWorkflow batch counting and loop bounds for empty compound sets (#8790)
 
 Documentation:
   - Comprehensive documentation for Targeted Quantitation algorithms (#8588)


### PR DESCRIPTION
## Summary

- Add 19 missing CHANGELOG entries from recently merged PRs to develop
- Covers PRs merged between Feb 9 – Mar 9, 2026 that were not yet documented
- Skipped minimal/style/CI-only PRs (#8840, #8835, #8827, #8811, #8838, #8777, #8782, #8820, #8839, #8847, #8859, #8832, and Bioconda CI fixes)

### Added entries by section

| Section | PRs |
|---------|-----|
| Dependencies | #8841 (libcurl), #8808 (libzip) |
| TOPP tools | #8796 (ProteomicsLFQ -in_feat) |
| PyOpenMS | #8825, #8842 (get_peaks_struct), #8762 (FileHandler) |
| Library Added | #8758 (FFM ion mobility), #8852 (IDMapper) |
| Library Changes | #8756, #8848, #8775, #8779, #8806, #8763, #8787, #8785 |
| Fixes | #8846, #8831, #8833, #8790 |

## Test plan
- [ ] Verify CHANGELOG formatting is consistent with existing entries
- [ ] Confirm no duplicate entries were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ProteomicsLFQ workflow now accepts pre-computed feature files via a new input parameter.
  * OpenSwathWorkflow gains ion mobility filtering support to better handle coeluting traces.

* **Bug Fixes**
  * IDMapper now preserves upstream identification processing metadata when annotating feature/consensus maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->