### PR TITLE
refactor(IMTypes): remove IMFormat::MIXED, require ms_level in determ…

### DIFF
--- a/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
+++ b/src/openms/include/OpenMS/IONMOBILITY/IMTypes.h
@@ -41,16 +41,13 @@ namespace OpenMS
   OPENMS_DLLAPI const std::string& driftTimeUnitToString(const DriftTimeUnit value);
 
   /// Different ways to represent ion mobility data in a spectrum
-  /// Note: 
-  /// 1. MIXED is only used for MSExperiment, not for MSSpectrum
-  /// 2. UNKNOWN should be used if the format is not yet determined. 
+  /// Note: UNKNOWN should be used if the format is not yet determined.
   /// FileHandler or e.g. IM peak picker should ideally set the format a known value.
   enum class IMFormat
   {
     NONE,            ///< no ion mobility
     IM_PEAK,         ///< full TIMS frame / per-scan IM-resolved data: ion mobility is annotated per peak in a float data array
     IM_SPECTRUM,     ///< conventional spectrum with one precursor IM value (i.e. has one IM annotation per spectrum via getDriftTime())
-    MIXED,           ///< an MSExperiment contains both IM_PEAK and IM_SPECTRUM
     UNKNOWN,         ///< ion mobility format not yet determined.
     SIZE_OF_IMFORMAT
   };
@@ -95,11 +92,10 @@ namespace OpenMS
     /// If drift time for a spectrum is unavailable (i.e. not an IM spectrum), it will have this value
     inline static constexpr double DRIFTTIME_NOT_SET = -1.0;
 
