### PR TITLE
Build: Add vcpkg-configuration.json to establish registry baseline for reproducible builds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ General:
   - Ubuntu CI runners updated to 24.04
   - macOS code signing and notarization integrated directly into CI (#8486, #8494, #8527)
   - Parquet support enabled across all platforms (#8370, #8422)
+  - Modernized TransformationModelInterpolated to use std::unique_ptr for memory safety
   - Modernized TransformationDescription to use std::unique_ptr for memory safety
   - Fix undefined behavior in ProteinIdentification get*DataArrayByName by throwing ElementNotFound when the name is missing
   - Removed leftover traces of removed doc_internal target (#2256)

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
@@ -12,10 +12,11 @@
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
 #include <memory>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
+
 
 namespace OpenMS
 {
+  class TransformationModelLinear;
   /**
     @brief Interpolation model for transformations
 

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h
@@ -11,6 +11,7 @@
 #include <OpenMS/config.h>
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
+#include <memory>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
 
 namespace OpenMS
@@ -113,13 +114,13 @@ private:
     std::vector<double> y_;
 
     /// Interpolation function
-    Interpolator* interp_;
+    std::unique_ptr<Interpolator> interp_;
 
     /// Linear model for extrapolation (front)
-    TransformationModelLinear* lm_front_;
+    std::unique_ptr<TransformationModelLinear> lm_front_;
 
     /// Linear model for extrapolation (back)
-    TransformationModelLinear* lm_back_;
+    std::unique_ptr<TransformationModelLinear> lm_back_;
 
     /// Preprocesses the incoming data and fills the (private) vectors x_ and y_
     void preprocessDataPoints_(const DataPoints& data);

--- a/src/openms/include/OpenMS/FORMAT/PercolatorInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/PercolatorInfile.h
@@ -8,82 +8,79 @@
 
 #pragma once
 
+#include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
-#include <OpenMS/FORMAT/TextFile.h>
-
 #include <vector>
 
 namespace OpenMS
 {
 
+/**
+   @brief Class for storing Percolator tab-delimited input files.
+
+*/
+class OPENMS_DLLAPI PercolatorInfile
+{
+public:
+  static void store(const String& pin_file,
+                    const PeptideIdentificationList& peptide_ids,
+                    const StringList& feature_set,
+                    const std::string& enz,
+                    int min_charge,
+                    int max_charge);
+
+
   /**
-     @brief Class for storing Percolator tab-delimited input files.
+  * @brief Loads peptide identifications from a Percolator input file.
+  *
+  * This function reads a Percolator input file (`pin_file`) and returns a vector of `PeptideIdentification` objects.
+  * It extracts relevantinformation such as peptide sequences, scores, charges, annotations, and protein accessions, applying
+  * specified thresholds and handling decoy targets as needed.
+  * Note: If a filename column is encountered the set of @p filenames is filled in the order of appearance and PeptideIdentifications annotated with
+  the id_merge_index meta value to link them to the filename (similar to a merged idXML file).
+  *
+  * @param[in] pin_file he path to the Percolator input file with a `.pin` extension.
+  *
+  * @param[in] higher_score_better A boolean flag indicating whether higher scores are considered better (`true`) or lower scores are better
+  (`false`).
+  *
+  * @param[in] score_name The name of the primary score to be used for ranking peptide hits.
+  *
+  * @param[out] extra_scores A list of additional score names that should be extracted and stored in each `PeptideHit`.
+  *
+  * @param[out] filenames Will be populated with the unique raw file names extracted from the input data.
+  *
+  * @param[in] decoy_prefix The prefix used to identify decoy protein accessions. Proteins with accessions starting with this prefix are marked as
+  decoys. Otherwise, it assumes that the pin file already contains the correctly annotated decoy status.
+  * @param[in] threshold A double value representing the threshold for the `spectrum_q` value. Only spectra with `spectrum_q` below this threshold are
+  processed. Implemented to allow prefiltering of Sage results.
+  * @param[in] sage_annotation A boolean value used to determine if the pin file is coming from Sage or not
+  * @return A `std::vector` of `PeptideIdentification` objects containing the peptide identifications.
 
+  * @throws `Exception::ParseError` if any line in the input file does not have the expected number of columns.
+  * TODO: implement something similar to PepXMLFile().setPreferredFixedModifications(getModifications_(fixed_modifications_names));
   */
-  class OPENMS_DLLAPI PercolatorInfile
-  {
-    public:
-      static void store(const String& pin_file, 
-        const PeptideIdentificationList& peptide_ids, 
-        const StringList& feature_set, 
-        const std::string& enz, 
-        int min_charge, 
-        int max_charge);
+  static PeptideIdentificationList load(const String& pin_file,
+                                        bool higher_score_better,
+                                        const String& score_name,
+                                        const StringList& extra_scores,
+                                        StringList& filenames,
+                                        String decoy_prefix = "",
+                                        double threshold = 0.01,
+                                        bool sage_annotation = false);
 
+  // uses spectrum_reference, if empty uses spectrum_id, if also empty fall back to using index
+  static String getScanIdentifier(const PeptideIdentification& pid, size_t index);
 
-      /**
-      * @brief Loads peptide identifications from a Percolator input file.
-      * 
-      * This function reads a Percolator input file (`pin_file`) and returns a vector of `PeptideIdentification` objects. 
-      * It extracts relevantinformation such as peptide sequences, scores, charges, annotations, and protein accessions, applying
-      * specified thresholds and handling decoy targets as needed.
-      * Note: If a filename column is encountered the set of @p filenames is filled in the order of appearance and PeptideIdentifications annotated with the id_merge_index meta value to link them to the filename (similar to a merged idXML file). 
-      * 
-      * @param[in] pin_file he path to the Percolator input file with a `.pin` extension.
-      * 
-      * @param[in] higher_score_better A boolean flag indicating whether higher scores are considered better (`true`) or lower scores are better (`false`).
-      * 
-      * @param[in] score_name The name of the primary score to be used for ranking peptide hits.
-      * 
-      * @param[out] extra_scores A list of additional score names that should be extracted and stored in each `PeptideHit`.
-      * 
-      * @param[out] filenames Will be populated with the unique raw file names extracted from the input data.
-      * 
-      * @param[in] decoy_prefix The prefix used to identify decoy protein accessions. Proteins with accessions starting with this prefix are marked as decoys. Otherwise, it assumes that the pin file already contains the correctly annotated decoy status.
-      * @param[in] threshold A double value representing the threshold for the `spectrum_q` value. Only spectra with `spectrum_q` below this threshold are processed.
-                         Implemented to allow prefiltering of Sage results.
-      * @param[in] SageAnnotation A boolean value used to determine if the pin file is coming from Sage or not 
-      * @return A `std::vector` of `PeptideIdentification` objects containing the peptide identifications.
-      
-      * @throws `Exception::ParseError` if any line in the input file does not have the expected number of columns.
-      * TODO: implement something similar to PepXMLFile().setPreferredFixedModifications(getModifications_(fixed_modifications_names));      
-      */
-      static PeptideIdentificationList load(const String& pin_file, 
-        bool higher_score_better, 
-        const String& score_name, 
-        const StringList& extra_scores,
-        StringList& filenames, 
-        String decoy_prefix = "",
-        double threshold = 0.01, 
-        bool SageAnnotation = false);
+protected:
+  // id <tab> label <tab> scannr <tab> calcmass <tab> expmass <tab> feature1 <tab> ... <tab> featureN <tab> peptide <tab> proteinId1 <tab> .. <tab>
+  // proteinIdM
+  static TextFile
+  preparePin_(const PeptideIdentificationList& peptide_ids, const StringList& feature_set, const std::string& enz, int min_charge, int max_charge);
 
-      // uses spectrum_reference, if empty uses spectrum_id, if also empty fall back to using index
-      static String getScanIdentifier(const PeptideIdentification& pid, size_t index);
-      
-    protected:
+  static bool isEnz_(const char& n, const char& c, const std::string& enz);
 
-      //id <tab> label <tab> scannr <tab> calcmass <tab> expmass <tab> feature1 <tab> ... <tab> featureN <tab> peptide <tab> proteinId1 <tab> .. <tab> proteinIdM
-      static TextFile preparePin_(
-        const PeptideIdentificationList& peptide_ids, 
-        const StringList& feature_set, 
-        const std::string& enz, 
-        int min_charge, 
-        int max_charge);
-
-      static bool isEnz_(const char& n, const char& c, const std::string& enz);
-
-      static Size countEnzymatic_(const String& peptide, const std::string& enz);
-
-  };
+  static Size countEnzymatic_(const String& peptide, const std::string& enz);
+};
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
 #include <OpenMS/MATH/StatisticFunctions.h>

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
 
 // Spline2dInterpolator
 #include <OpenMS/MATH/MISC/CubicSpline2d.h>
@@ -39,7 +40,7 @@ public:
       if (spline_ != (CubicSpline2d*) nullptr) 
 
       // initialize spline
-      spline_ = new CubicSpline2d(x, y);
+      spline_ = std::make_unique<CubicSpline2d>(x, y);
     }
 
     double eval(const double& x) const override
@@ -47,10 +48,7 @@ public:
       return spline_->eval(x);
     }
 
-    ~Spline2dInterpolator() override
-    {
-      
-    }
+    ~Spline2dInterpolator() override = default;
 
 private:
     CubicSpline2d* spline_{nullptr};
@@ -72,7 +70,7 @@ public:
     {
       if (interpolator_ != (gte::IntpAkimaNonuniform1<double>*) nullptr) 
       // re-construct a new interpolator
-      interpolator_ = new gte::IntpAkimaNonuniform1<double>(static_cast<int>(x.size()), &x.front(), &y.front());
+      interpolator_ = std::make_unique<gte::IntpAkimaNonuniform1<double>>(static_cast<int>(x.size()), &x.front(), &y.front());
     }
 
     double eval(const double& x) const override
@@ -80,10 +78,7 @@ public:
       return (* interpolator_)(x);
     }
 
-    ~AkimaInterpolator() override
-    {
-      
-    }
+    ~AkimaInterpolator() override = default;
 
 private:
     gte::IntpAkimaNonuniform1<double>* interpolator_{nullptr};
@@ -291,10 +286,7 @@ private:
     }
     else
     {
-      if (interp_)
-      {
-        
-      }
+      
 
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                        "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
@@ -362,22 +354,14 @@ private:
     }
     else
     {
-      if (interp_) 
-      {
-        
-      }
+      
 
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
           "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
     }
   }
 
-  TransformationModelInterpolated::~TransformationModelInterpolated()
-  {
-    
-    
-    
-  }
+  TransformationModelInterpolated::~TransformationModelInterpolated() = default;
 
   double TransformationModelInterpolated::evaluate(double value) const
   {

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -6,16 +6,14 @@
 // $Authors: Stephan Aiche $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/DATASTRUCTURES/ListUtils.h>
-
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
 // Spline2dInterpolator
 #include <OpenMS/MATH/MISC/CubicSpline2d.h>
-
 #include <numeric>
 
 // AkimaInterpolator
@@ -23,367 +21,330 @@
 
 namespace OpenMS
 {
-  /**
-   * @brief Spline2dInterpolator
-   */
-  class Spline2dInterpolator :
-    public TransformationModelInterpolated::Interpolator
-  {
+/**
+ * @brief Spline2dInterpolator
+ */
+class Spline2dInterpolator : public TransformationModelInterpolated::Interpolator
+{
 public:
-    Spline2dInterpolator() 
-      
+  Spline2dInterpolator()
+
     = default;
 
-    void init(std::vector<double>& x, std::vector<double>& y) override
-    {
-      // cleanup before we use a new one
-      if (spline_ != (CubicSpline2d*) nullptr) 
+  void init(std::vector<double>& x, std::vector<double>& y) override
+  {
+    // (re)initialize spline; unique_ptr assignment frees any prior instance
+    spline_ = std::make_unique<CubicSpline2d>(x, y);
+  }
 
-      // initialize spline
-      spline_ = std::make_unique<CubicSpline2d>(x, y);
-    }
+  double eval(const double& x) const override
+  {
+    return spline_->eval(x);
+  }
 
-    double eval(const double& x) const override
-    {
-      return spline_->eval(x);
-    }
-
-    ~Spline2dInterpolator() override = default;
+  ~Spline2dInterpolator() override = default;
 
 private:
-    CubicSpline2d* spline_{nullptr};
-    // Spline2d<double>* spline_;
-  };
+  std::unique_ptr<CubicSpline2d> spline_;
+};
 
-  /**
-   * @brief AkimaInterpolator
-   */
-  class AkimaInterpolator :
-    public TransformationModelInterpolated::Interpolator
-  {
+/**
+ * @brief AkimaInterpolator
+ */
+class AkimaInterpolator : public TransformationModelInterpolated::Interpolator
+{
 public:
-    AkimaInterpolator() 
-      
+  AkimaInterpolator()
+
     = default;
 
-    void init(std::vector<double>& x, std::vector<double>& y) override
-    {
-      if (interpolator_ != (gte::IntpAkimaNonuniform1<double>*) nullptr) 
-      // re-construct a new interpolator
-      interpolator_ = std::make_unique<gte::IntpAkimaNonuniform1<double>>(static_cast<int>(x.size()), &x.front(), &y.front());
-    }
+  void init(std::vector<double>& x, std::vector<double>& y) override
+  {
+    // (re)construct interpolator; unique_ptr assignment frees any prior instance
+    interpolator_ = std::make_unique<gte::IntpAkimaNonuniform1<double>>(static_cast<int>(x.size()), &x.front(), &y.front());
+  }
 
-    double eval(const double& x) const override
-    {
-      return (* interpolator_)(x);
-    }
+  double eval(const double& x) const override
+  {
+    return (*interpolator_)(x);
+  }
 
-    ~AkimaInterpolator() override = default;
+  ~AkimaInterpolator() override = default;
 
 private:
-    gte::IntpAkimaNonuniform1<double>* interpolator_{nullptr};
-  };
+  std::unique_ptr<gte::IntpAkimaNonuniform1<double>> interpolator_;
+};
 
-  /**
-   * @brief LinearInterpolator.
-   */
-  class LinearInterpolator :
-    public TransformationModelInterpolated::Interpolator
-  {
+/**
+ * @brief LinearInterpolator.
+ */
+class LinearInterpolator : public TransformationModelInterpolated::Interpolator
+{
 public:
-    LinearInterpolator()
-    = default;
+  LinearInterpolator() = default;
 
-    void init(std::vector<double>& x, std::vector<double>& y) override
+  void init(std::vector<double>& x, std::vector<double>& y) override
+  {
+    // clear data
+    x_.clear();
+    y_.clear();
+
+    // copy data
+    // TODO: should we solve this using pointers to the original data?
+    x_.insert(x_.begin(), x.begin(), x.end());
+    y_.insert(y_.begin(), y.begin(), y.end());
+  }
+
+  double eval(const double& x) const override
+  {
+    // find nearest pair of points
+    std::vector<double>::const_iterator it = std::upper_bound(x_.begin(), x_.end(), x);
+
+    // interpolator is guaranteed to be only evaluated on points x, x_.front() =< x =< x x.back()
+    // see TransformationModelInterpolated::evaluate
+
+    // compute interpolation
+    // the only point that is > then an element in our series is y_.back()
+    // see call guarantee above
+    if (it == x_.end()) { return y_.back(); }
+    else
     {
-      // clear data
-      x_.clear();
-      y_.clear();
+      // interpolate .. invariant: idx > 0
+      const SignedSize idx = it - x_.begin();
+      const double x_0 = x_[idx - 1];
+      const double x_1 = x_[idx];
+      const double y_0 = y_[idx - 1];
+      const double y_1 = y_[idx];
 
-      // copy data
-      // TODO: should we solve this using pointers to the original data?
-      x_.insert(x_.begin(), x.begin(), x.end());
-      y_.insert(y_.begin(), y.begin(), y.end());
+      return y_0 + (y_1 - y_0) * (x - x_0) / (x_1 - x_0);
     }
+  }
 
-    double eval(const double& x) const override
-    {
-      // find nearest pair of points
-      std::vector<double>::const_iterator it = std::upper_bound(x_.begin(), x_.end(), x);
-
-      // interpolator is guaranteed to be only evaluated on points x, x_.front() =< x =< x x.back()
-      // see TransformationModelInterpolated::evaluate
-
-      // compute interpolation
-      // the only point that is > then an element in our series is y_.back()
-      // see call guarantee above
-      if (it == x_.end())
-      {
-        return y_.back();
-      }
-      else
-      {
-        // interpolate .. invariant: idx > 0
-        const SignedSize idx = it - x_.begin();
-        const double x_0 = x_[idx - 1];
-        const double x_1 = x_[idx];
-        const double y_0 = y_[idx - 1];
-        const double y_1 = y_[idx];
-
-        return y_0 + (y_1 - y_0) * (x - x_0) / (x_1 - x_0);
-      }
-    }
-
-    ~LinearInterpolator() override
-    = default;
+  ~LinearInterpolator() override = default;
 
 private:
-    /// x values
-    std::vector<double> x_;
-    /// y values
-    std::vector<double> y_;
-  };
+  /// x values
+  std::vector<double> x_;
+  /// y values
+  std::vector<double> y_;
+};
 
-  void TransformationModelInterpolated::preprocessDataPoints_(const DataPoints& data)
+void TransformationModelInterpolated::preprocessDataPoints_(const DataPoints& data)
+{
+  // need monotonically increasing x values (can't have the same value twice):
+  std::map<double, std::vector<double>> mapping;
+  for (TransformationModel::DataPoints::const_iterator it = data.begin(); it != data.end(); ++it)
   {
-    // need monotonically increasing x values (can't have the same value twice):
-    std::map<double, std::vector<double> > mapping;
-    for (TransformationModel::DataPoints::const_iterator it = data.begin();
-         it != data.end();
-         ++it)
-    {
-      mapping[it->first].push_back(it->second);
-    }
-    x_.resize(mapping.size());
-    y_.resize(mapping.size());
-    size_t i = 0;
-    for (std::map<double, std::vector<double> >::const_iterator it = mapping.begin();
-         it != mapping.end();
-         ++it, ++i)
-    {
-      x_[i] = it->first;
-      // use average y value:
-      y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
-    }
+    mapping[it->first].push_back(it->second);
+  }
+  x_.resize(mapping.size());
+  y_.resize(mapping.size());
+  size_t i = 0;
+  for (std::map<double, std::vector<double>>::const_iterator it = mapping.begin(); it != mapping.end(); ++it, ++i)
+  {
+    x_[i] = it->first;
+    // use average y value:
+    y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
+  }
 
-    // ensure that we have enough points for an interpolation
-    if (x_.size() < 3)
+  // ensure that we have enough points for an interpolation
+  if (x_.size() < 3)
+  {
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "Cubic spline model needs at least 3 data points (with unique x values)");
+  }
+}
+
+void TransformationModelInterpolated::preprocessDataPoints_(const std::vector<std::pair<double, double>>& data)
+{
+  // need monotonically increasing x values (can't have the same value twice):
+  std::map<double, std::vector<double>> mapping;
+  for (std::vector<std::pair<double, double>>::const_iterator it = data.begin(); it != data.end(); ++it)
+  {
+    mapping[it->first].push_back(it->second);
+  }
+  x_.resize(mapping.size());
+  y_.resize(mapping.size());
+  size_t i = 0;
+  for (std::map<double, std::vector<double>>::const_iterator it = mapping.begin(); it != mapping.end(); ++it, ++i)
+  {
+    x_[i] = it->first;
+    // use average y value:
+    y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
+  }
+
+  // ensure that we have enough points for an interpolation
+  if (x_.size() < 3)
+  {
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "Cubic spline model needs at least 3 data points (with unique x values)");
+  }
+}
+
+TransformationModelInterpolated::TransformationModelInterpolated(const std::vector<std::pair<double, double>>& data,
+                                                                 const Param& params,
+                                                                 bool preprocess = true)
+{
+  params_ = params;
+  Param defaults;
+  getDefaultParameters(defaults);
+  params_.setDefaults(defaults);
+
+  // convert incoming data to x_ and y_
+  if (preprocess) { preprocessDataPoints_(data); }
+  else
+  {
+    x_.resize(data.size());
+    y_.resize(data.size());
+    for (Size i = 0; i < data.size(); ++i)
     {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "Cubic spline model needs at least 3 data points (with unique x values)");
+      x_[i] = data[i].first;
+      y_[i] = data[i].second;
     }
   }
 
