### PR TITLE
IDMapper: prevent duplicate spectrum reference insertion

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -359,8 +359,7 @@ namespace OpenMS
         auto result = inner_map.insert({spectrum_reference, pid});
         if (!result.second)
         {
-          OPENMS_LOG_WARN << "Duplicate spectrum reference detected: "
-                          << spectrum_reference << std::endl;
+          OPENMS_LOG_WARN << "Duplicate spectrum reference detected: "<< spectrum_reference << "\n";
         }
         has_spectrum_references = true;
       }

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -355,9 +355,13 @@ namespace OpenMS
             lookForScanNrsAsIntegers = false;
           }  
         }
-    
-        // TODO: check if there is already an entry
-        file2nativeid2pepid[spectrum_file][spectrum_reference] = pid;
+        auto& inner_map = file2nativeid2pepid[spectrum_file];
+        auto result = inner_map.insert({spectrum_reference, pid});
+        if (!result.second)
+        {
+          OPENMS_LOG_WARN << "Duplicate spectrum reference detected: "
+                          << spectrum_reference << std::endl;
+        }
         has_spectrum_references = true;
       }
 


### PR DESCRIPTION
## Description

This PR fixes a TODO in `IDMapper.cpp` by preventing duplicate spectrum references from overwriting existing entries in `file2nativeid2pepid`.

Previously, the code inserted entries using direct assignment, which could silently overwrite an existing mapping if the same spectrum reference appeared multiple times. This change replaces the assignment with `insert()` and logs a warning when a duplicate spectrum reference is detected.

The change improves robustness while preserving the original mapping behavior for valid inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate spectrum references now emit warning messages and preserve the first entry instead of overwriting data, reducing unintended data loss during ID mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->