### PR TITLE
Remove remaining GenericWrapper leftovers (#8981 review)

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/ToolDescription.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ToolDescription.h
@@ -125,9 +125,6 @@ namespace OpenMS
       /// Copy assignment
       ToolDescription& operator=(const ToolDescription& rhs) = default;
 
-      void addExternalType(const String& type, const ToolExternalDetails& details);
-
-      void append(const ToolDescription& other);
     };
   } // namespace Internal
 } // namespace OPENMS

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2453,15 +2453,6 @@ namespace OpenMS
     // .. they are empty/default at this point
     // We now fetch the (so-far unknown) subsection parameters (since they can be addressed on command line as well)
 
-    // extract '-type' from command line args upfront, since subsection defaults may depend on it
-    StringList sl_args = StringList(argv, argv + argc);
-    StringList::iterator it_type = std::find(sl_args.begin(), sl_args.end(), "-type");
-    if (it_type != sl_args.end())
-    { // found it
-      ++it_type; // advance to next argument -- this should be the value of -type
-      if (it_type != sl_args.end()) param_.setValue("type", *it_type);
-    }
-
     // prepare map of parameters:
     typedef map<String, vector<ParameterInformation>::const_iterator> ParamMap;
     ParamMap param_map;

--- a/src/openms/source/DATASTRUCTURES/ToolDescription.cpp
+++ b/src/openms/source/DATASTRUCTURES/ToolDescription.cpp
@@ -6,7 +6,6 @@
 // $Authors: Chris Bielow, Mathias Walzer $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/ToolDescription.h>
 
 using namespace std;
@@ -58,42 +57,6 @@ namespace OpenMS
     {
     }
 
-    void ToolDescription::addExternalType(const String& type, const ToolExternalDetails& details)
-    {
-      types.push_back(type);
-      external_details.push_back(details);
-    }
-
-    void ToolDescription::append(const ToolDescription& other)
-    {
-      // sanity check
-      if (is_internal != other.is_internal
-         || name != other.name
-          //|| category != other.category
-         || (is_internal && !external_details.empty())
-         || (other.is_internal && !other.external_details.empty())
-         || (!is_internal && external_details.size() != types.size())
-         || (!other.is_internal && other.external_details.size() != other.types.size())
-          )
-      {
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Extending (external) ToolDescription failed!", "");
-      }
-
-      // append types and external information
-      types.insert(types.end(), other.types.begin(), other.types.end());
-      external_details.insert(external_details.end(), other.external_details.begin(), other.external_details.end());
-
-      // check that types are unique
-      std::set<String> unique_check;
-      unique_check.insert(types.begin(), types.end());
-      if (unique_check.size() != types.size())
-      {
-        OPENMS_LOG_ERROR << "A type appears at least twice for the TOPP tool '" << name << "'. Types given are '" << ListUtils::concatenate(types, ", ") << "'\n";
-        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "see above!", "");
-      }
-    }
   }
-
-  Internal::ToolDescription bla;
 
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/source/ToolDescription_test.cpp
+++ b/src/tests/class_tests/openms/source/ToolDescription_test.cpp
@@ -41,18 +41,6 @@ START_SECTION((ToolDescription(const String &p_name, const String &p_category, c
 }
 END_SECTION
 
-START_SECTION((void addExternalType(const String &type, const ToolExternalDetails &details)))
-{
-  // TODO
-}
-END_SECTION
-
-START_SECTION((void append(const ToolDescription &other)))
-{
-  // TODO
-}
-END_SECTION
-
 START_SECTION((ToolDescription& operator=(const ToolDescription &rhs)))
 {
   // TODO

--- a/src/tests/class_tests/openms/source/ToolHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/ToolHandler_test.cpp
@@ -40,7 +40,6 @@ START_SECTION((static ToolListType getTOPPToolList()))
 {
   ToolListType list = ToolHandler::getTOPPToolList();
   TEST_TRUE(list.find("DecoyDatabase") != list.end())
-  TEST_FALSE(list.find("GenericWrapper") != list.end())
   TEST_TRUE(list.size() > 30)  // assume we have over 30 tools in there
 #ifdef WITH_GUI
   TEST_TRUE(list.find("ImageCreator") != list.end())


### PR DESCRIPTION
## Summary
- Addresses review feedback from cbielow on #8981
- Removes early `-type` extraction in `TOPPBase::parseCommandLine_` (only needed for GenericWrapper subsection defaults)
- Removes `ToolDescription::addExternalType()` and `append()` methods, stray `bla` variable, and unused `LogStream` include
- Removes stale GenericWrapper assertion in `ToolHandler_test` and dead test stubs in `ToolDescription_test`

## Test plan
- [x] OpenMS library builds successfully
- [x] `ToolHandler_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal tool description handling by removing unused methods.
  * Streamlined command-line argument processing flow.
  * Removed obsolete test cases corresponding to deleted functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->