### PR TITLE
(fix,osw): remove ZAF testing only hook

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -166,10 +166,6 @@ if (WITH_PARQUET)
     target_compile_definitions(OpenMS PUBLIC WITH_PARQUET=1)
 endif()
 
-## Enable test-only hooks when class tests are being built.
-if(ENABLE_CLASS_TESTING) 
-  target_compile_definitions(OpenMS PRIVATE OPENMS_ENABLE_TESTING_HOOKS=1)
-endif()
 
 
 #------------------------------------------------------------------------------

--- a/src/openms/include/OpenMS/FORMAT/ZipArchiveFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ZipArchiveFile.h
@@ -121,12 +121,6 @@ namespace OpenMS
     */
     static String extractEntryToTempFile(const String& archive_path, const String& entry_name, std::unique_ptr<File::TempDir>& temp_dir);
 
-  // Test helpers (used by unit tests to assert whether extraction was performed)
-#if defined(OPENMS_ENABLE_TESTING_HOOKS)
-  static void testResetExtractionCount();
-  static int testGetExtractionCount();
-#endif
-
   };
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ZipArchiveFile.cpp
+++ b/src/openms/source/FORMAT/ZipArchiveFile.cpp
@@ -22,7 +22,6 @@
 #include <filesystem>
 #include <fstream>
 #include <vector>
-#include <atomic>
 
 namespace OpenMS
 {
@@ -199,10 +198,6 @@ String ZipArchiveFile::unzipDirectory(const String& input_path, std::unique_ptr<
 #endif
 }
 
-// Simple global counter to help tests detect whether extractEntryToTempFile was used.
-#if defined(OPENMS_ENABLE_TESTING_HOOKS)
-static std::atomic<int> g_zip_extract_count{0};
-#endif
 
 
 void ZipArchiveFile::addOrReplaceFromFile(const String& archive_path, const String& entry_name, const String& source_file_path)
@@ -410,18 +405,6 @@ void ZipArchiveFile::writeSidecarIndex(const String& archive_path)
 #endif
 }
 
-#if defined(OPENMS_ENABLE_TESTING_HOOKS)
-void ZipArchiveFile::testResetExtractionCount()
-{
-  g_zip_extract_count.store(0);
-}
-
-int ZipArchiveFile::testGetExtractionCount()
-{
-  return static_cast<int>(g_zip_extract_count.load());
-}
-#endif
-
 String ZipArchiveFile::extractEntryToTempFile(const String& archive_path, const String& entry_name, std::unique_ptr<File::TempDir>& temp_dir)
 {
 #if defined(OPENMS_HAVE_LIBZIP)
@@ -467,10 +450,6 @@ String ZipArchiveFile::extractEntryToTempFile(const String& archive_path, const 
   }
 
   if (!temp_dir) temp_dir = std::make_unique<File::TempDir>();
-#if defined(OPENMS_ENABLE_TESTING_HOOKS)
-  // increment test counter to signal an extraction occurred
-  ++g_zip_extract_count;
-#endif
   const String base = temp_dir->getPath();
 
   // construct output path and create parent dirs

--- a/src/openms/source/FORMAT/ZipRandomAccessFile.cpp
+++ b/src/openms/source/FORMAT/ZipRandomAccessFile.cpp
@@ -140,9 +140,7 @@ arrow::Result<std::shared_ptr<arrow::io::RandomAccessFile>> ZipRandomAccessFile:
 	}
 
 #if !defined(OPENMS_HAVE_LIBZIP)
-	// Fall back: extract to temp file and open as ReadableFile
-	const String path = ZipArchiveFile::extractEntryToTempFile(archive_path, entry_name, temp_dir);
-	return arrow::io::ReadableFile::Open(std::string(path));
+	return arrow::Status::NotImplemented("libzip not available, cannot open ZIP entry directly");
 #else
 	int err = 0;
 	zip_t* za = zip_open(archive_path.c_str(), ZIP_RDONLY, &err);

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -141,7 +141,6 @@ if (WITH_PARQUET)
       ${OPENMS_ARROW_TARGET}
       ${OPENMS_PARQUET_TARGET}
     )
-    target_compile_definitions(OpenSwathOSWParquetRoundTrip_test PRIVATE OPENMS_ENABLE_TESTING_HOOKS=1)
   endif()
 endif()
 

--- a/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
@@ -62,7 +62,12 @@ START_SECTION(void round-trip write/read .oswpq archive using RAF path)
   // Verify the RAF path works: ZipRandomAccessFile::Open should succeed directly on the archive
   {
     std::unique_ptr<File::TempDir> raf_tmp;
-    TEST_EQUAL(ZipRandomAccessFile::Open(out_archive, "library/precursors.parquet", raf_tmp).ok(), true)
+    auto ra_res = ZipRandomAccessFile::Open(out_archive, "library/precursors.parquet", raf_tmp);
+#if __has_include(<zip.h>)
+    TEST_EQUAL(ra_res.ok(), true)
+#else
+    TEST_EQUAL(ra_res.status().IsNotImplemented(), true)
+#endif
   }
 
   // Read back using TransitionParquetFile and verify the round-trip data

--- a/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathOSWParquetRoundTrip_test.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
+#include <OpenMS/FORMAT/ZipRandomAccessFile.h>
 
 #ifdef WITH_PARQUET
 #include <arrow/api.h>
@@ -58,14 +59,16 @@ START_SECTION(void round-trip write/read .oswpq archive using RAF path)
     TEST_EQUAL(found, true)
   }
 
-  // Read back using TransitionParquetFile which should prefer RAF-based reads when available
-  // Reset test extraction counter and assert no extraction occurs (i.e., RAF path used)
-  ZipArchiveFile::testResetExtractionCount();
+  // Verify the RAF path works: ZipRandomAccessFile::Open should succeed directly on the archive
+  {
+    std::unique_ptr<File::TempDir> raf_tmp;
+    TEST_EQUAL(ZipRandomAccessFile::Open(out_archive, "library/precursors.parquet", raf_tmp).ok(), true)
+  }
+
+  // Read back using TransitionParquetFile and verify the round-trip data
   TransitionParquetFile reader;
   OpenSwath::LightTargetedExperiment roundtrip_exp;
   reader.convertParquetToTargetedExperiment(out_archive, roundtrip_exp);
-
-  TEST_EQUAL(ZipArchiveFile::testGetExtractionCount(), 0)
 
   TEST_EQUAL(roundtrip_exp.compounds.size(), light_exp.compounds.size())
   TEST_EQUAL(roundtrip_exp.transitions.size(), light_exp.transitions.size())


### PR DESCRIPTION
## Description

As suggested in [PR #8877](https://github.com/OpenMS/OpenMS/pull/8877#issuecomment-4032616339), this PR removes test-only hooks and related code for tracking ZIP extraction operations, and updates the fallback behavior for ZIP entry access when `libzip` is unavailable. The changes simplify the codebase and update tests to reflect the new implementation.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of archive paths that are directories to avoid unnecessary extraction.
  * Return an explicit error when ZIP support is unavailable instead of falling back to temporary extraction.

* **Chores**
  * Removed internal test-only interfaces and related test-specific build definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->