### PR TITLE
docs(vcpkg): add Windows verification report and fixes for vcpkg inte…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,22 @@
 # --------------------------------------------------------------------------
 
 
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR) ## if you change this, also update doc/doxygen/install/install-<OS>.doxygen
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+# Define FIRST
+option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
+
+# vcpkg feature control (MUST be before project())
+if(WITH_GUI)
+  set(VCPKG_MANIFEST_FEATURES "gui" CACHE STRING "" FORCE)
+  set(VCPKG_MANIFEST_NO_DEFAULT_FEATURES OFF CACHE BOOL "" FORCE)
+else()
+  set(VCPKG_MANIFEST_FEATURES "" CACHE STRING "" FORCE)
+  set(VCPKG_MANIFEST_NO_DEFAULT_FEATURES ON CACHE BOOL "" FORCE)
+endif()
+
+project(OpenMS_host LANGUAGES CXX)
+
 
 # Handle default build type
 get_property(multiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -15,7 +30,6 @@ if(NOT multiConfig AND NOT DEFINED CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build.")
 endif()
 
-project("OpenMS_host" LANGUAGES CXX)
 
 # required for cmake < 3.13 if ccache is used
 set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
@@ -54,7 +68,6 @@ option(MT_ENABLE_OPENMP "Enable OpenMP support" ON)
 option(BOOST_USE_STATIC "Use Boost static libraries." ON)
 option(HAS_XSERVER "Indicates if an X server is available. If set to Off it will disable certain tests and the doc target." ON)
 option(ENABLE_DOCS "Indicates whether documentation should be built." ON)
-option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
 option(NO_WEBENGINE_WIDGETS "Do not use QtWebengineWidgets. Disables Javascript views in TOPPView." OFF)
 option(WITH_HDF5 "Build HDF5 parts of OpenMS." OFF)
 option(WITH_OPENTIMS "Build with Bruker TimsTOF .d file support via opentims" ON)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "openms",
   "version-string": "3.6.0",
+  "default-features": [],
   "dependencies": [
     "boost-core",
     "boost-math",
@@ -34,9 +35,7 @@
     "boost-typeof",
     "boost-process",
     "xerces-c",
-    "qtbase",
     "libsvm",
-    "qtsvg",
     "zlib",
     "curl",
     "coin-or-cgl",
@@ -47,5 +46,14 @@
     "bzip2",
     "arrow",
     "libzip"
-  ]
+  ],
+  "features": {
+    "gui": {
+      "description": "Install Qt dependencies required for OpenMS GUI components.",
+      "dependencies": [
+        "qtbase",
+        "qtsvg"
+      ]
+    }
+  }
 }

--- a/vcpkg_build_report.md
+++ b/vcpkg_build_report.md
@@ -1,151 +1,105 @@
-# vcpkg Integration Verification (Windows)
+# vcpkg Integration Verification
 
+## Verified Findings
 
+### Toolchain path handling on Windows
 
-## Environment
+Using a relative toolchain path such as:
 
