### PR TITLE
refactor: replace QDir/QFile/QFileInfo with std::filesystem

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/ToolHandler.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/ToolHandler.h
@@ -10,10 +10,9 @@
 
 #include <OpenMS/DATASTRUCTURES/ToolDescription.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 
 #include <map>
-
-#include <QtCore/qcontainerfwd.h> // for QStringList
 
 
 namespace OpenMS
@@ -71,17 +70,16 @@ public:
 private:
 
     static Internal::ToolDescription getExternalTools_();
-    static QStringList getExternalToolConfigFiles_();
+    static StringList getExternalToolConfigFiles_();
     static void loadExternalToolConfig_();
     static Internal::ToolDescription tools_external_;
     static bool tools_external_loaded_;
 
     static std::vector<Internal::ToolDescription> getInternalTools_();
-    static QStringList getInternalToolConfigFiles_();
+    static StringList getInternalToolConfigFiles_();
     static void loadInternalToolConfig_();
     static std::vector<Internal::ToolDescription> tools_internal_;
     static bool tools_internal_loaded_;
   };
 
 } // namespace OpenMS
-

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -107,7 +107,7 @@ public:
        @return True on success
     */
     enum class CopyOptions {OVERWRITE,SKIP,CANCEL};
-    static bool copyDirRecursively(const QString &from_dir, const QString &to_dir, File::CopyOptions option = CopyOptions::OVERWRITE);
+    static bool copyDirRecursively(const String& from_dir, const String& to_dir, File::CopyOptions option = CopyOptions::OVERWRITE);
 
     /// Copy a file (if it exists). Returns true if successful.
     static bool copy(const String& from, const String& to);
@@ -123,7 +123,7 @@ public:
     static bool removeDirRecursively(const String& dir_name);
 
     /// Removes the directory and all subdirectories (absolute path).
-    static bool removeDir(const QString& dir_name);
+    static bool removeDir(const String& dir_name);
 
     /// Creates a directory (absolute path or relative to the current working dir), even if subdirectories do not exist. Returns true if successful.
     /// If the path already exists when this function is called, it will return true.

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -119,10 +119,10 @@ public:
     */
     static bool remove(const String& file);
 
-    /// Removes the subdirectories of the specified directory (absolute path). Returns true if successful.
+    /// Removes a directory and all its contents recursively (absolute path). Returns true if successful.
     static bool removeDirRecursively(const String& dir_name);
 
-    /// Removes the directory and all subdirectories (absolute path).
+    /// Removes an empty directory. Returns false if the directory is not empty or cannot be removed.
     static bool removeDir(const String& dir_name);
 
     /// Creates a directory (absolute path or relative to the current working dir), even if subdirectories do not exist. Returns true if successful.

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -122,7 +122,7 @@ public:
     /// Removes a directory and all its contents recursively (absolute path). Returns true if successful.
     static bool removeDirRecursively(const String& dir_name);
 
-    /// Removes an empty directory. Returns false if the directory is not empty or cannot be removed.
+    /// Removes a directory and all its contents (absolute path). Returns true if successful.
     static bool removeDir(const String& dir_name);
 
     /// Creates a directory (absolute path or relative to the current working dir), even if subdirectories do not exist. Returns true if successful.

