### PR TITLE
fix: link Boost::filesystem for static Arrow in Docker build

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -23,7 +23,7 @@ find_package(XercesC REQUIRED)
 
 #------------------------------------------------------------------------------
 # BOOST
-set(OpenMS_BOOST_COMPONENTS date_time regex CACHE INTERNAL "Boost components for core lib")
+set(OpenMS_BOOST_COMPONENTS date_time filesystem regex CACHE INTERNAL "Boost components for core lib")
 find_boost(iostreams ${OpenMS_BOOST_COMPONENTS})
 
 if(Boost_FOUND)
@@ -210,15 +210,6 @@ elseif(TARGET Arrow::arrow_shared)
   set(OPENMS_ARROW_TARGET Arrow::arrow_shared)
 else()
   message(FATAL_ERROR "No suitable Arrow target found")
-endif()
-
-# Static Arrow may depend on Boost::filesystem without propagating it.
-# Find and expose the component so OpenMS can link it.
-if(OPENMS_ARROW_TARGET MATCHES "static")
-  find_package(Boost QUIET COMPONENTS filesystem)
-  if(TARGET Boost::filesystem)
-    message(STATUS "Found Boost::filesystem (needed by static Arrow)")
-  endif()
 endif()
 
 # Determine Arrow Compute target (may be bundled into Arrow::arrow_* on some distros).

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -212,6 +212,15 @@ else()
   message(FATAL_ERROR "No suitable Arrow target found")
 endif()
 
+# Static Arrow may depend on Boost::filesystem without propagating it.
+# Find and expose the component so OpenMS can link it.
+if(OPENMS_ARROW_TARGET MATCHES "static")
+  find_package(Boost QUIET COMPONENTS filesystem)
+  if(TARGET Boost::filesystem)
+    message(STATUS "Found Boost::filesystem (needed by static Arrow)")
+  endif()
+endif()
+
 # Determine Arrow Compute target (may be bundled into Arrow::arrow_* on some distros).
 # We need compute kernels (e.g., "equal") for filter expression binding.
 if(ARROW_USE_STATIC AND TARGET Arrow::arrow_compute_static)

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
     coinor-libcoinmp-dev \
     libeigen3-dev \
     libboost-date-time1.74-dev \
+    libboost-filesystem1.74-dev \
     libboost-iostreams1.74-dev \
     libboost-regex1.74-dev \
     libboost-math1.74-dev \
@@ -173,6 +174,7 @@ RUN apt-get update \
     libxerces-c3.2 \
     coinor-libcoinmp1v5 \
     libboost-date-time1.74-dev  \
+    libboost-filesystem1.74-dev \
     libboost-iostreams1.74-dev \
     libboost-regex1.74-dev \
     libboost-math1.74-dev \

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -90,6 +90,10 @@ list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES
      ${OPENMS_ARROW_TARGET}
      ${OPENMS_ARROW_COMPUTE_TARGET}
      ${OPENMS_PARQUET_TARGET})
+# Static Arrow may need Boost::filesystem (not propagated by Arrow's CMake config)
+if(TARGET Boost::filesystem)
+  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES Boost::filesystem)
+endif()
 if (OPENMS_ARROW_DATASET_TARGET)
   list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES ${OPENMS_ARROW_DATASET_TARGET})
   # Dataset pushdown needs libxml2 when Arrow Dataset is linked statically.

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -70,6 +70,7 @@ set(OPENMS_DEP_PRIVATE_LIBRARIES
   BZip2::BZip2
   Boost::boost
   Boost::date_time
+  Boost::filesystem
   Boost::iostreams
   Boost::regex
   Eigen3::Eigen
@@ -90,10 +91,6 @@ list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES
      ${OPENMS_ARROW_TARGET}
      ${OPENMS_ARROW_COMPUTE_TARGET}
      ${OPENMS_PARQUET_TARGET})
-# Static Arrow may need Boost::filesystem (not propagated by Arrow's CMake config)
-if(TARGET Boost::filesystem)
-  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES Boost::filesystem)
-endif()
 if (OPENMS_ARROW_DATASET_TARGET)
   list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES ${OPENMS_ARROW_DATASET_TARGET})
   # Dataset pushdown needs libxml2 when Arrow Dataset is linked statically.

--- a/tools/ci/deps-ubuntu.sh
+++ b/tools/ci/deps-ubuntu.sh
@@ -45,6 +45,7 @@ sudo apt-get -qq install -y \
   libboost-random-dev \
   libboost-regex-dev \
   libboost-iostreams-dev \
+  libboost-filesystem-dev \
   libboost-date-time-dev \
   libboost-math-dev \
   libxerces-c-dev \


### PR DESCRIPTION
## Summary
- Fix Docker container build failure: `undefined reference to boost::filesystem::detail::status` when linking TOPP tools
- The Arrow APT package on Ubuntu 22.04 only provides `Arrow::arrow_static` (no `Arrow::arrow_shared` target), and the static library depends on `boost::filesystem` without propagating it via `INTERFACE_LINK_LIBRARIES`
- Conditionally find and link `Boost::filesystem` when static Arrow is selected

## Root cause
The `deploy-docker` CI uses `libparquet-dev` from the Apache Arrow APT repo. This package's CMake config only creates `Arrow::arrow_static` (not `Arrow::arrow_shared`), so the fallback target selection picks the static library. Static `libarrow.a` references `boost::filesystem` symbols, but Arrow's CMake target doesn't declare this transitive dependency, causing linker failures in TOPP tools that link `libOpenMS.so`.

## Test plan
- [ ] `deploy-docker` CI job passes (the nlohmann_json fix from #8996 is already merged)
- [ ] Regular builds unaffected — `Boost::filesystem` is only linked when static Arrow is detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by linking Boost Filesystem so builds that require filesystem now detect and link it correctly.
* **Chores**
  * Updated container and CI dependency lists to include Boost Filesystem, ensuring developer images and CI runs have the required filesystem libraries.
  * Updated a vendored subproject to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->