### PR TITLE
fix: upgrade Docker image from Ubuntu 22.04 to 24.04

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -161,6 +161,7 @@ ARG INSTALL_DIR
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
+    ca-certificates \
     wget \
     qt6-base-dev \
     libqt6opengl6 \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@ ARG MAKEFLAGS="-j${NUM_BUILD_CORES}"
 
 
 ### OpenMS base ###
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 ARG OPENMS_VERSION_TAG
 ARG CMAKE_VERSION=3.28.1
 ARG TARGETARCH
@@ -40,23 +40,23 @@ RUN apt-get update \
     libhdf5-dev\
     coinor-libcoinmp-dev \
     libeigen3-dev \
-    libboost-date-time1.74-dev \
-    libboost-iostreams1.74-dev \
-    libboost-regex1.74-dev \
-    libboost-math1.74-dev \
-    libboost-random1.74-dev \
+    libboost-date-time-dev \
+    libboost-iostreams-dev \
+    libboost-regex-dev \
+    libboost-math-dev \
+    libboost-random-dev \
     qt6-base-dev \
     libglx-dev \
     libgl1-mesa-dev \
     libqt6opengl6-dev \
-    libqt6svg6-dev \   
+    libqt6svg6-dev \
   && rm -rf /var/lib/apt/lists/* \
   && update-ca-certificates \
   && apt-get update && apt-get install -y --no-install-recommends wget \
-  && wget https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-jammy.deb \
-  && apt-get install -y --no-install-recommends ./apache-arrow-apt-source-latest-jammy.deb \
+  && wget https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
+  && apt-get install -y --no-install-recommends ./apache-arrow-apt-source-latest-noble.deb \
   && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests libparquet-dev \
-  && rm apache-arrow-apt-source-latest-jammy.deb
+  && rm apache-arrow-apt-source-latest-noble.deb
 
 # installing cmake
 WORKDIR /tmp
@@ -79,7 +79,7 @@ EOF
 # The main reason we're pulling this in is to make sure that the metadata
 # below is consistently formatted for releases irrespective of the base image
 LABEL version="${OPENMS_VERSION_TAG}"
-LABEL software.version="${OPENMS_VERSION_TAG}-Ubuntu22.04"
+LABEL software.version="${OPENMS_VERSION_TAG}-Ubuntu24.04"
 LABEL org.opencontainers.image.source https://github.com/OpenMS/OpenMS
 
 
@@ -156,11 +156,12 @@ RUN make install/strip
 
 
 ### OpenMS library ###
-FROM ubuntu:22.04 AS library
+FROM ubuntu:24.04 AS library
 ARG INSTALL_DIR
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends --no-install-suggests \
+    wget \
     qt6-base-dev \
     libqt6opengl6 \
     libsvm3 \
@@ -172,11 +173,18 @@ RUN apt-get update \
     libqt6svg6 \
     libxerces-c3.2 \
     coinor-libcoinmp1v5 \
-    libboost-date-time1.74-dev  \
-    libboost-iostreams1.74-dev \
-    libboost-regex1.74-dev \
-    libboost-math1.74-dev \
-    libboost-random1.74-dev \
+    libboost-date-time1.83.0 \
+    libboost-iostreams1.83.0 \
+    libboost-regex1.83.0 \
+    libboost-math1.83.0 \
+    libboost-random1.83.0 \
+  && wget https://repo1.maven.org/maven2/org/apache/arrow/ubuntu/apache-arrow-apt-source-latest-noble.deb \
+  && apt-get install -y --no-install-recommends ./apache-arrow-apt-source-latest-noble.deb \
+  && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+    libarrow2300 \
+    libparquet2300 \
+  && rm apache-arrow-apt-source-latest-noble.deb \
+  && apt-get purge -y wget && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build ${INSTALL_DIR}/lib ${INSTALL_DIR}/lib


### PR DESCRIPTION
Ubuntu 22.04 ships Boost 1.74 which does not support the BOOST_PROCESS_USE_STD_FS macro, causing unresolved boost::filesystem symbols when linking TOPP tools. Ubuntu 24.04 ships Boost 1.83 where the macro works correctly.

- Base and runtime images: ubuntu:22.04 → ubuntu:24.04
- Boost packages: version-pinned 1.74 → unversioned (1.83)
- Arrow APT source: jammy → noble
- Runtime Boost libs: 1.74-dev → 1.83.0

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment to Ubuntu 24.04.
  * Upgraded Boost development packages to the 1.83 series.
  * Switched Apache Arrow package source to the newer release for runtime compatibility.
  * Improved package installation and cleanup steps to reduce leftover artifacts and ensure certificate/wget tooling for downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->