### PR TITLE
feat: add Bruker .d file support and built-in IM centroiding to PeakPickerIM

### DIFF
--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
@@ -15,6 +16,10 @@
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/PROCESSING/CENTROIDING/PeakPickerIM.h>
 #include <OpenMS/IONMOBILITY/IMTypes.h>
+
+#ifdef WITH_OPENTIMS
+#include <OpenMS/FORMAT/BrukerTimsFile.h>
+#endif
 
 using namespace OpenMS;
 using namespace std;
@@ -26,7 +31,7 @@ using namespace std;
 /**
 @page TOPP_PeakPickerIM PeakPickerIM
 
-@brief A tool for peak detection in the ion mobility dimension for mzML files.
+@brief A tool for peak detection in the ion mobility dimension for mzML and Bruker .d files.
 
 <center>
 <table>
@@ -43,8 +48,9 @@ using namespace std;
 </center>
 
 This tool applies peak picking in the ion mobility dimension to raw LC-IMS-MS data.
-The input mzML file should contain ion mobility data in concatenated format
-(where each spectrum contains an ion mobility float data array).
+The input file can be an mzML file containing ion mobility data in concatenated format
+(where each spectrum contains an ion mobility float data array) or a Bruker TimsTOF .d
+directory (requires OpenMS built with WITH_OPENTIMS).
 
 Three peak picking methods are available:
 - @b mobilogram: Picks peaks along the ion mobility dimension using a peak picker.
@@ -67,14 +73,18 @@ class TOPPPeakPickerIM : public TOPPBase
 {
 public:
   TOPPPeakPickerIM() :
-      TOPPBase("PeakPickerIM", "Applies PeakPickerIM to an mzML file", false)
+      TOPPBase("PeakPickerIM", "Applies PeakPickerIM to an mzML or Bruker .d file", false)
   {}
 
 protected:
   void registerOptionsAndFlags_() override
   {
-    registerInputFile_("in", "<file>", "", "Input mzML file");
-    setValidFormats_("in", { "mzML" });
+    registerInputFile_("in", "<file>", "", "Input file (mzML or Bruker .d)");
+    setValidFormats_("in", { "mzML",
+#ifdef WITH_OPENTIMS
+      "d",
+#endif
+    });
 
     registerOutputFile_("out", "<file>", "", "Output mzML file");
     setValidFormats_("out", { "mzML" });
@@ -90,6 +100,17 @@ protected:
 
     addEmptyLine_();
     registerSubsection_("algorithm", "Algorithm parameters for PeakPickerIM (organized into pickIMTraces, pickIMCluster, pickIMElutionProfiles).");
+
+#ifdef WITH_OPENTIMS
+    registerTOPPSubsection_("bruker", "Options for reading Bruker TimsTOF .d files (requires WITH_OPENTIMS)");
+    registerStringOption_("bruker:export_mode", "<mode>", "frame", "Export mode: 'auto' detects DDA/DIA acquisition type, "
+      "'spectrum' forces per-precursor MS2 spectra (DDA-style), 'frame' returns raw 4D frames without signal processing.", false, true);
+    setValidStrings_("bruker:export_mode", {"auto", "spectrum", "frame"});
+    registerDoubleOption_("bruker:calibration_tolerance", "<float>", 0.0, "m/z recalibration tolerance (0 = library default)", false, true);
+    setMinFloat_("bruker:calibration_tolerance", 0.0);
+    registerStringOption_("bruker:calibrate", "<toggle>", "false", "Enable m/z recalibration (may fail on some datasets)", false, true);
+    setValidStrings_("bruker:calibrate", {"true", "false"});
+#endif
   }
 
   Param getSubsectionDefaults_(const String& section) const override
@@ -106,6 +127,20 @@ protected:
     }
     return Param();
   }
+
+#ifdef WITH_OPENTIMS
+  BrukerTimsFile::Config getBrukerConfig_()
+  {
+    BrukerTimsFile::Config c;
+    c.calibration_tolerance = getDoubleOption_("bruker:calibration_tolerance");
+    c.calibrate = (getStringOption_("bruker:calibrate") == "true");
+    String mode = getStringOption_("bruker:export_mode");
+    if (mode == "spectrum") c.export_mode = BrukerTimsFile::Config::SPECTRUM;
+    else if (mode == "frame") c.export_mode = BrukerTimsFile::Config::FRAME;
+    else c.export_mode = BrukerTimsFile::Config::AUTO;
+    return c;
+  }
+#endif
 
   // -------------------- Low-memory consumer --------------------
   class Consumer : public MSDataWritingConsumer
@@ -225,6 +260,55 @@ protected:
 
     PeakPickerIM picker;
     picker.setParameters(algo);
+
+    // Detect input file type
+    FileTypes::Type in_type = FileHandler::getType(input_file);
+
+#ifdef WITH_OPENTIMS
+    if (in_type == FileTypes::BRUKER_TDF)
+    {
+      // Load .d file using BrukerTimsFile (FRAME mode by default for raw per-peak IM data)
+      auto bruker_config = getBrukerConfig_();
+      BrukerTimsFile tims_file;
+      tims_file.setLogType(log_type_);
+
+      PeakMap exp;
+      tims_file.load(input_file, exp, bruker_config);
+
+      // Check MS1 spectra for IM format
+      IMFormat im_format = IMTypes::determineIMFormat(exp, 1);
+      if (im_format == IMFormat::NONE)
+      {
+        OPENMS_LOG_WARN << "Warning: Input file does not contain ion mobility data. "
+                        << "No peak picking will be performed." << std::endl;
+        MzMLFile().store(output_file, exp);
+        return EXECUTION_OK;
+      }
+
+#pragma omp parallel for
+      for (SignedSize i = 0; i < static_cast<SignedSize>(exp.size()); ++i)
+      {
+        MSSpectrum& spectrum = exp[static_cast<Size>(i)];
+
+        if (method == "mobilogram")
+        {
+          picker.pickIMTraces(spectrum);
+        }
+        else if (method == "cluster")
+        {
+          picker.pickIMCluster(spectrum);
+        }
+        else if (method == "traces")
+        {
+          picker.pickIMElutionProfiles(spectrum);
+        }
+      }
+
+      addDataProcessing_(exp, getProcessingInfo_(DataProcessing::PEAK_PICKING));
+      MzMLFile().store(output_file, exp);
+      return EXECUTION_OK;
+    }
+#endif
 
     if (process_opt == "lowmemory")
     {

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -110,6 +110,16 @@ protected:
     setMinFloat_("bruker:calibration_tolerance", 0.0);
     registerStringOption_("bruker:calibrate", "<toggle>", "false", "Enable m/z recalibration (may fail on some datasets)", false, true);
     setValidStrings_("bruker:calibrate", {"true", "false"});
+    registerDoubleOption_("bruker:ms1_centroid_mz_ppm", "<float>", 0.0,
+      "MS1 frame IM-centroiding m/z tolerance in ppm. Collapses the ion mobility dimension "
+      "by aggregating neighboring peaks directly on the raw gridded data (Sage algorithm, Lazear 2023). "
+      "Both this and ms1_centroid_im_pct must be > 0 to enable. Suggested value: 5.0. "
+      "When enabled, this replaces the PeakPickerIM algorithm for MS1 frames.", false, true);
+    setMinFloat_("bruker:ms1_centroid_mz_ppm", 0.0);
+    registerDoubleOption_("bruker:ms1_centroid_im_pct", "<float>", 0.0,
+      "MS1 frame IM-centroiding ion mobility tolerance in percent. Both this and ms1_centroid_mz_ppm "
+      "must be > 0 to enable. Suggested value: 3.0.", false, true);
+    setMinFloat_("bruker:ms1_centroid_im_pct", 0.0);
 #endif
   }
 
@@ -138,6 +148,8 @@ protected:
     if (mode == "spectrum") c.export_mode = BrukerTimsFile::Config::SPECTRUM;
     else if (mode == "frame") c.export_mode = BrukerTimsFile::Config::FRAME;
     else c.export_mode = BrukerTimsFile::Config::AUTO;
+    c.ms1_centroid_mz_ppm = static_cast<float>(getDoubleOption_("bruker:ms1_centroid_mz_ppm"));
+    c.ms1_centroid_im_pct = static_cast<float>(getDoubleOption_("bruker:ms1_centroid_im_pct"));
     return c;
   }
 #endif
@@ -267,13 +279,27 @@ protected:
 #ifdef WITH_OPENTIMS
     if (in_type == FileTypes::BRUKER_TDF)
     {
-      // Load .d file using BrukerTimsFile (FRAME mode by default for raw per-peak IM data)
       auto bruker_config = getBrukerConfig_();
       BrukerTimsFile tims_file;
       tims_file.setLogType(log_type_);
 
       PeakMap exp;
       tims_file.load(input_file, exp, bruker_config);
+
+      // If built-in IM centroiding was enabled, BrukerTimsFile already produced
+      // IM_CENTROIDED spectra — skip PeakPickerIM and write directly.
+      bool builtin_centroiding = (bruker_config.ms1_centroid_mz_ppm > 0.0f
+                                  && bruker_config.ms1_centroid_im_pct > 0.0f);
+      if (builtin_centroiding)
+      {
+        OPENMS_LOG_INFO << "Built-in Bruker IM centroiding was applied during .d loading "
+                        << "(ms1_centroid_mz_ppm=" << bruker_config.ms1_centroid_mz_ppm
+                        << ", ms1_centroid_im_pct=" << bruker_config.ms1_centroid_im_pct
+                        << "). Skipping PeakPickerIM algorithm." << std::endl;
+        addDataProcessing_(exp, getProcessingInfo_(DataProcessing::PEAK_PICKING));
+        MzMLFile().store(output_file, exp);
+        return EXECUTION_OK;
+      }
 
       // Check MS1 spectra for IM format
       IMFormat im_format = IMTypes::determineIMFormat(exp, 1);

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -104,7 +104,7 @@ protected:
 #ifdef WITH_OPENTIMS
     registerTOPPSubsection_("bruker", "Options for reading Bruker TimsTOF .d files (requires WITH_OPENTIMS)");
     registerStringOption_("bruker:export_mode", "<mode>", "frame", "Export mode: 'auto' detects DDA/DIA acquisition type, "
-      "'spectrum' forces per-precursor MS2 spectra (DDA-style), 'frame' returns raw 4D frames without signal processing.", false, true);
+      "'frame' returns raw 4D frames without signal processing.", false, true);
     setValidStrings_("bruker:export_mode", {"auto", "frame"});
     registerDoubleOption_("bruker:calibration_tolerance", "<float>", 0.0, "m/z recalibration tolerance (0 = library default)", false, true);
     setMinFloat_("bruker:calibration_tolerance", 0.0);
@@ -145,8 +145,7 @@ protected:
     c.calibration_tolerance = getDoubleOption_("bruker:calibration_tolerance");
     c.calibrate = (getStringOption_("bruker:calibrate") == "true");
     String mode = getStringOption_("bruker:export_mode");
-    if (mode == "spectrum") c.export_mode = BrukerTimsFile::Config::SPECTRUM;
-    else if (mode == "frame") c.export_mode = BrukerTimsFile::Config::FRAME;
+    if (mode == "frame") c.export_mode = BrukerTimsFile::Config::FRAME;
     else c.export_mode = BrukerTimsFile::Config::AUTO;
     c.ms1_centroid_mz_ppm = static_cast<float>(getDoubleOption_("bruker:ms1_centroid_mz_ppm"));
     c.ms1_centroid_im_pct = static_cast<float>(getDoubleOption_("bruker:ms1_centroid_im_pct"));
@@ -184,7 +183,7 @@ protected:
     String method_;
   };
 
-  // -------------------- Format detection consumer (reads first spectrum only) --------------------
+  // -------------------- Format detection consumer (reads first MS1 spectrum only) --------------------
   class FormatDetector : public Interfaces::IMSDataConsumer
   {
   public:
@@ -195,8 +194,9 @@ protected:
 
     void consumeSpectrum(SpectrumType& s) override
     {
+      if (s.getMSLevel() != 1) return; // Only check MS1 spectra (consistent with in-memory path)
       detected_format = IMTypes::determineIMFormat(s);
-      throw FirstSpectrumRead(); // Abort after reading first spectrum
+      throw FirstSpectrumRead(); // Abort after first MS1 spectrum
     }
     void consumeChromatogram(ChromatogramType&) override {}
     void setExperimentalSettings(const ExperimentalSettings&) override {}
@@ -226,7 +226,7 @@ protected:
       try
       {
         mzml.transform(input_file, &detector);
-        // If we reach here, file has no spectra - format stays NONE
+        // If we reach here, file has no MS1 spectra - format stays NONE
       }
       catch (const FormatDetector::FirstSpectrumRead&)
       {
@@ -237,10 +237,8 @@ protected:
     // Step 2: Validate format
     if (im_format == IMFormat::IM_SPECTRUM)
     {
-      OPENMS_LOG_ERROR << "Error: Input file contains ion mobility data in IM_SPECTRUM format "
-                       << "(one spectrum per IM frame). PeakPickerIM expects raw (per-peak) IM data "
-                       << "where each spectrum contains an ion mobility float data array. "
-                       << "This format is not supported." << std::endl;
+      OPENMS_LOG_ERROR << "Error: Input data has single drift time per spectrum (IM_SPECTRUM format). "
+                       << "PeakPickerIM requires per-peak IM arrays (IM_PEAK format)." << std::endl;
       return ILLEGAL_PARAMETERS;
     }
     if (im_format == IMFormat::NONE)
@@ -324,24 +322,24 @@ protected:
         return ILLEGAL_PARAMETERS;
       }
 
+      std::exception_ptr first_error = nullptr;
 #pragma omp parallel for
       for (SignedSize i = 0; i < static_cast<SignedSize>(exp.size()); ++i)
       {
-        MSSpectrum& spectrum = exp[static_cast<Size>(i)];
-
-        if (method == "mobilogram")
+        try
         {
-          picker.pickIMTraces(spectrum);
+          MSSpectrum& spectrum = exp[static_cast<Size>(i)];
+          if (method == "mobilogram")       picker.pickIMTraces(spectrum);
+          else if (method == "cluster")     picker.pickIMCluster(spectrum);
+          else if (method == "traces")      picker.pickIMElutionProfiles(spectrum);
         }
-        else if (method == "cluster")
+        catch (...)
         {
-          picker.pickIMCluster(spectrum);
-        }
-        else if (method == "traces")
-        {
-          picker.pickIMElutionProfiles(spectrum);
+#pragma omp critical
+          { if (!first_error) first_error = std::current_exception(); }
         }
       }
+      if (first_error) std::rethrow_exception(first_error);
 
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::PEAK_PICKING));
       MzMLFile().store(output_file, exp);
@@ -368,25 +366,31 @@ protected:
         mzml.store(output_file, exp);
         return EXECUTION_OK;
       }
+      if (im_format == IMFormat::IM_SPECTRUM)
+      {
+        OPENMS_LOG_ERROR << "Error: Input data has single drift time per spectrum (IM_SPECTRUM format). "
+                         << "PeakPickerIM requires per-peak IM arrays (IM_PEAK format)." << std::endl;
+        return ILLEGAL_PARAMETERS;
+      }
 
+      std::exception_ptr first_error = nullptr;
 #pragma omp parallel for
       for (SignedSize i = 0; i < static_cast<SignedSize>(exp.size()); ++i)
       {
-        MSSpectrum& spectrum = exp[static_cast<Size>(i)];
-
-        if (method == "mobilogram")
+        try
         {
-          picker.pickIMTraces(spectrum);
+          MSSpectrum& spectrum = exp[static_cast<Size>(i)];
+          if (method == "mobilogram")       picker.pickIMTraces(spectrum);
+          else if (method == "cluster")     picker.pickIMCluster(spectrum);
+          else if (method == "traces")      picker.pickIMElutionProfiles(spectrum);
         }
-        else if (method == "cluster")
+        catch (...)
         {
-          picker.pickIMCluster(spectrum);
-        }
-        else if (method == "traces")
-        {
-          picker.pickIMElutionProfiles(spectrum);
+#pragma omp critical
+          { if (!first_error) first_error = std::current_exception(); }
         }
       }
+      if (first_error) std::rethrow_exception(first_error);
 
       // Annotate processing info (same as low-memory path)
       addDataProcessing_(exp, getProcessingInfo_(DataProcessing::PEAK_PICKING));

--- a/src/topp/PeakPickerIM.cpp
+++ b/src/topp/PeakPickerIM.cpp
@@ -105,7 +105,7 @@ protected:
     registerTOPPSubsection_("bruker", "Options for reading Bruker TimsTOF .d files (requires WITH_OPENTIMS)");
     registerStringOption_("bruker:export_mode", "<mode>", "frame", "Export mode: 'auto' detects DDA/DIA acquisition type, "
       "'spectrum' forces per-precursor MS2 spectra (DDA-style), 'frame' returns raw 4D frames without signal processing.", false, true);
-    setValidStrings_("bruker:export_mode", {"auto", "spectrum", "frame"});
+    setValidStrings_("bruker:export_mode", {"auto", "frame"});
     registerDoubleOption_("bruker:calibration_tolerance", "<float>", 0.0, "m/z recalibration tolerance (0 = library default)", false, true);
     setMinFloat_("bruker:calibration_tolerance", 0.0);
     registerStringOption_("bruker:calibrate", "<toggle>", "false", "Enable m/z recalibration (may fail on some datasets)", false, true);
@@ -279,6 +279,12 @@ protected:
 #ifdef WITH_OPENTIMS
     if (in_type == FileTypes::BRUKER_TDF)
     {
+      if (process_opt == "lowmemory")
+      {
+        OPENMS_LOG_WARN << "Warning: 'lowmemory' processing is not yet supported for Bruker .d files. "
+                        << "Data will be loaded fully into memory." << std::endl;
+      }
+
       auto bruker_config = getBrukerConfig_();
       BrukerTimsFile tims_file;
       tims_file.setLogType(log_type_);
@@ -309,6 +315,13 @@ protected:
                         << "No peak picking will be performed." << std::endl;
         MzMLFile().store(output_file, exp);
         return EXECUTION_OK;
+      }
+      if (im_format == IMFormat::IM_SPECTRUM)
+      {
+        OPENMS_LOG_ERROR << "Error: Input data has single drift time per spectrum (IM_SPECTRUM format). "
+                         << "PeakPickerIM requires per-peak IM arrays (IM_PEAK format). "
+                         << "Try using bruker:export_mode=frame." << std::endl;
+        return ILLEGAL_PARAMETERS;
       }
 
 #pragma omp parallel for


### PR DESCRIPTION
## Summary

- **Bruker `.d` direct input**: PeakPickerIM now accepts Bruker TimsTOF `.d` directories directly, eliminating the need to convert to mzML via FileConverter first. Uses FRAME export mode by default to get raw per-peak IM data. Guarded by `WITH_OPENTIMS`.
- **Built-in Sage IM centroiding**: Exposes `bruker:ms1_centroid_mz_ppm` and `bruker:ms1_centroid_im_pct` parameters that trigger BrukerTimsFile's built-in IM-dimension centroiding (Sage algorithm, Lazear 2023) directly on the raw gridded TOF data during `.d` loading. When enabled, this is faster than PeakPickerIM's post-hoc algorithms and the tool skips the redundant PeakPickerIM step.
- **Bruker configuration options**: Adds a `bruker:` parameter subsection with `export_mode`, `calibration_tolerance`, and `calibrate` options, following the same pattern as FileConverter.

## New parameters (`.d` input only, requires `WITH_OPENTIMS`)

| Parameter | Default | Description |
|---|---|---|
| `bruker:export_mode` | `frame` | Export mode (`auto`, `spectrum`, `frame`) |
| `bruker:calibration_tolerance` | `0.0` | m/z recalibration tolerance in Da |
| `bruker:calibrate` | `false` | Enable m/z recalibration |
| `bruker:ms1_centroid_mz_ppm` | `0.0` | IM-centroiding m/z tolerance in ppm (suggested: 5.0) |
| `bruker:ms1_centroid_im_pct` | `0.0` | IM-centroiding IM tolerance in percent (suggested: 3.0) |

## Test plan

- [ ] Build with `WITH_OPENTIMS=ON` and verify compilation
- [ ] Run PeakPickerIM on a `.d` directory with default settings (no built-in centroiding) and verify mzML output matches the mzML-input workflow
- [ ] Run with `bruker:ms1_centroid_mz_ppm=5.0 bruker:ms1_centroid_im_pct=3.0` and verify the built-in centroiding path is taken (check log output)
- [ ] Verify existing mzML input paths (inmemory and lowmemory) are unaffected
- [ ] Build with `WITH_OPENTIMS=OFF` and verify `.d` format is not offered

https://claude.ai/code/session_01ExrNnWRF9ETqJLmkMpHspr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peak picking now supports Bruker TimsTOF .d directories alongside mzML inputs.
  * New Bruker-specific options for export mode, calibration tolerance/behavior, and MS1 centroiding control.
  * Automatic input-format detection now considers MS1 spectra for format decision and can take a faster path for native Bruker data when centroiding is applied.

* **Bug Fixes / UX**
  * Improved error handling for parallel peak-picking with clearer warnings and errors for incompatible ion-mobility formats and required per-peak IM arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->