### PR TITLE
feat: integrate BrukerTimsFile directly into OpenSwath chromatogram pipeline

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -82,7 +82,13 @@ public:
     std::vector<OpenSwath::SwathMap> loadSqMass(const String& file, std::shared_ptr<ExperimentalSettings>& /* exp_meta */);
 
 #ifdef WITH_OPENTIMS
-    /// Loads a Swath run from a Bruker .d (TDF) directory
+    /**
+      @brief Loads a Swath run from a Bruker .d (TDF) directory
+
+      @param[in] file Path to a Bruker .d (TDF) directory
+      @param[in,out] exp_meta Will be filled with ExperimentalSettings metadata
+      @return Vector of SwathMap structures representing the loaded Swath maps
+    */
     std::vector<OpenSwath::SwathMap> loadBrukerTdf(const String& file,
                                                     std::shared_ptr<ExperimentalSettings>& exp_meta);
 #endif
@@ -104,4 +110,3 @@ protected:
 
   };
 }
-

--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -10,6 +10,7 @@
 
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
+#include <OpenMS/config.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
@@ -79,6 +80,12 @@ public:
 
     /// Loads a Swath run from a single sqMass file
     std::vector<OpenSwath::SwathMap> loadSqMass(const String& file, std::shared_ptr<ExperimentalSettings>& /* exp_meta */);
+
+#ifdef WITH_OPENTIMS
+    /// Loads a Swath run from a Bruker .d (TDF) directory
+    std::vector<OpenSwath::SwathMap> loadBrukerTdf(const String& file,
+                                                    std::shared_ptr<ExperimentalSettings>& exp_meta);
+#endif
 
 protected:
 

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -142,8 +142,13 @@ namespace OpenMS
 #endif
         else
         {
+#ifdef WITH_OPENTIMS
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                            "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
+#else
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                           "Input file needs to have ending mzML, mzXML, or sqMass");
+#endif
         }
       }
     }
@@ -180,8 +185,13 @@ namespace OpenMS
 #endif
       else
       {
+#ifdef WITH_OPENTIMS
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                          "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
+#else
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Input file needs to have ending mzML, mzXML, or sqMass");
+#endif
       }
     }
   }

--- a/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
+++ b/src/openms/source/APPLICATIONS/OpenSwathBase.cpp
@@ -129,10 +129,21 @@ namespace OpenMS
             swath_map_sources.push_back(f);
           }
         }
+#ifdef WITH_OPENTIMS
+        else if (in_file_type == FileTypes::BRUKER_TDF)
+        {
+          auto maps = swath_file.loadBrukerTdf(f, exp_meta);
+          for (auto & m : maps)
+          {
+            swath_maps.push_back(m);
+            swath_map_sources.push_back(f);
+          }
+        }
+#endif
         else
         {
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                           "Input file needs to have ending mzML or mzXML");
+                                           "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
         }
       }
     }
@@ -159,10 +170,18 @@ namespace OpenMS
         swath_map_sources.clear();
         for (Size i = 0; i < swath_maps.size(); ++i) swath_map_sources.push_back(file_list[0]);
       }
+#ifdef WITH_OPENTIMS
+      else if (in_file_type == FileTypes::BRUKER_TDF)
+      {
+        swath_maps = swath_file.loadBrukerTdf(file_list[0], exp_meta);
+        swath_map_sources.clear();
+        for (Size i = 0; i < swath_maps.size(); ++i) swath_map_sources.push_back(file_list[0]);
+      }
+#endif
       else
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                         "Input file needs to have ending mzML or mzXML");
+                                         "Input file needs to have ending mzML, mzXML, sqMass, or .d (Bruker TDF)");
       }
     }
   }

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -1332,6 +1332,12 @@ namespace OpenMS
         prec.setIsolationWindowUpperOffset(win.mz_width / 2.0);
         spec.setPrecursors({prec});
 
+        // Set ion mobility window bounds for PASEF window grouping
+        // (required by SwathFile/OpenSwath pipeline to distinguish windows
+        // sharing the same m/z range but differing in IM)
+        spec.setMetaValue("ion mobility lower limit", win.im_lower);
+        spec.setMetaValue("ion mobility upper limit", win.im_upper);
+
         DataArrays::FloatDataArray im_array;
         IMDataConverter::setIMUnit(im_array, DriftTimeUnit::VSSC);
 

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -289,7 +289,7 @@ namespace OpenMS
     const String& file,
     std::shared_ptr<ExperimentalSettings>& exp_meta)
   {
-    std::cout << "Loading Bruker TDF file " << file << '\n';
+    LOG_INFO << "Loading Bruker TDF file " << file << '\n';
     startProgress(0, 1, "Loading Bruker TDF file " + file);
 
     // Load full MSExperiment via BrukerTimsFile (DIA auto-detected)

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -289,7 +289,7 @@ namespace OpenMS
     const String& file,
     std::shared_ptr<ExperimentalSettings>& exp_meta)
   {
-    LOG_INFO << "Loading Bruker TDF file " << file << '\n';
+    OPENMS_LOG_INFO << "Loading Bruker TDF file " << file << '\n';
     startProgress(0, 1, "Loading Bruker TDF file " + file);
 
     // Load full MSExperiment via BrukerTimsFile (DIA auto-detected)

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -24,6 +24,12 @@
 #include <OpenMS/METADATA/ExperimentalSettings.h>
 #include <OpenMS/SYSTEM/File.h>
 
+#ifdef WITH_OPENTIMS
+#include <OpenMS/FORMAT/BrukerTimsFile.h>
+#endif
+
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
+
 #include <memory> // for make_shared
 
 namespace OpenMS
@@ -277,6 +283,48 @@ namespace OpenMS
     return swath_maps;
   }
 
