### PR TITLE
refactor: replace QJson with nlohmann/json in OMSFileLoad

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
@@ -12,8 +12,6 @@
 #include <OpenMS/METADATA/ID/IdentificationData.h>
 #include <OpenMS/FORMAT/OMSFileStore.h>
 
-#include <nlohmann/json.hpp> // for JSON export
-
 namespace SQLite
 {
   class Database;
@@ -174,9 +172,6 @@ namespace OpenMS
       void handleQueryPeakAnnotation_(
         SQLite::Statement& query, IdentificationData::ObservationMatch& match,
         Key parent_id);
-
-      /// Export the contents of a database table to JSON
-      nlohmann::json exportTableToJSON_(const String& table, const String& order_by);
 
       /// The database connection (read)
       std::unique_ptr<SQLite::Database> db_;

--- a/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
@@ -176,7 +176,7 @@ namespace OpenMS
         Key parent_id);
 
       /// Export the contents of a database table to JSON
-      nlohmann::ordered_json exportTableToJSON_(const String& table, const String& order_by);
+      nlohmann::json exportTableToJSON_(const String& table, const String& order_by);
 
       /// The database connection (read)
       std::unique_ptr<SQLite::Database> db_;

--- a/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSFileLoad.h
@@ -12,7 +12,7 @@
 #include <OpenMS/METADATA/ID/IdentificationData.h>
 #include <OpenMS/FORMAT/OMSFileStore.h>
 
-#include <QtCore/QJsonArray> // for JSON export
+#include <nlohmann/json.hpp> // for JSON export
 
 namespace SQLite
 {
@@ -176,14 +176,14 @@ namespace OpenMS
         Key parent_id);
 
       /// Export the contents of a database table to JSON
-      QJsonArray exportTableToJSON_(const QString& table, const QString& order_by);
+      nlohmann::ordered_json exportTableToJSON_(const String& table, const String& order_by);
 
       /// The database connection (read)
       std::unique_ptr<SQLite::Database> db_;
 
       int version_number_; ///< schema version number
 
-      QString subquery_score_; ///< query for score types used in JSON export
+      String subquery_score_; ///< query for score types used in JSON export
 
       // mappings between database keys and loaded data:
       std::unordered_map<Key, IdentificationData::ScoreTypeRef> score_type_refs_;
@@ -198,8 +198,7 @@ namespace OpenMS
       std::unordered_map<Key, IdentificationData::AdductRef> adduct_refs_;
 
       // mapping: table name -> ordering critera (for JSON export)
-      // @TODO: could use 'unordered_map' here, but would need to specify hash function for 'QString'
-      static std::map<QString, QString> export_order_by_;
+      static std::map<String, String> export_order_by_;
     };
   }
 }

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -12,10 +12,7 @@
 #include <OpenMS/CHEMISTRY/RNaseDB.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 
-#include <QtCore/QString>
-// JSON export:
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonObject>
+#include <nlohmann/json.hpp> // for JSON export
 
 #include <SQLiteCpp/Database.h>
 
