### PR TITLE
cleanup: clang-tidy performance, emplace, and bugprone fixes

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -681,13 +681,13 @@ namespace OpenMS
       if (!dirty)
       {
         scores_clean_edge.push_back(String(feature_relation[i].getEdgeScore()));
-        scores_clean_edge_idx.push_back(String(i));
+        scores_clean_edge_idx.emplace_back(i);
         ef_clean_edge += ef;
       }
       else
       {
         scores_dirty_edge.push_back(String(feature_relation[i].getEdgeScore()));
-        scores_dirty_edge_idx.push_back(String(i));
+        scores_dirty_edge_idx.emplace_back(i);
         ef_dirty_edge += ef;
       }
 
@@ -873,11 +873,11 @@ namespace OpenMS
           }
         }
 
-        scores_e_active_idx.push_back(String(i));
+        scores_e_active_idx.emplace_back(i);
       }
       else // inactive edges
       {
-        scores_e_inactive_idx.push_back(String(i));
+        scores_e_inactive_idx.emplace_back(i);
 
         // DEBUG
 #ifdef DC_DEVEL

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -800,13 +800,13 @@ namespace OpenMS
       if (!dirty)
       {
         scores_clean_edge.push_back(String(feature_relation[i].getEdgeScore()));
-        scores_clean_edge_idx.push_back(String(i));
+        scores_clean_edge_idx.emplace_back(i);
         ef_clean_edge += ef;
       }
       else
       {
         scores_dirty_edge.push_back(String(feature_relation[i].getEdgeScore()));
-        scores_dirty_edge_idx.push_back(String(i));
+        scores_dirty_edge_idx.emplace_back(i);
         ef_dirty_edge += ef;
       }
 
@@ -953,7 +953,7 @@ namespace OpenMS
           }
         }
 
-        scores_e_active_idx.push_back(String(i));
+        scores_e_active_idx.emplace_back(i);
       }
 
     } // !for feature_relation (i.e. edges)

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -789,7 +789,7 @@ namespace OpenMS
         match.setMetaValue("mz_error_Da", mass_error_Da);
 
         // add adduct to the ObservationMatch