-  void TransformationModelInterpolated::preprocessDataPoints_(const std::vector<std::pair<double,double>>& data)
-  {
-    // need monotonically increasing x values (can't have the same value twice):
-    std::map<double, std::vector<double> > mapping;
-    for (std::vector<std::pair<double,double>>::const_iterator it = data.begin();
-         it != data.end();
-         ++it)
-    {
-      mapping[it->first].push_back(it->second);
-    }
-    x_.resize(mapping.size());
-    y_.resize(mapping.size());
-    size_t i = 0;
-    for (std::map<double, std::vector<double> >::const_iterator it = mapping.begin();
-         it != mapping.end();
-         ++it, ++i)
-    {
-      x_[i] = it->first;
-      // use average y value:
-      y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
-    }
 
-    // ensure that we have enough points for an interpolation
-    if (x_.size() < 3)
-    {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       "Cubic spline model needs at least 3 data points (with unique x values)");
-    }
+  // choose the actual interpolation type
+  const String interpolation_type = params_.getValue("interpolation_type").toString();
+  if (interpolation_type == "linear") { interp_ = std::make_unique<LinearInterpolator>(); }
+  else if (interpolation_type == "cspline") { interp_ = std::make_unique<Spline2dInterpolator>(); }
+  else if (interpolation_type == "akima") { interp_ = std::make_unique<AkimaInterpolator>(); }
+  else
+  {
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "unknown/unsupported interpolation type '" + interpolation_type + "'");
   }
 
-  TransformationModelInterpolated::TransformationModelInterpolated(const std::vector<std::pair<double,double>>& data, const Param& params, bool preprocess = true)
+  // assign data
+  interp_->init(x_, y_);
+
+  // linear model for extrapolation:
+  const String extrapolation_type = params_.getValue("extrapolation_type").toString();
+  if (extrapolation_type == "global-linear")
   {
-    params_ = params;
-    Param defaults;
-    getDefaultParameters(defaults);
-    params_.setDefaults(defaults);
+    std::vector<TransformationModel::DataPoint> bloated_data {};
+    bloated_data.reserve(x_.size());
+    // uff... well here we go.. adding an empty string
+    for (Size s = 0; s < x_.size(); ++s)
+    {
+      bloated_data.emplace_back(TransformationModel::DataPoint(x_[s], y_[s]));
+    }
+    lm_front_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
+    lm_back_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
+  }
+  else if (extrapolation_type == "two-point-linear")
+  {
+    TransformationModel::DataPoints lm_data(2);
+    lm_data[0] = std::make_pair(x_.front(), y_.front());
+    lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
+    lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+    lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+  }
+  else if (extrapolation_type == "four-point-linear")
+  {
+    TransformationModel::DataPoints lm_data(2);
+    lm_data[0] = std::make_pair(x_[0], y_[0]);
+    lm_data[1] = std::make_pair(x_[1], y_[1]);
+    lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
 
-    // convert incoming data to x_ and y_
-    if (preprocess)
-    {
-      preprocessDataPoints_(data);
-    }
-    else
-    {
-      x_.resize(data.size());
-      y_.resize(data.size());
-      for (Size i = 0; i < data.size(); ++i)
-      {
-        x_[i] = data[i].first;
-        y_[i] = data[i].second;
-      }
-    }
+    lm_data[0] = std::make_pair(x_[x_.size() - 2], y_[y_.size() - 2]); // second to last point
+    lm_data[1] = std::make_pair(x_.back(), y_.back());                 // last point
+    lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+  }
+  else
+  {
 
 
-    // choose the actual interpolation type
-    const String interpolation_type = params_.getValue("interpolation_type").toString();
-    if (interpolation_type == "linear")
-    {
-      interp_ = std::make_unique<LinearInterpolator>();
-    }
-    else if (interpolation_type == "cspline")
-    {
-      interp_ = std::make_unique<Spline2dInterpolator>();
-    }
-    else if (interpolation_type == "akima")
-    {
-      interp_ = std::make_unique<AkimaInterpolator>();
-    }
-    else
-    {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       "unknown/unsupported interpolation type '" + interpolation_type + "'");
-    }
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
+  }
+}
 
-    // assign data
-    interp_->init(x_, y_);
+TransformationModelInterpolated::TransformationModelInterpolated(const TransformationModel::DataPoints& data, const Param& params)
+{
+  params_ = params;
+  Param defaults;
+  getDefaultParameters(defaults);
+  params_.setDefaults(defaults);
 
-    // linear model for extrapolation:
-    const String extrapolation_type = params_.getValue("extrapolation_type").toString();
-    if (extrapolation_type == "global-linear")
-    {
-      std::vector<TransformationModel::DataPoint> bloated_data{};
-      bloated_data.resize(x_.size());
-      //uff... well here we go.. adding an empty string
-      for (Size s = 0; s < x_.size(); ++s)
-      {
-        bloated_data.emplace_back(TransformationModel::DataPoint(x_[s],y_[s]));
-      }
-      lm_front_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
-      lm_back_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
-    }
-    else if (extrapolation_type == "two-point-linear")
-    {
-      TransformationModel::DataPoints lm_data(2);
-      lm_data[0] = std::make_pair(x_.front(), y_.front());
-      lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-    }
-    else if (extrapolation_type == "four-point-linear")
-    {
-      TransformationModel::DataPoints lm_data(2);
-      lm_data[0] = std::make_pair(x_[0], y_[0]);
-      lm_data[1] = std::make_pair(x_[1], y_[1]);
-      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+  // convert incoming data to x_ and y_
+  preprocessDataPoints_(data);
 
-      lm_data[0] = std::make_pair(x_[ x_.size()-2 ], y_[ y_.size()-2] ); // second to last point
-      lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-    }
-    else
-    {
-      
-
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
-    }
+  // choose the actual interpolation type
+  const String interpolation_type = params_.getValue("interpolation_type").toString();
+  if (interpolation_type == "linear") { interp_ = std::make_unique<LinearInterpolator>(); }
+  else if (interpolation_type == "cspline") { interp_ = std::make_unique<Spline2dInterpolator>(); }
+  else if (interpolation_type == "akima") { interp_ = std::make_unique<AkimaInterpolator>(); }
+  else
+  {
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "unknown/unsupported interpolation type '" + interpolation_type + "'");
   }
 
-  TransformationModelInterpolated::TransformationModelInterpolated(const TransformationModel::DataPoints& data, const Param& params)
+  // assign data
+  interp_->init(x_, y_);
+
+  // linear model for extrapolation:
+  const String extrapolation_type = params_.getValue("extrapolation_type").toString();
+  if (extrapolation_type == "global-linear")
   {
-    params_ = params;
-    Param defaults;
-    getDefaultParameters(defaults);
-    params_.setDefaults(defaults);
-
-    // convert incoming data to x_ and y_
-    preprocessDataPoints_(data);
-
-    // choose the actual interpolation type
-    const String interpolation_type = params_.getValue("interpolation_type").toString();
-    if (interpolation_type == "linear")
-    {
-      interp_ = std::make_unique<LinearInterpolator>();
-    }
-    else if (interpolation_type == "cspline")
-    {
-      interp_ = std::make_unique<Spline2dInterpolator>();
-    }
-    else if (interpolation_type == "akima")
-    {
-      interp_ = std::make_unique<AkimaInterpolator>();
-    }
-    else
-    {
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "unknown/unsupported interpolation type '" + interpolation_type + "'");
-    }
-
-    // assign data
-    interp_->init(x_, y_);
-
-    // linear model for extrapolation:
-    const String extrapolation_type = params_.getValue("extrapolation_type").toString();
-    if (extrapolation_type == "global-linear")
-    {
-      lm_front_ = std::make_unique<TransformationModelLinear>(data, Param());
-      lm_back_ = std::make_unique<TransformationModelLinear>(data, Param());
-    }
-    else if (extrapolation_type == "two-point-linear")
-    {
-      TransformationModel::DataPoints lm_data(2);
-      lm_data[0] = std::make_pair(x_.front(), y_.front());
-      lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-    }
-    else if (extrapolation_type == "four-point-linear")
-    {
-      TransformationModel::DataPoints lm_data(2);
-      lm_data[0] = std::make_pair(x_[0], y_[0]); 
-      lm_data[1] = std::make_pair(x_[1], y_[1]);
-      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-
-      lm_data[0] = std::make_pair(x_[ x_.size()-2 ], y_[ y_.size()-2] ); // second to last point
-      lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
-    }
-    else
-    {
-      
-
-      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
-    }
+    lm_front_ = std::make_unique<TransformationModelLinear>(data, Param());
+    lm_back_ = std::make_unique<TransformationModelLinear>(data, Param());
   }
-
-  TransformationModelInterpolated::~TransformationModelInterpolated() = default;
-
-  double TransformationModelInterpolated::evaluate(double value) const
+  else if (extrapolation_type == "two-point-linear")
   {
-    if (value < x_.front()) // extrapolate front
-    {
-      return lm_front_->evaluate(value);
-    }
-    else if (value > x_.back()) // extrapolate back
-    {
-      return lm_back_->evaluate(value);
-    }
-    // interpolate:
-    return interp_->eval(value);
+    TransformationModel::DataPoints lm_data(2);
+    lm_data[0] = std::make_pair(x_.front(), y_.front());
+    lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
+    lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+    lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
   }
-
-  void TransformationModelInterpolated::getDefaultParameters(Param& params)
+  else if (extrapolation_type == "four-point-linear")
   {
-    params.clear();
-    params.setValue("interpolation_type", "cspline", "Type of interpolation to apply.");
-    params.setValidStrings("interpolation_type", {"linear","cspline","akima"});
-    params.setValue("extrapolation_type", "two-point-linear", "Type of extrapolation to apply: two-point-linear: use the first and last data point to build a single linear model, four-point-linear: build two linear models on both ends using the first two / last two points, global-linear: use all points to build a single linear model. Note that global-linear may not be continuous at the border.");
-    params.setValidStrings("extrapolation_type", {"two-point-linear","four-point-linear","global-linear"});
-  }
+    TransformationModel::DataPoints lm_data(2);
+    lm_data[0] = std::make_pair(x_[0], y_[0]);
+    lm_data[1] = std::make_pair(x_[1], y_[1]);
+    lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
 
