### PR TITLE
Fix ci matrix runs on forks

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -99,8 +99,9 @@ jobs:
 
     - id: set-vars
       name: Set extra variables
+      env:
+        DO_PACKAGE: ${{ (inputs.package == true || steps.extract_branch.outputs.RUN_NAME == 'nightly' || startsWith(steps.extract_branch.outputs.RUN_NAME, 'release/')) && matrix.compiler != 'clang++' }}
       run: |
-        DO_PACKAGE=$( [[ ( "${{ inputs.package }}" || "${{ steps.extract_branch.outputs.RUN_NAME }}" == "nightly" || "${{ steps.extract_branch.outputs.RUN_NAME }}" =~ release/* ) && "${{ matrix.compiler }}" != "clang++" ]] && echo true || echo false)
         echo $DO_PACKAGE
         if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
           echo "tp_folder=Linux" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

In the CI workflow, bash's `[[ "false" ]]` evaluates to true because it's a non-empty string test (not a boolean check), so every manual workflow_dispatch unconditionally triggered packaging, which fails on forks that lack the required Apple signing secrets.

Concretely:
`"${{ inputs.package }}"` always evaluates to true.

While we were at it, we also moved `DO_PACKAGE` from inline bash logic to a dedicated `env` section.

**Why:**
- Improves code clarity and reduces shell escaping complexity
- Leverages GitHub Actions native expression evaluation
- Makes the condition easier to understand and maintain
- Reduces potential for shell-related edge cases

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

**Note:** This is a CI workflow configuration change with no impact on source code or tests. No testing needed beyond CI validation.

https://claude.ai/code/session_01RqukCHR6S8n9SjYaRbekEx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve packaging decision logic in the automated build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->