-    /// Checks the all spectra for their type (see overload)
-    /// and returns the common type (or IMFormat::MIXED if both IM_PEAK and IM_SPECTRUM are present)
-    /// If @p exp is empty or contains no IM spectra at all, IMFormat::NONE is returned
-    /// @throws Exception::InvalidValue if IM values are annotated as single drift time and float array for any single spectrum
-    static IMFormat determineIMFormat(const MSExperiment& exp);
+    /// Checks only spectra of the given MS level for their IM format and returns the common type.
+    /// If no spectra of @p ms_level exist or none have IM data, IMFormat::NONE is returned.
+    /// @throws Exception::InvalidValue if spectra of the given MS level have different IM formats
+    static IMFormat determineIMFormat(const MSExperiment& exp, int ms_level);
 
     /** 
         @brief Checks for existence of a single driftTime (using spec.getDriftTime()) or an ion-mobility float data array (using spec.hasIMData()) 

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -334,7 +334,7 @@ namespace OpenMS
     // run feature detection
     //-------------------------------------------------------------
     // Check if data has ion mobility information
-    IMFormat im_format = IMTypes::determineIMFormat(ms_data_);
+    IMFormat im_format = IMTypes::determineIMFormat(ms_data_, 1);
     bool has_IM = (im_format == IMFormat::IM_PEAK || im_format == IMFormat::IM_SPECTRUM);
     if (has_IM)
     {

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -692,7 +692,7 @@ namespace OpenMS
 
     // Check IM format
     double IM_window = param_.getValue("extract:IM_window");
-    IMFormat im_format = IMTypes::determineIMFormat(ms_data_);
+    IMFormat im_format = IMTypes::determineIMFormat(ms_data_, 1);
     bool has_IM = false;
     if (im_format == IMFormat::IM_PEAK)
     {

--- a/src/openms/source/IONMOBILITY/IMTypes.cpp
+++ b/src/openms/source/IONMOBILITY/IMTypes.cpp
@@ -16,7 +16,7 @@ namespace OpenMS
 {
 
   const std::string NamesOfDriftTimeUnit[] = {"<NONE>", "ms", "1/K0", "FAIMS_CV", "CCS"};
-  const std::string NamesOfIMFormat[] = {"none", "im_peak", "im_spectrum", "mixed", "unknown"};
+  const std::string NamesOfIMFormat[] = {"none", "im_peak", "im_spectrum", "unknown"};
 
 
  DriftTimeUnit toDriftTimeUnit(const std::string& dtu_string)
@@ -82,21 +82,22 @@ namespace OpenMS
     return NamesOfIMPeakType[(int)im_peak_type];
   }
 
-  IMFormat IMTypes::determineIMFormat(const MSExperiment& exp)
+  IMFormat IMTypes::determineIMFormat(const MSExperiment& exp, int ms_level)
   {
     std::set<IMFormat> occs;
     for (const auto& spec : exp.getSpectra())
     {
+      if (spec.getMSLevel() != ms_level) continue;
       occs.insert(determineIMFormat(spec));
     }
-    occs.erase(IMFormat::NONE); // ignore NONE (i.e. normal spectra)
+    occs.erase(IMFormat::NONE);
 
     if (occs.empty())
     {
       return IMFormat::NONE;
-    }    
+    }
 
-    if (occs.size() == 1) 
+    if (occs.size() == 1)
     {
       auto format = *occs.begin();
       if (format != IMFormat::IM_PEAK && format != IMFormat::IM_SPECTRUM)
@@ -105,10 +106,12 @@ namespace OpenMS
       }
       return format;
     }
-    else    
+    else
     {
-      return IMFormat::MIXED;
-    }    
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "MSExperiment contains MS" + String(ms_level) + " spectra with different IM formats. "
+        "Handle per-spectrum.", "Number of different formats: " + String(occs.size()));
+    }
   }
 
   IMFormat IMTypes::determineIMFormat(const MSSpectrum& spec)

--- a/src/openms/source/METADATA/SpectrumSettings.cpp
+++ b/src/openms/source/METADATA/SpectrumSettings.cpp
@@ -79,10 +79,6 @@ namespace OpenMS
 
   void SpectrumSettings::setIMFormat(const IMFormat& im_type)
   {
-    if (im_type == IMFormat::MIXED)
-    {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Single spectrum can't have MIXED ion mobility format.", "SIZE_OF_IMFORMAT");
-    }
     im_type_ = im_type;
   }
   

--- a/src/pyOpenMS/bindings/bind_kernel.cpp
+++ b/src/pyOpenMS/bindings/bind_kernel.cpp
@@ -144,7 +144,6 @@ NB_MODULE(_pyopenms_kernel, m) {
         .value("NONE", OpenMS::IMFormat::NONE)
         .value("IM_PEAK", OpenMS::IMFormat::IM_PEAK)
         .value("IM_SPECTRUM", OpenMS::IMFormat::IM_SPECTRUM)
-        .value("MIXED", OpenMS::IMFormat::MIXED)
         .value("UNKNOWN", OpenMS::IMFormat::UNKNOWN)
         .value("SIZE_OF_IMFORMAT", OpenMS::IMFormat::SIZE_OF_IMFORMAT)
 

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -1185,7 +1185,7 @@ chromatograms to be consumed and need to be informed about this
         .def(nb::init<const OpenMS::IMTypes &>())
         .def("__copy__", [](const OpenMS::IMTypes& self) { return OpenMS::IMTypes(self); })
         .def("__deepcopy__", [](const OpenMS::IMTypes& self, nb::dict) { return OpenMS::IMTypes(self); }, "memo"_a)
-        .def_static("determineIMFormat", [](const OpenMS::MSExperiment& exp) { return OpenMS::IMTypes::determineIMFormat(exp); }, "exp"_a)
+        .def_static("determineIMFormat", [](const OpenMS::MSExperiment& exp, int ms_level) { return OpenMS::IMTypes::determineIMFormat(exp, ms_level); }, "exp"_a, "ms_level"_a)
         .def_static("determineIMFormat", [](const OpenMS::MSSpectrum& spec) { return OpenMS::IMTypes::determineIMFormat(spec); }, "spec"_a)
 
         .def_static("toDriftTimeUnit", [](const OpenMS::String& dtu_string) {
@@ -5082,7 +5082,7 @@ XMLFile
     // -----------------------------------------------------------------------
     // __static_* module-level wrappers for IMTypes
     // -----------------------------------------------------------------------
-    m.def("__static_IMTypes_determineIMFormat", [](const OpenMS::MSExperiment& exp) -> OpenMS::IMFormat { return OpenMS::IMTypes::determineIMFormat(exp); }, "exp"_a);
+    m.def("__static_IMTypes_determineIMFormat", [](const OpenMS::MSExperiment& exp, int ms_level) -> OpenMS::IMFormat { return OpenMS::IMTypes::determineIMFormat(exp, ms_level); }, "exp"_a, "ms_level"_a);
     m.def("__static_IMTypes_toDriftTimeUnit", [](const OpenMS::String& dtu_string) -> OpenMS::DriftTimeUnit { return OpenMS::toDriftTimeUnit(dtu_string); }, "dtu_string"_a);
     m.def("__static_IMTypes_driftTimeUnitToString", [](OpenMS::DriftTimeUnit value) -> OpenMS::String { return OpenMS::driftTimeUnitToString(value); }, "value"_a);
     m.def("__static_IMTypes_toIMFormat", [](const OpenMS::String& im_format) -> OpenMS::IMFormat { return OpenMS::toIMFormat(im_format); }, "im_format"_a);

--- a/src/tests/class_tests/openms/source/IMTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/IMTypes_test.cpp
@@ -105,47 +105,68 @@ const MSSpectrum IMwithFDA = [&]() {
   return single[0];
 }();
 
-START_SECTION(static IMFormat determineIMFormat(const MSExperiment& exp))
+START_SECTION(static IMFormat determineIMFormat(const MSExperiment& exp, int ms_level))
 
-  TEST_EQUAL(IMTypes::determineIMFormat(MSExperiment()) == IMFormat::NONE, true)
+  // empty experiment
+  TEST_EQUAL(IMTypes::determineIMFormat(MSExperiment(), 1) == IMFormat::NONE, true)
 
   {
     MSExperiment exp;
+    exp.addSpectrum(MSSpectrum()); // default MS level = 1
     exp.addSpectrum(MSSpectrum());
-    exp.addSpectrum(MSSpectrum());
-    TEST_EQUAL(IMTypes::determineIMFormat(exp) == IMFormat::NONE, true)
-  }
-  
-  {
-    MSExperiment exp;
-    exp.addSpectrum(MSSpectrum());
-    exp.addSpectrum(IMwithDrift);
-    TEST_EQUAL(IMTypes::determineIMFormat(exp) == IMFormat::IM_SPECTRUM, true)
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 1) == IMFormat::NONE, true)
   }
 
   {
+    auto ms1_drift = IMwithDrift;
+    ms1_drift.setMSLevel(1);
     MSExperiment exp;
     exp.addSpectrum(MSSpectrum());
-    exp.addSpectrum(IMwithFDA);
-    TEST_EQUAL(IMTypes::determineIMFormat(exp) == IMFormat::IM_PEAK, true)
+    exp.addSpectrum(ms1_drift);
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 1) == IMFormat::IM_SPECTRUM, true)
   }
 
   {
+    auto ms1_peak = IMwithFDA;
+    ms1_peak.setMSLevel(1);
     MSExperiment exp;
-    exp.addSpectrum(IMwithDrift);
-    exp.addSpectrum(IMwithFDA);
-    TEST_EQUAL(IMTypes::determineIMFormat(exp) == IMFormat::MIXED, true)
+    exp.addSpectrum(MSSpectrum());
+    exp.addSpectrum(ms1_peak);
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 1) == IMFormat::IM_PEAK, true)
   }
 
   {
-    // set both ... is valid (typically concatenated + some average value)
-    auto IMwithFDA2 = IMwithFDA;
-    IMwithFDA2.setDriftTime(123.4);
+    // MS1 = IM_PEAK, MS2 = IM_SPECTRUM — per-level queries work independently
+    auto ms1_peak = IMwithFDA;
+    ms1_peak.setMSLevel(1);
+    auto ms2_drift = IMwithDrift;
+    ms2_drift.setMSLevel(2);
     MSExperiment exp;
-    exp.addSpectrum(IMwithDrift);
-    exp.addSpectrum(IMwithFDA);
-    exp.addSpectrum(IMwithFDA2);
-    TEST_EQUAL(IMTypes::determineIMFormat(exp) == IMFormat::MIXED, true)
+    exp.addSpectrum(ms1_peak);
+    exp.addSpectrum(ms2_drift);
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 1) == IMFormat::IM_PEAK, true)
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 2) == IMFormat::IM_SPECTRUM, true)
+  }
+
+  {
+    // no spectra of requested level
+    MSExperiment exp;
+    auto ms1 = IMwithDrift;
+    ms1.setMSLevel(1);
+    exp.addSpectrum(ms1);
+    TEST_EQUAL(IMTypes::determineIMFormat(exp, 2) == IMFormat::NONE, true)
+  }
+
+  {
+    // mixed formats within same MS level throws
+    auto ms1_drift = IMwithDrift;
+    ms1_drift.setMSLevel(1);
+    auto ms1_peak = IMwithFDA;
+    ms1_peak.setMSLevel(1);
+    MSExperiment exp;
+    exp.addSpectrum(ms1_drift);
+    exp.addSpectrum(ms1_peak);
+    TEST_EXCEPTION(Exception::InvalidValue, IMTypes::determineIMFormat(exp, 1))
   }
 
 END_SECTION

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -1394,9 +1394,11 @@ END_SECTION
 
 START_SECTION(void setIMFormat(IMFormat imf))
 {
-  // test invalid format validation
   MSSpectrum spec;
-  TEST_EXCEPTION(Exception::InvalidValue, spec.setIMFormat(IMFormat::MIXED)); // this should trigger the validation check because a single spectrum can't be mixed
+  spec.setIMFormat(IMFormat::IM_PEAK);
+  TEST_EQUAL(spec.getIMFormat() == IMFormat::IM_PEAK, true)
+  spec.setIMFormat(IMFormat::NONE);
+  TEST_EQUAL(spec.getIMFormat() == IMFormat::NONE, true)
 }
 END_SECTION
 

--- a/src/topp/OpenNuXL.cpp
+++ b/src/topp/OpenNuXL.cpp
@@ -4545,7 +4545,7 @@ static void scoreXLIons_(
 
   std::tuple<IMFormat, DriftTimeUnit> getMS2IMType(const MSExperiment& spectra)
   {
-    IMFormat IM_format = IMTypes::determineIMFormat(spectra);  
+    IMFormat IM_format = IMTypes::determineIMFormat(spectra, 2);
     DriftTimeUnit IM_unit = DriftTimeUnit::NONE;
     if (IM_format == IMFormat::IM_SPECTRUM)
     {
@@ -4571,10 +4571,6 @@ static void scoreXLIons_(
     else if (IM_format == IMFormat::IM_PEAK)
     {
       OPENMS_LOG_INFO << "Per-peak Ion Mobility not supported. IM values need to be annotated at the spectrum level." << std::endl;
-    }
-    else if (IM_format == IMFormat::MIXED)
-    {
-      OPENMS_LOG_INFO << "Mixed Ion Mobility not supported. IM values need to be annotated at the spectrum level." << std::endl;
     }
     return make_tuple(IM_format, IM_unit);
   }

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -196,14 +196,6 @@ protected:
                        << "This format is not supported." << std::endl;
       return ILLEGAL_PARAMETERS;
     }
-    if (im_format == IMFormat::MIXED)
-    {
-      OPENMS_LOG_ERROR << "Error: Input file contains mixed ion mobility formats "
-                       << "(both IM_PEAK and IM_SPECTRUM). PeakPickerIM expects raw (per-peak) IM data "
-                       << "where each spectrum contains an ion mobility float data array. "
-                       << "Mixed formats are not supported." << std::endl;
-      return ILLEGAL_PARAMETERS;
-    }
     if (im_format == IMFormat::NONE)
     {
       OPENMS_LOG_WARN << "Warning: Input file does not contain ion mobility data. "
@@ -244,8 +236,8 @@ protected:
       MzMLFile mzml;
       mzml.load(input_file, exp);
 
-      // Check if input contains no IM data (warning)
-      IMFormat im_format = IMTypes::determineIMFormat(exp);
+      // Check MS1 spectra for IM format (PeakPickerIM works on per-peak IM data in MS1 frames)
+      IMFormat im_format = IMTypes::determineIMFormat(exp, 1);
       if (im_format == IMFormat::NONE)
       {
         OPENMS_LOG_WARN << "Warning: Input file does not contain ion mobility data. "


### PR DESCRIPTION
…ineIMFormat

MIXED was never meaningfully handled by any consumer — all callers either pre-filtered to a single MS level (OpenNuXL), detected from a single spectrum (PeakPickerIM low-mem), or ignored it entirely (PeakPickerIM high-mem).

Replace the experiment-level determineIMFormat(MSExperiment) with determineIMFormat(MSExperiment, int ms_level) so callers explicitly state which MS level they care about. This naturally handles files where MS1 has IM_PEAK and MS2 has IM_SPECTRUM (e.g. PASEF data) without needing a special MIXED enum value.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ion mobility format detection now evaluates spectra per MS level (e.g., MS1 vs MS2) rather than across the whole experiment.
  * The "MIXED" ion mobility format value has been removed; conflicting formats within the same MS level now raise an error.
  * Python bindings and tests updated to accept and validate an explicit MS level when querying ion mobility format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->