### PR TITLE
 perf: replace nested OMP loops with flat work queue in OpenSwathWork…

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -17,9 +17,21 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <algorithm>
 #include <cmath>
 #include <unordered_map>
 
+namespace
+{
+  /// Lightweight descriptor for a (window, batch) work item in the flat work queue.
+  struct WorkItem
+  {
+    OpenMS::SignedSize window_idx;
+    OpenMS::SignedSize batch_idx;
+    int batch_size;
+    OpenMS::Size n_compounds;  ///< total compounds in this window (used for sorting)
+  };
+}
 
 // OpenSwathWorkflow
 namespace OpenMS
@@ -88,8 +100,6 @@ namespace OpenMS
     trafo_inverse.invert();
 
     OPENMS_LOG_INFO << "Will analyze " << transition_exp.transitions.size() << " transitions in total." << std::endl;
-    int progress = 0;
-    this->startProgress(0, swath_maps.size(), "Extracting and scoring transitions");
 
     // (i) Obtain precursor chromatograms (MS1) if precursor extraction is enabled
     ChromExtractParams ms1_cp(cp_ms1);
@@ -206,33 +216,25 @@ namespace OpenMS
     };
 
     // (iv) Perform extraction and scoring of fragment ion chromatograms (MS2)
-    // We set dynamic scheduling such that the maps are worked on in the order
-    // in which they were given to the program / acquired. This gives much
-    // better load balancing than static allocation.
-#ifdef _OPENMP
-#ifdef MT_ENABLE_NESTED_OPENMP
-    int total_nr_threads = omp_get_max_threads(); // store total number of threads we are allowed to use
-    if (threads_outer_loop_ > -1)
-    {
-  OPENMS_LOG_INFO << "Setting up nested loop with " << std::min(threads_outer_loop_, omp_get_max_threads()) << " threads out of "<< omp_get_max_threads() << std::endl;
-      omp_set_nested(1);
-      omp_set_dynamic(0);
-      omp_set_num_threads(std::min(threads_outer_loop_, omp_get_max_threads()) ); // use at most threads_outer_loop_ threads here
-    }
-    else
-    {
-  OPENMS_LOG_INFO << "Use non-nested loop with " << total_nr_threads << " threads." << std::endl;
-    }
-#endif
-#pragma omp parallel for schedule(dynamic,1)
-#endif
+    //
+    // We use a flat work queue: pre-compute all (window, batch) pairs, sort
+    // them by descending compound count, then process with a single
+    // omp parallel for with dynamic scheduling. This replaces the previous
+    // nested loop (outer over windows, inner over batches) and gives much
+    // better load balancing, especially for diaPASEF where compound counts
+    // per window can vary by 40x+.
+
+    // --- Phase A: sequential pre-computation ---
+
+    // A1: Select transitions per window
+    std::vector<OpenSwath::LightTargetedExperiment> per_window_transitions(swath_maps.size());
     for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_maps.size()); ++i)
     {
       if (!swath_maps[i].ms1) // skip MS1
       {
 
         // Step 1: select which transitions to extract (proceed in batches)
-        OpenSwath::LightTargetedExperiment transition_exp_used_all;
+        OpenSwath::LightTargetedExperiment& transition_exp_used_all = per_window_transitions[i];
         if (!(prm_ || pasef_))
         {
           // Step 1.1: select transitions matching the window
@@ -274,144 +276,168 @@ namespace OpenMS
             }
           }
         }
+      }
+    }
 