--- a/src/openms/include/OpenMS/SYSTEM/PathUtils.h
+++ b/src/openms/include/OpenMS/SYSTEM/PathUtils.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace OpenMS
+{
+  /// Convert a UTF-8 std::string to std::filesystem::path safely on all platforms.
+  /// On Windows, std::filesystem::path(std::string) uses the current code page, not UTF-8.
+  inline std::filesystem::path to_path(const std::string& s)
+  {
+    return std::filesystem::path(
+      std::u8string(reinterpret_cast<const char8_t*>(s.data()), s.size()));
+  }
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/SYSTEM/sources.cmake
+++ b/src/openms/include/OpenMS/SYSTEM/sources.cmake
@@ -24,6 +24,7 @@ File.h
 JavaInfo.h
 Network.h
 NetworkGetRequest.h
+PathUtils.h
 PythonInfo.h
 RWrapper.h
 SIMDe.h

--- a/src/openms/source/ANALYSIS/ID/FIAMSScheduler.cpp
+++ b/src/openms/source/ANALYSIS/ID/FIAMSScheduler.cpp
@@ -13,7 +13,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
-#include <QDir>
+#include <OpenMS/SYSTEM/File.h>
 
 namespace OpenMS {
   /// default constructor
@@ -58,8 +58,7 @@ namespace OpenMS {
       Param p;
       p.setValue("filename", samples_[i].at("filename"));
       p.setValue("dir_output", output_dir_ + samples_[i].at("dir_output"));
-      QDir qd;
-      qd.mkpath(p.getValue("dir_output").toString().c_str());
+      File::makeDir(p.getValue("dir_output").toString());
       p.setValue("resolution", std::stof(samples_[i].at("resolution")));
       p.setValue("polarity", samples_[i].at("charge"));
       p.setValue("db:mapping", std::vector<std::string>{base_dir_ + samples_[i].at("db_mapping")});

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/ANALYSIS/ID/IDRipper.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/CONCEPT/Constants.h>
 
 #include <filesystem>
@@ -74,7 +75,7 @@ namespace OpenMS
               : pep_id.getMetaValue("file_origin").toString();
 
           // Extract the basename, used for output files when --numeric_filenames is not set
-          this->out_basename = std::filesystem::path(std::string(this->origin_fullname)).stem().string();
+          this->out_basename = to_path(this->origin_fullname).stem().string();
 
           // Drop the identification run identifier if we're not splitting by identification runs
           if (!split_ident_runs)

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -10,7 +10,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Constants.h>
 
-#include <QtCore/QDir>
+#include <filesystem>
 #include <array>
 #include <unordered_set>
 
@@ -74,7 +74,7 @@ namespace OpenMS
               : pep_id.getMetaValue("file_origin").toString();
 
           // Extract the basename, used for output files when --numeric_filenames is not set
-          this->out_basename = QFileInfo(this->origin_fullname.toQString()).completeBaseName().toStdString();
+          this->out_basename = std::filesystem::path(this->origin_fullname).stem().string();
 
           // Drop the identification run identifier if we're not splitting by identification runs
           if (!split_ident_runs)

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -74,7 +74,7 @@ namespace OpenMS
               : pep_id.getMetaValue("file_origin").toString();
 
           // Extract the basename, used for output files when --numeric_filenames is not set
-          this->out_basename = std::filesystem::path(this->origin_fullname).stem().string();
+          this->out_basename = std::filesystem::path(std::string(this->origin_fullname)).stem().string();
 
           // Drop the identification run identifier if we're not splitting by identification runs
           if (!split_ident_runs)

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -41,8 +41,9 @@
 #include <OpenMS/SYSTEM/SysInfo.h>
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/PathUtils.h>
 
+#include <filesystem>
 #include <iostream>
 
 // OpenMP support
@@ -64,7 +65,7 @@ namespace OpenMS
 
   using namespace Exception;
 
-  String TOPPBase::topp_ini_file_ = String(QDir::homePath()) + "/.TOPP.ini";
+  String TOPPBase::topp_ini_file_ = File::getOpenMSHomePath() + "/.TOPP.ini";
   const Citation TOPPBase::cite_openms
     = {"Pfeuffer, J., Bielow, C., Wein, S. et al.", "OpenMS 3 enables reproducible analysis of large-scale mass spectrometry data",
        "Nat Methods (2024)", "10.1038/s41592-024-02197-7"};
@@ -2386,10 +2387,10 @@ namespace OpenMS
   void TOPPBase::writeToolDescription_(Writer& writer, std::string write_type, std::string fileExtension)
   {
     //store ini-file content in ini_file_str
-    QString out_dir_str = String(param_cmdline_.getValue(write_type).toString()).toQString();
-    if (out_dir_str == "")
+    String out_dir_str = String(param_cmdline_.getValue(write_type).toString());
+    if (out_dir_str.empty())
     {
-      out_dir_str = QDir::currentPath();
+      out_dir_str = std::filesystem::current_path().string();
     }
     StringList type_list = ToolHandler::getTypes(tool_name_);
     if (type_list.empty())
@@ -2398,7 +2399,7 @@ namespace OpenMS
     for (Size i = 0; i < type_list.size(); ++i)
     {
       // check file is writable
-      QString write_file = out_dir_str + QDir::separator() + tool_name_.toQString() + type_list[i].toQString() + fileExtension.c_str();
+      String write_file = out_dir_str + "/" + tool_name_ + type_list[i] + fileExtension.c_str();
       outputFileWritable_(write_file, write_type);
 
       // set type on command line, so that getDefaultParameters_() does not fail (as it calls getSubSectionDefaults() of tool)

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2392,7 +2392,7 @@ namespace OpenMS
     String out_dir_str = String(param_cmdline_.getValue(write_type).toString());
     if (out_dir_str.empty())
     {
-      out_dir_str = std::filesystem::current_path().string();
+      out_dir_str = std::filesystem::current_path().generic_string();
     }
     StringList type_list = ToolHandler::getTypes(tool_name_);
     if (type_list.empty())

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -43,6 +43,8 @@
 
 #include <OpenMS/SYSTEM/PathUtils.h>
 
+#include <QtCore/QDateTime> // still needed for logging timestamps; removed in PR 2 (DateTime)
+
 #include <filesystem>
 #include <iostream>
 
@@ -2440,7 +2442,7 @@ namespace OpenMS
       toolInfo.citations_   = citation_dois;
 
       // this will write the actual data to disk
-      writer.store(write_file.toStdString(), default_params, toolInfo);
+      writer.store(write_file, default_params, toolInfo);
     }
   }
 

--- a/src/openms/source/APPLICATIONS/ToolHandler.cpp
+++ b/src/openms/source/APPLICATIONS/ToolHandler.cpp
@@ -11,15 +11,14 @@
 #include <OpenMS/FORMAT/ToolDescriptionFile.h>
 #include <OpenMS/SYSTEM/File.h>
 
-#include <QStringList>
-#include <QtCore/QDir>
+#include <algorithm>
 
 namespace OpenMS
 {
   ToolListType ToolHandler::getTOPPToolList(const bool includeGenericWrapper)
   {
     ToolListType tools_map;
-    // Note: don't use special characters like slashes in category names (leads to subcategories in KNIME) 
+    // Note: don't use special characters like slashes in category names (leads to subcategories in KNIME)
     const auto cat_calibration = "Mass Correction and Calibration";
     const auto cat_centroiding = "Spectrum processing: Centroiding";
     const auto cat_crosslinking = "Cross-Linking";
@@ -193,7 +192,7 @@ namespace OpenMS
     tools_map["TriqlerConverter"] = Internal::ToolDescription("TriqlerConverter", cat_file_converter);
     tools_map["XFDR"] = Internal::ToolDescription("XFDR", cat_crosslinking);
     tools_map["XMLValidator"] = Internal::ToolDescription("XMLValidator", cat_dev);
-    
+
     // STOP! insert your tool in alphabetical order for easier maintenance (tools requiring the GUI lib should be added below **in addition**)
 
     // ATTENTION: tools requiring the GUI lib
@@ -286,12 +285,12 @@ namespace OpenMS
 
   void ToolHandler::loadExternalToolConfig_()
   {
-    QStringList files = getExternalToolConfigFiles_();
-    for (int i = 0; i < files.size(); ++i)
+    StringList files = getExternalToolConfigFiles_();
+    for (size_t i = 0; i < files.size(); ++i)
     {
       ToolDescriptionFile tdf;
       std::vector<Internal::ToolDescription> tools;
-      tdf.load(String(files[i]), tools);
+      tdf.load(files[i], tools);
       // add every tool from file to list
       for (Size i_t = 0; i_t < tools.size(); ++i_t)
       {
@@ -311,12 +310,12 @@ namespace OpenMS
 
   void ToolHandler::loadInternalToolConfig_()
   {
-    QStringList files = getInternalToolConfigFiles_();
-    for (int i = 0; i < files.size(); ++i)
+    StringList files = getInternalToolConfigFiles_();
+    for (size_t i = 0; i < files.size(); ++i)
     {
       ToolDescriptionFile tdf;
       std::vector<Internal::ToolDescription> tools;
-      tdf.load(String(files[i]), tools);
+      tdf.load(files[i], tools);
       // add every tool from file to list
       for (Size i_t = 0; i_t < tools.size(); ++i_t)
       {
@@ -326,66 +325,56 @@ namespace OpenMS
     }
   }
 
-  QStringList ToolHandler::getExternalToolConfigFiles_()
+  StringList ToolHandler::getExternalToolConfigFiles_()
   {
-
-    QStringList paths;
+    StringList paths;
     // *.ttd default path
-    paths << getExternalToolsPath().toQString();
+    paths.push_back(getExternalToolsPath());
     // OS-specific path
 #ifdef OPENMS_WINDOWSPLATFORM
-    paths << (getExternalToolsPath() + "/WINDOWS").toQString();
+    paths.push_back(getExternalToolsPath() + "/WINDOWS");
 #else
-    paths << (getExternalToolsPath() + "/LINUX").toQString();
+    paths.push_back(getExternalToolsPath() + "/LINUX");
 #endif
     // additional environment
     if (getenv("OPENMS_TTD_PATH") != nullptr)
     {
-      paths << String(getenv("OPENMS_TTD_PATH")).toQString();
+      paths.push_back(String(getenv("OPENMS_TTD_PATH")));
     }
 
-    QStringList all_files;
-    for (int p = 0; p < paths.size(); ++p)
+    StringList all_files;
+    for (const auto& p : paths)
     {
-      QDir dir(paths[p], "*.ttd");
-      QStringList files = dir.entryList();
-      for (int i = 0; i < files.size(); ++i)
-      {
-        files[i] = dir.absolutePath() + QDir::separator() + files[i];
-      }
-      all_files << files;
+      StringList files;
+      File::fileList(p, "*.ttd", files, true);
+      all_files.insert(all_files.end(), files.begin(), files.end());
     }
-    //StringList list = ListUtils::create<String>(getExternalToolsPath() + "/" + "msconvert.ttd");
     return all_files;
   }
 
-  QStringList ToolHandler::getInternalToolConfigFiles_()
+  StringList ToolHandler::getInternalToolConfigFiles_()
   {
-    QStringList paths;
+    StringList paths;
     // *.ttd default path
-    paths << getInternalToolsPath().toQString();
+    paths.push_back(getInternalToolsPath());
     // OS-specific path
 #ifdef OPENMS_WINDOWSPLATFORM
-    paths << (getInternalToolsPath() + "/WINDOWS").toQString();
+    paths.push_back(getInternalToolsPath() + "/WINDOWS");
 #else
-    paths << (getInternalToolsPath() + "/LINUX").toQString();
+    paths.push_back(getInternalToolsPath() + "/LINUX");
 #endif
     // additional environment
     if (getenv("OPENMS_TTD_INTERNAL_PATH") != nullptr)
     {
-      paths << String(getenv("OPENMS_TTD_INTERNAL_PATH")).toQString();
+      paths.push_back(String(getenv("OPENMS_TTD_INTERNAL_PATH")));
     }
 
-    QStringList all_files;
-    for (int p = 0; p < paths.size(); ++p)
+    StringList all_files;
+    for (const auto& p : paths)
     {
-      QDir dir(paths[p], "*.ttd");
-      QStringList files = dir.entryList();
-      for (int i = 0; i < files.size(); ++i)
-      {
-        files[i] = dir.absolutePath() + QDir::separator() + files[i];
-      }
-      all_files << files;
+      StringList files;
+      File::fileList(p, "*.ttd", files, true);
+      all_files.insert(all_files.end(), files.begin(), files.end());
     }
     return all_files;
   }

--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -29,7 +29,7 @@
 #include <iomanip>
 #include <fstream>
 
-#include <QtCore/QFileInfo>
+#include <filesystem>
 
 namespace OpenMS::Internal::ClassTest
 {
@@ -364,8 +364,8 @@ namespace OpenMS::Internal::ClassTest
       std::string
       createTmpFileName(const std::string& file, int line, const std::string& extension)
       {
-        QFileInfo fi(file.c_str());
-        std::string filename = (String(fi.baseName())) + '_' + String(line) + ".tmp" + extension;
+        std::filesystem::path fp(file);
+        std::string filename = (String(fp.stem().string())) + '_' + String(line) + ".tmp" + extension;
         TEST::tmp_file_list.push_back(filename);
         TEST::initialNewline();
         stdcout << "    creating new temporary filename '"

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -11,7 +11,8 @@
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 #include <fstream>
 #include <istream>
 #include <iomanip>
@@ -191,26 +192,26 @@ namespace OpenMS
         << prefix << "\n"
         << prefix << "Offending lines:\t\t\t(tab_width = " << tab_width_ << ", first_column = " << first_column_ << ")\n"
         << prefix << "\n"
-        << prefix << "in1:  " << QDir::toNativeSeparators(File::absolutePath(input_1_name_).toQString()).toStdString() << "   (line: " << line_num_1_ << ", position/column: " << input_line_1_.line_position_ << '/' << prefix1.line_column << ")\n"
+        << prefix << "in1:  " << to_path(File::absolutePath(input_1_name_)).make_preferred().string() << "   (line: " << line_num_1_ << ", position/column: " << input_line_1_.line_position_ << '/' << prefix1.line_column << ")\n"
         << prefix << prefix1.prefix << "!\n"
         << prefix << prefix1.prefix_whitespaces << OpenMS::String(input_line_1_.line_.str()).suffix(input_line_1_.line_.str().size() - prefix1.prefix.size()) << "\n"
         << prefix <<  "\n"
-        << prefix << "in2:  " << QDir::toNativeSeparators(File::absolutePath(input_2_name_).toQString()).toStdString() << "   (line: " << line_num_2_ << ", position/column: " << input_line_2_.line_position_ << '/' << prefix2.line_column << ")\n"
+        << prefix << "in2:  " << to_path(File::absolutePath(input_2_name_)).make_preferred().string() << "   (line: " << line_num_2_ << ", position/column: " << input_line_2_.line_position_ << '/' << prefix2.line_column << ")\n"
         << prefix << prefix2.prefix << "!\n"
         << prefix << prefix2.prefix_whitespaces << OpenMS::String(input_line_2_.line_.str()).suffix(input_line_2_.line_.str().size() - prefix2.prefix.size()) << "\n"
         << prefix << "\n\n"
         << "Easy Access:" << "\n"
-        << QDir::toNativeSeparators(File::absolutePath(input_1_name_).toQString()).toStdString() << ':' << line_num_1_ << ":" << prefix1.line_column << ":\n"
-        << QDir::toNativeSeparators(File::absolutePath(input_2_name_).toQString()).toStdString() << ':' << line_num_2_ << ":" << prefix2.line_column << ":\n"
+        << to_path(File::absolutePath(input_1_name_)).make_preferred().string() << ':' << line_num_1_ << ":" << prefix1.line_column << ":\n"
+        << to_path(File::absolutePath(input_2_name_)).make_preferred().string() << ':' << line_num_2_ << ":" << prefix2.line_column << ":\n"
         << "\n"
         #ifdef WIN32
         << "TortoiseGitMerge"
-        << " /base:\"" << QDir::toNativeSeparators(File::absolutePath(input_1_name_).toQString()).toStdString() << "\""
-        << " /mine:\"" << QDir::toNativeSeparators(File::absolutePath(input_2_name_).toQString()).toStdString() << "\""
+        << " /base:\"" << to_path(File::absolutePath(input_1_name_)).make_preferred().string() << "\""
+        << " /mine:\"" << to_path(File::absolutePath(input_2_name_)).make_preferred().string() << "\""
         #else
         << "diff"
-        << " " << QDir::toNativeSeparators(File::absolutePath(input_1_name_).toQString()).toStdString()
-        << " " << QDir::toNativeSeparators(File::absolutePath(input_2_name_).toQString()).toStdString()
+        << " " << to_path(File::absolutePath(input_1_name_)).make_preferred().string()
+        << " " << to_path(File::absolutePath(input_2_name_)).make_preferred().string()
         #endif
         << '\n';
     }
@@ -258,10 +259,10 @@ namespace OpenMS
         *log_dest_ <<
           prefix << "Maximum relative error was attained at these lines, enclosed in \"\":\n" <<
           prefix << '\n' <<
-          QDir::toNativeSeparators(input_1_name_.c_str()).toStdString() << ':' << line_num_1_max_ << ":\n" <<
+          to_path(input_1_name_).make_preferred().string() << ':' << line_num_1_max_ << ":\n" <<
           "\"" << line_str_1_max_ << "\"\n" <<
           '\n' <<
-          QDir::toNativeSeparators(input_2_name_.c_str()).toStdString() << ':' << line_num_2_max_ << ":\n" <<
+          to_path(input_2_name_).make_preferred().string() << ':' << line_num_2_max_ << ":\n" <<
           "\"" << line_str_2_max_ << "\"\n" <<
           std::endl;
       }

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -22,7 +22,7 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Constants.h>
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/File.h>
 
 #include <boost/math/special_functions/fpclassify.hpp> // isnan
 
@@ -230,8 +230,7 @@ namespace OpenMS
     //clean up / create folders for debug information
     if (debug_)
     {
-      QDir dir(".");
-      dir.mkpath("debug/features");
+      File::makeDir("debug/features");
       log_.open("debug/log.txt");
     }
 

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -326,7 +326,7 @@ namespace OpenMS
         }
 
         // read file and save in MSSpectrum
-        ifstream fragment_annotation_file(sirius_result_file.string());
+        ifstream fragment_annotation_file(sirius_result_file);
         if (fragment_annotation_file)
         {
           // Target schema

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -10,8 +10,8 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <fstream>
-#include <QtCore/QDir>
-#include <QtCore/QString>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 
 using namespace std;
 
@@ -267,9 +267,10 @@ namespace OpenMS
     std::vector<MSSpectrum> result;
     std::string subfolder = decoy ? "/decoys/" : "/spectra/";
     const std::string sirius_spectra_dir = path_to_sirius_workspace + subfolder;
-    QDir dir(QString::fromStdString(sirius_spectra_dir));
+    namespace fs = std::filesystem;
+    auto dir_path = to_path(sirius_spectra_dir);
 
-    if (dir.exists())
+    if (fs::is_directory(dir_path))
     {
       // TODO this probably can and should be extracted in one go.
       OpenMS::String concat_native_ids = SiriusFragmentAnnotation::extractConcatNativeIDsFromSiriusMS_(path_to_sirius_workspace);
@@ -301,7 +302,7 @@ namespace OpenMS
         msspectrum_to_fill.setName(concat_m_ids + suffix);
         String filename = rank_filename.at(i); // rank 1
         double score = rank_score.at(i); // rank 1
-        QFileInfo sirius_result_file(dir,filename.toQString());
+        auto sirius_result_file = dir_path / to_path(filename);
 
         if (use_exact_mass)
         {
@@ -325,7 +326,7 @@ namespace OpenMS
         }
 
         // read file and save in MSSpectrum
-        ifstream fragment_annotation_file(sirius_result_file.absoluteFilePath().toStdString());
+        ifstream fragment_annotation_file(sirius_result_file.string());
         if (fragment_annotation_file)
         {
           // Target schema

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -26,7 +26,7 @@ namespace OpenMS
     {
       String result;
       namespace fs = std::filesystem;
-      if (fs::path(std::string(spec_file)).is_relative())
+      if (to_path(spec_file).is_relative())
       {
         // file name is relative, so we need to figure out the correct folder
 

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -33,7 +33,7 @@ namespace OpenMS
         // first check folder relative to folder of design file
         // to allow, for example, a design in ./design.tsv and spectra in ./spectra/a.mzML
         // where ./ is the same folder
-        String design_file_dir = fs::absolute(to_path(tsv_file)).parent_path().string();
+        String design_file_dir = fs::absolute(to_path(tsv_file)).parent_path().generic_string();
         String design_file_relative = design_file_dir + "/" + spec_file;
 
         if (File::exists(design_file_relative))

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -14,8 +14,8 @@
 #include <OpenMS/METADATA/ExperimentalDesign.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <QtCore/QFileInfo>
-#include <QtCore/QString>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 #include <iostream>
 
 using namespace std;
@@ -25,21 +25,20 @@ namespace OpenMS
     String findSpectraFile(const String &spec_file, const String &tsv_file, const bool require_spectra_files)
     {
       String result;
-      QFileInfo spectra_file_info(spec_file.toQString());
-      if (spectra_file_info.isRelative())
+      namespace fs = std::filesystem;
+      if (fs::path(spec_file).is_relative())
       {
         // file name is relative, so we need to figure out the correct folder
 
         // first check folder relative to folder of design file
         // to allow, for example, a design in ./design.tsv and spectra in ./spectra/a.mzML
         // where ./ is the same folder
-        QFileInfo design_file_info(tsv_file.toQString());
-        QString design_file_relative(design_file_info.absolutePath());
-        design_file_relative = design_file_relative + "/" + spec_file.toQString();
+        String design_file_dir = fs::absolute(to_path(tsv_file)).parent_path().string();
+        String design_file_relative = design_file_dir + "/" + spec_file;
 
         if (File::exists(design_file_relative))
         {
-          result = design_file_relative.toStdString();
+          result = design_file_relative;
         }
         else
         {

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -26,7 +26,7 @@ namespace OpenMS
     {
       String result;
       namespace fs = std::filesystem;
-      if (fs::path(spec_file).is_relative())
+      if (fs::path(std::string(spec_file)).is_relative())
       {
         // file name is relative, so we need to figure out the correct folder
 

--- a/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
+++ b/src/openms/source/FORMAT/ExperimentalDesignFile.cpp
@@ -26,7 +26,13 @@ namespace OpenMS
     {
       String result;
       namespace fs = std::filesystem;
-      if (to_path(spec_file).is_relative())
+      // On Windows, std::filesystem treats "/data/foo" as relative (no drive letter),
+      // but Qt treated it as absolute. Check for '/' prefix to match Qt behavior.
+      bool is_relative = to_path(spec_file).is_relative();
+#ifdef OPENMS_WINDOWSPLATFORM
+      if (!spec_file.empty() && spec_file[0] == '/') is_relative = false;
+#endif
+      if (is_relative)
       {
         // file name is relative, so we need to figure out the correct folder
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -933,6 +933,10 @@ namespace OpenMS::Internal
       // delete file if present
       std::error_code ec;
       std::filesystem::remove(OpenMS::to_path(filename_), ec);
+      if (ec)
+      {
+        OPENMS_LOG_WARN << "Warning: could not remove existing file '" << filename_ << "': " << ec.message() << std::endl;
+      }
 
       SqliteConnector conn(filename_);
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -15,7 +15,8 @@
 #include <OpenMS/FORMAT/SqliteConnector.h>
 #include <OpenMS/FORMAT/ZlibCompression.h>
 
-#include <QtCore/QFileInfo>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 
 // #include <type_traits> // for template arg detection
 #include <boost/type_traits.hpp>
@@ -930,8 +931,8 @@ namespace OpenMS::Internal
     void MzMLSqliteHandler::createTables()
     {
       // delete file if present
-      QFile file (filename_.toQString());
-      file.remove();
+      std::error_code ec;
+      std::filesystem::remove(OpenMS::to_path(filename_), ec);
 
       SqliteConnector conn(filename_);
 

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -16,6 +16,7 @@
 #include <OpenMS/METADATA/SpectrumSettings.h>
 #include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/METADATA/SpectrumLookup.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 
 #include <filesystem>
 
@@ -422,7 +423,7 @@ namespace OpenMS
     }
 
     static const std::regex non_alnum("[^a-zA-Z0-9]");
-    std::filesystem::path fileinfo{std::string(filename)};
+    auto fileinfo = to_path(filename);
     String filtered_filename = std::regex_replace(fileinfo.stem().string(), non_alnum, "");
 
 

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -422,7 +422,7 @@ namespace OpenMS
     }
 
     static const std::regex non_alnum("[^a-zA-Z0-9]");
-    std::filesystem::path fileinfo(std::string(filename));
+    std::filesystem::path fileinfo{std::string(filename)};
     String filtered_filename = std::regex_replace(fileinfo.stem().string(), non_alnum, "");
 
 

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -17,7 +17,7 @@
 #include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/METADATA/SpectrumLookup.h>
 
-#include <QtCore/QFileInfo>
+#include <filesystem>
 
 #include <iomanip>     // setw
 #include <regex>
@@ -422,8 +422,8 @@ namespace OpenMS
     }
 
     static const std::regex non_alnum("[^a-zA-Z0-9]");
-    QFileInfo fileinfo(filename.c_str());
-    String filtered_filename = std::regex_replace(fileinfo.completeBaseName().toStdString(), non_alnum, "");
+    std::filesystem::path fileinfo(filename);
+    String filtered_filename = std::regex_replace(fileinfo.stem().string(), non_alnum, "");
 
 
     String native_id_type_accession;

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -422,7 +422,7 @@ namespace OpenMS
     }
 
     static const std::regex non_alnum("[^a-zA-Z0-9]");
-    std::filesystem::path fileinfo(filename);
+    std::filesystem::path fileinfo(std::string(filename));
     String filtered_filename = std::regex_replace(fileinfo.stem().string(), non_alnum, "");
 
 

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
@@ -1051,7 +1052,7 @@ namespace OpenMS
       //-------------------------------------------------------------
       // MS acquisition
       //------------------------------------------------------------
-      String base_name = std::filesystem::path(std::string(inputfile_raw)).stem().string();
+      String base_name = to_path(inputfile_raw).stem().string();
 
       UInt min_mz = std::numeric_limits<UInt>::max();
       UInt max_mz = 0;

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -18,7 +18,7 @@
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/MATH/StatisticFunctions.h>
 
-#include <QtCore/QFileInfo>
+#include <filesystem>
 
 #include <fstream>
 #include <set>
@@ -1051,7 +1051,7 @@ namespace OpenMS
       //-------------------------------------------------------------
       // MS acquisition
       //------------------------------------------------------------
-      String base_name = QFileInfo(QString::fromStdString(inputfile_raw)).baseName();
+      String base_name = std::filesystem::path(inputfile_raw).stem().string();
 
       UInt min_mz = std::numeric_limits<UInt>::max();
       UInt max_mz = 0;

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -60,17 +60,17 @@ namespace OpenMS
 
   bool QcMLFile::QualityParameter::operator<(const QualityParameter& rhs) const
   {
-    return name.toQString() < rhs.name.toQString();
+    return name < rhs.name;
   }
 
   bool QcMLFile::QualityParameter::operator>(const QualityParameter& rhs) const
   {
-    return name.toQString() > rhs.name.toQString();
+    return name > rhs.name;
   }
 
   bool QcMLFile::QualityParameter::operator==(const QualityParameter& rhs) const
   {
-    return name.toQString() == rhs.name.toQString();
+    return name == rhs.name;
   }
 
   String QcMLFile::QualityParameter::toXMLString(UInt indentation_level) const
@@ -138,17 +138,17 @@ namespace OpenMS
 
   bool QcMLFile::Attachment::operator<(const Attachment& rhs) const
   {
-    return name.toQString() < rhs.name.toQString();
+    return name < rhs.name;
   }
 
   bool QcMLFile::Attachment::operator>(const Attachment& rhs) const
   {
-    return name.toQString() > rhs.name.toQString();
+    return name > rhs.name;
   }
 
   bool QcMLFile::Attachment::operator==(const Attachment& rhs) const
   {
-    return name.toQString() == rhs.name.toQString();
+    return name == rhs.name;
   }
 
   String QcMLFile::Attachment::toCSVString(const String& separator) const

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -1051,7 +1051,7 @@ namespace OpenMS
       //-------------------------------------------------------------
       // MS acquisition
       //------------------------------------------------------------
-      String base_name = std::filesystem::path(inputfile_raw).stem().string();
+      String base_name = std::filesystem::path(std::string(inputfile_raw)).stem().string();
 
       UInt min_mz = std::numeric_limits<UInt>::max();
       UInt max_mz = 0;

--- a/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
+++ b/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
@@ -106,9 +106,9 @@ namespace OpenMS::Math
           OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << plot_path.filename().string() << "'." << std::endl;
           return false;
         }
-        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.string()))
+        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.generic_string()))
         {
-          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.string() << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.generic_string() << "'." << std::endl;
           return false;
         }
         //
@@ -298,9 +298,9 @@ namespace OpenMS::Math
           OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << plot_path.filename().string() << "'." << std::endl;
           return false;
         }
-        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.string()))
+        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.generic_string()))
         {
-          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.string() << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.generic_string() << "'." << std::endl;
           return false;
         }
         //

--- a/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
+++ b/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
@@ -20,7 +20,9 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideHit.h>
 
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 
 #include <algorithm>
 
@@ -96,15 +98,17 @@ namespace OpenMS::Math
       if (output_plots)
       {
         // create output directory (if not already present)
-        QDir dir(String(param_.getValue("out_plot").toString()).toQString());
-        if (!dir.cdUp())
+        namespace fs = std::filesystem;
+        auto plot_path = to_path(String(param_.getValue("out_plot").toString()));
+        auto parent_dir = plot_path.parent_path();
+        if (parent_dir.empty())
         {
-          OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << plot_path.filename().string() << "'." << std::endl;
           return false;
         }
-        if (!dir.exists() && !dir.mkpath("."))
+        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.string()))
         {
-          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.string() << "'." << std::endl;
           return false;
         }
         //
@@ -286,15 +290,17 @@ namespace OpenMS::Math
       if (output_plots)
       {
         // create output directory (if not already present)
-        QDir dir(String(param_.getValue("out_plot").toString()).toQString());
-        if (!dir.cdUp())
+        namespace fs = std::filesystem;
+        auto plot_path = to_path(String(param_.getValue("out_plot").toString()));
+        auto parent_dir = plot_path.parent_path();
+        if (parent_dir.empty())
         {
-          OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << plot_path.filename().string() << "'." << std::endl;
           return false;
         }
-        if (!dir.exists() && !dir.mkpath("."))
+        if (!fs::exists(parent_dir) && !File::makeDir(parent_dir.string()))
         {
-          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << parent_dir.string() << "'." << std::endl;
           return false;
         }
         //

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -39,7 +39,7 @@ namespace OpenMS
   {
     // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
     // i.e., a call to this will report unmatched strings
-    if (std::filesystem::path(file_name).is_relative())
+    if (std::filesystem::path(std::string(file_name)).is_relative())
     {
       file_path_ = File::absolutePath(file_name);
     }

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/METADATA/DocumentIdentifier.h>
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 
 #include <filesystem>
@@ -39,7 +40,7 @@ namespace OpenMS
   {
     // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
     // i.e., a call to this will report unmatched strings
-    if (std::filesystem::path(std::string(file_name)).is_relative())
+    if (to_path(file_name).is_relative())
     {
       file_path_ = File::absolutePath(file_name);
     }

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -11,7 +11,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 
-#include <QtCore/QDir>
+#include <filesystem>
 
 namespace OpenMS
 {
@@ -39,7 +39,7 @@ namespace OpenMS
   {
     // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
     // i.e., a call to this will report unmatched strings
-    if (QDir::isRelativePath(file_name.toQString()))
+    if (std::filesystem::path(file_name).is_relative())
     {
       file_path_ = File::absolutePath(file_name);
     }

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -40,7 +40,14 @@ namespace OpenMS
   {
     // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
     // i.e., a call to this will report unmatched strings
-    if (to_path(file_name).is_relative())
+    // Treat paths starting with '/' as absolute on all platforms (matching Qt behavior).
+    // On Windows, std::filesystem considers "/data/foo" relative (no drive letter),
+    // but Qt treated it as absolute.
+    bool is_relative = to_path(file_name).is_relative();
+#ifdef OPENMS_WINDOWSPLATFORM
+    if (!file_name.empty() && file_name[0] == '/') is_relative = false;
+#endif
+    if (is_relative)
     {
       file_path_ = File::absolutePath(file_name);
     }

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -18,9 +18,6 @@
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
-#include <QtCore/QString>
-#include <QtCore/QFileInfo>
-
 #include <algorithm>
 #include <iostream>
 

--- a/src/openms/source/QC/MQEvidenceExporter.cpp
+++ b/src/openms/source/QC/MQEvidenceExporter.cpp
@@ -15,7 +15,8 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 #include <cmath> // isnan
 #include <fstream>
 #include <vector>
@@ -32,8 +33,7 @@ MQEvidence::MQEvidence(const String& path)
   filename_ = path + "/evidence.txt";
   try
   {
-    QString evi_path = QString::fromStdString(path);
-    QDir().mkpath(evi_path);
+    std::filesystem::create_directories(to_path(path));
     file_ = std::fstream(filename_, std::fstream::out);
   }
   catch (...)

--- a/src/openms/source/QC/MQMsmsExporter.cpp
+++ b/src/openms/source/QC/MQMsmsExporter.cpp
@@ -15,7 +15,8 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 
-#include <QtCore/QDir>
+#include <OpenMS/SYSTEM/PathUtils.h>
+#include <filesystem>
 #include <cmath> // isnan
 #include <fstream>
 //#include <vector>
@@ -32,8 +33,7 @@ MQMsms::MQMsms(const String& path)
   filename_ = path + "/msms.txt";
   try
   {
-    QString msms_path = QString::fromStdString(path);
-    QDir().mkpath(msms_path);
+    std::filesystem::create_directories(to_path(path));
     file_ = std::fstream(filename_, std::fstream::out);
   }
   catch (...)

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -318,6 +318,7 @@ namespace OpenMS
 
   String File::absolutePath(const String& file)
   {
+    if (file.empty()) return fs::current_path().string();
     return fs::absolute(to_path(file)).string();
   }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -287,7 +287,7 @@ namespace OpenMS
   bool File::removeDir(const String& dir_name)
   {
     std::error_code ec;
-    fs::remove(to_path(dir_name), ec); // non-recursive: fails on non-empty directories
+    fs::remove_all(to_path(dir_name), ec); // recursive, matching original Qt behavior
     if (ec)
     {
       std::cerr << "Could not remove directory " << dir_name << ": " << ec.message() << std::endl;
@@ -644,7 +644,7 @@ namespace OpenMS
 #else
       const char* home = getenv("HOME");
 #endif
-      dir = home ? String(home) : String(".");
+      dir = home ? String(home).substitute('\\', '/') : String(".");
     }
     dir.ensureLastChar('/');
     return dir;
@@ -683,7 +683,7 @@ namespace OpenMS
 #else
       const char* home = getenv("HOME");
 #endif
-      home_path = home ? String(home) : String(".");
+      home_path = home ? String(home).substitute('\\', '/') : String(".");
     }
     return home_path;
   }

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -345,10 +345,7 @@ namespace OpenMS
 #ifdef OPENMS_WINDOWSPLATFORM
     return _access_s(file.c_str(), 4) == 0; // 4 = read permission
 #else
-    auto st = fs::status(p, ec);
-    if (ec) return false;
-    auto perms = st.permissions();
-    return (perms & (fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read)) != fs::perms::none;
+    return access(file.c_str(), R_OK) == 0;
 #endif
   }
 
@@ -362,10 +359,7 @@ namespace OpenMS
 #ifdef OPENMS_WINDOWSPLATFORM
       return _access_s(file.c_str(), 2) == 0; // 2 = write permission
 #else
-      auto st = fs::status(p, ec);
-      if (ec) return false;
-      auto perms = st.permissions();
-      return (perms & (fs::perms::owner_write | fs::perms::group_write | fs::perms::others_write)) != fs::perms::none;
+      return access(file.c_str(), W_OK) == 0;
 #endif
     }
     else

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/openms_data_path.h>
 
 #include <OpenMS/CONCEPT/VersionInfo.h>
@@ -18,10 +19,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
-#include <QtCore/QDir>
-#include <QtCore/QFile>
-#include <QtCore/QFileInfo>
-
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <filesystem>
@@ -29,7 +27,11 @@
 
 #ifdef OPENMS_WINDOWSPLATFORM
 #include <Windows.h> // for GetCurrentProcessId() && GetModuleFileName() && GetComputerNameA()
+#include <Shlwapi.h> // for PathMatchSpecA
+#include <io.h>      // for _access_s
+#pragma comment(lib, "Shlwapi.lib")
 #else
+#include <fnmatch.h>
 #include <unistd.h> // for gethostname()
 #endif
 
@@ -41,6 +43,7 @@
 #include <mach-o/dyld.h>
 #endif
 
+namespace fs = std::filesystem;
 
 using namespace std;
 
@@ -52,8 +55,7 @@ namespace OpenMS
   {
     temp_dir_ = File::getTempDirectory() + "/" + File::getUniqueName() + "/";
     OPENMS_LOG_DEBUG << "Creating temporary directory '" << temp_dir_ << "'\n";
-    QDir d;
-    d.mkpath(temp_dir_.toQString());
+    fs::create_directories(to_path(temp_dir_));
   };
 
   File::TempDir::~TempDir()
@@ -120,38 +122,60 @@ namespace OpenMS
 
   bool File::exists(const String& file)
   {
-    QFileInfo fi(file.toQString());
-    return fi.exists();
+    return fs::exists(to_path(file));
   }
 
   bool File::empty(const String& file)
   {
-    QFileInfo fi(file.toQString());
-    return !fi.exists() || fi.size() == 0;
+    std::error_code ec;
+    auto p = to_path(file);
+    if (!fs::exists(p, ec)) return true;
+    auto sz = fs::file_size(p, ec);
+    if (ec) return true; // e.g. if it is a directory
+    return sz == 0;
   }
 
   bool File::executable(const String& file)
   {
-    QFileInfo fi(file.toQString());
-    return fi.exists() && fi.isExecutable();
+    auto p = to_path(file);
+    std::error_code ec;
+    auto st = fs::status(p, ec);
+    if (ec || !fs::exists(st)) return false;
+#ifdef OPENMS_WINDOWSPLATFORM
+    // On Windows, all files are considered executable
+    return true;
+#else
+    auto perms = st.permissions();
+    return (perms & (fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec)) != fs::perms::none;
+#endif
   }
 
   UInt64 File::fileSize(const String& file)
   {
     if (!File::exists(file)) return -1;
 
-    return QFile(file.toQString()).size();
+    std::error_code ec;
+    auto sz = fs::file_size(to_path(file), ec);
+    if (ec) return -1;
+    return sz;
   }
 
   bool File::rename(const String& from, const String& to, bool overwrite_existing, bool verbose)
   {
     // check for equality
-    if (QFileInfo(from.c_str()).canonicalFilePath() == QFileInfo(to.c_str()).canonicalFilePath())
-    { // same file; no need to to anything
-      return true;
+    std::error_code ec;
+    auto canon_from = fs::canonical(to_path(from), ec);
+    if (!ec)
+    {
+      auto canon_to = fs::canonical(to_path(to), ec);
+      if (!ec && canon_from == canon_to)
+      { // same file; no need to do anything
+        return true;
+      }
     }
 
-    // existing file? Qt won't overwrite, so try to remove it:
+    // existing file? std::filesystem::rename overwrites on POSIX but not always on Windows.
+    // To be consistent, handle overwrite explicitly:
     if (overwrite_existing && exists(to) && !remove(to))
     {
       if (verbose)
@@ -161,7 +185,9 @@ namespace OpenMS
       return false;
     }
     // move the file to the actual destination:
-    if (!QFile::rename(from.toQString(), to.toQString()))
+    std::error_code rename_ec;
+    fs::rename(to_path(from), to_path(to), rename_ec);
+    if (rename_ec)
     {
       if (verbose)
       {
@@ -172,59 +198,65 @@ namespace OpenMS
     return true;
   }
 
-  // https://stackoverflow.com/questions/2536524/copy-directory-using-qt
-  bool File::copyDirRecursively(const QString& from_dir, const QString& to_dir, File::CopyOptions option)
+  bool File::copyDirRecursively(const String& from_dir, const String& to_dir, File::CopyOptions option)
   {
-    QDir source_dir(from_dir);
-    QDir target_dir(to_dir);
+    auto source_path = to_path(from_dir);
+    auto target_path = to_path(to_dir);
 
-    QString canonical_source_dir = source_dir.canonicalPath();
-    QString canonical_target_dir = target_dir.canonicalPath();
-
-    // check canonical path
-    if (canonical_source_dir == canonical_target_dir)
+    std::error_code ec;
+    auto canonical_source = fs::canonical(source_path, ec);
+    // if source doesn't exist, canonical will fail
+    if (ec)
     {
-      OPENMS_LOG_ERROR << "Error: Could not copy  " << from_dir.toStdString() << " to " << to_dir.toStdString() << ". Same path given.\n";
+      OPENMS_LOG_ERROR << "Error: Source directory '" << from_dir << "' does not exist.\n";
       return false;
     }
 
-    // make directory if not present
-    if (!target_dir.exists())
+    // If target exists, check canonical to avoid copy onto self
+    if (fs::exists(target_path, ec))
     {
-      target_dir.mkpath(to_dir);
+      auto canonical_target = fs::canonical(target_path, ec);
+      if (!ec && canonical_source == canonical_target)
+      {
+        OPENMS_LOG_ERROR << "Error: Could not copy  " << from_dir << " to " << to_dir << ". Same path given.\n";
+        return false;
+      }
     }
 
+    // make directory if not present
+    fs::create_directories(target_path, ec);
+
     // copy folder recursively
-    QFileInfoList file_list = source_dir.entryInfoList();
-    for (const QFileInfo& entry : file_list)
+    for (const auto& entry : fs::directory_iterator(source_path))
     {
-      if (entry.fileName() == "." || entry.fileName() == "..")
+      auto target_file = target_path / entry.path().filename();
+
+      if (entry.is_directory())
       {
-        continue;
-      }
-      if (entry.isDir())
-      {
-        if (!copyDirRecursively(entry.filePath(), target_dir.filePath(entry.fileName()), option))
+        if (!copyDirRecursively(entry.path().string(), target_file.string(), option))
         {
           return false;
         }
       }
       else
       {
-        if (target_dir.exists(entry.fileName()))
+        if (fs::exists(target_file))
         {
           switch (option)
-            {
-              case CopyOptions::CANCEL:
-                return false;
-              case CopyOptions::SKIP:
-                OPENMS_LOG_WARN << "The file " << entry.fileName().toStdString() << " was skipped.\n";
-                continue;
-              case CopyOptions::OVERWRITE:
-                target_dir.remove(entry.fileName());
-            }
+          {
+            case CopyOptions::CANCEL:
+              return false;
+            case CopyOptions::SKIP:
+              OPENMS_LOG_WARN << "The file " << entry.path().filename().string() << " was skipped.\n";
+              continue;
+            case CopyOptions::OVERWRITE:
+              fs::remove(target_file, ec);
+              break;
+          }
         }
-        if (!QFile::copy(entry.filePath(), target_dir.filePath(entry.fileName())))
+        std::error_code copy_ec;
+        fs::copy_file(entry.path(), target_file, copy_ec);
+        if (copy_ec)
         {
           return false;
         }
@@ -235,7 +267,8 @@ namespace OpenMS
 
   bool File::copy(const String& from, const String& to)
   {
-    return QFile::copy(from.toQString(), to.toQString());
+    std::error_code ec;
+    return fs::copy_file(to_path(from), to_path(to), ec);
   }
 
   bool File::remove(const String& file)
@@ -251,79 +284,41 @@ namespace OpenMS
     return true;
   }
 
-  bool File::removeDir(const QString& dir_name)
+  bool File::removeDir(const String& dir_name)
   {
-    bool result = true;
-    QDir dir(dir_name);
-
-    if (dir.exists(dir_name))
+    std::error_code ec;
+    fs::remove_all(to_path(dir_name), ec);
+    if (ec)
     {
-      Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-        {
-          if (info.isDir())
-          {
-            result = removeDir(info.absoluteFilePath());
-          }
-          else
-          {
-            result = QFile::remove(info.absoluteFilePath());
-          }
-          if (!result)
-          {
-            return result;
-          }
-        }
-      result = dir.rmdir(dir_name);
+      std::cerr << "Could not remove directory " << dir_name << ": " << ec.message() << std::endl;
+      return false;
     }
-    return result;
+    return true;
   }
 
   bool File::makeDir(const String& dir_name)
   {
-    QDir dir;
-    return dir.mkpath(dir_name.toQString());
+    std::error_code ec;
+    fs::create_directories(to_path(dir_name), ec);
+    // create_directories returns false if the directory already existed, but that is not an error for us
+    return !ec;
   }
 
   bool File::removeDirRecursively(const String& dir_name)
   {
-    bool fail = false;
-    QString path = dir_name.toQString();
-    QDir dir(path);
-    QStringList files = dir.entryList(QDir::Files | QDir::NoDotAndDotDot);
-    foreach(const QString &file_name, files)
+    std::error_code ec;
+    fs::remove_all(to_path(dir_name), ec);
+    if (ec)
     {
-      if (!dir.remove(file_name))
-      {
-        OPENMS_LOG_WARN << "Could not remove file " << String(file_name) << "!\n";
-        fail = true;
-      }
+      std::cerr << "Could not remove directory " << dir_name << ": " << ec.message() << std::endl;
+      return false;
     }
-    QStringList contained_dirs = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
-    foreach(const QString &contained_dir, contained_dirs)
-    {
-      if (!removeDirRecursively(path + QDir::separator() + contained_dir))
-      {
-        fail = true;
-      }
-    }
-
-    QDir parent_dir(path);
-    if (parent_dir.cdUp())
-    {
-      if (!parent_dir.rmdir(path))
-      {
-        std::cerr << "Could not remove directory " << String(dir.dirName()) << "!" << std::endl;
-        fail = true;
-      }
-    }
-
-    return !fail;
+    return true;
   }
 
   String File::absolutePath(const String& file)
   {
-    QFileInfo fi(file.toQString());
-    return fi.absoluteFilePath();
+    return fs::absolute(to_path(file)).string();
   }
 
   String File::basename(const String& file)
@@ -343,29 +338,47 @@ namespace OpenMS
 
   bool File::readable(const String& file)
   {
-    QFileInfo fi(file.toQString());
-    return fi.exists() && fi.isReadable();
+    auto p = to_path(file);
+    std::error_code ec;
+    if (!fs::exists(p, ec)) return false;
+#ifdef OPENMS_WINDOWSPLATFORM
+    return _access_s(file.c_str(), 4) == 0; // 4 = read permission
+#else
+    auto st = fs::status(p, ec);
+    if (ec) return false;
+    auto perms = st.permissions();
+    return (perms & (fs::perms::owner_read | fs::perms::group_read | fs::perms::others_read)) != fs::perms::none;
+#endif
   }
 
   bool File::writable(const String& file)
   {
-    QFileInfo fi(file.toQString());
+    auto p = to_path(file);
+    std::error_code ec;
 
-    bool tmp = false;
-    if (fi.exists())
+    if (fs::exists(p, ec))
     {
-      tmp = fi.isWritable();
+#ifdef OPENMS_WINDOWSPLATFORM
+      return _access_s(file.c_str(), 2) == 0; // 2 = write permission
+#else
+      auto st = fs::status(p, ec);
+      if (ec) return false;
+      auto perms = st.permissions();
+      return (perms & (fs::perms::owner_write | fs::perms::group_write | fs::perms::others_write)) != fs::perms::none;
+#endif
     }
     else
     {
-      QFile f;
-      f.setFileName(file.toQString());
-      f.open(QIODevice::WriteOnly);
-      tmp = f.isWritable();
-      f.remove();
+      // File does not exist: probe by trying to create it
+      std::ofstream f(file.c_str());
+      bool ok = f.is_open() && f.good();
+      f.close();
+      if (ok)
+      {
+        std::remove(file.c_str());
+      }
+      return ok;
     }
-
-    return tmp;
   }
 
   String File::find(const String& filename, StringList directories)
@@ -409,7 +422,7 @@ namespace OpenMS
 
       if (exists(loc))
       {
-        return String(QDir::cleanPath(loc.toQString()));
+        return to_path(loc).lexically_normal().string();
       }
     }
 
@@ -419,27 +432,24 @@ namespace OpenMS
 
   bool File::fileList(const String& dir, const String& file_pattern, StringList& output, bool full_path)
   {
-    QDir d(dir.toQString(), file_pattern.toQString(), QDir::Name, QDir::Files);
-    QFileInfoList list = d.entryInfoList();
-
-    //clear and check if empty
     output.clear();
-    if (list.empty())
+    auto dir_path = to_path(dir);
+    std::error_code ec;
+    if (!fs::is_directory(dir_path, ec)) return false;
+
+    for (const auto& entry : fs::directory_iterator(dir_path, ec))
     {
-      return false;
+      if (!entry.is_regular_file()) continue;
+      String fname = entry.path().filename().string();
+#ifdef OPENMS_WINDOWSPLATFORM
+      if (!PathMatchSpecA(fname.c_str(), file_pattern.c_str())) continue;
+#else
+      if (fnmatch(file_pattern.c_str(), fname.c_str(), 0) != 0) continue;
+#endif
+      output.push_back(full_path ? entry.path().string() : fname);
     }
-
-    //resize output
-    output.resize(list.size());
-
-    //fill output
-    UInt i = 0;
-    for (QFileInfoList::const_iterator it = list.constBegin(); it != list.constEnd(); ++it)
-    {
-      output[i++] = full_path ? it->filePath() : it->fileName();
-    }
-
-    return true;
+    std::sort(output.begin(), output.end());
+    return !output.empty();
   }
 
   String File::findDoc(const String& filename)
@@ -592,8 +602,7 @@ namespace OpenMS
 
   bool File::isDirectory(const String& path)
   {
-    QFileInfo fi(path.toQString());
-    return fi.isDir();
+    return fs::is_directory(to_path(path));
   }
 
   String File::getTempDirectory()
@@ -610,7 +619,7 @@ namespace OpenMS
     }
     else
     {
-      dir = String(QDir::tempPath());
+      dir = fs::temp_directory_path().string();
     }
     return dir;
   }
@@ -630,7 +639,12 @@ namespace OpenMS
     }
     else
     {
-      dir = String(QDir::homePath());
+#ifdef OPENMS_WINDOWSPLATFORM
+      const char* home = getenv("USERPROFILE");
+#else
+      const char* home = getenv("HOME");
+#endif
+      dir = home ? String(home) : String(".");
     }
     dir.ensureLastChar('/');
     return dir;
@@ -664,7 +678,12 @@ namespace OpenMS
     }
     else
     {
-      home_path = String(QDir::homePath());
+#ifdef OPENMS_WINDOWSPLATFORM
+      const char* home = getenv("USERPROFILE");
+#else
+      const char* home = getenv("HOME");
+#endif
+      home_path = home ? String(home) : String(".");
     }
     return home_path;
   }
@@ -862,9 +881,9 @@ namespace OpenMS
     }
   }
 
-  File::MatchingFileListsStatus File::validateMatchingFileNames(const StringList& sl1, 
-                                                        const StringList& sl2, 
-                                                        bool basename, 
+  File::MatchingFileListsStatus File::validateMatchingFileNames(const StringList& sl1,
+                                                        const StringList& sl2,
+                                                        bool basename,
                                                         bool ignore_extension)
   {
       // Different counts means different sets
@@ -909,8 +928,8 @@ namespace OpenMS
       // Check if it's an order mismatch or complete mismatch
       if (same_set)
       {
-          return different_name_at_index ? 
-                MatchingFileListsStatus::ORDER_MISMATCH : 
+          return different_name_at_index ?
+                MatchingFileListsStatus::ORDER_MISMATCH :
                 MatchingFileListsStatus::MATCH;
       }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -287,7 +287,7 @@ namespace OpenMS
   bool File::removeDir(const String& dir_name)
   {
     std::error_code ec;
-    fs::remove_all(to_path(dir_name), ec);
+    fs::remove(to_path(dir_name), ec); // non-recursive: fails on non-empty directories
     if (ec)
     {
       std::cerr << "Could not remove directory " << dir_name << ": " << ec.message() << std::endl;

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -319,6 +319,11 @@ namespace OpenMS
   String File::absolutePath(const String& file)
   {
     if (file.empty()) return fs::current_path().generic_string();
+#ifdef OPENMS_WINDOWSPLATFORM
+    // On Windows, paths starting with '/' are treated as absolute by Qt
+    // but fs::absolute() prepends the current drive letter. Preserve Qt behavior.
+    if (file[0] == '/') return file;
+#endif
     return fs::absolute(to_path(file)).generic_string();
   }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -233,7 +233,7 @@ namespace OpenMS
 
       if (entry.is_directory())
       {
-        if (!copyDirRecursively(entry.path().string(), target_file.string(), option))
+        if (!copyDirRecursively(entry.path().generic_string(), target_file.generic_string(), option))
         {
           return false;
         }
@@ -318,8 +318,8 @@ namespace OpenMS
 
   String File::absolutePath(const String& file)
   {
-    if (file.empty()) return fs::current_path().string();
-    return fs::absolute(to_path(file)).string();
+    if (file.empty()) return fs::current_path().generic_string();
+    return fs::absolute(to_path(file)).generic_string();
   }
 
   String File::basename(const String& file)
@@ -417,7 +417,7 @@ namespace OpenMS
 
       if (exists(loc))
       {
-        return to_path(loc).lexically_normal().string();
+        return to_path(loc).lexically_normal().generic_string();
       }
     }
 
@@ -441,7 +441,7 @@ namespace OpenMS
 #else
       if (fnmatch(file_pattern.c_str(), fname.c_str(), 0) != 0) continue;
 #endif
-      output.push_back(full_path ? entry.path().string() : fname);
+      output.push_back(full_path ? entry.path().generic_string() : fname);
     }
     std::sort(output.begin(), output.end());
     return !output.empty();
@@ -614,7 +614,7 @@ namespace OpenMS
     }
     else
     {
-      dir = fs::temp_directory_path().string();
+      dir = fs::temp_directory_path().generic_string();
     }
     return dir;
   }

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -37,7 +37,7 @@ namespace OpenMS
           OPENMS_LOG_ERROR
             << "  Java not found at '" << java_executable << "'!\n"
             << "  Make sure Java is installed and this location is correct.\n";
-          if (std::filesystem::path(java_executable).is_relative())
+          if (std::filesystem::path(std::string(java_executable)).is_relative())
           {
             static String path;
             if (path.empty())

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 
 #include <QtCore/QProcess>
 
@@ -37,7 +38,7 @@ namespace OpenMS
           OPENMS_LOG_ERROR
             << "  Java not found at '" << java_executable << "'!\n"
             << "  Make sure Java is installed and this location is correct.\n";
-          if (std::filesystem::path(std::string(java_executable)).is_relative())
+          if (to_path(java_executable).is_relative())
           {
             static String path;
             if (path.empty())

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -12,7 +12,8 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <QtCore/QProcess>
-#include <QtCore/QDir>
+
+#include <filesystem>
 
 namespace OpenMS
 {
@@ -36,7 +37,7 @@ namespace OpenMS
           OPENMS_LOG_ERROR
             << "  Java not found at '" << java_executable << "'!\n"
             << "  Make sure Java is installed and this location is correct.\n";
-          if (QDir::isRelativePath(java_executable.toQString()))
+          if (std::filesystem::path(java_executable).is_relative())
           {
             static String path;
             if (path.empty())

--- a/src/openms/source/SYSTEM/PythonInfo.cpp
+++ b/src/openms/source/SYSTEM/PythonInfo.cpp
@@ -12,7 +12,8 @@
 #include <OpenMS/SYSTEM/File.h>
 
 #include <QtCore/QProcess>
-#include <QtCore/QDir>
+
+#include <filesystem>
 
 #include <sstream>
 
@@ -28,7 +29,7 @@ namespace OpenMS
     {
       ss << "  Python not found at '" << python_executable << "'!\n"
          << "  Make sure Python is installed and this location is correct.\n";
-      if (QDir::isRelativePath(python_executable.toQString()))
+      if (std::filesystem::path(python_executable).is_relative())
       {
         static String path;
         if (path.empty())

--- a/src/openms/source/SYSTEM/PythonInfo.cpp
+++ b/src/openms/source/SYSTEM/PythonInfo.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 
 #include <QtCore/QProcess>
 
@@ -29,7 +30,7 @@ namespace OpenMS
     {
       ss << "  Python not found at '" << python_executable << "'!\n"
          << "  Make sure Python is installed and this location is correct.\n";
-      if (std::filesystem::path(std::string(python_executable)).is_relative())
+      if (to_path(python_executable).is_relative())
       {
         static String path;
         if (path.empty())

--- a/src/openms/source/SYSTEM/PythonInfo.cpp
+++ b/src/openms/source/SYSTEM/PythonInfo.cpp
@@ -29,7 +29,7 @@ namespace OpenMS
     {
       ss << "  Python not found at '" << python_executable << "'!\n"
          << "  Make sure Python is installed and this location is correct.\n";
-      if (std::filesystem::path(python_executable).is_relative())
+      if (std::filesystem::path(std::string(python_executable)).is_relative())
       {
         static String path;
         if (path.empty())

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -8,6 +8,8 @@
 
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/SYSTEM/BuildInfo.h>
+#include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #ifdef OPENMS_WINDOWSPLATFORM
@@ -19,22 +21,21 @@
 #endif
 
 #include <sys/stat.h>
+#include <filesystem>
+#include <fstream>
 
 #include <OpenMS/SYSTEM/NetworkGetRequest.h>
-#include <QtCore/QDir>
-#include <QtCore/QDateTime>
-#include <QtCore/QFileInfo>
-#include <QtCore/QSysInfo>
 
 #include <OpenMS/CONCEPT/VersionInfo.h>
 
 using namespace std;
+namespace fs = std::filesystem;
 
 namespace OpenMS
 {
   void UpdateCheck::run(const String& tool_name, const String& version, int debug_level)
   {
-    String architecture = QSysInfo::WordSize == 32 ? "32" : "64";
+    String architecture = (sizeof(void*) == 4) ? "32" : "64";
 
     // if the revision info is meaningful, show it as well
     String revision("UNKNOWN");
@@ -83,28 +84,23 @@ namespace OpenMS
     if (!File::exists(version_file_name) || !File::readable(version_file_name))
     {
       // create OpenMS folder for .ver files
-      QDir dir(config_path.toQString());
-
-      if (!dir.exists())
-      {
-        dir.mkpath(".");
-      }
+      fs::create_directories(to_path(config_path));
 
       // touch file to create it and set initial modification time stamp
-      QFile f;
-      f.setFileName(version_file_name.toQString());
-      f.open(QIODevice::WriteOnly);
+      std::ofstream f(version_file_name.c_str());
       f.close();
       first_run = true;
     }
 
     if (File::readable(version_file_name))
     {
-      QDateTime last_modified_dt = QFileInfo(version_file_name.toQString()).lastModified();
-      QDateTime current_dt = QDateTime::currentDateTime();
+      // Get last modification time using std::filesystem
+      std::error_code ec;
+      auto last_modified_time = fs::last_write_time(to_path(version_file_name), ec);
+      auto current_time = fs::file_time_type::clock::now();
 
       // check if at least one day passed since last request
-      if (first_run || current_dt > last_modified_dt.addDays(1))
+      if (first_run || current_time > last_modified_time + std::chrono::hours(24))
       {
         // update modification time stamp
         struct stat old_stat;

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -8,7 +8,6 @@
 
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/SYSTEM/BuildInfo.h>
 #include <OpenMS/SYSTEM/PathUtils.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -17,7 +17,6 @@
 #include <OpenMS/CONCEPT/VersionInfo.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <QDir>
 
 #include <fstream>
 #include <filesystem>
@@ -156,14 +155,14 @@ END_SECTION
 
 // make source directory and copy it to new location
 // check copy function and if file exists in target path
-START_SECTION(static bool copyDirRecursively(const QString &fromDir, const QString &toDir,File::CopyOptions option = CopyOptions::OVERWRITE))
+START_SECTION(static bool copyDirRecursively(const String &fromDir, const String &toDir, File::CopyOptions option = CopyOptions::OVERWRITE))
   // folder OpenMS/src/tests/class_tests/openms/data/XMassFile_test 
   String source_name = OPENMS_GET_TEST_DATA_PATH("XMassFile_test");
   String target_name = File::getTempDirectory() + "/" + File::getUniqueName() + "/"; 
   // test canonical path
-  TEST_EQUAL(File::copyDirRecursively(source_name.toQString(),source_name.toQString()),false)
+  TEST_EQUAL(File::copyDirRecursively(source_name,source_name),false)
   // test default
-  TEST_EQUAL(File::copyDirRecursively(source_name.toQString(),target_name.toQString()),true)
+  TEST_EQUAL(File::copyDirRecursively(source_name,target_name),true)
   TEST_EQUAL(File::exists(target_name + "/pdata/1/proc"),true);
   // overwrite file content 
   std::ofstream ow_ofs;
@@ -178,29 +177,28 @@ START_SECTION(static bool copyDirRecursively(const QString &fromDir, const QStri
   infile.close();
   TEST_EQUAL(file_size,50)
   // test option skip
-  TEST_EQUAL(File::copyDirRecursively(source_name.toQString(),target_name.toQString(), File::CopyOptions::SKIP),true)
+  TEST_EQUAL(File::copyDirRecursively(source_name,target_name, File::CopyOptions::SKIP),true)
   infile.open(target_name + "/pdata/1/proc"); 
   infile.seekg(0,infile.end);
   file_size = infile.tellg();
   infile.close();
   TEST_EQUAL(file_size,50)
   // test option overwrite
-  TEST_EQUAL(File::copyDirRecursively(source_name.toQString(),target_name.toQString(), File::CopyOptions::OVERWRITE),true)
+  TEST_EQUAL(File::copyDirRecursively(source_name,target_name, File::CopyOptions::OVERWRITE),true)
   infile.open(target_name + "/pdata/1/proc"); 
   infile.seekg(0,infile.end);
   file_size = infile.tellg();
   infile.close();
   TEST_EQUAL(file_size,3558)
   // test option cancel 
-  TEST_EQUAL(File::copyDirRecursively(source_name.toQString(),target_name.toQString(), File::CopyOptions::CANCEL),false)
+  TEST_EQUAL(File::copyDirRecursively(source_name,target_name, File::CopyOptions::CANCEL),false)
   // remove temporary directory after testing
   File::removeDirRecursively(target_name);
 END_SECTION
 
 START_SECTION(static bool removeDirRecursively(const String &dir_name))
-  QDir d;
   String dirname = File::getTempDirectory() + "/" + File::getUniqueName() + "/" + File::getUniqueName() + "/";
-  TEST_TRUE(d.mkpath(dirname.toQString()));
+  TEST_TRUE(File::makeDir(dirname));
   TextFile tf;
   tf.store(dirname + "test.txt");
   TEST_EQUAL(File::removeDirRecursively(dirname), true)
@@ -236,9 +234,8 @@ START_SECTION(static String getUserDirectory())
 
   // set user directory to a path set by environmental variable and test that
   // it is correctly set (no changes on the file system occur)
-  QDir d;
   String dirname = File::getTempDirectory() + "/" + File::getUniqueName() + "/";
-  TEST_EQUAL(d.mkpath(dirname.toQString()), true);
+  TEST_EQUAL(File::makeDir(dirname), true);
 #ifdef OPENMS_WINDOWSPLATFORM
   _putenv_s("OPENMS_HOME_PATH", dirname.c_str());  
 #else
@@ -325,14 +322,14 @@ START_SECTION(File::~TempDir())
     TEST_EQUAL(File::exists(path), 1)
   }
   TEST_EQUAL(File::exists(path), 0)
-  if (File::exists(path)) File::removeDir(path.toQString());
+  if (File::exists(path)) File::removeDir(path);
   {
     File::TempDir dir2(true);
     path = dir2.getPath();
     TEST_EQUAL(File::exists(path), 1)
   }
   TEST_EQUAL(File::exists(path), 1)
-  if (File::exists(path)) File::removeDir(path.toQString());
+  if (File::exists(path)) File::removeDir(path);
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary
- Introduces PathUtils.h with `to_path()` for UTF-8 safe path construction on all platforms
- File.cpp completely rewritten to use std::filesystem
- ~20 secondary files updated (QDir/QFileInfo includes removed)
- `fileList()` explicitly sorts results (directory_iterator is unordered, unlike QDir)
- Uses `lexically_normal()` for cleanPath (lexical only, matching Qt behavior)
- Windows: uses `_access_s()` for ACL-aware permission checks
- UpdateCheck.cpp fully migrated (QDir + QDateTime + QSysInfo)
- Part 3/7 of removing Qt6::Core from libOpenMS core library

## Test plan
- [x] File_test passes
- [x] 16 related tests pass (ToolHandler, ClassTest, FuzzyStringComparator, etc.)
- [x] Full suite: 2488/2498 (10 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced Qt-based file and path handling with C++17 std::filesystem and project path utilities for more consistent, native cross-platform behavior.
* **New Features**
  * Added a safe UTF-8 → filesystem path helper for reliable path construction across platforms.
* **Chores**
  * Updated several public file/dir APIs to use the project string type instead of Qt-specific strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->