### PR TITLE
fix: segfault in FeatureLinkerUnlabeledKD with charge_merging=Any

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
@@ -129,6 +129,12 @@ namespace OpenMS
     distance_params.setValue("distance_RT:max_difference", rt_tol_secs_);
     distance_params.setValue("distance_MZ:max_difference", mz_tol_);
     distance_params.setValue("distance_MZ:unit", (mz_ppm_ ? "ppm" : "Da"));
+    // charge_merging="Any" allows all charge states into the candidate pool,
+    // so FeatureDistance must not reject charge-mismatched pairs (segfault: #8927)
+    if (param_.getValue("link:charge_merging").toString() == "Any")
+    {
+      distance_params.setValue("ignore_charge", "true");
+    }
     feature_distance_ = FeatureDistance(max_intensity, false);
     feature_distance_.setParameters(distance_params);
 

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2260,6 +2260,10 @@ set_tests_properties("TOPP_FeatureLinkerUnlabeledKD_6_out1" PROPERTIES DEPENDS "
 add_test("TOPP_FeatureLinkerUnlabeledKD_7" ${TOPP_BIN_PATH}/FeatureLinkerUnlabeledKD -test -ini ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_4_parameters.ini -in ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_dc_input1.featureXML ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_dc_input2.featureXML ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_dc_input3.featureXML ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_dc_input1.featureXML ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_dc_input2.featureXML -out ${TESTS_TEMP_DIR}/FeatureLinkerUnlabeledKD_7_output.tmp.consensusXML -algorithm:link:charge_merging Any -algorithm:link:adduct_merging Identical)
  add_test("TOPP_FeatureLinkerUnlabeledKD_7_out1" ${DIFF} -whitelist "id=" "href=" -in1 ${TESTS_TEMP_DIR}/FeatureLinkerUnlabeledKD_7_output.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_7_output.consensusXML )
 set_tests_properties("TOPP_FeatureLinkerUnlabeledKD_7_out1" PROPERTIES DEPENDS "TOPP_FeatureLinkerUnlabeledKD_7")
+# regression test for #8927: charge_merging=Any with different non-zero charges must not segfault
+add_test("TOPP_FeatureLinkerUnlabeledKD_8" ${TOPP_BIN_PATH}/FeatureLinkerUnlabeledKD -test -in ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_charge_any_input1.featureXML ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_charge_any_input2.featureXML -out ${TESTS_TEMP_DIR}/FeatureLinkerUnlabeledKD_8_output.tmp.consensusXML -algorithm:link:charge_merging Any)
+add_test("TOPP_FeatureLinkerUnlabeledKD_8_out1" ${DIFF} -whitelist "id=" "href=" -in1 ${TESTS_TEMP_DIR}/FeatureLinkerUnlabeledKD_8_output.tmp.consensusXML -in2 ${DATA_DIR_TOPP}/FeatureLinkerUnlabeledKD_8_output.consensusXML )
+set_tests_properties("TOPP_FeatureLinkerUnlabeledKD_8_out1" PROPERTIES DEPENDS "TOPP_FeatureLinkerUnlabeledKD_8")
 
 
 

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_8_output.consensusXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_8_output.consensusXML
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/ConsensusXML.xsl" ?>
+<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="FeatureLinkerUnlabeledKD" version="version_string" />
+		<processingAction name="Feature grouping" />
+		<UserParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<mapList count="2">
+		<map id="0" name="UNKNOWN" unique_id="1" label="" size="2">
+		</map>
+		<map id="1" name="UNKNOWN" unique_id="2" label="" size="2">
+		</map>
+	</mapList>
+	<consensusElementList>
+		<consensusElement id="e_4835329514588776807" quality="0.875" charge="2">
+			<centroid rt="100.25" mz="500.000499999999988" it="1050.0"/>
+			<groupedElementList>
+				<element map="0" id="1" rt="100.0" mz="500.0" it="1000.0" charge="2"/>
+				<element map="1" id="3" rt="100.5" mz="500.000999999999976" it="1100.0" charge="3"/>
+			</groupedElementList>
+		</consensusElement>
+		<consensusElement id="e_17749660155506638460" quality="0.775" charge="2">
+			<centroid rt="200.25" mz="600.000499999999988" it="2050.0"/>
+			<groupedElementList>
+				<element map="0" id="2" rt="200.0" mz="600.0" it="2000.0" charge="2"/>
+				<element map="1" id="4" rt="200.5" mz="600.000999999999976" it="2100.0" charge="3"/>
+			</groupedElementList>
+		</consensusElement>
+	</consensusElementList>
+</consensusXML>

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_charge_any_input1.featureXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_charge_any_input1.featureXML
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<featureList count="2">
+		<feature id="f_1">
+			<position dim="0">100.0</position>
+			<position dim="1">500.0</position>
+			<intensity>1000.0</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>0.9</overallquality>
+			<charge>2</charge>
+		</feature>
+		<feature id="f_2">
+			<position dim="0">200.0</position>
+			<position dim="1">600.0</position>
+			<intensity>2000.0</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>0.8</overallquality>
+			<charge>2</charge>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_charge_any_input2.featureXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_charge_any_input2.featureXML
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_2" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<featureList count="2">
+		<feature id="f_3">
+			<position dim="0">100.5</position>
+			<position dim="1">500.001</position>
+			<intensity>1100.0</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>0.85</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_4">
+			<position dim="0">200.5</position>
+			<position dim="1">600.001</position>
+			<intensity>2100.0</intensity>
+			<quality dim="0">0.0</quality>
+			<quality dim="1">0.0</quality>
+			<overallquality>0.75</overallquality>
+			<charge>3</charge>
+		</feature>
+	</featureList>
+</featureMap>


### PR DESCRIPTION
## Summary

- Fixes segfault when using `-algorithm:link:charge_merging Any` in FeatureLinkerUnlabeledKD
- Root cause: `FeatureDistance` functor rejected charge-mismatched pairs that the KD candidate filter intentionally allowed, leaving `best_index` at `SIZE_MAX` → out-of-bounds vector access

## Root Cause

The KD algorithm has two stages: a **candidate filter** (lines 369-387) that decides which features enter the pool, and a **distance functor** (`FeatureDistance`) that ranks them. When `charge_merging="Any"`, the candidate filter allows all charge states through. But `FeatureDistance` had `ignore_charge=false` (hardcoded default — the param was removed from the KD algorithm's parameter set at construction). This caused it to return `infinity` for non-zero charge mismatches (e.g., charge 2 vs charge 3).

If all candidates from a given map had a different non-zero charge than the center feature, every distance was `infinity`, `best_index` stayed at `numeric_limits<Size>::max()`, and `kd_data.feature(SIZE_MAX)` segfaulted.

## Fix

Set `ignore_charge=true` on `FeatureDistance` when `charge_merging="Any"`. This is correct because the KD filter already handles charge filtering — `FeatureDistance` should only compute distances for the candidates that passed.

`With_charge_zero` is **not affected** because `FeatureDistance`'s default charge logic (allow pairing when one side is charge 0) exactly matches what the KD filter allows through.

## Test plan

- [x] All 18 existing FeatureLinkerUnlabeledKD tests pass (including tests 6+7 which use `charge_merging=Any`)
- [x] Reference output for `charge_merging=Any` tests is identical (no behavior change for existing test data)
- [ ] CI passes

Closes #8927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash during feature grouping when the "Any" charge-merging option is used, ensuring charge-mismatched pairs are handled safely.
* **Tests**
  * Added a regression test and associated input/output fixtures to validate grouping behavior with "Any" charge merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->