-} // namespace
+    lm_data[0] = std::make_pair(x_[x_.size() - 2], y_[y_.size() - 2]); // second to last point
+    lm_data[1] = std::make_pair(x_.back(), y_.back());                 // last point
+    lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+  }
+  else
+  {
+
+
+    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                     "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
+  }
+}
+
+TransformationModelInterpolated::~TransformationModelInterpolated() = default;
+
+double TransformationModelInterpolated::evaluate(double value) const
+{
+  if (value < x_.front()) // extrapolate front
+  {
+    return lm_front_->evaluate(value);
+  }
+  else if (value > x_.back()) // extrapolate back
+  {
+    return lm_back_->evaluate(value);
+  }
+  // interpolate:
+  return interp_->eval(value);
+}
+
+void TransformationModelInterpolated::getDefaultParameters(Param& params)
+{
+  params.clear();
+  params.setValue("interpolation_type", "cspline", "Type of interpolation to apply.");
+  params.setValidStrings("interpolation_type", {"linear", "cspline", "akima"});
+  params.setValue("extrapolation_type", "two-point-linear",
+                  "Type of extrapolation to apply: two-point-linear: use the first and last data point to build a single linear model, "
+                  "four-point-linear: build two linear models on both ends using the first two / last two points, global-linear: use all points to "
+                  "build a single linear model. Note that global-linear may not be continuous at the border.");
+  params.setValidStrings("extrapolation_type", {"two-point-linear", "four-point-linear", "global-linear"});
+}
+
+} // namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -27,9 +27,7 @@ namespace OpenMS
 class Spline2dInterpolator : public TransformationModelInterpolated::Interpolator
 {
 public:
-  Spline2dInterpolator()
-
-    = default;
+  Spline2dInterpolator() = default;
 
   void init(std::vector<double>& x, std::vector<double>& y) override
   {
@@ -54,9 +52,7 @@ private:
 class AkimaInterpolator : public TransformationModelInterpolated::Interpolator
 {
 public:
-  AkimaInterpolator()
-
-    = default;
+  AkimaInterpolator() = default;
 
   void init(std::vector<double>& x, std::vector<double>& y) override
   {
@@ -129,61 +125,46 @@ private:
   std::vector<double> y_;
 };
 
-void TransformationModelInterpolated::preprocessDataPoints_(const DataPoints& data)
+template<typename Container>
+void preprocessDataPointsImpl_(const Container& data, std::vector<double>& x, std::vector<double>& y)
 {
   // need monotonically increasing x values (can't have the same value twice):
   std::map<double, std::vector<double>> mapping;
-  for (TransformationModel::DataPoints::const_iterator it = data.begin(); it != data.end(); ++it)
+  for (auto it = data.begin(); it != data.end(); ++it)
   {
     mapping[it->first].push_back(it->second);
   }
-  x_.resize(mapping.size());
-  y_.resize(mapping.size());
+  x.resize(mapping.size());
+  y.resize(mapping.size());
   size_t i = 0;
-  for (std::map<double, std::vector<double>>::const_iterator it = mapping.begin(); it != mapping.end(); ++it, ++i)
+  for (auto it = mapping.begin(); it != mapping.end(); ++it, ++i)
   {
-    x_[i] = it->first;
+    x[i] = it->first;
     // use average y value:
-    y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
+    y[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
   }
 
   // ensure that we have enough points for an interpolation
-  if (x_.size() < 3)
+  if (x.size() < 3)
   {
     throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                      "Cubic spline model needs at least 3 data points (with unique x values)");
   }
+}
+
+void TransformationModelInterpolated::preprocessDataPoints_(const DataPoints& data)
+{
+  preprocessDataPointsImpl_(data, x_, y_);
 }
 
 void TransformationModelInterpolated::preprocessDataPoints_(const std::vector<std::pair<double, double>>& data)
 {
-  // need monotonically increasing x values (can't have the same value twice):
-  std::map<double, std::vector<double>> mapping;
-  for (std::vector<std::pair<double, double>>::const_iterator it = data.begin(); it != data.end(); ++it)
-  {
-    mapping[it->first].push_back(it->second);
-  }
-  x_.resize(mapping.size());
-  y_.resize(mapping.size());
-  size_t i = 0;
-  for (std::map<double, std::vector<double>>::const_iterator it = mapping.begin(); it != mapping.end(); ++it, ++i)
-  {
-    x_[i] = it->first;
-    // use average y value:
-    y_[i] = std::accumulate(it->second.begin(), it->second.end(), 0.0) / it->second.size();
-  }
-
-  // ensure that we have enough points for an interpolation
-  if (x_.size() < 3)
-  {
-    throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                     "Cubic spline model needs at least 3 data points (with unique x values)");
-  }
+  preprocessDataPointsImpl_(data, x_, y_);
 }
 
 TransformationModelInterpolated::TransformationModelInterpolated(const std::vector<std::pair<double, double>>& data,
                                                                  const Param& params,
-                                                                 bool preprocess = true)
+                                                                 bool preprocess)
 {
   params_ = params;
   Param defaults;
@@ -253,8 +234,6 @@ TransformationModelInterpolated::TransformationModelInterpolated(const std::vect
   }
   else
   {
-
-
     throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                      "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
   }
@@ -312,8 +291,6 @@ TransformationModelInterpolated::TransformationModelInterpolated(const Transform
   }
   else
   {
-
-
     throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                      "unknown/unsupported extrapolation type '" + extrapolation_type + "'");
   }

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -220,10 +220,10 @@ private:
     {
       x_.resize(data.size());
       y_.resize(data.size());
-      for (const std::pair<double,double>& pair : data)
+      for (Size i = 0; i < data.size(); ++i)
       {
-        x_.push_back(pair.first);
-        y_.push_back(pair.second);
+        x_[i] = data[i].first;
+        y_[i] = data[i].second;
       }
     }
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -36,7 +36,7 @@ public:
     void init(std::vector<double>& x, std::vector<double>& y) override
     {
       // cleanup before we use a new one
-      if (spline_ != (CubicSpline2d*) nullptr) delete spline_;
+      if (spline_ != (CubicSpline2d*) nullptr) 
 
       // initialize spline
       spline_ = new CubicSpline2d(x, y);
@@ -49,7 +49,7 @@ public:
 
     ~Spline2dInterpolator() override
     {
-      delete spline_;
+      
     }
 
 private:
@@ -70,7 +70,7 @@ public:
 
     void init(std::vector<double>& x, std::vector<double>& y) override
     {
-      if (interpolator_ != (gte::IntpAkimaNonuniform1<double>*) nullptr) delete interpolator_;
+      if (interpolator_ != (gte::IntpAkimaNonuniform1<double>*) nullptr) 
       // re-construct a new interpolator
       interpolator_ = new gte::IntpAkimaNonuniform1<double>(static_cast<int>(x.size()), &x.front(), &y.front());
     }
@@ -82,7 +82,7 @@ public:
 
     ~AkimaInterpolator() override
     {
-      delete interpolator_;
+      
     }
 
 private:
@@ -237,15 +237,15 @@ private:
     const String interpolation_type = params_.getValue("interpolation_type").toString();
     if (interpolation_type == "linear")
     {
-      interp_ = new LinearInterpolator();
+      interp_ = std::make_unique<LinearInterpolator>();
     }
     else if (interpolation_type == "cspline")
     {
-      interp_ = new Spline2dInterpolator();
+      interp_ = std::make_unique<Spline2dInterpolator>();
     }
     else if (interpolation_type == "akima")
     {
-      interp_ = new AkimaInterpolator();
+      interp_ = std::make_unique<AkimaInterpolator>();
     }
     else
     {
@@ -267,33 +267,33 @@ private:
       {
         bloated_data.emplace_back(TransformationModel::DataPoint(x_[s],y_[s]));
       }
-      lm_front_ = new TransformationModelLinear(bloated_data, Param());
-      lm_back_ = new TransformationModelLinear(bloated_data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(bloated_data, Param());
     }
     else if (extrapolation_type == "two-point-linear")
     {
       TransformationModel::DataPoints lm_data(2);
       lm_data[0] = std::make_pair(x_.front(), y_.front());
       lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_front_ = new TransformationModelLinear(lm_data, Param());
-      lm_back_ = new TransformationModelLinear(lm_data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
     }
     else if (extrapolation_type == "four-point-linear")
     {
       TransformationModel::DataPoints lm_data(2);
       lm_data[0] = std::make_pair(x_[0], y_[0]);
       lm_data[1] = std::make_pair(x_[1], y_[1]);
-      lm_front_ = new TransformationModelLinear(lm_data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
 
       lm_data[0] = std::make_pair(x_[ x_.size()-2 ], y_[ y_.size()-2] ); // second to last point
       lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_back_ = new TransformationModelLinear(lm_data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
     }
     else
     {
       if (interp_)
       {
-        delete interp_;
+        
       }
 
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -315,15 +315,15 @@ private:
     const String interpolation_type = params_.getValue("interpolation_type").toString();
     if (interpolation_type == "linear")
     {
-      interp_ = new LinearInterpolator();
+      interp_ = std::make_unique<LinearInterpolator>();
     }
     else if (interpolation_type == "cspline")
     {
-      interp_ = new Spline2dInterpolator();
+      interp_ = std::make_unique<Spline2dInterpolator>();
     }
     else if (interpolation_type == "akima")
     {
-      interp_ = new AkimaInterpolator();
+      interp_ = std::make_unique<AkimaInterpolator>();
     }
     else
     {
@@ -338,33 +338,33 @@ private:
     const String extrapolation_type = params_.getValue("extrapolation_type").toString();
     if (extrapolation_type == "global-linear")
     {
-      lm_front_ = new TransformationModelLinear(data, Param());
-      lm_back_ = new TransformationModelLinear(data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(data, Param());
     }
     else if (extrapolation_type == "two-point-linear")
     {
       TransformationModel::DataPoints lm_data(2);
       lm_data[0] = std::make_pair(x_.front(), y_.front());
       lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_front_ = new TransformationModelLinear(lm_data, Param());
-      lm_back_ = new TransformationModelLinear(lm_data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
     }
     else if (extrapolation_type == "four-point-linear")
     {
       TransformationModel::DataPoints lm_data(2);
       lm_data[0] = std::make_pair(x_[0], y_[0]); 
       lm_data[1] = std::make_pair(x_[1], y_[1]);
-      lm_front_ = new TransformationModelLinear(lm_data, Param());
+      lm_front_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
 
       lm_data[0] = std::make_pair(x_[ x_.size()-2 ], y_[ y_.size()-2] ); // second to last point
       lm_data[1] = std::make_pair(x_.back(), y_.back()); // last point
-      lm_back_ = new TransformationModelLinear(lm_data, Param());
+      lm_back_ = std::make_unique<TransformationModelLinear>(lm_data, Param());
     }
     else
     {
       if (interp_) 
       {
-        delete interp_;
+        
       }
 
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -374,9 +374,9 @@ private:
 
   TransformationModelInterpolated::~TransformationModelInterpolated()
   {
-    if (interp_) delete interp_;
-    if (lm_front_) delete lm_front_;
-    if (lm_back_) delete lm_back_;
+    
+    
+    
   }
 
   double TransformationModelInterpolated::evaluate(double value) const

--- a/src/openms/source/CHEMISTRY/BuiltInProteaseDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/BuiltInProteaseDataProvider.cpp
@@ -299,6 +299,24 @@ vector<unique_ptr<DigestionEnzymeProtein>> BuiltInProteaseDataProvider::loadEnzy
                                                         17 // OMSSAID
                                                         ));
 
+  // Thermolysin
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Thermolysin", "(?=[AFVILM])(?<![DE])", set<String> {"thermolysin"},
+                                                        "Thermolysin cleaves before A, F, I, L, M, V unless preceded by D or E.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "", "",
+                                                        -1, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // Proteinase K
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Proteinase K", "(?<=[AEFILTVWY])", set<String> {"proteinasek"},
+                                                        "Proteinase K cleaves after A, E, F, I, L, T, V, W, Y.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "", "",
+                                                        -1, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
   return enzymes;
 }
 

--- a/src/openms/source/CHEMISTRY/BuiltInProteaseDataProvider.cpp
+++ b/src/openms/source/CHEMISTRY/BuiltInProteaseDataProvider.cpp
@@ -13,506 +13,293 @@ using namespace std;
 
 namespace OpenMS
 {
-  vector<unique_ptr<DigestionEnzymeProtein>> BuiltInProteaseDataProvider::loadEnzymes()
-  {
-    vector<unique_ptr<DigestionEnzymeProtein>> enzymes;
+vector<unique_ptr<DigestionEnzymeProtein>> BuiltInProteaseDataProvider::loadEnzymes()
+{
+  vector<unique_ptr<DigestionEnzymeProtein>> enzymes;
 
-    // Trypsin
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Trypsin",
-      "(?<=[KRX])(?!P)",
-      set<String>(),
-      "Trypsin cleaves following a K or R residue unless the next residue is P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001251",
-      "[KR]|{P}",
-      1,   // CometID
-      -1,  // MSGFID
-      0    // OMSSAID
+  // Trypsin
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Trypsin", "(?<=[KRX])(?!P)", set<String>(),
+                                                        "Trypsin cleaves following a K or R residue unless the next residue is P.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001251", "[KR]|{P}",
+                                                        1,  // CometID
+                                                        -1, // MSGFID
+                                                        0   // OMSSAID
+                                                        ));
+
+  // Arg-C
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Arg-C", "(?<=[RX])(?!P)", set<String> {"Clostripain", "argc", "arg_c"},
+                                                        "Arg-C cleaves following R residue unless the next residue is P.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001303", "[R]|{P}",
+                                                        5,  // CometID
+                                                        -1, // MSGFID
+                                                        1   // OMSSAID
+                                                        ));
+
+  // Arg-C/P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Arg-C/P", "(?<=[RX])", set<String>(), "Arg-C/P cleaves after R residues.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "", "[R]",
+                                                        12, // CometID
+                                                        6,  // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // Asp-N
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Asp-N", "(?=[DBX])", set<String> {"asp_n"}, "Asp-N cleaves before D(or B).",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001304", "[BD]",
+                                                        6,  // CometID
+                                                        -1, // MSGFID
+                                                        12  // OMSSAID
+                                                        ));
+
+  // Asp-N/B
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Asp-N/B", "(?=[DX])", set<String>(), "Asp-N/B cleaves before D(while B is ignored).",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "", "[D]",
+                                                        16, // CometID
+                                                        7,  // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // Asp-N_ambic
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Asp-N_ambic", "(?=[DBEZX])", set<String>(),
+                                                        "Asp-N Ammonium bicarbonate cleaves before D(or B) or E(or Z).", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001305", "[DE]",
+                                                        17, // CometID
+                                                        -1, // MSGFID
+                                                        19  // OMSSAID
+                                                        ));
+
+  // Chymotrypsin
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Chymotrypsin", "(?<=[FYWLJX])(?!P)", set<String>(),
+                                                        "Chymotrypsin cleaves following F, Y, W or L(or J) residue unless the next residue is P.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001306", "[FYWL]|{P}",
+                                                        10, // CometID
+                                                        -1, // MSGFID
+                                                        3   // OMSSAID
+                                                        ));
+
+  // Chymotrypsin/P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Chymotrypsin/P", "(?<=[FYWLJX])", set<String>(),
+                                                        "Chymotrypsin cleaves following F, Y, W or L(or J) residue.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "", "[FYWL]",
+                                                        15, // CometID
+                                                        2,  // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // CNBr
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("CNBr", "(?<=[MX])", set<String>(), "CNBr cleaves following M.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001307", "[M]",
+                                                        7,  // CometID
+                                                        -1, // MSGFID
+                                                        2   // OMSSAID
+                                                        ));
+
+  // Formic_acid
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Formic_acid", "(?<=[DBX])(?=[DBX])", set<String>(),
+                                                        "Formic_acid cuts after D(or B) and next residue is D (or B).", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001308", "[D]|[D]",
+                                                        18, // CometID
+                                                        -1, // MSGFID
+                                                        4   // OMSSAID
+                                                        ));
+
+  // Lys-C
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Lys-C", "(?<=[KX])(?!P)", set<String> {"lys_c"}, "Lys-C cuts after K if not followed by P.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001309", "[K]|{P}",
+                                                        3,  // CometID
+                                                        -1, // MSGFID
+                                                        5   // OMSSAID
+                                                        ));
+
+  // Lys-N
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Lys-N", "(?=[KX])", set<String> {"lys_n"}, "Lys-N cuts before K.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "", "[K]",
+                                                        4, // CometID
+                                                        4, // MSGFID
+                                                        -1 // OMSSAID
+                                                        ));
+
+  // Lys-C/P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Lys-C/P", "(?<=[KX])", set<String>(), "Lys-C/P cuts after K.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001310", "[K]",
+                                                        13, // CometID
+                                                        3,  // MSGFID
+                                                        6   // OMSSAID
+                                                        ));
+
+  // PepsinA
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("PepsinA", "(?<=[FLJX])", set<String>(), "PepsinA cuts after F or L(or J).",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001311", "[FL]",
+                                                        9,  // CometID
+                                                        -1, // MSGFID
+                                                        7   // OMSSAID
+                                                        ));
+
+  // TrypChymo
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("TrypChymo", "(?<=[FYWLJKRX])(?!P)", set<String>(),
+                                                        "TrypChymo cuts after F, Y, W, L(or J), K or R if not followed by P.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001312", "[FYWLKR]|{P}",
+                                                        19, // CometID
+                                                        -1, // MSGFID
+                                                        9   // OMSSAID
+                                                        ));
+
+  // Trypsin/P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Trypsin/P", "(?<=[KRX])", set<String>(), "Trypsin/P cuts after K or R.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001313", "[KR]",
+                                                        2, // CometID
+                                                        1, // MSGFID
+                                                        10 // OMSSAID
+                                                        ));
+
+  // V8-DE
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("V8-DE", "(?<=[DBEZX])(?!P)", set<String>(),
+                                                        "V8-DE cuts after D(or B) or E(or Z) if not followed by P.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001314", "[BDEZ]|{P}",
+                                                        20, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // V8-E
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("V8-E", "(?<=[EZX])(?!P)", set<String>(), "V8-E cuts after E(or Z) if not followed by P.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001315", "[EZ]|{P}",
+                                                        21, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // leukocyte elastase
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("leukocyte elastase", "(?<=[ALIJVX])(?!P)", set<String>(),
+                                                        "leukocyte elastase cuts after A or L or I(or J) or V if not followed by P.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001915", "[ALIV]|{P}",
+                                                        14, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // proline endopeptidase
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("proline endopeptidase", "(?<=[HKRX][PX])(?!P)", set<String>(),
+                                                        "proline endopeptidase cuts after HP, KP or RP if not followed by P.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001916",
+                                                        "", // No XTandemID available
+                                                        22, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
+
+  // glutamyl endopeptidase
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>(
+    "glutamyl endopeptidase", "(?<=[DBEZX])", set<String> {"Glu-C", "glu_c", "staphylococcal protease"},
+    "glutamyl endopeptidase cuts after D(or B) or E(or Z).", EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001917", "[DE]",
+    8, // CometID
+    5, // MSGFID
+    20 // OMSSAID
     ));
 
-    // Arg-C
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Arg-C",
-      "(?<=[RX])(?!P)",
-      set<String>{"Clostripain", "argc", "arg_c"},
-      "Arg-C cleaves following R residue unless the next residue is P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001303",
-      "[R]|{P}",
-      5,   // CometID
-      -1,  // MSGFID
-      1    // OMSSAID
-    ));
+  // Alpha-lytic protease
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Alpha-lytic protease", "(?<=[TASVX])", set<String>(),
+                                                        "Alpha-lytic protease (aLP) cuts after T, A, S, or V.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "", "[ASTV]",
+                                                        23, // CometID
+                                                        8,  // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Arg-C/P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Arg-C/P",
-      "(?<=[RX])",
-      set<String>(),
-      "Arg-C/P cleaves after R residues.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "",
-      "[R]|[X]",
-      12,  // CometID
-      6,   // MSGFID
-      -1   // OMSSAID
-    ));
+  // 2-iodobenzoate
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("2-iodobenzoate", "(?<=[WX])", set<String>(), "2-iodobenzoate cuts after W.",
+                                                        EmpiricalFormula("H"), EmpiricalFormula("OH"), "MS:1001918", "[W]",
+                                                        24, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Asp-N
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Asp-N",
-      "(?=[DBX])",
-      set<String>{"asp_n"},
-      "Asp-N cleaves before D(or B).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001304",
-      "[X]|[BD]",
-      6,   // CometID
-      -1,  // MSGFID
-      12   // OMSSAID
-    ));
+  // iodosobenzoate
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("iodosobenzoate", "(?<=W)", set<String>(), "iodosobenzoate cuts after W.",
+                                                        EmpiricalFormula(""), EmpiricalFormula(""), "", "",
+                                                        25, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Asp-N/B
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Asp-N/B",
-      "(?=[DX])",
-      set<String>(),
-      "Asp-N/B cleaves before D(while B is ignored).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "",
-      "[X]|[D]",
-      16,  // CometID
-      7,   // MSGFID
-      -1   // OMSSAID
-    ));
+  // staphylococcal protease/D
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("staphylococcal protease/D", "(?<=[EZX])", set<String> {"Glu-C/D"},
+                                                        "staphylococcal protease/D cuts after E(or Z).", EmpiricalFormula(""), EmpiricalFormula(""),
+                                                        "", "",
+                                                        26, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Asp-N_ambic
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Asp-N_ambic",
-      "(?=[DBEZX])",
-      set<String>(),
-      "Asp-N Ammonium bicarbonate cleaves before D(or B) or E(or Z).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001305",
-      "[X]|[DE]",
-      17,  // CometID
-      -1,  // MSGFID
-      19   // OMSSAID
-    ));
+  // proline-endopeptidase/HKR
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("proline-endopeptidase/HKR", "(?<=[PX])", set<String>(),
+                                                        "proline-endopeptidase/HKR cuts after P.", EmpiricalFormula(""), EmpiricalFormula(""), "", "",
+                                                        27, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Chymotrypsin
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Chymotrypsin",
-      "(?<=[FYWLJX])(?!P)",
-      set<String>(),
-      "Chymotrypsin cleaves following F, Y, W or L(or J) residue unless the next residue is P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001306",
-      "[FYWL]|{P}",
-      10,  // CometID
-      -1,  // MSGFID
-      3    // OMSSAID
-    ));
+  // Glu-C+P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Glu-C+P", "(?<=[DBEZX])(?!P)", set<String> {"staphylococcal protease+P"},
+                                                        "Glu-C+P cuts after D(or B) or E(or Z) unless followed by P.", EmpiricalFormula(""),
+                                                        EmpiricalFormula(""), "", "",
+                                                        28, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Chymotrypsin/P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Chymotrypsin/P",
-      "(?<=[FYWLJX])",
-      set<String>(),
-      "Chymotrypsin cleaves following F, Y, W or L(or J) residue.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "",
-      "[FYWL]|[X]",
-      15,  // CometID
-      2,   // MSGFID
-      -1   // OMSSAID
-    ));
+  // PepsinA + P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("PepsinA + P", "(?<=[FLJX])(?!P)", set<String>(),
+                                                        "PepsinA + P cuts after F or L(or J) unless followed by P.", EmpiricalFormula(""),
+                                                        EmpiricalFormula(""), "", "",
+                                                        29, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // CNBr
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "CNBr",
-      "(?<=[MX])",
-      set<String>(),
-      "CNBr cleaves following M.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001307",
-      "[M]|[X]",
-      7,   // CometID
-      -1,  // MSGFID
-      2    // OMSSAID
-    ));
+  // cyanogen-bromide
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("cyanogen-bromide", "(?<=[MX])", set<String>(), "cyanogen-bromide cuts after M.",
+                                                        EmpiricalFormula(""), EmpiricalFormula(""), "", "",
+                                                        30, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Formic_acid
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Formic_acid",
-      "(?<=[DBX])(?=[DBX])",
-      set<String>(),
-      "Formic_acid cuts after D(or B) and next residue is D (or B).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001308",
-      "[D]|[D]",
-      18,  // CometID
-      -1,  // MSGFID
-      4    // OMSSAID
-    ));
+  // Clostripain/P
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("Clostripain/P", "(?<=[RX])", set<String>(), "Clostripain/P cuts after R.",
+                                                        EmpiricalFormula(""), EmpiricalFormula(""), "", "",
+                                                        31, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Lys-C
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Lys-C",
-      "(?<=[KX])(?!P)",
-      set<String>{"lys_c"},
-      "Lys-C cuts after K if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001309",
-      "[K]|{P}",
-      3,   // CometID
-      -1,  // MSGFID
-      5    // OMSSAID
-    ));
+  // elastase-trypsin-chymotrypsin
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("elastase-trypsin-chymotrypsin", "(?<=[ALIVKRWFYX])(?!P)", set<String>(),
+                                                        "elastase-trypsin-chymotrypsin cuts after A,L,I(or J),V,K,R,W,F,Y unless followed by P.",
+                                                        EmpiricalFormula(""), EmpiricalFormula(""), "", "",
+                                                        32, // CometID
+                                                        -1, // MSGFID
+                                                        -1  // OMSSAID
+                                                        ));
 
-    // Lys-N
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Lys-N",
-      "(?=[KX])",
-      set<String>{"lys_n"},
-      "Lys-N cuts before K.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "",
-      "[X]|[K]",
-      4,   // CometID
-      4,   // MSGFID
-      -1   // OMSSAID
-    ));
+  // no cleavage
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("no cleavage", "()", set<String> {"no_cut"}, "no cleavage.", EmpiricalFormula("H"),
+                                                        EmpiricalFormula("OH"), "MS:1001955", "[Z]|[Z]",
+                                                        11, // CometID
+                                                        9,  // MSGFID
+                                                        11  // OMSSAID
+                                                        ));
 
