### PR TITLE
cleanup: trim transitive includes from KERNEL and METADATA headers

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/ConsensusMap.h
+++ b/src/openms/include/OpenMS/KERNEL/ConsensusMap.h
@@ -16,12 +16,10 @@
 #include <OpenMS/METADATA/DocumentIdentifier.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
-#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ID/IdentificationData.h>
 
 #include <OpenMS/CONCEPT/Types.h>
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/ExposedVector.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/DATASTRUCTURES/Utils/MapUtilities.h>

--- a/src/openms/include/OpenMS/KERNEL/FeatureMap.h
+++ b/src/openms/include/OpenMS/KERNEL/FeatureMap.h
@@ -10,14 +10,13 @@
 
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/RangeManager.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
 
+#include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/DocumentIdentifier.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
-#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ID/IdentificationData.h>
-#include <OpenMS/METADATA/ID/Observation.h>
 
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/UniqueIdInterface.h>
@@ -28,13 +27,10 @@
 #include <OpenMS/KERNEL/BaseFeature.h>
 #include <OpenMS/OpenMSConfig.h>
 
-#include <exception>
-
 namespace OpenMS
 {
-  class ProteinIdentification;
+  class MSExperiment;
   class PeptideIdentification;
-  class DataProcessing;
 
   /// summary of the peptide identification assigned to each feature of this map.
   /// Each feature contributes one vote (=state)

--- a/src/openms/include/OpenMS/METADATA/AnnotatedMSRun.h
+++ b/src/openms/include/OpenMS/METADATA/AnnotatedMSRun.h
@@ -12,6 +12,7 @@
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/CONCEPT/HashUtils.h>
 #include <boost/range/combine.hpp>
 

--- a/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
@@ -15,7 +15,7 @@
 #include <OpenMS/METADATA/ContactPerson.h>
 #include <OpenMS/METADATA/Instrument.h>
 #include <OpenMS/METADATA/DocumentIdentifier.h>
-#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <vector>
 

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/METADATA/ProteinHit.h>
 #include <OpenMS/METADATA/IdentifierMSRunMapper.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
@@ -16,7 +15,6 @@
 #include <OpenMS/CHEMISTRY/DigestionEnzymeProtein.h>
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/METADATA/DataArrays.h>
-#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/HashUtils.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/CONCEPT/Exception.h>
@@ -29,6 +27,7 @@ namespace OpenMS
 {
   class MSExperiment;
   class PeptideIdentification;
+  class PeptideIdentificationList;
   class PeptideEvidence;
   class ConsensusMap;
 

--- a/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
@@ -14,7 +14,6 @@
 #include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/METADATA/Product.h>
-#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/ANALYSIS/ID/AScore.h>
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
+#include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/DATASTRUCTURES/MatchedIterator.h>
 #include <OpenMS/KERNEL/RangeUtils.h>
 #include <OpenMS/MATH/MathFunctions.h>

--- a/src/openms/source/ANALYSIS/ID/IDScoreGetterSetter.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDScoreGetterSetter.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/ANALYSIS/ID/IDScoreGetterSetter.h>
 
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/StringView.h>
 
 using namespace std;

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/MATH/StatisticFunctions.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -14,6 +14,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/InspectOutfile.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <fstream>
 #include <regex>

--- a/src/openms/source/FORMAT/OMSFileLoad.cpp
+++ b/src/openms/source/FORMAT/OMSFileLoad.cpp
@@ -10,6 +10,7 @@
 #include <OpenMS/FORMAT/OMSFileStore.h> // for "raiseDBError_"
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/RNaseDB.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
 
 #include <QtCore/QString>

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/config.h>
 
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/METADATA/DataProcessing.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>

--- a/src/openms/source/KERNEL/MassTrace.cpp
+++ b/src/openms/source/KERNEL/MassTrace.cpp
@@ -10,6 +10,8 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include <numeric>
+
 namespace OpenMS
 {
     // must match MassTrace::MT_QUANTMETHOD enum!

--- a/src/openms_gui/include/OpenMS/VISUAL/MetaDataBrowser.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/MetaDataBrowser.h
@@ -12,6 +12,7 @@
 #include <OpenMS/VISUAL/OpenMS_GUIConfig.h>
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 

--- a/src/openms_gui/source/VISUAL/Painter1DBase.cpp
+++ b/src/openms_gui/source/VISUAL/Painter1DBase.cpp
@@ -11,6 +11,8 @@
 #include <OpenMS/VISUAL/LayerData1DPeak.h>
 #include <OpenMS/VISUAL/Painter1DBase.h>
 
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DDistanceItem.h>
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -9,6 +9,7 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/METADATA/PeptideHit.h>
 
 
 ///////////////////////////

--- a/src/tests/class_tests/openms/source/ExperimentalSettings_test.cpp
+++ b/src/tests/class_tests/openms/source/ExperimentalSettings_test.cpp
@@ -11,6 +11,7 @@
 
 ///////////////////////////
 #include <OpenMS/METADATA/ExperimentalSettings.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 ///////////////////////////
 
 using namespace OpenMS;

--- a/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentMassError_test.cpp
@@ -12,6 +12,7 @@
 ///////////////////////////
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/FragmentMassError.h>
 //////////////////////////

--- a/src/tests/class_tests/openms/source/InspectOutfile_test.cpp
+++ b/src/tests/class_tests/openms/source/InspectOutfile_test.cpp
@@ -11,6 +11,7 @@
 
 #include <OpenMS/FORMAT/InspectOutfile.h>
 #include <OpenMS/FORMAT/TextFile.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
+++ b/src/tests/class_tests/openms/source/PSMExplainedIonCurrent_test.cpp
@@ -12,6 +12,7 @@
 ///////////////////////////
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/PSMExplainedIonCurrent.h>
 #include <cmath>


### PR DESCRIPTION
## Summary
- Remove dead `#include` directives from 5 core headers (`ExperimentalSettings.h`, `SpectrumSettings.h`, `FeatureMap.h`, `ConsensusMap.h`, `ProteinIdentification.h`) and replace full includes with forward declarations where only references/pointers are used
- Breaks deep transitive include chains rooted in `MSExperiment.h` (~81 includers), notably removing the entire `ProteinIdentification.h` chain (25K + 15 transitive includes) from every `MSExperiment` consumer
- Adds direct includes to 15 downstream `.cpp`/test files that previously relied on transitive includes

## Test plan
- [x] Full build (`cmake --build` with `-j$(nproc)`) succeeds — all libraries, TOPP tools, and tests compile
- [x] Full test suite passes (2463/2465 — 2 pre-existing failures unrelated to this PR: `LPWrapper_test` missing COIN lib, `MRMFeatureSelector_test` vector bounds assert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal header dependencies across multiple core modules to reduce compile-time coupling while maintaining existing functionality and public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->