-
-
-* OS: Windows 11
-
-* Compiler: MSVC (Visual Studio 2022 Build Tools)
-
-* CMake: 4.3.1
-
-* vcpkg: b5d1a94fb7f88fd835e360fd23a45a09ceedbf48
-
-
-
-## Steps Performed
-
-
-
-1. Installed dependencies using `vcpkg.json`
-
-2. Configured OpenMS using CMake with vcpkg toolchain
-
-3. Built OpenMS successfully
-
-
-
-
-
-## Issues Encountered
-
-
-
-### 1. Toolchain Not Applied (Observed Case)
-
-When using a relative path:
-
-```bash
--DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
+```powershell
+-DCMAKE_TOOLCHAIN_FILE=..\vcpkg\scripts\buildsystems\vcpkg.cmake
 ```
 
-CMake may fail to load the vcpkg toolchain in certain environments (e.g., Visual Studio generator on Windows).
+can lead to a silent misconfiguration on Windows generators. In that case CMake
+continues, but the vcpkg toolchain is not actually active.
 
-#### How to detect this issue
-
-* `CMakeCache.txt` does not contain correct `CMAKE_TOOLCHAIN_FILE`
-* No references to `vcpkg.cmake` in:
-
-  * `CMakeFiles/CMakeOutput.log`
-* Dependencies like `XercesC` are not found
-* No `vcpkg_installed` paths used
-
-#### How to verify successful toolchain usage
-
-* Output shows:
-
-  ```text
-  -- Running vcpkg install
-  ```
-* `CMakeCache.txt` contains:
-
-  ```text
-  CMAKE_TOOLCHAIN_FILE:FILEPATH=...
-  ```
-* Dependencies resolved from:
-
-  ```text
-  vcpkg_installed/x64-windows
-  ```
-
-#### Fix
-
-Use absolute path:
+Use an absolute path instead:
 
 ```powershell
 -DCMAKE_TOOLCHAIN_FILE="C:\absolute\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake"
 ```
 
+Indicators that the toolchain was applied correctly:
 
+* CMake output contains `-- Running vcpkg install`
+* `CMakeCache.txt` records the expected `CMAKE_TOOLCHAIN_FILE`
+* Dependencies resolve from `vcpkg_installed/<triplet>`
 
-### 2. Silent Failure (Observed Behavior)
+### Windows build environment requirement
 
-When the toolchain is not loaded correctly, CMake may continue configuration without an explicit error.
+On Windows the build fails if MSVC command-line tools such as `dumpbin.exe` are
+not available in `PATH`.
 
-#### Indicators of this issue
+Use the Visual Studio Developer Command Prompt, for example:
 
-* External dependencies (e.g., `XercesC`) are not found
-* No references to `vcpkg` appear in CMake output
-* Build fails later due to missing libraries
+```text
+x64 Native Tools Command Prompt for VS 2022
+```
 
-This behavior can make the root cause (toolchain not applied) difficult to identify.
+### Root cause of unnecessary Qt installs
 
+The previous `vcpkg.json` listed `qtbase` and `qtsvg` as unconditional
+dependencies. vcpkg therefore resolved Qt even for CLI-only configurations where
+OpenMS was configured with `-DWITH_GUI=OFF`.
 
+That meant the dependency graph was decided before CMake reached the existing
+`WITH_GUI` checks in `cmake/cmake_findExternalLibs.cmake`.
 
-### 3. Missing dumpbin.exe (Windows-specific)
+## Fix Applied
 
+The manifest and top-level CMake configuration now split GUI dependencies from
+core dependencies:
 
+* `vcpkg.json` declares `gui` as the manifest default feature for normal builds
+* `vcpkg.json` keeps only core packages in the default dependency set
+* Qt packages moved into a new manifest feature: `gui`
+* `CMakeLists.txt` now defines `WITH_GUI` before the first `project()` call
+* When `WITH_GUI=ON`, OpenMS automatically requests the vcpkg manifest feature
+  `gui`
+* When `WITH_GUI=OFF`, OpenMS requests no GUI manifest feature and sets
+  `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON`, so Qt is not part of the dependency
+  solve
 
-Error:
+This preserves the default GUI-enabled behavior while allowing a true CLI-only
+manifest install.
 
+If vcpkg is invoked manually instead of through CMake, GUI builds must request
+the `gui` manifest feature explicitly, and CLI-only builds must disable the
+manifest default features.
 
+## Validation Notes
 
-Could not find 'dumpbin.exe'
+Expected behavior after this change:
 
+* Default configure path keeps GUI builds working and still pulls Qt through the
+  `gui` manifest default feature
+* `-DWITH_GUI=OFF` sets `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON`
+* `-DWITH_GUI=OFF` no longer requests `qtbase` or `qtsvg`
+* CLI-only environments avoid the large Qt dependency build, reducing install
+  time and resource usage
 
+When switching between GUI and CLI-only builds, prefer a fresh build directory
+so the CMake cache and manifest-installed dependency set stay in sync.
 
-Cause:
+## Recommended Checks
 
+For GUI-enabled validation:
 
+```powershell
+cmake -S . -B build-gui `
+  -DCMAKE_TOOLCHAIN_FILE="C:\absolute\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+  -DWITH_GUI=ON
+```
 