-    // Lys-C/P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Lys-C/P",
-      "(?<=[KX])",
-      set<String>(),
-      "Lys-C/P cuts after K.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001310",
-      "[K]|[X]",
-      13,  // CometID
-      3,   // MSGFID
-      6    // OMSSAID
-    ));
+  // unspecific cleavage
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("unspecific cleavage", "(?<=[A-Z])", set<String> {"no_enzyme", "nonspecific"},
+                                                        "unspecific cleavage cuts at every site.", EmpiricalFormula("H"), EmpiricalFormula("OH"),
+                                                        "MS:1001956", "",
+                                                        0, // CometID
+                                                        0, // MSGFID
+                                                        17 // OMSSAID
+                                                        ));
 
-    // PepsinA
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "PepsinA",
-      "(?<=[FLJX])",
-      set<String>(),
-      "PepsinA cuts after F or L(or J).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001311",
-      "[FL]|[X]",
-      9,   // CometID
-      -1,  // MSGFID
-      7    // OMSSAID
-    ));
-
-    // TrypChymo
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "TrypChymo",
-      "(?<=[FYWLJKRX])(?!P)",
-      set<String>(),
-      "TrypChymo cuts after F, Y, W, L(or J), K or R if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001312",
-      "[FYWLKR]|{P}",
-      19,  // CometID
-      -1,  // MSGFID
-      9    // OMSSAID
-    ));
-
-    // Trypsin/P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Trypsin/P",
-      "(?<=[KRX])",
-      set<String>(),
-      "Trypsin/P cuts after K or R.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001313",
-      "[KR]|[X]",
-      2,   // CometID
-      1,   // MSGFID
-      10   // OMSSAID
-    ));
-
-    // V8-DE
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "V8-DE",
-      "(?<=[DBEZX])(?!P)",
-      set<String>(),
-      "V8-DE cuts after D(or B) or E(or Z) if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001314",
-      "[BDEZ]|{P}",
-      20,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // V8-E
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "V8-E",
-      "(?<=[EZX])(?!P)",
-      set<String>(),
-      "V8-E cuts after E(or Z) if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001315",
-      "[EZ]|{P}",
-      21,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // leukocyte elastase
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "leukocyte elastase",
-      "(?<=[ALIJVX])(?!P)",
-      set<String>(),
-      "leukocyte elastase cuts after A or L or I(or J) or V if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001915",
-      "[ALIV]|{P}",
-      14,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // proline endopeptidase
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "proline endopeptidase",
-      "(?<=[HKRX][PX])(?!P)",
-      set<String>(),
-      "proline endopeptidase cuts after HP, KP or RP if not followed by P.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001916",
-      "",  // No XTandemID available
-      22,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // glutamyl endopeptidase
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "glutamyl endopeptidase",
-      "(?<=[DBEZX])",
-      set<String>{"Glu-C", "glu_c", "staphylococcal protease"},
-      "glutamyl endopeptidase cuts after D(or B) or E(or Z).",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001917",
-      "[DE]|[X]",
-      8,   // CometID
-      5,   // MSGFID
-      20   // OMSSAID
-    ));
-
-    // Alpha-lytic protease
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Alpha-lytic protease",
-      "(?<=[TASVX])",
-      set<String>(),
-      "Alpha-lytic protease (aLP) cuts after T, A, S, or V.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "",
-      "[ASTV]|[X]",
-      23,  // CometID
-      8,   // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // 2-iodobenzoate
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "2-iodobenzoate",
-      "(?<=[WX])",
-      set<String>(),
-      "2-iodobenzoate cuts after W.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001918",
-      "[W]|[X]",
-      24,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // iodosobenzoate
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "iodosobenzoate",
-      "(?<=W)",
-      set<String>(),
-      "iodosobenzoate cuts after W.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      25,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // staphylococcal protease/D
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "staphylococcal protease/D",
-      "(?<=[EZX])",
-      set<String>{"Glu-C/D"},
-      "staphylococcal protease/D cuts after E(or Z).",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      26,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // proline-endopeptidase/HKR
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "proline-endopeptidase/HKR",
-      "(?<=[PX])",
-      set<String>(),
-      "proline-endopeptidase/HKR cuts after P.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      27,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // Glu-C+P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Glu-C+P",
-      "(?<=[DBEZX])(?!P)",
-      set<String>{"staphylococcal protease+P"},
-      "Glu-C+P cuts after D(or B) or E(or Z) unless followed by P.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      28,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // PepsinA + P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "PepsinA + P",
-      "(?<=[FLJX])(?!P)",
-      set<String>(),
-      "PepsinA + P cuts after F or L(or J) unless followed by P.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      29,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // cyanogen-bromide
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "cyanogen-bromide",
-      "(?<=[MX])",
-      set<String>(),
-      "cyanogen-bromide cuts after M.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      30,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // Clostripain/P
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "Clostripain/P",
-      "(?<=[RX])",
-      set<String>(),
-      "Clostripain/P cuts after R.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      31,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // elastase-trypsin-chymotrypsin
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "elastase-trypsin-chymotrypsin",
-      "(?<=[ALIVKRWFYX])(?!P)",
-      set<String>(),
-      "elastase-trypsin-chymotrypsin cuts after A,L,I(or J),V,K,R,W,F,Y unless followed by P.",
-      EmpiricalFormula(""),
-      EmpiricalFormula(""),
-      "",
-      "",
-      32,  // CometID
-      -1,  // MSGFID
-      -1   // OMSSAID
-    ));
-
-    // no cleavage
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "no cleavage",
-      "()",
-      set<String>{"no_cut"},
-      "no cleavage.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001955",
-      "[Z]|[Z]",
-      11,  // CometID
-      9,   // MSGFID
-      11   // OMSSAID
-    ));
-
-    // unspecific cleavage
-    enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-      "unspecific cleavage",
-      "(?<=[A-Z])",
-      set<String>{"no_enzyme", "nonspecific"},
-      "unspecific cleavage cuts at every site.",
-      EmpiricalFormula("H"),
-      EmpiricalFormula("OH"),
-      "MS:1001956",
-      "[X]|[X]",
-      0,   // CometID
-      0,   // MSGFID
-      17   // OMSSAID
-    ));
-
-    return enzymes;
-  }
+  return enzymes;
+}
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/PercolatorInfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorInfile.cpp
@@ -6,6 +6,8 @@
 // $Authors: Timo Sachsenberg, Johannes von Kleist $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
