### PR TITLE
fix: suppress pyopenms test output on CDash and split into categories

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -500,11 +500,44 @@ if((DEFINED OPENMS_TARGET AND TARGET ${OPENMS_TARGET}) OR TARGET OpenMS)
   file(COPY ${PROJECT_SOURCE_DIR}/tests DESTINATION ${PYOPENMS_BUILD_DIR})
 
   enable_testing()
+
+  # Split pyopenms tests into separate CTest entries for better CDash reporting.
+  # Use -q (quiet) and --tb=short to avoid cluttering CDash with verbose passing output.
+  # Override pyproject.toml's addopts which uses -v (verbose).
+  set(_PYTEST_ARGS -m pytest -o addopts=-q\ --tb=short)
+
   add_test(
-    NAME pyopenms_tests
-    COMMAND ${Python_EXECUTABLE} -m pytest tests
+    NAME pyopenms_unittests
+    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS}
+      --ignore=tests/unittests/test_docstrings.py
+      --ignore=tests/unittests/test_docstring_format.py
+      tests/unittests
     WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
   )
+
+  add_test(
+    NAME pyopenms_docstring_tests
+    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS}
+      tests/unittests/test_docstrings.py
+      tests/unittests/test_docstring_format.py
+    WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
+  )
+
+  add_test(
+    NAME pyopenms_integration_tests
+    COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS} tests/integration_tests
+    WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
+  )
+
+  # Top-level test files (ProForma, modification discovery, matrix zerocopy, etc.)
+  file(GLOB _pyopenms_toplevel_tests "${PYOPENMS_BUILD_DIR}/tests/test_*.py")
+  if(_pyopenms_toplevel_tests)
+    add_test(
+      NAME pyopenms_feature_tests
+      COMMAND ${Python_EXECUTABLE} ${_PYTEST_ARGS} ${_pyopenms_toplevel_tests}
+      WORKING_DIRECTORY ${PYOPENMS_BUILD_DIR}
+    )
+  endif()
 endif()
 
 # --------------------------------------------------------------------------

--- a/tools/ci/citest.cmake
+++ b/tools/ci/citest.cmake
@@ -24,6 +24,10 @@ set(CTEST_CUSTOM_TESTS_IGNORE
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS 1000)
 set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
+# Limit output size for passed tests to avoid cluttering CDash (e.g. pyopenms verbose pytest output).
+# Failed tests still show full output.
+set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1024)
+
 # Define patterns that should NOT be classified as warnings
 set(CTEST_CUSTOM_WARNING_EXCEPTION
     # Ignore the generic "non-zero return value" warnings - let the actual errors be classified properly


### PR DESCRIPTION
## Summary
- Cap passed test output at 1KB on CDash (`CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE`). Failed tests still show full output.
- Split the monolithic `pyopenms_tests` CTest entry into four categories (`pyopenms_unittests`, `pyopenms_docstring_tests`, `pyopenms_integration_tests`, `pyopenms_feature_tests`) for better CDash granularity.
- Use quiet pytest output (`-q --tb=short`) for CTest while preserving verbose mode (`-v`) for local development via `pyproject.toml`.

## Test plan
- [ ] Verify CDash no longer shows verbose passing output for pyopenms tests
- [ ] Verify failed pyopenms tests still show full output on CDash
- [ ] Verify all four test categories appear as separate entries on CDash
- [ ] Verify local `pytest` still runs in verbose mode

Closes #8878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured test execution framework to organize test runs into distinct CTest entries with individual reporting.
  * Configured test output size limits for improved CI/CD pipeline performance and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->