### PR TITLE
fix: silence MSVC C4244 double-to-float narrowing in Peak1D emplace_back

### DIFF
--- a/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLAnnotateAndLocate.cpp
@@ -53,7 +53,7 @@ namespace OpenMS
         total_loss_spectrum.getStringDataArrays()[0].push_back(ion_name);
         total_loss_spectrum.getIntegerDataArrays()[NuXLConstants::IA_CHARGE_INDEX].push_back(charge);      
         double mono_pos = fixed_and_variable_modified_peptide.getMonoWeight(Residue::Full, charge) - M_star_pc_loss; // precursor peak
-        total_loss_spectrum.emplace_back(mono_pos / (double)charge, 1.0);
+        total_loss_spectrum.emplace_back(mono_pos / (double)charge, 1.0f);
       }
     }
     // add special immonium ions

--- a/src/openms/source/ANALYSIS/NUXL/NuXLFragmentIonGenerator.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLFragmentIonGenerator.cpp
@@ -28,7 +28,7 @@ void NuXLFragmentIonGenerator::addMS2MarkerIons(
   {
     const double mz = m.mass + Constants::PROTON_MASS_U;
 
-    spectrum.emplace_back(mz, 1.0);
+    spectrum.emplace_back(mz, 1.0f);
     spectrum_charge.emplace_back(1);
     spectrum_annotation.emplace_back(NuXLFragmentIonGenerator::ANNOTATIONS_MARKER_ION_PREFIX + m.name);  // add name (e.g., MI:U-H2O)
   }
@@ -46,17 +46,17 @@ void NuXLFragmentIonGenerator::addSpecialLysImmonumIons(
       // only add special ios if there is not already a peak
       if (spectrum.findNearest(immonium_ion2_mz, 1e-4) == -1)
       {  
-        spectrum.emplace_back(immonium_ion2_mz, 1.0);
+        spectrum.emplace_back(immonium_ion2_mz, 1.0f);
         spectrum_charge.emplace_back(1);
         spectrum_annotation.emplace_back(String("iK(C5H10N1)"));
       }
 
       // usually only observed without shift (A. Stuetzer)
-      const double immonium_ion3_mz = EmpiricalFormula("C6H13N2O").getMonoWeight(); 
+      const double immonium_ion3_mz = EmpiricalFormula("C6H13N2O").getMonoWeight();
       // only add special ios if there is not already a peak
       if (spectrum.findNearest(immonium_ion3_mz, 1e-4) == -1)
-      {  
-        spectrum.emplace_back(immonium_ion3_mz, 1.0);
+      {
+        spectrum.emplace_back(immonium_ion3_mz, 1.0f);
         spectrum_charge.emplace_back(1);
         spectrum_annotation.emplace_back(String("iK(C6H13N2O)"));
       }
@@ -75,7 +75,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("Y"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C8H10NO").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('Y', fragment_shift_name));
   }
@@ -83,7 +83,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("W"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C10H11N2").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('W', fragment_shift_name));
   }
@@ -91,7 +91,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("F"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C8H10N").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('F', fragment_shift_name));
   }
@@ -99,7 +99,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("H"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C5H8N3").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('H', fragment_shift_name));
   }
@@ -107,7 +107,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("C"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C2H6NS").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('C', fragment_shift_name));
   }
@@ -115,7 +115,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("P"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C4H8N").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('P', fragment_shift_name));
   }
@@ -123,7 +123,7 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   if (unmodified_sequence.hasSubstring("L") || unmodified_sequence.hasSubstring("I"))
   {
     const double immonium_ion_mz = EmpiricalFormula("C5H12N").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('L', fragment_shift_name));
   }
@@ -132,20 +132,20 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   {
     // classical immonium ion
     const double immonium_ion_mz = EmpiricalFormula("C5H13N2").getMonoWeight() + fragment_shift_mass;
-    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('K', fragment_shift_name));
 
     // TODO: check if only DNA specific and if also other shifts are observed
     // according to A. Stuetzer mainly observed with C‘-NH3 (94.0167 Da)
     const double immonium_ion2_mz = EmpiricalFormula("C5H10N1").getMonoWeight()  + fragment_shift_mass; 
-    partial_loss_spectrum.emplace_back(immonium_ion2_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion2_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(String("iK(C5H10N1)" + fragment_shift_name));
 
     // usually only observed without shift (A. Stuetzer)
     const double immonium_ion3_mz = EmpiricalFormula("C6H13N2O").getMonoWeight()  + fragment_shift_mass; 
-    partial_loss_spectrum.emplace_back(immonium_ion3_mz, 1.0);
+    partial_loss_spectrum.emplace_back(immonium_ion3_mz, 1.0f);
     partial_loss_spectrum_charge.emplace_back(1);
     partial_loss_spectrum_annotation.emplace_back(String("iK(C6H13N2O)" + fragment_shift_name));
   }
@@ -154,14 +154,14 @@ void NuXLFragmentIonGenerator::addShiftedImmoniumIons(const String &unmodified_s
   {
     {
       const double immonium_ion_mz = 104.05285 + fragment_shift_mass;
-      partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+      partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
       partial_loss_spectrum_charge.emplace_back(1);
       partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('M', fragment_shift_name));
     }
 
     {
       const double immonium_ion_mz = EmpiricalFormula("CH5S").getMonoWeight() + fragment_shift_mass; // methionine related fragment
-      partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0);
+      partial_loss_spectrum.emplace_back(immonium_ion_mz, 1.0f);
       partial_loss_spectrum_charge.emplace_back(1);
       partial_loss_spectrum_annotation.emplace_back(NuXLFragmentAnnotationHelper::getAnnotatedImmoniumIon('M', fragment_shift_name));
     }
@@ -320,7 +320,7 @@ void NuXLFragmentIonGenerator::addPrecursorWithCompleteRNA_(
   // only add special ions if there is not already a peak
   if (partial_loss_spectrum.findNearest(xl_mz, 1e-4) == -1)
   {  
-    partial_loss_spectrum.push_back(Peak1D(xl_mz, 1.0));
+    partial_loss_spectrum.push_back(Peak1D(xl_mz, 1.0f));
     partial_loss_spectrum_charge.push_back(charge);
     if (charge > 1)
     {

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -322,7 +322,7 @@ namespace OpenMS
         ion_names.emplace_back("iP+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(70.0656, 1.0); // emplace_back(MZ, intensity)
+      spectrum.emplace_back(70.0656, 1.0f); // emplace_back(MZ, intensity)
     }
 
     // Cysteine (C2H6NS)
@@ -333,7 +333,7 @@ namespace OpenMS
         ion_names.emplace_back("iC+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(76.0221, 1.0);
+      spectrum.emplace_back(76.0221, 1.0f);
     }
 
     // Iso/Leucin immonium ion (same mass for immonium ion)
@@ -344,7 +344,7 @@ namespace OpenMS
         ion_names.emplace_back("iL/I+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(86.09698, 1.0);
+      spectrum.emplace_back(86.09698, 1.0f);
     }
 
     // Histidin immonium ion (C5H8N3)
@@ -355,7 +355,7 @@ namespace OpenMS
         ion_names.emplace_back("iH+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(110.0718, 1.0);
+      spectrum.emplace_back(110.0718, 1.0f);
     }
 
     // Phenylalanin immonium ion (C8H10N)
@@ -366,7 +366,7 @@ namespace OpenMS
         ion_names.emplace_back("iF+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(120.0813, 1.0);
+      spectrum.emplace_back(120.0813, 1.0f);
     }
 
     // Tyrosine immonium ion (C8H10NO)
@@ -377,7 +377,7 @@ namespace OpenMS
         ion_names.emplace_back("iY+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(136.0762, 1.0);
+      spectrum.emplace_back(136.0762, 1.0f);
     }
 
     // Tryptophan immonium ion
@@ -388,7 +388,7 @@ namespace OpenMS
         ion_names.emplace_back("iW+");
         charges.push_back(1);
       }
-      spectrum.emplace_back(159.0922, 1.0);
+      spectrum.emplace_back(159.0922, 1.0f);
     }
   }
 
@@ -447,7 +447,7 @@ namespace OpenMS
     // TODO why do you need a separate set for the losses? Just use the keys from the formula_str_cache?
     for (const auto& formula : f_losses)
     {
-      spectrum.emplace_back((mz - formula.getMonoWeight()) / (double)charge, intensity);
+      spectrum.emplace_back((mz - formula.getMonoWeight()) / (double)charge, static_cast<float>(intensity));
 
       if (add_metainfo)
       {
@@ -535,7 +535,7 @@ namespace OpenMS
             ion_names.push_back(ion_name);
             charges.push_back(charge);
           }
-          spectrum.emplace_back(iso.getMZ() / (double)charge, intensity * rel_loss_intensity_ * iso.getIntensity());
+          spectrum.emplace_back(iso.getMZ() / (double)charge, static_cast<float>(intensity * rel_loss_intensity_ * iso.getIntensity()));
         }
       }
       else
@@ -545,7 +545,7 @@ namespace OpenMS
           ion_names.push_back(ion_name);
           charges.push_back(charge);
         }
