### PR TITLE
fix Windows non-Arrow build

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.cpp
@@ -312,8 +312,13 @@ namespace OpenMS
                                         bool enable_uis_scoring) const
   {
 #ifndef WITH_PARQUET
-    throw Exception::MissingFeature(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                    "OpenMS was built without Parquet support");
+    (void)output_path;
+    (void)assay_library;
+    (void)feature_map;
+    (void)run_id;
+    (void)input_filename;
+    (void)enable_uis_scoring;
+    throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
 #else
     const UInt64 run_id_clean = Internal::SqliteHelper::clearSignBit(run_id);
     const bool output_is_dir = File::isDirectory(output_path);

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -355,6 +355,8 @@ namespace OpenMS
       {
 #ifndef WITH_PARQUET
         (void)source_file;
+        (void)transition_exp;
+        (void)run_id;
         throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
 #else
         mobilogramConsumer = std::make_unique<MobilogramParquetConsumer>(out_mobilogram, run_id, source_file, transition_exp);


### PR DESCRIPTION
avoid unused symbol error; and halucinated `MissingFeature`. Thanks Claude!

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and internal code quality for OpenSWATH components to reduce compiler warnings and enhance code stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->