### PR TITLE
(feat,pyopenms): add XIMParquetFile pyopenms bindings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -111,6 +111,7 @@ PyOpenMS:
   - Param to_dict quality-of-life improvements: dict-like API for parameter access (#8631)
   - Fix: FileTypes wrapping updated with missing enum values and static methods (#8720)
   - XICParquetFile: Python bindings with multi-file support and filtering for reading XIC data from Parquet files (#8737, #8738)
+  - XIMParquetFile: Python bindings for reading extracted ion mobilogram data from Parquet files (#8894)
   - Zero-copy get_peaks_struct() accessor for MSChromatogram and Mobilogram (#8825, #8842)
   - Complete FileHandler wrapper: 14 new load/store methods for FeatureMap, ConsensusMap, identifications, and transformations (#8762)
 

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -2178,6 +2178,9 @@ or chromatograms only (SRM/MRM) and forwards to the appropriate loader.
             for (const auto& c : mobilos) {
                 if (explode) {
                     if (c.mobility.empty()) continue;
+                    if (c.mobility.size() != c.intensity.size()) {
+                        throw std::runtime_error("XIMParquetFile: mobility/intensity length mismatch");
+                    }
                     for (size_t j = 0; j < c.mobility.size(); ++j) {
                         run_id_list.append(c.run_id);
                         source_file_list.append(nb::str(c.source_file.c_str()));

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -61,6 +61,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessSqMass.h>
 #ifdef WITH_PARQUET
 #include <OpenMS/FORMAT/XICParquetFile.h>
+#include <OpenMS/FORMAT/XIMParquetFile.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/FORMAT/MSExperimentArrowExport.h>
 #include <OpenMS/FORMAT/FeatureMapArrowIO.h>
@@ -2045,6 +2046,215 @@ or chromatograms only (SRM/MRM) and forwards to the appropriate loader.
             return "XICParquetFile(n_files=" + std::to_string(files.size()) + ")";
         })
         .def("__str__", [](const OpenMS::XICParquetFile& self) { return nb::cast(self).attr("__repr__")(); })
+        ;
+
+    // -----------------------------------------------------------------------
+    // XIMParquetFile
+    // -----------------------------------------------------------------------
+    nb::class_<OpenMS::XIMParquetFile>(m, "XIMParquetFile", "OpenMS class XIMParquetFile")
+        .def(nb::init<OpenMS::String>())
+        .def(nb::init<std::vector<OpenMS::String>>())
+        .def(nb::init<const OpenMS::XIMParquetFile &>())
+        .def("__copy__", [](const OpenMS::XIMParquetFile& self) { return OpenMS::XIMParquetFile(self); })
+        .def("__deepcopy__", [](const OpenMS::XIMParquetFile& self, nb::dict) { return OpenMS::XIMParquetFile(self); }, "memo"_a)
+        .def("getFilename", [](const OpenMS::XIMParquetFile& self) { return self.getFilename(); }, "Reader for multiple OpenSWATH mobilogram Parquet files (.xim).")
+        .def("getFilenames", [](const OpenMS::XIMParquetFile& self) -> const std::vector<OpenMS::String> & { return self.getFilenames(); }, nb::rv_policy::reference_internal)
+
+        .def("getColumns", [](const OpenMS::XIMParquetFile& self) {
+            std::vector<OpenMS::String> columns;
+            self.getColumns(columns);
+            nb::list result;
+            for (const auto& col : columns) {
+                result.append(nb::str(col.c_str()));
+            }
+            return result;
+        }, "Return parquet schema column names as a list")
+
+        .def("getRuns", [](const OpenMS::XIMParquetFile& self) {
+            std::vector<OpenMS::XIMParquetFile::XIMRunInfo> runs;
+            self.getRuns(runs);
+            nb::list run_ids, source_files;
+            for (const auto& r : runs) {
+                run_ids.append(r.run_id);
+                source_files.append(nb::str(r.source_file.c_str()));
+            }
+            nb::dict result;
+            result["run_id"] = run_ids;
+            result["source_file"] = source_files;
+            return result;
+        }, "Return unique run metadata as a dict")
+
+        .def("getAnalytes", [](const OpenMS::XIMParquetFile& self, bool nest_transitions, nb::object columns_obj) {
+            std::vector<OpenMS::String> columns;
+            std::set<std::string> requested_cols;
+            bool filter_cols = !columns_obj.is_none();
+            if (filter_cols) {
+                for (auto item : columns_obj) {
+                    std::string col = nb::cast<std::string>(item);
+                    columns.push_back(col);
+                    std::string lower_col = col;
+                    std::transform(lower_col.begin(), lower_col.end(), lower_col.begin(), ::tolower);
+                    requested_cols.insert(lower_col);
+                }
+            }
+            std::vector<OpenMS::XIMParquetFile::XIMAnalyte> analytes;
+            self.getAnalytes(analytes, columns, nest_transitions);
+
+            nb::list precursor_id_list, modified_sequence_list, precursor_charge_list, precursor_decoy_list;
+            nb::list transition_id_list, product_charge_list, transition_ordinal_list;
+            nb::list detecting_transition_list, product_decoy_list, transition_type_list, annotation_list;
+
+            auto want = [&](const std::string& col) { return !filter_cols || requested_cols.count(col) > 0; };
+
+            for (const auto& a : analytes) {
+                if (want("precursor_id")) precursor_id_list.append(a.has_precursor_id ? nb::cast(a.precursor_id) : nb::none());
+                if (want("modified_sequence")) modified_sequence_list.append(nb::str(a.modified_sequence.c_str()));
+                if (want("precursor_charge")) precursor_charge_list.append(a.has_precursor_charge ? nb::cast(a.precursor_charge) : nb::none());
+                if (want("precursor_decoy")) precursor_decoy_list.append(a.has_precursor_decoy ? nb::cast(a.precursor_decoy) : nb::none());
+
+                if (!nest_transitions) {
+                    if (want("transition_id")) transition_id_list.append(a.has_transition_id ? nb::cast(a.transition_id) : nb::none());
+                    if (want("product_charge")) product_charge_list.append(a.has_product_charge ? nb::cast(a.product_charge) : nb::none());
+                    if (want("transition_ordinal")) transition_ordinal_list.append(a.has_transition_ordinal ? nb::cast(a.transition_ordinal) : nb::none());
+                    if (want("detecting_transition")) detecting_transition_list.append(a.has_detecting_transition ? nb::cast(a.detecting_transition) : nb::none());
+                    if (want("product_decoy")) product_decoy_list.append(a.has_product_decoy ? nb::cast(a.product_decoy) : nb::none());
+                    if (want("transition_type")) transition_type_list.append(nb::str(a.transition_type.c_str()));
+                    if (want("annotation")) annotation_list.append(nb::str(a.annotation.c_str()));
+                } else {
+                    nb::list t_ids, p_charges, t_ordinals, d_transitions, p_decoys, t_types, annots;
+                    for (auto v : a.transition_ids) t_ids.append(v >= 0 ? nb::cast(v) : nb::none());
+                    for (auto v : a.product_charges) p_charges.append(v >= 0 ? nb::cast(v) : nb::none());
+                    for (auto v : a.transition_ordinals) t_ordinals.append(v >= 0 ? nb::cast(v) : nb::none());
+                    for (auto v : a.detecting_transitions) d_transitions.append(v >= 0 ? nb::cast(v) : nb::none());
+                    for (auto v : a.product_decoys) p_decoys.append(v >= 0 ? nb::cast(v) : nb::none());
+                    for (const auto& s : a.transition_types) t_types.append(nb::str(s.c_str()));
+                    for (const auto& s : a.annotations) annots.append(nb::str(s.c_str()));
+                    if (want("transition_id")) transition_id_list.append(t_ids);
+                    if (want("product_charge")) product_charge_list.append(p_charges);
+                    if (want("transition_ordinal")) transition_ordinal_list.append(t_ordinals);
+                    if (want("detecting_transition")) detecting_transition_list.append(d_transitions);
+                    if (want("product_decoy")) product_decoy_list.append(p_decoys);
+                    if (want("transition_type")) transition_type_list.append(t_types);
+                    if (want("annotation")) annotation_list.append(annots);
+                }
+            }
+
+            nb::dict result;
+            if (want("precursor_id")) result["precursor_id"] = precursor_id_list;
+            if (want("modified_sequence")) result["modified_sequence"] = modified_sequence_list;
+            if (want("precursor_charge")) result["precursor_charge"] = precursor_charge_list;
+            if (want("precursor_decoy")) result["precursor_decoy"] = precursor_decoy_list;
+            if (want("transition_id")) result["transition_id"] = transition_id_list;
+            if (want("product_charge")) result["product_charge"] = product_charge_list;
+            if (want("transition_ordinal")) result["transition_ordinal"] = transition_ordinal_list;
+            if (want("detecting_transition")) result["detecting_transition"] = detecting_transition_list;
+            if (want("product_decoy")) result["product_decoy"] = product_decoy_list;
+            if (want("transition_type")) result["transition_type"] = transition_type_list;
+            if (want("annotation")) result["annotation"] = annotation_list;
+            return result;
+        }, "nest_transitions"_a = true, "columns"_a = nb::none(),
+           "Return unique analyte metadata as a dict")
+
+        .def("getMobilograms", [](const OpenMS::XIMParquetFile& self,
+                                    int64_t precursor_id, int64_t transition_id,
+                                    const std::string& modified_sequence,
+                                    int64_t precursor_charge, int64_t product_charge,
+                                    int64_t ms_level, int64_t run_id,
+                                    const std::string& mobilogram_type, int64_t feature_id, double feature_rt,
+                                    const std::string& filter, bool explode) {
+            std::vector<OpenMS::XIMParquetFile::XIMMobilogram> mobilos;
+            self.getMobilograms(mobilos, precursor_id, transition_id,
+                                  OpenMS::String(modified_sequence),
+                                  precursor_charge, product_charge,
+                                  ms_level, run_id, OpenMS::String(mobilogram_type), feature_id, feature_rt, OpenMS::String(filter));
+
+            nb::list run_id_list, source_file_list, ms_level_list;
+            nb::list precursor_id_list, transition_id_list, modified_sequence_list;
+            nb::list precursor_charge_list, product_charge_list, detecting_transition_list;
+            nb::list precursor_decoy_list, product_decoy_list, transition_ordinal_list;
+            nb::list transition_type_list, annotation_list, mobility_list, intensity_list;
+            nb::list mobilogram_type_list, feature_id_list, feature_rt_list;
+
+            for (const auto& c : mobilos) {
+                if (explode) {
+                    if (c.mobility.empty()) continue;
+                    for (size_t j = 0; j < c.mobility.size(); ++j) {
+                        run_id_list.append(c.run_id);
+                        source_file_list.append(nb::str(c.source_file.c_str()));
+                        ms_level_list.append(c.ms_level);
+                        precursor_id_list.append(c.has_precursor_id ? nb::cast(c.precursor_id) : nb::none());
+                        transition_id_list.append(c.has_transition_id ? nb::cast(c.transition_id) : nb::none());
+                        modified_sequence_list.append(nb::str(c.modified_sequence.c_str()));
+                        precursor_charge_list.append(c.has_precursor_charge ? nb::cast(c.precursor_charge) : nb::none());
+                        product_charge_list.append(c.has_product_charge ? nb::cast(c.product_charge) : nb::none());
+                        detecting_transition_list.append(c.has_detecting_transition ? nb::cast(c.detecting_transition) : nb::none());
+                        precursor_decoy_list.append(c.has_precursor_decoy ? nb::cast(c.precursor_decoy) : nb::none());
+                        product_decoy_list.append(c.has_product_decoy ? nb::cast(c.product_decoy) : nb::none());
+                        transition_ordinal_list.append(c.has_transition_ordinal ? nb::cast(c.transition_ordinal) : nb::none());
+                        transition_type_list.append(nb::str(c.transition_type.c_str()));
+                        annotation_list.append(nb::str(c.annotation.c_str()));
+                        mobilogram_type_list.append(nb::str(c.mobilogram_type.c_str()));
+                        feature_id_list.append(c.has_feature_id ? nb::cast(c.feature_id) : nb::none());
+                        feature_rt_list.append(c.has_feature_rt ? nb::cast(c.feature_rt) : nb::none());
+                        mobility_list.append(c.mobility[j]);
+                        intensity_list.append(c.intensity[j]);
+                    }
+                } else {
+                    run_id_list.append(c.run_id);
+                    source_file_list.append(nb::str(c.source_file.c_str()));
+                    ms_level_list.append(c.ms_level);
+                    precursor_id_list.append(c.has_precursor_id ? nb::cast(c.precursor_id) : nb::none());
+                    transition_id_list.append(c.has_transition_id ? nb::cast(c.transition_id) : nb::none());
+                    modified_sequence_list.append(nb::str(c.modified_sequence.c_str()));
+                    precursor_charge_list.append(c.has_precursor_charge ? nb::cast(c.precursor_charge) : nb::none());
+                    product_charge_list.append(c.has_product_charge ? nb::cast(c.product_charge) : nb::none());
+                    detecting_transition_list.append(c.has_detecting_transition ? nb::cast(c.detecting_transition) : nb::none());
+                    precursor_decoy_list.append(c.has_precursor_decoy ? nb::cast(c.precursor_decoy) : nb::none());
+                    product_decoy_list.append(c.has_product_decoy ? nb::cast(c.product_decoy) : nb::none());
+                    transition_ordinal_list.append(c.has_transition_ordinal ? nb::cast(c.transition_ordinal) : nb::none());
+                    transition_type_list.append(nb::str(c.transition_type.c_str()));
+                    annotation_list.append(nb::str(c.annotation.c_str()));
+                    mobilogram_type_list.append(nb::str(c.mobilogram_type.c_str()));
+                    feature_id_list.append(c.has_feature_id ? nb::cast(c.feature_id) : nb::none());
+                    feature_rt_list.append(c.has_feature_rt ? nb::cast(c.feature_rt) : nb::none());
+                    nb::list mobility_vals, int_vals;
+                    for (auto v : c.mobility) mobility_vals.append(v);
+                    for (auto v : c.intensity) int_vals.append(v);
+                    mobility_list.append(mobility_vals);
+                    intensity_list.append(int_vals);
+                }
+            }
+
+            nb::dict result;
+            result["run_id"] = run_id_list;
+            result["source_file"] = source_file_list;
+            result["ms_level"] = ms_level_list;
+            result["precursor_id"] = precursor_id_list;
+            result["transition_id"] = transition_id_list;
+            result["modified_sequence"] = modified_sequence_list;
+            result["precursor_charge"] = precursor_charge_list;
+            result["product_charge"] = product_charge_list;
+            result["detecting_transition"] = detecting_transition_list;
+            result["precursor_decoy"] = precursor_decoy_list;
+            result["product_decoy"] = product_decoy_list;
+            result["transition_ordinal"] = transition_ordinal_list;
+            result["transition_type"] = transition_type_list;
+            result["annotation"] = annotation_list;
+            result["mobilogram_type"] = mobilogram_type_list;
+            result["feature_id"] = feature_id_list;
+            result["feature_rt"] = feature_rt_list;
+            result["mobility"] = mobility_list;
+            result["intensity"] = intensity_list;
+            return result;
+        }, "precursor_id"_a = -1, "transition_id"_a = -1, "modified_sequence"_a = "",
+           "precursor_charge"_a = -1, "product_charge"_a = -1, "ms_level"_a = -1,
+           "run_id"_a = -1, "mobilogram_type"_a = "", "feature_id"_a = -1, "feature_rt"_a = -1.0, "filter"_a = "", "explode"_a = false,
+           "Return mobilogram data as a dict")
+        .def("__repr__", [](const OpenMS::XIMParquetFile& self) {
+            const auto& files = self.getFilenames();
+            return "XIMParquetFile(n_files=" + std::to_string(files.size()) + ")";
+        })
+        .def("__str__", [](const OpenMS::XIMParquetFile& self) { return nb::cast(self).attr("__repr__")(); })
         ;
 
     // -----------------------------------------------------------------------

--- a/src/pyOpenMS/pyopenms/addons/ximparquetfile.py
+++ b/src/pyOpenMS/pyopenms/addons/ximparquetfile.py
@@ -1,0 +1,337 @@
+"""XIMParquetFile addon methods for DataFrame support."""
+from . import addon
+
+
+class _MobilogramQuery:
+    """Chainable query builder for XIMParquetFile mobilograms.
+
+    Example::
+        q = xim.query_mobilograms()
+        df = q.filter_precursor_id(123).to_df()
+    """
+
+    def __init__(self, xim):
+        self._xim = xim
+        self._filters = []
+
+    def __repr__(self):
+        return f"MobilogramQuery(conditions={len(self._filters)})"
+
+    def _add_filter(self, column, value, op="="):
+        if isinstance(value, (list, tuple)):
+            values_str = ",".join(str(v) for v in value)
+            self._filters.append(f"{column} IN ({values_str})")
+        else:
+            self._filters.append(f"{column}{op}{value}")
+        return self
+
+    def filter_precursor_id(self, value, op="="):
+        return self._add_filter("precursor_id", value, op)
+
+    def filter_transition_id(self, value, op="="):
+        return self._add_filter("transition_id", value, op)
+
+    def filter_ms_level(self, value, op="="):
+        return self._add_filter("ms_level", value, op)
+
+    def filter_run_id(self, value, op="="):
+        return self._add_filter("run_id", value, op)
+
+    def filter_precursor_charge(self, value, op="="):
+        return self._add_filter("precursor_charge", value, op)
+
+    def filter_product_charge(self, value, op="="):
+        return self._add_filter("product_charge", value, op)
+
+    def filter_annotation(self, value, op="="):
+        if isinstance(value, str):
+            return self._add_filter("annotation", f'"{value}"', op)
+        return self._add_filter("annotation", value, op)
+
+    def filter_modified_sequence(self, value, op="="):
+        if isinstance(value, str):
+            return self._add_filter("modified_sequence", f'"{value}"', op)
+        return self._add_filter("modified_sequence", value, op)
+
+    def filter_transition_type(self, value, op="="):
+        if isinstance(value, str):
+            return self._add_filter("transition_type", f'"{value}"', op)
+        return self._add_filter("transition_type", value, op)
+
+    def to_dict(self, explode=False):
+        """Return mobilogram data as dict."""
+        filter_str = " AND ".join(self._filters) if self._filters else ""
+        return self._xim.get_data_dict(explode=explode, filter=filter_str)
+
+    def to_df(self, explode=True):
+        """Return mobilogram data as a pandas DataFrame."""
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise ImportError(
+                "pandas is required for to_df(). Install with `pip install pandas`."
+            ) from e
+        data = self.to_dict(explode=explode)
+        return pd.DataFrame({k: list(v) for k, v in data.items()})
+
+
+@addon("XIMParquetFile")
+def __len__(self):
+    """Return the number of files associated with this instance."""
+    try:
+        return len(self.getFilenames())
+    except Exception:
+        return 0
+
+
+@addon("XIMParquetFile")
+def df_columns(self):
+    """
+    Return the parquet schema column names.
+
+    Returns
+    -------
+    list
+        List of column names.
+    """
+    return self.getColumns()
+
+
+@addon("XIMParquetFile")
+def get_data_dict(self, explode=False, precursor_id=-1, transition_id=-1,
+                  modified_sequence="", precursor_charge=-1, product_charge=-1,
+                  ms_level=-1, run_id=-1, mobilogram_type="", feature_id=-1, feature_rt=-1.0, filter=""):
+    """
+    Return mobilogram data as a dict.
+
+    If explode=True, returns long format with mobility/intensity rows.
+    Otherwise, mobility and intensity are stored as lists.
+
+    Parameters
+    ----------
+    explode : bool
+        If True, return long format with one row per mobility/intensity.
+    precursor_id : int
+        Optional precursor id (-1 to ignore).
+    transition_id : int
+        Optional transition id (-1 to ignore).
+    modified_sequence : str
+        Optional modified sequence filter (empty to ignore).
+    precursor_charge : int
+        Optional precursor charge filter (-1 to ignore).
+    product_charge : int
+        Optional product charge filter (-1 to ignore).
+    ms_level : int
+        Optional MS level filter (-1 to ignore).
+    run_id : int
+        Optional run id filter (-1 to ignore).
+    mobilogram_type : str
+        Optional mobilogram type filter (empty to ignore).
+    feature_id : int
+        Optional feature id filter (-1 to ignore).
+    feature_rt : float
+        Optional feature RT filter (<0 to ignore).
+    filter : str
+        Optional filter expression string.
+
+    Returns
+    -------
+    dict
+        Dict of lists keyed by column name.
+    """
+    return self.getMobilograms(
+        precursor_id=precursor_id,
+        transition_id=transition_id,
+        modified_sequence=modified_sequence,
+        precursor_charge=precursor_charge,
+        product_charge=product_charge,
+        ms_level=ms_level,
+        run_id=run_id,
+        mobilogram_type=mobilogram_type,
+        feature_id=feature_id,
+        feature_rt=feature_rt,
+        filter=filter,
+        explode=explode
+    )
+
+
+@addon("XIMParquetFile")
+def get_run_dict(self):
+    """
+    Return unique run metadata as a dict.
+
+    Returns
+    -------
+    dict
+        Dict with run_id and source_file lists.
+    """
+    return self.getRuns()
+
+
+@addon("XIMParquetFile")
+def get_run_df(self):
+    """
+    Return unique run metadata as a pandas DataFrame.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with run_id and source_file.
+
+    Raises
+    ------
+    ImportError
+        If pandas is not installed.
+    """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas is required for this method. Install with `pip install pandas`."
+        ) from e
+    data = self.get_run_dict()
+    return pd.DataFrame(data)
+
+
+@addon("XIMParquetFile")
+def get_analyte_dict(self, nest_transitions=True, columns=None):
+    """
+    Return unique analyte metadata as a dict.
+
+    If nest_transitions=False, each row represents a unique precursor-transition
+    pair with scalar transition fields. If nest_transitions=True, each row
+    represents a unique precursor and transition fields are lists.
+
+    Parameters
+    ----------
+    nest_transitions : bool
+        Aggregate transition fields per precursor.
+    columns : list, optional
+        List of column names to return. If None, uses all columns.
+
+    Returns
+    -------
+    dict
+        Dict of lists keyed by column name.
+    """
+    return self.getAnalytes(nest_transitions=nest_transitions, columns=columns)
+
+
+@addon("XIMParquetFile")
+def get_analyte_df(self, nest_transitions=True, columns=None):
+    """
+    Return unique analyte metadata as a pandas DataFrame.
+
+    Parameters
+    ----------
+    nest_transitions : bool
+        Aggregate transition fields per precursor.
+    columns : list, optional
+        List of column names to return.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with analyte metadata.
+
+    Raises
+    ------
+    ImportError
+        If pandas is not installed.
+    """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas is required for this method. Install with `pip install pandas`."
+        ) from e
+    data = self.get_analyte_dict(nest_transitions=nest_transitions, columns=columns)
+    return pd.DataFrame({k: list(v) for k, v in data.items()})
+
+
+@addon("XIMParquetFile")
+def to_df(self, explode=False):
+    """
+    Return mobilogram data as a pandas DataFrame.
+
+    If explode=True, returns long format with mobility/intensity rows.
+
+    Parameters
+    ----------
+    explode : bool
+        If True, return long format with one row per mobility/intensity.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with mobilogram data.
+
+    Raises
+    ------
+    ImportError
+        If pandas is not installed.
+    """
+    try:
+        import pandas as pd
+    except ImportError as e:
+        raise ImportError(
+            "pandas is required for to_df(). Install with `pip install pandas`."
+        ) from e
+    data = self.get_data_dict(explode=explode)
+    if explode:
+        return pd.DataFrame(data)
+    # Convert to plain Python lists to avoid pandas inferring 2D arrays.
+    clean = {}
+    for k, v in data.items():
+        if hasattr(v, "ndim") and v.ndim > 1:
+            clean[k] = [row for row in v]
+        else:
+            clean[k] = list(v)
+    return pd.DataFrame(clean)
+
+
+@addon("XIMParquetFile")
+def to_arrow(self, explode=False):
+    """
+    Returns an Apache Arrow Table representation of the mobilograms.
+
+    If explode=True, returns long format with mobility/intensity rows.
+
+    Parameters
+    ----------
+    explode : bool
+        If True, return long format with one row per mobility/intensity.
+
+    Returns
+    -------
+    pyarrow.Table
+        Arrow Table with mobilogram data.
+
+    Raises
+    ------
+    ImportError
+        If pyarrow is not installed.
+    """
+    try:
+        import pyarrow as pa
+    except ImportError as e:
+        raise ImportError(
+            "pyarrow is required for to_arrow(). Install with `pip install pyarrow`."
+        ) from e
+    return pa.Table.from_pydict(self.get_data_dict(explode=explode))
+
+
+@addon("XIMParquetFile")
+def query_mobilograms(self):
+    """
+    Return a chainable query builder for mobilograms.
+
+    Example::
+        df = xim.query_mobilograms().filter_precursor_id(123).to_df()
+
+    Returns
+    -------
+    _MobilogramQuery
+        Query builder with filter methods and to_df()/to_dict().
+    """
+    return _MobilogramQuery(self)

--- a/src/pyOpenMS/pyopenms/addons/ximparquetfile.py
+++ b/src/pyOpenMS/pyopenms/addons/ximparquetfile.py
@@ -1,4 +1,5 @@
 """XIMParquetFile addon methods for DataFrame support."""
+
 from . import addon
 
 
@@ -17,12 +18,19 @@ class _MobilogramQuery:
     def __repr__(self):
         return f"MobilogramQuery(conditions={len(self._filters)})"
 
+    @staticmethod
+    def _format_filter_value(value):
+        if isinstance(value, str):
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        return str(value)
+
     def _add_filter(self, column, value, op="="):
         if isinstance(value, (list, tuple)):
-            values_str = ",".join(str(v) for v in value)
+            values_str = ",".join(self._format_filter_value(v) for v in value)
             self._filters.append(f"{column} IN ({values_str})")
         else:
-            self._filters.append(f"{column}{op}{value}")
+            self._filters.append(f"{column}{op}{self._format_filter_value(value)}")
         return self
 
     def filter_precursor_id(self, value, op="="):
@@ -44,24 +52,18 @@ class _MobilogramQuery:
         return self._add_filter("product_charge", value, op)
 
     def filter_annotation(self, value, op="="):
-        if isinstance(value, str):
-            return self._add_filter("annotation", f'"{value}"', op)
         return self._add_filter("annotation", value, op)
 
     def filter_modified_sequence(self, value, op="="):
-        if isinstance(value, str):
-            return self._add_filter("modified_sequence", f'"{value}"', op)
         return self._add_filter("modified_sequence", value, op)
 
     def filter_transition_type(self, value, op="="):
-        if isinstance(value, str):
-            return self._add_filter("transition_type", f'"{value}"', op)
         return self._add_filter("transition_type", value, op)
 
     def to_dict(self, explode=False):
         """Return mobilogram data as dict."""
         filter_str = " AND ".join(self._filters) if self._filters else ""
-        return self._xim.get_data_dict(explode=explode, filter=filter_str)
+        return self._xim.get_data_dict(explode=explode, filter_expr=filter_str)
 
     def to_df(self, explode=True):
         """Return mobilogram data as a pandas DataFrame."""
@@ -79,8 +81,9 @@ class _MobilogramQuery:
 def __len__(self):
     """Return the number of files associated with this instance."""
     try:
-        return len(self.getFilenames())
-    except Exception:
+        filenames = self.getFilenames()
+        return len(filenames) if filenames is not None else 0
+    except AttributeError:
         return 0
 
 
@@ -98,9 +101,22 @@ def df_columns(self):
 
 
 @addon("XIMParquetFile")
-def get_data_dict(self, explode=False, precursor_id=-1, transition_id=-1,
-                  modified_sequence="", precursor_charge=-1, product_charge=-1,
-                  ms_level=-1, run_id=-1, mobilogram_type="", feature_id=-1, feature_rt=-1.0, filter=""):
+def get_data_dict(
+    self,
+    explode=False,
+    precursor_id=-1,
+    transition_id=-1,
+    modified_sequence="",
+    precursor_charge=-1,
+    product_charge=-1,
+    ms_level=-1,
+    run_id=-1,
+    mobilogram_type="",
+    feature_id=-1,
+    feature_rt=-1.0,
+    filter_expr="",
+    **kwargs,
+):
     """
     Return mobilogram data as a dict.
 
@@ -131,7 +147,7 @@ def get_data_dict(self, explode=False, precursor_id=-1, transition_id=-1,
         Optional feature id filter (-1 to ignore).
     feature_rt : float
         Optional feature RT filter (<0 to ignore).
-    filter : str
+    filter_expr : str
         Optional filter expression string.
 
     Returns
@@ -150,8 +166,8 @@ def get_data_dict(self, explode=False, precursor_id=-1, transition_id=-1,
         mobilogram_type=mobilogram_type,
         feature_id=feature_id,
         feature_rt=feature_rt,
-        filter=filter,
-        explode=explode
+        filter=filter_expr,
+        explode=explode,
     )
 
 

--- a/src/pyOpenMS/tests/unittests/test_XIMParquetFile.py
+++ b/src/pyOpenMS/tests/unittests/test_XIMParquetFile.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+
+import pytest
+
+
+def _repo_root():
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+    )
+
+
+def _xim_path():
+    return os.path.join(
+        _repo_root(),
+        "src",
+        "tests",
+        "class_tests",
+        "openms",
+        "data",
+        "XIMParquetFile_23_input.xim",
+    )
+
+
+def _get_xim():
+    import pyopenms as poms
+
+    # Check if XIMParquetFile class exists (may be excluded when WITH_PARQUET=False)
+    if not hasattr(poms, 'XIMParquetFile'):
+        pytest.skip("pyopenms built without parquet support")
+
+    try:
+        return poms.XIMParquetFile(_xim_path())
+    except RuntimeError as e:
+        if "Parquet support" in str(e):
+            pytest.skip("pyopenms built without parquet support")
+        raise
+
+
+def test_xim_df_columns():
+    xim = _get_xim()
+    cols = xim.df_columns()
+    assert "RUN_ID" in cols
+    assert "MOBILITY_DATA" in cols
+
+
+def test_xim_run_dict():
+    xim = _get_xim()
+    runs = xim.get_run_dict()
+    assert "run_id" in runs
+    assert "source_file" in runs
+    assert len(runs["run_id"]) > 0
+
+
+def test_xim_analyte_dict_default_nested():
+    xim = _get_xim()
+    nested = xim.get_analyte_dict()
+    exploded = xim.get_analyte_dict(nest_transitions=False)
+    assert len(nested["precursor_id"]) > 0
+    assert len(exploded["precursor_id"]) >= len(nested["precursor_id"])
+    # nested transition fields should be list-like (list or array)
+    assert hasattr(nested["transition_id"][0], "__iter__")
+
+
+def test_xim_analyte_columns_subset():
+    xim = _get_xim()
+    subset = xim.get_analyte_dict(columns=["PRECURSOR_ID", "MODIFIED_SEQUENCE"])
+    assert set(subset.keys()) == {"precursor_id", "modified_sequence"}
+
+
+def test_xim_analyte_columns_invalid():
+    xim = _get_xim()
+    with pytest.raises(RuntimeError):
+        xim.get_analyte_dict(columns=["PRECURSOR_CHARGE5"])
+
+
+def test_xim_to_df_summary_and_exploded():
+    xim = _get_xim()
+    df_summary = xim.to_df()
+    df_exploded = xim.to_df(explode=True)
+    assert len(df_summary) > 0
+    assert len(df_exploded) >= len(df_summary)
+    assert hasattr(df_summary.iloc[0]["mobility"], "__iter__")
+    assert hasattr(df_summary.iloc[0]["intensity"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["mobility"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["intensity"], "__iter__")
+
+
+def test_xim_query_builder_summary_and_exploded():
+    xim = _get_xim()
+    analytes = xim.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
+    precursor_id = analytes["precursor_id"][0]
+    df_summary = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=False)
+    df_exploded = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=True)
+    assert len(df_summary) > 0
+    assert len(df_exploded) >= len(df_summary)
+    assert hasattr(df_summary.iloc[0]["mobility"], "__iter__")
+    assert hasattr(df_summary.iloc[0]["intensity"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["mobility"], "__iter__")
+    assert not hasattr(df_exploded.iloc[0]["intensity"], "__iter__")
+
+
+def test_xim_query_builder():
+    xim = _get_xim()
+    analytes = xim.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
+    precursor_id = analytes["precursor_id"][0]
+    df = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=False)
+    assert len(df) > 0

--- a/src/pyOpenMS/tests/unittests/test_XIMParquetFile.py
+++ b/src/pyOpenMS/tests/unittests/test_XIMParquetFile.py
@@ -28,7 +28,7 @@ def _get_xim():
     import pyopenms as poms
 
     # Check if XIMParquetFile class exists (may be excluded when WITH_PARQUET=False)
-    if not hasattr(poms, 'XIMParquetFile'):
+    if not hasattr(poms, "XIMParquetFile"):
         pytest.skip("pyopenms built without parquet support")
 
     try:
@@ -91,9 +91,16 @@ def test_xim_to_df_summary_and_exploded():
 def test_xim_query_builder_summary_and_exploded():
     xim = _get_xim()
     analytes = xim.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
-    precursor_id = analytes["precursor_id"][0]
-    df_summary = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=False)
-    df_exploded = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=True)
+    precursor_id = next(
+        (pid for pid in analytes["precursor_id"] if pid is not None), None
+    )
+    assert precursor_id is not None
+    df_summary = (
+        xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=False)
+    )
+    df_exploded = (
+        xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=True)
+    )
     assert len(df_summary) > 0
     assert len(df_exploded) >= len(df_summary)
     assert hasattr(df_summary.iloc[0]["mobility"], "__iter__")
@@ -105,6 +112,9 @@ def test_xim_query_builder_summary_and_exploded():
 def test_xim_query_builder():
     xim = _get_xim()
     analytes = xim.get_analyte_dict(columns=["PRECURSOR_ID"], nest_transitions=False)
-    precursor_id = analytes["precursor_id"][0]
+    precursor_id = next(
+        (pid for pid in analytes["precursor_id"] if pid is not None), None
+    )
+    assert precursor_id is not None
     df = xim.query_mobilograms().filter_precursor_id(precursor_id).to_df(explode=False)
     assert len(df) > 0


### PR DESCRIPTION
## Description

Added python bindings fir the extracted ion mobilogram parquet files introduced in [PR #8871](https://github.com/OpenMS/OpenMS/pull/8871). The bindings are pretty much the same as the XIC parquet fles python bindings.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XIMParquetFile for reading and analyzing ion-mobility Parquet data.
  * Chainable query builder for flexible mobilogram filtering.
  * Export mobilogram data to pandas DataFrame and PyArrow table.
  * Direct access to run and analyte metadata and rich mobilogram structures.

* **Tests**
  * Added unit tests covering schema, queries, DataFrame/arrow exports, and metadata access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->