### PR TITLE
Correctly locate a locally installed nanobind

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -133,6 +133,9 @@ else()
   # Find or fetch nanobind
   if(NOT TARGET nanobind::nanobind)
     # Try find_package first (installed via pip or system package)
+    execute_process(
+      COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+      OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
     find_package(nanobind CONFIG QUIET)
     if(NOT nanobind_FOUND)
       include(FetchContent)


### PR DESCRIPTION
Correctly locate a locally installed nanobind as per step 1 in the nanobind documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to enhance nanobind discovery during the build process, ensuring more reliable and consistent compilation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->