### PR TITLE
feat: stream Bruker DIA-PASEF data frame-by-frame for constant memory usage

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
@@ -78,11 +78,25 @@ namespace OpenMS
     void load(const String& path, MSExperiment& exp, const Config& config);
 
     /// Feed spectra from a .d directory to a consumer.
-    /// @note Currently loads the full dataset into memory before streaming to the consumer.
-    ///       A future optimization should iterate frame-by-frame for true constant-memory operation.
+    /// For DIA data, this streams frame-by-frame with constant memory usage.
+    /// For DDA/FRAME modes, the full dataset is loaded before streaming to the consumer.
     void transform(const String& path, Interfaces::IMSDataConsumer* consumer);
     /// @overload with explicit configuration
     void transform(const String& path, Interfaces::IMSDataConsumer* consumer, const Config& config);
+
+    /// SWATH window descriptor read from the TDF SQL metadata.
+    struct SwathWindow
+    {
+      int window_group;
+      double mz_center;
+      double mz_width;
+      double im_lower;  ///< 1/K0 lower bound
+      double im_upper;  ///< 1/K0 upper bound
+    };
+
+    /// Read SWATH window definitions from a .d directory without loading peak data.
+    /// Returns an empty vector for non-DIA datasets.
+    static std::vector<SwathWindow> getSwathWindows(const String& path, const Config& config = Config());
 
   private:
     /// Load DDA-PASEF data: MS1 frames (IM_PEAK) + MS2 spectra (scalar IM)
@@ -90,6 +104,9 @@ namespace OpenMS
 
     /// Load DIA-PASEF data: MS1 frames (IM_PEAK) + MS2 frames split by SWATH window
     void loadDIA_(TimsDataHandle& handle, MSExperiment& exp, const Config& config);
+
+    /// Stream DIA-PASEF data frame-by-frame directly to consumer (constant memory)
+    void streamDIA_(TimsDataHandle& handle, Interfaces::IMSDataConsumer* consumer, const Config& config);
 
     /// Load raw frames without precursor grouping or SWATH splitting
     void loadFrames_(TimsDataHandle& handle, MSExperiment& exp, const Config& config);

--- a/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
+++ b/src/openms/include/OpenMS/FORMAT/BrukerTimsFile.h
@@ -96,7 +96,9 @@ namespace OpenMS
 
     /// Read SWATH window definitions from a .d directory without loading peak data.
     /// Returns an empty vector for non-DIA datasets.
-    static std::vector<SwathWindow> getSwathWindows(const String& path, const Config& config = Config());
+    static std::vector<SwathWindow> getSwathWindows(const String& path);
+    /// @overload with explicit configuration
+    static std::vector<SwathWindow> getSwathWindows(const String& path, const Config& config);
 
   private:
     /// Load DDA-PASEF data: MS1 frames (IM_PEAK) + MS2 spectra (scalar IM)

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -727,6 +727,39 @@ namespace OpenMS
   }
 
   // =====================================================================
+  // getSwathWindows: read SWATH window definitions without loading peak data
+  // =====================================================================
+  std::vector<BrukerTimsFile::SwathWindow> BrukerTimsFile::getSwathWindows(const String& path, const Config& config)
+  {
+    std::vector<SwathWindow> result;
+
+    String tdf_path = path + "/analysis.tdf";
+    try
+    {
+      SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
+      if (!isDIA(db)) return result;
+
+      // We need an IM converter to translate scan bounds to 1/K0.
+      // Open the handle just for calibration — no peak data is read.
+      auto handle = openTimsDataHandle(path, config);
+      std::vector<DIAWindow> windows = readDIAWindows(db, *handle->scan2inv_ion_mobility_converter);
+
+      result.reserve(windows.size());
+      for (const auto& w : windows)
+      {
+        result.push_back({w.window_group, w.mz_center, w.mz_width, w.im_lower, w.im_upper});
+      }
+    }
+    catch (const SQLite::Exception& e)
+    {
+      OPENMS_LOG_WARN << "Warning: could not read SWATH windows from " << tdf_path
+                      << ": " << e.what() << std::endl;
+    }
+
+    return result;
+  }
+
+  // =====================================================================
   // load() overloads
   // =====================================================================
   void BrukerTimsFile::load(const String& path, MSExperiment& exp)
