### PR TITLE
refactor: replace QDateTime/QDate/QSysInfo/QLocale with std::chrono

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/Date.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Date.h
@@ -12,11 +12,6 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/OpenMSConfig.h>
 
-#include <memory>
-
-// forward declaration
-class QDate;
-
 namespace OpenMS
 {
   /**
@@ -39,22 +34,19 @@ public:
     Date();
 
     /// Copy constructor
-    Date(const Date& date);
-
-    /// Copy constructor from Qt base class
-    Date(const QDate& date);
+    Date(const Date& date) = default;
 
     /// Move constructor
-    Date(Date&&) noexcept;
+    Date(Date&&) noexcept = default;
 
     /// Destructor
-    ~Date();
+    ~Date() = default;
 
     /// Assignment operator
-    Date& operator=(const Date& source);
+    Date& operator=(const Date& source) = default;
 
     /// Move assignment operator
-    Date& operator=(Date&&) & noexcept;
+    Date& operator=(Date&&) & noexcept = default;
 
     /// Equality operator
     bool operator==(const Date& rhs) const;
@@ -120,7 +112,9 @@ public:
     int day() const;
 
 private:
-    std::unique_ptr<QDate> date_; ///< Internal QDate representation
+    struct Fields {
+      int year = 0, month = 0, day = 0;
+      bool valid = false;
+    } fields_;
   };
-} // namespace OPENMS
-
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
@@ -14,11 +14,7 @@
 #include <OpenMS/OpenMSConfig.h>
 
 #include <functional>
-#include <memory> // unique_ptr
 #include <string>
-
-// foward declarations
-class QDateTime;
 
 namespace OpenMS
 {
@@ -43,19 +39,19 @@ public:
     DateTime();
 
     /// Copy constructor
-    DateTime(const DateTime& date);
+    DateTime(const DateTime& date) = default;
 
     /// Move constructor
-    DateTime(DateTime&&) noexcept;
+    DateTime(DateTime&&) noexcept = default;
 
     /// Assignment operator
-    DateTime& operator=(const DateTime& source);
+    DateTime& operator=(const DateTime& source) = default;
 
     /// Move assignment operator
-    DateTime& operator=(DateTime&&) & noexcept;
+    DateTime& operator=(DateTime&&) & noexcept = default;
 
     /// Destructor
-    ~DateTime();
+    ~DateTime() = default;
 
     /// equal operator
     bool operator==(const DateTime& rhs) const;
@@ -197,7 +193,11 @@ public:
       void set(const String& date);
 
     private:
-      std::unique_ptr<QDateTime> dt_; // use PImpl, to avoid costly #include
+      struct Fields {
+        int year = 0, month = 0, day = 0;
+        int hour = 0, minute = 0, second = 0, millisecond = 0;
+        bool valid = false;
+      } fields_;
   };
 
 } // namespace OpenMS
@@ -211,8 +211,6 @@ namespace std
     std::size_t operator()(const OpenMS::DateTime& dt) const noexcept
     {
       // Hash the date/time components including milliseconds to match operator==
-      // (which compares the underlying QDateTime including milliseconds)
-      // Use toString with millisecond format and convert to std::string for hashing
       std::string datetime_str = dt.toString("yyyy-MM-ddThh:mm:ss.zzz");
       return OpenMS::fnv1a_hash_string(datetime_str);
     }

--- a/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/BuildInfo.h
@@ -11,8 +11,18 @@
 #include <OpenMS/build_config.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 
-#include <QtCore/QSysInfo>
-#include <QtCore/QString>
+#include <cstddef>
+#include <string>
+#include <fstream>
+#include <cstring>
+
+#ifdef _WIN32
+  #include <windows.h>
+  #include <winternl.h>
+#elif defined(__APPLE__)
+  #include <sys/types.h>
+  #include <sys/sysctl.h>
+#endif
 
 #ifdef _OPENMP
   #include "omp.h"
@@ -27,6 +37,59 @@ namespace OpenMS
     inline const std::string OpenMS_OSNames[] = {"unknown", "MacOS", "Windows", "Linux"};
     enum class OpenMS_Architecture {ARCH_UNKNOWN, ARCH_32BIT, ARCH_64BIT, SIZE_OF_OPENMS_ARCHITECTURE};
     inline const std::string OpenMS_ArchNames[] = {"unknown", "32 bit", "64 bit"};
+
+    /// @brief Helper: get OS version string using platform APIs
+    inline std::string getOSVersionString_()
+    {
+#if defined(_WIN32)
+      // Use RtlGetVersion to get the real version (not compatibility-shimmed)
+      typedef NTSTATUS (WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+      HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
+      if (hMod)
+      {
+        auto fxPtr = reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(hMod, "RtlGetVersion"));
+        if (fxPtr)
+        {
+          RTL_OSVERSIONINFOW rovi{};
+          rovi.dwOSVersionInfoSize = sizeof(rovi);
+          if (fxPtr(&rovi) == 0)
+          {
+            return std::to_string(rovi.dwMajorVersion) + "." + std::to_string(rovi.dwMinorVersion)
+                   + "." + std::to_string(rovi.dwBuildNumber);
+          }
+        }
+      }
+      return "unknown";
+#elif defined(__APPLE__)
+      char version[64] = {};
+      size_t len = sizeof(version);
+      if (sysctlbyname("kern.osproductversion", version, &len, nullptr, 0) == 0)
+      {
+        return std::string(version);
+      }
+      return "unknown";
+#elif defined(__unix__)
+      // Read VERSION_ID from /etc/os-release
+      std::ifstream ifs("/etc/os-release");
+      std::string line;
+      while (std::getline(ifs, line))
+      {
+        if (line.compare(0, 11, "VERSION_ID=") == 0)
+        {
+          std::string val = line.substr(11);
+          // Strip surrounding quotes if present
+          if (val.size() >= 2 && val.front() == '"' && val.back() == '"')
+          {
+            val = val.substr(1, val.size() - 2);
+          }
+          return val;
+        }
+      }
+      return "unknown";
+#else
+      return "unknown";
+#endif
+    }
 
     class OPENMS_DLLAPI OpenMSOSInfo
     {
@@ -89,11 +152,11 @@ namespace OpenMS
         info.os_ = OpenMS_OS::OS_LINUX;
         #endif // else stays unknown
 
-        // returns something meaningful for basically all important platforms
-        info.os_version_ = QSysInfo::productVersion();
+        // Get OS version using platform APIs
+        info.os_version_ = getOSVersionString_();
 
-        // identify architecture
-        if (QSysInfo::WordSize == 32)
+        // identify architecture by pointer size
+        if (sizeof(void*) == 4)
         {
           info.arch_ = OpenMS_Architecture::ARCH_32BIT;
         }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 
 #include <OpenMS/DATASTRUCTURES/Date.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
@@ -1638,21 +1639,21 @@ namespace OpenMS
   {
     OPENMS_LOG_INFO << text << endl;
     enableLogging_();
-    log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << text << endl;
+    log_ << DateTime::now().get() << ' ' << getIniLocation_() << ": " << text << endl;
   }
 
   void TOPPBase::writeLogWarn_(const String& text) const
   {
     OPENMS_LOG_WARN << text << endl;
     enableLogging_();
-    log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << text << endl;
+    log_ << DateTime::now().get() << ' ' << getIniLocation_() << ": " << text << endl;
   }
 
   void TOPPBase::writeLogError_(const String& text) const
   {
     OPENMS_LOG_ERROR << text << endl;
     enableLogging_();
-    log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << text << endl;
+    log_ << DateTime::now().get() << ' ' << getIniLocation_() << ": " << text << endl;
   }
 
   void TOPPBase::writeDebug_(const String& text, UInt min_level) const
@@ -1661,7 +1662,7 @@ namespace OpenMS
     {
       OPENMS_LOG_DEBUG << text << endl;
       enableLogging_();
-      log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << text << endl;
+      log_ << DateTime::now().get() << ' ' << getIniLocation_() << ": " << text << endl;
     }
   }
 
@@ -1670,12 +1671,12 @@ namespace OpenMS
     if (debug_level_ >= (Int)min_level)
     {
       OPENMS_LOG_DEBUG << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl
-                << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << " " << text << endl
+                << DateTime::now().get() << ' ' << getIniLocation_() << " " << text << endl
                 << param
                 << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl;
       enableLogging_();
       log_ << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl
-           << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << " " << text << endl
+           << DateTime::now().get() << ' ' << getIniLocation_() << " " << text << endl
            << param
            << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl;
     }
@@ -1870,7 +1871,7 @@ namespace OpenMS
     if (debug_level_ >= 1)
     {
       cout << "Writing to '" << log_destination << '\'' << "\n";
-      log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << "Writing to '" << log_destination << '\'' <<  "\n";
+      log_ << DateTime::now().get() << ' ' << getIniLocation_() << ": " << "Writing to '" << log_destination << '\'' <<  "\n";
     }
   }
 

--- a/src/openms/source/DATASTRUCTURES/Date.cpp
+++ b/src/openms/source/DATASTRUCTURES/Date.cpp
@@ -10,74 +10,38 @@
 
 #include <OpenMS/CONCEPT/Exception.h>
 
-#include <QtCore/QDate>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <tuple>
 
 using namespace std;
 
 namespace OpenMS
 {
-
-  Date::Date() :
-    date_(make_unique<QDate>())
+  // helper: validate date fields
+  static bool isValidDate_(int year, int month, int day)
   {
-  }
-
-  Date::Date(const Date& date) :
-    date_(date.date_ ? make_unique<QDate>(*date.date_) : make_unique<QDate>())
-  {
-  }
-
-  Date::Date(const QDate& date) :
-    date_(make_unique<QDate>(date))
-  {
-  }
-
-  Date::Date(Date&& rhs) noexcept :
-    date_(rhs.date_ ? std::move(rhs.date_) : make_unique<QDate>())
-  {
-  }
-
-  Date::~Date() = default;
-
-  Date& Date::operator=(const Date& source)
-  {
-    if (&source == this)
+    if (month < 1 || month > 12 || day < 1 || year < 1)
     {
-      return *this;
+      return false;
     }
-
-    if (source.date_ == nullptr)
+    static const int days_in_month[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int max_day = days_in_month[month];
+    if (month == 2)
     {
-      // Source is in a 'moved-from' state; create a default date
-      date_ = make_unique<QDate>();
+      bool leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+      if (leap) max_day = 29;
     }
-    else if (date_ == nullptr)
-    { // *this is in a 'moved-from' state; we need to create a date_ object first
-      date_ = make_unique<QDate>(*source.date_);
-    }
-    else
-    {
-      *date_ = *source.date_;
-    }
-
-    return *this;
+    return day <= max_day;
   }
 
-  Date& Date::operator=(Date&& source) & noexcept
-  {
-    if (&source == this)
-    {
-      return *this;
-    }
-
-    std::swap(date_, source.date_);
-
-    return *this;
-  }
+  Date::Date() = default;
 
   bool Date::operator==(const Date& rhs) const
   {
-    return (*date_ == *rhs.date_);
+    return std::tie(fields_.year, fields_.month, fields_.day, fields_.valid)
+        == std::tie(rhs.fields_.year, rhs.fields_.month, rhs.fields_.day, rhs.fields_.valid);
   }
 
   bool Date::operator!=(const Date& rhs) const
@@ -87,91 +51,134 @@ namespace OpenMS
 
   bool Date::operator<(const Date& rhs) const
   {
-    return (*date_ < *rhs.date_);
+    return std::tie(fields_.year, fields_.month, fields_.day)
+         < std::tie(rhs.fields_.year, rhs.fields_.month, rhs.fields_.day);
   }
 
   void Date::set(const String& date)
   {
     clear();
 
-    //check for format (german/english)
+    int year = 0, month = 0, day = 0;
+    bool parsed = false;
+
+    int n = 0; // track how many chars consumed
+
     if (date.has('.'))
     {
-      *date_ = QDate::fromString(date.c_str(), "dd.MM.yyyy");
+      if (sscanf(date.c_str(), "%d.%d.%d%n", &day, &month, &year, &n) == 3
+          && n == (int)date.size())
+      {
+        parsed = true;
+      }
     }
     else if (date.has('/'))
     {
-      *date_ = QDate::fromString(date.c_str(), "MM/dd/yyyy");
+      if (sscanf(date.c_str(), "%d/%d/%d%n", &month, &day, &year, &n) == 3
+          && n == (int)date.size())
+      {
+        parsed = true;
+      }
     }
     else if (date.has('-'))
     {
-      *date_ = QDate::fromString(date.c_str(), "yyyy-MM-dd");
+      if (sscanf(date.c_str(), "%d-%d-%d%n", &year, &month, &day, &n) == 3
+          && n == (int)date.size())
+      {
+        parsed = true;
+      }
     }
 
-    if (!date_->isValid())
+    if (!parsed || !isValidDate_(year, month, day))
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Is no valid german, english or iso date");
     }
+
+    fields_.year = year;
+    fields_.month = month;
+    fields_.day = day;
+    fields_.valid = true;
   }
 
   void Date::set(UInt month, UInt day, UInt year)
   {
-    if (!date_->setDate(year, month, day))
+    if (!isValidDate_((int)year, (int)month, (int)day))
     {
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(year) + "-" + String(month) + "-" + String(day), "Invalid date");
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  String(year) + "-" + String(month) + "-" + String(day), "Invalid date");
     }
+
+    fields_.year = (int)year;
+    fields_.month = (int)month;
+    fields_.day = (int)day;
+    fields_.valid = true;
   }
 
   Date Date::today()
   {
-    return Date(QDate::currentDate());
+    auto tp = chrono::system_clock::now();
+    time_t tt = chrono::system_clock::to_time_t(tp);
+    struct tm local{};
+#ifdef _WIN32
+    localtime_s(&local, &tt);
+#else
+    localtime_r(&tt, &local);
+#endif
+
+    Date d;
+    d.fields_.year = local.tm_year + 1900;
+    d.fields_.month = local.tm_mon + 1;
+    d.fields_.day = local.tm_mday;
+    d.fields_.valid = true;
+    return d;
   }
 
   String Date::get() const
   {
-    if (date_->isValid())
+    if (fields_.valid)
     {
-      return date_->toString("yyyy-MM-dd");
+      char buf[16];
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02d", fields_.year, fields_.month, fields_.day);
+      return String(buf);
     }
     return "0000-00-00";
   }
 
   void Date::get(UInt& month, UInt& day, UInt& year) const
   {
-    day = date_->day();
-    month = date_->month();
-    year = date_->year();
+    day = fields_.day;
+    month = fields_.month;
+    year = fields_.year;
   }
 
   void Date::clear()
   {
-    *date_ = QDate();
+    fields_ = Fields{};
   }
 
   bool Date::isValid() const
   {
-    return date_->isValid();
+    return fields_.valid;
   }
 
   bool Date::isNull() const
   {
-    return date_->isNull();
+    return !fields_.valid;
   }
 
   int Date::year() const
   {
-    return date_->year();
+    return fields_.year;
   }
 
   int Date::month() const
   {
-    return date_->month();
+    return fields_.month;
   }
 
   int Date::day() const
   {
-    return date_->day();
+    return fields_.day;
   }
 
 } // namespace OpenMS
-

--- a/src/openms/source/DATASTRUCTURES/DateTime.cpp
+++ b/src/openms/source/DATASTRUCTURES/DateTime.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
@@ -131,6 +132,8 @@ namespace OpenMS
 
   String DateTime::toString(const std::string& format) const
   {
+    if (!fields_.valid) return String();
+
     char buf[64];
 
     if (format == "yyyy-MM-ddThh:mm:ss")
@@ -218,6 +221,15 @@ namespace OpenMS
             // with milliseconds
             if (sscanf(stripped.c_str(), "%d-%d-%dT%d:%d:%d.%d", &year, &month, &day, &hour, &minute, &second, &millisecond) == 7)
             {
+              // Normalize fractional seconds: e.g. ".4" -> 400, ".46" -> 460, ".468" -> 468
+              auto dot_pos = stripped.find('.');
+              if (dot_pos != String::npos)
+              {
+                int frac_digits = 0;
+                for (size_t i = dot_pos + 1; i < stripped.size() && std::isdigit(static_cast<unsigned char>(stripped[i])); ++i) ++frac_digits;
+                for (int i = frac_digits; i < 3; ++i) millisecond *= 10;
+                millisecond %= 1000;
+              }
               parsed = true;
             }
           }
@@ -227,6 +239,23 @@ namespace OpenMS
             {
               parsed = true;
             }
+          }
+        }
+        else if (date.has('.'))
+        {
+          // ISO 8601 with milliseconds, no timezone: yyyy-MM-ddThh:mm:ss.zzz
+          if (sscanf(date.c_str(), "%d-%d-%dT%d:%d:%d.%d", &year, &month, &day, &hour, &minute, &second, &millisecond) == 7)
+          {
+            // Normalize fractional seconds: e.g. ".4" -> 400, ".46" -> 460, ".468" -> 468
+            auto dot_pos = date.find('.');
+            if (dot_pos != String::npos)
+            {
+              int frac_digits = 0;
+              for (size_t i = dot_pos + 1; i < date.size() && std::isdigit(static_cast<unsigned char>(date[i])); ++i) ++frac_digits;
+              for (int i = frac_digits; i < 3; ++i) millisecond *= 10;
+              millisecond %= 1000;
+            }
+            parsed = true;
           }
         }
         else
@@ -548,6 +577,15 @@ namespace OpenMS
     {
       n = sscanf(date.c_str(), "%d-%d-%dT%d:%d:%d.%d", &year, &month, &day, &hour, &minute, &second, &millisecond);
       if (n != 7) return d;
+      // Normalize fractional seconds: e.g. ".4" -> 400, ".46" -> 460, ".468" -> 468
+      auto dot_pos = date.find('.');
+      if (dot_pos != std::string::npos)
+      {
+        int frac_digits = 0;
+        for (size_t i = dot_pos + 1; i < date.size() && std::isdigit(static_cast<unsigned char>(date[i])); ++i) ++frac_digits;
+        for (int i = frac_digits; i < 3; ++i) millisecond *= 10;
+        millisecond %= 1000;
+      }
     }
     else if (format == "yyyy-MM-dd hh:mm:ss")
     {

--- a/src/openms/source/DATASTRUCTURES/DateTime.cpp
+++ b/src/openms/source/DATASTRUCTURES/DateTime.cpp
@@ -11,64 +11,104 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
-#include <QtCore/QDateTime> // very expensive to include!
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <tuple>
 
 using namespace std;
 
 namespace OpenMS
 {
-  DateTime::DateTime() :
-    dt_(new QDateTime)
+  // helper: validate date fields
+  static bool isValidDate_(int year, int month, int day)
   {
-  }
-
-  DateTime::DateTime(const DateTime& date)
-    : dt_(new QDateTime(*date.dt_))
-  {
-  }
-
-  DateTime::DateTime(DateTime&& rhs) noexcept
-    : dt_(rhs.dt_.release())
-  {
-  }
-
-
-  DateTime& DateTime::operator=(const DateTime& source)
-  {
-    if (&source == this)
+    if (month < 1 || month > 12 || day < 1 || year < 1)
     {
-      return *this;
+      return false;
     }
-
-    if (dt_ == nullptr)
-    { // *this is in a 'moved-from' state; we need to create a dt_ object first
-      dt_ = make_unique<QDateTime>(*source.dt_);
-    }
-    else
+    static const int days_in_month[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int max_day = days_in_month[month];
+    if (month == 2)
     {
-      *dt_ = *source.dt_;
+      bool leap = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+      if (leap) max_day = 29;
     }
-
-    return *this;
+    return day <= max_day;
   }
 
-  DateTime& DateTime::operator=(DateTime&& source) & noexcept
+  // helper: validate time fields
+  static bool isValidTime_(int hour, int minute, int second)
   {
-    if (&source == this)
-    {
-      return *this;
-    }
-
-    std::swap(dt_, source.dt_);
-
-    return *this;
+    return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59;
   }
 
-  DateTime::~DateTime() = default;
+  // helper: convert fields to a time_point, add seconds, convert back
+  // Uses std::chrono year_month_day and hh_mm_ss (C++20)
+  static void addSecsToFields_(int& year, int& month, int& day,
+                               int& hour, int& minute, int& second, int secs)
+  {
+    // Build a tm struct and use mktime/gmtime approach via chrono
+    struct tm t{};
+    t.tm_year = year - 1900;
+    t.tm_mon = month - 1;
+    t.tm_mday = day;
+    t.tm_hour = hour;
+    t.tm_min = minute;
+    t.tm_sec = second;
+    t.tm_isdst = -1; // let mktime figure it out -- actually we want naive arithmetic
+
+    // Use timegm (POSIX) or _mkgmtime (MSVC) to avoid timezone issues
+    // since our DateTime is naive (no timezone state)
+#ifdef _WIN32
+    time_t tt = _mkgmtime(&t);
+#else
+    time_t tt = timegm(&t);
+#endif
+
+    tt += secs;
+
+    struct tm result{};
+#ifdef _WIN32
+    _gmtime64_s(&result, &tt);
+#else
+    gmtime_r(&tt, &result);
+#endif
+
+    year = result.tm_year + 1900;
+    month = result.tm_mon + 1;
+    day = result.tm_mday;
+    hour = result.tm_hour;
+    minute = result.tm_min;
+    second = result.tm_sec;
+  }
+
+  // helper: parse 3-letter month abbreviation to month number (1-12), returns 0 on failure
+  static int parseMonthAbbrev_(const char* s)
+  {
+    static const char* months[] = {
+      "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+    for (int i = 0; i < 12; ++i)
+    {
+      if (strncmp(s, months[i], 3) == 0)
+      {
+        return i + 1;
+      }
+    }
+    return 0;
+  }
+
+  DateTime::DateTime() = default;
 
   bool DateTime::operator==(const DateTime& rhs) const
   {
-    return (*dt_ == *rhs.dt_);
+    return std::tie(fields_.year, fields_.month, fields_.day,
+                    fields_.hour, fields_.minute, fields_.second, fields_.millisecond, fields_.valid)
+        == std::tie(rhs.fields_.year, rhs.fields_.month, rhs.fields_.day,
+                    rhs.fields_.hour, rhs.fields_.minute, rhs.fields_.second, rhs.fields_.millisecond, rhs.fields_.valid);
   }
 
   bool DateTime::operator!=(const DateTime& rhs) const
@@ -78,30 +118,92 @@ namespace OpenMS
 
   bool DateTime::operator<(const DateTime& rhs) const
   {
-    return (*dt_ < *rhs.dt_);
+    return std::tie(fields_.year, fields_.month, fields_.day,
+                    fields_.hour, fields_.minute, fields_.second, fields_.millisecond)
+         < std::tie(rhs.fields_.year, rhs.fields_.month, rhs.fields_.day,
+                    rhs.fields_.hour, rhs.fields_.minute, rhs.fields_.second, rhs.fields_.millisecond);
   }
 
   bool DateTime::isValid() const
   {
-    return dt_->isValid();
+    return fields_.valid;
   }
 
   String DateTime::toString(const std::string& format) const
   {
-    return dt_->toString(QString::fromStdString(format)).toStdString();
+    char buf[64];
+
+    if (format == "yyyy-MM-ddThh:mm:ss")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d",
+               fields_.year, fields_.month, fields_.day,
+               fields_.hour, fields_.minute, fields_.second);
+    }
+    else if (format == "yyyy-MM-ddThh:mm:ss.zzz")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%03d",
+               fields_.year, fields_.month, fields_.day,
+               fields_.hour, fields_.minute, fields_.second, fields_.millisecond);
+    }
+    else if (format == "yyyy-MM-dd hh:mm:ss")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
+               fields_.year, fields_.month, fields_.day,
+               fields_.hour, fields_.minute, fields_.second);
+    }
+    else if (format == "yyyy-MM-dd+hh:mm")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02d+%02d:%02d",
+               fields_.year, fields_.month, fields_.day,
+               fields_.hour, fields_.minute);
+    }
+    else if (format == "yyyy-MM-ddThh:mm:ssZ")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02dZ",
+               fields_.year, fields_.month, fields_.day,
+               fields_.hour, fields_.minute, fields_.second);
+    }
+    else if (format == "yyyy-MM-dd")
+    {
+      snprintf(buf, sizeof(buf), "%04d-%02d-%02d",
+               fields_.year, fields_.month, fields_.day);
+    }
+    else if (format == "hh:mm:ss")
+    {
+      snprintf(buf, sizeof(buf), "%02d:%02d:%02d",
+               fields_.hour, fields_.minute, fields_.second);
+    }
+    else
+    {
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                    "Unknown DateTime format string", format);
+    }
+
+    return String(buf);
   }
 
   void DateTime::set(const String& date)
   {
     clear();
 
+    int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, millisecond = 0;
+    bool parsed = false;
+
     if (date.has('.') && !date.has('T'))
     {
-      *dt_ = (QDateTime::fromString(date.c_str(), "dd.MM.yyyy hh:mm:ss"));
+      // German format: dd.MM.yyyy hh:mm:ss
+      if (sscanf(date.c_str(), "%d.%d.%d %d:%d:%d", &day, &month, &year, &hour, &minute, &second) == 6)
+      {
+        parsed = true;
+      }
     }
     else if (date.has('/'))
     {
-      *dt_ = (QDateTime::fromString(date.c_str(), "MM/dd/yyyy hh:mm:ss"));
+      // US format: MM/dd/yyyy hh:mm:ss
+      if (sscanf(date.c_str(), "%d/%d/%d %d:%d:%d", &month, &day, &year, &hour, &minute, &second) == 6)
+      {
+        parsed = true;
+      }
     }
     else if (date.has('-'))
     {
@@ -109,78 +211,180 @@ namespace OpenMS
       {
         if (date.has('+'))
         {
-          // remove timezone part, since Qt cannot handle this, check if we also have a millisecond part
-          if (date.has('.'))
+          // ISO with timezone suffix -- strip at '+'
+          String stripped = date.prefix('+');
+          if (stripped.has('.'))
           {
-            *dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss.zzz"));
+            // with milliseconds
+            if (sscanf(stripped.c_str(), "%d-%d-%dT%d:%d:%d.%d", &year, &month, &day, &hour, &minute, &second, &millisecond) == 7)
+            {
+              parsed = true;
+            }
           }
           else
           {
-            *dt_ = (QDateTime::fromString(date.prefix('+').c_str(), "yyyy-MM-ddThh:mm:ss"));
+            if (sscanf(stripped.c_str(), "%d-%d-%dT%d:%d:%d", &year, &month, &day, &hour, &minute, &second) == 6)
+            {
+              parsed = true;
+            }
           }
         }
         else
         {
-          *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddThh:mm:ss"));
+          // ISO 8601: yyyy-MM-ddThh:mm:ss
+          if (sscanf(date.c_str(), "%d-%d-%dT%d:%d:%d", &year, &month, &day, &hour, &minute, &second) == 6)
+          {
+            parsed = true;
+          }
         }
       }
       else if (date.has('Z'))
       {
-        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-ddZ"));
+        // Legacy literal: yyyy-MM-ddZ  (Z is discarded, NOT UTC)
+        if (sscanf(date.c_str(), "%d-%d-%dZ", &year, &month, &day) == 3)
+        {
+          // Verify there's nothing unexpected after Z
+          // Check: the format is exactly "yyyy-MM-ddZ" -- if there's more after Z, it's invalid
+          // Find Z position
+          auto zpos = date.find('Z');
+          if (zpos != std::string::npos && zpos + 1 == date.size())
+          {
+            parsed = true;
+          }
+        }
       }
       else if (date.has('+'))
       {
-        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd+hh:mm"));
+        // Legacy literal: yyyy-MM-dd+hh:mm  (+ is separator, NOT timezone)
+        if (sscanf(date.c_str(), "%d-%d-%d+%d:%d", &year, &month, &day, &hour, &minute) == 5)
+        {
+          parsed = true;
+        }
       }
       else
       {
-        *dt_ = (QDateTime::fromString(date.c_str(), "yyyy-MM-dd hh:mm:ss"));
+        // ISO with space: yyyy-MM-dd hh:mm:ss
+        if (sscanf(date.c_str(), "%d-%d-%d %d:%d:%d", &year, &month, &day, &hour, &minute, &second) == 6)
+        {
+          parsed = true;
+        }
       }
     }
 
-    if (!dt_->isValid())
+    // Fallback: Legacy protXML format "ddd MMM d YYYY" e.g. "Tue Jul 13 2004"
+    // or "ddd MMM dd hh:mm:ss yyyy" e.g. "Thu Dec 14 11:45:26 2006"
+    if (!parsed)
     {
-      *dt_ = QDateTime::fromString(date.c_str());  // ddd MMM d YYYY format as found in (old?) protXML files
+      // Try: "Xxx Xxx dd hh:mm:ss yyyy"
+      char day_name[4] = {};
+      char month_name[4] = {};
+      int d2 = 0, h2 = 0, m2 = 0, s2 = 0, y2 = 0;
+      if (sscanf(date.c_str(), "%3s %3s %d %d:%d:%d %d", day_name, month_name, &d2, &h2, &m2, &s2, &y2) == 7)
+      {
+        int mon = parseMonthAbbrev_(month_name);
+        if (mon > 0)
+        {
+          year = y2; month = mon; day = d2;
+          hour = h2; minute = m2; second = s2;
+          parsed = true;
+        }
+      }
+      else if (sscanf(date.c_str(), "%3s %3s %d %d", day_name, month_name, &d2, &y2) == 4)
+      {
+        int mon = parseMonthAbbrev_(month_name);
+        if (mon > 0)
+        {
+          year = y2; month = mon; day = d2;
+          parsed = true;
+        }
+      }
     }
 
-    if (!dt_->isValid())
+    if (!parsed || !isValidDate_(year, month, day) || !isValidTime_(hour, minute, second))
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Invalid date time string");
     }
+
+    fields_.year = year;
+    fields_.month = month;
+    fields_.day = day;
+    fields_.hour = hour;
+    fields_.minute = minute;
+    fields_.second = second;
+    fields_.millisecond = millisecond;
+    fields_.valid = true;
   }
 
   void DateTime::set(UInt month, UInt day, UInt year, UInt hour, UInt minute, UInt second)
   {
-    dt_->setDate(QDate(year, month, day));
-    dt_->setTime(QTime(hour, minute, second));
-
-    if (!dt_->isValid())
+    if (!isValidDate_((int)year, (int)month, (int)day) || !isValidTime_((int)hour, (int)minute, (int)second))
     {
       String date_time = String(year) + "-" + String(month) + "-" + String(day)
                          + " " + String(hour) + ":" + String(minute) + ":" + String(second);
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date_time, "Invalid date time");
     }
+
+    fields_.year = (int)year;
+    fields_.month = (int)month;
+    fields_.day = (int)day;
+    fields_.hour = (int)hour;
+    fields_.minute = (int)minute;
+    fields_.second = (int)second;
+    fields_.millisecond = 0;
+    fields_.valid = true;
   }
 
   DateTime DateTime::now()
   {
+    auto tp = chrono::system_clock::now();
+    time_t tt = chrono::system_clock::to_time_t(tp);
+    struct tm local{};
+#ifdef _WIN32
+    localtime_s(&local, &tt);
+#else
+    localtime_r(&tt, &local);
+#endif
+
     DateTime d;
-    *d.dt_ = QDateTime::currentDateTime();
+    d.fields_.year = local.tm_year + 1900;
+    d.fields_.month = local.tm_mon + 1;
+    d.fields_.day = local.tm_mday;
+    d.fields_.hour = local.tm_hour;
+    d.fields_.minute = local.tm_min;
+    d.fields_.second = local.tm_sec;
+    d.fields_.millisecond = 0;
+    d.fields_.valid = true;
     return d;
   }
 
   DateTime DateTime::nowUTC()
   {
+    auto tp = chrono::system_clock::now();
+    time_t tt = chrono::system_clock::to_time_t(tp);
+    struct tm utc{};
+#ifdef _WIN32
+    _gmtime64_s(&utc, &tt);
+#else
+    gmtime_r(&tt, &utc);
+#endif
+
     DateTime d;
-    *d.dt_ = QDateTime::currentDateTimeUtc();
+    d.fields_.year = utc.tm_year + 1900;
+    d.fields_.month = utc.tm_mon + 1;
+    d.fields_.day = utc.tm_mday;
+    d.fields_.hour = utc.tm_hour;
+    d.fields_.minute = utc.tm_min;
+    d.fields_.second = utc.tm_sec;
+    d.fields_.millisecond = 0;
+    d.fields_.valid = true;
     return d;
   }
 
   String DateTime::get() const
   {
-    if (dt_->isValid())
+    if (fields_.valid)
     {
-      return dt_->toString("yyyy-MM-dd hh:mm:ss");
+      return toString("yyyy-MM-dd hh:mm:ss");
     }
     return "0000-00-00 00:00:00";
   }
@@ -188,138 +392,210 @@ namespace OpenMS
   void DateTime::get(UInt& month, UInt& day, UInt& year,
                      UInt& hour, UInt& minute, UInt& second) const
   {
-    const QDate& temp_date = dt_->date();
-    const QTime& temp_time = dt_->time();
-
-    year = temp_date.year();
-    month = temp_date.month();
-    day = temp_date.day();
-    hour = temp_time.hour();
-    minute = temp_time.minute();
-    second = temp_time.second();
+    year = fields_.year;
+    month = fields_.month;
+    day = fields_.day;
+    hour = fields_.hour;
+    minute = fields_.minute;
+    second = fields_.second;
   }
 
   void DateTime::clear()
   {
-    *dt_ = QDateTime();
+    fields_ = Fields{};
   }
 
   void DateTime::setDate(const String& date)
   {
-    QDate temp_date;
+    int year = 0, month = 0, day = 0;
+    bool parsed = false;
 
     if (date.has('-'))
     {
-      temp_date = QDate::fromString(date.c_str(), "yyyy-MM-dd");
+      if (sscanf(date.c_str(), "%d-%d-%d", &year, &month, &day) == 3)
+      {
+        parsed = true;
+      }
     }
     else if (date.has('.'))
     {
-      temp_date = QDate::fromString(date.c_str(), "dd-MM-yyyy");
+      if (sscanf(date.c_str(), "%d.%d.%d", &day, &month, &year) == 3)
+      {
+        parsed = true;
+      }
     }
     else if (date.has('/'))
     {
-      temp_date = QDate::fromString(date.c_str(), "MM/dd/yyyy");
+      if (sscanf(date.c_str(), "%d/%d/%d", &month, &day, &year) == 3)
+      {
+        parsed = true;
+      }
     }
-    else
-    {
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Could not set date");
-    }
-    if (!temp_date.isValid())
+
+    if (!parsed || !isValidDate_(year, month, day))
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, date, "Could not set date");
     }
 
-    dt_->setDate(temp_date);
+    fields_.year = year;
+    fields_.month = month;
+    fields_.day = day;
+    fields_.valid = true;
   }
 
   void DateTime::setTime(const String& time)
   {
-    QTime temp_time;
+    int hour = 0, minute = 0, second = 0;
 
-    temp_time = QTime::fromString(time.c_str(), "hh:mm:ss");
-    if (!temp_time.isValid())
+    if (sscanf(time.c_str(), "%d:%d:%d", &hour, &minute, &second) != 3 || !isValidTime_(hour, minute, second))
     {
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, time, "Could not set time");
     }
 
-    dt_->setTime(temp_time);
+    fields_.hour = hour;
+    fields_.minute = minute;
+    fields_.second = second;
+    // If we're setting time on a previously null DateTime, mark as valid
+    // (matches Qt behavior where setTime on a null QDateTime makes it valid with date 0)
+    fields_.valid = true;
   }
 
   void DateTime::setDate(UInt month, UInt day, UInt year)
   {
-    QDate temp_date;
-
-    if (!temp_date.setDate(year, month, day))
+    if (!isValidDate_((int)year, (int)month, (int)day))
     {
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(year) + "-" + String(month) + "-" + String(day), "Could not set date");
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  String(year) + "-" + String(month) + "-" + String(day), "Could not set date");
     }
 
-    dt_->setDate(temp_date);
+    fields_.year = (int)year;
+    fields_.month = (int)month;
+    fields_.day = (int)day;
+    fields_.valid = true;
   }
 
   void DateTime::setTime(UInt hour, UInt minute, UInt second)
   {
-    QTime temp_time;
-
-    if (!temp_time.setHMS(hour, minute, second))
+    if (!isValidTime_((int)hour, (int)minute, (int)second))
     {
-      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String(hour) + ":" + String(minute) + ":" + String(second), "Could not set time");
+      throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                  String(hour) + ":" + String(minute) + ":" + String(second), "Could not set time");
     }
-    dt_->setTime(temp_time);
+
+    fields_.hour = (int)hour;
+    fields_.minute = (int)minute;
+    fields_.second = (int)second;
+    fields_.valid = true;
   }
 
   void DateTime::getDate(UInt& month, UInt& day, UInt& year) const
   {
-    const QDate& temp_date = dt_->date();
-
-    month = temp_date.month();
-    day = temp_date.day();
-    year = temp_date.year();
+    month = fields_.month;
+    day = fields_.day;
+    year = fields_.year;
   }
 
   String DateTime::getDate() const
   {
-    if (dt_->isValid())
+    if (fields_.valid)
     {
-      return dt_->date().toString("yyyy-MM-dd");
+      return toString("yyyy-MM-dd");
     }
     return "0000-00-00";
   }
 
   void DateTime::getTime(UInt& hour, UInt& minute, UInt& second) const
   {
-    const QTime& temp_time =dt_->time();
-
-    hour = temp_time.hour();
-    minute = temp_time.minute();
-    second = temp_time.second();
+    hour = fields_.hour;
+    minute = fields_.minute;
+    second = fields_.second;
   }
 
   String DateTime::getTime() const
   {
-    if (dt_->isValid())
+    if (fields_.valid)
     {
-      return dt_->time().toString("hh:mm:ss");
+      return toString("hh:mm:ss");
     }
     return "00:00:00";
   }
-  
+
   DateTime& DateTime::addSecs(int s)
   {
-    *dt_ = dt_->addSecs(s);
+    addSecsToFields_(fields_.year, fields_.month, fields_.day,
+                     fields_.hour, fields_.minute, fields_.second, s);
     return *this;
   }
 
   bool DateTime::isNull() const
   {
-    return dt_->isNull();
+    return !fields_.valid;
   }
 
   // static
   DateTime DateTime::fromString(const std::string& date, const std::string& format)
   {
     DateTime d;
-    *d.dt_ = QDateTime::fromString(QString::fromStdString(date), QString::fromStdString(format));
+    int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, millisecond = 0;
+    int n = 0;
+
+    if (format == "yyyy-MM-ddThh:mm:ss")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%dT%d:%d:%d", &year, &month, &day, &hour, &minute, &second);
+      if (n != 6) return d; // return invalid
+    }
+    else if (format == "yyyy-MM-ddThh:mm:ss.zzz")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%dT%d:%d:%d.%d", &year, &month, &day, &hour, &minute, &second, &millisecond);
+      if (n != 7) return d;
+    }
+    else if (format == "yyyy-MM-dd hh:mm:ss")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%d %d:%d:%d", &year, &month, &day, &hour, &minute, &second);
+      if (n != 6) return d;
+    }
+    else if (format == "yyyy-MM-dd+hh:mm")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%d+%d:%d", &year, &month, &day, &hour, &minute);
+      if (n != 5) return d;
+    }
+    else if (format == "yyyy-MM-ddThh:mm:ssZ")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%dT%d:%d:%dZ", &year, &month, &day, &hour, &minute, &second);
+      if (n != 6) return d;
+    }
+    else if (format == "yyyy-MM-dd")
+    {
+      n = sscanf(date.c_str(), "%d-%d-%d", &year, &month, &day);
+      if (n != 3) return d;
+    }
+    else if (format == "hh:mm:ss")
+    {
+      n = sscanf(date.c_str(), "%d:%d:%d", &hour, &minute, &second);
+      if (n != 3) return d;
+    }
+    else
+    {
+      return d; // return invalid for unknown format
+    }
+
+    if (!isValidDate_(year, month, day) && format != "hh:mm:ss")
+    {
+      return d;
+    }
+    if (!isValidTime_(hour, minute, second))
+    {
+      return d;
+    }
+
+    d.fields_.year = year;
+    d.fields_.month = month;
+    d.fields_.day = day;
+    d.fields_.hour = hour;
+    d.fields_.minute = minute;
+    d.fields_.second = second;
+    d.fields_.millisecond = millisecond;
+    d.fields_.valid = true;
     return d;
   }
 

--- a/src/openms/source/KERNEL/DimMapper.cpp
+++ b/src/openms/source/KERNEL/DimMapper.cpp
@@ -10,7 +10,9 @@
 
 #include <OpenMS/DATASTRUCTURES/String.h>
 
-#include <QtCore/QLocale>
+#include <cstdio>
+#include <cstring>
+#include <string>
 
 using namespace std;
 
@@ -24,12 +26,56 @@ namespace OpenMS
     DimMapper<1> d2(d);
     bool x = (d == dims);
     Area<2> area(nullptr);
+
+    /// Format a double with fixed precision and comma thousands separators (C locale style).
+    /// Mimics QLocale::c().toString(value, 'f', precision).
+    std::string formatWithGroupSeparators(double value, int precision)
+    {
+      char buf[128];
+      snprintf(buf, sizeof(buf), "%.*f", precision, value);
+
+      std::string result(buf);
+
+      // Find the decimal point (or end of string)
+      auto dot_pos = result.find('.');
+      std::string integer_part = result.substr(0, dot_pos);
+      std::string fractional_part;
+      if (dot_pos != std::string::npos)
+      {
+        fractional_part = result.substr(dot_pos);
+      }
+
+      // Handle negative sign
+      bool negative = (!integer_part.empty() && integer_part[0] == '-');
+      if (negative)
+      {
+        integer_part = integer_part.substr(1);
+      }
+
+      // Insert commas for thousands separators
+      int len = (int)integer_part.size();
+      if (len > 3)
+      {
+        std::string formatted;
+        int first_group = len % 3;
+        if (first_group == 0) first_group = 3;
+        formatted = integer_part.substr(0, first_group);
+        for (int i = first_group; i < len; i += 3)
+        {
+          formatted += ',';
+          formatted += integer_part.substr(i, 3);
+        }
+        integer_part = formatted;
+      }
+
+      return (negative ? "-" : "") + integer_part + fractional_part;
+    }
   }
 
   String DimBase::formattedValue(const ValueType value) const
   {
-    // hint: QLocale::c().toString adds group separators to better visualize large numbers (e.g. 23.009.646.54,3)
-    return String(this->getDimNameShort()) + ": " + QLocale::c().toString(value, 'f', valuePrecision());
+    // Format with group separators (commas) to better visualize large numbers
+    return String(this->getDimNameShort()) + ": " + formatWithGroupSeparators(value, valuePrecision());
   }
 
   String DimBase::formattedValue(const ValueType value, const String& prefix) const

--- a/src/openms/source/KERNEL/DimMapper.cpp
+++ b/src/openms/source/KERNEL/DimMapper.cpp
@@ -77,7 +77,7 @@ namespace OpenMS
   String DimBase::formattedValue(const ValueType value) const
   {
     // Format with group separators (commas) to better visualize large numbers
-    return String(this->getDimNameShort()) + ": " + formatWithGroupSeparators(value, valuePrecision());
+    return String(this->getDimNameShort()) + ": " + String(formatWithGroupSeparators(value, valuePrecision()));
   }
 
   String DimBase::formattedValue(const ValueType value, const String& prefix) const

--- a/src/openms/source/KERNEL/DimMapper.cpp
+++ b/src/openms/source/KERNEL/DimMapper.cpp
@@ -70,7 +70,7 @@ namespace OpenMS
         integer_part = formatted;
       }
 
-      return (negative ? "-" : "") + integer_part + fractional_part;
+      return std::string(negative ? "-" : "") + integer_part + fractional_part;
     }
   }
 

--- a/src/openms/source/KERNEL/DimMapper.cpp
+++ b/src/openms/source/KERNEL/DimMapper.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/DATASTRUCTURES/String.h>
 
+#include <charconv>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -32,7 +33,8 @@ namespace OpenMS
     std::string formatWithGroupSeparators(double value, int precision)
     {
       char buf[128];
-      snprintf(buf, sizeof(buf), "%.*f", precision, value);
+      auto [ptr, ec] = std::to_chars(buf, buf + sizeof(buf), value, std::chars_format::fixed, precision);
+      *ptr = '\0';
 
       std::string result(buf);
 

--- a/src/tests/class_tests/openms/source/Date_test.cpp
+++ b/src/tests/class_tests/openms/source/Date_test.cpp
@@ -12,7 +12,6 @@
 ///////////////////////////
 
 #include <OpenMS/DATASTRUCTURES/Date.h>
-#include <QtCore/QDate>
 #include <iostream>
 #include <vector>
 
@@ -37,9 +36,9 @@ START_SECTION(([EXTRA]~Date()))
 	delete s_ptr;
 END_SECTION
 
-START_SECTION(Date(const QDate &date))
-	QDate qd(1999,12,24);
-	Date d(qd);
+START_SECTION(([EXTRA] Date constructed from set()))
+	Date d;
+	d.set(12, 24, 1999);
 	TEST_EQUAL(d.year(),1999)
 	TEST_EQUAL(d.month(),12)
 	TEST_EQUAL(d.day(),24)


### PR DESCRIPTION
## Summary
- DateTime and Date classes rewritten from `unique_ptr<QDateTime/QDate>` pimpl to plain struct
- All parsing uses sscanf, formatting uses snprintf — locale-independent
- BuildInfo.h uses platform-specific APIs (RtlGetVersion, sysctlbyname, /etc/os-release)
- DimMapper uses custom formatWithGroupSeparators (locale-independent via std::to_chars)
- TOPPBase direct QDateTime calls replaced with DateTime::now().get()
- Part 2/7 of removing Qt6::Core from libOpenMS core library

## Test plan
- [x] DateTime_test passes (all 8 parse formats, 7 toString formats)
- [x] Date_test passes
- [x] DimMapper_test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced Qt-based date/time internals with a lightweight native implementation; improves parsing, validation, supported input/output formats, and current-time retrieval used in logs.
  * Replaced legacy OS/version detection with a more accurate, platform-aware approach.
  * Streamlined numeric formatting for dimension displays for consistent grouping and precision.

* **Tests**
  * Updated unit tests to match the new date handling implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->