-        spectrum.emplace_back(loss_pos / (double)charge, intensity * rel_loss_intensity_);
+        spectrum.emplace_back(loss_pos / (double)charge, static_cast<float>(intensity * rel_loss_intensity_));
       }
     }
   }
@@ -639,7 +639,7 @@ namespace OpenMS
         }
         pos = (pos + ion_offset) / charge;
 
-        spectrum.emplace_back(pos, intensity);
+        spectrum.emplace_back(pos, static_cast<float>(intensity));
         if (add_metainfo_)
         {
           if (res_type == Residue::AIon)
@@ -810,7 +810,7 @@ namespace OpenMS
           }
           pos = (pos + ion_offset) / charge;
 
-          spectrum.emplace_back(pos, intensity);
+          spectrum.emplace_back(pos, static_cast<float>(intensity));
           if (add_metainfo_)
           {
             ion_names.emplace_back(ion_name_str);
@@ -910,7 +910,7 @@ namespace OpenMS
           }
           pos = (pos + ion_offset) / charge;
 
-          spectrum.emplace_back(pos, intensity);
+          spectrum.emplace_back(pos, static_cast<float>(intensity));
           if (add_metainfo_)
           {
             ion_names.emplace_back(ion_name_str);
@@ -1025,7 +1025,7 @@ namespace OpenMS
           ion_names.push_back(ion_name);
           charges.push_back(charge);
         }
