### PR TITLE
[FIX] MSNumpressCoder: replace std::cerr with OPENMS_LOG_WARN and re-…

### DIFF
--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -256,8 +256,9 @@ namespace OpenMS
       }
       if (n >= 0)
       {
-        //Comment: throw?
-        std::cerr << "Error occurred at position n = " << n << ". Enable NUMPRESS_DEBUG to get more info." << std::endl;
+        OPENMS_LOG_WARN << "[MSNumpressCoder] Numpress encoding accuracy loss at position n = " << n
+                        << " (tolerance: " << config.numpressErrorTolerance << "). "
+                        << "Result discarded. Consider disabling numpressErrorTolerance or using a different compression.";
       }
       else
       {
@@ -269,15 +270,18 @@ namespace OpenMS
     }
     catch (int e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
+      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "MSNumpress encoder threw integer exception: " + String(e));
     }
-    catch (char const * e)
+    catch (char const* e)
     {
-      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
+      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        String("MSNumpress encoder threw exception: ") + e);
     }
     catch (...)
     {
-      std::cerr << "Unknown exception while encoding " << dataSize << " doubles" << std::endl;
+      throw Exception::ConversionError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "Unknown exception while encoding " + String(dataSize) + " doubles with MSNumpress.");
     }
   }
 


### PR DESCRIPTION
## Description
Fixes #8924 

### Summary
`MSNumpressCoder::encodeNPRaw` was silently discarding encoding errors by writing to `std::cerr` and leaving the result as an empty string, giving callers no way to detect failure programmatically.

### Changes
- Replaced `std::cerr` in the accuracy-loss branch (`n >= 0`) with `OPENMS_LOG_WARN`,
  so the warning appears in OpenMS's proper logging system instead of being invisible.
- Changed all three `catch` blocks (catching [int](cci:1://file:///d:/GSOC%202026/openms/developer/OpenMS/src/openms/source/FORMAT/MzTab.cpp:2488:2-2510:5), `char const*`, and `...` from the MSNumpress library) to re-throw as `Exception::ConversionError`, consistent with OpenMS error handling conventions.

### Reproducer (pyOpenMS 3.5.0)
```python
import pyopenms as pms
config = pms.NumpressConfig()
config.setCompression("linear")
config.numpressErrorTolerance = 1e-12
config.estimate_fixed_point = True
coder = pms.MSNumpressCoder()
result = pms.String()
coder.encodeNP([500.123456789, 500.123456790, 500.123456791], result, False, config)
print(result.toString() == '')  # True — silent failure before this fix


## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [X] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved error reporting** – Enhanced warning and error messages for Numpress compression accuracy loss detection, now providing clearer guidance on tolerance settings and compression configuration.
* **Better exception handling** – Encoding errors now produce descriptive messages instead of generic outputs, improving troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->