### PR TITLE
Fix Sphinx doc warnings: RST markup issues in docstrings

### DIFF
--- a/src/pyOpenMS/bindings/bind_chemistry.cpp
+++ b/src/pyOpenMS/bindings/bind_chemistry.cpp
@@ -214,7 +214,7 @@ Sets the C-terminal modification by the monoisotopic mass difference it introduc
     nb::class_<OpenMS::CoarseIsotopePatternGenerator>(m, "CoarseIsotopePatternGenerator", "OpenMS class CoarseIsotopePatternGenerator")
         .def(nb::init<size_t, bool>())
         .def("setMaxIsotope", [](OpenMS::CoarseIsotopePatternGenerator& self, const size_t& max_isotope) { return self.setMaxIsotope(max_isotope); }, "max_isotope"_a, "Sets the maximal isotope with 'max_isotope'")
-        .def("setRoundMasses", [](OpenMS::CoarseIsotopePatternGenerator& self, bool round_masses) { return self.setRoundMasses(round_masses); }, "round_masses"_a, "Sets the round_masses_ flag to round masses to integer values (true) or return accurate masses (false)")
+        .def("setRoundMasses", [](OpenMS::CoarseIsotopePatternGenerator& self, bool round_masses) { return self.setRoundMasses(round_masses); }, "round_masses"_a, "Sets the round_masses flag to round masses to integer values (true) or return accurate masses (false)")
         .def("getMaxIsotope", [](const OpenMS::CoarseIsotopePatternGenerator& self) { return self.getMaxIsotope(); }, "Returns the currently set maximum isotope")
         .def("getRoundMasses", [](const OpenMS::CoarseIsotopePatternGenerator& self) { return self.getRoundMasses(); }, "Returns the current value of the flag to round masses to integer values (true) or return accurate masses (false)")
         .def("run", [](const OpenMS::CoarseIsotopePatternGenerator& self, const OpenMS::EmpiricalFormula& ef) { return self.run(ef); }, "ef"_a)

--- a/src/pyOpenMS/pyopenms/addons/consensusmap.py
+++ b/src/pyOpenMS/pyopenms/addons/consensusmap.py
@@ -441,7 +441,7 @@ def to_feature_df(self, **kwargs):
 
     Parameters
     ----------
-    **kwargs
+    ``**kwargs``
         Passed to to_feature_arrow().
 
     Returns
@@ -463,7 +463,7 @@ def to_feature_parquet(self, filename, compression='snappy', **kwargs):
         Output file path.
     compression : str
         Compression codec (default: 'snappy').
-    **kwargs
+    ``**kwargs``
         Passed to to_feature_arrow().
     """
     try:
@@ -489,7 +489,7 @@ def to_feature_qpx(self, qpx_version="1.0", creator="pyopenms", software_provide
         Creator identifier.
     software_provider : str
         Software provider name.
-    **kwargs
+    ``**kwargs``
         Passed to to_feature_arrow().
 
     Returns


### PR DESCRIPTION
- Remove trailing underscore from `round_masses_` in setRoundMasses
  docstring to prevent Sphinx interpreting it as an RST hyperlink
  reference (fixes "Unknown target name: round_masses" error)
- Escape `**kwargs` as ``**kwargs`` in ConsensusMap addon docstrings
  to prevent Sphinx interpreting `**` as bold markup start (fixes
  "Inline strong start-string without end-string" warnings)

https://claude.ai/code/session_01FbxMxP1DHknmpqVJt68xGL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed parameter name references in Python API documentation.
  * Enhanced documentation formatting consistency across addon methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->