### PR TITLE
feat: add IM_PEAK format checks to four TOPP tools

### DIFF
--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -15,6 +15,7 @@
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/IONMOBILITY/IMDataConverter.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/PROCESSING/FEATURE/FeatureOverlapFilter.h>
 
@@ -188,6 +189,20 @@ protected:
     if (exp.getSpectra().empty())
     {
       throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS1 spectra in input file.");
+    }
+
+    // Check for unsupported per-peak ion mobility data
+    for (const auto& spec : exp)
+    {
+      IMFormat im_format = IMTypes::determineIMFormat(spec);
+      if (im_format == IMFormat::IM_PEAK)
+      {
+        OPENMS_LOG_ERROR << "Error: Input contains per-peak ion mobility data (IM_PEAK, "
+                         << imPeakTypeToString(spec.getIMPeakType())
+                         << ") which is not supported by FeatureFinderCentroided. "
+                         << "Preprocess with IonMobilityBinning or PeakPickerIM first." << std::endl;
+        return INCOMPATIBLE_INPUT_DATA;
+      }
     }
 
     // determine type of spectral data (profile or centroided)

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -255,6 +255,20 @@ public:
     OPENMS_LOG_DEBUG << "Loading input..." << endl;
     file.loadExperiment(in_, exp, {FileTypes::MZML}, log_type_);
 
+    // Check for unsupported per-peak ion mobility data
+    for (const auto& spec : exp)
+    {
+      IMFormat im_format = IMTypes::determineIMFormat(spec);
+      if (im_format == IMFormat::IM_PEAK)
+      {
+        OPENMS_LOG_ERROR << "Error: Input contains per-peak ion mobility data (IM_PEAK, "
+                         << imPeakTypeToString(spec.getIMPeakType())
+                         << ") which is not supported by FeatureFinderMultiplex. "
+                         << "Preprocess with IonMobilityBinning or PeakPickerIM first." << std::endl;
+        return INCOMPATIBLE_INPUT_DATA;
+      }
+    }
+
     // Prepare algorithm parameters
     Param params = getParam_();
     params.remove("in");

--- a/src/topp/PeakPickerHiRes.cpp
+++ b/src/topp/PeakPickerHiRes.cpp
@@ -12,6 +12,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerHiRes.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 
 #include <OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h>
@@ -210,6 +211,21 @@ protected:
     //-------------------------------------------------------------
     PeakMap ms_exp_raw;
     FileHandler().loadExperiment(in, ms_exp_raw, {FileTypes::MZML}, log_type_);
+
+    // Warn about per-peak ion mobility data (PeakPickerHiRes picks m/z only)
+    for (const auto& spec : ms_exp_raw)
+    {
+      IMFormat im_format = IMTypes::determineIMFormat(spec);
+      if (im_format == IMFormat::IM_PEAK)
+      {
+        OPENMS_LOG_WARN << "Warning: Input contains per-peak ion mobility data (IM_PEAK, "
+                        << imPeakTypeToString(spec.getIMPeakType())
+                        << "). PeakPickerHiRes picks in m/z only and reports intensity-weighted "
+                        << "mean ion mobility. This produces incorrect results on unbinned data. "
+                        << "Consider IonMobilityBinning or PeakPickerIM first." << std::endl;
+        break; // warn once
+      }
+    }
 
     if (ms_exp_raw.empty() && ms_exp_raw.getChromatograms().empty())
     {

--- a/src/topp/Resampler.cpp
+++ b/src/topp/Resampler.cpp
@@ -11,6 +11,7 @@
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/VISUAL/MultiGradient.h>
 #include <OpenMS/PROCESSING/RESAMPLING/LinearResamplerAlign.h>
 #include <OpenMS/PROCESSING/FILTERING/ThresholdMower.h>
@@ -100,6 +101,20 @@ protected:
     exp.updateRanges();
 
     FileHandler().loadExperiment(in, exp, {FileTypes::MZML}, log_type_);
+
+    // Check for unsupported per-peak ion mobility data
+    for (const auto& spec : exp)
+    {
+      IMFormat im_format = IMTypes::determineIMFormat(spec);
+      if (im_format == IMFormat::IM_PEAK)
+      {
+        OPENMS_LOG_ERROR << "Error: Input contains per-peak ion mobility data (IM_PEAK, "
+                         << imPeakTypeToString(spec.getIMPeakType())
+                         << ") which is not supported by Resampler. "
+                         << "Preprocess with IonMobilityBinning or PeakPickerIM first." << std::endl;
+        return INCOMPATIBLE_INPUT_DATA;
+      }
+    }
 
     Param resampler_param;
     resampler_param.setValue("spacing", sampling_rate);


### PR DESCRIPTION
## Summary

- **Resampler**, **FeatureFinderCentroided**, **FeatureFinderMultiplex**: error out (`INCOMPATIBLE_INPUT_DATA`) when input contains per-peak ion mobility data (`IM_PEAK`) they cannot properly handle
- **PeakPickerHiRes**: warns but continues, since it has partial `IM_PEAK` support (intensity-weighted mean IM per picked peak) that works correctly on pre-binned data but produces incorrect results on unbinned 2D data

All checks report the detected `IMPeakType` (`im_profile`/`im_centroided`) in the message and suggest preprocessing with `IonMobilityBinning` or `PeakPickerIM`.

## Motivation

With direct Bruker `.d` file reading now supported, tools can receive `IM_PEAK` format data (per-peak ion mobility in FloatDataArrays). Tools that operate in m/z only would silently produce wrong results (merging IM-separated species) or destroy IM metadata. These checks make the limitation explicit.

## Test plan

- [ ] Existing TOPP tests for all four tools still pass (non-IM data unaffected)
- [ ] Manual test: feed IM_PEAK mzML to Resampler/FFC/FFM → exits with `INCOMPATIBLE_INPUT_DATA`
- [ ] Manual test: feed IM_PEAK mzML to PeakPickerHiRes → warning printed, processing continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * FeatureFinderCentroided, FeatureFinderMultiplex, and Resampler now validate input and reject unsupported per-peak ion mobility data before processing.
  * PeakPickerHiRes now warns when processing per-peak ion mobility data due to potential accuracy concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->