### PR TITLE
fix(ci): trigger container deploy from nightly update workflow

### DIFF
--- a/.github/workflows/update_nightly.yml
+++ b/.github/workflows/update_nightly.yml
@@ -83,3 +83,10 @@ jobs:
         gh workflow run "Deploy to Bioconda" --ref nightly
       env:
         GH_TOKEN: ${{ github.token }}
+
+    - name: Deploy container images
+      if: steps.compare_branches.outputs.behind == 'true' || inputs.force
+      run: |
+        gh workflow run containerdeploy.yml --ref nightly
+      env:
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

The nightly container images (`ghcr.io/openms/openms-*:latest`) have never been built automatically — only via manual `workflow_dispatch`.

## Root cause

`containerdeploy.yml` triggers on `push` to the `nightly` branch. The `update_nightly.yml` workflow pushes to `nightly` nightly at 01:07 UTC, but uses the default `GITHUB_TOKEN` for the push. [GitHub does not trigger workflows from pushes made with `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) to prevent recursive triggers.

## Fix

Add `gh workflow run containerdeploy.yml --ref nightly` to `update_nightly.yml`, matching the existing pattern for CI, wheels, and bioconda deploys.

## Test plan

- [x] Verify the step matches the pattern of adjacent steps (same `if` condition, same `GH_TOKEN`)
- [ ] After merge: manually trigger `update_nightly.yml` with force=true and verify container deploy starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated container deployment workflow for nightly builds with improved conditional execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->