### PR TITLE
fix: bump minimum Boost to 1.78 to fix boost::filesystem link errors

### DIFF
--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -43,13 +43,9 @@ macro(find_boost)
     "1.81.1" "1.81.0" "1.81"
     "1.80.1" "1.80.0" "1.80"
     "1.79.1" "1.79.0" "1.79"
-    "1.78.1" "1.78.0" "1.78"
-    "1.77.1" "1.77.0" "1.77"
-    "1.76.1" "1.76.0" "1.76"
-    "1.75.1" "1.75.0" "1.75"
-    "1.74.1" "1.74.0" "1.74")
+    "1.78.1" "1.78.0" "1.78")
 
-  find_package(Boost 1.74.0 COMPONENTS ${ARGN} REQUIRED CONFIG)
+  find_package(Boost 1.78.0 COMPONENTS ${ARGN} REQUIRED CONFIG)
 
 endmacro(find_boost)
 

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -163,6 +163,7 @@ if (ENABLE_TDL)
 endif()
 
 # Use std::filesystem instead of boost::filesystem in boost::process (avoids linking boost_filesystem)
+# Requires Boost >= 1.78 (where BOOST_PROCESS_USE_STD_FS was introduced)
 target_compile_definitions(OpenMS PRIVATE BOOST_PROCESS_USE_STD_FS)
 
 if (WITH_OPENTIMS)


### PR DESCRIPTION
## Summary
- Fixes #9039
- Bumps minimum required Boost from 1.74 to 1.78
- `BOOST_PROCESS_USE_STD_FS` (defined at `src/openms/CMakeLists.txt:166`) was introduced in Boost 1.78. On older versions, `boost::process` still uses `boost::filesystem` internally, but `Boost::filesystem` is not linked — causing undefined reference errors at link time.
- Boost 1.78 was released in December 2021. All CI environments and current distros (Ubuntu 24.04, Debian 12, macOS Homebrew, conda-forge) ship Boost >= 1.78.

## Test plan
- [ ] CI builds pass on all platforms (the actual compilation/linking validates the fix)
- [ ] Users on Boost < 1.78 now get a clear CMake configure-time error instead of a cryptic linker failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased minimum Boost dependency requirement to version 1.78.0.
  * Updated build configuration to use standard filesystem implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->