-        spectrum.emplace_back(it->getMZ() / (double)charge, pre_int_ * it->getIntensity());
+        spectrum.emplace_back(it->getMZ() / (double)charge, static_cast<float>(pre_int_ * it->getIntensity()));
       }
     }
     else
@@ -1035,7 +1035,7 @@ namespace OpenMS
         ion_names.push_back(ion_name);
         charges.push_back(charge);
       }
-      spectrum.emplace_back(mono_pos / (double)charge, pre_int_);
+      spectrum.emplace_back(mono_pos / (double)charge, static_cast<float>(pre_int_));
     }
     // loss peaks of the precursor
 
@@ -1074,7 +1074,7 @@ namespace OpenMS
           ion_names.push_back(ion_name);
           charges.push_back(charge);
         }
-        spectrum.emplace_back(it->getMZ() / charge, pre_int_H2O_ * it->getIntensity());
+        spectrum.emplace_back(it->getMZ() / charge, static_cast<float>(pre_int_H2O_ * it->getIntensity()));
       }
     }
     else
@@ -1093,7 +1093,7 @@ namespace OpenMS
         ion_names.push_back(ion_name);
         charges.push_back(charge);
       }
-      spectrum.emplace_back(mono_pos / (double)charge, pre_int_H2O_);
+      spectrum.emplace_back(mono_pos / (double)charge, static_cast<float>(pre_int_H2O_));
     }
 
     //loss of ammonia
@@ -1133,7 +1133,7 @@ namespace OpenMS
           ion_names.push_back(ion_name);
           charges.push_back(charge);
         }
-        spectrum.emplace_back(it->getMZ() / (double)charge, pre_int_NH3_ * it->getIntensity());
+        spectrum.emplace_back(it->getMZ() / (double)charge, static_cast<float>(pre_int_NH3_ * it->getIntensity()));
       }
     }
     else
@@ -1152,7 +1152,7 @@ namespace OpenMS
         ion_names.push_back(ion_name);
         charges.push_back(charge);
       }
-      spectrum.emplace_back(mono_pos / (double)charge, pre_int_NH3_);
+      spectrum.emplace_back(mono_pos / (double)charge, static_cast<float>(pre_int_NH3_));
     }
   }
 

--- a/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
+++ b/src/openms/source/PROCESSING/CENTROIDING/PeakPickerIM.cpp
@@ -873,7 +873,7 @@ namespace OpenMS
 #endif
         MSSpectrum summed_trace;
         summed_trace.reserve(trace.size() + 1);
-        summed_trace.emplace_back(-1.0, -1.0);
+        summed_trace.emplace_back(-1.0, -1.0f);
         sumFrame_(trace, summed_trace, sum_tolerance_im_, false);
 #ifdef DEBUG_PICKER
         OPENMS_LOG_DEBUG << "Trace after sumFrame_ has " << summed_trace.size() << " peaks.\n";


### PR DESCRIPTION
## Summary
- Fix ~37 MSVC C4244 warnings caused by passing `double` values to `Peak1D` constructor via `emplace_back`, where `IntensityType` is `float`
- Use `1.0f` literals for constant intensity values
- Add `static_cast<float>()` for `double` variables/expressions (e.g., `TheoreticalSpectrumGenerator` intensity parameters and `pre_int_*` members)

**Files changed:**
- `NuXLFragmentIonGenerator.cpp` — 16 literal fixes
- `NuXLAnnotateAndLocate.cpp` — 1 literal fix
- `TheoreticalSpectrumGenerator.cpp` — 7 literal + 12 cast fixes
- `PeakPickerIM.cpp` — 1 literal fix

## Test plan
- [x] Builds successfully on Linux (GCC)
- [ ] MSVC CI build should show reduced C4244 warning count
- [ ] Existing tests pass (no behavioral change — all values are well within float range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected numeric type inconsistencies in peak intensity calculations across spectrum generation and peak detection modules to ensure proper data type handling and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->