-        String adduct = r.getFoundAdduct(); // M+Na;1+
+        const String& adduct = r.getFoundAdduct(); // M+Na;1+
         if (!adduct.empty() && adduct != "null")
         {
           AdductInfo ainfo = AdductInfo::parseAdductString(adduct);
@@ -950,7 +950,7 @@ namespace OpenMS
         {
           MzTabSmallMoleculeSectionRow mztab_row_record;
           // set the identifier field
-          String hid_temp = matching_ids[id_idx];
+          const String& hid_temp = matching_ids[id_idx];
           bool db_hit = (hid_temp != "null");
           if (db_hit)
           {

--- a/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
+++ b/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
@@ -74,7 +74,7 @@ namespace OpenMS
     // remember a needle ends here
     if (vec_index2needles_.size() <= cn()) // make sure there is enough space
     { // increase to next power of 2
-      vec_index2needles_.resize(std::bit_ceil(cn() + 1)); // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
+      vec_index2needles_.resize(std::__bit_ceil(cn() + 1)); // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
     }
     vec_index2needles_[cn()].push_back(needle_count_);
     ++needle_count_;
@@ -285,7 +285,7 @@ namespace OpenMS
   {
     if (vec_index2children_naive_.size() <= index())
     { // doubling is not enough
-      vec_index2children_naive_.resize(std::bit_ceil(index() + 1));  // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
+      vec_index2children_naive_.resize(std::__bit_ceil(index() + 1));  // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
     }
     Index ch = findChildNaive_(index, label);
     if (ch.isInvalid())

--- a/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
+++ b/src/openms/source/ANALYSIS/ID/AhoCorasickAmbiguous.cpp
@@ -74,7 +74,7 @@ namespace OpenMS
     // remember a needle ends here
     if (vec_index2needles_.size() <= cn()) // make sure there is enough space
     { // increase to next power of 2
-      vec_index2needles_.resize(std::__bit_ceil(cn() + 1)); // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
+      vec_index2needles_.resize(std::bit_ceil(cn() + 1)); // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
     }
     vec_index2needles_[cn()].push_back(needle_count_);
     ++needle_count_;
@@ -285,7 +285,7 @@ namespace OpenMS
   {
     if (vec_index2children_naive_.size() <= index())
     { // doubling is not enough
-      vec_index2children_naive_.resize(std::__bit_ceil(index() + 1));  // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
+      vec_index2children_naive_.resize(std::bit_ceil(index() + 1));  // +1 since bit_ceil(x)^2 == x iff x is a power of 2 (i.e. no resize takes place)
     }
     Index ch = findChildNaive_(index, label);
     if (ch.isInvalid())

--- a/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDBoostGraph.cpp
@@ -793,7 +793,7 @@ namespace OpenMS
     // Cluster proteins
     for (; ui != ui_end; ++ui)
     {
-      IDBoostGraph::IDPointer curr_idObj = fg[*ui];
+      const IDBoostGraph::IDPointer& curr_idObj = fg[*ui];
       //TODO introduce an enum for the types to make it more clear.
       // Or use the static_visitor pattern: You have to pass the vertex with its neighbors as a second arg though.
       if (curr_idObj.which() == 0) //protein: find indist. ones

--- a/src/openms/source/ANALYSIS/ID/IDRipper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDRipper.cpp
@@ -37,7 +37,7 @@ namespace OpenMS
     // build index_ map that maps the identifiers in prot_ids to indices 0,1,...
     for (const auto& prot_id : prot_ids)
     {
-      String id_run_id = prot_id.getIdentifier();
+      const String& id_run_id = prot_id.getIdentifier();
       if (this->index_map.find(id_run_id) != this->index_map.end())
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "IdentificationRun IDs are not unique!", id_run_id);

--- a/src/openms/source/ANALYSIS/ID/MetaboliteSpectralMatching.cpp
+++ b/src/openms/source/ANALYSIS/ID/MetaboliteSpectralMatching.cpp
@@ -649,7 +649,7 @@ namespace OpenMS
 
     for (Size id_idx = 0; id_idx < overall_results.size(); ++id_idx)
     {
-      SpectralMatch current_id(overall_results[id_idx]);
+      const SpectralMatch& current_id(overall_results[id_idx]);
 
       MzTabSmallMoleculeSectionRow mztab_row_record;
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
     data_ = rhs.data_;
     model_type_ = "none";
     model_ = nullptr; // initialize this before the "delete" call in "fitModel"!
-    Param params = rhs.getModelParameters();
+    const Param& params = rhs.getModelParameters();
     fitModel(rhs.model_type_, params);
   }
 
@@ -59,7 +59,7 @@ namespace OpenMS
 
     data_ = rhs.data_;
     model_type_ = "none";
-    Param params = rhs.getModelParameters();
+    const Param& params = rhs.getModelParameters();
     fitModel(rhs.model_type_, params);
 
     return *this;

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.cpp
@@ -265,7 +265,7 @@ private:
       //uff... well here we go.. adding an empty string
       for (Size s = 0; s < x_.size(); ++s)
       {
-        bloated_data.emplace_back(TransformationModel::DataPoint(x_[s],y_[s]));
+        bloated_data.emplace_back(x_[s],y_[s]);
       }
       lm_front_ = new TransformationModelLinear(bloated_data, Param());
       lm_back_ = new TransformationModelLinear(bloated_data, Param());

--- a/src/openms/source/ANALYSIS/NUXL/NuXLMarkerIonExtractor.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLMarkerIonExtractor.cpp
@@ -18,14 +18,14 @@ namespace OpenMS
 NuXLMarkerIonExtractor::MarkerIonsType NuXLMarkerIonExtractor::extractMarkerIons(const PeakSpectrum& s, const double marker_tolerance)
 {
   MarkerIonsType marker_ions;
-  marker_ions["A"].push_back(make_pair(136.06231, 0.0));
-  marker_ions["A"].push_back(make_pair(330.06033, 0.0));
-  marker_ions["C"].push_back(make_pair(112.05108, 0.0));
-  marker_ions["C"].push_back(make_pair(306.04910, 0.0));
-  marker_ions["G"].push_back(make_pair(152.05723, 0.0));
-  marker_ions["G"].push_back(make_pair(346.05525, 0.0));
-  marker_ions["U"].push_back(make_pair(113.03509, 0.0));
-  marker_ions["U"].push_back(make_pair(307.03311, 0.0));
+  marker_ions["A"].emplace_back(136.06231, 0.0);
+  marker_ions["A"].emplace_back(330.06033, 0.0);
+  marker_ions["C"].emplace_back(112.05108, 0.0);
+  marker_ions["C"].emplace_back(306.04910, 0.0);
+  marker_ions["G"].emplace_back(152.05723, 0.0);
+  marker_ions["G"].emplace_back(346.05525, 0.0);
+  marker_ions["U"].emplace_back(113.03509, 0.0);
+  marker_ions["U"].emplace_back(307.03311, 0.0);
 
   PeakSpectrum spec(s);
   Normalizer normalizer;

--- a/src/openms/source/ANALYSIS/NUXL/NuXLModificationsGenerator.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLModificationsGenerator.cpp
@@ -379,7 +379,7 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
       // nucleotide style formula (e.g., AATU matches to more than one group (e.g., RNA and DNA))?
       if (found_in_n_groups > 1)
       {
-        violates_restriction.push_back({formula, s}); 
+        violates_restriction.emplace_back(formula, s); 
         continue;
       }
 
@@ -395,7 +395,7 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
 
       if (containment_violated)
       { 
-        violates_restriction.push_back({formula, s}); // chemical formula, nucleotide style formula pair violates restrictions
+        violates_restriction.emplace_back(formula, s); // chemical formula, nucleotide style formula pair violates restrictions
       }
 
       // last check: if the sorted nucleotide composition string and mass have already been added
@@ -405,11 +405,11 @@ NuXLModificationMassesResult NuXLModificationsGenerator::initModificationMassesN
         unique_nucleotide_and_mod_composition.end(),
         make_pair(nucleotide_style_formula, mass)) != unique_nucleotide_and_mod_composition.end())
       {
-        violates_restriction.push_back({formula, s}); 
+        violates_restriction.emplace_back(formula, s); 
       }
 
       // record that nucleotide and mod combination has passed all filters and will be considered in further processing
-      unique_nucleotide_and_mod_composition.push_back({nucleotide_style_formula, mass});
+      unique_nucleotide_and_mod_composition.emplace_back(nucleotide_style_formula, mass);
     }
   }
 

--- a/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLParameterParsing.cpp
@@ -119,7 +119,7 @@ NuXLParameterParsing::getAllFeasibleFragmentAdducts(
       // we want to track if a certain MS1 mass and set of MS2 ions allow to distinguish 
       // (at least in theory) precursor adduct and cross-linked nucleotide 
       // to do so, we map mass and set of fragment ions to precursor adduct and cross-linked nucleotide 
-      mass_frags2pc_xlnuc[{pc2mass[pc], fragments}].push_back({pc, nucleotide});
+      mass_frags2pc_xlnuc[{pc2mass[pc], fragments}].emplace_back(pc, nucleotide);
 
       OPENMS_LOG_DEBUG << "  Cross-linkable nucleotide '" << nucleotide << "' and feasible fragment adducts:" << endl;
       for (auto const & a : ffa.second)
@@ -337,7 +337,7 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
         // store feasible adducts associated with a cross-link with character nucleotide
         vector<NuXLFragmentAdductDefinition> faa;
         std::copy(fragment_adducts.begin(), fragment_adducts.end(), back_inserter(faa));
-        ret.feasible_adducts.emplace_back(make_pair(nucleotide, faa));
+        ret.feasible_adducts.emplace_back(nucleotide, faa);
       }
     }
     
@@ -388,7 +388,7 @@ NuXLParameterParsing::getFeasibleFragmentAdducts(const String &exp_pc_adduct,
         // store feasible adducts associated with a cross-link with character nucleotide[0]
         vector<NuXLFragmentAdductDefinition> faa;
         std::copy(fas.begin(), fas.end(), back_inserter(faa));
-        ret.feasible_adducts.emplace_back(make_pair(nucleotide, faa));
+        ret.feasible_adducts.emplace_back(nucleotide, faa);
 
         // We only have one nucleotide in the precursor adduct (the cross-linked one)
         // Note: marker ions of the cross-linked nucleotide are often missing or of very low intensity

--- a/src/openms/source/ANALYSIS/NUXL/NuXLReport.cpp
+++ b/src/openms/source/ANALYSIS/NUXL/NuXLReport.cpp
@@ -407,7 +407,7 @@ Output format:
       peptide_seq2XLFDR[peptide_sequence_string] = peptide_XL_level_qvalue;
 
       // loop over all target proteins the peptide maps to
-      const std::set<std::string> proteins = peptide2proteins.at(peptide_sequence_string);
+      const std::set<std::string>& proteins = peptide2proteins.at(peptide_sequence_string);
       const bool is_unique = proteins.size() == 1;
 
       for (const auto& acc : proteins)
@@ -813,7 +813,7 @@ Output format:
       }
 
       // determine peptides/regions not yet printed (e.g., no site localization exists for those)
-      set<string> all_peptides = protein2peptides.at(accession);
+      const set<string>& all_peptides = protein2peptides.at(accession);
 
       set<string> remaining_peptides;
       std::set_difference(all_peptides.begin(), all_peptides.end(), 

--- a/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
@@ -214,7 +214,7 @@ namespace OpenMS
     linear_params.setValue("outlierMethod", linear_outlier_detection_);
 
     // Configure calibration parameters - let SwathMapMassCorrection use its own m/z and IM parameters
-    Param calibration_params_configured = calibration_param;
+    const Param& calibration_params_configured = calibration_param;
 
     TransformationDescription im_trafo;
     // Call the member implementation (moved into CalibrationWorkflow)
@@ -316,7 +316,7 @@ namespace OpenMS
     nl_params.setValue("outlierMethod", nonlinear_outlier_detection_); // Use nonlinear-specific outlier method
     
     // Configure calibration parameters - let SwathMapMassCorrection use its own m/z and IM parameters
-    Param calibration_params_configured = calibration_param;
+    const Param& calibration_params_configured = calibration_param;
     
     TransformationDescription im_trafo;
     TransformationDescription nonlinear_trafo = this->doDataNormalization_(

--- a/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/IonMobilityScoring.cpp
@@ -301,7 +301,7 @@ namespace OpenMS
     {
       double im(0), intensity(0);
       Mobilogram res;
-      const TransitionType transition = transitions[k];
+      const TransitionType& transition = transitions[k];
       // Calculate the difference of the theoretical ion mobility and the actually measured ion mobility
       RangeMZ mz_range = DIAHelpers::createMZRangePPM(transition.getProductMZ(), dia_extract_window_, dia_extraction_ppm_);
 
@@ -415,7 +415,7 @@ namespace OpenMS
     OPENMS_PRECONDITION(!spectra.empty(), "Spectra cannot be empty")
     OPENMS_PRECONDITION(!transitions.empty(), "Need at least one transition");
 
-    for (auto s:spectra){
+    for (const auto& s:spectra){
       if (s->getDriftTimeArray() == nullptr)
       {
         OPENMS_LOG_DEBUG << " ERROR: Drift time is missing in ion mobility spectrum!\n";
@@ -468,7 +468,7 @@ namespace OpenMS
                                          Int64 feature_id)
   {
     OPENMS_PRECONDITION(!spectra.empty(), "Spectra cannot be empty");
-    for (auto s:spectra)
+    for (const auto& s:spectra)
     {
       if (s->getDriftTimeArray() == nullptr)
       {
@@ -494,7 +494,7 @@ namespace OpenMS
     std::vector< Mobilogram > ms2_mobilograms;
     for (std::size_t k = 0; k < transitions.size(); k++)
     {
-      const TransitionType transition = transitions[k];
+      const TransitionType& transition = transitions[k];
       Mobilogram res;
       double im(0), intensity(0);
 
@@ -653,7 +653,7 @@ namespace OpenMS
       // }
 
       OPENMS_PRECONDITION(!spectra.empty(), "Spectra cannot be empty");
-      for (auto s:spectra)
+      for (const auto& s:spectra)
       {
         if (s->getDriftTimeArray() == nullptr)
         {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -603,7 +603,7 @@ namespace OpenMS
     { 
       setProgress(progress++);
 
-      TargetedExperiment::Peptide peptide = exp.getPeptideByRef(pep_it.first);
+      const TargetedExperiment::Peptide& peptide = exp.getPeptideByRef(pep_it.first);
       int precursor_charge = 1;
       if (peptide.hasCharge()) 
       {
@@ -768,7 +768,7 @@ namespace OpenMS
     {
       String peptide_ref = pep_it->first;
 
-      TargetedExperiment::Peptide target_peptide = exp.getPeptideByRef(peptide_ref);
+      const TargetedExperiment::Peptide& target_peptide = exp.getPeptideByRef(peptide_ref);
       OpenMS::AASequence target_peptide_sequence = TargetedExperimentHelper::getAASequence(target_peptide);
 
       int precursor_charge = 1;
@@ -1182,7 +1182,7 @@ namespace OpenMS
         String potential_target = current_decoy;
         potential_target.erase(potential_target.find(decoy_suffix), decoy_suffix.size());
         descriptions_decoys.emplace_back(potential_target);
-        reference_decoys.emplace_back(std::make_pair(current_decoy, potential_target));
+        reference_decoys.emplace_back(current_decoy, potential_target);
       }
       else
       {

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetReader.cpp
@@ -44,7 +44,7 @@ void OpenSwathOSWParquetReader::load(const String& oswpq_dir)
     auto ra_res = ZipRandomAccessFile::Open(oswpq_dir, entry, temp_dir);
     if (ra_res.ok())
     {
-      auto raf = ra_res.ValueOrDie();
+      const auto& raf = ra_res.ValueOrDie();
       return ParquetFile::readTable(std::static_pointer_cast<arrow::io::RandomAccessFile>(raf));
     }
     // Fallback: extract to temp file and read
@@ -159,7 +159,7 @@ OpenSwathOSWParquetReader::PeakGroupFeatureScoresResult OpenSwathOSWParquetReade
     auto ra_res = ZipRandomAccessFile::Open(oswpq_dir, entry, temp_dir);
     if (ra_res.ok())
     {
-      auto raf = ra_res.ValueOrDie();
+      const auto& raf = ra_res.ValueOrDie();
       return ParquetFile::readTable(std::static_pointer_cast<arrow::io::RandomAccessFile>(raf));
     }
     const String path = ZipArchiveFile::extractEntryToTempFile(oswpq_dir, entry, temp_dir);
@@ -367,11 +367,11 @@ OpenSwathOSWParquetReader::PeakGroupFeatureScoresResult OpenSwathOSWParquetReade
   result.group_id = std::move(group_id_v);
 
   result.ms2_columns.reserve(all_ms2_cols.size());
-  for (const auto &s : all_ms2_cols) result.ms2_columns.emplace_back(String(s));
+  for (const auto &s : all_ms2_cols) result.ms2_columns.emplace_back(s);
   result.ms2_values = std::move(ms2_values);
 
   result.ms1_columns.reserve(all_ms1_cols.size());
-  for (const auto &s : all_ms1_cols) result.ms1_columns.emplace_back(String(s));
+  for (const auto &s : all_ms1_cols) result.ms1_columns.emplace_back(s);
   result.ms1_values = std::move(ms1_values);
 
   // If a main_score was requested, place it first among ms2 columns/values
@@ -423,7 +423,7 @@ OpenSwathOSWParquetReader::TransitionFeaturesResult OpenSwathOSWParquetReader::f
     auto ra_res = ZipRandomAccessFile::Open(oswpq_dir, entry, temp_dir);
     if (ra_res.ok())
     {
-      auto raf = ra_res.ValueOrDie();
+      const auto& raf = ra_res.ValueOrDie();
       return ParquetFile::readTable(std::static_pointer_cast<arrow::io::RandomAccessFile>(raf));
     }
     const String path = ZipArchiveFile::extractEntryToTempFile(oswpq_dir, entry, temp_dir);
@@ -490,7 +490,7 @@ OpenSwathOSWParquetReader::TransitionFeaturesResult OpenSwathOSWParquetReader::f
 
   std::sort(all_var_cols.begin(), all_var_cols.end());
   result.transition_var_columns.reserve(all_var_cols.size());
-  for (const auto &s : all_var_cols) result.transition_var_columns.emplace_back(String(s));
+  for (const auto &s : all_var_cols) result.transition_var_columns.emplace_back(s);
   result.transition_var_values.assign(all_var_cols.size(), std::vector<double>());
 
   // Second pass: populate vectors
@@ -679,7 +679,7 @@ OpenSwathOSWParquetReader::UnscoredResult OpenSwathOSWParquetReader::fetchUnscor
     auto ra_res = ZipRandomAccessFile::Open(oswpq_dir, entry, temp_dir);
     if (ra_res.ok())
     {
-      auto raf = ra_res.ValueOrDie();
+      const auto& raf = ra_res.ValueOrDie();
       return ParquetFile::readTable(std::static_pointer_cast<arrow::io::RandomAccessFile>(raf));
     }
     const String path = ZipArchiveFile::extractEntryToTempFile(oswpq_dir, entry, temp_dir);
@@ -781,10 +781,10 @@ OpenSwathOSWParquetReader::UnscoredResult OpenSwathOSWParquetReader::fetchUnscor
 
   // Prepare ms score storage
   result.ms2_columns.reserve(all_ms2_cols.size());
-  for (const auto &s : all_ms2_cols) result.ms2_columns.emplace_back(String(s));
+  for (const auto &s : all_ms2_cols) result.ms2_columns.emplace_back(s);
   result.ms2_values.assign(all_ms2_cols.size(), std::vector<double>());
   result.ms1_columns.reserve(all_ms1_cols.size());
-  for (const auto &s : all_ms1_cols) result.ms1_columns.emplace_back(String(s));
+  for (const auto &s : all_ms1_cols) result.ms1_columns.emplace_back(s);
   result.ms1_values.assign(all_ms1_cols.size(), std::vector<double>());
 
   // Second pass: populate rows

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
@@ -877,7 +877,7 @@ namespace OpenMS
 
         for (Size i = 0; i < id_target_transition_names.size(); ++i)
         {
-          const String transition_name = id_target_transition_names[i];
+          const String& transition_name = id_target_transition_names[i];
           auto it = transition_to_id.find(transition_name);
           if (it == transition_to_id.end()) continue;
 
@@ -992,7 +992,7 @@ namespace OpenMS
 
         for (Size i = 0; i < id_decoy_transition_names.size(); ++i)
         {
-          const String transition_name = id_decoy_transition_names[i];
+          const String& transition_name = id_decoy_transition_names[i];
           auto it = transition_to_id.find(transition_name);
           if (it == transition_to_id.end()) continue;
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -641,7 +641,7 @@ namespace OpenMS
         String prec_id = OpenSwathHelper::computePrecursorId(transition_group.getTransitionGroupID(), iso);
         if (!ms1_chromatograms.empty() && ms1_chromatogram_map.find(prec_id) != ms1_chromatogram_map.end())
         {
-          MSChromatogram chromatogram = ms1_chromatograms[ ms1_chromatogram_map[prec_id] ];
+          const MSChromatogram& chromatogram = ms1_chromatograms[ ms1_chromatogram_map[prec_id] ];
           transition_group.addPrecursorChromatogram(chromatogram, chromatogram.getNativeID());
         }
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/SpectrumAddition.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SpectrumAddition.cpp
@@ -183,7 +183,7 @@ namespace OpenMS
     // since resampling is not supported on 3D data first filter by drift time (if possible) and then add
     // (!im_range.isEmpty())
     SpectrumSequence filteredSpectra;
-    for (auto spec: all_spectra)
+    for (const auto& spec: all_spectra)
     {
       filteredSpectra.push_back(OpenSwath::ISpectrumAccess::filterByDrift(spec, im_range.getMin(), im_range.getMax()));
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionParquetFile.cpp
@@ -221,7 +221,7 @@ namespace OpenMS
       auto ra_res = ZipRandomAccessFile::Open(oswpq_dir, entry, temp_dir);
       if (ra_res.ok())
       {
-        auto raf = ra_res.ValueOrDie();
+        const auto& raf = ra_res.ValueOrDie();
         return ParquetFile::readTable(std::static_pointer_cast<arrow::io::RandomAccessFile>(raf));
       }
       // Fallback to extract

--- a/src/openms/source/ANALYSIS/TARGETED/ChromatogramProcessor.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/ChromatogramProcessor.cpp
@@ -22,7 +22,7 @@ void ChromatogramProcessor::pickExperiment(
 {
   OPENMS_LOG_INFO << "ChromatogramProcessor::pickExperiment() called with " << chromatograms.size() << " chromatograms." << std::endl;
   MRMFeatureFinderScoring featureFinder;
-  Param ffparam(feature_finder_param);
+  const Param& ffparam(feature_finder_param);
   featureFinder.setParameters(ffparam);
 
   // Prepare the data with the chromatograms

--- a/src/openms/source/ANALYSIS/TARGETED/DIAChromHandler.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/DIAChromHandler.cpp
@@ -224,7 +224,7 @@ std::vector<MSChromatogram> DIAChromHandler::extractAndMapChromatogramsForTransi
 
   std::vector< OpenSwath::ChromatogramPtr > chrom_list;
   std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
-  OpenSwath::LightTargetedExperiment transition_exp_copy = transition_exp;
+  const OpenSwath::LightTargetedExperiment& transition_exp_copy = transition_exp;
   ChromatogramExtractor::prepare_coordinates(chrom_list, coordinates, transition_exp_copy, cp.rt_extraction_window, /*ms1*/ false, /*ms1_isotopes*/ 0);
 
     try

--- a/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedAssay.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedAssay.cpp
@@ -602,7 +602,7 @@ namespace OpenMS
 
           float current_int = spec_it->getIntensity();
           double current_mz = spec_it->getMZ();
-          String current_explanation = explanation_array[peak_index];
+          const String& current_explanation = explanation_array[peak_index];
 
           // write row for each transition
           // current int has to be higher than transition threshold and should not be smaller than threshold noise

--- a/src/openms/source/ANALYSIS/TOPDOWN/FLASHDeconvAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/TOPDOWN/FLASHDeconvAlgorithm.cpp
@@ -627,7 +627,7 @@ void FLASHDeconvAlgorithm::findPrecursorPeakGroupsForMSnSpectra_(const MSExperim
     const auto& spec = map[index];
     if (spec.getMSLevel() != ms_level) { continue; }
 
-    String native_id = spec.getNativeID();
+    const String& native_id = spec.getNativeID();
 
     auto [b_scan_number, a_scan_number] = findScanNumberBounds_(map, index, ms_level);
     auto survey_scans = collectSurveyScans_(deconvolved_spectra, b_scan_number, a_scan_number, ms_level);

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -380,7 +380,7 @@ namespace OpenMS
 #pragma omp parallel for schedule(guided)
     for (int i = 0; i < static_cast<int>(candidates.size()); ++i)
     {
-      OPXLDataStructs::XLPrecursor candidate = candidates[i];
+      const OPXLDataStructs::XLPrecursor& candidate = candidates[i];
       vector <SignedSize> link_pos_first;
       vector <SignedSize> link_pos_second;
       const AASequence* peptide_first = &(peptide_masses[candidate.alpha_index].peptide_seq);
@@ -1281,7 +1281,7 @@ namespace OpenMS
       }
     }
 
-    for (String index : spectrum_indices)
+    for (const String& index : spectrum_indices)
     {
       for (PeptideIdentification& id : peptide_ids)
       {

--- a/src/openms/source/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.cpp
@@ -262,7 +262,7 @@ namespace OpenMS
         if (e >= n_e - 1)
         {
           // add match
-          alignment.emplace_back(std::make_pair(t, e));
+          alignment.emplace_back(t, e);
           // add ppm error
           double ppm_error = (exp_spectrum[e].getMZ() - theo_mz) / theo_mz * 1e6;
           ppm_error_array.emplace_back(ppm_error);
@@ -314,7 +314,7 @@ namespace OpenMS
         while (e < n_e - 1);
 
         // search in tolerance window for an experimental peak closer to theoretical one
-        alignment.emplace_back(std::make_pair(t, closest_exp_peak));
+        alignment.emplace_back(t, closest_exp_peak);
 
         // add ppm error for this match
         double ppm_error = (exp_spectrum[closest_exp_peak].getMZ() - theo_mz) / theo_mz * 1e6;
@@ -407,7 +407,7 @@ namespace OpenMS
         if (e >= n_e - 1)
         {
           // add match
-          alignment.emplace_back(std::make_pair(t, e));
+          alignment.emplace_back(t, e);
           return;
         }
 
@@ -454,7 +454,7 @@ namespace OpenMS
         while (e < n_e - 1);
 
         // search in tolerance window for an experimental peak closer to theoretical one
-        alignment.emplace_back(std::make_pair(t, closest_exp_peak));
+        alignment.emplace_back(t, closest_exp_peak);
         e = closest_exp_peak + 1;  // advance experimental peak to 1-after the best match
         ++t; // advance theoretical peak
       }

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -854,9 +854,9 @@ using namespace OpenMS;
             auto num_iso_peaks_array_it = getDataArrayByName(all_peaks.getIntegerDataArrays(), "iso_peak_count");
             DataArrays::IntegerDataArray num_iso_peaks_array = *num_iso_peaks_array_it;
             auto num_iso_peaks_array_linear_it = getDataArrayByName(linear_peaks.getIntegerDataArrays(), "iso_peak_count");
-            DataArrays::IntegerDataArray num_iso_peaks_array_linear = *num_iso_peaks_array_linear_it;
+            const DataArrays::IntegerDataArray& num_iso_peaks_array_linear = *num_iso_peaks_array_linear_it;
             auto num_iso_peaks_array_xlinks_it = getDataArrayByName(xlink_peaks.getIntegerDataArrays(), "iso_peak_count");
-            DataArrays::IntegerDataArray num_iso_peaks_array_xlinks = *num_iso_peaks_array_xlinks_it;
+            const DataArrays::IntegerDataArray& num_iso_peaks_array_xlinks = *num_iso_peaks_array_xlinks_it;
 
             csm.num_iso_peaks_mean = Math::mean(num_iso_peaks_array.begin(), num_iso_peaks_array.end());
 

--- a/src/openms/source/ANALYSIS/XLMS/XFDRAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/XFDRAlgorithm.cpp
@@ -225,7 +225,7 @@ using namespace OpenMS;
         for (StringList::const_iterator crosslink_types_it = crosslink_types.begin();
             crosslink_types_it != crosslink_types.end(); ++crosslink_types_it)
         {
-          String current_crosslink_type = *crosslink_types_it;
+          const String& current_crosslink_type = *crosslink_types_it;
           Size idx = std::floor((score - this->min_score_) / arg_binsize_);
           if (   current_crosslink_type == crosslink_class_fulldecoysinterlinks_
               || current_crosslink_type == crosslink_class_hybriddecoysinterlinks_
@@ -268,10 +268,10 @@ using namespace OpenMS;
 
   void XFDRAlgorithm::initDataStructures_(PeptideIdentificationList& peptide_ids, ProteinIdentification& protein_id)
   {
-    const String prot_identifier = protein_id.getIdentifier();
+    const String& prot_identifier = protein_id.getIdentifier();
 
     // if the metaValue exists in search_params and the default value for XFDR was not changed, use the one in search_params
-    ProteinIdentification::SearchParameters search_params = protein_id.getSearchParameters();
+    const ProteinIdentification::SearchParameters& search_params = protein_id.getSearchParameters();
     if (search_params.metaValueExists("decoy_string") && decoy_string_ == "DECOY_")
     {
       decoy_string_ = search_params.getMetaValue("decoy_string");
@@ -316,7 +316,7 @@ using namespace OpenMS;
         {
           StringList alpha_prots;
           const std::vector<PeptideEvidence> pevs_alpha = ph.getPeptideEvidences();
-          for (PeptideEvidence pev : pevs_alpha)
+          for (const PeptideEvidence& pev : pevs_alpha)
           {
             alpha_prots.push_back(pev.getProteinAccession());
           }

--- a/src/openms/source/APPLICATIONS/ConsoleUtils.cpp
+++ b/src/openms/source/APPLICATIONS/ConsoleUtils.cpp
@@ -179,7 +179,7 @@ namespace OpenMS
     if (input.back() == '\n')
     { // last char input was a linebreak (which would put the cursor at column 0 in the next line)
       // --> but we want indentation!
-      result.push_back(String(indentation, ' '));
+      result.emplace_back(indentation, ' ');
     }
 
     if (result.size() > max_lines) // remove lines from end if we get too many (but leave the last one)...

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -1021,7 +1021,7 @@ namespace OpenMS
     StringList defaults;
 
     if (p.type == ParameterInformation::STRING)
-      defaults.push_back(String(p.default_value.toString()));
+      defaults.emplace_back(p.default_value.toString());
     else
       defaults = ListUtils::toStringList<std::string>(p.default_value);
 
@@ -1409,7 +1409,7 @@ namespace OpenMS
     // check if all input files are readable
     if (p.type == ParameterInformation::INPUT_FILE_LIST)
     {
-      for (String t : param_value)
+      for (const String& t : param_value)
       {
         if (!ListUtils::contains(p.tags, "skipexists")) inputFileReadable_(t, param_name);
 
@@ -2593,7 +2593,7 @@ namespace OpenMS
           // which is the LAST occurrence on the command line.
           if (cmd_params.exists(pos->second->name))
           {
-            ParamValue existing_value = cmd_params.getValue(pos->second->name);
+            const ParamValue& existing_value = cmd_params.getValue(pos->second->name);
             writeLogWarn_(String("Warning: Duplicate parameter '") + arg + "' given. Using last occurrence with value '" + String(existing_value.toString()) + "' (ignoring '" + String(value.toString()) + "').");
           }
           else

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -656,7 +656,7 @@ namespace OpenMS
       double iso_mono_weight = iso_avg_weight;
       IsotopeDistribution iso_isotopes;
       IsotopeDistribution::ContainerType iso_container;
-      iso_container.push_back(Peak1D(atomic_mass, 1.0));
+      iso_container.emplace_back(atomic_mass, 1.0);
       iso_isotopes.set(iso_container);  
 
       auto iso_element = make_unique<const Element>(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
@@ -680,7 +680,7 @@ namespace OpenMS
     
     for (map<unsigned int, double>::const_iterator it = abundance.begin(); it != abundance.end(); ++it)
     { 
-      dist.push_back(Peak1D(mass.at(it->first) , abundance.at(it->first)));
+      dist.emplace_back(mass.at(it->first) , abundance.at(it->first));
     }
 
     IsotopeDistribution iso_dist;

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
@@ -345,7 +345,7 @@ namespace OpenMS
     else
     {
       result.clear();
-      result.push_back(IsotopeDistribution::MassAbundance(0, 1.0));
+      result.emplace_back(0, 1.0);
     }
 
 

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
@@ -208,7 +208,7 @@ namespace OpenMS
     ITG->reset();
 
     while (ITG->advanceToNextConfiguration())
-        distribution.emplace_back(Peak1D(ITG->mass(), ITG->prob()));
+        distribution.emplace_back(ITG->mass(), ITG->prob());
 
     IsotopeDistribution ID;
 
@@ -260,7 +260,7 @@ namespace OpenMS
     {
         double p = ILG->prob();
         acc_prob += p;
-        distribution.emplace_back(Peak1D(ILG->mass(), p));
+        distribution.emplace_back(ILG->mass(), p);
     }
 
     if (do_p_trim)
@@ -268,7 +268,7 @@ namespace OpenMS
         // the p_trim: extract the rest of the last layer, and perform quickselect
 
         while (ILG->advanceToNextConfigurationWithinLayer())
-            distribution.emplace_back(Peak1D(ILG->mass(), ILG->prob()));
+            distribution.emplace_back(ILG->mass(), ILG->prob());
 
         size_t start = 0;
         size_t end = distribution.size();

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
@@ -32,7 +32,7 @@ namespace OpenMS
   
   IsotopeDistribution::IsotopeDistribution()
   {
-    distribution_.push_back(Peak1D(0, 1));
+    distribution_.emplace_back(0, 1);
   }
 
   IsotopeDistribution& IsotopeDistribution::operator=(const IsotopeDistribution & iso)

--- a/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ModifiedPeptideGenerator.cpp
@@ -45,7 +45,7 @@ namespace OpenMS
     ModifiedPeptideGenerator::MapToResidueType m;
     for (auto const & r : mods)
     {
-      String name = r->getFullId();
+      const String& name = r->getFullId();
       bool is_terminal = r->getTermSpecificity() == ResidueModification::N_TERM || r->getTermSpecificity() == ResidueModification::C_TERM || r->getTermSpecificity() == ResidueModification::PROTEIN_N_TERM || r->getTermSpecificity() == ResidueModification::PROTEIN_C_TERM;
       if (!is_terminal)
       {

--- a/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
+++ b/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
@@ -377,7 +377,7 @@ namespace OpenMS
       }
       //TODO add "FragmentArray"s
 
-      Param sap = sa.getParameters();
+      const Param& sap = sa.getParameters();
       pi.setMetaValue("fragment_match_tolerance", (double)sap.getValue("tolerance"));
     }  
   }

--- a/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
+++ b/src/openms/source/FEATUREFINDER/ElutionPeakDetection.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
   {
     // compute RMSE
     double squared_sum(0.0);
-    std::vector<double> smooth_ints(tr.getSmoothedIntensities());
+    const std::vector<double>& smooth_ints(tr.getSmoothedIntensities());
 
     for (Size i = 0; i < smooth_ints.size(); ++i)
     {

--- a/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFindingMetabo.cpp
@@ -360,7 +360,7 @@ namespace OpenMS
     auto isodist = solver.estimateFromPeptideWeight(mol_weight);
     // isodist.renormalize();
 
-    IsotopeDistribution::ContainerType averagine_dist = isodist.getContainer();
+    const IsotopeDistribution::ContainerType& averagine_dist = isodist.getContainer();
     double max_int(0.0), theo_max_int(0.0);
     for (Size i = 0; i < hypo_ints.size(); ++i)
     {

--- a/src/openms/source/FORMAT/Base64.cpp
+++ b/src/openms/source/FORMAT/Base64.cpp
@@ -261,7 +261,7 @@ namespace OpenMS
      
       if (first_sep + 1 < next_sep) // non-empty string
       { 
-        out.push_back(String(first_sep, next_sep - first_sep));
+        out.emplace_back(first_sep, next_sep - first_sep);
       }
       first_sep = next_sep + 1; // move to substring
     }

--- a/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowExport.cpp
@@ -860,7 +860,7 @@ bool ConsensusMapArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ConsensusMapArrowExport: Failed to open file: " << filename << std::endl;
     return false;
   }
-  auto outfile = *result;
+  const auto& outfile = *result;
 
   // Configure Parquet writer
   auto builder = parquet::WriterProperties::Builder();

--- a/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/ConsensusMapArrowIO.cpp
@@ -717,7 +717,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to open file: " << filename << std::endl;
       return false;
     }
-    auto outfile = *result;
+    const auto& outfile = *result;
 
     auto builder = parquet::WriterProperties::Builder();
 
@@ -781,7 +781,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to open file: " << filename << std::endl;
       return nullptr;
     }
-    auto infile = *infile_result;
+    const auto& infile = *infile_result;
 
     auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
     if (!reader_result.ok())
@@ -1314,7 +1314,7 @@ bool ConsensusMapArrowIO::importFeaturesFromArrow(
     OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks" << std::endl;
     return false;
   }
-  auto tbl = *combined_result;
+  const auto& tbl = *combined_result;
 
   int64_t num_rows = tbl->num_rows();
   if (num_rows == 0)
@@ -1382,7 +1382,7 @@ bool ConsensusMapArrowIO::importPSMsFromArrow(
     OPENMS_LOG_ERROR << "ConsensusMapArrowIO: Failed to combine chunks in importPSMsFromArrow" << std::endl;
     return false;
   }
-  auto tbl = *combined_result;
+  const auto& tbl = *combined_result;
   int64_t num_rows = tbl->num_rows();
 
   // Build consensus feature lookup: unique_id -> ConsensusFeature*

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -222,8 +222,8 @@ namespace OpenMS
         candidates.getRow(i, sl);
         String adduct = sl[columnname_to_columnindex.at("adduct")];
         adduct.erase(std::remove_if(adduct.begin(), adduct.end(), ::isspace), adduct.end());
-        rank_filename.emplace(std::make_pair(sl[columnname_to_columnindex.at("formulaRank")].toInt(),
-                              String(sl[columnname_to_columnindex.at("molecularFormula")] + "_" + adduct + ".tsv")));
+        rank_filename.emplace(sl[columnname_to_columnindex.at("formulaRank")].toInt(),
+                              String(sl[columnname_to_columnindex.at("molecularFormula")] + "_" + adduct + ".tsv"));
       }
     }
     fcandidates.close();
@@ -253,8 +253,8 @@ namespace OpenMS
       {
         StringList sl;
         candidates.getRow(i, sl);
-        rank_score.emplace(std::make_pair(sl[columnname_to_columnindex.at("formulaRank")].toInt(),
-                                             sl[columnname_to_columnindex.at("explainedIntensity")].toDouble()));
+        rank_score.emplace(sl[columnname_to_columnindex.at("formulaRank")].toInt(),
+                                             sl[columnname_to_columnindex.at("explainedIntensity")].toDouble());
       }
     }
     fcandidates.close();

--- a/src/openms/source/FORMAT/EDTAFile.cpp
+++ b/src/openms/source/FORMAT/EDTAFile.cpp
@@ -295,7 +295,7 @@ namespace OpenMS
 
     for (Size i = 0; i < map.size(); ++i)
     {
-      ConsensusFeature f = map[i];
+      const ConsensusFeature& f = map[i];
       // consensus
       String entry = String(f.getRT()) + "\t" + f.getMZ() + "\t" + f.getIntensity() + "\t" + f.getCharge();
       // sub-features

--- a/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
+++ b/src/openms/source/FORMAT/FeatureMapArrowIO.cpp
@@ -511,7 +511,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to open file: " << filename << std::endl;
       return false;
     }
-    auto outfile = *result;
+    const auto& outfile = *result;
 
     // Configure Parquet writer
     auto builder = parquet::WriterProperties::Builder();
@@ -589,7 +589,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to open file: " << filename << std::endl;
       return nullptr;
     }
-    auto infile = *infile_result;
+    const auto& infile = *infile_result;
 
     auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
     if (!reader_result.ok())
@@ -1247,7 +1247,7 @@ bool FeatureMapArrowIO::importFeaturesFromArrow(
     OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks" << std::endl;
     return false;
   }
-  auto tbl = *combined_result;
+  const auto& tbl = *combined_result;
 
   int64_t num_rows = tbl->num_rows();
   if (num_rows == 0)
@@ -1403,7 +1403,7 @@ bool FeatureMapArrowIO::importPSMsFromArrow(
     OPENMS_LOG_ERROR << "FeatureMapArrowIO: Failed to combine chunks in importPSMsFromArrow" << std::endl;
     return false;
   }
-  auto tbl = *combined_result;
+  const auto& tbl = *combined_result;
   int64_t num_rows = tbl->num_rows();
 
   // Build feature lookup: unique_id -> Feature* (recursively includes subordinates)

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -155,7 +155,7 @@ namespace OpenMS
       good_types.erase(std::remove_if(good_types.begin(), good_types.end(),[i](auto j) { return (std::find(j.features.begin(),j.features.end(),i) == j.features.end()); }), good_types.end());
     }
     
-    for (auto t : good_types)
+    for (const auto& t : good_types)
     {
       compatible.push_back(t.type);
     }

--- a/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/CachedMzMLHandler.cpp
@@ -412,7 +412,7 @@ namespace OpenMS::Internal
 
     for (Size j = 2; j < data.size(); j++)
     {
-      spectrum.getFloatDataArrays().push_back(MSSpectrum::FloatDataArray());
+      spectrum.getFloatDataArrays().emplace_back();
       spectrum.getFloatDataArrays().back().reserve(data[j]->data.size());
       spectrum.getFloatDataArrays().back().setName(data[j]->description);
       for (const auto& k : data[j]->data) spectrum.getFloatDataArrays().back().push_back(k);

--- a/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/FeatureXMLHandler.cpp
@@ -897,7 +897,7 @@ namespace OpenMS::Internal
     os << indent << "\t\t\t<charge>" << feat.getCharge() << "</charge>\n";
 
     // write convex hull
-    vector<ConvexHull2D> hulls = feat.getConvexHulls();
+    const vector<ConvexHull2D>& hulls = feat.getConvexHulls();
 
     Size hulls_count = hulls.size();
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -842,7 +842,7 @@ namespace OpenMS::Internal
           SpectrumIdentification temp_struct = {spectra_data_ref, searchDatabase_ref, spectrumIdentificationProtocol_ref, spectrumIdentificationList_ref};
           si_map_.insert(make_pair(id, temp_struct));
 
-          pro_id_->push_back(ProteinIdentification());
+          pro_id_->emplace_back();
           ProteinIdentification::SearchParameters sp;
           sp.db = db_map_[searchDatabase_ref].location;
           sp.db_version = db_map_[searchDatabase_ref].version;
@@ -1836,7 +1836,7 @@ namespace OpenMS::Internal
       for (Size pep = 0; pep < unique_peptides.size(); ++pep)
       {
 
-        String peptide_ref = unique_peptides[pep];
+        const String& peptide_ref = unique_peptides[pep];
 
         // Debug output
 //        cout << "peptides: ";

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1239,13 +1239,13 @@ namespace OpenMS::Internal
           annotation_map[pep.charge][lt] = std::vector<StringList> (3);
           if (is_ppxl)
           {
-            annotation_map[pep.charge][lt].push_back(StringList());  // alpha|beta
-            annotation_map[pep.charge][lt].push_back(StringList());  // ci|xi
+            annotation_map[pep.charge][lt].emplace_back();  // alpha|beta
+            annotation_map[pep.charge][lt].emplace_back();  // ci|xi
           }
         }
         annotation_map[pep.charge][lt][0].push_back(ionseries_index);
-        annotation_map[pep.charge][lt][1].push_back(String(pep.mz));
-        annotation_map[pep.charge][lt][2].push_back(String(pep.intensity));
+        annotation_map[pep.charge][lt][1].emplace_back(pep.mz);
+        annotation_map[pep.charge][lt][2].emplace_back(pep.intensity);
         if (is_ppxl)
         {
           String ab = ListUtils::contains<String>(extra ,String("alpha")) ? String("alpha"):String("beta");

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -1371,7 +1371,7 @@ namespace OpenMS::Internal
         const MSChromatogram& chrom = chroms[k];
         insert_chrom_sql << "INSERT INTO CHROMATOGRAM (ID, RUN_ID, NATIVE_ID) VALUES (" << chrom_id_ << "," << run_id_ << ",'" << chrom.getNativeID() << "'); ";
 
-        OpenMS::Precursor prec = chrom.getPrecursor();
+        const OpenMS::Precursor& prec = chrom.getPrecursor();
         // see src/openms/include/OpenMS/METADATA/Precursor.h for activation modes
         int activation_method = -1;
         if (!prec.getActivationMethods().empty() )
@@ -1402,7 +1402,7 @@ namespace OpenMS::Internal
             "," << activation_method << "); ";
         }
 
-        OpenMS::Product prod = chrom.getProduct();
+        const OpenMS::Product& prod = chrom.getProduct();
         insert_product_sql << "INSERT INTO PRODUCT (CHROMATOGRAM_ID, CHARGE, ISOLATION_TARGET, " << 
           "ISOLATION_LOWER, ISOLATION_UPPER) VALUES (" << 
           chrom_id_ << "," << 0 << "," << prod.getMZ() << 

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -459,7 +459,7 @@ namespace OpenMS::Internal
   
           if (zero_mask != 0)
           { // Found a zero character
-              auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
+              auto byte_pos_zero = std::__countr_zero(zero_mask); // count trailing zeros to find the first zero character
               auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
               return processed_chars + char_pos_zero;
           }

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -459,7 +459,7 @@ namespace OpenMS::Internal
   
           if (zero_mask != 0)
           { // Found a zero character
-              auto byte_pos_zero = std::__countr_zero(zero_mask); // count trailing zeros to find the first zero character
+              auto byte_pos_zero = std::countr_zero(zero_mask); // count trailing zeros to find the first zero character
               auto char_pos_zero = byte_pos_zero / 2;           // each UTF-16 character is 2 bytes, so divide by 2 to get character position
               return processed_chars + char_pos_zero;
           }

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -101,7 +101,7 @@ namespace OpenMS::Internal
         // for single digit days, there are two spaces and the day is in the 4th string instead of the 3rd
         // that also moves the time and year one slot further
         UInt correction = 0;
-        String day_string = xquest_datetime_string_split[2];
+        const String& day_string = xquest_datetime_string_split[2];
         if (day_string.empty())
         {
           correction = 1;
@@ -136,7 +136,7 @@ namespace OpenMS::Internal
            prot_list_it != prot_list.end(); ++prot_list_it)
       {
         PeptideEvidence pep_ev;
-        String accession = *prot_list_it;
+        const String& accession = *prot_list_it;
 
         if (this->accessions_.find(accession) == this->accessions_.end())
         {

--- a/src/openms/source/FORMAT/IBSpectraFile.cpp
+++ b/src/openms/source/FORMAT/IBSpectraFile.cpp
@@ -258,7 +258,7 @@ namespace OpenMS
 
         // extract channel intensities and positions
         std::map<Int, double> intensityMap;
-        ConsensusFeature::HandleSetType features = cFeature.getFeatures();
+        const ConsensusFeature::HandleSetType& features = cFeature.getFeatures();
 
         for (ConsensusFeature::HandleSetType::const_iterator fIt = features.begin();
              fIt != features.end();

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -1201,7 +1201,7 @@ namespace OpenMS
     protein_identification.setSearchEngineVersion("unknown");
     // searching for something like this: InsPecT version 20060907, InsPecT version 20100331
     std::smatch match;
-    std::string response(cmd_output);
+    const std::string& response(cmd_output);
     static const std::regex rx("InsPecT (version|vesrion) (\\d+)"); // older versions of InsPecT have typo...
     if (!std::regex_search(response, match, rx))
     {

--- a/src/openms/source/FORMAT/KroenikFile.cpp
+++ b/src/openms/source/FORMAT/KroenikFile.cpp
@@ -38,7 +38,7 @@ namespace OpenMS
     // process content
     for (; it != input.end(); ++it)
     {
-      String line = *it;
+      const String& line = *it;
 
       //split lines: File,  First Scan,  Last Scan,  Num of Scans,  Charge,  Monoisotopic Mass,  Base Isotope Peak,  Best Intensity,  Summed Intensity,  First RTime,  Last RTime,  Best RTime,  Best Correlation,  Modifications
       std::vector<String> parts;

--- a/src/openms/source/FORMAT/MSExperimentArrowExport.cpp
+++ b/src/openms/source/FORMAT/MSExperimentArrowExport.cpp
@@ -1055,7 +1055,7 @@ bool MSExperimentArrowExport::exportSpectraToArrowCDataInterface(
                      << batch_result.status().ToString() << std::endl;
     return false;
   }
-  auto batch = batch_result.ValueOrDie();
+  const auto& batch = batch_result.ValueOrDie();
 
   // Export schema
   auto schema_status = arrow::ExportSchema(*batch->schema(), out_schema);
@@ -1106,7 +1106,7 @@ bool MSExperimentArrowExport::exportChromatogramsToArrowCDataInterface(
                      << batch_result.status().ToString() << std::endl;
     return false;
   }
-  auto batch = batch_result.ValueOrDie();
+  const auto& batch = batch_result.ValueOrDie();
 
   // Export schema
   auto schema_status = arrow::ExportSchema(*batch->schema(), out_schema);
@@ -1173,7 +1173,7 @@ bool writeTableToParquet(
                      << filename << " - " << file_result.status().ToString() << std::endl;
     return false;
   }
-  auto outfile = file_result.ValueOrDie();
+  const auto& outfile = file_result.ValueOrDie();
 
   // Configure Parquet writer properties
   auto builder = parquet::WriterProperties::Builder();

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -961,7 +961,7 @@ namespace OpenMS
       row.search_engine_score_ms_run[1][ms_run] = MzTabDouble();
     }
 
-    ConsensusFeature::HandleSetType fs = c.getFeatures();
+    const ConsensusFeature::HandleSetType& fs = c.getFeatures();
     for (auto fit = fs.begin(); fit != fs.end(); ++fit)
     {
       UInt study_variable{1};

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -672,25 +672,25 @@ namespace OpenMS
       else if (meta_key.hasPrefix("colunit") && meta_key_fields[1] == "protein")
       {
         Int n = meta_key_fields[0].substitute("colunit[", "").substitute("]","").trim().toInt();
-        String s = cells[2];
+        const String& s = cells[2];
         mz_tab_metadata.colunit_protein[n] = s;
       }
       else if (meta_key.hasPrefix("colunit") && meta_key_fields[1] == "peptide")
       {
         Int n = meta_key_fields[0].substitute("colunit[", "").substitute("]","").trim().toInt();
-        String s = cells[2];
+        const String& s = cells[2];
         mz_tab_metadata.colunit_peptide[n] = s;
       }
       else if (meta_key.hasPrefix("colunit") && meta_key_fields[1] == "psm")
       {
         Int n = meta_key_fields[0].substitute("colunit[", "").substitute("]","").trim().toInt();
-        String s = cells[2];
+        const String& s = cells[2];
         mz_tab_metadata.colunit_psm[n] = s;
       }
       else if (meta_key.hasPrefix("colunit") && meta_key_fields[1] == "small_molecule")
       {
         Int n = meta_key_fields[0].substitute("colunit[", "").substitute("]","").trim().toInt();
-        String s = cells[2];
+        const String& s = cells[2];
         mz_tab_metadata.colunit_small_molecule[n] = s;
       }
     }

--- a/src/openms/source/FORMAT/MzTabM.cpp
+++ b/src/openms/source/FORMAT/MzTabM.cpp
@@ -532,7 +532,7 @@ namespace OpenMS
     int evidence_section_entry_counter = 1;
     for (auto& f : feature_map) // iterate over features and fill all sections
     {
-      auto match_refs = f.getIDMatches();
+      const auto& match_refs = f.getIDMatches();
       if (match_refs.empty()) // features without identification
       {
         MzTabMSmallMoleculeFeatureSectionRow smf;

--- a/src/openms/source/FORMAT/PEFFFile.cpp
+++ b/src/openms/source/FORMAT/PEFFFile.cpp
@@ -1451,7 +1451,7 @@ namespace OpenMS
     // If no headers found, create a default one
     if (headers_.empty())
     {
-      headers_.push_back(PEFFDatabaseMetadata());
+      headers_.emplace_back();
     }
 
     // Validate required header keys (spec section 3.3.1)

--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -71,7 +71,7 @@ namespace OpenMS
     tdl_tool_info.metaInfo.docurl = tool_info.docurl_;
     tdl_tool_info.metaInfo.category = tool_info.category_;
     tdl_tool_info.metaInfo.description = tool_info.description_;
-    for (auto cite : tool_info.citations_)
+    for (const auto& cite : tool_info.citations_)
     {
       tdl::Citation tdl_citation;
       tdl_citation.doi = cite;

--- a/src/openms/source/FORMAT/ParquetFile.cpp
+++ b/src/openms/source/FORMAT/ParquetFile.cpp
@@ -58,7 +58,7 @@ namespace OpenMS
     {
       throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
-    auto outfile = outfile_result.ValueOrDie();
+    const auto& outfile = outfile_result.ValueOrDie();
     // Use a larger default row_group_size than 1024 to improve compression and reduce metadata overhead.
     // Default is configurable by callers via the row_group_size parameter.
     auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, static_cast<int>(row_group_size));
@@ -77,7 +77,7 @@ namespace OpenMS
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                     "Failed to open parquet file", filename);
     }
-    std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+    const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
     auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
     if (!reader_result.ok())

--- a/src/openms/source/FORMAT/ParquetFilter.cpp
+++ b/src/openms/source/FORMAT/ParquetFilter.cpp
@@ -65,7 +65,7 @@ namespace OpenMS
     str_values.reserve(values.size());
     for (const auto& v : values)
     {
-      str_values.emplace_back(String(v));
+      str_values.emplace_back(v);
     }
     return addCondition_(column, "IN", ColumnType::INT, str_values);
   }

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -551,7 +551,7 @@ namespace OpenMS
       }
       for (const PeptideHit& hit : pep.getHits())
       {
-        PeptideHit h = hit;
+        const PeptideHit& h = hit;
         const AASequence& seq = h.getSequence();
         double precursor_neutral_mass = seq.getMonoWeight();
 
@@ -632,7 +632,7 @@ namespace OpenMS
         f << ">\n";
         f << "\t<search_result>" << "\n";
 
-        vector<PeptideEvidence> pes = h.getPeptideEvidences();
+        const vector<PeptideEvidence>& pes = h.getPeptideEvidences();
 
         // select first one if multiple are present as "leader"
         PeptideEvidence pe;

--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -130,7 +130,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: Failed to open file: " << filename << std::endl;
       return false;
     }
-    auto outfile = *result;
+    const auto& outfile = *result;
 
     // Configure Parquet writer
     auto builder = parquet::WriterProperties::Builder();
@@ -196,7 +196,7 @@ namespace // anonymous
       OPENMS_LOG_ERROR << "ProteinIdentificationArrowIO: Failed to open file: " << filename << std::endl;
       return nullptr;
     }
-    auto infile = *infile_result;
+    const auto& infile = *infile_result;
 
     auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
     if (!reader_result.ok())

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -258,7 +258,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         if (seq.hasNTerminalModification())
         {
           const auto* mod = seq.getNTerminalModification();
-          std::string name = seq.getNTerminalModificationName();
+          const std::string& name = seq.getNTerminalModificationName();
           std::string acc_str;
           if (mod && mod->getUniModRecordId() > 0)
           {
@@ -275,7 +275,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
           if (residue.isModified())
           {
             const auto* mod = residue.getModification();
-            std::string name = residue.getModificationName();
+            const std::string& name = residue.getModificationName();
             std::string acc_str;
             if (mod && mod->getUniModRecordId() > 0)
             {
@@ -294,7 +294,7 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
         if (seq.hasCTerminalModification())
         {
           const auto* mod = seq.getCTerminalModification();
-          std::string name = seq.getCTerminalModificationName();
+          const std::string& name = seq.getCTerminalModificationName();
           std::string acc_str;
           if (mod && mod->getUniModRecordId() > 0)
           {
@@ -741,7 +741,7 @@ bool QPXFile::exportToParquet(
     OPENMS_LOG_ERROR << "QPXFile: Failed to open file: " << filename << std::endl;
     return false;
   }
-  auto outfile = *result;
+  const auto& outfile = *result;
 
   // Configure Parquet writer
   auto builder = parquet::WriterProperties::Builder();

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -1262,7 +1262,7 @@ namespace OpenMS
       at.colTypes.emplace_back("MS:1000894_[sec]");
       at.colTypes.emplace_back("MS:1000285");
       Size below_10k = 0;
-      std::vector<OpenMS::Chromatogram> chroms = exp.getChromatograms();
+      const std::vector<OpenMS::Chromatogram>& chroms = exp.getChromatograms();
       if (!chroms.empty()) //real TIC from the mzML
       {
         for (Size t = 0; t < chroms.size(); ++t)
@@ -1686,7 +1686,7 @@ namespace OpenMS
             }
             for (const Residue& z : tmp.getSequence())
             {
-              Residue res = z;
+              const Residue& res = z;
               String temp;
               if (res.isModified() && res.getModificationName() != "Carbamidomethyl")
               {
@@ -1947,7 +1947,7 @@ namespace OpenMS
           for (ConsensusFeature::const_iterator cfit = CF.begin(); cfit != CF.end(); ++cfit)
           {
             std::vector<String> row;
-            FeatureHandle FH = *cfit;
+            const FeatureHandle& FH = *cfit;
             row.emplace_back(CF.getMetaValue("spectrum_native_id"));
             row.emplace_back(CF.getRT()); row.emplace_back(CF.getMZ());
             row.emplace_back(CF.getIntensity());

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -329,7 +329,7 @@ namespace OpenMS
             throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
               "Found SWATH scan (MS level 2 scan) without a precursor. Cannot determine SWATH window.");
           }
-          const std::vector<Precursor> prec = s.getPrecursors();
+          const std::vector<Precursor>& prec = s.getPrecursors();
 
           // set ion mobility if exists, otherwise will take default value of -1
           double imLower, imUpper;

--- a/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
@@ -73,7 +73,7 @@ namespace OpenMS::Internal
         {
           if (!parsed_term.has_unit_accession)
           {
-            errors_.push_back(String("CV term must have a unit: " + parsed_term.accession + " - " + parsed_term.name));
+            errors_.emplace_back("CV term must have a unit: " + parsed_term.accession + " - " + parsed_term.name);
           }
           else
           {
@@ -101,13 +101,13 @@ namespace OpenMS::Internal
 
                 if (!found_unit)
                 {
-                  errors_.push_back(String("Unit CV term not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+                  errors_.emplace_back("Unit CV term not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
                 }
               }
             }
             else
             {
-              errors_.push_back(String("Unit CV term not found: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+              errors_.emplace_back("Unit CV term not found: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
             }
           }
         }
@@ -116,7 +116,7 @@ namespace OpenMS::Internal
           // check whether unit was used
           if (parsed_term.has_unit_accession || parsed_term.has_unit_name)
           {
-            warnings_.push_back(String("Unit CV term used, but not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+            warnings_.emplace_back("Unit CV term used, but not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
           }
         }
       }

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -316,7 +316,7 @@ namespace OpenMS::Internal
         {
           if (!parsed_term.has_unit_accession)
           {
-            errors_.push_back(String("CV term must have a unit: " + parsed_term.accession + " - " + parsed_term.name));
+            errors_.emplace_back("CV term must have a unit: " + parsed_term.accession + " - " + parsed_term.name);
           }
           else
           {
@@ -346,13 +346,13 @@ namespace OpenMS::Internal
 
                 if (!found_unit)
                 {
-                  errors_.push_back(String("Unit CV term not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+                  errors_.emplace_back("Unit CV term not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
                 }
               }
             }
             else
             {
-              errors_.push_back(String("Unit CV term not found: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+              errors_.emplace_back("Unit CV term not found: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
             }
           }
         }
@@ -361,7 +361,7 @@ namespace OpenMS::Internal
           // check whether unit was used
           if (parsed_term.has_unit_accession || parsed_term.has_unit_name)
           {
-            warnings_.push_back(String("Unit CV term used, but not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name));
+            warnings_.emplace_back("Unit CV term used, but not allowed: " + parsed_term.unit_accession + " - " + parsed_term.unit_name + " of term " + parsed_term.accession + " - " + parsed_term.name);
           }
         }
       }

--- a/src/openms/source/FORMAT/XICParquetFile.cpp
+++ b/src/openms/source/FORMAT/XICParquetFile.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -84,7 +84,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -136,7 +136,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -463,7 +463,7 @@ namespace OpenMS
             tokens.push_back(current);
             current.clear();
           }
-          tokens.emplace_back(String(c));
+          tokens.emplace_back(c);
           continue;
         }
 
@@ -1136,7 +1136,7 @@ namespace OpenMS
       paths.reserve(filenames.size());
       for (const auto& filename : filenames)
       {
-        paths.emplace_back(std::string(filename));
+        paths.emplace_back(filename);
       }
       auto factory_result = arrow::dataset::FileSystemDatasetFactory::Make(
         filesystem, paths, format, options);
@@ -1234,7 +1234,7 @@ namespace OpenMS
                         << bound_result.status().ToString() << '\n';
         return applyManualFilter_(table, pruned, filter_context);
       }
-      arrow::compute::Expression bound_expr = *bound_result;
+      const arrow::compute::Expression& bound_expr = *bound_result;
 
       arrow::TableBatchReader reader(*table);
       std::vector<std::shared_ptr<arrow::RecordBatch>> batches;

--- a/src/openms/source/FORMAT/XIMParquetFile.cpp
+++ b/src/openms/source/FORMAT/XIMParquetFile.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -86,7 +86,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -138,7 +138,7 @@ namespace OpenMS
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                       "Failed to open parquet file", filename);
       }
-      std::shared_ptr<arrow::io::ReadableFile> infile = *infile_result;
+      const std::shared_ptr<arrow::io::ReadableFile>& infile = *infile_result;
 
       auto reader_result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
       if (!reader_result.ok())
@@ -529,7 +529,7 @@ namespace OpenMS
             tokens.push_back(current);
             current.clear();
           }
-          tokens.emplace_back(String(c));
+          tokens.emplace_back(c);
           continue;
         }
 
@@ -1224,7 +1224,7 @@ namespace OpenMS
       paths.reserve(filenames.size());
       for (const auto& filename : filenames)
       {
-        paths.emplace_back(std::string(filename));
+        paths.emplace_back(filename);
       }
       auto factory_result = arrow::dataset::FileSystemDatasetFactory::Make(
         filesystem, paths, format, options);
@@ -1324,7 +1324,7 @@ namespace OpenMS
                         << bound_result.status().ToString() << '\n';
         return applyManualFilter_(table, pruned, filter_context);
       }
-      arrow::compute::Expression bound_expr = *bound_result;
+      const arrow::compute::Expression& bound_expr = *bound_result;
 
       arrow::TableBatchReader reader(*table);
       std::vector<std::shared_ptr<arrow::RecordBatch>> batches;

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -63,9 +63,11 @@ namespace OpenMS
 
   void ConsensusFeature::insert(FeatureHandle&& handle)
   {
+    auto map_index = handle.getMapIndex();
+    auto unique_id = handle.getUniqueId();
     if (!(handles_.insert(std::move(handle)).second))
     {
-      String key = String("map") + handle.getMapIndex() + "/feature" + handle.getUniqueId();
+      String key = String("map") + map_index + "/feature" + unique_id;
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The set already contained an element with this key.", key);
     }
   }

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -158,8 +158,8 @@ namespace OpenMS
       {
         t = (float)it.getRT();
         rt.push_back(t);
-        mz.push_back(std::vector<float>());
-        intensity.push_back(std::vector<float>());
+        mz.emplace_back();
+        intensity.emplace_back();
       }
       mz.back().push_back((float)it->getMZ());
       intensity.back().push_back(it->getIntensity());
@@ -187,9 +187,9 @@ namespace OpenMS
         t = (float)it.getRT();
         rt.push_back(t);
         std::tie(unit, im) = it.getSpectrum().maybeGetIMData();
-        mz.push_back(std::vector<float>());
-        intensity.push_back(std::vector<float>());
-        ion_mobility.push_back(std::vector<float>());
+        mz.emplace_back();
+        intensity.emplace_back();
+        ion_mobility.emplace_back();
       }
 
       if (unit != DriftTimeUnit::NONE)
@@ -1322,7 +1322,7 @@ namespace OpenMS
 
   MSExperiment::SpectrumType* MSExperiment::createSpec_(PeakType::CoordinateType rt)
   {
-    spectra_.emplace_back(SpectrumType());
+    spectra_.emplace_back();
     SpectrumType* spectrum = &(spectra_.back());
     spectrum->setRT(rt);
     spectrum->setMSLevel(1);
@@ -1343,7 +1343,7 @@ namespace OpenMS
     spectrum->getFloatDataArrays().reserve(metadata_names.size());
     for (StringList::const_iterator itm = metadata_names.begin(); itm != metadata_names.end(); ++itm)
     {
-      spectrum->getFloatDataArrays().push_back(MSSpectrum::FloatDataArray());
+      spectrum->getFloatDataArrays().emplace_back();
       spectrum->getFloatDataArrays().back().setName(*itm);
     }
     return spectrum;

--- a/src/openms/source/MATH/STATISTICS/KernelDensityEstimation.cpp
+++ b/src/openms/source/MATH/STATISTICS/KernelDensityEstimation.cpp
@@ -240,7 +240,7 @@ namespace OpenMS
 
       // M = 2^ceil(log2(max(gridsize, n, 512)))
       std::size_t target = std::max<std::size_t>(gridsize, std::max<std::size_t>(n, 512));
-      std::size_t M = std::__bit_ceil(target);
+      std::size_t M = std::bit_ceil(target);
 
       // compute a,b
       double a = 0.0, b = 0.0;

--- a/src/openms/source/MATH/STATISTICS/KernelDensityEstimation.cpp
+++ b/src/openms/source/MATH/STATISTICS/KernelDensityEstimation.cpp
@@ -240,7 +240,7 @@ namespace OpenMS
 
       // M = 2^ceil(log2(max(gridsize, n, 512)))
       std::size_t target = std::max<std::size_t>(gridsize, std::max<std::size_t>(n, 512));
-      std::size_t M = std::bit_ceil(target);
+      std::size_t M = std::__bit_ceil(target);
 
       // compute a,b
       double a = 0.0, b = 0.0;

--- a/src/openms/source/ML/ROCCURVE/ROCCurve.cpp
+++ b/src/openms/source/ML/ROCCURVE/ROCCurve.cpp
@@ -51,7 +51,7 @@ namespace OpenMS::Math
 
     void ROCCurve::insertPair(double score, bool clas)
     {
-      score_clas_pairs_.emplace_back(std::make_pair(score, clas));
+      score_clas_pairs_.emplace_back(score, clas);
       if (clas)
       {
         ++pos_;
@@ -121,7 +121,7 @@ namespace OpenMS::Math
       {
         if (fabs(cit->first - prevsim) > 1e-8)
         {
-          polygon.emplace_back(DPosition<2>((double)falsePos / neg_, (double)truePos / pos_));
+          polygon.emplace_back((double)falsePos / neg_, (double)truePos / pos_);
         }
         if (cit->second)
         {
@@ -132,7 +132,7 @@ namespace OpenMS::Math
           ++falsePos;
         }
       }
-      polygon.emplace_back(DPosition<2>(1, 1));
+      polygon.emplace_back(1, 1);
       std::sort(polygon.begin(), polygon.end());
       DPosition<2> last(0, 0);
       double area(0);
@@ -163,7 +163,7 @@ namespace OpenMS::Math
         pair.second ? ++truePos : ++falsePos;
         if (((double)++position / score_clas_pairs_.size()) * resolution > result.size())
         {
-          result.emplace_back(std::make_pair((double)falsePos / neg_, (double)truePos / pos_));
+          result.emplace_back((double)falsePos / neg_, (double)truePos / pos_);
         }
       }
       return result;

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASIOMappingDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASIOMappingDialog.cpp
@@ -124,7 +124,7 @@ namespace OpenMS
         ui_->source_type_label->setVisible(false);
       }
       ui_->source_combo->addItem("<select>");
-      for (TOPPASToolVertex::IOInfo info : source_output_files)
+      for (const TOPPASToolVertex::IOInfo& info : source_output_files)
       {
         if (info.type == TOPPASToolVertex::IOInfo::IOT_DIR) continue;
         String item_name;
@@ -177,7 +177,7 @@ namespace OpenMS
         ui_->target_type_label->setVisible(false);
       }
       ui_->target_combo->addItem("<select>");
-      for (TOPPASToolVertex::IOInfo info : target_input_files)
+      for (const TOPPASToolVertex::IOInfo& info : target_input_files)
       {
         // check if parameter occupied by another edge already
         bool occupied = false;


### PR DESCRIPTION
## Summary
- Apply clang-tidy auto-fixes for `modernize-use-emplace` (~415), `performance-unnecessary-copy-initialization` (~95), and `performance-for-range-copy` (~9) across 122 `.cpp` files
- Manually fix a real `bugprone-use-after-move` bug in `ConsensusFeature::insert(FeatureHandle&&)` where `handle` was read after `std::move` on the error path
- Header auto-fixes were reverted because clang-tidy broke template/concept syntax in `ExposedVector.h`, `IDFilter.h`, and `AhoCorasickAmbiguous.h`

## Test plan
- [x] Full build succeeds
- [x] Full test suite passes (same 2 pre-existing failures: `LPWrapper_test` missing COIN, `MRMFeatureSelector_test` vector bounds assert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data handling throughout the codebase by replacing copy-based operations with reference-based bindings and in-place object construction patterns. Changes affect how containers are populated and objects are passed between functions without altering functional behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->