+
+#ifdef WITH_OPENTIMS
+  std::vector<OpenSwath::SwathMap> SwathFile::loadBrukerTdf(
+    const String& file,
+    std::shared_ptr<ExperimentalSettings>& exp_meta)
+  {
+    std::cout << "Loading Bruker TDF file " << file << '\n';
+    startProgress(0, 1, "Loading Bruker TDF file " + file);
+
+    // Load full MSExperiment via BrukerTimsFile (DIA auto-detected)
+    BrukerTimsFile bruker_reader;
+    bruker_reader.setLogType(this->getLogType());
+    std::shared_ptr<PeakMap> experiment(new PeakMap);
+    bruker_reader.load(file, *experiment);
+    exp_meta = experiment; // preserve experimental settings for downstream
+
+    // Discover unique SWATH windows from spectrum metadata
+    std::vector<int> swath_counter;
+    int nr_ms1_spectra = 0;
+    std::vector<OpenSwath::SwathMap> known_window_boundaries;
+    countScansInSwath_(experiment->getSpectra(), swath_counter,
+                       nr_ms1_spectra, known_window_boundaries);
+
+    OPENMS_LOG_INFO << "Bruker TDF: " << swath_counter.size()
+                    << " SWATH windows and " << nr_ms1_spectra
+                    << " MS1 spectra" << std::endl;
+
+    // Partition spectra into per-window MSExperiment objects via RegularSwathFileConsumer
+    RegularSwathFileConsumer consumer(known_window_boundaries);
+    consumer.setExperimentalSettings(*exp_meta);
+    for (auto& spec : experiment->getSpectra())
+    {
+      consumer.consumeSpectrum(spec);
+    }
+
+    std::vector<OpenSwath::SwathMap> swath_maps;
+    consumer.retrieveSwathMaps(swath_maps);
+
+    endProgress();
+    return swath_maps;
+  }
+#endif
 
   /// Cache a file to disk
   OpenSwath::SpectrumAccessPtr SwathFile::doCacheFile_(const String& in, const String& tmp, const String& tmp_fname,

--- a/src/topp/OpenSwathWorkflow.cpp
+++ b/src/topp/OpenSwathWorkflow.cpp
@@ -25,6 +25,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWParquetWriter.h>
 #include <OpenMS/FORMAT/ParquetFile.h>
 #include <OpenMS/FORMAT/ZipArchiveFile.h>
+#include <OpenMS/config.h>
 #include <filesystem>
 #include <OpenMS/SYSTEM/File.h>
 
@@ -231,7 +232,11 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFileList_("in", "<files>", StringList(), "Input files separated by blank");
-    setValidFormats_("in", ListUtils::create<String>("mzML,mzXML,sqMass"));
+    StringList in_formats = {"mzML", "mzXML", "sqMass"};
+#ifdef WITH_OPENTIMS
+    in_formats.push_back("d");
+#endif
+    setValidFormats_("in", in_formats);
 
     registerInputFile_("tr", "<file>", "", "transition file ('TraML','tsv','pqp','oswpq')");
     StringList tr_formats = {"traML", "tsv", "pqp"};


### PR DESCRIPTION
Allow Bruker .d (TDF) files to be passed directly to OpenSwathWorkflow
without prior mzML conversion. The integration bridges BrukerTimsFile's
DIA-PASEF output into the existing SwathMap infrastructure.

Key changes:
- BrukerTimsFile::loadDIA_(): add "ion mobility lower/upper limit" meta
  values to MS2 spectra so PASEF windows sharing the same m/z range but
  differing in IM are correctly distinguished by countScansInSwath_()
- SwathFile::loadBrukerTdf(): new method that loads .d via BrukerTimsFile,
  discovers SWATH windows, and partitions spectra via RegularSwathFileConsumer
- OpenSwathBase::loadSwathFiles_(): dispatch BRUKER_TDF file type to the
  new loadBrukerTdf() method (both multi-file and single-file branches)
- OpenSwathWorkflow: accept "d" as valid input format (WITH_OPENTIMS only)

https://claude.ai/code/session_01QSsBJj9apkny9nrxgQNmrT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional support for loading Bruker TDF (.d) TIMS data in OpenSwath workflows (when TIMS support is enabled).
  * Spectra now include ion mobility lower/upper boundary metadata to better distinguish PASEF/SWATH windows.
  * Input-format validation updated to recognize Bruker TDF alongside mzML, mzXML, and sqMass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->