@@ -28,7 +25,7 @@ using ID = OpenMS::IdentificationData;
 namespace OpenMS::Internal
 {
   // initialize lookup table:
-  map<QString, QString> OMSFileLoad::export_order_by_ = {
+  map<String, String> OMSFileLoad::export_order_by_ = {
     {"version", ""},
     {"ID_IdentifiedCompound", "molecule_id"},
     {"ID_ParentMatch", "molecule_id, parent_id, start_pos, end_pos"},
@@ -206,13 +203,13 @@ namespace OpenMS::Internal
     if (!db_->tableExists(table_name)) return false;
 
     String sql_select =
-    "SELECT * FROM " + table_name.toQString() + " AS MI " \
+    "SELECT * FROM " + table_name + " AS MI " \
     "WHERE MI.parent_id = :id";
 
     if (version_number_ < 4)
     {
       sql_select =
-      "SELECT * FROM " + table_name.toQString() + " AS MI " \
+      "SELECT * FROM " + table_name + " AS MI " \
       "JOIN DataValue AS DV ON MI.data_value_id = DV.id "   \
       "WHERE MI.parent_id = :id";
     }
@@ -228,7 +225,7 @@ namespace OpenMS::Internal
     if (!db_->tableExists(table_name)) return false;
 
     //
-    String sql_select = "SELECT * FROM " + table_name.toQString() +
+    String sql_select = "SELECT * FROM " + table_name +
       " WHERE parent_id = :id ORDER BY processing_step_order ASC";
     query = SQLite::Statement(*db_, sql_select);
     return true;
@@ -1101,21 +1098,21 @@ namespace OpenMS::Internal
   }
 
 
-  QJsonArray OMSFileLoad::exportTableToJSON_(const QString& table, const QString& order_by)
+  nlohmann::ordered_json OMSFileLoad::exportTableToJSON_(const String& table, const String& order_by)
   {
     // code based on: https://stackoverflow.com/a/18067555
     String sql = "SELECT * FROM " + table;
-    if (!order_by.isEmpty())
+    if (!order_by.empty())
     {
       sql += " ORDER BY " + order_by;
     }
 
     SQLite::Statement query(*db_, sql);
 
-    QJsonArray array;
+    nlohmann::ordered_json array = nlohmann::ordered_json::array();
     while (query.executeStep())
     {
-      QJsonObject record;
+      nlohmann::ordered_json record = nlohmann::ordered_json::object();
       for (int i = 0; i < query.getColumnCount(); ++i)
       {
         // @TODO: this will repeat field names for every row -
@@ -1125,11 +1122,11 @@ namespace OpenMS::Internal
         // thus, we could use query.getColumnDeclaredType(i), but it would incur conversion
         switch (query.getColumn(i).getType())
         {
-          case SQLITE_INTEGER: record.insert(query.getColumnName(i), qint64(query.getColumn(i).getInt64())); break;
-          case SQLITE_FLOAT: record.insert(query.getColumnName(i), query.getColumn(i).getDouble()); break;
-          case SQLITE_BLOB: record.insert(query.getColumnName(i), query.getColumn(i).getText()); break;
-          case SQLITE_NULL: record.insert(query.getColumnName(i), ""); break;
-          case SQLITE3_TEXT: record.insert(query.getColumnName(i), query.getColumn(i).getText()); break;
+          case SQLITE_INTEGER: record[query.getColumnName(i)] = query.getColumn(i).getInt64(); break;
+          case SQLITE_FLOAT: record[query.getColumnName(i)] = query.getColumn(i).getDouble(); break;
+          case SQLITE_BLOB: record[query.getColumnName(i)] = query.getColumn(i).getText(); break;
+          case SQLITE_NULL: record[query.getColumnName(i)] = ""; break;
+          case SQLITE3_TEXT: record[query.getColumnName(i)] = query.getColumn(i).getText(); break;
           default:
             throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
         }
@@ -1144,13 +1141,13 @@ namespace OpenMS::Internal
   {
     // @TODO: this constructs the whole JSON file in memory - write directly to stream instead?
     // (more code, but would use less memory)
-    QJsonObject json_data;
+    nlohmann::ordered_json json_data = nlohmann::ordered_json::object();
     // get names of all tables (except SQLite-internal ones) in the database:
     SQLite::Statement query(*db_, "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name");
     while (query.executeStep())
     {
       String table = query.getColumn("name").getString();
-      QString order_by = "id"; // row order for most tables
+      String order_by = "id"; // row order for most tables
       // special cases regarding ordering, e.g. tables without "id" column:
       if (table.hasSuffix("_MetaInfo"))
       {
@@ -1160,15 +1157,13 @@ namespace OpenMS::Internal
       {
         order_by = "parent_id, processing_step_order, score_type_id";
       }
-      else if (auto pos = export_order_by_.find(table.toQString()); pos != export_order_by_.end())
+      else if (auto pos = export_order_by_.find(table); pos != export_order_by_.end())
       {
         order_by = pos->second;
       }
-      json_data.insert(table.toQString(), exportTableToJSON_(table.toQString(), order_by));
+      json_data[table] = exportTableToJSON_(table, order_by);
     }
 
-    QJsonDocument json_doc;
-    json_doc.setObject(json_data);
-    output << json_doc.toJson().toStdString();
+    output << json_data.dump(2);
   }
 }

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -1098,8 +1098,9 @@ namespace OpenMS::Internal
   }
 
 
-  nlohmann::ordered_json OMSFileLoad::exportTableToJSON_(const String& table, const String& order_by)
+  nlohmann::json OMSFileLoad::exportTableToJSON_(const String& table, const String& order_by)
   {
+    using json = nlohmann::json;
     // code based on: https://stackoverflow.com/a/18067555
     String sql = "SELECT * FROM " + table;
     if (!order_by.empty())
@@ -1109,10 +1110,10 @@ namespace OpenMS::Internal
 
     SQLite::Statement query(*db_, sql);
 
-    nlohmann::ordered_json array = nlohmann::ordered_json::array();
+    json array = json::array();
     while (query.executeStep())
     {
-      nlohmann::ordered_json record = nlohmann::ordered_json::object();
+      json record = json::object();
       for (int i = 0; i < query.getColumnCount(); ++i)
       {
         // @TODO: this will repeat field names for every row -
@@ -1139,9 +1140,10 @@ namespace OpenMS::Internal
 
   void OMSFileLoad::exportToJSON(ostream& output)
   {
+    using json = nlohmann::json;
     // @TODO: this constructs the whole JSON file in memory - write directly to stream instead?
     // (more code, but would use less memory)
-    nlohmann::ordered_json json_data = nlohmann::ordered_json::object();
+    json json_data = json::object();
     // get names of all tables (except SQLite-internal ones) in the database:
     SQLite::Statement query(*db_, "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name");
     while (query.executeStep())
@@ -1164,6 +1166,6 @@ namespace OpenMS::Internal
       json_data[table] = exportTableToJSON_(table, order_by);
     }
 
-    output << json_data.dump(2);
+    output << json_data.dump(4) << '\n';
   }
 }

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -1098,7 +1098,8 @@ namespace OpenMS::Internal
   }
 
 
-  nlohmann::json OMSFileLoad::exportTableToJSON_(const String& table, const String& order_by)
+  // file-local helper (was private method, moved here to avoid nlohmann include in header)
+  static nlohmann::json exportTableToJSON_(SQLite::Database& db, const String& table, const String& order_by)
   {
     using json = nlohmann::json;
     // code based on: https://stackoverflow.com/a/18067555
@@ -1108,7 +1109,7 @@ namespace OpenMS::Internal
       sql += " ORDER BY " + order_by;
     }
 
-    SQLite::Statement query(*db_, sql);
+    SQLite::Statement query(db, sql);
 
     json array = json::array();
     while (query.executeStep())
@@ -1163,7 +1164,7 @@ namespace OpenMS::Internal
       {
         order_by = pos->second;
       }
-      json_data[table] = exportTableToJSON_(table, order_by);
+      json_data[table] = exportTableToJSON_(*db_, table, order_by);
     }
 
     output << json_data.dump(4) << '\n';


### PR DESCRIPTION
## Summary
- Replace QJsonArray/QJsonObject/QJsonDocument with nlohmann::json in OMSFileLoad.h/.cpp
- Change `std::map<QString, QString>` to `std::map<String, String>`
- Use `dump(4)` for indented output matching Qt's default formatting
- Part 1/7 of removing Qt6::Core from libOpenMS core library

## Test plan
- [x] OMSFile_test passes
- [x] JSONExporter TOPP tests pass (output byte-identical to Qt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal JSON export rewritten to use a standard JSON implementation and unified string handling for consistency.
  * Improved JSON construction and output formatting, and streamlined table export logic.
  * No changes to external behavior or user-visible data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->