-        if (!transition_exp_used_all.getTransitions().empty()) // skip if no transitions found
-        {
+    // A2: Build flat work queue of (window, batch) pairs
+    std::vector<WorkItem> work_items;
+    for (SignedSize i = 0; i < boost::numeric_cast<SignedSize>(swath_maps.size()); ++i)
+    {
+      if (swath_maps[i].ms1) continue;
+      const auto& trans = per_window_transitions[i];
+      if (trans.getTransitions().empty()) continue;
 
-          OpenSwath::SpectrumAccessPtr current_swath_map = swath_maps[i].sptr;
-          if (load_into_memory)
-          {
-            // This creates an InMemory object that keeps all data in memory
-            current_swath_map = std::shared_ptr<SpectrumAccessOpenMSInMemory>( new SpectrumAccessOpenMSInMemory(*current_swath_map) );
-          }
+      int batch_size;
+      if (batchSize <= 0 || batchSize >= (int)trans.getCompounds().size())
+      {
+        batch_size = trans.getCompounds().size();
+      }
+      else
+      {
+        batch_size = batchSize;
+      }
 
-          int batch_size;
-          if (batchSize <= 0 || batchSize >= (int)transition_exp_used_all.getCompounds().size())
-          {
-            batch_size = transition_exp_used_all.getCompounds().size();
-          }
-          else
-          {
-            batch_size = batchSize;
-          }
+      const Size n_compounds = trans.getCompounds().size();
+      SignedSize nr_batches = (batch_size > 0)
+          ? static_cast<SignedSize>((n_compounds + batch_size - 1) / batch_size)
+          : 0;
 
-          const Size n_compounds = transition_exp_used_all.getCompounds().size();
-          SignedSize nr_batches = 0;
-          if (batch_size > 0)
-          {
-            nr_batches = static_cast<SignedSize>((n_compounds + batch_size - 1) / batch_size);
-          }
+      for (SignedSize j = 0; j < nr_batches; ++j)
+      {
+        work_items.push_back({i, j, batch_size, n_compounds});
+      }
+    }
 
+    // A3: Sort by descending compound count for better load balancing with
+    // dynamic scheduling. Only sort when multi-threaded. single-threaded must
+    // preserve window/batch order to produce deterministic output.
 #ifdef _OPENMP
-#ifdef MT_ENABLE_NESTED_OPENMP
-          // If we have a multiple of threads_outer_loop_ here, then use nested
-          // parallelization here. E.g. if we use 8 threads for the outer loop,
-          // but we have a total of 24 cores available, each of the 8 threads
-          // will then create a team of 3 threads to work on the batches
-          // individually.
-          //
-          // We should avoid oversubscribing the CPUs, therefore we use integer division.
-          // -- see https://docs.oracle.com/cd/E19059-01/stud.10/819-0501/2_nested.html
-          int outer_thread_nr = omp_get_thread_num();
-          omp_set_num_threads(std::max(1, total_nr_threads / threads_outer_loop_) );
+    if (omp_get_max_threads() > 1)
+    {
+      std::sort(work_items.begin(), work_items.end(),
+          [](const WorkItem& a, const WorkItem& b) { return a.n_compounds > b.n_compounds; });
+    }
+#endif
+
+    // A4: Prepare per-window spectrum access with lazy init + ref counting.
+    // When load_into_memory is set, InMemory copies are created on first
+    // access (thread-safe via critical section) and released when all batches
+    // for that window are done. This keeps memory proportional to the number
+    // of concurrently active windows (~thread count), not total windows.
+    std::vector<OpenSwath::SpectrumAccessPtr> per_window_sptr(swath_maps.size());
+    std::vector<int> window_refcounts(swath_maps.size(), 0);
+    for (const auto& wi : work_items)
+    {
+      window_refcounts[wi.window_idx]++;
+    }
+
+    int progress = 0;
+    this->startProgress(0, work_items.size(), "Extracting and scoring transitions");
+
+    // --- Phase B: flat parallel loop over all work items ---
+#ifdef _OPENMP
+    OPENMS_LOG_INFO << "Processing " << work_items.size() << " work items with " << omp_get_max_threads() << " threads." << std::endl;
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
-#endif
-          for (SignedSize pep_idx = 0; pep_idx < nr_batches; ++pep_idx)
+    for (SignedSize k = 0; k < boost::numeric_cast<SignedSize>(work_items.size()); ++k)
+    {
+      const WorkItem& wi = work_items[k];
+      const OpenSwath::LightTargetedExperiment& transition_exp_used_all = per_window_transitions[wi.window_idx];
+
+      // Obtain thread-safe spectrum access for this work item.
+      // When load_into_memory is set, lazily create one InMemory copy per
+      // window (serialized to avoid concurrent file reads on the same sptr).
+      // When not set, lightClone creates a new independent file handle.
+      OpenSwath::SpectrumAccessPtr current_swath_map;
+      if (load_into_memory)
+      {
+        #pragma omp critical (window_cache_init)
+        {
+          if (!per_window_sptr[wi.window_idx])
           {
-            OpenSwath::SpectrumAccessPtr current_swath_map_inner = current_swath_map;
+            per_window_sptr[wi.window_idx] = std::make_shared<SpectrumAccessOpenMSInMemory>(*swath_maps[wi.window_idx].sptr);
+          }
+        }
+        current_swath_map = per_window_sptr[wi.window_idx]->lightClone();
+      }
+      else
+      {
+        current_swath_map = swath_maps[wi.window_idx].sptr->lightClone();
+      }
 
 #ifdef _OPENMP
-#ifdef MT_ENABLE_NESTED_OPENMP
-            // To ensure multi-threading safe access to the individual spectra, we
-            // need to use a light clone of the spectrum access (if multiple threads
-            // share a single filestream and call seek on it, chaos will ensue).
-            if (total_nr_threads / threads_outer_loop_ > 1)
-            {
-              current_swath_map_inner = current_swath_map->lightClone();
-            }
-#endif
 #pragma omp critical (osw_write_stdout)
 #endif
-            {
-              OPENMS_LOG_INFO << "Thread " <<
+      {
+        OPENMS_LOG_INFO << "Thread " <<
 #ifdef _OPENMP
-#ifdef MT_ENABLE_NESTED_OPENMP
-              outer_thread_nr << "_" << omp_get_thread_num() << " " <<
+            omp_get_thread_num() <<
 #else
-              omp_get_thread_num() << "_0 " <<
+            "0" <<
 #endif
-#else
-              "0" <<
-#endif
-              "will analyze " << transition_exp_used_all.getCompounds().size() <<  " compounds and "
-              << transition_exp_used_all.getTransitions().size() <<  " transitions "
-              "from SWATH " << i << " (batch " << pep_idx << " out of " << nr_batches << ")" << std::endl;
-            }
+            " will analyze " << transition_exp_used_all.getCompounds().size() << " compounds and "
+            << transition_exp_used_all.getTransitions().size() << " transitions "
+            "from SWATH " << wi.window_idx << " (batch " << wi.batch_idx << ")" << std::endl;
+      }
 
-            // Create the new, batch-size transition experiment
-            OpenSwath::LightTargetedExperiment transition_exp_used;
-            selectCompoundsForBatch_(transition_exp_used_all, transition_exp_used, batch_size, pep_idx);
+      // Select compounds for this batch
+      OpenSwath::LightTargetedExperiment transition_exp_used;
+      selectCompoundsForBatch_(transition_exp_used_all, transition_exp_used, wi.batch_size, wi.batch_idx);
 
-            // Extract MS1 chromatograms for this batch
-            std::vector< MSChromatogram > ms1_chromatograms;
-            if (ms1_map_ != nullptr)
-            {
-              OpenSwath::SpectrumAccessPtr threadsafe_ms1 = ms1_map_->lightClone();
-              MS1Extraction_(threadsafe_ms1, swath_maps, ms1_chromatograms, ms1_cp,
-                  transition_exp_used, trafo_inverse, ms1_only, ms1_isotopes);
-            }
+      // Extract MS1 chromatograms for this batch
+      std::vector< MSChromatogram > ms1_chromatograms;
+      if (ms1_map_ != nullptr)
+      {
+        OpenSwath::SpectrumAccessPtr threadsafe_ms1 = ms1_map_->lightClone();
+        MS1Extraction_(threadsafe_ms1, swath_maps, ms1_chromatograms, ms1_cp,
+            transition_exp_used, trafo_inverse, ms1_only, ms1_isotopes);
+      }
 
-            // Step 2.1: extract these transitions
-            ChromatogramExtractor extractor;
-            std::vector< OpenSwath::ChromatogramPtr > chrom_list;
-            std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
+      // Step 2.1: extract these transitions
+      ChromatogramExtractor extractor;
+      std::vector< OpenSwath::ChromatogramPtr > chrom_list;
+      std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
 
-            // Step 2.2: prepare the extraction coordinates and extract chromatograms
-            // chrom_list contains one entry for each fragment ion (transition) in transition_exp_used
-            prepareExtractionCoordinates_(chrom_list, coordinates, transition_exp_used, trafo_inverse, cp);
-            extractor.extractChromatograms(current_swath_map_inner, chrom_list, coordinates, cp.mz_extraction_window,
-                cp.ppm, cp.im_extraction_window, cp.extraction_function);
+      // Step 2.2: prepare the extraction coordinates and extract chromatograms
+      prepareExtractionCoordinates_(chrom_list, coordinates, transition_exp_used, trafo_inverse, cp);
+      extractor.extractChromatograms(current_swath_map, chrom_list, coordinates, cp.mz_extraction_window,
+          cp.ppm, cp.im_extraction_window, cp.extraction_function);
 
-            // Step 2.3: convert chromatograms back to OpenMS::MSChromatogram and write to output
-            PeakMap chrom_exp;
-            extractor.return_chromatogram(chrom_list, coordinates, transition_exp_used,  SpectrumSettings(),
-                                          chrom_exp.getChromatograms(), false, cp.im_extraction_window);
+      // Step 2.3: convert chromatograms back to OpenMS::MSChromatogram and write to output
+      PeakMap chrom_exp;
+      extractor.return_chromatogram(chrom_list, coordinates, transition_exp_used, SpectrumSettings(),
+                                    chrom_exp.getChromatograms(), false, cp.im_extraction_window);
 
+      // Step 3: score these extracted transitions
+      FeatureMap featureFile;
+      std::vector< OpenSwath::SwathMap > tmp = {swath_maps[wi.window_idx]};
+      tmp.back().sptr = current_swath_map;
+      scoreAllChromatograms_(chrom_exp.getChromatograms(), ms1_chromatograms, tmp, transition_exp_used,
+          feature_finder_param, trafo, cp.rt_extraction_window, featureFile, osw_writer, ms1_isotopes, false, mobilogram_consumer);
 
-            // Step 3: score these extracted transitions
-            FeatureMap featureFile;
-            std::vector< OpenSwath::SwathMap > tmp = {swath_maps[i]};
-            tmp.back().sptr = current_swath_map_inner;
-            scoreAllChromatograms_(chrom_exp.getChromatograms(), ms1_chromatograms, tmp, transition_exp_used,
-              feature_finder_param, trafo, cp.rt_extraction_window, featureFile, osw_writer, ms1_isotopes, false, mobilogram_consumer);
+      // Step 4: write all chromatograms and features out into an output object / file
+      // (critical section since we only have one output file and one output map)
+      #pragma omp critical (osw_write_out)
+      {
+        writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), ms1_chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
+      }
 
-            // Step 4: write all chromatograms and features out into an output object / file
-            // (this needs to be done in a critical section since we only have one
-            // output file and one output map).
-            #pragma omp critical (osw_write_out)
-            {
-              writeOutFeaturesAndChroms_(chrom_exp.getChromatograms(), ms1_chromatograms, featureFile, out_featureFile, store_features, chromConsumer);
-            }
+      // Release InMemory copy when all batches for this window are done
+      if (load_into_memory)
+      {
+        #pragma omp critical (window_cache_init)
+        {
+          if (--window_refcounts[wi.window_idx] == 0)
+          {
+            per_window_sptr[wi.window_idx].reset();
           }
-
-        } // continue 2 (no continue due to OpenMP)
-      } // continue 1 (no continue due to OpenMP)
+        }
+      }
 
       #pragma omp critical (progress)
       this->setProgress(++progress);