@@ -826,22 +859,29 @@ namespace OpenMS
     settings.getSourceFiles().push_back(sf);
     consumer->setExperimentalSettings(settings);
 
-    // NOTE: This loads into a temporary experiment then feeds to consumer.
-    // Not truly constant-memory -- a future optimization should iterate
-    // frame-by-frame and call consumer->consumeSpectrum() inline.
-    OPENMS_LOG_INFO << "BrukerTimsFile::transform(): loading full dataset (streaming optimization pending)" << std::endl;
-    MSExperiment exp;
-    if (mode == Config::FRAME)
-      loadFrames_(*handle, exp, config);
-    else if (is_dia && mode != Config::SPECTRUM)
-      loadDIA_(*handle, exp, config);
-    else
-      loadDDA_(*handle, exp, config);
-
-    exp.sortSpectra(true);
-    for (auto& spec : exp)
+    if (is_dia && mode != Config::SPECTRUM && mode != Config::FRAME)
     {
-      consumer->consumeSpectrum(spec);
+      // DIA: stream frame-by-frame directly to consumer (constant memory).
+      // Frames are iterated in ID order which is acquisition (RT) order,
+      // so no global sort is needed.
+      streamDIA_(*handle, consumer, config);
+    }
+    else
+    {
+      // DDA and FRAME modes: load into temporary experiment, then feed to consumer.
+      // DDA cannot easily stream due to optional OLS m/z recalibration which
+      // needs precursor data across multiple frames before re-extracting.
+      MSExperiment exp;
+      if (mode == Config::FRAME)
+        loadFrames_(*handle, exp, config);
+      else
+        loadDDA_(*handle, exp, config);
+
+      exp.sortSpectra(true);
+      for (auto& spec : exp)
+      {
+        consumer->consumeSpectrum(spec);
+      }
     }
   }
 
@@ -1360,6 +1400,120 @@ namespace OpenMS
           spec.setIMPeakType(IMPeakType::IM_PROFILE);
           exp.addSpectrum(std::move(spec));
         }