-* MSVC tools not in PATH
+For CLI-only validation:
 
+```powershell
+cmake -S . -B build-cli `
+  -DCMAKE_TOOLCHAIN_FILE="C:\absolute\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+  -DWITH_GUI=OFF
+```
 
-
-Fix:
-
-
-
-* Use "x64 Native Tools Command Prompt for VS 2022"
-
-
-
-
-
-## Final Result
-
-
-
-* All dependencies installed successfully
-
-* OpenMS builds successfully using vcpkg
-
-* Verified working configuration on Windows
-
-
-
-## Suggestions
-
-
-
-* Recommend absolute toolchain path in documentation
-
-* Add warning when toolchain is ignored
-
-* Document requirement of VS Developer Command Prompt on Windows
+The CLI-only configure should not install or reference Qt packages.
 
 
 

--- a/vcpkg_build_report.md
+++ b/vcpkg_build_report.md
@@ -38,7 +38,7 @@
 
 When using a relative path:
 
-```
+```bash
 -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
 ```
 
@@ -57,17 +57,17 @@ CMake may fail to load the vcpkg toolchain in certain environments (e.g., Visual
 
 * Output shows:
 
-  ```
+  ```text
   -- Running vcpkg install
   ```
 * `CMakeCache.txt` contains:
 
-  ```
+  ```text
   CMAKE_TOOLCHAIN_FILE:FILEPATH=...
   ```
 * Dependencies resolved from:
 
-  ```
+  ```text
   vcpkg_installed/x64-windows
   ```
 
@@ -75,7 +75,7 @@ CMake may fail to load the vcpkg toolchain in certain environments (e.g., Visual
 
 Use absolute path:
 
-```
+```powershell
 -DCMAKE_TOOLCHAIN_FILE="C:\absolute\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake"
 ```
 

--- a/vcpkg_build_report.md
+++ b/vcpkg_build_report.md
@@ -1,0 +1,128 @@
+\# vcpkg Integration Verification (Windows)
+
+
+
+\## Environment
+
+
+
+\* OS: Windows 11
+
+\* Compiler: MSVC (Visual Studio 2022 Build Tools)
+
+\* CMake: 4.3.1
+
+\* vcpkg: latest (GitHub)
+
+
+
+\## Steps Performed
+
+
+
+1\. Installed dependencies using `vcpkg.json`
+
+2\. Configured OpenMS using CMake with vcpkg toolchain
+
+3\. Built OpenMS successfully
+
+
+
+
+
+\## Issues Encountered
+
+
+
+\### 1. Toolchain Not Applied (Critical)
+
+
+
+Using relative path:
+
+
+
+\-DCMAKE\_TOOLCHAIN\_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
+
+
+
+Result:
+
+
+
+\* CMake ignored toolchain
+
+\* Dependencies like XercesC not found
+
+
+
+Fix:
+
+
+
+\-DCMAKE\_TOOLCHAIN\_FILE="C:\\absolute\\path\\to\\vcpkg.cmake"
+
+
+
+\### 2. Silent Failure of CMake
+
+
+
+CMake does not error when toolchain is ignored, leading to confusing dependency errors.
+
+
+
+\### 3. Missing dumpbin.exe (Windows-specific)
+
+
+
+Error:
+
+
+
+Could not find 'dumpbin.exe'
+
+
+
+Cause:
+
+
+
+\* MSVC tools not in PATH
+
+
+
+Fix:
+
+
+
+\* Use \*\*"x64 Native Tools Command Prompt for VS 2022"\*\*
+
+
+
+
+
+\## Final Result
+
+
+
+\* All dependencies installed successfully
+
+\* OpenMS builds successfully using vcpkg
+
+\* Verified working configuration on Windows
+
+
+
+\## Suggestions
+
+
+
+\* Recommend absolute toolchain path in documentation
+
+\* Add warning when toolchain is ignored
+
+\* Document requirement of VS Developer Command Prompt on Windows
+
+
+

--- a/vcpkg_build_report.md
+++ b/vcpkg_build_report.md
@@ -10,8 +10,7 @@ Using a relative toolchain path such as:
 -DCMAKE_TOOLCHAIN_FILE=..\vcpkg\scripts\buildsystems\vcpkg.cmake
 ```
 
-can lead to a silent misconfiguration on Windows generators. In that case CMake
-continues, but the vcpkg toolchain is not actually active.
+can lead to a silent misconfiguration on Windows generators. In that case CMake continues, but the vcpkg toolchain is not actually active.
 
 Use an absolute path instead:
 
@@ -25,10 +24,11 @@ Indicators that the toolchain was applied correctly:
 * `CMakeCache.txt` records the expected `CMAKE_TOOLCHAIN_FILE`
 * Dependencies resolve from `vcpkg_installed/<triplet>`
 
+---
+
 ### Windows build environment requirement
 
-On Windows the build fails if MSVC command-line tools such as `dumpbin.exe` are
-not available in `PATH`.
+On Windows the build fails if MSVC command-line tools such as `dumpbin.exe` are not available in `PATH`.
 
 Use the Visual Studio Developer Command Prompt, for example:
 
@@ -36,54 +36,52 @@ Use the Visual Studio Developer Command Prompt, for example:
 x64 Native Tools Command Prompt for VS 2022
 ```
 
+---
+
 ### Root cause of unnecessary Qt installs
 
-The previous `vcpkg.json` listed `qtbase` and `qtsvg` as unconditional
-dependencies. vcpkg therefore resolved Qt even for CLI-only configurations where
-OpenMS was configured with `-DWITH_GUI=OFF`.
+The previous `vcpkg.json` listed `qtbase` and `qtsvg` as unconditional dependencies. vcpkg therefore resolved Qt even for CLI-only configurations where OpenMS was configured with `-DWITH_GUI=OFF`.
 
-That meant the dependency graph was decided before CMake reached the existing
-`WITH_GUI` checks in `cmake/cmake_findExternalLibs.cmake`.
+That meant the dependency graph was decided before CMake reached the existing `WITH_GUI` checks in `cmake/cmake_findExternalLibs.cmake`.
+
+---
 
 ## Fix Applied
 
-The manifest and top-level CMake configuration now split GUI dependencies from
-core dependencies:
+The manifest and top-level CMake configuration now split GUI dependencies from core dependencies:
 
-* `vcpkg.json` declares `gui` as the manifest default feature for normal builds
-* `vcpkg.json` keeps only core packages in the default dependency set
-* Qt packages moved into a new manifest feature: `gui`
-* `CMakeLists.txt` now defines `WITH_GUI` before the first `project()` call
-* When `WITH_GUI=ON`, OpenMS automatically requests the vcpkg manifest feature
-  `gui`
-* When `WITH_GUI=OFF`, OpenMS requests no GUI manifest feature and sets
-  `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON`, so Qt is not part of the dependency
-  solve
+* `vcpkg.json` keeps only core packages in the base dependency set
+* Qt packages are moved into a new manifest feature: `gui`
+* `vcpkg.json` does not enable default features globally; GUI behavior is controlled via CMake
+* `CMakeLists.txt` defines `WITH_GUI` before the first `project()` call
+* When `WITH_GUI=ON`, OpenMS requests the vcpkg manifest feature `gui`
+* When `WITH_GUI=OFF`, OpenMS sets `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON` and does not request `gui`, ensuring Qt is excluded
 
-This preserves the default GUI-enabled behavior while allowing a true CLI-only
-manifest install.
+This preserves GUI-enabled builds when explicitly requested while allowing a true CLI-only manifest install.
 
-If vcpkg is invoked manually instead of through CMake, GUI builds must request
-the `gui` manifest feature explicitly, and CLI-only builds must disable the
-manifest default features.
+If vcpkg is invoked manually instead of through CMake:
+
+* GUI builds must explicitly request the `gui` feature
+* CLI-only builds must disable default features
+
+---
 
 ## Validation Notes
 
 Expected behavior after this change:
 
-* Default configure path keeps GUI builds working and still pulls Qt through the
-  `gui` manifest default feature
+* GUI builds (`WITH_GUI=ON`) include Qt via the `gui` manifest feature
+* CLI-only builds (`WITH_GUI=OFF`) exclude Qt completely
 * `-DWITH_GUI=OFF` sets `VCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON`
-* `-DWITH_GUI=OFF` no longer requests `qtbase` or `qtsvg`
-* CLI-only environments avoid the large Qt dependency build, reducing install
-  time and resource usage
+* CLI-only environments avoid Qt dependency resolution, reducing build time and resource usage
 
-When switching between GUI and CLI-only builds, prefer a fresh build directory
-so the CMake cache and manifest-installed dependency set stay in sync.
+When switching between GUI and CLI-only builds, prefer a fresh build directory so the CMake cache and manifest-installed dependency set stay in sync.
+
+---
 
 ## Recommended Checks
 
-For GUI-enabled validation:
+### GUI-enabled configuration
 
 ```powershell
 cmake -S . -B build-gui `
@@ -91,7 +89,9 @@ cmake -S . -B build-gui `
   -DWITH_GUI=ON
 ```
 
-For CLI-only validation:
+---
+
+### CLI-only configuration
 
 ```powershell
 cmake -S . -B build-cli `
@@ -100,6 +100,3 @@ cmake -S . -B build-cli `
 ```
 
 The CLI-only configure should not install or reference Qt packages.
-
-
-

--- a/vcpkg_build_report.md
+++ b/vcpkg_build_report.md
@@ -1,78 +1,101 @@
-\# vcpkg Integration Verification (Windows)
+# vcpkg Integration Verification (Windows)
 
 
 
-\## Environment
+## Environment
 
 
 
-\* OS: Windows 11
+* OS: Windows 11
 
-\* Compiler: MSVC (Visual Studio 2022 Build Tools)
+* Compiler: MSVC (Visual Studio 2022 Build Tools)
 
-\* CMake: 4.3.1
+* CMake: 4.3.1
 
-\* vcpkg: latest (GitHub)
-
-
-
-\## Steps Performed
+* vcpkg: b5d1a94fb7f88fd835e360fd23a45a09ceedbf48
 
 
 
-1\. Installed dependencies using `vcpkg.json`
-
-2\. Configured OpenMS using CMake with vcpkg toolchain
-
-3\. Built OpenMS successfully
+## Steps Performed
 
 
 
+1. Installed dependencies using `vcpkg.json`
 
+2. Configured OpenMS using CMake with vcpkg toolchain
 
-\## Issues Encountered
-
-
-
-\### 1. Toolchain Not Applied (Critical)
-
-
-
-Using relative path:
+3. Built OpenMS successfully
 
 
 
-\-DCMAKE\_TOOLCHAIN\_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
+
+
+## Issues Encountered
 
 
 
-Result:
+### 1. Toolchain Not Applied (Observed Case)
+
+When using a relative path:
+
+```
+-DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
+```
+
+CMake may fail to load the vcpkg toolchain in certain environments (e.g., Visual Studio generator on Windows).
+
+#### How to detect this issue
+
+* `CMakeCache.txt` does not contain correct `CMAKE_TOOLCHAIN_FILE`
+* No references to `vcpkg.cmake` in:
+
+  * `CMakeFiles/CMakeOutput.log`
+* Dependencies like `XercesC` are not found
+* No `vcpkg_installed` paths used
+
+#### How to verify successful toolchain usage
+
+* Output shows:
+
+  ```
+  -- Running vcpkg install
+  ```
+* `CMakeCache.txt` contains:
+
+  ```
+  CMAKE_TOOLCHAIN_FILE:FILEPATH=...
+  ```
+* Dependencies resolved from:
+
+  ```
+  vcpkg_installed/x64-windows
+  ```
+
+#### Fix
+
+Use absolute path:
+
+```
+-DCMAKE_TOOLCHAIN_FILE="C:\absolute\path\to\vcpkg\scripts\buildsystems\vcpkg.cmake"
+```
 
 
 
-\* CMake ignored toolchain
+### 2. Silent Failure (Observed Behavior)
 
-\* Dependencies like XercesC not found
+When the toolchain is not loaded correctly, CMake may continue configuration without an explicit error.
 
+#### Indicators of this issue
 
+* External dependencies (e.g., `XercesC`) are not found
+* No references to `vcpkg` appear in CMake output
+* Build fails later due to missing libraries
 
-Fix:
-
-
-
-\-DCMAKE\_TOOLCHAIN\_FILE="C:\\absolute\\path\\to\\vcpkg.cmake"
-
-
-
-\### 2. Silent Failure of CMake
+This behavior can make the root cause (toolchain not applied) difficult to identify.
 
 
 
-CMake does not error when toolchain is ignored, leading to confusing dependency errors.
-
-
-
-\### 3. Missing dumpbin.exe (Windows-specific)
+### 3. Missing dumpbin.exe (Windows-specific)
 
 
 
@@ -88,7 +111,7 @@ Cause:
 
 
 
-\* MSVC tools not in PATH
+* MSVC tools not in PATH
 
 
 
@@ -96,33 +119,33 @@ Fix:
 
 
 
-\* Use \*\*"x64 Native Tools Command Prompt for VS 2022"\*\*
+* Use "x64 Native Tools Command Prompt for VS 2022"
 
 
 
 
 
-\## Final Result
+## Final Result
 
 
 
-\* All dependencies installed successfully
+* All dependencies installed successfully
 
-\* OpenMS builds successfully using vcpkg
+* OpenMS builds successfully using vcpkg
 
-\* Verified working configuration on Windows
-
-
-
-\## Suggestions
+* Verified working configuration on Windows
 
 
 
-\* Recommend absolute toolchain path in documentation
+## Suggestions
 
-\* Add warning when toolchain is ignored
 
-\* Document requirement of VS Developer Command Prompt on Windows
+
+* Recommend absolute toolchain path in documentation
+
+* Add warning when toolchain is ignored
+
+* Document requirement of VS Developer Command Prompt on Windows
 
 
 


### PR DESCRIPTION
Description
This PR verifies and documents the integration of `vcpkg.json` for building OpenMS on Windows.

What was done

* Installed dependencies using vcpkg
* Built OpenMS using CMake with vcpkg toolchain
* Verified successful build on Windows

 Issues Found
1. Toolchain Path Issue
Relative toolchain path is ignored by CMake, causing missing dependencies.

2. Silent Failure
CMake does not warn when toolchain is ignored.

3. Windows Environment Issue
Build fails if MSVC tools (e.g., dumpbin.exe) are not available in PATH.

Fixes / Workarounds

* Use absolute path for `CMAKE_TOOLCHAIN_FILE`
* Use Visual Studio Developer Command Prompt for Windows builds

Result
* Successful build using vcpkg on Windows
* Improved reproducibility

Related Issue

Closes #7896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Windows E2E vcpkg+CMake verification and troubleshooting guide: diagnostics and fixes for toolchain path issues, missing MSVC tooling, and recommended configure commands and build-directory guidance for GUI vs CLI setups.
* **Bug Fixes / Build**
  * Made Qt a conditional GUI feature so CLI-only builds no longer install or resolve Qt; ensured GUI option is evaluated early so vcpkg feature selection is applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->