### PR TITLE
fix: exclude MSVC runtime DLLs from dependency resolution (CMake 4.x)

### DIFF
--- a/cmake/package_general.cmake
+++ b/cmake/package_general.cmake
@@ -89,12 +89,17 @@ endif()
 
 if(WIN32)
   # exclude dll's which are system dll's and should not be shipped (bloats installer and leads to incompatibilities)
-  set(PRE_EXCLUDE 
+  set(PRE_EXCLUDE
                   ## these two are direct systems deps of TOPPView etc. Exclude to save time
-                  "api-ms" "ext-ms" 
+                  "api-ms" "ext-ms"
                   ## "HvsiFileTrust" "PdmUtilities" are detected as a dependency by CMake which cannot be resolved (and would lead to errors), so ignore it
                   "hvsi" "pdmutilities"  ## make all lower case, since this is what CMake extracts from the targets and the regex is case sensitive
-                  ) ## TODO I have found that sometimes vcruntime140_1.dll cannot be resolved (but vcruntime140.dll is found). Maybe add it here too?
+                  ## MSVC runtime DLLs are handled separately by InstallRequiredSystemLibraries (in package_nsis.cmake).
+                  ## Exclude them here to avoid "Multiple conflicting paths" errors when the same DLL
+                  ## exists in multiple search directories (e.g. Conda env and contrib/bin). CMake 4.x
+                  ## treats such conflicts as fatal errors.
+                  "vcruntime" "msvcp" "concrt" "vccorlib" "ucrtbase"
+                  )
   ## exclude every Dll from c:\Windows\System32
   ## Note: CMake extracts Dll names and will have a list like
   ##-- Resolved runtime dependencies:


### PR DESCRIPTION
## Summary

- **Fix nightly Windows CI Package step failure** caused by CMake 4.2.3 (installed via chocolatey on `windows-2025` runners) treating conflicting runtime dependency paths as fatal errors
- `VCRUNTIME140.dll` is found in both `C:/Miniconda/envs/ci/Library/bin/` and `contrib/bin/`, causing `install(RUNTIME_DEPENDENCY_SET ...)` to fail with "Multiple conflicting paths"
- Added MSVC runtime DLLs (`vcruntime`, `msvcp`, `concrt`, `vccorlib`, `ucrtbase`) to `PRE_EXCLUDE_REGEXES` in `package_general.cmake` — these are already installed separately by `InstallRequiredSystemLibraries` in `package_nsis.cmake`

## Details

The error in CI:
```
CMake Error at cmake_install.cmake:77 (file):
  file Multiple conflicting paths found for VCRUNTIME140.dll:
    C:/Miniconda/envs/ci/Library/bin/vcruntime140.dll
    D:/a/OpenMS/OpenMS/OpenMS/contrib/bin/vcruntime140.dll
```

This started on Mar 10 when the `windows-2025` runner image updated CMake from 3.x to 4.2.3. CMake 4.x changed `file(GET_RUNTIME_DEPENDENCIES)` to report conflicts as fatal errors instead of silently picking the first match.

The existing `TODO` comment on the old code even mentioned vcruntime issues:
> `TODO I have found that sometimes vcruntime140_1.dll cannot be resolved (but vcruntime140.dll is found). Maybe add it here too?`

## Test plan

- [ ] Verify Windows nightly CI Package step passes with this change
- [ ] Verify the NSIS installer still contains the MSVC runtime DLLs (they come from `InstallRequiredSystemLibraries`, not from `RUNTIME_DEPENDENCY_SET`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows package build configuration to properly exclude MSVC runtime DLLs from the packaged application, ensuring cleaner and more efficient deployment artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->