-
     }
     this->endProgress();
-
-#ifdef _OPENMP
-#ifdef MT_ENABLE_NESTED_OPENMP
-    if (threads_outer_loop_ > -1)
-    {
-      omp_set_num_threads(total_nr_threads); // set number of available threads back to initial value
-    }
-#endif
-#endif
   }
 
   void OpenSwathWorkflow::writeOutFeaturesAndChroms_(


### PR DESCRIPTION


## Description

OpenSwathWorkflow's extraction+scoring phase uses nested OpenMP parallel loops which are outer    
  over SWATH windows, inner over compound batches. This creates severe load imbalance in    
  diaPASEF data where compound counts per window vary by up to 41x (246 to 10,146           
  compounds/window), causing threads to spin-wait while a few overloaded windows finish.
                                                      
  ### Datasets used for profiling and benchmarking

  | Dataset | Source | Library | Transitions | Compounds |
  |---------|--------|---------|-------------|-----------|
  | SWATH-MS (Mtb) | PASS00779 | Mtb_library.tsv | 477,335 | 95,467 |
  | diaPASEF (HeLa 200SPD) | PXD017703 | HeLa fractions PQP | 880,728 | 146,788 |           
                                                                                            
  Hardware: AMD Ryzen 7 5800H (8C/16T, 4.47 GHz), 16 GB RAM, NVMe SSD, Linux. GCC Release   
  (-O2). All runs with `batchSize=1000`, `cacheWorkingInMemory`.                            
                                                                                            
  ## Profiling                                                    
                                                      
  Profiling with `perf` revealed a key bottleneck:

  ### 1. Thread spin-wait (diaPASEF)                                                        
  ~55% of CPU time was spent in thread spinlock (`__kmp_wait_4` / `__kmp_suspend_oncore`), 
  caused by the nested OMP outer loop assigning entire windows to threads. With compound    
  counts ranging from 246 to 10,146 per window (41x ratio), threads finishing small windows 
  idled while a few overloaded windows dominated wall time.                                 

                                                                                            
  The work queue directly targets the problem by flattening the (window, batch) pairs into a 
  single parallel loop with dynamic scheduling, so all threads stay busy until the last work
   item completes.                                                                          
                                                                 
  ## Solution                                         

  Replace the nested loops with a flat work queue:

  1. Pre compute per window transition selections sequentially
  2. Build a flat vector of `(window_idx, batch_idx)` work items
  3. Sort by descending compound count when multi-threaded (single-threaded preserves       
  original order for deterministic output)
  4. Process with a single `#pragma omp parallel for schedule(dynamic, 1)`                  
  5. Lazy per-window InMemory initialization with reference counting. InMemory copies 
  created on first access, released when all batches for that window complete. Keeps peak   
  memory proportional to thread count, not total windows.
                                                                                            
  ## Results                                                     
                                                      
  ### SWATH-MS

  | Metric | Baseline 1T | Work Queue 1T | Baseline 8T | Work Queue 8T |                    
  |--------|-------------|---------------|-------------|---------------|
  | Total wall | 237s | 215s (**-9.3%**) | 79.8s | 76.0s (**-4.8%**) |                      
  | Extract+Score wall | 180s | 156s (**-13.3%**) | ~26s | 24.4s (**-6.2%**) |              
  | Peak RSS | 1,067 MB | 1,067 MB (=) | 2,028 MB | 2,438 MB (+20%) |
                                                                                            
  ### diaPASEF (8 threads)                                       
                                                                                            
  | Metric | Baseline | Work Queue |                             
  |--------|----------|------------|                  
  | Total wall | 3m47s | 3m36s (**-4.8%**) |
  | Extract+Score wall | 84s | 66s (**-21.4%**) |                                           
  | Peak RSS | 8,318 MB | 7,984 MB (**-4.0%**) |
  | CPU utilization | 625% (78%) | 657% (82%) |                                             
                                                                                            
<details>
<summary>Benchmark commands</summary>

### SWATH-MS (1 thread)

```bash
OpenSwathWorkflow \
  -in olgas_R1.mzML -tr Mtb_library.tsv \
  -Calibration:files:linear_irt_file iRTassays.TraML \
  -swath_windows_file SWATHwindows_analysis.tsv \
  -out_features output.osw -threads 1 -sort_swath_maps \
  -batchSize 1000 -readOptions cacheWorkingInMemory
```

---

### SWATH-MS (8 threads)

```bash
OpenSwathWorkflow \
  -in olgas_R1.mzML -tr Mtb_library.tsv \
  -Calibration:files:linear_irt_file iRTassays.TraML \
  -swath_windows_file SWATHwindows_analysis.tsv \
  -out_features output.osw -threads 8 -sort_swath_maps \
  -batchSize 1000 -readOptions cacheWorkingInMemory
```

---

### diaPASEF (8 threads)

```bash
OpenSwathWorkflow \
  -in diaPASEF_200SPD.mzML -tr hela_library.pqp \
  -pasef -ion_mobility_window 0.06 -im_extraction_window_ms1 0.06 \
  -Scoring:Scores:use_ion_mobility_scores true -rt_extraction_window 250 \
  -mz_extraction_window 25 -mz_extraction_window_unit ppm \
  -batchSize 1000 -readOptions cacheWorkingInMemory \
  -out_features output.osw -threads 8
```

</details>





## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).

@jcharkow 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized MS2 extraction and scoring workflow with an improved parallelization strategy and enhanced memory management for spectrum access handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->