+      }
+    }
+    endProgress();
+  }
+
+  // =====================================================================
+  // streamDIA_: constant-memory DIA streaming directly to consumer
+  // =====================================================================
+  void BrukerTimsFile::streamDIA_(TimsDataHandle& handle, Interfaces::IMSDataConsumer* consumer, const Config& config)
+  {
+    String tdf_path = handle.get_tims_dir_path() + "/analysis.tdf";
+    SQLite::Database db(std::string(tdf_path), SQLite::OPEN_READONLY);
+
+    // Read SWATH windows (small SQL query, typically ~20 rows)
+    std::vector<DIAWindow> windows = readDIAWindows(db, *handle.scan2inv_ion_mobility_converter);
+    if (windows.empty())
+    {
+      OPENMS_LOG_WARN << "Warning: DIA dataset detected but no SWATH windows found" << std::endl;
+      return;
+    }
+
+    bool do_centroid = isCentroidingEnabled(config);
+    FrameCentroider centroider;  // reusable buffer across frames
+
+    // Count total frames for progress
+    size_t total_frames = 0;
+    for (uint32_t fid = handle.min_frame_id(); fid <= handle.max_frame_id(); ++fid)
+    {
+      if (handle.has_frame(fid)) ++total_frames;
+    }
+
+    startProgress(0, total_frames, "Streaming DIA-PASEF data");
+    size_t frame_idx = 0;
+
+    // Single pass over all frames in ID order (= RT order).
+    // MS1 and MS2 are interleaved as they occur in the acquisition,
+    // which is the natural RT-sorted order.
+    for (uint32_t fid = handle.min_frame_id(); fid <= handle.max_frame_id(); ++fid)
+    {
+      if (!handle.has_frame(fid)) continue;
+      TimsFrame& frame = handle.get_frame(fid);
+      setProgress(frame_idx++);
+
+      if (frame.msms_type == 0)
+      {
+        // --- MS1: build spectrum and emit immediately ---
+        MSSpectrum spec;
+        if (do_centroid)
+        {
+          centroidMS1Frame(frame, spec, config, centroider);
+        }
+        else
+        {
+          frameToSpectrum(frame, spec, 1);
+        }
+        consumer->consumeSpectrum(spec);
+        // spec destroyed here -> memory freed
+      }
+      else
+      {
+        // --- MS2: extract frame data, split by window, emit each ---
+        if (frame.num_peaks == 0) continue;
+
+        std::vector<uint32_t> scan_ids(frame.num_peaks);
+        std::vector<uint32_t> intensities(frame.num_peaks);
+        std::vector<double> mzs(frame.num_peaks);
+        std::vector<double> inv_ion_mobilities(frame.num_peaks);
+
+        frame.save_to_buffs(nullptr, scan_ids.data(), nullptr, intensities.data(),
+                            mzs.data(), inv_ion_mobilities.data(), nullptr);
+
+        for (const DIAWindow& win : windows)
+        {
+          MSSpectrum spec;
+          spec.setRT(frame.time);
+          spec.setMSLevel(2);
+          spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+          spec.setNativeID("frame=" + String(frame.id) + " windowGroup=" + String(win.window_group));
+
+          // Set isolation window
+          Precursor prec;
+          prec.setMZ(win.mz_center);
+          prec.setIsolationWindowLowerOffset(win.mz_width / 2.0);
+          prec.setIsolationWindowUpperOffset(win.mz_width / 2.0);
+          spec.setPrecursors({prec});
+
+          // Set ion mobility window bounds for PASEF window grouping
+          spec.setMetaValue("ion mobility lower limit", win.im_lower);
+          spec.setMetaValue("ion mobility upper limit", win.im_upper);
+
+          DataArrays::FloatDataArray im_array;
+          IMDataConverter::setIMUnit(im_array, DriftTimeUnit::VSSC);
+
+          for (uint32_t p = 0; p < frame.num_peaks; ++p)
+          {
+            if (inv_ion_mobilities[p] >= win.im_lower && inv_ion_mobilities[p] <= win.im_upper)
+            {
+              Peak1D peak;
+              peak.setMZ(mzs[p]);
+              peak.setIntensity(static_cast<double>(intensities[p]));
+              spec.push_back(peak);
+              im_array.push_back(static_cast<float>(inv_ion_mobilities[p]));
+            }
+          }
+
+          if (!spec.empty())
+          {
+            spec.getFloatDataArrays().push_back(std::move(im_array));
+            spec.setIMPeakType(IMPeakType::IM_PROFILE);
+            consumer->consumeSpectrum(spec);
+            // spec destroyed here -> memory freed
+          }
+        }
+        // frame buffers destroyed here -> memory freed
       }
     }
     endProgress();

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -729,6 +729,11 @@ namespace OpenMS
   // =====================================================================
   // getSwathWindows: read SWATH window definitions without loading peak data
   // =====================================================================
+  std::vector<BrukerTimsFile::SwathWindow> BrukerTimsFile::getSwathWindows(const String& path)
+  {
+    return getSwathWindows(path, Config());
+  }
+
   std::vector<BrukerTimsFile::SwathWindow> BrukerTimsFile::getSwathWindows(const String& path, const Config& config)
   {
     std::vector<SwathWindow> result;

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -292,31 +292,43 @@ namespace OpenMS
     OPENMS_LOG_INFO << "Loading Bruker TDF file " << file << '\n';
     startProgress(0, 1, "Loading Bruker TDF file " + file);
 
-    // Load full MSExperiment via BrukerTimsFile (DIA auto-detected)
+    // Read SWATH window definitions from SQL metadata (no peak data loaded)
+    auto swath_windows = BrukerTimsFile::getSwathWindows(file);
+
+    // Build known_window_boundaries from SQL metadata directly
+    std::vector<OpenSwath::SwathMap> known_window_boundaries;
+    for (const auto& w : swath_windows)
+    {
+      OpenSwath::SwathMap boundary;
+      boundary.lower = w.mz_center - w.mz_width / 2.0;
+      boundary.upper = w.mz_center + w.mz_width / 2.0;
+      boundary.center = w.mz_center;
+      boundary.imLower = w.im_lower;
+      boundary.imUpper = w.im_upper;
+      boundary.ms1 = false;
+      known_window_boundaries.push_back(boundary);
+    }
+
+    OPENMS_LOG_INFO << "Bruker TDF: " << known_window_boundaries.size()
+                    << " SWATH windows (from SQL metadata)" << std::endl;
+
+    // Stream spectra frame-by-frame into the consumer (constant memory).
+    // The consumer partitions spectra into per-window MSExperiment objects.
+    RegularSwathFileConsumer consumer(known_window_boundaries);
+
     BrukerTimsFile bruker_reader;
     bruker_reader.setLogType(this->getLogType());
-    std::shared_ptr<PeakMap> experiment(new PeakMap);
-    bruker_reader.load(file, *experiment);
-    exp_meta = experiment; // preserve experimental settings for downstream
+    bruker_reader.transform(file, &consumer);
 
-    // Discover unique SWATH windows from spectrum metadata
-    std::vector<int> swath_counter;
-    int nr_ms1_spectra = 0;
-    std::vector<OpenSwath::SwathMap> known_window_boundaries;
-    countScansInSwath_(experiment->getSpectra(), swath_counter,
-                       nr_ms1_spectra, known_window_boundaries);
-
-    OPENMS_LOG_INFO << "Bruker TDF: " << swath_counter.size()
-                    << " SWATH windows and " << nr_ms1_spectra
-                    << " MS1 spectra" << std::endl;
-
-    // Partition spectra into per-window MSExperiment objects via RegularSwathFileConsumer
-    RegularSwathFileConsumer consumer(known_window_boundaries);
-    consumer.setExperimentalSettings(*exp_meta);
-    for (auto& spec : experiment->getSpectra())
-    {
-      consumer.consumeSpectrum(spec);
-    }
+    // Populate experimental settings for downstream consumers
+    exp_meta = std::make_shared<ExperimentalSettings>();
+    SourceFile sf;
+    sf.setNameOfFile(File::basename(file));
+    sf.setPathToFile(File::path(file));
+    sf.setFileType("Bruker TDF");
+    sf.setNativeIDType("scan number only nativeID format");
+    sf.setNativeIDTypeAccession("MS:1000776");
+    exp_meta->getSourceFiles().push_back(sf);
 
     std::vector<OpenSwath::SwathMap> swath_maps;
     consumer.retrieveSwathMaps(swath_maps);


### PR DESCRIPTION
Instead of loading all spectra into an MSExperiment before feeding them
to a consumer, the DIA path in transform() now iterates frames in
acquisition order and emits spectra directly to the IMSDataConsumer.
This reduces memory from O(all spectra) to O(1 frame) for DIA datasets.

- Add streamDIA_() that processes one frame at a time, splitting by
  SWATH window and calling consumeSpectrum() inline
- Add static getSwathWindows() to read window definitions from SQL
  metadata without loading any peak data
- Update SwathFile::loadBrukerTdf to build window boundaries from SQL
  metadata and stream via transform() instead of load()
- DDA and FRAME modes remain unchanged (load-then-stream)

https://claude.ai/code/session_01XKHxz5wQ9qyzp9u39K6PVh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SWATH window discovery from Bruker TIMS `.d` metadata without loading peak data.
  * Added constant-memory, frame-by-frame streaming for DIA-PASEF (DDA/FRAME behavior unchanged).

* **Improvements**
  * Updated SWATH file loading to derive window boundaries from metadata and stream partitions directly to consumers.

* **Bug Fixes**
  * Improved resilience: SQL lookup failures for window discovery now fall back to an empty result with warnings.

* **Documentation**
  * Refreshed processing-mode documentation to reflect DIA streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->