+#include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/CsvFile.h>
@@ -542,29 +544,39 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
 
 bool PercolatorInfile::isEnz_(const char& n, const char& c, const std::string& enz)
 {
-  if (enz == "trypsin") { return ((n == 'K' || n == 'R') && c != 'P') || n == '-' || c == '-'; }
-  else if (enz == "trypsinp") { return (n == 'K' || n == 'R') || n == '-' || c == '-'; }
-  else if (enz == "chymotrypsin") { return ((n == 'F' || n == 'W' || n == 'Y' || n == 'L') && c != 'P') || n == '-' || c == '-'; }
-  else if (enz == "thermolysin")
+  // Terminal positions (protein N/C-terminus) are always considered enzymatic
+  if (n == '-' || c == '-') { return true; }
+
+  // Use OpenMS ProteaseDigestion to check enzymatic cleavage.
+  // We do not cache locally; setEnzyme is reasonably fast, and caller should optimize if needed.
+  ProteaseDigestion digest;
+
+  // Map Percolator enzyme names to OpenMS ProteaseDB enzyme names via ProteaseDB
+  try
   {
-    return ((c == 'A' || c == 'F' || c == 'I' || c == 'L' || c == 'M' || c == 'V' || (n == 'R' && c == 'G')) && n != 'D' && n != 'E') || n == '-'
-           || c == '-';
+    if (ProteaseDB::getInstance()->hasEnzyme(String(enz))) { digest.setEnzyme(String(enz)); }
+    else
+    {
+      // Try checking if it's a known synonym. ProteaseDB handles synonyms.
+      digest.setEnzyme(String(enz)); // this throws if not found
+    }
   }
-  else if (enz == "proteinasek")
+  catch (Exception::ElementNotFound&)
   {
-    return (n == 'A' || n == 'E' || n == 'F' || n == 'I' || n == 'L' || n == 'T' || n == 'V' || n == 'W' || n == 'Y') || n == '-' || c == '-';
+    // Map known Percolator enzyme names to OpenMS ProteaseDB enzyme names
+    static const std::unordered_map<std::string, std::string> name_map
+      = {{"trypsinp", "Trypsin/P"},           {"elastase", "leukocyte elastase"}, {"pepsin", "PepsinA"},
+         {"glu-c", "glutamyl endopeptidase"}, {"proteinasek", "Proteinase K"},    {"no_enzyme", "unspecific cleavage"}};
+
+    auto mapped_enz = name_map.find(enz);
+    if (mapped_enz != name_map.end()) { digest.setEnzyme(mapped_enz->second); }
+    else { throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown enzyme name in isEnz_", enz); }
   }
-  else if (enz == "pepsin")
-  {
-    return ((c == 'F' || c == 'L' || c == 'W' || c == 'Y' || n == 'F' || n == 'L' || n == 'W' || n == 'Y') && n != 'R') || n == '-' || c == '-';
-  }
-  else if (enz == "elastase") { return ((n == 'L' || n == 'V' || n == 'A' || n == 'G') && c != 'P') || n == '-' || c == '-'; }
-  else if (enz == "lys-n") { return (c == 'K') || n == '-' || c == '-'; }
-  else if (enz == "lys-c") { return ((n == 'K') && c != 'P') || n == '-' || c == '-'; }
-  else if (enz == "arg-c") { return ((n == 'R') && c != 'P') || n == '-' || c == '-'; }
-  else if (enz == "asp-n") { return (c == 'D') || n == '-' || c == '-'; }
-  else if (enz == "glu-c") { return ((n == 'E') && (c != 'P')) || n == '-' || c == '-'; }
-  else { throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown enzyme name in isEnz_", enz); }
+
+  // Construct a minimal 2-residue "protein" and check if the
+  // single-residue peptide at position 0 is a valid digestion product
+  const String mini_protein = String(1, n) + String(1, c);
+  return digest.isValidProduct(mini_protein, 0, 1, true);
 }
 
 // Function adapted from Enzyme.h in Percolator converter

--- a/src/openms/source/FORMAT/PercolatorInfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorInfile.cpp
@@ -6,647 +6,577 @@
 // $Authors: Timo Sachsenberg, Johannes von Kleist $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/PercolatorInfile.h>
-
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Constants.h>
-#include <OpenMS/METADATA/SpectrumLookup.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/CsvFile.h>
+#include <OpenMS/FORMAT/PercolatorInfile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-
+#include <OpenMS/METADATA/SpectrumLookup.h>
 #include <regex>
-#include <functional>
-#include <unordered_set>
 
 namespace OpenMS
 {
-  using namespace std;
+using namespace std;
 
-  void PercolatorInfile::store(const String& pin_file,
-    const PeptideIdentificationList& peptide_ids, 
-    const StringList& feature_set, 
-    const std::string& enz, 
-    int min_charge, 
-    int max_charge)
+void PercolatorInfile::store(const String& pin_file,
+                             const PeptideIdentificationList& peptide_ids,
+                             const StringList& feature_set,
+                             const std::string& enz,
+                             int min_charge,
+                             int max_charge)
+{
+  TextFile txt = preparePin_(peptide_ids, feature_set, enz, min_charge, max_charge);
+  txt.store(pin_file);
+}
+
+// uses spectrum_reference, if empty uses spectrum_id, if also empty fall back to using index
+String PercolatorInfile::getScanIdentifier(const PeptideIdentification& pid, size_t index)
+{
+  // MSGF+ uses this field, is empty if not specified
+  String scan_identifier = pid.getSpectrumReference();
+
+  if (scan_identifier.empty())
   {
-    TextFile txt = preparePin_(peptide_ids, feature_set, enz, min_charge, max_charge);
-    txt.store(pin_file);
-  }
-
-  // uses spectrum_reference, if empty uses spectrum_id, if also empty fall back to using index
-  String PercolatorInfile::getScanIdentifier(
-    const PeptideIdentification& pid, size_t index)
-  {
-    // MSGF+ uses this field, is empty if not specified
-    String scan_identifier = pid.getSpectrumReference();
-
-    if (scan_identifier.empty())
+    // XTandem uses this (integer) field
+    // these ids are 1-based in contrast to the index which is 0-based. This might be problematic to use for merging
+    if (pid.metaValueExists("spectrum_id") && ! pid.getMetaValue("spectrum_id").toString().empty())
     {
-      // XTandem uses this (integer) field
-      // these ids are 1-based in contrast to the index which is 0-based. This might be problematic to use for merging
-      if (pid.metaValueExists("spectrum_id") && !pid.getMetaValue("spectrum_id").toString().empty())
-      {
-        scan_identifier = "scan=" + pid.getMetaValue("spectrum_id").toString();
-      }
-      else
-      {
-        scan_identifier = "index=" + String(index); // fall back
-        OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
-      }
-    }
-    return scan_identifier.removeWhitespaces();
-  }
-
-  PeptideIdentificationList PercolatorInfile::load(
-    const String& pin_file,
-    bool higher_score_better,
-    const String& score_name,
-    const StringList& extra_scores,
-    StringList& filenames,
-    String decoy_prefix, 
-    double threshold, 
-    bool SageAnnotation)
-  {
-    CsvFile csv(pin_file, '\t');
-    
-    //Sage Variables, initialized in the following block if SageAnnotation is set 
-    map<int, vector<PeptideHit::PeakAnnotation>> anno_mapping; 
-    CsvFile tsv; 
-    CsvFile annos; 
-    unordered_map<String, size_t> to_idx_t; 
-
-    if (SageAnnotation) // Block for special treatment of sage 
-    {
-      String tsv_file_path = pin_file.substr(0, pin_file.size()-3);
-      tsv_file_path = tsv_file_path + "tsv"; 
-      tsv = CsvFile(tsv_file_path,'\t'); 
-
-      String temp_diff = "results.sage.pin"; 
-      String anno_file_path = pin_file.substr(0, pin_file.size()-temp_diff.length());
-      anno_file_path = anno_file_path + "matched_fragments.sage.tsv"; 
-      annos = CsvFile(anno_file_path, '\t'); 
-      //map PSMID to vec of PeakAnnotation 
-      StringList sage_tsv_header;
-      tsv.getRow(0, sage_tsv_header); 
-      {
-        int idx_t{};
-        for (const auto& h : sage_tsv_header) { to_idx_t[h] = idx_t++; }
-      }
-
-      // processs annotation file
-      StringList sage_annotation_header; 
-      annos.getRow(0, sage_annotation_header);
-      unordered_map<String, size_t> to_idx_a; // map column name to column index, for full annotation file file 
-      {
-        int idx_a{};
-        for (const auto& h : sage_annotation_header) { to_idx_a[h] = idx_a++; }
-      }
-      // map PSMs -> PeakAnnotation vector
-      auto num_rows = annos.rowCount(); 
-
-      for (size_t i = 1; i < num_rows; ++i)
-      {
-        StringList row;
-        annos.getRow(i, row);
-        
-        //Check if mapping already has PSM, if it does add 
-        if (anno_mapping.find(row[to_idx_a.at("psm_id")].toInt()) == anno_mapping.end())
-        {                 
-          //Make a new vector of annotations 
-          PeptideHit::PeakAnnotation peak_temp; 
-
-          peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")]; 
-          peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt(); 
-          peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble(); 
-          peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble(); 
-
-          vector<PeptideHit::PeakAnnotation> temp_anno_vec; 
-          temp_anno_vec.push_back(peak_temp); 
-          anno_mapping[ row[to_idx_a.at("psm_id")].toInt() ] = temp_anno_vec;
-        }
-        else
-        {
-          //Add values to exisiting vector 
-          PeptideHit::PeakAnnotation peak_temp; 
-
-          peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")]; 
-          peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt(); 
-          peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble(); 
-          peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble(); 
-
-          anno_mapping[ row[to_idx_a.at("psm_id")].toInt() ].push_back(peak_temp);         
-        }
-      }      
-    }
-    
-    StringList pin_header;
-
-    csv.getRow(0, pin_header);
-
-    unordered_map<String, size_t> to_idx; // map column name to column index
-    {
-      int idx{};
-      for (const auto& h : pin_header) { to_idx[h] = idx++; }
-    }
-
-    // determine file name column index in percolator in file
-    int file_name_column_index{-1};
-    if (auto it = std::find(pin_header.begin(), pin_header.end(), "FileName"); it != pin_header.end())
-    {
-      file_name_column_index = it - pin_header.begin();
-    }
- 
-    // determine extra scores and store column indices
-    std::set<String> found_extra_scores; // additional (non-main) scores that should be stored in the PeptideHit, order important for comparable idXML  
-    for (const String& s : extra_scores)
-    {
-      if (auto it = std::find(pin_header.begin(), pin_header.end(), s); it != pin_header.end())
-      {
-        found_extra_scores.insert(s);
-      }
-      else
-      {
-        OPENMS_LOG_WARN << "Extra score: " << s << " not found in Percolator input file." << endl;
-      }
-    }
-      
-    // charge columns are not standardized, so we check for the format and create hash to lookup column name to charge mapping
-    std::regex charge_one_hot_pattern("^charge\\d+$");
-    std::regex sage_one_hot_pattern("^z=\\d+$");
-    String charge_prefix;
-    unordered_map<String, int> col_name_to_charge;
-
-    // Special handling for sage: sage produces an additional column for PSMs outside of the "suggested" charge search range (e.g., charge 2-5).
-    // The reason is that sage searches always for the charge annotated in the spectrum raw file. Only if the annotation is missing it will search
-    // the suggested charge range.
-    bool found_sage_otherz_charge_column{false}; 
-    for (const String& c : pin_header)
-    {
-      if (std::regex_match(c, charge_one_hot_pattern))
-      {
-        col_name_to_charge[c] = c.substr(6).toInt();
-        charge_prefix = "charge";
-      }
-      else if (std::regex_match(c, sage_one_hot_pattern))
-      {
-        col_name_to_charge[c] = c.substr(2).toInt();
-        charge_prefix = "z=";
-      }      
-      else if (c == "z=other") // SAGE
-      {
-        found_sage_otherz_charge_column = true;
-        OPENMS_LOG_DEBUG << "Found SAGE charge column 'z=other'. Will extract charge from this column if charge was not set in the one-hot encoded charge columns." << endl;
-      }
-    }
-
-    auto n_rows = csv.rowCount();
-
-    PeptideIdentificationList pids;
-    pids.reserve(n_rows);
-    String spec_id;
-    String raw_file_name("UNKNOWN");
-    unordered_map<String, size_t> map_filename_to_idx; // fast lookup of filename to index in filenames vector
-
-    for (size_t i = 1; i != n_rows; ++i)
-    {
-      StringList row;
-      csv.getRow(i, row);
-
-      StringList t_row; 
-
-      if (SageAnnotation)
-      {
-        tsv.getRow(i, t_row); 
-        // skip if spectrum_q is above threshold
-        if (t_row[to_idx_t.at("spectrum_q")].toDouble() > threshold ) continue;
-      }
-
-      if (row.size() != pin_header.size())
-      {
-        throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Error: line " + String(i) + " of file '" + pin_file + "' does not have the same number of columns as the pin_header!", String(i));
-      }
-
-
-      if (file_name_column_index >= 0)
-      {
-        raw_file_name = row[file_name_column_index];
-        if (map_filename_to_idx.find(raw_file_name) == map_filename_to_idx.end())
-        {
-          filenames.push_back(raw_file_name);
-          map_filename_to_idx[raw_file_name] = filenames.size() - 1;
-        }
-      }
-      // NOTE: In our pin files that we WRITE, SpecID will be filename + vendor spectrum native ID
-      // However, many search engines (e.g. Sage) choose arbitrary IDs, which is unfortunately allowed
-      //  by this loosely defined format.
-      const String& sSpecId = row[to_idx.at("SpecId")];
-
-      double IM = 0.0;
-      if (auto it = to_idx.find("ion_mobility"); it != to_idx.end())
-      {
-        const String& sIM = row[it->second]; // read IM from e.g. Sage output
-        IM = sIM.toDouble();  
-      }
-      // In theory, this should be an integer, but Sage currently cannot extract the number from all vendor spectrum IDs,
-      //  so it writes the full ID as string
-      String sScanNr = row[to_idx.at("ScanNr")];
-      if (sSpecId != spec_id)
-      {
-        pids.resize(pids.size() + 1);
-        pids.back().setHigherScoreBetter(higher_score_better);
-        pids.back().setScoreType(score_name);
-        pids.back().setMetaValue(Constants::UserParam::ID_MERGE_INDEX, map_filename_to_idx.at(raw_file_name));
-        pids.back().setRT(row[to_idx.at("retentiontime")].toDouble() * 60.0); // search engines typically write minutes (e.g., sage)
-        pids.back().setMetaValue("PinSpecId", sSpecId);
-        if (IM > 0.0) // Sage might annotate 0.0 if no IM is present
-        {
-          pids.back().setMetaValue(Constants::UserParam::IM, IM);
-        }
-        // Since ScanNr is the closest to help in identifying the spectrum in the file later on,
-        // we use it as spectrum_reference. Since it can be integer only or the complete
-        // vendor ID, you will need a lookup in case of number only later!!
-        pids.back().setSpectrumReference(sScanNr);     
-      }
-      String sPeptide = row[to_idx.at("Peptide")];
-      const double score = row[to_idx.at(score_name)].toDouble();
-      String target_decoy = row[to_idx.at("Label")].toInt() == 1 ? "target" : "decoy";
-      const String& sProteins = row[to_idx.at("Proteins")];
-      int rank = to_idx.count("rank") ? row[to_idx.at("rank")].toInt() : 1;
-      StringList accessions;
-
-      int charge = 0;
-      for (const auto& [name, z] : col_name_to_charge)
-      {        
-        if (row[to_idx.at(name)] == "1")
-        {
-          charge = z;
-          break;
-        }
-      }
-
-      // all one-hot encoded charge columns are zero. Use value in the sage "z=other" column if it exists.
-      if (charge == 0 && found_sage_otherz_charge_column)
-      {
-        charge = row[to_idx.at("z=other")].toInt();
-      }
-      
-      if (charge != 0)
-      {
-        pids.back().setMZ(row[to_idx.at("ExpMass")].toDouble() / std::fabs(charge) + Constants::PROTON_MASS_U);
-      }
-
-      sProteins.split(';', accessions);
-
-      // deduce decoy state from accessions if decoy_prefix is set
-      if (!decoy_prefix.empty())
-      {
-        bool dec = false;
-        bool tgt = false;
-        for (const auto& acc : accessions)
-        {
-          if (!(dec && tgt))
-          {
-            if (acc.hasPrefix(decoy_prefix))
-            {
-              dec = true;
-            }
-            else
-            {
-              tgt = true;
-            }
-          }
-          else
-          {
-            break;
-          }
-        }
-        if (tgt && dec)
-        {
-          target_decoy = "target+decoy";
-        }
-        else if (tgt)
-        {
-          target_decoy = "target";
-        }
-        else {
-          target_decoy = "decoy";
-        }
-      }
-
-      // needs to handle strings like: [+42]-MVLVQDLLHPTAASEAR, [+304.207]-ETC[+57.0215]RQLGLGTNIYNAER etc.
-      sPeptide.substitute("]-", "]."); // we can parse [+42].MVLVQDLLHPTAASEAR
-      sPeptide.substitute("-[", ".["); // we can parse MVLVQDLLHPTAASEAR.[+111]
-      AASequence aa_seq = AASequence::fromString(sPeptide);
-      PeptideHit ph(score, rank - 1, charge, std::move(aa_seq));
-      ph.setMetaValue("target_decoy", target_decoy);
-
-      for (const auto& name : found_extra_scores)
-      {
-        String value = row[to_idx.at(name)];
-        if (name == "ln(-poisson)" && value == "inf") value = "3.5"; // workaround for Sage
-        ph.setMetaValue(name, value);
-      }
-
-      // adding own meta values 
-      if (SageAnnotation)
-      {
-        ph.setMetaValue("spectrum_q", t_row[to_idx_t.at("spectrum_q")].toDouble());  //TODO: check if column exists / SAGE specific treatment
-      }
-      ph.setMetaValue("DeltaMass", ( row[to_idx.at("ExpMass")].toDouble() - row[to_idx.at("CalcMass")].toDouble()) ); 
-      // add annotations
-      if (SageAnnotation)
-      {
-        if (anno_mapping.find(sSpecId.toInt()) != anno_mapping.end())
-        {
-          // copy annotations from mapping to PeptideHit
-          vector<PeptideHit::PeakAnnotation> pep_vec;
-          for (const PeptideHit::PeakAnnotation& pep : anno_mapping[sSpecId.toInt()])
-          {
-            pep_vec.push_back(pep) ; 
-          }        
-          ph.setPeakAnnotations(pep_vec);        
-        } 
-      }
-      // add link to protein (we only know the accession but not start/end, aa_before/after in protein at this point)
-      for (const String& accession : accessions)
-      {
-        ph.addPeptideEvidence(PeptideEvidence(accession));
-      }
-
-      pids.back().insertHit(std::move(ph));
-    }
-
-    return pids;
-  }
-
-
-  TextFile PercolatorInfile::preparePin_(
-    const PeptideIdentificationList& peptide_ids, 
-    const StringList& feature_set, 
-    const std::string& enz, 
-    int min_charge, 
-    int max_charge)
-  {
-    TextFile txt;  
-    txt.addLine(ListUtils::concatenate(feature_set, '\t'));
-    if (peptide_ids.empty()) 
-    {
-      OPENMS_LOG_WARN << "No identifications provided. Creating empty percolator input." << endl;
-      return txt;
-    }
-
-    // extract native id (usually in spectrum_reference)
-    const String sid = getScanIdentifier(peptide_ids[0], 0);
-
-    // determine RegEx to extract scan/index number
-    boost::regex scan_regex = boost::regex(SpectrumLookup::getRegExFromNativeID(sid));
-
-    // keep track of errors
-    size_t missing_meta_value_count{};
-    set<String> missing_meta_values;
-
-    size_t index = 0;
-    for (const PeptideIdentification& pep_id : peptide_ids)
-    {
-      index++;
-      // try to make a file and scan unique identifier
-      String scan_identifier = getScanIdentifier(pep_id, index);
-      String file_identifier = pep_id.getMetaValue("file_origin", String());
-
-      file_identifier += (String)pep_id.getMetaValue("id_merge_index", String());
-
-      Int scan_number = SpectrumLookup::extractScanNumber(scan_identifier, scan_regex, true);
-      
-      double exp_mass = pep_id.getMZ();
-      double retention_time = pep_id.getRT();
-      for (const PeptideHit& psm : pep_id.getHits())
-      {
-        if (psm.getPeptideEvidences().empty())
-        {
-          OPENMS_LOG_WARN << "PSM (PeptideHit) without protein reference found. "
-                  << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong enzyme settings)." 
-                  << "Will skip this PSM." << endl;
-          continue;
-        }
-        PeptideHit hit(psm); // make a copy of the hit to store temporary features
-        hit.setMetaValue("SpecId", file_identifier + scan_identifier);
-        hit.setMetaValue("ScanNr", scan_number);
-        
-        if (hit.getTargetDecoyType() == PeptideHit::TargetDecoyType::UNKNOWN)
-        { 
-          OPENMS_LOG_WARN << "PSM without target/decoy information found. "
-                  << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong decoy prefix settings)." 
-                  << "Will skip this PSM." << endl;
-          continue;
-        }
-        
-        int label = hit.isDecoy() ? -1 : 1;
-        hit.setMetaValue("Label", label);
-        
-        int charge = hit.getCharge();
-        String unmodified_sequence = hit.getSequence().toUnmodifiedString();
-      
-        double calc_mass; 
-        if (!hit.metaValueExists("CalcMass"))
-        {
-          calc_mass = hit.getSequence().getMZ(charge);
-          hit.setMetaValue("CalcMass", calc_mass); // Percolator calls is CalcMass instead of m/z
-        }
-        else
-        {
-          calc_mass = hit.getMetaValue("CalcMass");
-        }
-
-        if (hit.metaValueExists("IsotopeError"))  // for backwards compatibility (generated by MSGFPlusAdaper OpenMS < 2.6)
-        {
-          float isoErr = hit.getMetaValue("IsotopeError").toString().toFloat();
-          exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
-        }
-        else if (hit.metaValueExists(Constants::UserParam::ISOTOPE_ERROR)) // OpenMS user param name for isotope error
-        {
-          float isoErr = hit.getMetaValue(Constants::UserParam::ISOTOPE_ERROR).toString().toFloat();
-          exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
-        }
-                
-        hit.setMetaValue("ExpMass", exp_mass);
-
-        // needed in case "description of correct" option is used
-        double delta_mass = exp_mass - calc_mass;
-        hit.setMetaValue("deltamass", delta_mass);
-        hit.setMetaValue("retentiontime", retention_time);
-
-        hit.setMetaValue("mass", exp_mass);
-        
-        double score = hit.getScore();
-        // TODO better to use log scores for E-value based scores
-        hit.setMetaValue("score", score);
-        
-        int peptide_length = unmodified_sequence.size();
-        hit.setMetaValue("peplen", peptide_length);
-        
-        for (int i = min_charge; i <= max_charge; ++i)
-        {
-          hit.setMetaValue("charge" + String(i), charge == i);
-        }
-
-        // just first peptide evidence
-        char aa_before = hit.getPeptideEvidences().front().getAABefore();
-        char aa_after = hit.getPeptideEvidences().front().getAAAfter();
-
-        bool enzN = isEnz_(aa_before, unmodified_sequence.prefix(1)[0], enz);
-        hit.setMetaValue("enzN", enzN);
-        bool enzC = isEnz_(unmodified_sequence.suffix(1)[0], aa_after, enz);
-        hit.setMetaValue("enzC", enzC);
-        int enzInt = countEnzymatic_(unmodified_sequence, enz);
-        hit.setMetaValue("enzInt", enzInt);
-
-        hit.setMetaValue("dm", delta_mass);
-        
-        double abs_delta_mass = abs(delta_mass);
-        hit.setMetaValue("absdm", abs_delta_mass);
-        
-        //peptide
-        String sequence = "";
-
-        aa_before = aa_before == '[' ? '-' : aa_before;
-        aa_after = aa_after == ']' ? '-' : aa_after;
-
-        sequence += aa_before;
-        sequence += "."; 
-        // Percolator uses square brackets to indicate PTMs
-        sequence += hit.getSequence().toBracketString(false, true);
-        sequence += "."; 
-        sequence += aa_after;
-        
-        hit.setMetaValue("Peptide", sequence);
-        
-        //proteinId1
-        StringList proteins;
-        for (const PeptideEvidence& pep : hit.getPeptideEvidences())
-        {
-          proteins.push_back(pep.getProteinAccession());
-        }
-        hit.setMetaValue("Proteins", ListUtils::concatenate(proteins, '\t'));
-        
-        StringList feats;
-        for (const String& feat : feature_set)
-        {
-        // Some Hits have no NumMatchedMainIons, and MeanError, etc. values. Have to ignore them!
-          if (hit.metaValueExists(feat))
-          {
-            feats.push_back(hit.getMetaValue(feat).toString());
-          }
-        }
-        // here: feats (metavalues in peptide hits) and feature_set are equal if they have same size (if no metavalue is missing)
-
-        if (feats.size() == feature_set.size())
-        { // only if all feats were present add
-          txt.addLine(ListUtils::concatenate(feats, '\t'));
-        }        
-        else
-        { // at least one feature is missing in the current peptide hit
-          missing_meta_value_count++;        
-          for (const auto& f : feature_set)
-          {
-            if (std::find(feats.begin(), feats.end(), f) == feats.end()) missing_meta_values.insert(f);
-          }
-        }
-      }
-    }
-
-    // print warnings
-    if (missing_meta_value_count != 0)
-    {
-      OPENMS_LOG_WARN << "There were peptide hits with missing features/meta values. Skipped peptide hits: " << missing_meta_value_count << endl;
-      OPENMS_LOG_WARN << "Names of missing meta values: " << endl;
-      for (const auto& f : missing_meta_values)
-      {
-        OPENMS_LOG_WARN << f << endl;
-      }
-    }
-
-    return txt;
-  }
-
-
-  bool PercolatorInfile::isEnz_(const char& n, const char& c, const std::string& enz)
-  {
-    if (enz == "trypsin")
-    {
-      return ((n == 'K' || n == 'R') && c != 'P') || n == '-' || c == '-';
-    }
-    else if (enz == "trypsinp")
-    {
-      return (n == 'K' || n == 'R') || n == '-' || c == '-';
-    }
-    else if (enz == "chymotrypsin")
-    {
-      return ((n == 'F' || n == 'W' || n == 'Y' || n == 'L') && c != 'P') || n == '-' || c == '-';
-    }
-    else if (enz == "thermolysin")
-    {
-      return ((c == 'A' || c == 'F' || c == 'I' || c == 'L' || c == 'M'
-              || c == 'V' || (n == 'R' && c == 'G')) && n != 'D' && n != 'E') || n == '-' || c == '-';
-    }
-    else if (enz == "proteinasek")
-    {
-      return (n == 'A' || n == 'E' || n == 'F' || n == 'I' || n == 'L'
-             || n == 'T' || n == 'V' || n == 'W' || n == 'Y') || n == '-' || c == '-';
-    }
-    else if (enz == "pepsin")
-    {
-      return ((c == 'F' || c == 'L' || c == 'W' || c == 'Y' || n == 'F'
-              || n == 'L' || n == 'W' || n == 'Y') && n != 'R') || n == '-' || c == '-';
-    }
-    else if (enz == "elastase")
-    {
-      return ((n == 'L' || n == 'V' || n == 'A' || n == 'G') && c != 'P')
-             || n == '-' || c == '-';
-    }
-    else if (enz == "lys-n")
-    {
-      return (c == 'K')
-             || n == '-' || c == '-';
-    }
-    else if (enz == "lys-c")
-    {
-      return ((n == 'K') && c != 'P')
-             || n == '-' || c == '-';
-    }
-    else if (enz == "arg-c")
-    {
-      return ((n == 'R') && c != 'P')
-             || n == '-' || c == '-';
-    }
-    else if (enz == "asp-n")
-    {
-      return (c == 'D')
-             || n == '-' || c == '-';
-    }
-    else if (enz == "glu-c")
-    {
-      return ((n == 'E') && (c != 'P'))
-             || n == '-' || c == '-';
+      scan_identifier = "scan=" + pid.getMetaValue("spectrum_id").toString();
     }
     else
     {
-      return true;
+      scan_identifier = "index=" + String(index); // fall back
+      OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
     }
   }
+  return scan_identifier.removeWhitespaces();
+}
 
-  // Function adapted from Enzyme.h in Percolator converter
-  // TODO: Use existing OpenMS functionality.
-  Size PercolatorInfile::countEnzymatic_(const String& peptide, const string& enz)
+PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
+                                                 bool higher_score_better,
+                                                 const String& score_name,
+                                                 const StringList& extra_scores,
+                                                 StringList& filenames,
+                                                 String decoy_prefix,
+                                                 double threshold,
+                                                 bool SageAnnotation)
+{
+  CsvFile csv(pin_file, '\t');
+
+  // Sage Variables, initialized in the following block if SageAnnotation is set
+  map<int, vector<PeptideHit::PeakAnnotation>> anno_mapping;
+  CsvFile tsv;
+  CsvFile annos;
+  unordered_map<String, size_t> to_idx_t;
+
+  if (SageAnnotation) // Block for special treatment of sage
   {
-    Size count = 0;
-    for (Size ix = 1; ix < peptide.size(); ++ix)
+    String tsv_file_path = pin_file.substr(0, pin_file.size() - 3);
+    tsv_file_path = tsv_file_path + "tsv";
+    tsv = CsvFile(tsv_file_path, '\t');
+
+    String temp_diff = "results.sage.pin";
+    String anno_file_path = pin_file.substr(0, pin_file.size() - temp_diff.length());
+    anno_file_path = anno_file_path + "matched_fragments.sage.tsv";
+    annos = CsvFile(anno_file_path, '\t');
+    // map PSMID to vec of PeakAnnotation
+    StringList sage_tsv_header;
+    tsv.getRow(0, sage_tsv_header);
     {
-      if (isEnz_(peptide[ix - 1], peptide[ix], enz))
+      int idx_t {};
+      for (const auto& h : sage_tsv_header)
       {
-        ++count;
+        to_idx_t[h] = idx_t++;
       }
     }
-    return count;
+
+    // processs annotation file
+    StringList sage_annotation_header;
+    annos.getRow(0, sage_annotation_header);
+    unordered_map<String, size_t> to_idx_a; // map column name to column index, for full annotation file file
+    {
+      int idx_a {};
+      for (const auto& h : sage_annotation_header)
+      {
+        to_idx_a[h] = idx_a++;
+      }
+    }
+    // map PSMs -> PeakAnnotation vector
+    auto num_rows = annos.rowCount();
+
+    for (size_t i = 1; i < num_rows; ++i)
+    {
+      StringList row;
+      annos.getRow(i, row);
+
+      // Check if mapping already has PSM, if it does add
+      if (anno_mapping.find(row[to_idx_a.at("psm_id")].toInt()) == anno_mapping.end())
+      {
+        // Make a new vector of annotations
+        PeptideHit::PeakAnnotation peak_temp;
+
+        peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")];
+        peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt();
+        peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble();
+        peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble();
+
+        vector<PeptideHit::PeakAnnotation> temp_anno_vec;
+        temp_anno_vec.push_back(peak_temp);
+        anno_mapping[row[to_idx_a.at("psm_id")].toInt()] = temp_anno_vec;
+      }
+      else
+      {
+        // Add values to exisiting vector
+        PeptideHit::PeakAnnotation peak_temp;
+
+        peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")];
+        peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt();
+        peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble();
+        peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble();
+
+        anno_mapping[row[to_idx_a.at("psm_id")].toInt()].push_back(peak_temp);
+      }
+    }
   }
 
+  StringList pin_header;
+
+  csv.getRow(0, pin_header);
+
+  unordered_map<String, size_t> to_idx; // map column name to column index
+  {
+    int idx {};
+    for (const auto& h : pin_header)
+    {
+      to_idx[h] = idx++;
+    }
+  }
+
+  // determine file name column index in percolator in file
+  int file_name_column_index {-1};
+  if (auto it = std::find(pin_header.begin(), pin_header.end(), "FileName"); it != pin_header.end())
+  {
+    file_name_column_index = it - pin_header.begin();
+  }
+
+  // determine extra scores and store column indices
+  std::set<String> found_extra_scores; // additional (non-main) scores that should be stored in the PeptideHit, order important for comparable idXML
+  for (const String& s : extra_scores)
+  {
+    if (auto it = std::find(pin_header.begin(), pin_header.end(), s); it != pin_header.end()) { found_extra_scores.insert(s); }
+    else { OPENMS_LOG_WARN << "Extra score: " << s << " not found in Percolator input file." << endl; }
+  }
+
+  // charge columns are not standardized, so we check for the format and create hash to lookup column name to charge mapping
+  std::regex charge_one_hot_pattern("^charge\\d+$");
+  std::regex sage_one_hot_pattern("^z=\\d+$");
+  String charge_prefix;
+  unordered_map<String, int> col_name_to_charge;
+
+  // Special handling for sage: sage produces an additional column for PSMs outside of the "suggested" charge search range (e.g., charge 2-5).
+  // The reason is that sage searches always for the charge annotated in the spectrum raw file. Only if the annotation is missing it will search
+  // the suggested charge range.
+  bool found_sage_otherz_charge_column {false};
+  for (const String& c : pin_header)
+  {
+    if (std::regex_match(c, charge_one_hot_pattern))
+    {
+      col_name_to_charge[c] = c.substr(6).toInt();
+      charge_prefix = "charge";
+    }
+    else if (std::regex_match(c, sage_one_hot_pattern))
+    {
+      col_name_to_charge[c] = c.substr(2).toInt();
+      charge_prefix = "z=";
+    }
+    else if (c == "z=other") // SAGE
+    {
+      found_sage_otherz_charge_column = true;
+      OPENMS_LOG_DEBUG
+        << "Found SAGE charge column 'z=other'. Will extract charge from this column if charge was not set in the one-hot encoded charge columns."
+        << endl;
+    }
+  }
+
+  auto n_rows = csv.rowCount();
+
+  PeptideIdentificationList pids;
+  pids.reserve(n_rows);
+  String spec_id;
+  String raw_file_name("UNKNOWN");
+  unordered_map<String, size_t> map_filename_to_idx; // fast lookup of filename to index in filenames vector
+
+  for (size_t i = 1; i != n_rows; ++i)
+  {
+    StringList row;
+    csv.getRow(i, row);
+
+    StringList t_row;
+
+    if (SageAnnotation)
+    {
+      tsv.getRow(i, t_row);
+      // skip if spectrum_q is above threshold
+      if (t_row[to_idx_t.at("spectrum_q")].toDouble() > threshold) continue;
+    }
+
+    if (row.size() != pin_header.size())
+    {
+      throw Exception::ParseError(
+        __FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Error: line " + String(i) + " of file '" + pin_file + "' does not have the same number of columns as the pin_header!", String(i));
+    }
+
+
+    if (file_name_column_index >= 0)
+    {
+      raw_file_name = row[file_name_column_index];
+      if (map_filename_to_idx.find(raw_file_name) == map_filename_to_idx.end())
+      {
+        filenames.push_back(raw_file_name);
+        map_filename_to_idx[raw_file_name] = filenames.size() - 1;
+      }
+    }
+    // NOTE: In our pin files that we WRITE, SpecID will be filename + vendor spectrum native ID
+    // However, many search engines (e.g. Sage) choose arbitrary IDs, which is unfortunately allowed
+    //  by this loosely defined format.
+    const String& sSpecId = row[to_idx.at("SpecId")];
+
+    double IM = 0.0;
+    if (auto it = to_idx.find("ion_mobility"); it != to_idx.end())
+    {
+      const String& sIM = row[it->second]; // read IM from e.g. Sage output
+      IM = sIM.toDouble();
+    }
+    // In theory, this should be an integer, but Sage currently cannot extract the number from all vendor spectrum IDs,
+    //  so it writes the full ID as string
+    String sScanNr = row[to_idx.at("ScanNr")];
+    if (sSpecId != spec_id)
+    {
+      pids.resize(pids.size() + 1);
+      pids.back().setHigherScoreBetter(higher_score_better);
+      pids.back().setScoreType(score_name);
+      pids.back().setMetaValue(Constants::UserParam::ID_MERGE_INDEX, map_filename_to_idx.at(raw_file_name));
+      pids.back().setRT(row[to_idx.at("retentiontime")].toDouble() * 60.0); // search engines typically write minutes (e.g., sage)
+      pids.back().setMetaValue("PinSpecId", sSpecId);
+      if (IM > 0.0) // Sage might annotate 0.0 if no IM is present
+      {
+        pids.back().setMetaValue(Constants::UserParam::IM, IM);
+      }
+      // Since ScanNr is the closest to help in identifying the spectrum in the file later on,
+      // we use it as spectrum_reference. Since it can be integer only or the complete
+      // vendor ID, you will need a lookup in case of number only later!!
+      pids.back().setSpectrumReference(sScanNr);
+    }
+    String sPeptide = row[to_idx.at("Peptide")];
+    const double score = row[to_idx.at(score_name)].toDouble();
+    String target_decoy = row[to_idx.at("Label")].toInt() == 1 ? "target" : "decoy";
+    const String& sProteins = row[to_idx.at("Proteins")];
+    int rank = to_idx.count("rank") ? row[to_idx.at("rank")].toInt() : 1;
+    StringList accessions;
+
+    int charge = 0;
+    for (const auto& [name, z] : col_name_to_charge)
+    {
+      if (row[to_idx.at(name)] == "1")
+      {
+        charge = z;
+        break;
+      }
+    }
+
+    // all one-hot encoded charge columns are zero. Use value in the sage "z=other" column if it exists.
+    if (charge == 0 && found_sage_otherz_charge_column) { charge = row[to_idx.at("z=other")].toInt(); }
+
+    if (charge != 0) { pids.back().setMZ(row[to_idx.at("ExpMass")].toDouble() / std::fabs(charge) + Constants::PROTON_MASS_U); }
+
+    sProteins.split(';', accessions);
+
+    // deduce decoy state from accessions if decoy_prefix is set
+    if (! decoy_prefix.empty())
+    {
+      bool dec = false;
+      bool tgt = false;
+      for (const auto& acc : accessions)
+      {
+        if (! (dec && tgt))
+        {
+          if (acc.hasPrefix(decoy_prefix)) { dec = true; }
+          else { tgt = true; }
+        }
+        else { break; }
+      }
+      if (tgt && dec) { target_decoy = "target+decoy"; }
+      else if (tgt) { target_decoy = "target"; }
+      else { target_decoy = "decoy"; }
+    }
+
+    // needs to handle strings like: [+42]-MVLVQDLLHPTAASEAR, [+304.207]-ETC[+57.0215]RQLGLGTNIYNAER etc.
+    sPeptide.substitute("]-", "]."); // we can parse [+42].MVLVQDLLHPTAASEAR
+    sPeptide.substitute("-[", ".["); // we can parse MVLVQDLLHPTAASEAR.[+111]
+    AASequence aa_seq = AASequence::fromString(sPeptide);
+    PeptideHit ph(score, rank - 1, charge, std::move(aa_seq));
+    ph.setMetaValue("target_decoy", target_decoy);
+
+    for (const auto& name : found_extra_scores)
+    {
+      String value = row[to_idx.at(name)];
+      if (name == "ln(-poisson)" && value == "inf") value = "3.5"; // workaround for Sage
+      ph.setMetaValue(name, value);
+    }
+
+    // adding own meta values
+    if (SageAnnotation)
+    {
+      ph.setMetaValue("spectrum_q", t_row[to_idx_t.at("spectrum_q")].toDouble()); // TODO: check if column exists / SAGE specific treatment
+    }
+    ph.setMetaValue("DeltaMass", (row[to_idx.at("ExpMass")].toDouble() - row[to_idx.at("CalcMass")].toDouble()));
+    // add annotations
+    if (SageAnnotation)
+    {
+      if (anno_mapping.find(sSpecId.toInt()) != anno_mapping.end())
+      {
+        // copy annotations from mapping to PeptideHit
+        vector<PeptideHit::PeakAnnotation> pep_vec;
+        for (const PeptideHit::PeakAnnotation& pep : anno_mapping[sSpecId.toInt()])
+        {
+          pep_vec.push_back(pep);
+        }
+        ph.setPeakAnnotations(pep_vec);
+      }
+    }
+    // add link to protein (we only know the accession but not start/end, aa_before/after in protein at this point)
+    for (const String& accession : accessions)
+    {
+      ph.addPeptideEvidence(PeptideEvidence(accession));
+    }
+
+    pids.back().insertHit(std::move(ph));
+  }
+
+  return pids;
 }
+
+
+TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_ids,
+                                       const StringList& feature_set,
+                                       const std::string& enz,
+                                       int min_charge,
+                                       int max_charge)
+{
+  TextFile txt;
+  txt.addLine(ListUtils::concatenate(feature_set, '\t'));
+  if (peptide_ids.empty())
+  {
+    OPENMS_LOG_WARN << "No identifications provided. Creating empty percolator input." << endl;
+    return txt;
+  }
+
+  // extract native id (usually in spectrum_reference)
+  const String sid = getScanIdentifier(peptide_ids[0], 0);
+
+  // determine RegEx to extract scan/index number
+  boost::regex scan_regex = boost::regex(SpectrumLookup::getRegExFromNativeID(sid));
+
+  // keep track of errors
+  size_t missing_meta_value_count {};
+  set<String> missing_meta_values;
+
+  size_t index = 0;
+  for (const PeptideIdentification& pep_id : peptide_ids)
+  {
+    index++;
+    // try to make a file and scan unique identifier
+    String scan_identifier = getScanIdentifier(pep_id, index);
+    String file_identifier = pep_id.getMetaValue("file_origin", String());
+
+    file_identifier += (String)pep_id.getMetaValue("id_merge_index", String());
+
+    Int scan_number = SpectrumLookup::extractScanNumber(scan_identifier, scan_regex, true);
+
+    double exp_mass = pep_id.getMZ();
+    double retention_time = pep_id.getRT();
+    for (const PeptideHit& psm : pep_id.getHits())
+    {
+      if (psm.getPeptideEvidences().empty())
+      {
+        OPENMS_LOG_WARN << "PSM (PeptideHit) without protein reference found. "
+                        << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong enzyme settings)."
+                        << "Will skip this PSM." << endl;
+        continue;
+      }
+      PeptideHit hit(psm); // make a copy of the hit to store temporary features
+      hit.setMetaValue("SpecId", file_identifier + scan_identifier);
+      hit.setMetaValue("ScanNr", scan_number);
+
+      if (hit.getTargetDecoyType() == PeptideHit::TargetDecoyType::UNKNOWN)
+      {
+        OPENMS_LOG_WARN << "PSM without target/decoy information found. "
+                        << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong decoy prefix settings)."
+                        << "Will skip this PSM." << endl;
+        continue;
+      }
+
+      int label = hit.isDecoy() ? -1 : 1;
+      hit.setMetaValue("Label", label);
+
+      int charge = hit.getCharge();
+      String unmodified_sequence = hit.getSequence().toUnmodifiedString();
+
+      double calc_mass;
+      if (! hit.metaValueExists("CalcMass"))
+      {
+        calc_mass = hit.getSequence().getMZ(charge);
+        hit.setMetaValue("CalcMass", calc_mass); // Percolator calls is CalcMass instead of m/z
+      }
+      else { calc_mass = hit.getMetaValue("CalcMass"); }
+
+      if (hit.metaValueExists("IsotopeError")) // for backwards compatibility (generated by MSGFPlusAdaper OpenMS < 2.6)
+      {
+        float isoErr = hit.getMetaValue("IsotopeError").toString().toFloat();
+        exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
+      }
+      else if (hit.metaValueExists(Constants::UserParam::ISOTOPE_ERROR)) // OpenMS user param name for isotope error
+      {
+        float isoErr = hit.getMetaValue(Constants::UserParam::ISOTOPE_ERROR).toString().toFloat();
+        exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
+      }
+
+      hit.setMetaValue("ExpMass", exp_mass);
+
+      // needed in case "description of correct" option is used
+      double delta_mass = exp_mass - calc_mass;
+      hit.setMetaValue("deltamass", delta_mass);
+      hit.setMetaValue("retentiontime", retention_time);
+
+      hit.setMetaValue("mass", exp_mass);
+
+      double score = hit.getScore();
+      // TODO better to use log scores for E-value based scores
+      hit.setMetaValue("score", score);
+
+      int peptide_length = unmodified_sequence.size();
+      hit.setMetaValue("peplen", peptide_length);
+
+      for (int i = min_charge; i <= max_charge; ++i)
+      {
+        hit.setMetaValue("charge" + String(i), charge == i);
+      }
+
+      // just first peptide evidence
+      char aa_before = hit.getPeptideEvidences().front().getAABefore();
+      char aa_after = hit.getPeptideEvidences().front().getAAAfter();
+
+      bool enzN = isEnz_(aa_before, unmodified_sequence.prefix(1)[0], enz);
+      hit.setMetaValue("enzN", enzN);
+      bool enzC = isEnz_(unmodified_sequence.suffix(1)[0], aa_after, enz);
+      hit.setMetaValue("enzC", enzC);
+      int enzInt = countEnzymatic_(unmodified_sequence, enz);
+      hit.setMetaValue("enzInt", enzInt);
+
+      hit.setMetaValue("dm", delta_mass);
+
+      double abs_delta_mass = abs(delta_mass);
+      hit.setMetaValue("absdm", abs_delta_mass);
+
+      // peptide
+      String sequence = "";
+
+      aa_before = aa_before == '[' ? '-' : aa_before;
+      aa_after = aa_after == ']' ? '-' : aa_after;
+
+      sequence += aa_before;
+      sequence += ".";
+      // Percolator uses square brackets to indicate PTMs
+      sequence += hit.getSequence().toBracketString(false, true);
+      sequence += ".";
+      sequence += aa_after;
+
+      hit.setMetaValue("Peptide", sequence);
+
+      // proteinId1
+      StringList proteins;
+      for (const PeptideEvidence& pep : hit.getPeptideEvidences())
+      {
+        proteins.push_back(pep.getProteinAccession());
+      }
+      hit.setMetaValue("Proteins", ListUtils::concatenate(proteins, '\t'));
+
+      StringList feats;
+      for (const String& feat : feature_set)
+      {
+        // Some Hits have no NumMatchedMainIons, and MeanError, etc. values. Have to ignore them!
+        if (hit.metaValueExists(feat)) { feats.push_back(hit.getMetaValue(feat).toString()); }
+      }
+      // here: feats (metavalues in peptide hits) and feature_set are equal if they have same size (if no metavalue is missing)
+
+      if (feats.size() == feature_set.size())
+      { // only if all feats were present add
+        txt.addLine(ListUtils::concatenate(feats, '\t'));
+      }
+      else
+      { // at least one feature is missing in the current peptide hit
+        missing_meta_value_count++;
+        for (const auto& f : feature_set)
+        {
+          if (std::find(feats.begin(), feats.end(), f) == feats.end()) missing_meta_values.insert(f);
+        }
+      }
+    }
+  }
+
+  // print warnings
+  if (missing_meta_value_count != 0)
+  {
+    OPENMS_LOG_WARN << "There were peptide hits with missing features/meta values. Skipped peptide hits: " << missing_meta_value_count << endl;
+    OPENMS_LOG_WARN << "Names of missing meta values: " << endl;
+    for (const auto& f : missing_meta_values)
+    {
+      OPENMS_LOG_WARN << f << endl;
+    }
+  }
+
+  return txt;
+}
+
+
+bool PercolatorInfile::isEnz_(const char& n, const char& c, const std::string& enz)
+{
+  if (enz == "trypsin") { return ((n == 'K' || n == 'R') && c != 'P') || n == '-' || c == '-'; }
+  else if (enz == "trypsinp") { return (n == 'K' || n == 'R') || n == '-' || c == '-'; }
+  else if (enz == "chymotrypsin") { return ((n == 'F' || n == 'W' || n == 'Y' || n == 'L') && c != 'P') || n == '-' || c == '-'; }
+  else if (enz == "thermolysin")
+  {
+    return ((c == 'A' || c == 'F' || c == 'I' || c == 'L' || c == 'M' || c == 'V' || (n == 'R' && c == 'G')) && n != 'D' && n != 'E') || n == '-'
+           || c == '-';
+  }
+  else if (enz == "proteinasek")
+  {
+    return (n == 'A' || n == 'E' || n == 'F' || n == 'I' || n == 'L' || n == 'T' || n == 'V' || n == 'W' || n == 'Y') || n == '-' || c == '-';
+  }
+  else if (enz == "pepsin")
+  {
+    return ((c == 'F' || c == 'L' || c == 'W' || c == 'Y' || n == 'F' || n == 'L' || n == 'W' || n == 'Y') && n != 'R') || n == '-' || c == '-';
+  }
+  else if (enz == "elastase") { return ((n == 'L' || n == 'V' || n == 'A' || n == 'G') && c != 'P') || n == '-' || c == '-'; }
+  else if (enz == "lys-n") { return (c == 'K') || n == '-' || c == '-'; }
+  else if (enz == "lys-c") { return ((n == 'K') && c != 'P') || n == '-' || c == '-'; }
+  else if (enz == "arg-c") { return ((n == 'R') && c != 'P') || n == '-' || c == '-'; }
+  else if (enz == "asp-n") { return (c == 'D') || n == '-' || c == '-'; }
+  else if (enz == "glu-c") { return ((n == 'E') && (c != 'P')) || n == '-' || c == '-'; }
+  else { throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown enzyme name in isEnz_", enz); }
+}
+
+// Function adapted from Enzyme.h in Percolator converter
+// TODO: Use existing OpenMS functionality.
+Size PercolatorInfile::countEnzymatic_(const String& peptide, const string& enz)
+{
+  Size count = 0;
+  for (Size ix = 1; ix < peptide.size(); ++ix)
+  {
+    if (isEnz_(peptide[ix - 1], peptide[ix], enz)) { ++count; }
+  }
+  return count;
+}
+
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/PercolatorInfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorInfile.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/FORMAT/PercolatorInfile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/SpectrumLookup.h>
+#include <cmath>
 #include <regex>
 
 namespace OpenMS
@@ -48,7 +49,7 @@ String PercolatorInfile::getScanIdentifier(const PeptideIdentification& pid, siz
     else
     {
       scan_identifier = "index=" + String(index); // fall back
-      OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
+      OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << '\n';
     }
   }
   return scan_identifier.removeWhitespaces();
@@ -61,25 +62,36 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
                                                  StringList& filenames,
                                                  String decoy_prefix,
                                                  double threshold,
-                                                 bool SageAnnotation)
+                                                 bool sage_annotation)
 {
   CsvFile csv(pin_file, '\t');
 
-  // Sage Variables, initialized in the following block if SageAnnotation is set
+  // Sage Variables, initialized in the following block if sage_annotation is set
   map<int, vector<PeptideHit::PeakAnnotation>> anno_mapping;
   CsvFile tsv;
   CsvFile annos;
   unordered_map<String, size_t> to_idx_t;
 
-  if (SageAnnotation) // Block for special treatment of sage
+  if (sage_annotation) // Block for special treatment of sage
   {
-    String tsv_file_path = pin_file.substr(0, pin_file.size() - 3);
-    tsv_file_path = tsv_file_path + "tsv";
+    // Normalize: replace the file extension with .tsv
+    size_t dot_pos = pin_file.rfind('.');
+    String base_name = (dot_pos != std::string::npos) ? pin_file.substr(0, dot_pos) : pin_file;
+    String tsv_file_path = base_name + ".tsv";
     tsv = CsvFile(tsv_file_path, '\t');
 
-    String temp_diff = "results.sage.pin";
-    String anno_file_path = pin_file.substr(0, pin_file.size() - temp_diff.length());
-    anno_file_path = anno_file_path + "matched_fragments.sage.tsv";
+    // Build annotation file path: check for "results.sage.pin" suffix
+    String anno_file_path;
+    String sage_suffix = "results.sage.pin";
+    if (pin_file.hasSuffix(sage_suffix))
+    {
+      anno_file_path = pin_file.substr(0, pin_file.size() - sage_suffix.length()) + "matched_fragments.sage.tsv";
+    }
+    else
+    {
+      // Fallback: replace extension
+      anno_file_path = base_name + ".matched_fragments.sage.tsv";
+    }
     annos = CsvFile(anno_file_path, '\t');
     // map PSMID to vec of PeakAnnotation
     StringList sage_tsv_header;
@@ -111,33 +123,13 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
       StringList row;
       annos.getRow(i, row);
 
-      // Check if mapping already has PSM, if it does add
-      if (anno_mapping.find(row[to_idx_a.at("psm_id")].toInt()) == anno_mapping.end())
-      {
-        // Make a new vector of annotations
-        PeptideHit::PeakAnnotation peak_temp;
+      PeptideHit::PeakAnnotation peak_temp;
+      peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")];
+      peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt();
+      peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble();
+      peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble();
 
-        peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")];
-        peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt();
-        peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble();
-        peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble();
-
-        vector<PeptideHit::PeakAnnotation> temp_anno_vec;
-        temp_anno_vec.push_back(peak_temp);
-        anno_mapping[row[to_idx_a.at("psm_id")].toInt()] = temp_anno_vec;
-      }
-      else
-      {
-        // Add values to exisiting vector
-        PeptideHit::PeakAnnotation peak_temp;
-
-        peak_temp.annotation = row[to_idx_a.at("fragment_type")] + row[to_idx_a.at("fragment_ordinals")];
-        peak_temp.charge = row[to_idx_a.at("fragment_charge")].toInt();
-        peak_temp.intensity = row[to_idx_a.at("fragment_intensity")].toDouble();
-        peak_temp.mz = row[to_idx_a.at("fragment_mz_experimental")].toDouble();
-
-        anno_mapping[row[to_idx_a.at("psm_id")].toInt()].push_back(peak_temp);
-      }
+      anno_mapping[row[to_idx_a.at("psm_id")].toInt()].push_back(peak_temp);
     }
   }
 
