### PR TITLE
fix: increase CDash output cap and fix Windows parquet file locking

### DIFF
--- a/src/pyOpenMS/tests/unittests/test_arrow_io_classes.py
+++ b/src/pyOpenMS/tests/unittests/test_arrow_io_classes.py
@@ -349,42 +349,30 @@ class TestConsensusMapArrowZerocopy:
 
 class TestProteinIdentificationArrowIOParquet:
 
-    def test_export_proteins_to_parquet(self, protein_identifications):
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            ok = oms.ProteinIdentificationArrowIO.exportProteinsToParquet(
-                protein_identifications, path)
-            assert ok
-            assert os.path.exists(path)
-            table = pq.read_table(path)
-            assert table.num_rows == 2  # 2 protein hits
-        finally:
-            os.unlink(path)
+    def test_export_proteins_to_parquet(self, protein_identifications, tmp_path):
+        path = str(tmp_path / "proteins.parquet")
+        ok = oms.ProteinIdentificationArrowIO.exportProteinsToParquet(
+            protein_identifications, path)
+        assert ok
+        assert os.path.exists(path)
+        table = pq.read_table(path)
+        assert table.num_rows == 2  # 2 protein hits
 
-    def test_export_groups_to_parquet(self, protein_identifications):
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            ok = oms.ProteinIdentificationArrowIO.exportProteinGroupsToParquet(
-                protein_identifications, path)
-            assert ok
-            table = pq.read_table(path)
-            assert table.num_rows >= 1
-        finally:
-            os.unlink(path)
+    def test_export_groups_to_parquet(self, protein_identifications, tmp_path):
+        path = str(tmp_path / "groups.parquet")
+        ok = oms.ProteinIdentificationArrowIO.exportProteinGroupsToParquet(
+            protein_identifications, path)
+        assert ok
+        table = pq.read_table(path)
+        assert table.num_rows >= 1
 
-    def test_export_search_params_to_parquet(self, protein_identifications):
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            path = f.name
-        try:
-            ok = oms.ProteinIdentificationArrowIO.exportSearchParamsToParquet(
-                protein_identifications, path)
-            assert ok
-            table = pq.read_table(path)
-            assert table.num_rows == 1  # 1 search run
-        finally:
-            os.unlink(path)
+    def test_export_search_params_to_parquet(self, protein_identifications, tmp_path):
+        path = str(tmp_path / "params.parquet")
+        ok = oms.ProteinIdentificationArrowIO.exportSearchParamsToParquet(
+            protein_identifications, path)
+        assert ok
+        table = pq.read_table(path)
+        assert table.num_rows == 1  # 1 search run
 
     def test_parquet_full_round_trip(self, protein_identifications):
         """Export all three files, reimport via importFromParquet."""

--- a/tools/ci/citest.cmake
+++ b/tools/ci/citest.cmake
@@ -26,7 +26,7 @@ set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS 1000)
 
 # Limit output size for passed tests to avoid cluttering CDash (e.g. pyopenms verbose pytest output).
 # Failed tests still show full output.
-set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1024)
+set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 51200)
 
 # Define patterns that should NOT be classified as warnings
 set(CTEST_CUSTOM_WARNING_EXCEPTION


### PR DESCRIPTION
## Summary
- Increase `CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE` from 1KB to 50KB so pytest summary lines (pass/fail/skip counts) remain visible on CDash
- Use `tmp_path` fixture in `TestProteinIdentificationArrowIOParquet` tests to avoid Windows `PermissionError` from pyarrow memory-mapping parquet files

## Test plan
- [ ] Verify CDash shows pytest summary counts for passing pyopenms tests
- [ ] Verify `build-wheels-windows` CI passes (no more `PermissionError` in parquet tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for Parquet I/O testing with improved temporary file handling.

* **Chores**
  * Updated CI configuration to increase test output reporting capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->