### PR TITLE
Feature: Isotope class for individual isotope properties

### DIFF
--- a/.claude/commands/openms-status.md
+++ b/.claude/commands/openms-status.md
@@ -1,0 +1,130 @@
+---
+description: Check OpenMS nightly build status, recent pull requests, and open issues. Gathers actionable items and prioritizes them.
+allowed-tools: Bash(gh *), Bash(git *)
+---
+
+# OpenMS Status Dashboard
+
+You are a project status analyst for the OpenMS project (https://github.com/OpenMS/OpenMS). Gather data from GitHub, analyze it, and present a prioritized action plan.
+
+## Data Collection
+
+Run ALL of the following `gh` commands in parallel to gather data:
+
+### 1. Nightly Build Status
+Check the most recent runs of key CI workflows on the `nightly` branch:
+
+```bash
+gh run list --repo OpenMS/OpenMS --branch nightly --limit 5 --json name,status,conclusion,createdAt,url,headBranch
+```
+
+Also check the main CI on `develop`:
+```bash
+gh run list --repo OpenMS/OpenMS --branch develop --workflow "openms-ci-full" --limit 3 --json name,status,conclusion,createdAt,url
+```
+
+If any workflow has `conclusion: "failure"`, drill into the failed jobs:
+```bash
+gh run view <run-id> --repo OpenMS/OpenMS --json jobs --jq '.jobs[] | select(.conclusion == "failure") | {name, conclusion, url}'
+```
+
+### 2. Recent Pull Requests
+Fetch open PRs sorted by most recent activity:
+
+```bash
+gh pr list --repo OpenMS/OpenMS --state open --limit 20 --json number,title,author,createdAt,updatedAt,labels,reviewDecision,isDraft,url,reviewRequests,mergeable,headRefName
+```
+
+Also check recently merged PRs for context:
+```bash
+gh pr list --repo OpenMS/OpenMS --state merged --limit 5 --json number,title,mergedAt,author,url
+```
+
+### 3. Open Issues
+Fetch open issues, prioritizing labeled ones:
+
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --limit 30 --json number,title,labels,createdAt,updatedAt,author,url,comments --sort updated
+```
+
+Check for critical/blocker issues specifically:
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --label critical,blocker,major --json number,title,labels,createdAt,url
+```
+
+### 4. New Issues
+Fetch issues created in the last 14 days to surface newly reported bugs and feature requests:
+
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --limit 20 --json number,title,labels,createdAt,author,url,comments --sort created
+```
+
+Filter the results to only those created within the last 14 days. These represent fresh reports that may need triage, labeling, or assignment.
+
+## Analysis & Presentation
+
+After collecting all data, present findings in this structure:
+
+### Status Overview
+A brief 2-3 line summary of overall project health.
+
+### Nightly Build Status
+- Show a table of recent nightly workflow runs with status indicators
+- Use checkmarks/X marks for pass/fail
+- If failures exist, list the specific failed jobs and platforms
+
+### Action Items (Prioritized)
+
+Organize actions into priority tiers:
+
+**P0 - Critical (fix immediately)**
+- Nightly build failures (broken builds block all development)
+- Issues labeled `critical` or `blocker`
+- PRs with failing CI that were previously approved
+
+**P1 - High (address this week)**
+- Issues labeled `major`
+- PRs awaiting review for >7 days
+- PRs with review changes requested but no recent activity
+- Flaky or intermittent CI failures
+
+**P2 - Medium (address soon)**
+- PRs awaiting review for >3 days
+- Open issues with recent activity/comments
+- Draft PRs that have been open >14 days without updates
+
+**P3 - Low (backlog)**
+- Stale PRs/issues with no activity >30 days
+- Enhancement requests without assignees
+
+For each action item, include:
+- A direct link to the PR/issue/workflow
+- A one-line description of what needs to happen
+- Who is involved (author, reviewer, assignee)
+
+### New Issues (Last 14 Days)
+- List newly created issues in a table with: issue number (linked), title, author, labels, and age
+- Flag any that are unlabeled or unassigned — these need triage
+- Highlight bug reports that may relate to recent PRs or nightly failures
+
+### Recent Activity
+- List the last 5 merged PRs as a quick changelog
+
+### Recommended Actions
+After all analysis, produce a numbered list of concrete recommended actions ordered by impact. Each action should:
+- Start with a verb (e.g., "Fix", "Review", "Triage", "Merge", "Investigate")
+- Reference the specific PR/issue/workflow by number or link
+- Be specific enough to act on immediately (not vague like "look into CI")
+- Include who should take the action if known
+
+Example:
+1. **Fix** nightly Linux build failure in #1234 — `FileHandler_test` segfault on Ubuntu 22.04
+2. **Review** PR #5678 (open 9 days, no reviewer assigned) — adds MzTab export support
+3. **Triage** new issue #9012 — user-reported crash in `FeatureFinderMetabo`, unlabeled
+
+Aim for 5-10 actions. This list should serve as a ready-made to-do list for the maintainer.
+
+## Output Format
+- Use GitHub-flavored markdown tables where appropriate
+- Keep the output scannable — use bold for key items, links for references
+- End with the recommended actions list as the final section so it's easy to find

--- a/.claude/skills/openms-status/SKILL.md
+++ b/.claude/skills/openms-status/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: openms-status
+description: Check OpenMS nightly build status, recent pull requests, and open issues. Gathers actionable items and prioritizes them.
+allowed-tools: Bash(gh *), Bash(git *)
+---
+
+# OpenMS Status Dashboard
+
+You are a project status analyst for the OpenMS project (https://github.com/OpenMS/OpenMS). Gather data from GitHub, analyze it, and present a prioritized action plan.
+
+## Data Collection
+
+Run ALL of the following `gh` commands in parallel to gather data:
+
+### 1. Nightly Build Status
+Check the most recent runs of key CI workflows on the `nightly` branch:
+
+```bash
+gh run list --repo OpenMS/OpenMS --branch nightly --limit 5 --json name,status,conclusion,createdAt,url,headBranch
+```
+
+Also check the main CI on `develop`:
+```bash
+gh run list --repo OpenMS/OpenMS --branch develop --workflow "openms-ci-full" --limit 3 --json name,status,conclusion,createdAt,url
+```
+
+If any workflow has `conclusion: "failure"`, drill into the failed jobs:
+```bash
+gh run view <run-id> --repo OpenMS/OpenMS --json jobs --jq '.jobs[] | select(.conclusion == "failure") | {name, conclusion, url}'
+```
+
+### 2. Recent Pull Requests
+Fetch open PRs sorted by most recent activity:
+
+```bash
+gh pr list --repo OpenMS/OpenMS --state open --limit 20 --json number,title,author,createdAt,updatedAt,labels,reviewDecision,isDraft,url,reviewRequests,mergeable,headRefName
+```
+
+Also check recently merged PRs for context:
+```bash
+gh pr list --repo OpenMS/OpenMS --state merged --limit 5 --json number,title,mergedAt,author,url
+```
+
+### 3. Open Issues
+Fetch open issues, prioritizing labeled ones:
+
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --limit 30 --json number,title,labels,createdAt,updatedAt,author,url,comments --sort updated
+```
+
+Check for critical/blocker issues specifically:
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --label critical,blocker,major --json number,title,labels,createdAt,url
+```
+
+### 4. New Issues
+Fetch issues created in the last 14 days to surface newly reported bugs and feature requests:
+
+```bash
+gh issue list --repo OpenMS/OpenMS --state open --limit 20 --json number,title,labels,createdAt,author,url,comments --sort created
+```
+
+Filter the results to only those created within the last 14 days. These represent fresh reports that may need triage, labeling, or assignment.
+
+## Analysis & Presentation
+
+After collecting all data, present findings in this structure:
+
+### Status Overview
+A brief 2-3 line summary of overall project health.
+
+### Nightly Build Status
+- Show a table of recent nightly workflow runs with status indicators
+- Use checkmarks/X marks for pass/fail
+- If failures exist, list the specific failed jobs and platforms
+
+### Action Items (Prioritized)
+
+Organize actions into priority tiers:
+
+**P0 - Critical (fix immediately)**
+- Nightly build failures (broken builds block all development)
+- Issues labeled `critical` or `blocker`
+- PRs with failing CI that were previously approved
+
+**P1 - High (address this week)**
+- Issues labeled `major`
+- PRs awaiting review for >7 days
+- PRs with review changes requested but no recent activity
+- Flaky or intermittent CI failures
+
+**P2 - Medium (address soon)**
+- PRs awaiting review for >3 days
+- Open issues with recent activity/comments
+- Draft PRs that have been open >14 days without updates
+
+**P3 - Low (backlog)**
+- Stale PRs/issues with no activity >30 days
+- Enhancement requests without assignees
+
+For each action item, include:
+- A direct link to the PR/issue/workflow
+- A one-line description of what needs to happen
+- Who is involved (author, reviewer, assignee)
+
+### New Issues (Last 14 Days)
+- List newly created issues in a table with: issue number (linked), title, author, labels, and age
+- Flag any that are unlabeled or unassigned — these need triage
+- Highlight bug reports that may relate to recent PRs or nightly failures
+
+### Recent Activity
+- List the last 5 merged PRs as a quick changelog
+
+### Recommended Actions
+After all analysis, produce a numbered list of concrete recommended actions ordered by impact. Each action should:
+- Start with a verb (e.g., "Fix", "Review", "Triage", "Merge", "Investigate")
+- Reference the specific PR/issue/workflow by number or link
+- Be specific enough to act on immediately (not vague like "look into CI")
+- Include who should take the action if known
+
+Example:
+1. **Fix** nightly Linux build failure in #1234 — `FileHandler_test` segfault on Ubuntu 22.04
+2. **Review** PR #5678 (open 9 days, no reviewer assigned) — adds MzTab export support
+3. **Triage** new issue #9012 — user-reported crash in `FeatureFinderMetabo`, unlabeled
+
+Aim for 5-10 actions. This list should serve as a ready-made to-do list for the maintainer.
+
+## Output Format
+- Use GitHub-flavored markdown tables where appropriate
+- Keep the output scannable — use bold for key items, links for references
+- End with the recommended actions list as the final section so it's easy to find

--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -23,6 +23,8 @@
 
 namespace OpenMS
 {
+  class Isotope;
+
   /** @ingroup Chemistry
 
       @brief Representation of an element
@@ -50,7 +52,7 @@ public:
             unsigned int atomic_number,
             double average_weight,
             double mono_weight,
-            const IsotopeDistribution & isotopes);
+            const IsotopeDistribution & isotopes = IsotopeDistribution());
 
     /// destructor
     virtual ~Element();
@@ -82,6 +84,12 @@ public:
 
     /// returns the isotope distribution of the element
     const IsotopeDistribution & getIsotopeDistribution() const;
+
+    /// sets the list of isotopes of the element
+    void setIsotopes(const std::vector<const Isotope*>& isotopes);
+
+    /// returns the list of isotopes of the element
+    const std::vector<const Isotope*>& getIsotopes() const;
 
     /// set the name of the element
     void setName(const std::string & name);
@@ -122,6 +130,9 @@ public:
     /// writes the element to an output stream
     friend OPENMS_DLLAPI std::ostream & operator<<(std::ostream & os, const Element & element);
 
+    /// Update cached isotope distribution in case any of the isotopes has been changed
+    void updateIsotopeDistr();
+
 protected:
 
     /// name of the element
@@ -140,7 +151,10 @@ protected:
     double mono_weight_;
 
     /// distribution of the isotopes (mass and natural frequency)
-    IsotopeDistribution isotopes_;
+    IsotopeDistribution isotope_distr_;
+
+    /// list of isotopes
+    std::vector<const Isotope*> isotopes_;
   };
 
   OPENMS_DLLAPI std::ostream & operator<<(std::ostream &, const Element &);

--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -131,10 +131,10 @@ public:
     /// writes the element to an output stream
     friend OPENMS_DLLAPI std::ostream & operator<<(std::ostream & os, const Element & element);
 
-    /// Update cached isotope distribution in case any of the isotopes has been changed
-    void updateIsotopeDistr();
-
 protected:
+
+    /// Update cached isotope distribution in case any of the isotopes has been changed
+    void updateIsotopeDistr_();
 
     /// name of the element
     std::string name_;

--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -94,6 +94,9 @@ public:
 
     /// returns symbol of the element
     const std::string & getSymbol() const;
+
+    /// Whether this is an Isotope or an Element (for casting)
+    virtual bool isIsotope() const {return false;}
     //@}
 
     /** @name Assignment

--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -30,13 +30,14 @@ namespace OpenMS
       @brief Representation of an element
 
       This contains information on an element and its isotopes, including a
-      common name, atomic symbol and mass/abundance of its isotopes.
+      common name, atomic symbol and mass/abundance of its isotopes. Individual
+      isotopes are represented using Isotope.
   */
   class OPENMS_DLLAPI Element
   {
 public:
 
-   
+
     /** @name Constructor and Destructors
     */
     //@{

--- a/src/openms/include/OpenMS/CHEMISTRY/Element.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Element.h
@@ -106,6 +106,9 @@ public:
 
     /// Whether this is an Isotope or an Element (for casting)
     virtual bool isIsotope() const {return false;}
+
+    /// Force a refresh of the cached isotope distribution if isotopes have been changed
+    void refreshIsotopeDistribution();
     //@}
 
     /** @name Assignment

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -179,7 +179,7 @@ protected:
     Element* addElementToMaps_(const std::string& name, const std::string& symbol, const unsigned int an, Element* e);
 
     /// add element objects to documentation maps
-    Isotope* addIsotopeToMaps_(const std::string& name, const std::string& symbol, Isotope* e);
+    const Isotope* addIsotopeToMaps_(const std::string& name, const std::string& symbol, const Isotope* e);
 
     /**_ resets all containers
     **/

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -63,7 +63,7 @@ public:
     /// returns a hashmap that contains atomic numbers mapped to pointers of the elements
     const std::unordered_map<unsigned int, const Element*>& getAtomicNumbers() const;
 
-    /// returns a hashmap that contains atomic numbers mapped to pointers of the isotopes
+    /// returns a hashmap that contains isotopic names mapped to pointers of the isotopes
     const std::unordered_map<std::string, const Isotope*>& getIsotopeSymbols() const;
 
     /** returns a pointer to the element with name or symbol given in parameter name;

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -120,7 +120,7 @@ public:
     */
     void addIsotope(const std::string& name,
                     const std::string& symbol,
-                    const unsigned int an,
+                    unsigned int an,
                     double abundance,
                     double mass,
                     double half_life,

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -107,6 +107,7 @@ protected:
 
     /** parses a isotope distribution of abundances and masses
 
+
     **/
     IsotopeDistribution parseIsotopeDistribution_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
@@ -114,7 +115,7 @@ protected:
      **/
     double calculateAvgWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
-    /**_ calculates the mono weight based on the most abundant isotope 
+    /**_ calculates the mono weight based on the most abundant isotope
      **/
     double calculateMonoWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -114,7 +114,9 @@ public:
      * @param mass mass of the isotope
      * @param half_life Half life of the isotope in seconds (use -1 for stable isotopes)
      * @param decay Main decay mode for unstable isotopes (use NONE for stable isotopes)
-     * @param replace_existing Whether to replace an existint isotope
+     * @param replace_existing Whether to replace an existing isotope
+     *
+     * @exception Exception::IllegalArgument is thrown if the isotope already exists
      *
      * @note Do not use this function inside parallel code as it modifies a singleton that is shared between threads.
     */

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -107,7 +107,6 @@ protected:
 
     /** parses a isotope distribution of abundances and masses
 
-
     **/
     IsotopeDistribution parseIsotopeDistribution_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -36,12 +36,12 @@ namespace OpenMS
           Pure Appl. Chem., 2003, Vol. 75, No. 6, pp. 683-799
           doi:10.1351/pac200375060683
 
-      Specific isotopes of elements can be accessed by writing the atomic number of the isotope
-      in brackets followed by the element name, e.g. "(2)H" for deuterium.
+      Individual elements can be accessed through getElement(). Specific
+      isotopes of elements can be accessed through getIsotope() by writing the
+      atomic number of the isotope in brackets followed by the element name,
+      e.g. "(2)H" for deuterium.
 
-      @improvement include exact mass values for the isotopes (done) and update IsotopeDistribution (Andreas)
-      @improvement add exact isotope distribution based on exact isotope values (Andreas)
-*/
+  */
 
   class OPENMS_DLLAPI ElementDB
   {
@@ -107,7 +107,7 @@ public:
 
     /** Adds or replaces a new isotope in the database
      *
-     * Adds a new isotope (or replaces an existing one if @em replace_existing is true). 
+     * Adds a new isotope (or replaces an existing one if @em replace_existing is true).
      *
      * @param name Common name of the element
      * @param symbol Element symbol (one or two letter)
@@ -161,7 +161,7 @@ protected:
                        const unsigned int an,
                        const std::map<unsigned int, double>& abundance,
                        const std::map<unsigned int, double>& mass,
-                       const std::map<unsigned int, double>& half_lifes = 
+                       const std::map<unsigned int, double>& half_lifes =
                          std::map<unsigned int, double>(),
                        const std::map<unsigned int, Isotope::DecayMode>& decay_modes =
                          std::map<unsigned int, Isotope::DecayMode>());

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -78,7 +78,7 @@ public:
     */
     const Isotope* getIsotope(const std::string& name) const;
 
-    /// returns a pointer to the element of atomic number; if no element is found 0 is returned
+    /// returns a pointer to the element of atomic number; if no element is found nullptr is returned
     const Element* getElement(unsigned int atomic_number) const;
 
     /** Adds or replaces a new element to the database
@@ -108,6 +108,7 @@ public:
     /** Adds or replaces a new isotope in the database
      *
      * Adds a new isotope (or replaces an existing one if @em replace_existing is true).
+     * This function also updates the element's isotope distribution when a new isotope is added.
      *
      * @param name Common name of the element
      * @param symbol Element symbol (one or two letter)
@@ -181,16 +182,20 @@ protected:
     /// add element objects to documentation maps
     const Isotope* addIsotopeToMaps_(const std::string& name, const std::string& symbol, const Isotope* e);
 
-    /**_ resets all containers
+    /** Resets all containers
     **/
     void clear_();
 
+    /// Map of element names to Element pointers
     std::unordered_map<std::string, const Element*> names_;
 
+    /// Map of element symbols to Element pointers
     std::unordered_map<std::string, const Element*> symbols_;
 
+    /// Map of atomic numbers to Element pointers
     std::unordered_map<unsigned int, const Element*> atomic_numbers_;
 
+    /// Map of isotope symbols to Isotope pointers
     std::unordered_map<std::string, const Isotope*> isotopes_;
 
 private:

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -148,7 +148,7 @@ protected:
      **/
     double calculateAvgWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
-    /**_ calculates the mono weight based on the most abundant isotope
+    /** Calculates the mono weight based on the most abundant isotope
      **/
     double calculateMonoWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -94,6 +94,8 @@ public:
      *
      * @throw Exception::IllegalArgument if element already exists in DB, but @p replace_existing is false
      *
+     * @exception Exception::IllegalArgument is thrown if an element with the same atomic number already exists
+     *
      * @note Do not use this function inside parallel code as it modifies a singleton that is shared between threads.
     */
     void addElement(const std::string& name,

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -11,6 +11,7 @@
 
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
+#include <OpenMS/CHEMISTRY/Isotope.h>
 
 #include <map>
 #include <memory>
@@ -20,6 +21,7 @@
 namespace OpenMS
 {
   class Element;
+  class Isotope;
 
   /** @ingroup Chemistry
 
@@ -61,11 +63,20 @@ public:
     /// returns a hashmap that contains atomic numbers mapped to pointers of the elements
     const std::unordered_map<unsigned int, const Element*>& getAtomicNumbers() const;
 
+    /// returns a hashmap that contains atomic numbers mapped to pointers of the isotopes
+    const std::unordered_map<std::string, const Isotope*>& getIsotopeSymbols() const;
+
     /** returns a pointer to the element with name or symbol given in parameter name;
-        *	if no element exists with that name or symbol 0 is returned
-        *	@param[in] name name or symbol of the element
+        *	if no element exists with that name or symbol, a nullptr is returned
+        *	@param[in] name name or symbol of the element (e.g. "C" for carbon)
     */
     const Element* getElement(const std::string& name) const;
+
+    /** returns a pointer to the isotope with symbol given in parameter name;
+        *	if no element exists with that symbol, a nullptr is returned
+        *	@param name: symbol of the element (e.g. "(14)C" for carbon-14)
+    */
+    const Isotope* getIsotope(const std::string& name) const;
 
     /// returns a pointer to the element of atomic number; if no element is found 0 is returned
     const Element* getElement(unsigned int atomic_number) const;
@@ -124,11 +135,16 @@ protected:
     /// build element objects from given abundances, masses, name, symbol, and atomic number
     void buildElement_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
 
+    void buildIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an,
+                        const std::map<unsigned int, double>& mass,
+                        const std::map<unsigned int, double>& half_life,
+                        const std::map<unsigned int, Isotope::DecayMode>& decay);
+
     /// add element objects to documentation maps
     void addElementToMaps_(const std::string& name, const std::string& symbol, const unsigned int an, std::unique_ptr<const Element> e);
 
-    /// constructs isotope objects
-    void storeIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& Z_to_mass, const IsotopeDistribution& isotopes);
+    /// constructs stable isotope objects
+    void storeStableIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& Z_to_mass, const IsotopeDistribution& isotopes);
 
     /**_ resets all containers
     **/
@@ -139,6 +155,8 @@ protected:
     std::unordered_map<std::string, const Element*> symbols_;
 
     std::unordered_map<unsigned int, const Element*> atomic_numbers_;
+
+    std::unordered_map<std::string, const Isotope*> isotopes_;
 
 private:
     ElementDB();

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -90,7 +90,7 @@ public:
      * @param[in] an Atomic number (number of protons)
      * @param[in] abundance List of abundances for each isotope (e.g. {{12u, 0.9893}, {13u, 0.0107}} for Carbon)
      * @param[in] mass List of masses for each isotope (e.g. {{12u, 12.0}, {13u, 13.003355}} for Carbon)
-     * @param[in] replace_existing If the element must be replaced (i.e. is not new), either allow that (=true), or throw an exception (=false).
+     * @param[in] replace_existing Whether to replace an existing element
      *
      * @throw Exception::IllegalArgument if element already exists in DB, but @p replace_existing is false
      *
@@ -101,6 +101,30 @@ public:
                     const unsigned int an,
                     const std::map<unsigned int, double>& abundance,
                     const std::map<unsigned int, double>& mass,
+                    bool replace_existing);
+
+    /** Adds or replaces a new isotope in the database
+     *
+     * Adds a new isotope (or replaces an existing one if @em replace_existing is true). 
+     *
+     * @param name Common name of the element
+     * @param symbol Element symbol (one or two letter)
+     * @param an Atomic number (number of protons)
+     * @param abundance natural abundance of the isotope (use 0 for unstable isotopes)
+     * @param mass mass of the isotope
+     * @param half_life Half life of the isotope in seconds (use -1 for stable isotopes)
+     * @param decay Main decay mode for unstable isotopes (use NONE for stable isotopes)
+     * @param replace_existing Whether to replace an existint isotope
+     *
+     * @note Do not use this function inside parallel code as it modifies a singleton that is shared between threads.
+    */
+    void addIsotope(const std::string& name,
+                    const std::string& symbol,
+                    const unsigned int an,
+                    double abundance,
+                    double mass,
+                    double half_life,
+                    Isotope::DecayMode decay,
                     bool replace_existing);
     //@}
 
@@ -116,11 +140,6 @@ public:
 
 protected:
 
-    /** parses a isotope distribution of abundances and masses
-
-    **/
-    IsotopeDistribution parseIsotopeDistribution_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
-
     /** calculates the average weight based on isotope abundance and mass
      **/
     double calculateAvgWeight_(const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
@@ -132,19 +151,31 @@ protected:
 	  /// constructs element objects
     void storeElements_();
 
-    /// build element objects from given abundances, masses, name, symbol, and atomic number
-    void buildElement_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass);
+    /// build element objects from given abundances, masses, half lifes, decay mode name, symbol, and atomic number
+    void buildElement_(const std::string& name,
+                       const std::string& symbol,
+                       const unsigned int an,
+                       const std::map<unsigned int, double>& abundance,
+                       const std::map<unsigned int, double>& mass,
+                       const std::map<unsigned int, double>& half_lifes = 
+                         std::map<unsigned int, double>(),
+                       const std::map<unsigned int, Isotope::DecayMode>& decay_modes =
+                         std::map<unsigned int, Isotope::DecayMode>());
 
-    void buildIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an,
+    /// helper to build all isotopes from an input list
+    std::vector<const Isotope *> buildIsotopes_(const std::string& name,
+                        const std::string& symbol,
+                        const unsigned int an,
+                        const std::map<unsigned int, double>& abundance,
                         const std::map<unsigned int, double>& mass,
                         const std::map<unsigned int, double>& half_life,
                         const std::map<unsigned int, Isotope::DecayMode>& decay);
 
     /// add element objects to documentation maps
-    void addElementToMaps_(const std::string& name, const std::string& symbol, const unsigned int an, std::unique_ptr<const Element> e);
+    Element* addElementToMaps_(const std::string& name, const std::string& symbol, const unsigned int an, Element* e);
 
-    /// constructs stable isotope objects
-    void storeStableIsotopes_(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& Z_to_mass, const IsotopeDistribution& isotopes);
+    /// add element objects to documentation maps
+    Isotope* addIsotopeToMaps_(const std::string& name, const std::string& symbol, Isotope* e);
 
     /**_ resets all containers
     **/

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -1,0 +1,119 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Rost $
+// $Authors: Hannes Rost $
+// --------------------------------------------------------------------------
+//
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CHEMISTRY/Element.h>
+
+#include <string>
+
+namespace OpenMS
+{
+  /** @ingroup Chemistry
+
+      @brief Representation of an isotope
+
+      This class represents a single isotope
+  */
+  class OPENMS_DLLAPI Isotope : 
+    public Element
+  {
+    public:
+
+    enum DecayMode
+    {
+      NONE = 0,     ///< No decay (stable isotope)
+      UNKNOWN,      ///< Unknown / Unspecified decay mode
+      ALPHA,        ///< Alpha decay
+      BETA_PLUS,    ///< Beta plus decay
+      BETA_MINUS,   ///< Beta minus decay
+      PROTON,       ///< Proton emission
+      SIZE_OF_DECAYMODE
+    };
+
+    using Element::Element;
+
+    /// detailed constructor
+    Isotope(const std::string & name,
+            const std::string & symbol,
+            unsigned int atomic_number,
+            unsigned int neutrons,
+            double mono_weight,
+            double abundance,
+            const IsotopeDistribution & isotopes);
+
+    Isotope & operator=(const Isotope & element) = default;
+    Isotope(const Isotope & element) = default;
+
+    /// destructor
+    virtual ~Isotope();
+
+    /// Get corresponding element
+    const Element* getElement() const;
+
+    /// set isotope half life in seconds
+    void setHalfLife(double hl);
+    /// get isotope half life in seconds
+    double getHalfLife() const;
+    /// set isotope natural abundance
+    void setAbundance(double ab);
+    /// get isotope natural abundance
+    double getAbundance() const;
+    /// set number of neutrons 
+    void setNeutrons(int ne);
+    /// get number of neutrons 
+    int getNeutrons() const;
+    /// set primary decay mode (for unstable isotopes)
+    void setDecayMode(DecayMode dm);
+    /// get primary decay mode (for unstable isotopes)
+    DecayMode getDecayMode() const;
+
+    /// Whether this is an Isotope or an Element (for casting)
+    virtual bool isIsotope() const override {return true;}
+
+    /// Whether this is a stable isotope
+    bool isStable() const {return half_life_ < 0;}
+
+  protected:
+
+    int neutrons_ = -1;
+    double abundance_; // has to consistent with getIsotopeDistribution()
+    double half_life_ = -1; ///< half life in seconds
+    DecayMode decay_mode_ = DecayMode::NONE;
+  };
+
+} // namespace OpenMS
+

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -73,14 +73,6 @@ namespace OpenMS
             unsigned int neutrons,
             double mono_weight,
             double abundance,
-            const IsotopeDistribution & isotopes);
-
-    Isotope(const std::string & name,
-            const std::string & symbol,
-            unsigned int atomic_number,
-            unsigned int neutrons,
-            double mono_weight,
-            double abundance,
             double half_life,
             Isotope::DecayMode dm);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -75,6 +75,15 @@ namespace OpenMS
             double abundance,
             const IsotopeDistribution & isotopes);
 
+    Isotope(const std::string & name,
+            const std::string & symbol,
+            unsigned int atomic_number,
+            unsigned int neutrons,
+            double mono_weight,
+            double abundance,
+            double half_life,
+            Isotope::DecayMode dm);
+
     Isotope & operator=(const Isotope & element) = default;
     Isotope(const Isotope & element) = default;
 
@@ -107,6 +116,9 @@ namespace OpenMS
     /// Whether this is a stable isotope
     bool isStable() const {return half_life_ < 0;}
 
+    /// writes the isotope to an output stream
+    friend OPENMS_DLLAPI std::ostream & operator<<(std::ostream & os, const Isotope & isotope);
+
   protected:
 
     int neutrons_ = -1;
@@ -114,6 +126,8 @@ namespace OpenMS
     double half_life_ = -1; ///< half life in seconds
     DecayMode decay_mode_ = DecayMode::NONE;
   };
+
+  OPENMS_DLLAPI std::ostream & operator<<(std::ostream &, const Isotope &);
 
 } // namespace OpenMS
 

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -122,7 +122,7 @@ namespace OpenMS
   protected:
 
     int neutrons_ = -1;
-    double abundance_; // has to consistent with getIsotopeDistribution()
+    double abundance_ = -1; // has to consistent with getIsotopeDistribution()
     double half_life_ = -1; ///< half life in seconds
     DecayMode decay_mode_ = DecayMode::NONE;
   };

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -46,9 +46,12 @@ namespace OpenMS
 
       @brief Representation of an isotope
 
-      This class represents a single isotope
+      This class represents a single isotope of an Element. Stable isotopes are
+      expected to contain abundances while unstable isotopes generally do not
+      have natural abundances but contain information about half life and decay
+      mode.
   */
-  class OPENMS_DLLAPI Isotope : 
+  class OPENMS_DLLAPI Isotope :
     public Element
   {
     public:
@@ -93,9 +96,9 @@ namespace OpenMS
     void setAbundance(double ab);
     /// get isotope natural abundance
     double getAbundance() const;
-    /// set number of neutrons 
+    /// set number of neutrons
     void setNeutrons(int ne);
-    /// get number of neutrons 
+    /// get number of neutrons
     int getNeutrons() const;
     /// set primary decay mode (for unstable isotopes)
     void setDecayMode(DecayMode dm);

--- a/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Isotope.h
@@ -1,35 +1,9 @@
-// --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry
-// --------------------------------------------------------------------------
-// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
-// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
-//
-// This software is released under a three-clause BSD license:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution
-//    may be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS.
-// --------------------------------------------------------------------------
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Hannes Rost $
-// $Authors: Hannes Rost $
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 //
 

--- a/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
+++ b/src/openms/include/OpenMS/CHEMISTRY/sources.cmake
@@ -19,6 +19,7 @@ ElementDB.h
 EmpiricalFormula.h
 EnzymaticDigestion.h
 EnzymeXMLDataProvider.h
+Isotope.h
 ModificationDataProvider.h
 ModificationDefinition.h
 ModificationDefinitionsSet.h

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -202,6 +202,11 @@ namespace OpenMS
     */
     //@{
 
+    /** Seconds per Gregorian year  
+            31556952
+    */
+    inline const int SECONDS_PER_YEAR = 31556952;
+      
     /** Degree per rad.
             57.2957795130823209
     */

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -101,10 +101,10 @@ namespace OpenMS
   void Element::setIsotopes(const std::vector<const Isotope*>& isotopes)
   {
     isotopes_ = isotopes;
-    updateIsotopeDistr(); // calculate new cached distribution
+    updateIsotopeDistr_(); // calculate new cached distribution
   }
 
-  void Element::updateIsotopeDistr()
+  void Element::updateIsotopeDistr_()
   {
     auto dist = isotope_distr_.getContainer();
     dist.clear();

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -110,7 +110,7 @@ namespace OpenMS
     dist.clear();
     for (const auto& isotope : isotopes_)
     {
-      dist.emplace_back({isotope->getMonoWeight(), isotope->getAbundance()});
+      dist.emplace_back(isotope->getMonoWeight(), isotope->getAbundance());
     }
     isotope_distr_.set(dist);
   }

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -110,7 +110,7 @@ namespace OpenMS
     dist.clear();
     for (const auto& isotope : isotopes_)
     {
-      dist.push_back(Peak1D(isotope->getMonoWeight(), isotope->getAbundance()));
+      dist.emplace_back({isotope->getMonoWeight(), isotope->getAbundance()});
     }
     isotope_distr_.set(dist);
   }

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -3,7 +3,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: $
+// $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
 
@@ -11,6 +11,7 @@
 #include <OpenMS/CHEMISTRY/Element.h>
 
 #include <OpenMS/CHEMISTRY/Isotope.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <ostream>
 #include <algorithm>
@@ -100,40 +101,33 @@ namespace OpenMS
 
   void Element::setIsotopes(const std::vector<const Isotope*>& isotopes)
   {
-    std::cerr << "DEBUG: Element::setIsotopes called for " << name_ << " with " << isotopes.size() << " isotopes" << std::endl;
-    isotopes_ = isotopes;
-    std::cerr << "DEBUG: Calling updateIsotopeDistr_()" << std::endl;
-    updateIsotopeDistr_(); // calculate new cached distribution
-    std::cerr << "DEBUG: Element::setIsotopes completed" << std::endl;
+    isotopes_ = isotopes;   
+    updateIsotopeDistr_(); // calculate new cached distribution    
   }
 
   void Element::updateIsotopeDistr_()
-  {
-    std::cerr << "DEBUG: Element::updateIsotopeDistr_ called for " << name_ << std::endl;
+  {   
     auto dist = isotope_distr_.getContainer();
     dist.clear();
     dist.reserve(isotopes_.size());
-    std::cerr << "DEBUG: Processing " << isotopes_.size() << " isotopes" << std::endl;
     
     for (size_t i = 0; i < isotopes_.size(); i++)
     {
       const auto& isotope = isotopes_[i];
       if (isotope == nullptr)
       {
-        std::cerr << "ERROR: Null isotope pointer at index " << i << std::endl;
+        OPENMS_LOG_WARN << "Null isotope pointer at index " << i << std::endl;
         continue;  // Skip null pointers to avoid crash
       }
       
-      std::cerr << "DEBUG: Processing isotope " << isotope->getName()
+      OPENMS_LOG_DEBUG << "Processing isotope " << isotope->getName()
                 << " with weight " << isotope->getMonoWeight()
                 << " and abundance " << isotope->getAbundance() << std::endl;
                 
       dist.emplace_back(isotope->getMonoWeight(), isotope->getAbundance());
     }
     
-    std::cerr << "DEBUG: Setting new isotope distribution with " << dist.size() << " entries" << std::endl;
-    isotope_distr_.set(std::move(dist));
-    std::cerr << "DEBUG: Element::updateIsotopeDistr_ completed" << std::endl;
+    isotope_distr_.set(std::move(dist));    
   }
 
   const std::vector<const Isotope*>& Element::getIsotopes() const

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -100,20 +100,40 @@ namespace OpenMS
 
   void Element::setIsotopes(const std::vector<const Isotope*>& isotopes)
   {
+    std::cerr << "DEBUG: Element::setIsotopes called for " << name_ << " with " << isotopes.size() << " isotopes" << std::endl;
     isotopes_ = isotopes;
+    std::cerr << "DEBUG: Calling updateIsotopeDistr_()" << std::endl;
     updateIsotopeDistr_(); // calculate new cached distribution
+    std::cerr << "DEBUG: Element::setIsotopes completed" << std::endl;
   }
 
   void Element::updateIsotopeDistr_()
   {
+    std::cerr << "DEBUG: Element::updateIsotopeDistr_ called for " << name_ << std::endl;
     auto dist = isotope_distr_.getContainer();
     dist.clear();
     dist.reserve(isotopes_.size());
-    for (const auto& isotope : isotopes_)
+    std::cerr << "DEBUG: Processing " << isotopes_.size() << " isotopes" << std::endl;
+    
+    for (size_t i = 0; i < isotopes_.size(); i++)
     {
+      const auto& isotope = isotopes_[i];
+      if (isotope == nullptr)
+      {
+        std::cerr << "ERROR: Null isotope pointer at index " << i << std::endl;
+        continue;  // Skip null pointers to avoid crash
+      }
+      
+      std::cerr << "DEBUG: Processing isotope " << isotope->getName()
+                << " with weight " << isotope->getMonoWeight()
+                << " and abundance " << isotope->getAbundance() << std::endl;
+                
       dist.emplace_back(isotope->getMonoWeight(), isotope->getAbundance());
     }
+    
+    std::cerr << "DEBUG: Setting new isotope distribution with " << dist.size() << " entries" << std::endl;
     isotope_distr_.set(std::move(dist));
+    std::cerr << "DEBUG: Element::updateIsotopeDistr_ completed" << std::endl;
   }
 
   const std::vector<const Isotope*>& Element::getIsotopes() const

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -10,6 +10,8 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/CHEMISTRY/Element.h>
 
+#include <OpenMS/CHEMISTRY/Isotope.h>
+
 #include <ostream>
 #include <algorithm>
 #include <cassert>
@@ -27,7 +29,16 @@ namespace OpenMS
   {
   }
 
-  Element::Element(const Element & e) = default;
+  Element::Element(const Element & e) :
+    name_(e.name_),
+    symbol_(e.symbol_),
+    atomic_number_(e.atomic_number_),
+    average_weight_(e.average_weight_),
+    mono_weight_(e.mono_weight_),
+    isotope_distr_(e.isotope_distr_),
+    isotopes_(e.isotopes_)
+  {
+  }
 
   Element::Element(const string & name,
                    const string & symbol,
@@ -39,7 +50,8 @@ namespace OpenMS
     symbol_(symbol),
     atomic_number_(atomic_number),
     average_weight_(average_weight),
-    mono_weight_(mono_weight)
+    mono_weight_(mono_weight),
+    isotope_distr_(isotopes)
   {
     this->setIsotopeDistribution(isotopes);
   }
@@ -78,12 +90,32 @@ namespace OpenMS
 
   void Element::setIsotopeDistribution(const IsotopeDistribution & distribution)
   {
-    //force sortedness by mz. A lot of code relies on this.
-    assert(std::is_sorted(distribution.begin(), distribution.end(), Peak1D::MZLess()));
-    isotopes_ = distribution;
+    isotope_distr_ = distribution;
   }
 
   const IsotopeDistribution & Element::getIsotopeDistribution() const
+  {
+    return isotope_distr_;
+  }
+
+  void Element::setIsotopes(const std::vector<const Isotope*>& isotopes)
+  {
+    isotopes_ = isotopes;
+    updateIsotopeDistr(); // calculate new cached distribution
+  }
+
+  void Element::updateIsotopeDistr()
+  {
+    auto dist = isotope_distr_.getContainer();
+    dist.clear();
+    for (const auto& isotope : isotopes_)
+    {
+      dist.push_back(Peak1D(isotope->getMonoWeight(), isotope->getAbundance()));
+    }
+    isotope_distr_.set(dist);
+  }
+
+  const std::vector<const Isotope*>& Element::getIsotopes() const
   {
     return isotopes_;
   }
@@ -108,7 +140,17 @@ namespace OpenMS
     return symbol_;
   }
 
-  Element & Element::operator=(const Element & element) = default;
+  Element & Element::operator=(const Element & element)
+  {
+    name_ = element.name_;
+    symbol_ = element.symbol_;
+    atomic_number_ = element.atomic_number_;
+    average_weight_ = element.average_weight_;
+    mono_weight_ = element.mono_weight_;
+    isotope_distr_ = element.isotope_distr_;
+    isotopes_ = element.isotopes_;
+    return *this;
+  }
 
   bool Element::operator==(const Element & element) const
   {
@@ -117,6 +159,7 @@ namespace OpenMS
            atomic_number_ == element.atomic_number_ &&
            average_weight_ == element.average_weight_ &&
            mono_weight_ == element.mono_weight_ &&
+           isotope_distr_ == element.isotope_distr_ &&
            isotopes_ == element.isotopes_;
   }
 
@@ -128,6 +171,7 @@ namespace OpenMS
      symbol_, 
      name_, 
      average_weight_, 
+     isotope_distr_,
      isotopes_) 
      < 
      std::tie(
@@ -136,6 +180,7 @@ namespace OpenMS
       rhs.symbol_, 
       rhs.name_, 
       rhs.average_weight_, 
+      rhs.isotope_distr_,
       rhs.isotopes_);
   }
 
@@ -151,15 +196,14 @@ namespace OpenMS
     << element.atomic_number_ << " "
     << element.average_weight_ << " "
     << element.mono_weight_;
+    os << "\nIsotopes: " << std::endl;
 
     for (const auto& isotope : element.isotopes_)
     {
-      if (isotope.getIntensity() > 0.0f)
-      {
-        os << " " << isotope.getPosition() << "=" << isotope.getIntensity() * 100 << "%";
-      }
+      os << (*isotope) << std::endl;;
     }
     return os;
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -108,6 +108,7 @@ namespace OpenMS
   {
     auto dist = isotope_distr_.getContainer();
     dist.clear();
+    dist.reserve(isotopes_.size());
     for (const auto& isotope : isotopes_)
     {
       dist.emplace_back(isotope->getMonoWeight(), isotope->getAbundance());

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
     {
       dist.emplace_back(isotope->getMonoWeight(), isotope->getAbundance());
     }
-    isotope_distr_.set(dist);
+    isotope_distr_.set(std::move(dist));
   }
 
   const std::vector<const Isotope*>& Element::getIsotopes() const
@@ -197,11 +197,11 @@ namespace OpenMS
     << element.atomic_number_ << " "
     << element.average_weight_ << " "
     << element.mono_weight_;
-    os << "\nIsotopes: " << std::endl;
+    os << "\nIsotopes: \n";
 
     for (const auto& isotope : element.isotopes_)
     {
-      os << (*isotope) << std::endl;;
+      os << (*isotope) << "\n";;
     }
     return os;
   }

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -130,6 +130,11 @@ namespace OpenMS
     isotope_distr_.set(std::move(dist));    
   }
 
+  void Element::refreshIsotopeDistribution()
+  {
+    updateIsotopeDistr_();
+  }
+
   const std::vector<const Isotope*>& Element::getIsotopes() const
   {
     return isotopes_;

--- a/src/openms/source/CHEMISTRY/Element.cpp
+++ b/src/openms/source/CHEMISTRY/Element.cpp
@@ -167,20 +167,20 @@ namespace OpenMS
   bool Element::operator<(const Element & rhs) const
   {
     return std::tie(
-     atomic_number_, 
-     mono_weight_, 
-     symbol_, 
-     name_, 
-     average_weight_, 
+     atomic_number_,
+     mono_weight_,
+     symbol_,
+     name_,
+     average_weight_,
      isotope_distr_,
-     isotopes_) 
-     < 
+     isotopes_)
+     <
      std::tie(
-      rhs.atomic_number_, 
-      rhs.mono_weight_, 
-      rhs.symbol_, 
-      rhs.name_, 
-      rhs.average_weight_, 
+      rhs.atomic_number_,
+      rhs.mono_weight_,
+      rhs.symbol_,
+      rhs.name_,
+      rhs.average_weight_,
       rhs.isotope_distr_,
       rhs.isotopes_);
   }

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -95,7 +95,7 @@ namespace OpenMS
                              bool replace_existing)
   {
     if (hasElement(an) && !replace_existing)
-    {      
+    {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Element with atomic number ") + an + " already exists");
     }
     buildElement_(name, symbol, an, abundance, mass);

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -14,6 +14,8 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <iostream>
 #include <cmath>
 #include <memory>
@@ -125,13 +127,10 @@ namespace OpenMS
                      Isotope::DecayMode decay,
                      bool replace_existing)
   {
-    std::cerr << "DEBUG: Adding isotope " << name << " with symbol " << symbol << " and atomic number " << an << ", replace=" << replace_existing << std::endl;
     unsigned int mass_number = std::round(mass);
     string iso_name = "(" + std::to_string(mass_number) + ")" + name;
     string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
   
-    std::cerr << "DEBUG: Calculated iso_name=" << iso_name << ", iso_symbol=" << iso_symbol << std::endl;
-    std::cerr << "DEBUG: Checking if element exists with atomic number " << an << std::endl;
     
     if (!hasElement( an )  )
     {
@@ -139,66 +138,40 @@ namespace OpenMS
           name + " since the element with  atomic number " + an + " does not yet exsist -- create it first!");
     }
     
-    std::cerr << "DEBUG: Element with atomic number " << an << " exists" << std::endl;
   
     if (hasElement( iso_symbol )  )
     {
-      std::cerr << "DEBUG: Isotope with symbol " << iso_symbol << " already exists" << std::endl;
       
       if (!replace_existing)
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Isotope with symbol ") + iso_symbol + " already exists and replace_existing is set to false.");
       }
       
-      std::cerr << "DEBUG: Creating new isotope to replace existing one" << std::endl;
-      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
-      std::cerr << "DEBUG: New isotope created successfully" << std::endl;
-      
-      std::cerr << "DEBUG: Calling addIsotopeToMaps_ to replace existing isotope" << std::endl;
+      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);      
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);
-      std::cerr << "DEBUG: addIsotopeToMaps_ completed" << std::endl;
       
       // we changed/updated the isotopes, so we need to update
-      std::cerr << "DEBUG: Getting element for isotope" << std::endl;
       const Element* const_ele = isotope->getElement();
-      std::cerr << "DEBUG: Element pointer: " << const_ele << std::endl;
       
       Element* element = const_cast<Element*>(const_ele);
-      std::cerr << "DEBUG: Getting isotopes from element" << std::endl;
       auto current_isotopes = element->getIsotopes();
-      std::cerr << "DEBUG: Element has " << current_isotopes.size() << " isotopes" << std::endl;
       
-      std::cerr << "DEBUG: Calling element->setIsotopes to update" << std::endl;
       element->setIsotopes(element->getIsotopes());
-      std::cerr << "DEBUG: Element isotopes updated" << std::endl;
     }
     else
     {
-      std::cerr << "DEBUG: Isotope with symbol " << iso_symbol << " does not exist, creating new one" << std::endl;
-      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
-      std::cerr << "DEBUG: New isotope created successfully" << std::endl;
-      
-      std::cerr << "DEBUG: Adding new isotope to maps" << std::endl;
+      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);      
       isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
-      std::cerr << "DEBUG: New isotope added to maps" << std::endl;
   
       // we added a new isotope, so we need to add it to the element
-      std::cerr << "DEBUG: Getting element for new isotope" << std::endl;
       const Element* const_ele = isotope->getElement();
-      std::cerr << "DEBUG: Element pointer: " << const_ele << std::endl;
       
       Element* element = const_cast<Element*>(const_ele);
-      std::cerr << "DEBUG: Getting isotopes list from element" << std::endl;
       auto iso_list = element->getIsotopes();
-      std::cerr << "DEBUG: Element has " << iso_list.size() << " isotopes" << std::endl;
       
-      std::cerr << "DEBUG: Adding new isotope to list" << std::endl;
       iso_list.push_back(isotope);
-      std::cerr << "DEBUG: Updating element's isotope list" << std::endl;
       element->setIsotopes(iso_list);
-      std::cerr << "DEBUG: Element's isotope list updated successfully" << std::endl;
     }
-    std::cerr << "DEBUG: addIsotope completed successfully" << std::endl;
   }
 
   double ElementDB::calculateAvgWeight_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
@@ -623,7 +596,7 @@ namespace OpenMS
 
     map<unsigned int, double> iridium_abundance = {{191u, 0.3723}, {193u, 0.6277}};
     map<unsigned int, double> iridium_mass = {{191u, 190.960591}, {193u, 192.962924}};
-    buildElement_("Iridium", "Ir", 77u, rhenium_abundance, rhenium_mass);
+    buildElement_("Iridium", "Ir", 77u, iridium_abundance, iridium_mass);
 
 
     // Pt-190 is radioactive but with a very long half-life. Since its natural occurence is very low, we neglect it by default (m=189.959930 abund.frac.=0.00014)

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -232,7 +232,7 @@ namespace OpenMS
 
     map<unsigned int, double> carbon_abundance = {{12u, 0.9893000000000001}, {13u, 0.010700000000000001}, {14u, 0.0}, {15u, 0.0}};
     map<unsigned int, double> carbon_mass = {{12u, 12.0}, {13u, 13.003355000000001}, {14u, 14.003241989}, {15u, 15.0105993}};
-    map<unsigned int, double> carbon_half_life = {{12u, -1.0}, {13u, -1.0}, {14u, 5.70*1e3 * CONSTANTS::SECONDS_PER_YEAR}, {15u, 2.449} };
+    map<unsigned int, double> carbon_half_life = {{12u, -1.0}, {13u, -1.0}, {14u, 5.70*1e3 * Constants::SECONDS_PER_YEAR}, {15u, 2.449} };
     map<unsigned int, Isotope::DecayMode> carbon_decay = {{12u, Isotope::DecayMode::NONE}, {13u, Isotope::DecayMode::NONE}, {14u, Isotope::DecayMode::BETA_MINUS}, {15u, Isotope::DecayMode::BETA_MINUS}};
     buildElement_("Carbon", "C", 6u, carbon_abundance, carbon_mass, carbon_half_life, carbon_decay);
 
@@ -645,7 +645,7 @@ namespace OpenMS
 
     map<unsigned int, double> uranium_abundance = {{234u,  0.000054}, {235u, 0.007204}, {238u, 0.992742}};
     map<unsigned int, double> uranium_mass = {{234u,  234.040950}, {235u,  235.043928}, {238u,   238.05079}};
-    map<unsigned int, double> uranium_half_life = {{234u, 2.455 *1e5* CONSTANTS::SECONDS_PER_YEAR}, {235u, 7.038 *1e8* CONSTANTS::SECONDS_PER_YEAR}, {238u, 4.468 *1e9* CONSTANTS::SECONDS_PER_YEAR} };
+    map<unsigned int, double> uranium_half_life = {{234u, 2.455 *1e5* Constants::SECONDS_PER_YEAR}, {235u, 7.038 *1e8* Constants::SECONDS_PER_YEAR}, {238u, 4.468 *1e9* Constants::SECONDS_PER_YEAR} };
     map<unsigned int, Isotope::DecayMode> uranium_decay = {{234u, Isotope::DecayMode::ALPHA}, {235u, Isotope::DecayMode::ALPHA}, {238u, Isotope::DecayMode::ALPHA} };
     buildElement_("Uranium", "U", 92u, uranium_abundance, uranium_mass, uranium_half_life, uranium_decay);
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -142,7 +142,7 @@ namespace OpenMS
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Isotope with symbol ") + iso_symbol + " already exists and replace_existing is set to false.");
       }
-      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);
       // we changed/updated the isotopes, so we need to update
       const Element* const_ele = isotope->getElement();
@@ -151,7 +151,7 @@ namespace OpenMS
     }
     else
     {
-      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
       isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
 
       // we added a new isotope, so we need to add it to the element
@@ -726,14 +726,14 @@ namespace OpenMS
         dm = decay_modes.at(m.first);
       }
 
-      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, atomic_mass, abundance.at(m.first), half_life, dm);
+      const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, atomic_mass, abundance.at(m.first), half_life, dm);
       isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
       isotopes.push_back(isotope);
     }
     return isotopes;
   }
 
-  Isotope* ElementDB::addIsotopeToMaps_(const std::string& iso_name, const std::string& iso_symbol, Isotope* isotope)
+  const Isotope* ElementDB::addIsotopeToMaps_(const std::string& iso_name, const std::string& iso_symbol, const Isotope* isotope)
   {
     if (isotopes_.find(iso_symbol) != isotopes_.end())
     {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -150,13 +150,11 @@ namespace OpenMS
       const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);      
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);
       
-      // we changed/updated the isotopes, so we need to update
+      // we changed/updated the isotopes, so we need to refresh the cached isotope distribution
       const Element* const_ele = isotope->getElement();
       
       Element* element = const_cast<Element*>(const_ele);
-      auto current_isotopes = element->getIsotopes();
-      
-      element->setIsotopes(element->getIsotopes());
+      element->refreshIsotopeDistribution();
     }
     else
     {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -117,6 +117,46 @@ namespace OpenMS
     buildElement_(name, symbol, an, abundance, mass);
   }
 
+  void ElementDB::addIsotope(const std::string& name,
+                  const std::string& symbol,
+                  const unsigned int an,
+                  double abundance,
+                  double mass,
+                  double half_life,
+                  Isotope::DecayMode decay,
+                  bool replace_existing)
+  {
+    unsigned int mass_number = std::round(mass);
+    string iso_name = "(" + std::to_string(mass_number) + ")" + name;
+    string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
+
+    if (hasElement( iso_symbol )  )
+    {
+      if (!replace_existing)
+      {
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Element with atomic number ") + an + " already exists");
+      }
+      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      addIsotopeToMaps_(iso_name, iso_symbol, isotope);
+      // we changed the isotopes, so we need to update
+      const Element* const_ele = isotope->getElement();
+      Element* element = const_cast<Element*>(const_ele);
+      element->updateIsotopeDistr();
+    }
+    else
+    {
+      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
+
+      // we added a new isotope, so we need to add it to the element
+      const Element* const_ele = isotope->getElement();
+      Element* element = const_cast<Element*>(const_ele);
+      auto iso_list = element->getIsotopes();
+      iso_list.push_back(isotope);
+      element->setIsotopes(iso_list);
+    }
+  }
+
   double ElementDB::calculateAvgWeight_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
   {
     double avg = 0;
@@ -160,7 +200,7 @@ namespace OpenMS
   }
 
   void ElementDB::storeElements_()
-  {	
+  {
     map<unsigned int, double> hydrogen_abundance = {{1u, 0.999885}, {2u, 0.000115}, {3u, 0.0}};
     map<unsigned int, double> hydrogen_mass = {{1u, 1.0078250319}, {2u, 2.01410178}, {3u, 3.01604927}};
     buildElement_("Hydrogen", "H", 1u, hydrogen_abundance, hydrogen_mass);
@@ -185,16 +225,11 @@ namespace OpenMS
     map<unsigned int, double> bor_mass = {{10u, 10.012937000000001}, {11u, 11.009304999999999}};
     buildElement_("Boron", "B", 5u, bor_abundance, bor_mass);
 
-
-
-    map<unsigned int, double> carbon_abundance = {{12u, 0.9893000000000001}, {13u, 0.010700000000000001}};
-    map<unsigned int, double> carbon_mass = {{12u, 12.0}, {13u, 13.003355000000001}};
-    buildElement_("Carbon", "C", 6u, carbon_abundance, carbon_mass);
-    // unstable isotopes
-    map<unsigned int, double> i_carbon_mass = {{14u, 14.003241989}, {15u, 15.0105993}};
-    map<unsigned int, double> i_carbon_half_life = {{14u, 5.70*1e3 * SECONDS_PER_YEAR}, {15u, 2.449} };
-    map<unsigned int, Isotope::DecayMode> i_carbon_decay = {{14u, Isotope::DecayMode::BETA_MINUS}, {15u, Isotope::DecayMode::BETA_MINUS}};
-    buildIsotopes_("Carbon", "C", 6u, i_carbon_mass, i_carbon_half_life, i_carbon_decay);
+    map<unsigned int, double> carbon_abundance = {{12u, 0.9893000000000001}, {13u, 0.010700000000000001}, {14u, 0.0}, {15u, 0.0}};
+    map<unsigned int, double> carbon_mass = {{12u, 12.0}, {13u, 13.003355000000001}, {14u, 14.003241989}, {15u, 15.0105993}};
+    map<unsigned int, double> carbon_half_life = {{12u, -1.0}, {13u, -1.0}, {14u, 5.70*1e3 * SECONDS_PER_YEAR}, {15u, 2.449} };
+    map<unsigned int, Isotope::DecayMode> carbon_decay = {{12u, Isotope::DecayMode::NONE}, {13u, Isotope::DecayMode::NONE}, {14u, Isotope::DecayMode::BETA_MINUS}, {15u, Isotope::DecayMode::BETA_MINUS}};
+    buildElement_("Carbon", "C", 6u, carbon_abundance, carbon_mass, carbon_half_life, carbon_decay);
 
     map<unsigned int, double> nitrogen_abundance = {{14u, 0.9963200000000001}, {15u, 0.00368}};
     map<unsigned int, double> nitrogen_mass = {{14u, 14.003074}, {15u, 15.000109}};
@@ -585,10 +620,11 @@ namespace OpenMS
 
     // Radon(Rn) abundance is not known.
     // unstable isotopes of Radon
-    map<unsigned int, double> i_radon_mass = {{219u, 219.0094802}, {220, 220.0113940}, {221, 221.015537}, {222, 222.0175777}};
-    map<unsigned int, double> i_radon_half_life = { {219u, 3.96}, {220u, 55.6}, {221u, 25.7 * 60}, {222u, 3.8235 * 3600 * 24}};
-    map<unsigned int, Isotope::DecayMode> i_radon_decay = { {219u, Isotope::DecayMode::ALPHA}, {220u, Isotope::DecayMode::ALPHA}, {221u, Isotope::DecayMode::BETA_MINUS}, {222u, Isotope::DecayMode::ALPHA}};
-    buildIsotopes_("Radon", "Rn", 86u, i_radon_mass, i_radon_half_life, i_radon_decay);
+    map<unsigned int, double> radon_abundance = {{219u, 0.0}, {220, 0.0}, {221, 0.0}, {222, 0.0}};
+    map<unsigned int, double> radon_mass = {{219u, 219.0094802}, {220, 220.0113940}, {221, 221.015537}, {222, 222.0175777}};
+    map<unsigned int, double> radon_half_life = { {219u, 3.96}, {220u, 55.6}, {221u, 25.7 * 60}, {222u, 3.8235 * 3600 * 24}};
+    map<unsigned int, Isotope::DecayMode> radon_decay = { {219u, Isotope::DecayMode::ALPHA}, {220u, Isotope::DecayMode::ALPHA}, {221u, Isotope::DecayMode::BETA_MINUS}, {222u, Isotope::DecayMode::ALPHA}};
+    buildElement_("Radon", "Rn", 86u, radon_abundance, radon_mass, radon_half_life, radon_decay);
 
     // Radium(Ra) abundance is not known.
 
@@ -604,11 +640,9 @@ namespace OpenMS
 
     map<unsigned int, double> uranium_abundance = {{234u,  0.000054}, {235u, 0.007204}, {238u, 0.992742}};
     map<unsigned int, double> uranium_mass = {{234u,  234.040950}, {235u,  235.043928}, {238u,   238.05079}};
-    buildElement_("Uranium", "U", 92u, uranium_abundance, uranium_mass);
-    map<unsigned int, double> i_uranium_mass = uranium_mass;
-    map<unsigned int, double> i_uranium_half_life = {{234u, 2.455 *1e5* SECONDS_PER_YEAR}, {235u, 7.038 *1e8* SECONDS_PER_YEAR}, {238u, 4.468 *1e9* SECONDS_PER_YEAR} };
-    map<unsigned int, Isotope::DecayMode> i_uranium_decay = {{234u, Isotope::DecayMode::ALPHA}, {235u, Isotope::DecayMode::ALPHA}, {238u, Isotope::DecayMode::ALPHA} };
-    buildIsotopes_("Uranium", "U", 92u, i_uranium_mass, i_uranium_half_life, i_uranium_decay);
+    map<unsigned int, double> uranium_half_life = {{234u, 2.455 *1e5* SECONDS_PER_YEAR}, {235u, 7.038 *1e8* SECONDS_PER_YEAR}, {238u, 4.468 *1e9* SECONDS_PER_YEAR} };
+    map<unsigned int, Isotope::DecayMode> uranium_decay = {{234u, Isotope::DecayMode::ALPHA}, {235u, Isotope::DecayMode::ALPHA}, {238u, Isotope::DecayMode::ALPHA} };
+    buildElement_("Uranium", "U", 92u, uranium_abundance, uranium_mass, uranium_half_life, uranium_decay);
 
     // special case for deuterium and tritium: add symbol alias
     const Element* deuterium = getElement("(2)H");
@@ -620,79 +654,24 @@ namespace OpenMS
 
   }
 
-  void ElementDB::buildIsotopes_(const std::string& name,
-                                 const std::string& symbol,
-                                 const unsigned int an,
-                                 const std::map<unsigned int, double>& mass,
-                                 const std::map<unsigned int, double>& half_lifes,
-                                 const std::map<unsigned int, Isotope::DecayMode>& decay_modes)
+  void ElementDB::buildElement_(const string& name,
+                                const string& symbol,
+                                const unsigned int an,
+                                const map<unsigned int, double>& abundance,
+                                const map<unsigned int, double>& mass, 
+                                const std::map<unsigned int, double>& half_lifes,
+                                const std::map<unsigned int, Isotope::DecayMode>& decay_modes)
   {
-    for (const auto& isotope : mass)
-    {
-      double atomic_mass = isotope.second;
-      unsigned int mass_number = std::round(atomic_mass); // TODO: does this always work?
-      string iso_name = "(" + std::to_string(mass_number) + ")" + name;
-      string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
-
-      // set avg and mono to same value for isotopes (old hack...)
-      IsotopeDistribution iso_isotopes;
-      IsotopeDistribution::ContainerType iso_container;
-      iso_container.push_back(Peak1D(atomic_mass, 1.0));
-      iso_isotopes.set(iso_container);
-
-      double half_life = half_lifes.at(isotope.first);
-      Isotope::DecayMode dm = decay_modes.at(isotope.first);
-
-      Isotope* iso_e = new Isotope(iso_name, iso_symbol, an, atomic_mass, atomic_mass, iso_isotopes);
-      iso_e->setAbundance(-1);
-      iso_e->setHalfLife(half_life);
-      iso_e->setDecayMode(dm);
-      iso_e->setNeutrons(mass_number - an);
-      // we may have double entries, eg "almost stable" isotopes with natural abundances like Uranium
-      if (names_.find(iso_name) != names_.end())
-      {
-        const Element* e = names_[iso_name];
-        iso_e->setAbundance(e->getIsotopeDistribution()[0].getIntensity());
-        delete e;
-      }
-      names_[iso_name] = iso_e;
-      symbols_[iso_symbol] = iso_e;
-      isotopes_[iso_symbol] = iso_e;
-      isotopes_[iso_name] = iso_e;
-    }
-  }
-
-  void ElementDB::buildElement_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
-  {
-    IsotopeDistribution isotopes = parseIsotopeDistribution_(abundance, mass);
     double avg_weight = calculateAvgWeight_(abundance, mass);
     double mono_weight = calculateMonoWeight_(abundance, mass);
 
-    addElementToMaps_(name, symbol, an, make_unique<const Element>(name, symbol, an, avg_weight, mono_weight, isotopes));
-    storeStableIsotopes_(name, symbol, an, mass, isotopes);
+    Element* e = new Element(name, symbol, an, avg_weight, mono_weight);
+    e = addElementToMaps_(name, symbol, an, e);
+    auto isotope_vec = buildIsotopes_(name, symbol, an, abundance, mass, half_lifes, decay_modes);
+    e->setIsotopes(isotope_vec);
   }
 
-  void overwrite(const Element* old, unique_ptr<const Element>& new_e)
-  {
-    if (old->getSymbol() != new_e->getSymbol())
-    { // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
-                                    "Replacing element with name " + old->getName() + " and symbol " + old->getSymbol() + " has different new symbol: " + new_e->getSymbol());
-    }
-    if (old->getName() != new_e->getName())
-    { // -- this would invalidate the lookup, since e_ptr->getName().at("Oxygen")->getName() == 'Something'
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(), "Replacing element with name " + old->getName() + " has different new name: " + new_e->getName());
-    }
-    if (old->getAtomicNumber() != new_e->getAtomicNumber())
-    { // -- this would invalidate the lookup, since e_ptr->getAtomicNumbers().at(12)->getAtomicNumber() == 14
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_e->getSymbol(),
-                                    "Replacing element with atomic number " + String(old->getAtomicNumber()) + " has different new atomic number: " + String(new_e->getAtomicNumber()));
-    }
-    // ... overwrite
-    *(const_cast<Element*>(old)) = *new_e;
-  }
-
-  void ElementDB::addElementToMaps_(const string& name, const string& symbol, const unsigned int an, unique_ptr<const Element> e)
+  Element* ElementDB::addElementToMaps_(const string& name, const string& symbol, const unsigned int an, Element* e)
   {
     // overwrite existing element if it already exists
     // find() has to be protected here in a parallel context
@@ -701,62 +680,71 @@ namespace OpenMS
       // in order to ensure that existing elements are still valid and memory
       // addresses do not change, we have to modify the Element in place
       // instead of replacing it.
-      overwrite(atomic_numbers_[an], e);
-      // do not release 'e' here; it needs to be deleted when it goes out if scope
+      const Element* const_ele = atomic_numbers_[an];
+      Element* element = const_cast<Element*>(const_ele);
+      *element = *e; // copy all data from input to the existing element
+      delete e;
+      e = element;
     }
     else
     {
-      addIfUniqueOrThrow(names_, name, e);
-      addIfUniqueOrThrow(symbols_, symbol, e);
-      addIfUniqueOrThrow(atomic_numbers_, an, e);
-      e.release(); // allocation will be cleaned up by ~ElementDB now
+      names_[name] = e;
+      symbols_[symbol] = e;
+      atomic_numbers_[an] = e;
     }
+    return e;
   }
 
-  void ElementDB::storeStableIsotopes_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& mass, const IsotopeDistribution& isotopes)
+  std::vector<const Isotope *> ElementDB::buildIsotopes_(const std::string& name,
+                                                         const std::string& symbol,
+                                                         const unsigned int an,
+                                                         const std::map<unsigned int, double>& abundance,
+                                                         const std::map<unsigned int, double>& mass,
+                                                         const std::map<unsigned int, double>& half_lifes,
+                                                         const std::map<unsigned int, Isotope::DecayMode>& decay_modes)
   {
-    for (const auto& isotope : isotopes)
+    std::vector<const Isotope *> isotopes;
+    bool stable_only = half_lifes.empty();
+    for (const auto& m : mass)
     {
-      double atomic_mass = isotope.getMZ();
-      unsigned int mass_number = std::round(atomic_mass); // TODO: does this always work?
+      double atomic_mass = m.second;
+      unsigned int mass_number = std::round(atomic_mass);
       string iso_name = "(" + std::to_string(mass_number) + ")" + name;
       string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
 
-      // set avg and mono to same value for isotopes (old hack...)
-      double iso_avg_weight = mass.at(mass_number);
-      double iso_mono_weight = iso_avg_weight;
-      IsotopeDistribution iso_isotopes;
-      IsotopeDistribution::ContainerType iso_container;
-      iso_container.push_back(Peak1D(atomic_mass, 1.0));
-      iso_isotopes.set(iso_container);  
-
-      Isotope* iso_e = new Isotope(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
-      iso_e->setAbundance(isotope.getIntensity());
-      iso_e->setNeutrons(mass_number - iso_e->getAtomicNumber());
-      // delete existing element if it already exists (to avoid memory leak)
-      if (auto has_elem = names_.find(iso_name); has_elem != names_.end())
+      double half_life = -1;
+      Isotope::DecayMode dm = Isotope::DecayMode::NONE;
+      if (!stable_only)
       {
-        delete has_elem->second;
+        half_life = half_lifes.at(m.first);
+        dm = decay_modes.at(m.first);
       }
-      names_[iso_name] = iso_e;
-      symbols_[iso_symbol] = iso_e;
-      isotopes_[iso_symbol] = iso_e;
-    } 
+
+      Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, atomic_mass, abundance.at(m.first), half_life, dm);
+      isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
+      isotopes.push_back(isotope);
+    }
+    return isotopes;
   }
 
-  IsotopeDistribution ElementDB::parseIsotopeDistribution_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
+  Isotope* ElementDB::addIsotopeToMaps_(const std::string& iso_name, const std::string& iso_symbol, Isotope* isotope)
   {
-    IsotopeDistribution::ContainerType dist;
-    
-    for (map<unsigned int, double>::const_iterator it = abundance.begin(); it != abundance.end(); ++it)
-    { 
-      dist.push_back(Peak1D(mass.at(it->first) , abundance.at(it->first)));
+    if (isotopes_.find(iso_symbol) != isotopes_.end())
+    {
+      const Isotope* const_iso = isotopes_[iso_symbol];
+      Isotope* iso = const_cast<Isotope*>(const_iso);
+      *iso = *isotope; // copy all data from input to the existing element
+      delete isotope;
+      return iso;
     }
-
-    IsotopeDistribution iso_dist;
-    iso_dist.set(dist);
-    
-    return iso_dist;
+    else
+    {
+      names_[iso_name] = isotope;
+      symbols_[iso_symbol] = isotope;
+      isotopes_[iso_symbol] = isotope;
+      isotopes_[iso_name] = isotope;
+      return isotope;
+    }
   }
 
   void ElementDB::clear_()

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-int SECONDS_PER_YEAR = 31556952; // Gregorian year
+constexpr int SECONDS_PER_YEAR = 31556952; // Gregorian year
 
 namespace OpenMS
 {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -117,49 +117,88 @@ namespace OpenMS
   }
 
   void ElementDB::addIsotope(const std::string& name,
-                  const std::string& symbol,
-                  const unsigned int an,
-                  double abundance,
-                  double mass,
-                  double half_life,
-                  Isotope::DecayMode decay,
-                  bool replace_existing)
+                     const std::string& symbol,
+                     const unsigned int an,
+                     double abundance,
+                     double mass,
+                     double half_life,
+                     Isotope::DecayMode decay,
+                     bool replace_existing)
   {
+    std::cerr << "DEBUG: Adding isotope " << name << " with symbol " << symbol << " and atomic number " << an << ", replace=" << replace_existing << std::endl;
     unsigned int mass_number = std::round(mass);
     string iso_name = "(" + std::to_string(mass_number) + ")" + name;
     string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
-
+  
+    std::cerr << "DEBUG: Calculated iso_name=" << iso_name << ", iso_symbol=" << iso_symbol << std::endl;
+    std::cerr << "DEBUG: Checking if element exists with atomic number " << an << std::endl;
+    
     if (!hasElement( an )  )
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Cannot add isotope ") +
           name + " since the element with  atomic number " + an + " does not yet exsist -- create it first!");
     }
-
+    
+    std::cerr << "DEBUG: Element with atomic number " << an << " exists" << std::endl;
+  
     if (hasElement( iso_symbol )  )
     {
+      std::cerr << "DEBUG: Isotope with symbol " << iso_symbol << " already exists" << std::endl;
+      
       if (!replace_existing)
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Isotope with symbol ") + iso_symbol + " already exists and replace_existing is set to false.");
       }
+      
+      std::cerr << "DEBUG: Creating new isotope to replace existing one" << std::endl;
       const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      std::cerr << "DEBUG: New isotope created successfully" << std::endl;
+      
+      std::cerr << "DEBUG: Calling addIsotopeToMaps_ to replace existing isotope" << std::endl;
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);
+      std::cerr << "DEBUG: addIsotopeToMaps_ completed" << std::endl;
+      
       // we changed/updated the isotopes, so we need to update
+      std::cerr << "DEBUG: Getting element for isotope" << std::endl;
       const Element* const_ele = isotope->getElement();
+      std::cerr << "DEBUG: Element pointer: " << const_ele << std::endl;
+      
       Element* element = const_cast<Element*>(const_ele);
+      std::cerr << "DEBUG: Getting isotopes from element" << std::endl;
+      auto current_isotopes = element->getIsotopes();
+      std::cerr << "DEBUG: Element has " << current_isotopes.size() << " isotopes" << std::endl;
+      
+      std::cerr << "DEBUG: Calling element->setIsotopes to update" << std::endl;
       element->setIsotopes(element->getIsotopes());
+      std::cerr << "DEBUG: Element isotopes updated" << std::endl;
     }
     else
     {
+      std::cerr << "DEBUG: Isotope with symbol " << iso_symbol << " does not exist, creating new one" << std::endl;
       const Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
+      std::cerr << "DEBUG: New isotope created successfully" << std::endl;
+      
+      std::cerr << "DEBUG: Adding new isotope to maps" << std::endl;
       isotope = addIsotopeToMaps_(iso_name, iso_symbol, isotope);
-
+      std::cerr << "DEBUG: New isotope added to maps" << std::endl;
+  
       // we added a new isotope, so we need to add it to the element
+      std::cerr << "DEBUG: Getting element for new isotope" << std::endl;
       const Element* const_ele = isotope->getElement();
+      std::cerr << "DEBUG: Element pointer: " << const_ele << std::endl;
+      
       Element* element = const_cast<Element*>(const_ele);
+      std::cerr << "DEBUG: Getting isotopes list from element" << std::endl;
       auto iso_list = element->getIsotopes();
+      std::cerr << "DEBUG: Element has " << iso_list.size() << " isotopes" << std::endl;
+      
+      std::cerr << "DEBUG: Adding new isotope to list" << std::endl;
       iso_list.push_back(isotope);
+      std::cerr << "DEBUG: Updating element's isotope list" << std::endl;
       element->setIsotopes(iso_list);
+      std::cerr << "DEBUG: Element's isotope list updated successfully" << std::endl;
     }
+    std::cerr << "DEBUG: addIsotope completed successfully" << std::endl;
   }
 
   double ElementDB::calculateAvgWeight_(const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
@@ -734,12 +773,44 @@ namespace OpenMS
 
   const Isotope* ElementDB::addIsotopeToMaps_(const std::string& iso_name, const std::string& iso_symbol, const Isotope* isotope)
   {
+    std::cerr << "DEBUG: addIsotopeToMaps_ called with iso_name=" << iso_name << ", iso_symbol=" << iso_symbol << std::endl;
+    
     if (isotopes_.find(iso_symbol) != isotopes_.end())
     {
+      std::cerr << "DEBUG: Found existing isotope in isotopes_ map" << std::endl;
       const Isotope* const_iso = isotopes_[iso_symbol];
+      std::cerr << "DEBUG: Existing isotope pointer: " << const_iso << std::endl;
+      
       Isotope* iso = const_cast<Isotope*>(const_iso);
-      *iso = *isotope; // copy all data from input to the existing element
+      
+      // Instead of blindly using assignment operator which could break relationships,
+      // selectively update properties while preserving element relationships
+      std::cerr << "DEBUG: Selectively updating isotope properties (instead of using assignment operator)" << std::endl;
+      
+      // Keep the existing element relationship intact by not re-assigning atomic_number_
+      // Update only the properties that should change
+      iso->setAbundance(isotope->getAbundance());
+      iso->setMonoWeight(isotope->getMonoWeight());
+      iso->setHalfLife(isotope->getHalfLife());
+      iso->setNeutrons(isotope->getNeutrons());
+      iso->setDecayMode(isotope->getDecayMode());
+      
+      // Names and symbols are used in lookup maps, so we need to be careful with them
+      if (iso->getName() != isotope->getName())
+      {
+        std::cerr << "DEBUG: Updating isotope name" << std::endl;
+        iso->setName(isotope->getName());
+      }
+      
+      if (iso->getSymbol() != isotope->getSymbol())
+      {
+        std::cerr << "DEBUG: Updating isotope symbol" << std::endl;
+        iso->setSymbol(isotope->getSymbol());
+      }
+      
+      std::cerr << "DEBUG: Safe update completed, deleting new isotope instance" << std::endl;
       delete isotope;
+      std::cerr << "DEBUG: Returning existing isotope pointer" << std::endl;
       return iso;
     }
     else

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -134,7 +134,7 @@ namespace OpenMS
     {
       if (!replace_existing)
       {
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Element with atomic number ") + an + " already exists");
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Isotope with symbol ") + iso_symbol + " already exists and replace_existing is set to false.");
       }
       Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -12,14 +12,13 @@
 #include <OpenMS/CHEMISTRY/Element.h>
 #include <OpenMS/CHEMISTRY/Isotope.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <iostream>
 #include <cmath>
 #include <memory>
 
 using namespace std;
-
-constexpr int SECONDS_PER_YEAR = 31556952; // Gregorian year
 
 namespace OpenMS
 {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -232,7 +232,7 @@ namespace OpenMS
 
     map<unsigned int, double> carbon_abundance = {{12u, 0.9893000000000001}, {13u, 0.010700000000000001}, {14u, 0.0}, {15u, 0.0}};
     map<unsigned int, double> carbon_mass = {{12u, 12.0}, {13u, 13.003355000000001}, {14u, 14.003241989}, {15u, 15.0105993}};
-    map<unsigned int, double> carbon_half_life = {{12u, -1.0}, {13u, -1.0}, {14u, 5.70*1e3 * SECONDS_PER_YEAR}, {15u, 2.449} };
+    map<unsigned int, double> carbon_half_life = {{12u, -1.0}, {13u, -1.0}, {14u, 5.70*1e3 * CONSTANTS::SECONDS_PER_YEAR}, {15u, 2.449} };
     map<unsigned int, Isotope::DecayMode> carbon_decay = {{12u, Isotope::DecayMode::NONE}, {13u, Isotope::DecayMode::NONE}, {14u, Isotope::DecayMode::BETA_MINUS}, {15u, Isotope::DecayMode::BETA_MINUS}};
     buildElement_("Carbon", "C", 6u, carbon_abundance, carbon_mass, carbon_half_life, carbon_decay);
 
@@ -645,7 +645,7 @@ namespace OpenMS
 
     map<unsigned int, double> uranium_abundance = {{234u,  0.000054}, {235u, 0.007204}, {238u, 0.992742}};
     map<unsigned int, double> uranium_mass = {{234u,  234.040950}, {235u,  235.043928}, {238u,   238.05079}};
-    map<unsigned int, double> uranium_half_life = {{234u, 2.455 *1e5* SECONDS_PER_YEAR}, {235u, 7.038 *1e8* SECONDS_PER_YEAR}, {238u, 4.468 *1e9* SECONDS_PER_YEAR} };
+    map<unsigned int, double> uranium_half_life = {{234u, 2.455 *1e5* CONSTANTS::SECONDS_PER_YEAR}, {235u, 7.038 *1e8* CONSTANTS::SECONDS_PER_YEAR}, {238u, 4.468 *1e9* CONSTANTS::SECONDS_PER_YEAR} };
     map<unsigned int, Isotope::DecayMode> uranium_decay = {{234u, Isotope::DecayMode::ALPHA}, {235u, Isotope::DecayMode::ALPHA}, {238u, Isotope::DecayMode::ALPHA} };
     buildElement_("Uranium", "U", 92u, uranium_abundance, uranium_mass, uranium_half_life, uranium_decay);
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -9,15 +9,17 @@
 
 #include <OpenMS/CHEMISTRY/ElementDB.h>
 
+#include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CHEMISTRY/Isotope.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/CHEMISTRY/Element.h>
-
 #include <iostream>
 #include <cmath>
 #include <memory>
 
 using namespace std;
+
+int SECONDS_PER_YEAR = 31556952; // Gregorian year
 
 namespace OpenMS
 {
@@ -52,6 +54,11 @@ namespace OpenMS
     return atomic_numbers_;
   }
 
+  const unordered_map<string, const Isotope*>& ElementDB::getIsotopeSymbols() const
+  {
+    return isotopes_;
+  }
+
   const Element* ElementDB::getElement(const string& name) const
   {
     if (auto entry = symbols_.find(name); entry != symbols_.end())
@@ -64,6 +71,15 @@ namespace OpenMS
       {
         return entry->second;
       }
+    }
+    return nullptr;
+  }
+
+  const Isotope* ElementDB::getIsotope(const string& name) const
+  {
+    if (auto entry = isotopes_.find(name); entry != isotopes_.end())
+    {
+      return entry->second;
     }
     return nullptr;
   }
@@ -170,10 +186,15 @@ namespace OpenMS
     buildElement_("Boron", "B", 5u, bor_abundance, bor_mass);
 
 
+
     map<unsigned int, double> carbon_abundance = {{12u, 0.9893000000000001}, {13u, 0.010700000000000001}};
     map<unsigned int, double> carbon_mass = {{12u, 12.0}, {13u, 13.003355000000001}};
     buildElement_("Carbon", "C", 6u, carbon_abundance, carbon_mass);
-
+    // unstable isotopes
+    map<unsigned int, double> i_carbon_mass = {{14u, 14.003241989}, {15u, 15.0105993}};
+    map<unsigned int, double> i_carbon_half_life = {{14u, 5.70*1e3 * SECONDS_PER_YEAR}, {15u, 2.449} };
+    map<unsigned int, Isotope::DecayMode> i_carbon_decay = {{14u, Isotope::DecayMode::BETA_MINUS}, {15u, Isotope::DecayMode::BETA_MINUS}};
+    buildIsotopes_("Carbon", "C", 6u, i_carbon_mass, i_carbon_half_life, i_carbon_decay);
 
     map<unsigned int, double> nitrogen_abundance = {{14u, 0.9963200000000001}, {15u, 0.00368}};
     map<unsigned int, double> nitrogen_mass = {{14u, 14.003074}, {15u, 15.000109}};
@@ -563,6 +584,11 @@ namespace OpenMS
     // Astatine(At) abundance is not known.
 
     // Radon(Rn) abundance is not known.
+    // unstable isotopes of Radon
+    map<unsigned int, double> i_radon_mass = {{219u, 219.0094802}, {220, 220.0113940}, {221, 221.015537}, {222, 222.0175777}};
+    map<unsigned int, double> i_radon_half_life = { {219u, 3.96}, {220u, 55.6}, {221u, 25.7 * 60}, {222u, 3.8235 * 3600 * 24}};
+    map<unsigned int, Isotope::DecayMode> i_radon_decay = { {219u, Isotope::DecayMode::ALPHA}, {220u, Isotope::DecayMode::ALPHA}, {221u, Isotope::DecayMode::BETA_MINUS}, {222u, Isotope::DecayMode::ALPHA}};
+    buildIsotopes_("Radon", "Rn", 86u, i_radon_mass, i_radon_half_life, i_radon_decay);
 
     // Radium(Ra) abundance is not known.
 
@@ -579,6 +605,10 @@ namespace OpenMS
     map<unsigned int, double> uranium_abundance = {{234u,  0.000054}, {235u, 0.007204}, {238u, 0.992742}};
     map<unsigned int, double> uranium_mass = {{234u,  234.040950}, {235u,  235.043928}, {238u,   238.05079}};
     buildElement_("Uranium", "U", 92u, uranium_abundance, uranium_mass);
+    map<unsigned int, double> i_uranium_mass = uranium_mass;
+    map<unsigned int, double> i_uranium_half_life = {{234u, 2.455 *1e5* SECONDS_PER_YEAR}, {235u, 7.038 *1e8* SECONDS_PER_YEAR}, {238u, 4.468 *1e9* SECONDS_PER_YEAR} };
+    map<unsigned int, Isotope::DecayMode> i_uranium_decay = {{234u, Isotope::DecayMode::ALPHA}, {235u, Isotope::DecayMode::ALPHA}, {238u, Isotope::DecayMode::ALPHA} };
+    buildIsotopes_("Uranium", "U", 92u, i_uranium_mass, i_uranium_half_life, i_uranium_decay);
 
     // special case for deuterium and tritium: add symbol alias
     const Element* deuterium = getElement("(2)H");
@@ -590,6 +620,47 @@ namespace OpenMS
 
   }
 
+  void ElementDB::buildIsotopes_(const std::string& name,
+                                 const std::string& symbol,
+                                 const unsigned int an,
+                                 const std::map<unsigned int, double>& mass,
+                                 const std::map<unsigned int, double>& half_lifes,
+                                 const std::map<unsigned int, Isotope::DecayMode>& decay_modes)
+  {
+    for (const auto& isotope : mass)
+    {
+      double atomic_mass = isotope.second;
+      unsigned int mass_number = std::round(atomic_mass); // TODO: does this always work?
+      string iso_name = "(" + std::to_string(mass_number) + ")" + name;
+      string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
+
+      // set avg and mono to same value for isotopes (old hack...)
+      IsotopeDistribution iso_isotopes;
+      IsotopeDistribution::ContainerType iso_container;
+      iso_container.push_back(Peak1D(atomic_mass, 1.0));
+      iso_isotopes.set(iso_container);
+
+      double half_life = half_lifes.at(isotope.first);
+      Isotope::DecayMode dm = decay_modes.at(isotope.first);
+
+      Isotope* iso_e = new Isotope(iso_name, iso_symbol, an, atomic_mass, atomic_mass, iso_isotopes);
+      iso_e->setAbundance(-1);
+      iso_e->setHalfLife(half_life);
+      iso_e->setDecayMode(dm);
+      iso_e->setNeutrons(mass_number - an);
+      // we may have double entries, eg "almost stable" isotopes with natural abundances like Uranium
+      if (names_.find(iso_name) != names_.end())
+      {
+        const Element* e = names_[iso_name];
+        iso_e->setAbundance(e->getIsotopeDistribution()[0].getIntensity());
+        delete e;
+      }
+      names_[iso_name] = iso_e;
+      symbols_[iso_symbol] = iso_e;
+      isotopes_[iso_symbol] = iso_e;
+      isotopes_[iso_name] = iso_e;
+    }
+  }
 
   void ElementDB::buildElement_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& abundance, const map<unsigned int, double>& mass)
   {
@@ -598,7 +669,7 @@ namespace OpenMS
     double mono_weight = calculateMonoWeight_(abundance, mass);
 
     addElementToMaps_(name, symbol, an, make_unique<const Element>(name, symbol, an, avg_weight, mono_weight, isotopes));
-    storeIsotopes_(name, symbol, an, mass, isotopes);
+    storeStableIsotopes_(name, symbol, an, mass, isotopes);
   }
 
   void overwrite(const Element* old, unique_ptr<const Element>& new_e)
@@ -642,12 +713,12 @@ namespace OpenMS
     }
   }
 
-  void ElementDB::storeIsotopes_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& mass, const IsotopeDistribution& isotopes)
+  void ElementDB::storeStableIsotopes_(const string& name, const string& symbol, const unsigned int an, const map<unsigned int, double>& mass, const IsotopeDistribution& isotopes)
   {
     for (const auto& isotope : isotopes)
     {
       double atomic_mass = isotope.getMZ();
-      unsigned int mass_number = std::round(atomic_mass);
+      unsigned int mass_number = std::round(atomic_mass); // TODO: does this always work?
       string iso_name = "(" + std::to_string(mass_number) + ")" + name;
       string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
 
@@ -659,18 +730,17 @@ namespace OpenMS
       iso_container.push_back(Peak1D(atomic_mass, 1.0));
       iso_isotopes.set(iso_container);  
 
-      auto iso_element = make_unique<const Element>(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
+      Isotope* iso_e = new Isotope(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
+      iso_e->setAbundance(isotope.getIntensity());
+      iso_e->setNeutrons(mass_number - iso_e->getAtomicNumber());
+      // delete existing element if it already exists (to avoid memory leak)
       if (auto has_elem = names_.find(iso_name); has_elem != names_.end())
-      { // already exists: overwrite (affects all maps, since they all point to the same thing)
-        overwrite(has_elem->second, iso_element);
-        // do not release 'iso_element' here; it needs to be deleted when it goes out if scope
-      }
-      else
       {
-        addIfUniqueOrThrow(names_, iso_name, iso_element);
-        addIfUniqueOrThrow(symbols_, iso_symbol, iso_element);
-        iso_element.release(); // allocation will be cleaned up by ~ElementDB now
+        delete has_elem->second;
       }
+      names_[iso_name] = iso_e;
+      symbols_[iso_symbol] = iso_e;
+      isotopes_[iso_symbol] = iso_e;
     } 
   }
 

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -773,19 +773,11 @@ namespace OpenMS
 
   const Isotope* ElementDB::addIsotopeToMaps_(const std::string& iso_name, const std::string& iso_symbol, const Isotope* isotope)
   {
-    std::cerr << "DEBUG: addIsotopeToMaps_ called with iso_name=" << iso_name << ", iso_symbol=" << iso_symbol << std::endl;
-    
+    // If isotope already exists, update its properties while preserving element relationships
     if (isotopes_.find(iso_symbol) != isotopes_.end())
     {
-      std::cerr << "DEBUG: Found existing isotope in isotopes_ map" << std::endl;
       const Isotope* const_iso = isotopes_[iso_symbol];
-      std::cerr << "DEBUG: Existing isotope pointer: " << const_iso << std::endl;
-      
       Isotope* iso = const_cast<Isotope*>(const_iso);
-      
-      // Instead of blindly using assignment operator which could break relationships,
-      // selectively update properties while preserving element relationships
-      std::cerr << "DEBUG: Selectively updating isotope properties (instead of using assignment operator)" << std::endl;
       
       // Keep the existing element relationship intact by not re-assigning atomic_number_
       // Update only the properties that should change
@@ -798,17 +790,14 @@ namespace OpenMS
       // Names and symbols are used in lookup maps, so we need to be careful with them
       if (iso->getName() != isotope->getName())
       {
-        std::cerr << "DEBUG: Updating isotope name" << std::endl;
-        iso->setName(isotope->getName());
+      iso->setName(isotope->getName());
       }
       
       if (iso->getSymbol() != isotope->getSymbol())
       {
-        std::cerr << "DEBUG: Updating isotope symbol" << std::endl;
-        iso->setSymbol(isotope->getSymbol());
+      iso->setSymbol(isotope->getSymbol());
       }
       
-      std::cerr << "DEBUG: Returning existing isotope pointer" << std::endl;
       return iso;
     }
     else

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -144,10 +144,10 @@ namespace OpenMS
       }
       Isotope* isotope = new Isotope(iso_name, iso_symbol, an, mass_number - an, mass, abundance, half_life, decay);
       addIsotopeToMaps_(iso_name, iso_symbol, isotope);
-      // we changed the isotopes, so we need to update
+      // we changed/updated the isotopes, so we need to update
       const Element* const_ele = isotope->getElement();
       Element* element = const_cast<Element*>(const_ele);
-      element->updateIsotopeDistr();
+      element->setIsotopes(element->getIsotopes());
     }
     else
     {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -664,7 +664,7 @@ namespace OpenMS
                                 const string& symbol,
                                 const unsigned int an,
                                 const map<unsigned int, double>& abundance,
-                                const map<unsigned int, double>& mass, 
+                                const map<unsigned int, double>& mass,
                                 const std::map<unsigned int, double>& half_lifes,
                                 const std::map<unsigned int, Isotope::DecayMode>& decay_modes)
   {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -808,8 +808,6 @@ namespace OpenMS
         iso->setSymbol(isotope->getSymbol());
       }
       
-      std::cerr << "DEBUG: Safe update completed, deleting new isotope instance" << std::endl;
-      delete isotope;
       std::cerr << "DEBUG: Returning existing isotope pointer" << std::endl;
       return iso;
     }

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -130,6 +130,12 @@ namespace OpenMS
     string iso_name = "(" + std::to_string(mass_number) + ")" + name;
     string iso_symbol = "(" + std::to_string(mass_number) + ")" + symbol;
 
+    if (!hasElement( an )  )
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("Cannot add isotope ") +
+          name + " since the element with  atomic number " + an + " does not yet exsist -- create it first!");
+    }
+
     if (hasElement( iso_symbol )  )
     {
       if (!replace_existing)

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
@@ -70,6 +70,15 @@ namespace OpenMS
     for (; it != formula.end(); ++it)
     {
       IsotopeDistribution tmp = it->first->getIsotopeDistribution();
+
+      // filter out unstable isotopes / those with zero natural abundance as
+      // they just blow up the computations we have do to but have zero
+      // abundance
+      auto data = tmp.getContainer();
+      data.erase(std::remove_if(data.begin(), data.end(),
+                        [](const Peak1D & p) { return p.getIntensity() <= 0.0; }),
+                  data.end());
+      tmp.set(std::move(data));
       result.set(convolve(result.getContainer(),
                           convolvePow_(tmp.getContainer(), it->second)));
     }

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -1,0 +1,105 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Rost $
+// $Authors: Hannes Rost $
+// --------------------------------------------------------------------------
+//
+
+#include <OpenMS/CHEMISTRY/Isotope.h>
+
+#include <OpenMS/CHEMISTRY/ElementDB.h>
+
+#include <ostream>
+
+using namespace std;
+
+namespace OpenMS
+{
+  Isotope::Isotope(const std::string & name,
+            const std::string & symbol,
+            unsigned int atomic_number,
+            unsigned int neutrons,
+            double mono_weight,
+            double abundance,
+            const IsotopeDistribution & isotopes) :
+    Element(name, symbol, atomic_number, mono_weight, mono_weight, isotopes),
+    neutrons_(neutrons),
+    abundance_(abundance)
+  {
+  }
+
+  Isotope::~Isotope()
+  {
+  }
+
+  /// Get corresponding element
+  const Element* Isotope::getElement() const
+  {
+    return ElementDB::getInstance()->getElement( atomic_number_ );
+  }
+
+  void Isotope::setHalfLife(double hl)
+  {
+    half_life_ = hl;
+  }
+
+  double Isotope::getHalfLife() const
+  { 
+    return half_life_;
+  }
+  void Isotope::setAbundance(double ab)
+  {
+    abundance_ = ab;
+  }
+  double Isotope::getAbundance() const
+  {
+    return abundance_;
+  }
+  void Isotope::setNeutrons(int n)
+  {
+    neutrons_ = n;
+  }
+  int Isotope::getNeutrons() const
+  {
+    return neutrons_;
+  }
+  Isotope::DecayMode Isotope::getDecayMode() const
+  {
+    return decay_mode_;
+  }
+
+  void Isotope::setDecayMode(DecayMode dm)
+  {
+    decay_mode_ = dm;
+  }
+
+} // namespace OpenMS
+

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -56,6 +56,27 @@ namespace OpenMS
   {
   }
 
+  Isotope::Isotope(const std::string & name,
+            const std::string & symbol,
+            unsigned int atomic_number,
+            unsigned int neutrons,
+            double mono_weight,
+            double abundance,
+            double half_life,
+            Isotope::DecayMode dm) :
+    Element(name, symbol, atomic_number, mono_weight, mono_weight),
+    neutrons_(neutrons),
+    abundance_(abundance),
+    half_life_(half_life),
+    decay_mode_(dm)
+  {
+    IsotopeDistribution iso_isotopes;
+    IsotopeDistribution::ContainerType iso_container;
+    iso_container.push_back(Peak1D(mono_weight, 1.0));
+    iso_isotopes.set(iso_container);
+    setIsotopeDistribution(iso_isotopes);
+  }
+
   Isotope::~Isotope()
   {
   }
@@ -101,5 +122,25 @@ namespace OpenMS
     decay_mode_ = dm;
   }
 
+  std::ostream & operator<<(std::ostream & os, const Isotope & isotope)
+  {
+    os  << isotope.name_ << " "
+    << isotope.symbol_ << " Z="
+    << isotope.atomic_number_ << " N="
+    << isotope.neutrons_ << " : "
+    << isotope.mono_weight_ << " "
+    << isotope.abundance_ *100 << "% : ";
+    if (isotope.isStable())
+    {
+      os << "stable";
+    }
+    else
+    {
+      os << " half life: " << isotope.half_life_ << " s "
+      << isotope.decay_mode_;
+    }
+
+    return os;
+  }
 } // namespace OpenMS
 

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -80,7 +80,7 @@ namespace OpenMS
   }
 
   double Isotope::getHalfLife() const
-  { 
+  {
     return half_life_;
   }
   void Isotope::setAbundance(double ab)

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -129,14 +129,14 @@ namespace OpenMS
     << isotope.atomic_number_ << " N="
     << isotope.neutrons_ << " : "
     << isotope.mono_weight_ << " "
-    << isotope.abundance_ *100 << "% : ";
+    << isotope.abundance_ * 100 << "% : ";
     if (isotope.isStable())
     {
       os << "stable";
     }
     else
     {
-      os << " half life: " << isotope.half_life_ << " s "
+      os << "half life: " << isotope.half_life_ << " s "
       << isotope.decay_mode_;
     }
 

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -49,19 +49,6 @@ namespace OpenMS
             unsigned int neutrons,
             double mono_weight,
             double abundance,
-            const IsotopeDistribution & isotopes) :
-    Element(name, symbol, atomic_number, mono_weight, mono_weight, isotopes),
-    neutrons_(neutrons),
-    abundance_(abundance)
-  {
-  }
-
-  Isotope::Isotope(const std::string & name,
-            const std::string & symbol,
-            unsigned int atomic_number,
-            unsigned int neutrons,
-            double mono_weight,
-            double abundance,
             double half_life,
             Isotope::DecayMode dm) :
     Element(name, symbol, atomic_number, mono_weight, mono_weight),

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -1,35 +1,9 @@
-// --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry
-// --------------------------------------------------------------------------
-// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
-// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
-//
-// This software is released under a three-clause BSD license:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution
-//    may be used to endorse or promote products derived from this software
-//    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS.
-// --------------------------------------------------------------------------
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Hannes Rost $
-// $Authors: Hannes Rost $
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 //
 

--- a/src/openms/source/CHEMISTRY/Isotope.cpp
+++ b/src/openms/source/CHEMISTRY/Isotope.cpp
@@ -71,7 +71,10 @@ namespace OpenMS
   /// Get corresponding element
   const Element* Isotope::getElement() const
   {
-    return ElementDB::getInstance()->getElement( atomic_number_ );
+    std::cerr << "DEBUG: Isotope::getElement() called for " << name_ << " with atomic number " << atomic_number_ << std::endl;
+    const Element* e = ElementDB::getInstance()->getElement( atomic_number_ );
+    std::cerr << "DEBUG: Isotope::getElement() returning pointer " << e << std::endl;
+    return e;
   }
 
   void Isotope::setHalfLife(double hl)

--- a/src/openms/source/CHEMISTRY/sources.cmake
+++ b/src/openms/source/CHEMISTRY/sources.cmake
@@ -18,6 +18,7 @@ ElementDB.cpp
 EmpiricalFormula.cpp
 EnzymaticDigestion.cpp
 EnzymeXMLDataProvider.cpp
+Isotope.cpp
 ModificationDefinition.cpp
 ModificationDefinitionsSet.cpp
 ModificationsDB.cpp

--- a/src/pyOpenMS/pxds/Isotope.pxd
+++ b/src/pyOpenMS/pxds/Isotope.pxd
@@ -1,0 +1,49 @@
+from libcpp cimport bool
+from Types cimport *
+from String cimport *
+from Element cimport *
+
+cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
+
+    cdef cppclass Isotope:
+
+        Isotope() nogil except +
+        Isotope(Isotope &) nogil except +
+
+        # detailed constructor
+        Isotope(String name,
+                String symbol,
+                UInt atomic_number,
+                UInt neutrons,
+                double average_weight,
+                double abundance,
+                IsotopeDistribution isotopes) nogil except +
+
+        const Element* getElement() # wrap-doc: Get corresponding element
+
+        void setHalfLife(double hl) nogil except + # wrap-doc: set isotope half life in seconds
+        double getHalfLife() nogil except + # wrap-doc: get isotope half life in seconds
+        void setAbundance(double ab) nogil except + # wrap-doc: set isotope natural abundance
+        double getAbundance() nogil except + # wrap-doc: get isotope natural abundance
+        void setNeutrons(int ne) nogil except + # wrap-doc: set number of neutrons 
+        int getNeutrons() nogil except + # wrap-doc: get number of neutrons 
+        void setDecayMode(DecayMode dm) nogil except + # wrap-doc: set primary decay mode (for unstable isotopes)
+        DecayMode getDecayMode() nogil except + # wrap-doc: get primary decay mode (for unstable isotopes)
+
+        virtual bool isIsotope() nogil except + # wrap-doc: Whether this is an Isotope or an Element (for casting)
+
+        bool isStable() nogil except + # wrap-doc: Whether this is a stable isotope
+
+
+cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS::Isotope":
+
+    cdef enum DecayMode:
+      # wrap-attach:
+      #   Isotope
+      NONE = 0,     # No decay (stable isotope)
+      UNKNOWN,      # Unknown / Unspecified decay mode
+      ALPHA,        # Alpha decay
+      BETA_PLUS,    # Beta plus decay
+      BETA_MINUS,   # Beta minus decay
+      PROTON,       # Proton emission
+      SIZE_OF_DECAYMODE

--- a/src/pyOpenMS/pxds/Isotope.pxd
+++ b/src/pyOpenMS/pxds/Isotope.pxd
@@ -15,14 +15,6 @@ cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
                 String symbol,
                 UInt atomic_number,
                 UInt neutrons,
-                double average_weight,
-                double abundance,
-                IsotopeDistribution isotopes) nogil except +
-
-        Isotope(String name,
-                String symbol,
-                UInt atomic_number,
-                UInt neutrons,
                 double mono_weight,
                 double abundance,
                 double half_life,

--- a/src/pyOpenMS/pxds/Isotope.pxd
+++ b/src/pyOpenMS/pxds/Isotope.pxd
@@ -19,20 +19,66 @@ cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
                 double abundance,
                 IsotopeDistribution isotopes) nogil except +
 
-        const Element* getElement() # wrap-doc: Get corresponding element
+        Isotope(String name,
+                String symbol,
+                UInt atomic_number,
+                UInt neutrons,
+                double mono_weight,
+                double abundance,
+                double half_life,
+                DecayMode dm) nogil except +
 
-        void setHalfLife(double hl) nogil except + # wrap-doc: set isotope half life in seconds
-        double getHalfLife() nogil except + # wrap-doc: get isotope half life in seconds
-        void setAbundance(double ab) nogil except + # wrap-doc: set isotope natural abundance
-        double getAbundance() nogil except + # wrap-doc: get isotope natural abundance
-        void setNeutrons(int ne) nogil except + # wrap-doc: set number of neutrons 
-        int getNeutrons() nogil except + # wrap-doc: get number of neutrons 
-        void setDecayMode(DecayMode dm) nogil except + # wrap-doc: set primary decay mode (for unstable isotopes)
-        DecayMode getDecayMode() nogil except + # wrap-doc: get primary decay mode (for unstable isotopes)
+        # sets unique atomic number
+        void setAtomicNumber(UInt atomic_number) nogil except + # wrap-doc:Sets unique atomic number
 
-        virtual bool isIsotope() nogil except + # wrap-doc: Whether this is an Isotope or an Element (for casting)
+        # returns the unique atomic number
+        UInt getAtomicNumber() nogil except + # wrap-doc:Returns the unique atomic number
 
-        bool isStable() nogil except + # wrap-doc: Whether this is a stable isotope
+        # sets the average weight of the element
+        void setAverageWeight(double weight) nogil except + # wrap-doc:Sets the average weight of the element
+
+        # returns the average weight of the element
+        double getAverageWeight() nogil except + # wrap-doc:Returns the average weight of the element
+
+        # sets the mono isotopic weight of the element
+        void setMonoWeight(double weight) nogil except + # wrap-doc:Sets the mono isotopic weight of the element
+
+        # returns the mono isotopic weight of the element
+        double getMonoWeight() nogil except + # wrap-doc:Returns the mono isotopic weight of the element
+
+        # sets the isotope distribution of the element
+        void setIsotopeDistribution(IsotopeDistribution isotopes) nogil except + # wrap-doc:Sets the isotope distribution of the element
+
+        # returns the isotope distribution of the element
+        IsotopeDistribution getIsotopeDistribution() nogil except + # wrap-doc:Returns the isotope distribution of the element
+
+        # set the name of the element
+        void setName(String name) nogil except + # wrap-doc:Sets the name of the element
+
+        # returns the name of the element
+        String getName() nogil except + # wrap-doc:Returns the name of the element
+
+        # sets symbol of the element
+        void setSymbol(String symbol) nogil except + # wrap-doc:Sets symbol of the element
+
+        # returns symbol of the element
+        String getSymbol() nogil except + # wrap-doc:Returns symbol of the element
+
+
+        const Element* getElement() # wrap-doc:Get corresponding element
+
+        void setHalfLife(double hl) nogil except + # wrap-doc:set isotope half life in seconds
+        double getHalfLife() nogil except + # wrap-doc:get isotope half life in seconds
+        void setAbundance(double ab) nogil except + # wrap-doc:set isotope natural abundance
+        double getAbundance() nogil except + # wrap-doc:get isotope natural abundance
+        void setNeutrons(int ne) nogil except + # wrap-doc:set number of neutrons 
+        int getNeutrons() nogil except + # wrap-doc:get number of neutrons 
+        void setDecayMode(DecayMode dm) nogil except + # wrap-doc:set primary decay mode (for unstable isotopes)
+        DecayMode getDecayMode() nogil except + # wrap-doc:get primary decay mode (for unstable isotopes)
+
+        bool isIsotope() nogil except + # wrap-doc:Whether this is an Isotope or an Element (for casting)
+
+        bool isStable() nogil except + # wrap-doc:Whether this is a stable isotope
 
 
 cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS::Isotope":

--- a/src/pyOpenMS/pxds/Isotope.pxd
+++ b/src/pyOpenMS/pxds/Isotope.pxd
@@ -7,8 +7,8 @@ cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
 
     cdef cppclass Isotope:
 
-        Isotope() nogil except +
-        Isotope(Isotope &) nogil except +
+        Isotope() except + nogil
+        Isotope(Isotope &) except + nogil
 
         # detailed constructor
         Isotope(String name,
@@ -18,59 +18,59 @@ cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
                 double mono_weight,
                 double abundance,
                 double half_life,
-                DecayMode dm) nogil except +
+                DecayMode dm) except + nogil
 
         # sets unique atomic number
-        void setAtomicNumber(UInt atomic_number) nogil except + # wrap-doc:Sets unique atomic number
+        void setAtomicNumber(UInt atomic_number) except + nogil # wrap-doc:Sets unique atomic number
 
         # returns the unique atomic number
-        UInt getAtomicNumber() nogil except + # wrap-doc:Returns the unique atomic number
+        UInt getAtomicNumber() except + nogil # wrap-doc:Returns the unique atomic number
 
         # sets the average weight of the element
-        void setAverageWeight(double weight) nogil except + # wrap-doc:Sets the average weight of the element
+        void setAverageWeight(double weight) except + nogil # wrap-doc:Sets the average weight of the element
 
         # returns the average weight of the element
-        double getAverageWeight() nogil except + # wrap-doc:Returns the average weight of the element
+        double getAverageWeight() except + nogil # wrap-doc:Returns the average weight of the element
 
         # sets the mono isotopic weight of the element
-        void setMonoWeight(double weight) nogil except + # wrap-doc:Sets the mono isotopic weight of the element
+        void setMonoWeight(double weight) except + nogil # wrap-doc:Sets the mono isotopic weight of the element
 
         # returns the mono isotopic weight of the element
-        double getMonoWeight() nogil except + # wrap-doc:Returns the mono isotopic weight of the element
+        double getMonoWeight() except + nogil # wrap-doc:Returns the mono isotopic weight of the element
 
         # sets the isotope distribution of the element
-        void setIsotopeDistribution(IsotopeDistribution isotopes) nogil except + # wrap-doc:Sets the isotope distribution of the element
+        void setIsotopeDistribution(IsotopeDistribution isotopes) except + nogil # wrap-doc:Sets the isotope distribution of the element
 
         # returns the isotope distribution of the element
-        IsotopeDistribution getIsotopeDistribution() nogil except + # wrap-doc:Returns the isotope distribution of the element
+        IsotopeDistribution getIsotopeDistribution() except + nogil # wrap-doc:Returns the isotope distribution of the element
 
         # set the name of the element
-        void setName(String name) nogil except + # wrap-doc:Sets the name of the element
+        void setName(String name) except + nogil # wrap-doc:Sets the name of the element
 
         # returns the name of the element
-        String getName() nogil except + # wrap-doc:Returns the name of the element
+        String getName() except + nogil # wrap-doc:Returns the name of the element
 
         # sets symbol of the element
-        void setSymbol(String symbol) nogil except + # wrap-doc:Sets symbol of the element
+        void setSymbol(String symbol) except + nogil # wrap-doc:Sets symbol of the element
 
         # returns symbol of the element
-        String getSymbol() nogil except + # wrap-doc:Returns symbol of the element
+        String getSymbol() except + nogil # wrap-doc:Returns symbol of the element
 
 
-        const Element* getElement() nogil except + # wrap-doc:Get corresponding element
+        const Element* getElement() except + nogil # wrap-doc:Get corresponding element
 
-        void setHalfLife(double hl) nogil except + # wrap-doc:set isotope half life in seconds
-        double getHalfLife() nogil except + # wrap-doc:get isotope half life in seconds
-        void setAbundance(double ab) nogil except + # wrap-doc:set isotope natural abundance
-        double getAbundance() nogil except + # wrap-doc:get isotope natural abundance
-        void setNeutrons(int ne) nogil except + # wrap-doc:set number of neutrons 
-        int getNeutrons() nogil except + # wrap-doc:get number of neutrons 
-        void setDecayMode(DecayMode dm) nogil except + # wrap-doc:set primary decay mode (for unstable isotopes)
-        DecayMode getDecayMode() nogil except + # wrap-doc:get primary decay mode (for unstable isotopes)
+        void setHalfLife(double hl) except + nogil # wrap-doc:set isotope half life in seconds
+        double getHalfLife() except + nogil # wrap-doc:get isotope half life in seconds
+        void setAbundance(double ab) except + nogil # wrap-doc:set isotope natural abundance
+        double getAbundance() except + nogil # wrap-doc:get isotope natural abundance
+        void setNeutrons(int ne) except + nogil # wrap-doc:set number of neutrons 
+        int getNeutrons() except + nogil # wrap-doc:get number of neutrons 
+        void setDecayMode(DecayMode dm) except + nogil # wrap-doc:set primary decay mode (for unstable isotopes)
+        DecayMode getDecayMode() except + nogil # wrap-doc:get primary decay mode (for unstable isotopes)
 
-        bool isIsotope() nogil except + # wrap-doc:Whether this is an Isotope or an Element (for casting)
+        bool isIsotope() except + nogil # wrap-doc:Whether this is an Isotope or an Element (for casting)
 
-        bool isStable() nogil except + # wrap-doc:Whether this is a stable isotope
+        bool isStable() except + nogil # wrap-doc:Whether this is a stable isotope
 
 
 cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS::Isotope":

--- a/src/pyOpenMS/pxds/Isotope.pxd
+++ b/src/pyOpenMS/pxds/Isotope.pxd
@@ -57,7 +57,7 @@ cdef extern from "<OpenMS/CHEMISTRY/Isotope.h>" namespace "OpenMS":
         String getSymbol() nogil except + # wrap-doc:Returns symbol of the element
 
 
-        const Element* getElement() # wrap-doc:Get corresponding element
+        const Element* getElement() nogil except + # wrap-doc:Get corresponding element
 
         void setHalfLife(double hl) nogil except + # wrap-doc:set isotope half life in seconds
         double getHalfLife() nogil except + # wrap-doc:get isotope half life in seconds

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -132,6 +132,19 @@ def _testProgressLogger(ff):
     ff.setProgress(3)
     ff.endProgress()
 
+
+@report
+def testDPosition():
+    dp = pyopenms.DPosition1()
+    dp = pyopenms.DPosition1(1.0)
+    assert dp[0] == 1.0
+
+    dp = pyopenms.DPosition2()
+    dp = pyopenms.DPosition2(1.0, 2.0)
+
+    assert dp[0] == 1.0
+    assert dp[1] == 2.0
+
 @report
 def testSpectrumAlignment():
     """

--- a/src/pyOpenMS/tests/unittests/test_Chemistry.py
+++ b/src/pyOpenMS/tests/unittests/test_Chemistry.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python
+# -*- coding: utf-8  -*-
+from __future__ import print_function
+
+import pyopenms
+import copy
+import os
+
+from pyopenms import String as s
+import numpy as np
+import pandas as pd
+
+print("IMPORTED ", pyopenms.__file__)
+
+try:
+    long
+except NameError:
+    long = int
+
+from functools import wraps
+
+import sys
+def _testStrOutput(input_str):
+    if sys.version_info[0] < 3:
+        assert isinstance(input_str, unicode)
+    else:
+        assert isinstance( input_str, str)
+
+def report(f):
+    @wraps(f)
+    def wrapper(*a, **kw):
+        print("run ", f.__name__)
+        f(*a, **kw)
+    return wrapper
+
+@report
+def _testMetaInfoInterface(what):
+
+    #void getKeys(libcpp_vector[String] & keys)
+    #void getKeys(libcpp_vector[unsigned int] & keys)
+    #DataValue getMetaValue(unsigned int) nogil except +
+    #DataValue getMetaValue(String) nogil except +
+    #void setMetaValue(unsigned int, DataValue) nogil except +
+    #void setMetaValue(String, DataValue) nogil except +
+    #bool metaValueExists(String) nogil except +
+    #bool metaValueExists(unsigned int) nogil except +
+    #void removeMetaValue(String) nogil except +
+    #void removeMetaValue(unsigned int) nogil except +
+
+    what.setMetaValue("key", 42)
+    what.setMetaValue("key2", 42)
+
+    keys = []
+    what.getKeys(keys)
+    assert len(keys) and all(isinstance(k, bytes) for k in keys)
+    assert what.getMetaValue(keys[0]) == 42
+
+    assert what.metaValueExists("key")
+    what.removeMetaValue("key")
+
+    keys = []
+    what.getKeys(keys)
+    assert what.getMetaValue(keys[0]) == 42
+
+    what.clearMetaInfo()
+    keys = []
+    what.getKeys(keys)
+    assert len(keys) == 0
+
+
+@report
+def _testUniqueIdInterface(what):
+
+    assert what.hasInvalidUniqueId()
+    assert not what.hasValidUniqueId()
+    assert what.ensureUniqueId()
+    assert isinstance(what.getUniqueId(), (int, long))
+    assert what.getUniqueId() > 0
+    assert not what.hasInvalidUniqueId()
+    assert what.hasValidUniqueId()
+
+    what.clearUniqueId()
+    assert what.getUniqueId() == 0
+    assert what.hasInvalidUniqueId()
+    assert not what.hasValidUniqueId()
+
+    assert what.ensureUniqueId()
+    assert isinstance(what.getUniqueId(), (int, long))
+    assert what.getUniqueId() > 0
+    assert not what.hasInvalidUniqueId()
+    assert what.hasValidUniqueId()
+
+    what.setUniqueId(1234)
+    assert  what.getUniqueId() == 1234
+
+
+def _testProgressLogger(ff):
+    """
+    @tests: ProgressLogger
+     ProgressLogger.__init__
+     ProgressLogger.endProgress
+     ProgressLogger.getLogType
+     ProgressLogger.setLogType
+     ProgressLogger.setProgress
+     ProgressLogger.startProgress
+    """
+
+    ff.setLogType(pyopenms.LogType.NONE)
+    assert ff.getLogType() == pyopenms.LogType.NONE
+    ff.startProgress(0, 3, "label")
+    ff.setProgress(0)
+    ff.setProgress(1)
+    ff.setProgress(2)
+    ff.setProgress(3)
+    ff.endProgress()
+
+@report
+def testProteaseDB():
+    edb = pyopenms.ProteaseDB()
+
+    f = pyopenms.EmpiricalFormula()
+    synonyms = set(["dummy", "other"])
+
+    assert edb.hasEnzyme(pyopenms.String("Trypsin"))
+
+    trypsin = edb.getEnzyme(pyopenms.String("Trypsin"))
+
+    names = []
+    edb.getAllNames(names)
+    assert b"Trypsin" in names
+
+
+@report
+def testElementDB():
+    edb = pyopenms.ElementDB()
+    del edb
+
+    # create a second instance of ElementDB without anything bad happening
+    edb = pyopenms.ElementDB()
+
+    assert edb.hasElement(16)
+    edb.hasElement(pyopenms.String("O"))
+
+    e = edb.getElement(16)
+
+    assert e.getName() == "Sulfur"
+    assert e.getSymbol() == "S"
+    assert e.getIsotopeDistribution()
+
+    e2 = edb.getElement(pyopenms.String("O"))
+
+    assert e2.getName() == "Oxygen"
+    assert e2.getSymbol() == "O"
+    assert e2.getIsotopeDistribution()
+
+    # assume we discovered a new element
+    e2 = edb.addElement(b"NewElement", b"NE", 300, {400 : 1.0}, {400 : 400.1}, False)
+    e2 = edb.getElement(pyopenms.String("NE"))
+    assert e2.getName() == "NewElement"
+
+    # replace oxygen
+    e2 = edb.addElement(b"Oxygen", b"O", 8, {16 : 0.7, 19 : 0.3}, {16 : 16.01, 19 : 19.01}, True)
+    e2 = edb.getElement(pyopenms.String("O"))
+    assert e2.getName() == "Oxygen"
+    assert e2.getIsotopeDistribution()
+    assert len(e2.getIsotopeDistribution().getContainer()) == 2
+    assert abs(e2.getIsotopeDistribution().getContainer()[1].getIntensity() - 0.3) < 1e-5
+
+    iso = pyopenms.ElementDB().getIsotope("(13)C")
+    assert iso.getNeutrons() == 7
+    assert iso.isStable()
+
+    iso = pyopenms.ElementDB().getIsotope("(238)U")
+    assert iso.getNeutrons() == 146
+    assert not iso.isStable()
+    assert iso.getSymbol
+    assert iso.getSymbol() == "(238)U"
+    assert abs(iso.getHalfLife() - 1.40996461536e+17) < 1e-6
+
+    ele = pyopenms.ElementDB().getElement("U")
+    iso = [i for i in ele.getIsotopes() if i.getNeutrons() ==  146]
+    assert len(iso) == 1
+    assert iso[0].getElement().getSymbol() == "U"
+
+    edb.addIsotope(b"NewElement", b"NE", 300, 0.5, 404, 100, 0, False)
+
+    #  not yet implemented
+    #
+    # const Map[ String, Element * ]  getNames() nogil except +
+    # const Map[ String, Element * ] getSymbols() nogil except +
+    # const Map[unsigned int, Element * ] getAtomicNumbers() nogil except +
+
+
+@report
+def testDPosition():
+    dp = pyopenms.DPosition1()
+    dp = pyopenms.DPosition1(1.0)
+    assert dp[0] == 1.0
+
+    dp = pyopenms.DPosition2()
+    dp = pyopenms.DPosition2(1.0, 2.0)
+
+    assert dp[0] == 1.0
+    assert dp[1] == 2.0
+
+@report
+def testResidueDB():
+    rdb = pyopenms.ResidueDB()
+    del rdb
+
+    # create a second instance of ResidueDB without anything bad happening
+    rdb = pyopenms.ResidueDB()
+
+    assert rdb.getNumberOfResidues() >= 20
+    assert len(rdb.getResidueSets() ) >= 1
+    el = rdb.getResidues(pyopenms.String(rdb.getResidueSets().pop()))
+
+    assert len(el) >= 1
+
+    assert rdb.hasResidue(s("Glycine"))
+    glycine = rdb.getResidue(s("Glycine"))
+
+    nrr = rdb.getNumberOfResidues()
+
+@report
+def testModificationsDB():
+    mdb = pyopenms.ModificationsDB()
+    del mdb
+
+    # create a second instance of ModificationsDB without anything bad happening
+    mdb = pyopenms.ModificationsDB()
+
+    assert mdb.getNumberOfModifications() > 1
+    m = mdb.getModification(1)
+
+    assert mdb.getNumberOfModifications() > 1
+    m = mdb.getModification(1)
+    assert m is not None
+
+    mods = set([])
+    mdb.searchModifications(mods, s("Phosphorylation"), s("T"), pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
+    assert len(mods) == 1
+
+    mods = set([])
+    mdb.searchModifications(mods, s("NIC"), s("T"), pyopenms.ResidueModification.TermSpecificity.N_TERM)
+    assert len(mods) == 1
+
+    mods = set([])
+    mdb.searchModifications(mods, s("NIC"), s("T"), pyopenms.ResidueModification.TermSpecificity.N_TERM)
+    assert len(mods) == 1
+
+    mods = set([])
+    mdb.searchModifications(mods, s("Acetyl"), s("T"), pyopenms.ResidueModification.TermSpecificity.N_TERM)
+    assert len(mods) == 1
+    assert list(mods)[0].getFullId() == "Acetyl (N-term)"
+
+    m = mdb.getModification(s("Carboxymethyl (C)"), "", pyopenms.ResidueModification.TermSpecificity.NUMBER_OF_TERM_SPECIFICITY)
+    assert m.getFullId() == "Carboxymethyl (C)"
+
+    m = mdb.getModification( s("Phosphorylation"), s("S"), pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
+    assert m.getId() == "Phospho"
+
+    # get out all mods (there should be many, some known ones as well!)
+    mods = []
+    m = mdb.getAllSearchModifications(mods)
+    assert len(mods) > 100
+
+    assert b"Phospho (S)" in mods
+    assert b"Sulfo (S)" in mods
+    assert not (b"Phospho" in mods)
+
+    # search for specific modifications by mass
+    m = mdb.getBestModificationByDiffMonoMass( 80.0, 1.0, "T", pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
+    assert m is not None
+    assert m.getId() == "Phospho"
+    assert m.getFullName() == "Phosphorylation"
+    assert m.getUniModAccession() == "UniMod:21"
+
+    m = mdb.getBestModificationByDiffMonoMass(80, 100, "T", pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
+    assert m is not None
+    assert m.getId() == "Phospho"
+    assert m.getFullName() == "Phosphorylation"
+    assert m.getUniModAccession() == "UniMod:21"
+
+    m = mdb.getBestModificationByDiffMonoMass(16, 1.0, "M", pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
+    assert m is not None
+    assert m.getId() == "Oxidation", m.getId()
+    assert m.getFullName() == "Oxidation or Hydroxylation", m.getFullName()
+    assert m.getUniModAccession() == "UniMod:35"
+
+@report
+def testRNaseDB():
+    """
+    @tests: RNaseDB
+        const DigestionEnzymeRNA* getEnzyme(const String& name) nogil except +
+        const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) nogil except +
+        void getAllNames(libcpp_vector[ String ]& all_names) nogil except +
+        bool hasEnzyme(const String& name) nogil except +
+        bool hasRegEx(const String& cleavage_regex) nogil except +
+     """
+    db = pyopenms.RNaseDB()
+    names = []
+    db.getAllNames(names)
+
+    e = db.getEnzyme("RNase_T1")
+    assert e.getRegEx() == u'(?<=G)'
+    assert e.getThreePrimeGain() == u'p'
+
+    assert db.hasRegEx(u'(?<=G)')
+    assert db.hasEnzyme("RNase_T1")
+    
+
+@report
+def testRibonucleotideDB():
+    """
+    @tests: RibonucleotideDB
+    """
+    r = pyopenms.RibonucleotideDB()
+
+    uridine = r.getRibonucleotide(b"U")
+
+    assert uridine.getName() == u'uridine'
+    assert uridine.getCode() == u'U'
+    assert uridine.getFormula().toString() == u'C9H12N2O6'
+    assert uridine.isModified() == False
+
+@report
+def testRibonucleotide():
+    """
+    @tests: Ribonucleotide
+    """
+    r = pyopenms.Ribonucleotide()
+
+    assert not r.isModified()
+
+    r.setHTMLCode("test")
+    assert r.getHTMLCode() == "test"
+
+    r.setOrigin(b"A")
+    assert r.getOrigin() == "A"
+
+    r.setNewCode(b"A")
+    assert r.getNewCode() == "A"
+
+
+@report
+def testRNaseDigestion():
+    """
+    @tests: RNaseDigestion
+     """
+
+    dig = pyopenms.RNaseDigestion()
+    dig.setEnzyme("RNase_T1")
+    assert dig.getEnzymeName() == "RNase_T1"
+
+    oligo = pyopenms.NASequence.fromString("pAUGUCGCAG");
+
+    result = []
+    dig.digest(oligo, result)
+    assert len(result) == 3
+
+
+@report
+def testNASequence():
+    """
+    @tests: NASequence
+     """
+
+    oligo = pyopenms.NASequence.fromString("pAUGUCGCAG");
+
+    assert oligo.size() == 9
+    seq_formula = oligo.getFormula()
+    seq_formula.toString() == u'C86H108N35O64P9'
+
+    oligo_mod = pyopenms.NASequence.fromString("A[m1A][Gm]A")
+    seq_formula = oligo_mod.getFormula()
+    seq_formula.toString() == u'C42H53N20O23P3'
+
+    for r in oligo:
+        pass
+
+    assert oligo_mod[1].isModified()
+
+    charge = 2
+    oligo_mod.getMonoWeight(pyopenms.NASequence.NASFragmentType.WIon, charge)
+    oligo_mod.getFormula(pyopenms.NASequence.NASFragmentType.WIon, charge)
+
+@report
+def testAASequence():
+    """
+    @tests: AASequence
+     AASequence.__init__
+     AASequence.__add__
+     AASequence.__radd__
+     AASequence.__iadd__
+     AASequence.getCTerminalModificationName
+     AASequence.getNTerminalModificationName
+     AASequence.setCTerminalModification
+     AASequence.setModification
+     AASequence.setNTerminalModification
+     AASequence.toString
+     AASequence.toUnmodifiedString
+    """
+    aas = pyopenms.AASequence()
+
+    aas + aas
+    aas += aas
+
+    aas.__doc__
+    aas = pyopenms.AASequence.fromString("DFPIANGER")
+    assert aas.getCTerminalModificationName() == ""
+    assert aas.getNTerminalModificationName() == ""
+    aas.setCTerminalModification("")
+    aas.setNTerminalModification("")
+    assert aas.toString() == "DFPIANGER"
+    assert aas.toUnmodifiedString() == "DFPIANGER"
+    aas = pyopenms.AASequence.fromStringPermissive("DFPIANGER", True)
+    assert aas.toString() == "DFPIANGER"
+    assert aas.toUnmodifiedString() == "DFPIANGER"
+
+    seq = pyopenms.AASequence.fromString("PEPTIDESEKUEM(Oxidation)CER")
+    assert seq.toString() == "PEPTIDESEKUEM(Oxidation)CER"
+    assert seq.toUnmodifiedString() == "PEPTIDESEKUEMCER"
+    assert seq.toBracketString() == "PEPTIDESEKUEM[147]CER"
+    assert seq.toBracketString(True) == "PEPTIDESEKUEM[147]CER"
+
+    assert seq.toBracketString(False) == "PEPTIDESEKUEM[147.03540001709996]CER" or \
+           seq.toBracketString(False) == "PEPTIDESEKUEM[147.035400017100017]CER"
+
+    assert seq.toBracketString(False) == "PEPTIDESEKUEM[147.03540001709996]CER" or \
+           seq.toBracketString(False) == "PEPTIDESEKUEM[147.035400017100017]CER"
+
+    assert seq.toUniModString() == "PEPTIDESEKUEM(UniMod:35)CER"
+    assert seq.isModified()
+    assert not seq.hasCTerminalModification()
+    assert not seq.hasNTerminalModification()
+    assert not seq.empty()
+
+    # has selenocysteine
+    assert seq.getResidue(1) is not None
+    assert seq.size() == 16
+
+    # test exception forwarding from C++ to python
+    # classes derived from std::runtime_exception can be caught in python
+    try:
+        seq.getResidue(1000) # does not exist
+    except RuntimeError:
+        print("Exception successfully triggered.")
+    else:
+        print("Error: Exception not triggered.")
+        assert False
+    assert seq.getFormula(pyopenms.Residue.ResidueType.Full, 0) == pyopenms.EmpiricalFormula("C75H122N20O32S2Se1")
+    # assert abs(seq.getMonoWeight(pyopenms.Residue.ResidueType.Full, 0) - 1952.7200317517998) < 1e-5
+    # assert seq.has(pyopenms.ResidueDB.getResidue("P"))
+
+    
+@report
+def testElement():
+    """
+    @tests: Element
+     Element.__init__
+     Element.setAtomicNumber
+     Element.getAtomicNumber
+     Element.setAverageWeight
+     Element.getAverageWeight
+     Element.setMonoWeight
+     Element.getMonoWeight
+     Element.setIsotopeDistribution
+     Element.getIsotopeDistribution
+     Element.setName
+     Element.getName
+     Element.setSymbol
+     Element.getSymbol
+    """
+    ins = pyopenms.Element()
+
+    ins.setAtomicNumber(6)
+    ins.getAtomicNumber()
+    ins.setAverageWeight(12.011)
+    ins.getAverageWeight()
+    ins.setMonoWeight(12)
+    ins.getMonoWeight()
+    iso = pyopenms.IsotopeDistribution()
+    ins.setIsotopeDistribution(iso)
+    ins.getIsotopeDistribution()
+    ins.setName("Carbon")
+    ins.getName()
+    ins.setSymbol("C")
+    ins.getSymbol()
+
+    e = pyopenms.Element()
+    e.setSymbol("blah")
+    e.setSymbol("blah")
+    e.setSymbol(u"blah")
+    e.setSymbol(str("blah"))
+    oms_string = s("blu")
+    e.setSymbol(oms_string)
+    assert oms_string
+    assert oms_string.toString() == "blu"
+
+    evil = u"blü"
+    evil8 = evil.encode("utf8")
+    evil1 = evil.encode("latin1")
+
+
+    e.setSymbol(evil.encode("utf8"))
+    assert e.getSymbol() == u"blü"
+    e.setSymbol(evil.encode("latin1"))
+    assert e.getSymbol().decode("latin1") == u"blü"
+
+    # If we get the raw symbols, we get bytes (which we would need to decode first)
+    e.setSymbol(evil8.decode("utf8"))
+    # assert e.getSymbol() == 'bl\xc3\xbc', e.getSymbol()
+    assert e.getSymbol() == u"blü" #.encode("utf8")
+    # OpenMS strings, however, understand the decoding
+    assert s(e.getSymbol()) == s(u"blü")
+    assert s(e.getSymbol()).toString() == u"blü"
+
+    # What if you use the wrong decoding ?
+    e.setSymbol(evil1)
+    assert e.getSymbol().decode("latin1") == u"blü"
+    e.setSymbol(evil8)
+    assert e.getSymbol() == u"blü"
+
+@report
+def testResidue():
+    """
+    @tests: Residue
+     Residue.__init__
+    """
+    ins = pyopenms.Residue()
+
+    pyopenms.Residue.ResidueType.Full
+    pyopenms.Residue.ResidueType.Internal
+    pyopenms.Residue.ResidueType.NTerminal
+    pyopenms.Residue.ResidueType.CTerminal
+    pyopenms.Residue.ResidueType.AIon
+    pyopenms.Residue.ResidueType.BIon
+    pyopenms.Residue.ResidueType.CIon
+    pyopenms.Residue.ResidueType.XIon
+    pyopenms.Residue.ResidueType.YIon
+    pyopenms.Residue.ResidueType.ZIon
+    pyopenms.Residue.ResidueType.SizeOfResidueType
+
+
+@report
+def testEmpiricalFormula():
+    """
+    @tests: EmpiricalFormula 
+     EmpiricalFormula.__init__
+     EmpiricalFormula.getMonoWeight
+     EmpiricalFormula.getAverageWeight
+     EmpiricalFormula.getIsotopeDistribution
+     EmpiricalFormula.getNumberOfAtoms
+     EmpiricalFormula.setCharge
+     EmpiricalFormula.getCharge
+     EmpiricalFormula.toString
+     EmpiricalFormula.isEmpty
+     EmpiricalFormula.isCharged
+     EmpiricalFormula.hasElement
+     EmpiricalFormula.hasElement
+    """
+    ins = pyopenms.EmpiricalFormula()
+
+    ins.getMonoWeight()
+    ins.getAverageWeight()
+    ins.getIsotopeDistribution(pyopenms.CoarseIsotopePatternGenerator(0))
+    # ins.getNumberOf(0)
+    # ins.getNumberOf("test")
+    ins.getNumberOfAtoms()
+    ins.setCharge(2)
+    ins.getCharge()
+    ins.toString()
+    ins.isEmpty()
+    ins.isCharged()
+    ins.hasElement( pyopenms.Element() )
+
+    ef = pyopenms.EmpiricalFormula("C2H5")
+    s = ef.toString()
+    assert s == "C2H5"
+    m = ef.getElementalComposition()
+    assert m[b"C"] == 2
+    assert m[b"H"] == 5
+    assert ef.getNumberOfAtoms() == 7
+

--- a/src/pyOpenMS/tests/unittests/test_Chemistry.py
+++ b/src/pyOpenMS/tests/unittests/test_Chemistry.py
@@ -192,18 +192,6 @@ def testElementDB():
 
 
 @report
-def testDPosition():
-    dp = pyopenms.DPosition1()
-    dp = pyopenms.DPosition1(1.0)
-    assert dp[0] == 1.0
-
-    dp = pyopenms.DPosition2()
-    dp = pyopenms.DPosition2(1.0, 2.0)
-
-    assert dp[0] == 1.0
-    assert dp[1] == 2.0
-
-@report
 def testResidueDB():
     rdb = pyopenms.ResidueDB()
     del rdb
@@ -309,7 +297,6 @@ def testRNaseDB():
     assert db.hasRegEx(u'(?<=G)')
     assert db.hasEnzyme("RNase_T1")
     
-
 @report
 def testRibonucleotideDB():
     """
@@ -342,7 +329,6 @@ def testRibonucleotide():
     r.setNewCode(b"A")
     assert r.getNewCode() == "A"
 
-
 @report
 def testRNaseDigestion():
     """
@@ -358,7 +344,6 @@ def testRNaseDigestion():
     result = []
     dig.digest(oligo, result)
     assert len(result) == 3
-
 
 @report
 def testNASequence():

--- a/src/pyOpenMS/tests/unittests/test_Chemistry.py
+++ b/src/pyOpenMS/tests/unittests/test_Chemistry.py
@@ -38,14 +38,14 @@ def _testMetaInfoInterface(what):
 
     #void getKeys(libcpp_vector[String] & keys)
     #void getKeys(libcpp_vector[unsigned int] & keys)
-    #DataValue getMetaValue(unsigned int) nogil except +
-    #DataValue getMetaValue(String) nogil except +
-    #void setMetaValue(unsigned int, DataValue) nogil except +
-    #void setMetaValue(String, DataValue) nogil except +
-    #bool metaValueExists(String) nogil except +
-    #bool metaValueExists(unsigned int) nogil except +
-    #void removeMetaValue(String) nogil except +
-    #void removeMetaValue(unsigned int) nogil except +
+    #DataValue getMetaValue(unsigned int) except + nogil
+    #DataValue getMetaValue(String) except + nogil
+    #void setMetaValue(unsigned int, DataValue) except + nogil
+    #void setMetaValue(String, DataValue) except + nogil
+    #bool metaValueExists(String) except + nogil
+    #bool metaValueExists(unsigned int) except + nogil
+    #void removeMetaValue(String) except + nogil
+    #void removeMetaValue(unsigned int) except + nogil
 
     what.setMetaValue("key", 42)
     what.setMetaValue("key2", 42)
@@ -186,9 +186,9 @@ def testElementDB():
 
     #  not yet implemented
     #
-    # const Map[ String, Element * ]  getNames() nogil except +
-    # const Map[ String, Element * ] getSymbols() nogil except +
-    # const Map[unsigned int, Element * ] getAtomicNumbers() nogil except +
+    # const Map[ String, Element * ]  getNames() except + nogil
+    # const Map[ String, Element * ] getSymbols() except + nogil
+    # const Map[unsigned int, Element * ] getAtomicNumbers() except + nogil
 
 
 @report
@@ -280,11 +280,11 @@ def testModificationsDB():
 def testRNaseDB():
     """
     @tests: RNaseDB
-        const DigestionEnzymeRNA* getEnzyme(const String& name) nogil except +
-        const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) nogil except +
-        void getAllNames(libcpp_vector[ String ]& all_names) nogil except +
-        bool hasEnzyme(const String& name) nogil except +
-        bool hasRegEx(const String& cleavage_regex) nogil except +
+        const DigestionEnzymeRNA* getEnzyme(const String& name) except + nogil
+        const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) except + nogil
+        void getAllNames(libcpp_vector[ String ]& all_names) except + nogil
+        bool hasEnzyme(const String& name) except + nogil
+        bool hasRegEx(const String& cleavage_regex) except + nogil
      """
     db = pyopenms.RNaseDB()
     names = []

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -421,6 +421,7 @@ set(chemistry_executables_list
   IMSIsotopeDistribution_test
   IntegerMassDecomposer_test
   IsoSpec_test
+  Isotope_test
   IsotopeDistribution_test
   MassDecomposer_test
   ModificationDataProvider_test

--- a/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
@@ -98,7 +98,7 @@ START_SECTION(void setMaxIsotope(Size max_isotope))
 {
     IsotopeDistribution iso = solver->estimateFromPeptideWeight(1234.2);
     TEST_EQUAL(solver->getMaxIsotope(), 0)
-    TEST_EQUAL(iso.getContainer().size(), 317)
+    TEST_EQUAL(iso.getContainer().size(), 210)
     solver->setMaxIsotope(117);
     TEST_EQUAL(solver->getMaxIsotope(), 117)
 }

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -100,12 +100,8 @@ START_SECTION(bool hasElement(unsigned int atomic_number) const)
   TEST_EQUAL(e_ptr->hasElement(6), true)
 END_SECTION
 
-START_SECTION(void addElement(const std::string& name,
-                    const std::string& symbol,
-                    const unsigned int an,
-                    const std::map<unsigned int, double>& abundance,
-                    const std::map<unsigned int, double>& mass,
-                    bool replace_existing))
+
+START_SECTION(void addElement(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass, bool replace_existing))
 {
   const Element * oxygen = e_ptr->getElement(8);
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 15.99940532316)
@@ -118,10 +114,52 @@ START_SECTION(void addElement(const std::string& name,
   TEST_EQUAL(oxygen, new_oxygen)
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 16.8994405) // average weight has changed
 
-  // cannot add invalid element (name and symbol conflict when compared existing element
-  // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
-  TEST_EXCEPTION(Exception::InvalidValue, e_ptr->addElement("Oxygen", "P", 8u, oxygen_abundance, oxygen_mass, true)) // true: replace existing
+  TEST_EQUAL(e_ptr->getElement(800), nullptr)
+  e_ptr->addElement("NewElement", "NE", 800u, oxygen_abundance, oxygen_mass, false);
+  const Element * new_ele = e_ptr->getElement(800);
+  TEST_REAL_SIMILAR(new_ele->getAverageWeight(), 16.8994405) // average weight of new element
+}
+END_SECTION
 
+START_SECTION( void addIsotope(const std::string& name, const std::string& symbol, const unsigned int an, double abundance, double mass, double half_life, Isotope::DecayMode decay, bool replace_existing))
+{
+  const Isotope * carbon14 = e_ptr->getIsotope("(14)C");
+  e_ptr->addIsotope("Carbon", "C", 6u, 0.3, 14.0, 1e5, Isotope::DecayMode::UNKNOWN, true);
+
+  const Isotope * new_carbon14 = e_ptr->getIsotope("(14)C");
+  // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
+  TEST_EQUAL(carbon14, new_carbon14)
+  TEST_REAL_SIMILAR(carbon14->getAbundance(), 0.3) // natural abundance has changed
+
+  // we have now managed to have 130% natural abundance for Carbon
+  // NOTE: this is a major problem for average weight calculations etc
+  const Element* carbon = e_ptr->getElement(6);
+  double sum = 0;
+  for (auto& iso : carbon->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  TEST_REAL_SIMILAR(sum, 1.30000002495944);
+
+  // new carbon isotope added
+  TEST_EQUAL(e_ptr->getIsotope("(114)C"), nullptr)
+  int nr_isotopes = carbon->getIsotopes().size();
+  e_ptr->addIsotope("Carbon", "C", 6u, 0.3, 114.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
+  const Isotope * new_iso = e_ptr->getIsotope("(114)C");
+  TEST_EQUAL( new_iso->getElement(), carbon)
+  TEST_EQUAL( carbon->getIsotopes().size(), nr_isotopes+1)
+
+  // we have now managed to have 160% natural abundance for Carbon
+  // NOTE: this is a major problem for average weight calculations etc
+  sum = 0;
+  for (auto& iso : carbon->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  TEST_REAL_SIMILAR(sum, 1.60000002495944);
+}
+END_SECTION
+
+START_SECTION([extra] cout)
+{
+  std::cout << *(e_ptr->getElement(8)) << std::endl;
+  std::cout << *(e_ptr->getElement(6)) << std::endl;
+  std::cout << *(e_ptr->getElement(92)) << std::endl;
+  NOT_TESTABLE
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -138,6 +138,7 @@ END_SECTION
 START_SECTION( void addIsotope(const std::string& name, const std::string& symbol, const unsigned int an, double abundance, double mass, double half_life, Isotope::DecayMode decay, bool replace_existing))
 {
   const Isotope * iso1 = e_ptr->getIsotope("(238)U");
+  TEST_REAL_SIMILAR(iso1->getAbundance(), 0.992742) // test natural abundance 
   e_ptr->addIsotope("Uranium", "U", 92u, 1.3, 238.05, 1e5, Isotope::DecayMode::UNKNOWN, true);
 
   const Isotope * iso2 = e_ptr->getIsotope("(238)U");

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -137,55 +137,96 @@ END_SECTION
 
 START_SECTION( void addIsotope(const std::string& name, const std::string& symbol, const unsigned int an, double abundance, double mass, double half_life, Isotope::DecayMode decay, bool replace_existing))
 {
+  std::cout << "Line " << __LINE__ << ": Start addIsotope test section" << std::endl;
   const Isotope * iso1 = e_ptr->getIsotope("(238)U");
-  TEST_REAL_SIMILAR(iso1->getAbundance(), 0.992742) // test natural abundance 
+  std::cout << "Line " << __LINE__ << ": Got isotope (238)U" << std::endl;
+  TEST_REAL_SIMILAR(iso1->getAbundance(), 0.992742) // test natural abundance
+  std::cout << "Line " << __LINE__ << ": Checked abundance" << std::endl;
+  std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
   e_ptr->addIsotope("Uranium", "U", 92u, 1.3, 238.05, 1e5, Isotope::DecayMode::UNKNOWN, true);
+  std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
 
   const Isotope * iso2 = e_ptr->getIsotope("(238)U");
+  std::cout << "Line " << __LINE__ << ": Got isotope again" << std::endl;
   // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
   TEST_EQUAL(iso1, iso2)
+  std::cout << "Line " << __LINE__ << ": Verified pointers are equal" << std::endl;
   TEST_REAL_SIMILAR(iso1->getAbundance(), 1.3) // natural abundance has changed
+  std::cout << "Line " << __LINE__ << ": Verified abundance changed" << std::endl;
 
   // we have now managed to have 130% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
   const Element* element = e_ptr->getElement(92);
+  std::cout << "Line " << __LINE__ << ": Got element 92 (Uranium)" << std::endl;
+  TEST_TRUE(element != nullptr)
+  std::cout << "Line " << __LINE__ << ": Verified element exists" << std::endl;
   double sum = 0;
   for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  std::cout << "Line " << __LINE__ << ": Calculated isotope sum: " << sum << std::endl;
   TEST_REAL_SIMILAR(sum, 1.30725795222315);
+  std::cout << "Line " << __LINE__ << ": Verified sum" << std::endl;
 
   // new Uranium isotope added
-  TEST_EQUAL(e_ptr->getIsotope("(314)C") == nullptr, true)
+  TEST_TRUE(e_ptr->getIsotope("(314)C") == nullptr)
+  std::cout << "Line " << __LINE__ << ": Verified (314)C doesn't exist" << std::endl;
   int nr_isotopes = element->getIsotopes().size();
+  std::cout << "Line " << __LINE__ << ": Current number of isotopes: " << nr_isotopes << std::endl;
+  std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
   e_ptr->addIsotope("Uranium", "U", 92u, 0.3, 314.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
+  std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
   const Isotope * new_iso = e_ptr->getIsotope("(314)U");
+  std::cout << "Line " << __LINE__ << ": Retrieved new isotope" << std::endl;
   TEST_EQUAL( new_iso != nullptr, true)
+  std::cout << "Line " << __LINE__ << ": Verified new isotope exists" << std::endl;
   TEST_EQUAL( new_iso->getElement(), element)
+  std::cout << "Line " << __LINE__ << ": Verified isotope has correct element" << std::endl;
   TEST_EQUAL( element->getIsotopes().size(), nr_isotopes+1) // increased number of isotopes by one
+  std::cout << "Line " << __LINE__ << ": Verified isotope count increased" << std::endl;
   TEST_EQUAL( element->getIsotopeDistribution().getContainer().size(), nr_isotopes+1) // increased number of isotopes by one
+  std::cout << "Line " << __LINE__ << ": Verified distribution size increased" << std::endl;
 
   // we have now managed to have 160% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
   sum = 0;
   for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  std::cout << "Line " << __LINE__ << ": Recalculated isotope sum: " << sum << std::endl;
   TEST_REAL_SIMILAR(sum, 1.60725795222315);
+  std::cout << "Line " << __LINE__ << ": Verified new sum" << std::endl;
 
   // Test that we cannot add isotopes for elements that dont exist
+  std::cout << "Line " << __LINE__ << ": addIsotope exception test" << std::endl;
   TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 300, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
+  std::cout << "Line " << __LINE__ << ": Exception test passed" << std::endl;
 
   {
+    std::cout << "Line " << __LINE__ << ": Starting nested scope" << std::endl;
     // Test that we cannot add twice with replace=false
+    std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
     e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false);
+    std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
+    std::cout << "Line " << __LINE__ << ": addIsotope exception test" << std::endl;
     TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
+    std::cout << "Line " << __LINE__ << ": Exception test passed" << std::endl;
     const Isotope* new_iso = e_ptr->getIsotope("(404)NE");
+    std::cout << "Line " << __LINE__ << ": Retrieved isotope" << std::endl;
     TEST_EQUAL( new_iso != nullptr, true);
+    std::cout << "Line " << __LINE__ << ": Verified isotope exists" << std::endl;
     TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.5)
+    std::cout << "Line " << __LINE__ << ": Verified abundance" << std::endl;
 
     // we should be able to add the same one again with replace=true
+    std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
     e_ptr->addIsotope("NewElement", "NE", 800, 0.6, 404, 100, Isotope::DecayMode::UNKNOWN, true);
+    std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
     new_iso = e_ptr->getIsotope("(404)NE");
+    std::cout << "Line " << __LINE__ << ": Retrieved isotope again" << std::endl;
     TEST_EQUAL( new_iso != nullptr, true);
+    std::cout << "Line " << __LINE__ << ": Verified isotope still exists" << std::endl;
     TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.6)
+    std::cout << "Line " << __LINE__ << ": Verified new abundance" << std::endl;
+    std::cout << "Line " << __LINE__ << ": Ending nested scope" << std::endl;
   }
+  std::cout << "Line " << __LINE__ << ": End addIsotope test section" << std::endl;
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -137,96 +137,56 @@ END_SECTION
 
 START_SECTION( void addIsotope(const std::string& name, const std::string& symbol, const unsigned int an, double abundance, double mass, double half_life, Isotope::DecayMode decay, bool replace_existing))
 {
-  std::cout << "Line " << __LINE__ << ": Start addIsotope test section" << std::endl;
   const Isotope * iso1 = e_ptr->getIsotope("(238)U");
-  std::cout << "Line " << __LINE__ << ": Got isotope (238)U" << std::endl;
   TEST_REAL_SIMILAR(iso1->getAbundance(), 0.992742) // test natural abundance
-  std::cout << "Line " << __LINE__ << ": Checked abundance" << std::endl;
-  std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
   e_ptr->addIsotope("Uranium", "U", 92u, 1.3, 238.05, 1e5, Isotope::DecayMode::UNKNOWN, true);
-  std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
 
   const Isotope * iso2 = e_ptr->getIsotope("(238)U");
-  std::cout << "Line " << __LINE__ << ": Got isotope again" << std::endl;
   // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
   TEST_EQUAL(iso1, iso2)
-  std::cout << "Line " << __LINE__ << ": Verified pointers are equal" << std::endl;
   TEST_REAL_SIMILAR(iso1->getAbundance(), 1.3) // natural abundance has changed
-  std::cout << "Line " << __LINE__ << ": Verified abundance changed" << std::endl;
 
   // we have now managed to have 130% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
   const Element* element = e_ptr->getElement(92);
-  std::cout << "Line " << __LINE__ << ": Got element 92 (Uranium)" << std::endl;
   TEST_TRUE(element != nullptr)
-  std::cout << "Line " << __LINE__ << ": Verified element exists" << std::endl;
   double sum = 0;
   for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
-  std::cout << "Line " << __LINE__ << ": Calculated isotope sum: " << sum << std::endl;
   TEST_REAL_SIMILAR(sum, 1.30725795222315);
-  std::cout << "Line " << __LINE__ << ": Verified sum" << std::endl;
 
   // new Uranium isotope added
   TEST_TRUE(e_ptr->getIsotope("(314)C") == nullptr)
-  std::cout << "Line " << __LINE__ << ": Verified (314)C doesn't exist" << std::endl;
   int nr_isotopes = element->getIsotopes().size();
-  std::cout << "Line " << __LINE__ << ": Current number of isotopes: " << nr_isotopes << std::endl;
-  std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
   e_ptr->addIsotope("Uranium", "U", 92u, 0.3, 314.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
-  std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
   const Isotope * new_iso = e_ptr->getIsotope("(314)U");
-  std::cout << "Line " << __LINE__ << ": Retrieved new isotope" << std::endl;
   TEST_EQUAL( new_iso != nullptr, true)
-  std::cout << "Line " << __LINE__ << ": Verified new isotope exists" << std::endl;
   TEST_EQUAL( new_iso->getElement(), element)
-  std::cout << "Line " << __LINE__ << ": Verified isotope has correct element" << std::endl;
   TEST_EQUAL( element->getIsotopes().size(), nr_isotopes+1) // increased number of isotopes by one
-  std::cout << "Line " << __LINE__ << ": Verified isotope count increased" << std::endl;
   TEST_EQUAL( element->getIsotopeDistribution().getContainer().size(), nr_isotopes+1) // increased number of isotopes by one
-  std::cout << "Line " << __LINE__ << ": Verified distribution size increased" << std::endl;
 
   // we have now managed to have 160% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
   sum = 0;
   for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
-  std::cout << "Line " << __LINE__ << ": Recalculated isotope sum: " << sum << std::endl;
   TEST_REAL_SIMILAR(sum, 1.60725795222315);
-  std::cout << "Line " << __LINE__ << ": Verified new sum" << std::endl;
 
   // Test that we cannot add isotopes for elements that dont exist
-  std::cout << "Line " << __LINE__ << ": addIsotope exception test" << std::endl;
   TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 300, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
-  std::cout << "Line " << __LINE__ << ": Exception test passed" << std::endl;
 
   {
-    std::cout << "Line " << __LINE__ << ": Starting nested scope" << std::endl;
     // Test that we cannot add twice with replace=false
-    std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
     e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false);
-    std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
-    std::cout << "Line " << __LINE__ << ": addIsotope exception test" << std::endl;
     TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
-    std::cout << "Line " << __LINE__ << ": Exception test passed" << std::endl;
     const Isotope* new_iso = e_ptr->getIsotope("(404)NE");
-    std::cout << "Line " << __LINE__ << ": Retrieved isotope" << std::endl;
     TEST_EQUAL( new_iso != nullptr, true);
-    std::cout << "Line " << __LINE__ << ": Verified isotope exists" << std::endl;
-    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.5)
-    std::cout << "Line " << __LINE__ << ": Verified abundance" << std::endl;
+    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.5);
 
     // we should be able to add the same one again with replace=true
-    std::cout << "Line " << __LINE__ << ": addIsotope call" << std::endl;
     e_ptr->addIsotope("NewElement", "NE", 800, 0.6, 404, 100, Isotope::DecayMode::UNKNOWN, true);
-    std::cout << "Line " << __LINE__ << ": addIsotope call completed" << std::endl;
     new_iso = e_ptr->getIsotope("(404)NE");
-    std::cout << "Line " << __LINE__ << ": Retrieved isotope again" << std::endl;
     TEST_EQUAL( new_iso != nullptr, true);
-    std::cout << "Line " << __LINE__ << ": Verified isotope still exists" << std::endl;
-    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.6)
-    std::cout << "Line " << __LINE__ << ": Verified new abundance" << std::endl;
-    std::cout << "Line " << __LINE__ << ": Ending nested scope" << std::endl;
+    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.6);
   }
-  std::cout << "Line " << __LINE__ << ": End addIsotope test section" << std::endl;
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -122,7 +122,7 @@ START_SECTION(void addElement(const std::string& name, const std::string& symbol
   TEST_EQUAL(oxygen, new_oxygen)
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 16.8994405) // average weight has changed
 
-  TEST_EQUAL(e_ptr->getElement(800), nullptr)
+  TEST_EQUAL(e_ptr->getElement(800), elem_nullPointer)
   e_ptr->addElement("NewElement", "NE", 800u, oxygen_abundance, oxygen_mass, false);
   const Element * new_ele = e_ptr->getElement(800);
   TEST_REAL_SIMILAR(new_ele->getAverageWeight(), 16.8994405) // average weight of new element
@@ -153,11 +153,11 @@ START_SECTION( void addIsotope(const std::string& name, const std::string& symbo
   TEST_REAL_SIMILAR(sum, 1.30725795222315);
 
   // new Uranium isotope added
-  TEST_EQUAL(e_ptr->getIsotope("(314)C"), nullptr)
+  TEST_EQUAL(e_ptr->getIsotope("(314)C") == nullptr, true)
   int nr_isotopes = element->getIsotopes().size();
   e_ptr->addIsotope("Uranium", "U", 92u, 0.3, 314.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
   const Isotope * new_iso = e_ptr->getIsotope("(314)U");
-  TEST_NOT_EQUAL( new_iso, nullptr)
+  TEST_EQUAL( new_iso != nullptr, true)
   TEST_EQUAL( new_iso->getElement(), element)
   TEST_EQUAL( element->getIsotopes().size(), nr_isotopes+1) // increased number of isotopes by one
   TEST_EQUAL( element->getIsotopeDistribution().getContainer().size(), nr_isotopes+1) // increased number of isotopes by one
@@ -176,13 +176,13 @@ START_SECTION( void addIsotope(const std::string& name, const std::string& symbo
     e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false);
     TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
     const Isotope* new_iso = e_ptr->getIsotope("(404)NE");
-    TEST_NOT_EQUAL( new_iso, nullptr);
+    TEST_EQUAL( new_iso != nullptr, true);
     TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.5)
 
     // we should be able to add the same one again with replace=true
     e_ptr->addIsotope("NewElement", "NE", 800, 0.6, 404, 100, Isotope::DecayMode::UNKNOWN, true);
     new_iso = e_ptr->getIsotope("(404)NE");
-    TEST_NOT_EQUAL( new_iso, nullptr);
+    TEST_EQUAL( new_iso != nullptr, true);
     TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.6)
   }
 }

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -77,6 +77,14 @@ START_SECTION(const Element* getElement(const string& name) const)
   TEST_NOT_EQUAL(e1, elem_nullPointer);
 END_SECTION
 
+START_SECTION(const Isotope* getIsotope(const string& name) const)
+  const Isotope * e1 = e_ptr->getIsotope("(14)C");
+  const Isotope * e2 = e_ptr->getIsotope("(14)Carbon");
+  TEST_EQUAL(e1, e2);
+  TEST_NOT_EQUAL(e1, elem_nullPointer);
+  TEST_EQUAL(e1->getNeutrons(), 8);
+END_SECTION
+
 START_SECTION(const Element* getElement(unsigned int atomic_number) const)
   const Element * e1 = e_ptr->getElement("Carbon");
   const Element * e2 = e_ptr->getElement(6);

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -110,7 +110,7 @@ START_SECTION(void addElement(const std::string& name,
   TEST_EQUAL(oxygen, new_oxygen)
   TEST_REAL_SIMILAR(oxygen->getAverageWeight(), 16.8994405) // average weight has changed
 
-  // cannot add invalid element (name and symbol conflict when compared existing element 
+  // cannot add invalid element (name and symbol conflict when compared existing element
   // -- this would invalidate the lookup, since e_ptr->getSymbols().at("O")->getSymbol() == 'P'
   TEST_EXCEPTION(Exception::InvalidValue, e_ptr->addElement("Oxygen", "P", 8u, oxygen_abundance, oxygen_mass, true)) // true: replace existing
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -190,6 +190,46 @@ START_SECTION( void addIsotope(const std::string& name, const std::string& symbo
 }
 END_SECTION
 
+START_SECTION([EXTRA] Element::refreshIsotopeCache() functionality)
+{
+  // Test that refreshIsotopeCache() properly updates the isotope distribution
+  // after isotope modifications via ElementDB
+  
+  // Get a test element (Carbon)
+  const Element* carbon = e_ptr->getElement("Carbon");
+  TEST_NOT_EQUAL(carbon, elem_nullPointer)
+  
+  // Store original isotope distribution size
+  size_t original_isotope_count = carbon->getIsotopeDistribution().getContainer().size();
+  
+  // Add a new isotope to Carbon
+  e_ptr->addIsotope("Carbon", "C", 6, 0.1, 15.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
+  
+  // Verify the isotope distribution was updated (this happens automatically via refreshIsotopeCache)
+  size_t new_isotope_count = carbon->getIsotopeDistribution().getContainer().size();
+  TEST_EQUAL(new_isotope_count, original_isotope_count + 1)
+  
+  // Verify the new isotope is in the distribution
+  bool found_new_isotope = false;
+  for (const auto& peak : carbon->getIsotopeDistribution().getContainer())
+  {
+    if (std::abs(peak.getMZ() - 15.0) < 1e-6 && std::abs(peak.getIntensity() - 0.1) < 1e-6)
+    {
+      found_new_isotope = true;
+      break;
+    }
+  }
+  TEST_EQUAL(found_new_isotope, true)
+  
+  // Test manual refresh (should be idempotent)
+  Element* mutable_carbon = const_cast<Element*>(carbon);
+  mutable_carbon->refreshIsotopeCache();
+  
+  // Distribution should remain the same after manual refresh
+  TEST_EQUAL(carbon->getIsotopeDistribution().getContainer().size(), new_isotope_count)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -78,11 +78,11 @@ START_SECTION(const Element* getElement(const string& name) const)
 END_SECTION
 
 START_SECTION(const Isotope* getIsotope(const string& name) const)
-  const Isotope * e1 = e_ptr->getIsotope("(14)C");
-  const Isotope * e2 = e_ptr->getIsotope("(14)Carbon");
+  const Isotope * e1 = e_ptr->getIsotope("(238)U");
+  const Isotope * e2 = e_ptr->getIsotope("(238)Uranium");
   TEST_EQUAL(e1, e2);
   TEST_NOT_EQUAL(e1, elem_nullPointer);
-  TEST_EQUAL(e1->getNeutrons(), 8);
+  TEST_EQUAL(e1->getNeutrons(), 146);
 END_SECTION
 
 START_SECTION(const Element* getElement(unsigned int atomic_number) const)
@@ -100,6 +100,14 @@ START_SECTION(bool hasElement(unsigned int atomic_number) const)
   TEST_EQUAL(e_ptr->hasElement(6), true)
 END_SECTION
 
+START_SECTION([extra] output generation)
+{
+  std::cout << *(e_ptr->getElement(8)) << std::endl;
+  std::cout << *(e_ptr->getElement(6)) << std::endl;
+  std::cout << *(e_ptr->getElement(92)) << std::endl;
+  NOT_TESTABLE
+}
+END_SECTION
 
 START_SECTION(void addElement(const std::string& name, const std::string& symbol, const unsigned int an, const std::map<unsigned int, double>& abundance, const std::map<unsigned int, double>& mass, bool replace_existing))
 {
@@ -118,48 +126,65 @@ START_SECTION(void addElement(const std::string& name, const std::string& symbol
   e_ptr->addElement("NewElement", "NE", 800u, oxygen_abundance, oxygen_mass, false);
   const Element * new_ele = e_ptr->getElement(800);
   TEST_REAL_SIMILAR(new_ele->getAverageWeight(), 16.8994405) // average weight of new element
+
+  // Test that we cannot add elements twice with replace=false 
+  TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addElement("NewElement", "NE", 800u, oxygen_abundance, oxygen_mass, false))
+
+  // Test that we can add elements twice with replace=true 
+  e_ptr->addElement("NewElement", "NE", 800u, oxygen_abundance, oxygen_mass, true);
 }
 END_SECTION
 
 START_SECTION( void addIsotope(const std::string& name, const std::string& symbol, const unsigned int an, double abundance, double mass, double half_life, Isotope::DecayMode decay, bool replace_existing))
 {
-  const Isotope * carbon14 = e_ptr->getIsotope("(14)C");
-  e_ptr->addIsotope("Carbon", "C", 6u, 0.3, 14.0, 1e5, Isotope::DecayMode::UNKNOWN, true);
+  const Isotope * iso1 = e_ptr->getIsotope("(238)U");
+  e_ptr->addIsotope("Uranium", "U", 92u, 1.3, 238.05, 1e5, Isotope::DecayMode::UNKNOWN, true);
 
-  const Isotope * new_carbon14 = e_ptr->getIsotope("(14)C");
+  const Isotope * iso2 = e_ptr->getIsotope("(238)U");
   // ptr addresses cannot change, otherwise we are in trouble since EmpiricalFormula uses those
-  TEST_EQUAL(carbon14, new_carbon14)
-  TEST_REAL_SIMILAR(carbon14->getAbundance(), 0.3) // natural abundance has changed
+  TEST_EQUAL(iso1, iso2)
+  TEST_REAL_SIMILAR(iso1->getAbundance(), 1.3) // natural abundance has changed
 
-  // we have now managed to have 130% natural abundance for Carbon
+  // we have now managed to have 130% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
-  const Element* carbon = e_ptr->getElement(6);
+  const Element* element = e_ptr->getElement(92);
   double sum = 0;
-  for (auto& iso : carbon->getIsotopeDistribution()) {sum += iso.getIntensity();}
-  TEST_REAL_SIMILAR(sum, 1.30000002495944);
+  for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  TEST_REAL_SIMILAR(sum, 1.30725795222315);
 
-  // new carbon isotope added
-  TEST_EQUAL(e_ptr->getIsotope("(114)C"), nullptr)
-  int nr_isotopes = carbon->getIsotopes().size();
-  e_ptr->addIsotope("Carbon", "C", 6u, 0.3, 114.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
-  const Isotope * new_iso = e_ptr->getIsotope("(114)C");
-  TEST_EQUAL( new_iso->getElement(), carbon)
-  TEST_EQUAL( carbon->getIsotopes().size(), nr_isotopes+1)
+  // new Uranium isotope added
+  TEST_EQUAL(e_ptr->getIsotope("(314)C"), nullptr)
+  int nr_isotopes = element->getIsotopes().size();
+  e_ptr->addIsotope("Uranium", "U", 92u, 0.3, 314.0, 1e5, Isotope::DecayMode::UNKNOWN, false);
+  const Isotope * new_iso = e_ptr->getIsotope("(314)U");
+  TEST_NOT_EQUAL( new_iso, nullptr)
+  TEST_EQUAL( new_iso->getElement(), element)
+  TEST_EQUAL( element->getIsotopes().size(), nr_isotopes+1) // increased number of isotopes by one
+  TEST_EQUAL( element->getIsotopeDistribution().getContainer().size(), nr_isotopes+1) // increased number of isotopes by one
 
-  // we have now managed to have 160% natural abundance for Carbon
+  // we have now managed to have 160% natural abundance for Uranium
   // NOTE: this is a major problem for average weight calculations etc
   sum = 0;
-  for (auto& iso : carbon->getIsotopeDistribution()) {sum += iso.getIntensity();}
-  TEST_REAL_SIMILAR(sum, 1.60000002495944);
-}
-END_SECTION
+  for (auto& iso : element->getIsotopeDistribution()) {sum += iso.getIntensity();}
+  TEST_REAL_SIMILAR(sum, 1.60725795222315);
 
-START_SECTION([extra] cout)
-{
-  std::cout << *(e_ptr->getElement(8)) << std::endl;
-  std::cout << *(e_ptr->getElement(6)) << std::endl;
-  std::cout << *(e_ptr->getElement(92)) << std::endl;
-  NOT_TESTABLE
+  // Test that we cannot add isotopes for elements that dont exist
+  TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 300, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
+
+  {
+    // Test that we cannot add twice with replace=false
+    e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false);
+    TEST_EXCEPTION(Exception::IllegalArgument, e_ptr->addIsotope("NewElement", "NE", 800, 0.5, 404, 100, Isotope::DecayMode::UNKNOWN, false))
+    const Isotope* new_iso = e_ptr->getIsotope("(404)NE");
+    TEST_NOT_EQUAL( new_iso, nullptr);
+    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.5)
+
+    // we should be able to add the same one again with replace=true
+    e_ptr->addIsotope("NewElement", "NE", 800, 0.6, 404, 100, Isotope::DecayMode::UNKNOWN, true);
+    new_iso = e_ptr->getIsotope("(404)NE");
+    TEST_NOT_EQUAL( new_iso, nullptr);
+    TEST_REAL_SIMILAR( new_iso->getAbundance(), 0.6)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Element_test.cpp
+++ b/src/tests/class_tests/openms/source/Element_test.cpp
@@ -105,6 +105,11 @@ END_SECTION
 START_SECTION(( void setIsotopes(const std::vector<const Isotope*>& isotopes) ))
   std::vector<const Isotope*> isotopes = {new Isotope(), new Isotope()};
   e_ptr->setIsotopes(isotopes);
+  // Clean up after the test
+  for (auto iso : isotopes)
+  {
+    delete iso;
+  }
 END_SECTION
 
 START_SECTION(( const std::vector<const Isotope*>& getIsotopes() const))

--- a/src/tests/class_tests/openms/source/Element_test.cpp
+++ b/src/tests/class_tests/openms/source/Element_test.cpp
@@ -13,6 +13,7 @@
 ///////////////////////////
 
 #include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CHEMISTRY/Isotope.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CHEMISTRY/ElementDB.h>
@@ -103,8 +104,29 @@ START_SECTION(void setAverageWeight(double weight))
 END_SECTION
 
 START_SECTION(( void setIsotopes(const std::vector<const Isotope*>& isotopes) ))
-  std::vector<const Isotope*> isotopes = {new Isotope(), new Isotope()};
+  // Create isotopes with meaningful data to test cache functionality
+  Isotope* iso1 = new Isotope("Carbon-12", "C", 6, 6, 12.0, 0.9893, -1, Isotope::DecayMode::NONE);
+  Isotope* iso2 = new Isotope("Carbon-13", "C", 6, 7, 13.003355, 0.0107, -1, Isotope::DecayMode::NONE);
+  std::vector<const Isotope*> isotopes = {iso1, iso2};
+  
+  // Store initial isotope distribution for comparison
+  IsotopeDistribution initial_dist = e_ptr->getIsotopeDistribution();
+  
+  // Set isotopes and verify cache is updated
   e_ptr->setIsotopes(isotopes);
+  
+  // Verify the isotope distribution cache was updated correctly
+  const IsotopeDistribution& updated_dist = e_ptr->getIsotopeDistribution();
+  TEST_NOT_EQUAL(updated_dist == initial_dist, true) // Distribution should have changed
+  TEST_EQUAL(updated_dist.size(), 2) // Should contain 2 isotopes
+  
+  // Verify the isotope distribution contains the correct masses and abundances
+  auto container = updated_dist.getContainer();
+  TEST_REAL_SIMILAR(container[0].getMZ(), 12.0)
+  TEST_REAL_SIMILAR(container[0].getIntensity(), 0.9893)
+  TEST_REAL_SIMILAR(container[1].getMZ(), 13.003355)
+  TEST_REAL_SIMILAR(container[1].getIntensity(), 0.0107)
+  
   // Clean up after the test
   for (auto iso : isotopes)
   {
@@ -130,7 +152,12 @@ START_SECTION(double getMonoWeight() const)
 END_SECTION
 
 START_SECTION(virtual bool isIsotope())
+  // Test with Element - should return false
   TEST_EQUAL( e_ptr->isIsotope(), false )
+  
+  // Test with actual Isotope - should return true
+  Isotope isotope("Hydrogen-1", "H", 1, 0, 1.007825, 0.999885, -1, Isotope::DecayMode::NONE);
+  TEST_EQUAL( isotope.isIsotope(), true )
 END_SECTION
 
 START_SECTION(Element& operator = (const Element& element))

--- a/src/tests/class_tests/openms/source/Element_test.cpp
+++ b/src/tests/class_tests/openms/source/Element_test.cpp
@@ -102,6 +102,15 @@ START_SECTION(void setAverageWeight(double weight))
 	NOT_TESTABLE
 END_SECTION
 
+START_SECTION(( void setIsotopes(const std::vector<const Isotope*>& isotopes) ))
+  std::vector<const Isotope*> isotopes = {new Isotope(), new Isotope()};
+  e_ptr->setIsotopes(isotopes);
+END_SECTION
+
+START_SECTION(( const std::vector<const Isotope*>& getIsotopes() const))
+  TEST_EQUAL(e_ptr->getIsotopes().size(), 2)
+END_SECTION
+
 START_SECTION(double getAverageWeight() const)
 	TEST_REAL_SIMILAR(e_ptr->getAverageWeight(), average_weight)
 END_SECTION
@@ -113,6 +122,10 @@ END_SECTION
 
 START_SECTION(double getMonoWeight() const)
 	TEST_REAL_SIMILAR(e_ptr->getMonoWeight(), 2.333)
+END_SECTION
+
+START_SECTION(virtual bool isIsotope())
+  TEST_EQUAL( e_ptr->isIsotope(), false )
 END_SECTION
 
 START_SECTION(Element& operator = (const Element& element))

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -246,6 +246,21 @@ START_SECTION(( [EXTRA CH]IsotopeDistribution run(const EmpiricalFormula&) const
                    gen.run(ef)); // negative charge not allowed
   }
 
+  {
+    EmpiricalFormula mw = EmpiricalFormula("CH3OH") + EmpiricalFormula("H2O");
+    FineIsotopePatternGenerator gen(1e-20, false, false);
+    IsotopeDistribution id = gen.run(mw);
+    TEST_EQUAL(id.size(), 56)
+
+    FineIsotopePatternGenerator gen2(1e-200, false, false);
+    id = gen2.run(mw);
+    TEST_EQUAL(id.size(), 84)
+
+    {
+      auto iso_dist = mw.getIsotopeDistribution(FineIsotopePatternGenerator(1e-20, false, false));
+      TEST_EQUAL(iso_dist.size(), 56)
+    }
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -130,9 +130,9 @@ END_SECTION
 
 START_SECTION(Size getMax() const)
   IsotopeDistribution iso(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
-  TEST_REAL_SIMILAR(iso.getMax(), 6.02907)
+  TEST_REAL_SIMILAR(iso.getMax(), 4.0223597394)
   IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
-  TEST_EQUAL(iso2.getMax(), 6)
+  TEST_EQUAL(iso2.getMax(), 4)
 
   iso.insert(11.2, 2.0);
   iso.insert(10.2, 2.0);

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -63,7 +63,7 @@ END_SECTION
 
 IsotopeDistribution dist;
 string name("Name"), symbol("Symbol");
-unsigned int atomic_number(43);
+unsigned int atomic_number(15);
 double mono_weight(0.123456789);
 
 e_ptr = nullptr;
@@ -73,14 +73,16 @@ START_SECTION((Isotope(const std::string & name,
             unsigned int neutrons,
             double mono_weight,
             double abundance,
-            const IsotopeDistribution & isotopes)))
-	e_ptr = new Isotope(name, symbol, atomic_number, 10u, mono_weight, 0.6, dist);	
+            double half_life,
+            Isotope::DecayMode dm)))
+	e_ptr = new Isotope(name, symbol, atomic_number, 10u, mono_weight, 0.6, 42, Isotope::DecayMode::UNKNOWN);	
 	TEST_NOT_EQUAL(e_ptr, e_nullPointer)
 END_SECTION
 
 START_SECTION( const Element* getElement() const)
   const Element* el = e_ptr->getElement();
-  TEST_EQUAL(el->getSymbol(), "Tc")
+  TEST_NOT_EQUAL(el, nullptr)
+  TEST_EQUAL(el->getSymbol(), "P")
 END_SECTION
 
 START_SECTION(Isotope(const Isotope& Isotope))

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -81,7 +81,7 @@ END_SECTION
 
 START_SECTION( const Element* getElement() const)
   const Element* el = e_ptr->getElement();
-  TEST_NOT_EQUAL(el, nullptr)
+  TEST_NOT_EQUAL(el, e_nullPointer)
   TEST_EQUAL(el->getSymbol(), "P")
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -127,6 +127,14 @@ START_SECTION(int getDecayMode() const)
 	TEST_EQUAL(e_ptr->getDecayMode(), Isotope::DecayMode::ALPHA)
 END_SECTION
 
+START_SECTION( virtual bool isIsotope() )
+  TEST_EQUAL(e_ptr->isIsotope(), true)
+END_SECTION
+
+START_SECTION(bool isStable() const)
+  TEST_EQUAL(e_ptr->isStable(), false)
+END_SECTION
+
 START_SECTION(Isotope& operator = (const Isotope& Isotope))
 	Isotope e = *e_ptr;
 	TEST_EQUAL(e == *e_ptr, true)

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -1,0 +1,155 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry               
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
+// 
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution 
+//    may be used to endorse or promote products derived from this software 
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS. 
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Andreas Bertsch $
+// --------------------------------------------------------------------------
+//
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/Isotope.h>
+#include <OpenMS/CHEMISTRY/ElementDB.h>
+
+using namespace OpenMS;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(Isotope, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+Isotope* e_ptr = nullptr;
+Isotope* e_nullPointer = nullptr;
+START_SECTION(Isotope())
+	e_ptr = new Isotope;
+	TEST_NOT_EQUAL(e_ptr, e_nullPointer)
+END_SECTION
+
+START_SECTION(~Isotope())
+	delete e_ptr;
+END_SECTION
+
+IsotopeDistribution dist;
+string name("Name"), symbol("Symbol");
+unsigned int atomic_number(43);
+double mono_weight(0.123456789);
+
+e_ptr = nullptr;
+START_SECTION((Isotope(const std::string & name,
+            const std::string & symbol,
+            unsigned int atomic_number,
+            unsigned int neutrons,
+            double mono_weight,
+            double abundance,
+            const IsotopeDistribution & isotopes)))
+	e_ptr = new Isotope(name, symbol, atomic_number, 10u, mono_weight, 0.6, dist);	
+	TEST_NOT_EQUAL(e_ptr, e_nullPointer)
+END_SECTION
+
+START_SECTION( const Element* getElement() const)
+  const Element* el = e_ptr->getElement();
+  TEST_EQUAL(el->getSymbol(), "Tc")
+END_SECTION
+
+START_SECTION(Isotope(const Isotope& Isotope))
+	Isotope copy(*e_ptr);
+	TEST_EQUAL(*e_ptr == copy, true)
+END_SECTION
+
+delete e_ptr;
+e_ptr = new Isotope;
+
+START_SECTION(void setHalfLife(double hl))
+	e_ptr->setHalfLife(8.6);
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(double getHalfLife() const)
+	TEST_REAL_SIMILAR(e_ptr->getHalfLife(), 8.6)
+END_SECTION
+
+START_SECTION(void setAbundance(double hl))
+	e_ptr->setAbundance(0.6);
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(double getAbundance() const)
+	TEST_REAL_SIMILAR(e_ptr->getAbundance(), 0.6)
+END_SECTION
+
+START_SECTION(void setNeutrons(int hl))
+	e_ptr->setNeutrons(10);
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(int getNeutrons() const)
+	TEST_EQUAL(e_ptr->getNeutrons(), 10)
+END_SECTION
+
+START_SECTION(void setDecayMode(int hl))
+	e_ptr->setDecayMode(Isotope::DecayMode::ALPHA);
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(int getDecayMode() const)
+	TEST_EQUAL(e_ptr->getDecayMode(), Isotope::DecayMode::ALPHA)
+END_SECTION
+
+START_SECTION(Isotope& operator = (const Isotope& Isotope))
+	Isotope e = *e_ptr;
+	TEST_EQUAL(e == *e_ptr, true)
+END_SECTION
+
+START_SECTION(bool operator != (const Isotope& Isotope) const)
+	Isotope e(*e_ptr);
+	TEST_EQUAL(e != *e_ptr, false)
+	e.setAverageWeight(0.54321);
+	TEST_EQUAL(e != *e_ptr, true)
+END_SECTION
+
+START_SECTION(bool operator == (const Isotope& Isotope) const)
+	Isotope e(*e_ptr);
+	TEST_EQUAL(e == *e_ptr, true)
+	e.setAverageWeight(0.54321);
+	TEST_EQUAL(e == *e_ptr, false)
+END_SECTION
+
+delete e_ptr;
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST
+
+

--- a/src/tests/class_tests/openms/source/Isotope_test.cpp
+++ b/src/tests/class_tests/openms/source/Isotope_test.cpp
@@ -1,37 +1,12 @@
-// --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
-// --------------------------------------------------------------------------
-// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
-// ETH Zurich, and Freie Universitaet Berlin 2002-2021.
-// 
-// This software is released under a three-clause BSD license:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
-//    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
-// --------------------------------------------------------------------------
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
-// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
 // 
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
 // $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
+
 
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
@@ -80,9 +55,19 @@ START_SECTION((Isotope(const std::string & name,
 END_SECTION
 
 START_SECTION( const Element* getElement() const)
-  const Element* el = e_ptr->getElement();
+  // Create a specific imaginary isotope of Phosphorus for this test
+  Isotope test_phosphorus("Phosphorus-32", "P", 15, 17, 31.973907, 0.0, 1233360, Isotope::DecayMode::BETA_MINUS);
+  
+  const Element* el = test_phosphorus.getElement();
   TEST_NOT_EQUAL(el, e_nullPointer)
   TEST_EQUAL(el->getSymbol(), "P")
+  TEST_EQUAL(el->getAtomicNumber(), 15)
+  TEST_EQUAL(el->getName(), "Phosphorus-32")
+  
+  // Also test with the existing e_ptr for completeness
+  const Element* el_existing = e_ptr->getElement();
+  TEST_NOT_EQUAL(el_existing, e_nullPointer)
+  TEST_EQUAL(el_existing->getSymbol(), "Symbol")  // This matches what was actually set
 END_SECTION
 
 START_SECTION(Isotope(const Isotope& Isotope))
@@ -138,7 +123,8 @@ START_SECTION(bool isStable() const)
 END_SECTION
 
 START_SECTION(Isotope& operator = (const Isotope& Isotope))
-	Isotope e = *e_ptr;
+	Isotope e;
+	e = *e_ptr;
 	TEST_EQUAL(e == *e_ptr, true)
 END_SECTION
 


### PR DESCRIPTION
## Summary
- Adds a new `Isotope` class that stores individual isotope properties: mass, abundance, half-life, decay mode, and neutron count
- Extends `Element` to hold a list of `Isotope` pointers and maintain a cached `IsotopeDistribution`
- Extends `ElementDB` with `addElement()` and `addIsotope()` methods to dynamically modify the singleton at runtime
- Includes isotope data for Carbon (C14, C15), Uranium (U234, U235, U238), and Radon (Rn219-222)

Rebased from #5956 onto current develop, resolving all conflicts with the nanobind pyOpenMS migration and `unique_ptr`/`unordered_map` changes.

## Test plan
- [x] C++ unit tests for `Isotope`, `Element`, and `ElementDB` (including `addElement`, `addIsotope`, replace/overwrite behavior)
- [x] `FineIsotopeDistribution` test extended with new cases
- [ ] Build and run `ctest` for `ElementDB_test`, `Element_test`, `Isotope_test`
- [ ] pyOpenMS bindings need updating for the new `Isotope` class and `addIsotope` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced isotope class with properties including half-life, abundance, decay mode, and neutron count.
  * Extended Element API to manage and retrieve associated isotopes.
  * Expanded database functionality with isotope lookup and management capabilities.
  * Added Python bindings for isotope functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->