@@ -155,7 +147,7 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
   }
 
   // determine file name column index in percolator in file
-  int file_name_column_index {-1};
+  SignedSize file_name_column_index {-1};
   if (auto it = std::find(pin_header.begin(), pin_header.end(), "FileName"); it != pin_header.end())
   {
     file_name_column_index = it - pin_header.begin();
@@ -166,7 +158,7 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
   for (const String& s : extra_scores)
   {
     if (auto it = std::find(pin_header.begin(), pin_header.end(), s); it != pin_header.end()) { found_extra_scores.insert(s); }
-    else { OPENMS_LOG_WARN << "Extra score: " << s << " not found in Percolator input file." << endl; }
+    else { OPENMS_LOG_WARN << "Extra score: " << s << " not found in Percolator input file." << '\n'; }
   }
 
   // charge columns are not standardized, so we check for the format and create hash to lookup column name to charge mapping
@@ -196,7 +188,7 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
       found_sage_otherz_charge_column = true;
       OPENMS_LOG_DEBUG
         << "Found SAGE charge column 'z=other'. Will extract charge from this column if charge was not set in the one-hot encoded charge columns."
-        << endl;
+        << '\n';
     }
   }
 
@@ -215,7 +207,7 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
 
     StringList t_row;
 
-    if (SageAnnotation)
+    if (sage_annotation)
     {
       tsv.getRow(i, t_row);
       // skip if spectrum_q is above threshold
@@ -255,7 +247,7 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
     String sScanNr = row[to_idx.at("ScanNr")];
     if (sSpecId != spec_id)
     {
-      pids.resize(pids.size() + 1);
+      pids.emplace_back();
       pids.back().setHigherScoreBetter(higher_score_better);
       pids.back().setScoreType(score_name);
       pids.back().setMetaValue(Constants::UserParam::ID_MERGE_INDEX, map_filename_to_idx.at(raw_file_name));
@@ -328,24 +320,15 @@ PeptideIdentificationList PercolatorInfile::load(const String& pin_file,
     }
 
     // adding own meta values
-    if (SageAnnotation)
+    if (sage_annotation)
     {
       ph.setMetaValue("spectrum_q", t_row[to_idx_t.at("spectrum_q")].toDouble()); // TODO: check if column exists / SAGE specific treatment
     }
     ph.setMetaValue("DeltaMass", (row[to_idx.at("ExpMass")].toDouble() - row[to_idx.at("CalcMass")].toDouble()));
     // add annotations
-    if (SageAnnotation)
+    if (sage_annotation)
     {
-      if (anno_mapping.find(sSpecId.toInt()) != anno_mapping.end())
-      {
-        // copy annotations from mapping to PeptideHit
-        vector<PeptideHit::PeakAnnotation> pep_vec;
-        for (const PeptideHit::PeakAnnotation& pep : anno_mapping[sSpecId.toInt()])
-        {
-          pep_vec.push_back(pep);
-        }
-        ph.setPeakAnnotations(pep_vec);
-      }
+      if (anno_mapping.find(sSpecId.toInt()) != anno_mapping.end()) { ph.setPeakAnnotations(anno_mapping[sSpecId.toInt()]); }
     }
     // add link to protein (we only know the accession but not start/end, aa_before/after in protein at this point)
     for (const String& accession : accessions)
@@ -370,7 +353,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
   txt.addLine(ListUtils::concatenate(feature_set, '\t'));
   if (peptide_ids.empty())
   {
-    OPENMS_LOG_WARN << "No identifications provided. Creating empty percolator input." << endl;
+    OPENMS_LOG_WARN << "No identifications provided. Creating empty percolator input." << '\n';
     return txt;
   }
 
@@ -392,7 +375,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
     String scan_identifier = getScanIdentifier(pep_id, index);
     String file_identifier = pep_id.getMetaValue("file_origin", String());
 
-    file_identifier += (String)pep_id.getMetaValue("id_merge_index", String());
+    file_identifier += pep_id.getMetaValue("id_merge_index", String()).toString();
 
     Int scan_number = SpectrumLookup::extractScanNumber(scan_identifier, scan_regex, true);
 
@@ -404,7 +387,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
       {
         OPENMS_LOG_WARN << "PSM (PeptideHit) without protein reference found. "
                         << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong enzyme settings)."
-                        << "Will skip this PSM." << endl;
+                        << "Will skip this PSM." << '\n';
         continue;
       }
       PeptideHit hit(psm); // make a copy of the hit to store temporary features
@@ -415,7 +398,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
       {
         OPENMS_LOG_WARN << "PSM without target/decoy information found. "
                         << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong decoy prefix settings)."
-                        << "Will skip this PSM." << endl;
+                        << "Will skip this PSM." << '\n';
         continue;
       }
 
