### PR TITLE
fix: remove /Od /Ob0 override for Windows CI Release builds

### DIFF
--- a/tools/ci/cibuild.cmake
+++ b/tools/ci/cibuild.cmake
@@ -42,9 +42,6 @@ message(STATUS "CTEST_SOURCE_DIRECTORY: ${CTEST_SOURCE_DIRECTORY}")
 message(STATUS "CTEST_BINARY_DIRECTORY: ${CTEST_BINARY_DIRECTORY}")
 
 set(OWN_OPTIONS "")
-if($ENV{CMAKE_GENERATOR} MATCHES ".*Visual Studio.*")
-  set(OWN_OPTIONS "-DCMAKE_CXX_RELEASE_FLAGS='/MD /Od /Ob0 /DNDEBUG /EHsc'")
-endif()
 
 # run the classical CTest suite
 ctest_start(Continuous) # TODO think about adding GROUP GitHub-Actions to separate visually


### PR DESCRIPTION
## Summary

Fixes #8932.

- Removes the `/Od /Ob0` override in `tools/ci/cibuild.cmake` that disabled all optimizations and inlining for Windows CI Release builds
- Windows CI will now use CMake's default Release flags (`/MD /O2 /Ob2 /DNDEBUG`)

## Context

The override was added in March 2021 (`2cdd0c5a`) by @jpfeuffer as a workaround for Windows CI builds being too slow to compile with optimizations on GitHub Actions runners — **not** because of nanobind (which wasn't part of the project until years later). The commit message was simply "disable optimization" and the surrounding commits show a sequence of attempts to get Windows CI build times under control.

Since 2021, GitHub Actions runners have gotten faster and the codebase/build system has evolved significantly, so this workaround is likely no longer needed. This PR tests whether Windows CI completes in time with default optimization flags.

## Test plan

- [ ] Windows CI build completes within the job timeout with `/O2 /Ob2`
- [ ] No new build errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI build configuration by removing platform-specific compiler flag overrides, standardizing build settings across all generator environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->