### PR TITLE
Fix Windows file locking in parquet tests

### DIFF
--- a/src/pyOpenMS/tests/unittests/test_feature_dataframe.py
+++ b/src/pyOpenMS/tests/unittests/test_feature_dataframe.py
@@ -10,8 +10,6 @@ Tests the feature export methods:
 """
 
 import pytest
-import os
-import tempfile
 
 # Skip entire module if pyarrow is not installed
 pytest.importorskip("pyarrow")
@@ -305,42 +303,30 @@ class TestFeatureDf:
 class TestFeatureParquet:
     """Tests for to_feature_parquet()."""
 
-    def test_write_read(self):
+    def test_write_read(self, tmp_path):
         import pyarrow.parquet as pq
         cmap = create_test_consensus_map()
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            cmap.to_feature_parquet(path)
-            table = pq.read_table(path)
-            assert table.num_rows == 3
-            assert "sequence" in table.column_names
-        finally:
-            os.unlink(path)
+        path = str(tmp_path / "test.parquet")
+        cmap.to_feature_parquet(path)
+        table = pq.read_table(path)
+        assert table.num_rows == 3
+        assert "sequence" in table.column_names
 
-    def test_compression_snappy(self):
+    def test_compression_snappy(self, tmp_path):
         import pyarrow.parquet as pq
         cmap = create_test_consensus_map()
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            cmap.to_feature_parquet(path, compression='snappy')
-            table = pq.read_table(path)
-            assert table.num_rows == 3
-        finally:
-            os.unlink(path)
+        path = str(tmp_path / "test.parquet")
+        cmap.to_feature_parquet(path, compression='snappy')
+        table = pq.read_table(path)
+        assert table.num_rows == 3
 
-    def test_compression_none(self):
+    def test_compression_none(self, tmp_path):
         import pyarrow.parquet as pq
         cmap = create_test_consensus_map()
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            cmap.to_feature_parquet(path, compression='none')
-            table = pq.read_table(path)
-            assert table.num_rows == 3
-        finally:
-            os.unlink(path)
+        path = str(tmp_path / "test.parquet")
+        cmap.to_feature_parquet(path, compression='none')
+        table = pq.read_table(path)
+        assert table.num_rows == 3
 
 
 class TestFeatureQPX:


### PR DESCRIPTION
## Summary
- Replace manual `NamedTemporaryFile` + `os.unlink()` with pytest's `tmp_path` fixture in `TestFeatureParquet` tests
- On Windows, `pyarrow.parquet.read_table()` memory-maps the file, keeping the handle open. The `os.unlink()` in the `finally` block then fails with `PermissionError: [WinError 32]`
- `tmp_path` defers cleanup to after the test session when file handles are released

## Test plan
- [ ] Verify `pyopenms-wheels-cibuildwheel` Windows job passes (specifically `test_feature_dataframe.py::TestFeatureParquet::test_compression_none`)
- [ ] Verify Linux/macOS pyopenms tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure by refactoring temporary file handling in feature dataframe tests for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->