### PR TITLE
fix(ci): use xcrun to resolve Apple Clang path on macOS

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -151,7 +151,7 @@ jobs:
           if [[ "${{ matrix.compiler }}" == "xcode" ]]; then
             ls -la /Applications/Xcode*
             sudo xcode-select -s '/Applications/Xcode_${{ matrix.compiler_ver }}.app/Contents/Developer'
-            echo "cxx_compiler=clang++" >> $GITHUB_OUTPUT
+            echo "cxx_compiler=$(xcrun -f clang++)" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.compiler }}" == "clang++" ]]; then
             echo "cxx_compiler=$(brew --prefix llvm@${{ matrix.compiler_ver }})/bin/clang++" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

- Fix macOS CI build failure caused by Homebrew's `apache-arrow` pulling in LLVM 22.1.1, which shadows Apple Clang via `/opt/homebrew/bin/clang++`
- Use `xcrun -f clang++` instead of bare `clang++` to resolve the Xcode-selected Apple Clang, immune to Homebrew PATH changes

Fixes #8952

## Test plan

- [ ] macOS-14 CI job passes (the `cmath` errors from LLVM 22 / Xcode SDK mismatch should be gone)
- [ ] Other matrix entries (Ubuntu, Windows) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration in CI/CD pipeline to improve compiler resolution accuracy on the runner environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->