### PR TITLE
New CI workflow for checking the ToolHandler.cpp file

### DIFF
--- a/.github/workflows/check-tool-handler.yml
+++ b/.github/workflows/check-tool-handler.yml
@@ -1,0 +1,32 @@
+name: Check ToolHandler.cpp
+on:
+  pull_request_target:
+    types: [ "opened" ]
+    branches: [ "develop" ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Clone PR Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Clone OpenMS CI Tools Repository
+        uses: actions/checkout@v6
+        with:
+          repository: OpenMS/ci-tools
+          path: ci-tools
+      - name: Check the ToolHandler.cpp file
+        run: |
+          if ! ci-tools/scripts/check-tool-handler.sh "$GITHUB_BASE_REF" "HEAD"; then
+            ci-tools/scripts/check-tool-handler.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" |
+              gh pr comment "$PR" --body-file -
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+          ACTOR: ${{ github.actor }}


### PR DESCRIPTION
If a PR adds a TOPP tool, this check will post a PR comment if that tool isn't listed in the `ToolHandler.cpp` file.

Related to #8984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code quality checks for pull requests to improve overall code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->