### PR TITLE
fix(ci): resolve Apple Clang via xcrun to avoid Homebrew LLVM shadowing

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -151,7 +151,7 @@ jobs:
           if [[ "${{ matrix.compiler }}" == "xcode" ]]; then
             ls -la /Applications/Xcode*
             sudo xcode-select -s '/Applications/Xcode_${{ matrix.compiler_ver }}.app/Contents/Developer'
-            echo "cxx_compiler=clang++" >> $GITHUB_OUTPUT
+            echo "cxx_compiler=$(xcrun -f clang++)" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.compiler }}" == "clang++" ]]; then
             echo "cxx_compiler=$(brew --prefix llvm@${{ matrix.compiler_ver }})/bin/clang++" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

- Homebrew's `apache-arrow` now pulls in LLVM 22.1.1, placing `/opt/homebrew/bin/clang++` on PATH before `/usr/bin/clang++`
- The bare `clang++` in the CI workflow resolved to LLVM 22 whose libc++ headers are incompatible with the Xcode 15.4 SDK, breaking all macOS builds
- Use `xcrun -f clang++` which respects the `xcode-select` setting to always resolve Apple Clang

Fixes #8952

## Test plan

- [ ] macOS-14 CI job passes (the `cmath`/`nullptr_t`/`signbit` errors should be gone)
- [ ] Other matrix entries (Ubuntu, Windows) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)