### PR TITLE
Improve docs version dropdown: show 'latest' as pinned entry

### DIFF
--- a/doc/doxygen/common/selectversion.js
+++ b/doc/doxygen/common/selectversion.js
@@ -54,13 +54,14 @@ function parseDirectoryListing(stringOfHtml) {
 
     docs = foo.sort().reverse()
 
+    let latestEntry = null;
     docs = docs.filter(function (line) {
-        // suppress link to current version
+        if (line === "latest") {
+            latestEntry = line;
+            return false;
+        }
         return (line != thisvers) &&
             (line != "Parent Directory") &&
-            // TODO decide how to display latest version
-            (line != "latest") &&
-            // suppress hidden dirs
             !/^[.]/.test(line);
     });
 
@@ -69,6 +70,15 @@ function parseDirectoryListing(stringOfHtml) {
         + '/release/' + x + '/html/' + patharr[patharr.length - 1] + '">'
         + x
         + '</a>');
+        
+    // Add latest as a pinned entry
+    if (latestEntry) {
+        docs.unshift('<a class="verslink latest" href="'
+            + urlrootdir
+            + '/release/latest/html/' + patharr[patharr.length - 1] + '">'
+            + 'latest (stable)'
+            + '</a>');
+}
         
     // This assumes that a nightly documentation folder is always present.
     // A specific class does not necessarily need to be present there,


### PR DESCRIPTION
Description

This PR improves the documentation version dropdown by handling the latest entry more explicitly.

Previously, the latest version was filtered out and not shown in the dropdown. This change:

Captures the latest entry instead of discarding it
Displays it as a pinned entry at the top of the dropdown
Labels it clearly as "latest (stable)" for better user understanding
Keeps existing behavior intact for version sorting and nightly builds

This is a small UI/UX improvement that makes it easier for users to quickly access the most recent stable documentation.

Checklist
Add relevant changes and new features to the CHANGELOG file (not required – UI-only change)
I have commented my code, particularly in hard-to-understand areas
New and existing unit tests pass locally with my changes (not applicable – JS UI change)
Updated or added python bindings for changed or new classes (not applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version selector now displays a dedicated "latest (stable)" option, providing quick access to the most recent stable documentation release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->