### PR TITLE
feat(devcontainer): support arm64 architecture

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# TARGETARCH is set automatically by Docker BuildKit (default since Docker 23.0).
+# Falls back to amd64 when BuildKit is not available.
+# ARM64/Apple Silicon users: if auto-detection fails, add to devcontainer.json:
+#   "build": { "args": { "TARGETARCH": "arm64" } }
+ARG TARGETARCH=amd64
+FROM ghcr.io/openms/contrib_manylinux_2_34:latest-${TARGETARCH}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,0 @@
-# TARGETARCH is set automatically by Docker BuildKit (default since Docker 23.0).
-# Falls back to amd64 when BuildKit is not available.
-# ARM64/Apple Silicon users: if auto-detection fails, add to devcontainer.json:
-#   "build": { "args": { "TARGETARCH": "arm64" } }
-ARG TARGETARCH=amd64
-FROM ghcr.io/openms/contrib_manylinux_2_34:latest-${TARGETARCH}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
     "name": "OpenMS Dev Container",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "image": "ghcr.io/openms/contrib_manylinux_2_34:latest",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
     "name": "OpenMS Dev Container",
-    "image": "ghcr.io/openms/contrib_manylinux_2_34:latest-amd64",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
## Summary

- Adds a minimal Dockerfile that uses Docker BuildKit's `TARGETARCH` to automatically select the correct base image (`latest-amd64` or `latest-arm64`)
- Falls back to `amd64` when BuildKit is not available (via `ARG TARGETARCH=amd64`)
- ARM64/Apple Silicon users can manually override by adding `"args": {"TARGETARCH": "arm64"}` to the build config in `devcontainer.json`

Supersedes #8741 — that PR had a non-functional multi-stage `archdetect` build and unnecessary files. This PR keeps it to a 6-line Dockerfile and a 1-line change to `devcontainer.json`.

Fixes #8740

## Test plan

- [ ] Open devcontainer on x86_64 — should pull `latest-amd64` image
- [ ] Open devcontainer on ARM64/Apple Silicon — should auto-detect and pull `latest-arm64` image
- [ ] On older Docker without BuildKit — should fall back to `latest-amd64`
- [ ] Manual override: add `"args": {"TARGETARCH": "arm64"}` to devcontainer.json build config and verify it pulls `latest-arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development environment container configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->