@@ -457,8 +440,8 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
       // TODO better to use log scores for E-value based scores
       hit.setMetaValue("score", score);
 
-      int peptide_length = unmodified_sequence.size();
-      hit.setMetaValue("peplen", peptide_length);
+      Size peptide_length = unmodified_sequence.size();
+      hit.setMetaValue("peplen", static_cast<int>(peptide_length));
 
       for (int i = min_charge; i <= max_charge; ++i)
       {
@@ -478,7 +461,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
 
       hit.setMetaValue("dm", delta_mass);
 
-      double abs_delta_mass = abs(delta_mass);
+      double abs_delta_mass = std::fabs(delta_mass);
       hit.setMetaValue("absdm", abs_delta_mass);
 
       // peptide
@@ -521,7 +504,7 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
         missing_meta_value_count++;
         for (const auto& f : feature_set)
         {
-          if (std::find(feats.begin(), feats.end(), f) == feats.end()) missing_meta_values.insert(f);
+          if (! hit.metaValueExists(f)) missing_meta_values.insert(f);
         }
       }
     }
@@ -530,11 +513,11 @@ TextFile PercolatorInfile::preparePin_(const PeptideIdentificationList& peptide_
   // print warnings
   if (missing_meta_value_count != 0)
   {
-    OPENMS_LOG_WARN << "There were peptide hits with missing features/meta values. Skipped peptide hits: " << missing_meta_value_count << endl;
-    OPENMS_LOG_WARN << "Names of missing meta values: " << endl;
+    OPENMS_LOG_WARN << "There were peptide hits with missing features/meta values. Skipped peptide hits: " << missing_meta_value_count << '\n';
+    OPENMS_LOG_WARN << "Names of missing meta values: " << '\n';
     for (const auto& f : missing_meta_values)
     {
-      OPENMS_LOG_WARN << f << endl;
+      OPENMS_LOG_WARN << f << '\n';
     }
   }
 

--- a/src/pyOpenMS/tests/unittests/test_msspectrum.py
+++ b/src/pyOpenMS/tests/unittests/test_msspectrum.py
@@ -13,18 +13,18 @@ class TestMSSpectrum(unittest.TestCase):
         spec.push_back(p)
 
         p_back, = list(spec)
-        assert isinstance(p_back, pyopenms.Peak1D)
-        assert p_back.getMZ() == 500.0
-        assert p_back.getIntensity() == 1e5
+        self.assertIsInstance(p_back, pyopenms.Peak1D)
+        self.assertEqual(p_back.getMZ(), 500.0)
+        self.assertEqual(p_back.getIntensity(), 1e5)
 
         spec.updateRanges()
-        assert isinstance(spec.getMinMZ(), float)
-        assert isinstance(spec.getMaxMZ(), float)
-        assert isinstance(spec.getMinIntensity(), float)
-        assert isinstance(spec.getMaxIntensity(), float)
+        self.assertIsInstance(spec.getMinMZ(), float)
+        self.assertIsInstance(spec.getMaxMZ(), float)
+        self.assertIsInstance(spec.getMinIntensity(), float)
+        self.assertIsInstance(spec.getMaxIntensity(), float)
 
-        assert spec.getMinIntensity() == 1e5
-        assert spec.getMaxIntensity() == 1e5
+        self.assertEqual(spec.getMinIntensity(), 1e5)
+        self.assertEqual(spec.getMaxIntensity(), 1e5)
 
     def testMSSpectrumGetPeaks(self):
         """Test optimized get_peaks method"""
@@ -40,9 +40,9 @@ class TestMSSpectrum(unittest.TestCase):
         self.assertEqual(mz.dtype, np.float64)
         self.assertEqual(intensities.dtype, np.float32)
 
-        for m, e in zip(mz, mz_exp):
+        for m, e in zip(mz, mz_exp, strict=True):
             self.assertAlmostEqual(m, e)
-        for i, e in zip(intensities, int_exp):
+        for i, e in zip(intensities, int_exp, strict=True):
             self.assertAlmostEqual(i, e, places=1)
 
     def testMSSpectrumGetPeaksEmpty(self):
@@ -65,7 +65,7 @@ class TestMSSpectrum(unittest.TestCase):
         mz = spec.get_mz_array()
         self.assertEqual(len(mz), 3)
         self.assertEqual(mz.dtype, np.float64)
-        for m, e in zip(mz, mz_exp):
+        for m, e in zip(mz, mz_exp, strict=True):
             self.assertAlmostEqual(m, e)
 
     def testMSSpectrumGetIntensityArray(self):
@@ -78,7 +78,7 @@ class TestMSSpectrum(unittest.TestCase):
         intensities = spec.get_intensity_array()
         self.assertEqual(len(intensities), 3)
         self.assertEqual(intensities.dtype, np.float32)
-        for i, e in zip(intensities, int_exp):
+        for i, e in zip(intensities, int_exp, strict=True):
             self.assertAlmostEqual(i, e, places=1)
 
     def testMSSpectrumDriftTimeNoIM(self):

--- a/src/pyOpenMS/tests/unittests/test_msspectrum.py
+++ b/src/pyOpenMS/tests/unittests/test_msspectrum.py
@@ -176,11 +176,7 @@ class TestMSSpectrum(unittest.TestCase):
         
         # Empty spectrum - should return UNKNOWN
         spec_type = spec.getType(False)
-        self.assertIn(spec_type, [
-            pyopenms.SpectrumSettings.SpectrumType.UNKNOWN,
-            pyopenms.SpectrumSettings.SpectrumType.CENTROID,
-            pyopenms.SpectrumSettings.SpectrumType.PROFILE
-        ])
+        self.assertEqual(spec_type, pyopenms.SpectrumSettings.SpectrumType.UNKNOWN)
         
         # Set type explicitly
         spec.setType(pyopenms.SpectrumSettings.SpectrumType.CENTROID)

--- a/src/pyOpenMS/tests/unittests/test_msspectrum.py
+++ b/src/pyOpenMS/tests/unittests/test_msspectrum.py
@@ -1,255 +1,207 @@
-"""
-Tests for MSSpectrum class bindings.
-"""
+import unittest
 
-import pytest
 import numpy as np
+import pyopenms
 
+class TestMSSpectrum(unittest.TestCase):
 
-def test_msspectrum_creation():
-    """Test MSSpectrum constructor."""
-    from pyopenms import MSSpectrum
-
-    # Default constructor
-    spec = MSSpectrum()
-    assert spec.size() == 0
-    assert len(spec) == 0
-
-    # Copy constructor
-    spec.setRT(123.45)
-    spec.setMSLevel(2)
-    spec2 = MSSpectrum(spec)
-    assert spec2.getRT() == pytest.approx(123.45)
-    assert spec2.getMSLevel() == 2
-
-
-def test_msspectrum_basic_properties():
-    """Test MSSpectrum basic property getters/setters."""
-    from pyopenms import MSSpectrum
-
-    spec = MSSpectrum()
-
-    # RT
-    spec.setRT(456.78)
-    assert spec.getRT() == pytest.approx(456.78)
-
-    # MS Level
-    spec.setMSLevel(3)
-    assert spec.getMSLevel() == 3
-
-    # Name
-    spec.setName("test_spectrum")
-    assert spec.getName() == "test_spectrum"
-
-    # Drift time
-    spec.setDriftTime(25.5)
-    assert spec.getDriftTime() == pytest.approx(25.5)
-
-
-def test_msspectrum_peaks():
-    """Test MSSpectrum peak operations."""
-    from pyopenms import MSSpectrum, Peak1D
-
-    spec = MSSpectrum()
-
-    # Add peaks using push_back
-    for i in range(5):
-        p = Peak1D()
-        p.setMZ(100.0 + i * 10)
-        p.setIntensity(1000.0 + i * 100)
+    def testMSSpectrum(self):
+        spec = pyopenms.MSSpectrum()
+        p = pyopenms.Peak1D()
+        p.setMZ(500.0)
+        p.setIntensity(1e5)
         spec.push_back(p)
 
-    assert spec.size() == 5
-    assert len(spec) == 5
+        p_back, = list(spec)
+        assert isinstance(p_back, pyopenms.Peak1D)
+        assert p_back.getMZ() == 500.0
+        assert p_back.getIntensity() == 1e5
 
-    # Access individual peaks
-    assert spec[0].getMZ() == pytest.approx(100.0)
-    assert spec[4].getMZ() == pytest.approx(140.0)
+        spec.updateRanges()
+        assert isinstance(spec.getMinMZ(), float)
+        assert isinstance(spec.getMaxMZ(), float)
+        assert isinstance(spec.getMinIntensity(), float)
+        assert isinstance(spec.getMaxIntensity(), float)
 
-    # Index out of range
-    with pytest.raises(IndexError):
-        _ = spec[10]
+        assert spec.getMinIntensity() == 1e5
+        assert spec.getMaxIntensity() == 1e5
 
+    def testMSSpectrumGetPeaks(self):
+        """Test optimized get_peaks method"""
+        spec = pyopenms.MSSpectrum()
+        mz_exp = [100.0, 200.0, 300.0]
+        int_exp = [1000.0, 2000.0, 500.0]
+        spec.set_peaks((mz_exp, int_exp))
 
-def test_msspectrum_get_set_peaks():
-    """Test MSSpectrum get_peaks/set_peaks methods."""
-    from pyopenms import MSSpectrum
+        mz, intensities = spec.get_peaks()
 
-    spec = MSSpectrum()
+        self.assertEqual(len(mz), 3)
+        self.assertEqual(len(intensities), 3)
+        self.assertEqual(mz.dtype, np.float64)
+        self.assertEqual(intensities.dtype, np.float32)
 
-    # Set peaks from numpy arrays
-    mz = np.array([100.0, 200.0, 300.0, 400.0, 500.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0, 2000.0, 1000.0])
+        for m, e in zip(mz, mz_exp):
+            self.assertAlmostEqual(m, e)
+        for i, e in zip(intensities, int_exp):
+            self.assertAlmostEqual(i, e, places=1)
 
-    spec.set_peaks(mz, intensity)
+    def testMSSpectrumGetPeaksEmpty(self):
+        """Test get_peaks on empty spectrum"""
+        spec = pyopenms.MSSpectrum()
+        mz, intensities = spec.get_peaks()
 
-    assert spec.size() == 5
+        self.assertEqual(len(mz), 0)
+        self.assertEqual(len(intensities), 0)
+        self.assertEqual(mz.dtype, np.float64)
+        self.assertEqual(intensities.dtype, np.float32)
 
-    # Get peaks back
-    mz_out, int_out = spec.get_peaks()
+    def testMSSpectrumGetMzArray(self):
+        """Test get_mz_array method"""
+        spec = pyopenms.MSSpectrum()
+        mz_exp = [100.0, 200.0, 300.0]
+        int_exp = [1000.0, 2000.0, 500.0]
+        spec.set_peaks((mz_exp, int_exp))
 
-    np.testing.assert_array_almost_equal(mz_out, mz)
-    np.testing.assert_array_almost_equal(int_out, intensity, decimal=3)
+        mz = spec.get_mz_array()
+        self.assertEqual(len(mz), 3)
+        self.assertEqual(mz.dtype, np.float64)
+        for m, e in zip(mz, mz_exp):
+            self.assertAlmostEqual(m, e)
 
+    def testMSSpectrumGetIntensityArray(self):
+        """Test get_intensity_array method"""
+        spec = pyopenms.MSSpectrum()
+        mz_exp = [100.0, 200.0, 300.0]
+        int_exp = [1000.0, 2000.0, 500.0]
+        spec.set_peaks((mz_exp, int_exp))
 
-def test_msspectrum_get_set_peaks_tuple():
-    """Test MSSpectrum set_peaks with tuple argument."""
-    from pyopenms import MSSpectrum
+        intensities = spec.get_intensity_array()
+        self.assertEqual(len(intensities), 3)
+        self.assertEqual(intensities.dtype, np.float32)
+        for i, e in zip(intensities, int_exp):
+            self.assertAlmostEqual(i, e, places=1)
 
-    spec = MSSpectrum()
+    def testMSSpectrumDriftTimeNoIM(self):
+        """Test drift time methods when no IM data present"""
+        spec = pyopenms.MSSpectrum()
+        spec.set_peaks(([100.0, 200.0], [1000.0, 2000.0]))
 
-    mz = np.array([100.0, 200.0, 300.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0])
+        # Should return None when no IM data
+        self.assertFalse(spec.containsIMData())
+        self.assertIsNone(spec.get_drift_time_array())
+        self.assertIsNone(spec.get_drift_time_array_mv())
+        self.assertIsNone(spec.get_drift_time_unit())
 
-    # Set using tuple
-    spec.set_peaks((mz, intensity))
+    def testMSSpectrumDriftTimeWithIM(self):
+        """Test drift time methods with ion mobility data"""
+        spec = pyopenms.MSSpectrum()
+        spec.set_peaks(([100.0, 200.0, 300.0], [1000.0, 2000.0, 500.0]))
 
-    mz_out, int_out = spec.get_peaks()
-    np.testing.assert_array_almost_equal(mz_out, mz)
+        # Add ion mobility data via FloatDataArray
+        fda = pyopenms.FloatDataArray()
+        fda.setName("Ion Mobility")
+        fda.push_back(1.5)
+        fda.push_back(2.5)
+        fda.push_back(3.5)
+        spec.setFloatDataArrays([fda])
 
+        # Should now have IM data
+        self.assertTrue(spec.containsIMData())
 
-def test_msspectrum_iteration():
-    """Test MSSpectrum iteration."""
-    from pyopenms import MSSpectrum
+        # Test get_drift_time_array (copy)
+        drift = spec.get_drift_time_array()
+        self.assertIsNotNone(drift)
+        self.assertEqual(len(drift), 3)
+        self.assertEqual(drift.dtype, np.float32)
+        self.assertAlmostEqual(drift[0], 1.5, places=1)
+        self.assertAlmostEqual(drift[1], 2.5, places=1)
+        self.assertAlmostEqual(drift[2], 3.5, places=1)
 
-    spec = MSSpectrum()
-    mz = np.array([100.0, 200.0, 300.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0])
-    spec.set_peaks(mz, intensity)
+        # Test get_drift_time_unit
+        unit = spec.get_drift_time_unit()
+        self.assertIsNotNone(unit)
 
-    # Iterate over peaks
-    peaks = list(spec)
-    assert len(peaks) == 3
+    def testFloatDataArrayGetData(self):
+        """Test FloatDataArray get_data method (returns copy - safe)"""
+        fda = pyopenms.FloatDataArray()
+        fda.push_back(1.0)
+        fda.push_back(2.0)
+        fda.push_back(3.0)
 
-    for i, peak in enumerate(spec):
-        assert peak.getMZ() == pytest.approx(mz[i])
+        # Get a copy (safe default)
+        data_copy = fda.get_data()
+        self.assertEqual(len(data_copy), 3)
+        self.assertEqual(data_copy.dtype, np.float32)
+        self.assertAlmostEqual(data_copy[0], 1.0, places=1)
+        self.assertAlmostEqual(data_copy[1], 2.0, places=1)
+        self.assertAlmostEqual(data_copy[2], 3.0, places=1)
 
+        # Modify copy - original should be unchanged
+        data_copy[0] = 100.0
+        self.assertAlmostEqual(fda[0], 1.0, places=1)
 
-def test_msspectrum_sorting():
-    """Test MSSpectrum sorting methods."""
-    from pyopenms import MSSpectrum
+    def testFloatDataArrayGetDataMv(self):
+        """Test FloatDataArray get_data_mv method (memory view - fast, unsafe)"""
+        fda = pyopenms.FloatDataArray()
+        fda.push_back(1.0)
+        fda.push_back(2.0)
+        fda.push_back(3.0)
 
-    spec = MSSpectrum()
-    mz = np.array([300.0, 100.0, 200.0])
-    intensity = np.array([3000.0, 1000.0, 2000.0])
-    spec.set_peaks(mz, intensity)
+        # Get a view (fast but unsafe)
+        data_view = fda.get_data_mv()
+        self.assertEqual(len(data_view), 3)
+        self.assertAlmostEqual(data_view[0], 1.0, places=1)
+        self.assertAlmostEqual(data_view[1], 2.0, places=1)
+        self.assertAlmostEqual(data_view[2], 3.0, places=1)
 
-    # Should not be sorted initially
-    assert not spec.isSorted()
+        # Modify view - original SHOULD change (it's a view)
+        data_view[0] = 100.0
+        self.assertAlmostEqual(fda[0], 100.0, places=1)
 
-    # Sort by position (m/z)
-    spec.sortByPosition()
-    assert spec.isSorted()
+    def testFloatDataArrayEmpty(self):
+        """Test FloatDataArray methods on empty array"""
+        fda = pyopenms.FloatDataArray()
 
-    mz_sorted, _ = spec.get_peaks()
-    np.testing.assert_array_almost_equal(mz_sorted, [100.0, 200.0, 300.0])
+        # get_data returns empty array
+        data_copy = fda.get_data()
+        self.assertEqual(len(data_copy), 0)
 
+        # get_data_mv returns None for empty
+        data_view = fda.get_data_mv()
+        self.assertIsNone(data_view)
 
-def test_msspectrum_find_nearest():
-    """Test MSSpectrum findNearest methods."""
-    from pyopenms import MSSpectrum
+    def testGetTypeWithQueryData(self):
+        """Test getType(bool) method with query_data parameter"""
+        spec = pyopenms.MSSpectrum()
+        
+        # Empty spectrum - should return UNKNOWN
+        spec_type = spec.getType(False)
+        self.assertIn(spec_type, [
+            pyopenms.SpectrumSettings.SpectrumType.UNKNOWN,
+            pyopenms.SpectrumSettings.SpectrumType.CENTROID,
+            pyopenms.SpectrumSettings.SpectrumType.PROFILE
+        ])
+        
+        # Set type explicitly
+        spec.setType(pyopenms.SpectrumSettings.SpectrumType.CENTROID)
+        spec_type = spec.getType(False)
+        self.assertEqual(spec_type, pyopenms.SpectrumSettings.SpectrumType.CENTROID)
+        
+        # Test with query_data=True on spectrum with peaks
+        spec2 = pyopenms.MSSpectrum()
+        spec2.set_peaks(([100.0, 200.0, 300.0], [1000.0, 2000.0, 500.0]))
+        
+        # Without setting type, getType(False) should return UNKNOWN
+        spec_type_no_query = spec2.getType(False)
+        self.assertEqual(spec_type_no_query, pyopenms.SpectrumSettings.SpectrumType.UNKNOWN)
+        
+        # With query_data=True, it may estimate the type based on peak data
+        spec_type_with_query = spec2.getType(True)
+        self.assertIn(spec_type_with_query, [
+            pyopenms.SpectrumSettings.SpectrumType.UNKNOWN,
+            pyopenms.SpectrumSettings.SpectrumType.CENTROID,
+            pyopenms.SpectrumSettings.SpectrumType.PROFILE
+        ])
 
-    spec = MSSpectrum()
-    mz = np.array([100.0, 200.0, 300.0, 400.0, 500.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0, 2000.0, 1000.0])
-    spec.set_peaks(mz, intensity)
-    spec.sortByPosition()
-
-    # Find nearest
-    idx = spec.findNearest(195.0)
-    assert idx == 1  # 200.0 is nearest
-
-    # Find nearest with tolerance
-    idx = spec.findNearest(195.0, 10.0)
-    assert idx == 1
-
-    # No match within tolerance
-    idx = spec.findNearest(195.0, 1.0)
-    assert idx == -1
-
-
-def test_msspectrum_tic():
-    """Test MSSpectrum TIC calculation."""
-    from pyopenms import MSSpectrum
-
-    spec = MSSpectrum()
-    mz = np.array([100.0, 200.0, 300.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0])
-    spec.set_peaks(mz, intensity)
-
-    tic = spec.calculateTIC()
-    assert tic == pytest.approx(6000.0)
-
-
-def test_msspectrum_comparison():
-    """Test MSSpectrum comparison operators."""
-    from pyopenms import MSSpectrum
-
-    spec1 = MSSpectrum()
-    spec1.setRT(100.0)
-
-    spec2 = MSSpectrum()
-    spec2.setRT(100.0)
-
-    spec3 = MSSpectrum()
-    spec3.setRT(200.0)
-
-    # Same RT should be equal (before adding peaks)
-    assert spec1 == spec2
-    assert spec1 != spec3
-
-
-def test_msspectrum_repr():
-    """Test MSSpectrum string representation."""
-    from pyopenms import MSSpectrum
-
-    spec = MSSpectrum()
-    spec.setRT(123.45)
-    spec.setMSLevel(2)
-    mz = np.array([100.0, 200.0, 300.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0])
-    spec.set_peaks(mz, intensity)
-
-    repr_str = repr(spec)
-    assert "MSSpectrum" in repr_str
-    assert "3" in repr_str  # n_peaks
-    assert "123" in repr_str  # RT
-
-
-def test_msspectrum_reserve_resize():
-    """Test MSSpectrum reserve and resize."""
-    from pyopenms import MSSpectrum
-
-    spec = MSSpectrum()
-
-    # Reserve space (should not change size)
-    spec.reserve(100)
-    assert spec.size() == 0
-
-    # Resize
-    spec.resize(10)
-    assert spec.size() == 10
-
-
-def test_msspectrum_clear():
-    """Test MSSpectrum clear method."""
-    from pyopenms import MSSpectrum
-
-    spec = MSSpectrum()
-    mz = np.array([100.0, 200.0, 300.0])
-    intensity = np.array([1000.0, 2000.0, 3000.0])
-    spec.set_peaks(mz, intensity)
-    spec.setRT(123.0)
-    spec.setMSLevel(2)
-
-    assert spec.size() == 3
-
-    # Clear without clearing metadata
-    spec.clear(False)
-    assert spec.size() == 0
-    assert spec.getRT() == pytest.approx(123.0)
-
-    # Restore and clear with metadata
-    spec.set_peaks(mz, intensity)
-    spec.clear(True)
-    assert spec.size() == 0
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/class_tests/openms/source/DigestionEnzymeDataProvider_test.cpp
+++ b/src/tests/class_tests/openms/source/DigestionEnzymeDataProvider_test.cpp
@@ -12,14 +12,14 @@
 
 ///////////////////////////
 
-#include <OpenMS/CHEMISTRY/DigestionEnzymeDataProvider.h>
-#include <OpenMS/CHEMISTRY/EnzymeXMLDataProvider.h>
 #include <OpenMS/CHEMISTRY/BuiltInProteaseDataProvider.h>
+#include <OpenMS/CHEMISTRY/DigestionEnzymeDataProvider.h>
 #include <OpenMS/CHEMISTRY/DigestionEnzymeProtein.h>
 #include <OpenMS/CHEMISTRY/DigestionEnzymeRNA.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/EnzymeXMLDataProvider.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/RNaseDB.h>
-#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -35,10 +35,8 @@ START_TEST(DigestionEnzymeDataProvider, "$Id$")
 START_SECTION(InMemoryDigestionEnzymeDataProvider - DigestionEnzymeProtein)
 {
   vector<unique_ptr<DigestionEnzymeProtein>> enzymes;
-  enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-    "TestProtease", "(?<=[K])", set<String>{"test_syn"}, "Test protease description"));
-  enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-    "TestProtease2", "(?<=[R])", set<String>(), "Another test protease"));
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("TestProtease", "(?<=[K])", set<String> {"test_syn"}, "Test protease description"));
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("TestProtease2", "(?<=[R])", set<String>(), "Another test protease"));
 
   InMemoryDigestionEnzymeDataProvider<DigestionEnzymeProtein> provider(std::move(enzymes));
   auto loaded = provider.loadEnzymes();
