### PR TITLE
fix: remove BUILD_WITH_INSTALL_RPATH so dev builds find libOpenMS.so

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -235,7 +235,6 @@ else()
     if(NOT PYOPENMS_PREPARE_WHEEL_REPAIR)
       set_target_properties(${target_name} PROPERTIES
         INSTALL_RPATH "${PY_RPATH}"
-        BUILD_WITH_INSTALL_RPATH 1
       )
       if(APPLE)
         set_target_properties(${target_name} PROPERTIES

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -236,6 +236,13 @@ else()
       set_target_properties(${target_name} PROPERTIES
         INSTALL_RPATH "${PY_RPATH}"
       )
+      if(NOT NO_DEPENDENCIES)
+        # When dependencies are bundled alongside the modules, use the install
+        # RPATH at build time so $ORIGIN/ finds the co-located libraries.
+        set_target_properties(${target_name} PROPERTIES
+          BUILD_WITH_INSTALL_RPATH 1
+        )
+      endif()
       if(APPLE)
         set_target_properties(${target_name} PROPERTIES
           BUILD_WITH_INSTALL_NAME_DIR 1


### PR DESCRIPTION
## Summary

- Removes `BUILD_WITH_INSTALL_RPATH 1` from the non-wheel-repair RPATH code path in `src/pyOpenMS/CMakeLists.txt`
- This property replaced CMake's default build-tree RPATH (absolute path to `build/lib/`) with the install RPATH (`$ORIGIN/../lib/`), which resolves to `build/pyOpenMS/lib/` — a directory that doesn't exist
- Without it, CMake embeds the correct build-tree path at build time and still applies `INSTALL_RPATH` during `cmake --install`

**Before:** nanobind modules had RUNPATH `$ORIGIN/../lib/:$ORIGIN/` → `libOpenMS.so` not found → import fails

**After:** nanobind modules have RUNPATH `/abs/path/to/build/lib/` → `libOpenMS.so` found → import works

Wheel builds are unaffected — they use the `PYOPENMS_PREPARE_WHEEL_REPAIR=ON` code path which never set this property.

Fixes #8891

## Test plan

- [x] Verified RUNPATH on built module now includes absolute build-tree lib path
- [x] Verified `import pyopenms` succeeds without `LD_LIBRARY_PATH` from build tree
- [ ] CI wheel builds still pass (different code path, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to apply bundled-dependency runtime path settings only when dependencies are included, leaving builds without bundled dependencies unaffected. This refines packaging behavior during build and reduces unnecessary install-time path adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->