### PR TITLE
github action: welcome new contributors + tally survey

### DIFF
--- a/.github/workflows/welcome_new_contributor.yml
+++ b/.github/workflows/welcome_new_contributor.yml
@@ -32,7 +32,7 @@ jobs:
             const association = '${{ steps.contributor.outputs.association }}';
             const username = '${{ steps.contributor.outputs.username }}';
             const eventName = context.eventName;
-            const issueNumber = eventName === 'pull_request'
+            const issueNumber = eventName === 'pull_request_target'
               ? context.payload.pull_request.number
               : context.issue.number;
             
@@ -50,7 +50,7 @@ jobs:
               });
 
               // 2. Post Comment
-              const type = eventName === 'pull_request' ? 'PR' : 'issue';
+              const type = eventName === 'pull_request_target' ? 'PR' : 'issue';
               const body = `Welcome @${username} and thank you for your contribution to OpenMS! To help us better understand our userbase and contributors, we would appreciate if you could complete the survey at the link below. Completing this survey will help us get to your ${type} sooner. Thank you for your participation!\n\n[Survey](https://tally.so/r/pbV6Qq)`;
 
               await github.rest.issues.createComment({

--- a/.github/workflows/welcome_new_contributor.yml
+++ b/.github/workflows/welcome_new_contributor.yml
@@ -1,0 +1,65 @@
+name: Welcome New Contributor
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Get contributor info
+        id: contributor
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            echo "username=${{ github.event.pull_request.user.login }}" >> $GITHUB_OUTPUT
+            echo "association=${{ github.event.pull_request.author_association }}" >> $GITHUB_OUTPUT
+          else
+            echo "username=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
+            echo "association=${{ github.event.issue.author_association }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Welcome Contributor
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const association = '${{ steps.contributor.outputs.association }}';
+            const username = '${{ steps.contributor.outputs.username }}';
+            const eventName = context.eventName;
+            const issueNumber = eventName === 'pull_request'
+              ? context.payload.pull_request.number
+              : context.issue.number;
+            
+            // NONE means they have never had a PR merged in this repo
+            // another implementation https://github.com/llvm/llvm-project/blob/c8655fce45af6f2c13285f218bba83d39c84d5a4/.github/workflows/new-prs.yml
+            // https://github.com/llvm/llvm-project/blob/c8655fce45af6f2c13285f218bba83d39c84d5a4/.github/workflows/new-issues.yml
+            if (!['OWNER', 'CONTRIBUTOR', 'COLLABORATOR', 'MEMBER', 'MANNEQUIN'].includes(association)) {
+              
+              // 1. Add Label
+              await github.rest.issues.addLabels({
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['new contributor']
+              });
+
+              // 2. Post Comment
+              const type = eventName === 'pull_request' ? 'PR' : 'issue';
+              const body = `Welcome @${username} and thank you for your contribution to OpenMS! To help us better understand our userbase and contributors, we would appreciate if you could complete the survey at the link below. Completing this survey will help us get to your ${type} sooner. Thank you for your participation!\n\n[Survey](https://tally.so/r/pbV6Qq)`;
+
+              await github.rest.issues.createComment({
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }
+
+      - name: Debug association
+        run: echo "Association=${{ steps.contributor.outputs.association }}"


### PR DESCRIPTION
## Description

As part of ongoing efforts to better profile the OpenMS userbase and contributors, this GHA detects new contributors (to either a PR or an issue), tags the issue as "new contributor", welcomes them and prompts them to fill out our tally survey. This action should ignore PRs/issues from members/contributors. 

One caveat is that if someone opens multiple issues without actually contributing they will continue to get this prompt however I think that is ok. If there is someone who constantly contributes issues and no PRs (which I don't think is too common?), we can add them as a collaborator or another role to prevent them from getting the prompt.  

Feedback on the survey/message is also welcome.  

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated welcome system: first-time contributors opening pull requests or issues are automatically labeled "new contributor" and receive a personalized welcome comment with links to community resources and a survey.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->