@@ -89,7 +87,7 @@ START_SECTION(EnzymeXMLDataProvider - load RNA enzymes from XML)
   bool found_rnase = false;
   for (const auto& e : loaded)
   {
-    if (!e->getName().empty())
+    if (! e->getName().empty())
     {
       found_rnase = true;
       break;
@@ -118,7 +116,7 @@ END_SECTION
 // BuiltInProteaseDataProvider tests
 /////////////////////////////////////////////////////////////
 
-START_SECTION(BuiltInProteaseDataProvider - load built-in enzymes)
+START_SECTION(BuiltInProteaseDataProvider - load built - in enzymes)
 {
   BuiltInProteaseDataProvider provider;
   auto loaded = provider.loadEnzymes();
@@ -128,15 +126,23 @@ START_SECTION(BuiltInProteaseDataProvider - load built-in enzymes)
   bool found_trypsin = false;
   bool found_argc = false;
   bool found_lysc = false;
+  bool found_thermo = false;
+  bool found_pk = false;
   for (const auto& e : loaded)
   {
     if (e->getName() == "Trypsin") found_trypsin = true;
     if (e->getName() == "Arg-C") found_argc = true;
     if (e->getName() == "Lys-C") found_lysc = true;
+    if (e->getName() == "thermolysin" || e->hasSynonym("thermolysin") || e->getName() == "Thermolysin" || e->hasSynonym("Thermolysin"))
+      found_thermo = true;
+    if (e->getName() == "proteinasek" || e->hasSynonym("proteinasek") || e->getName() == "Proteinase K" || e->hasSynonym("Proteinase K"))
+      found_pk = true;
   }
-  TEST_EQUAL(found_trypsin, true)
-  TEST_EQUAL(found_argc, true)
-  TEST_EQUAL(found_lysc, true)
+  TEST_TRUE(found_trypsin)
+  TEST_TRUE(found_argc)
+  TEST_TRUE(found_lysc)
+  TEST_TRUE(found_thermo)
+  TEST_TRUE(found_pk)
 }
 END_SECTION
 
@@ -173,17 +179,15 @@ START_SECTION(ProteaseDB - construct from providers)
 
   // Add just two test enzymes via InMemoryDigestionEnzymeDataProvider
   vector<unique_ptr<DigestionEnzymeProtein>> enzymes;
-  enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-    "CustomEnzyme1", "(?<=[K])", set<String>{"custom_syn"}, "Custom enzyme 1"));
-  enzymes.push_back(make_unique<DigestionEnzymeProtein>(
-    "CustomEnzyme2", "(?<=[R])", set<String>(), "Custom enzyme 2"));
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("CustomEnzyme1", "(?<=[K])", set<String> {"custom_syn"}, "Custom enzyme 1"));
+  enzymes.push_back(make_unique<DigestionEnzymeProtein>("CustomEnzyme2", "(?<=[R])", set<String>(), "Custom enzyme 2"));
   providers.push_back(make_unique<InMemoryDigestionEnzymeDataProvider<DigestionEnzymeProtein>>(std::move(enzymes)));
 
   ProteaseDB db(std::move(providers));
   TEST_EQUAL(db.hasEnzyme("CustomEnzyme1"), true)
   TEST_EQUAL(db.hasEnzyme("CustomEnzyme2"), true)
   TEST_EQUAL(db.hasEnzyme("custom_syn"), true) // synonym
-  TEST_EQUAL(db.hasEnzyme("Trypsin"), false) // not loaded
+  TEST_EQUAL(db.hasEnzyme("Trypsin"), false)   // not loaded
 
   vector<String> names;
   db.getAllNames(names);

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/schema/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "baseline": "38a3560662d515a805f11dae6c2780b621e25e1a",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}


### PR DESCRIPTION
## Description

As part of my preparation for the **GSoC 2026 Project B1 (Unify Development Dependencies Using vcpkg)**, I was auditing the current `vcpkg` integration in OpenMS. 

I noticed that while `vcpkg.json` defines the dependencies, there is no `vcpkg-configuration.json` or `builtin-baseline` specified. Without a baseline, `vcpkg` pulls the absolute latest version of every dependency at the time of installation. This can lead to **"works on my machine"** issues, where two developers (or CI runners) end up with different versions of Boost or Qt simply because they ran `vcpkg install` on different days.

This PR introduces `vcpkg-configuration.json` to pin the default registry to a specific baseline commit. This ensures **reproducible builds** across the entire team and CI environments. 

When updating dependencies in the future, maintainers simply bump the `baseline` hash.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sage annotation support for Percolator input file format.
  * Enhanced scan identifier derivation with improved fallback handling.

* **Improvements**
  * Strengthened memory safety in transformation models.
  * Extended enzyme detection coverage in protease analysis.

* **Tests**
  * Expanded test suite coverage for core modules including MSSpectrum and enzyme analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->