### PR TITLE
feat: add TMTpro_Ox combined modification to custom_mods.xml

### DIFF
--- a/share/OpenMS/CHEMISTRY/custom_mods.xml
+++ b/share/OpenMS/CHEMISTRY/custom_mods.xml
@@ -4,7 +4,7 @@
 <!--Please modify the following information if you update the file-->
 <!-- version:1.0 -->
 <!-- date:2024-10-10 -->
-<!-- last-accession: 99913-->
+<!-- last-accession: 99914-->
 <umod:unimod
 	xmlns:umod="http://www.unimod.org/xmlns/schema/unimod_2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -467,6 +467,26 @@
 				<umod:url>https://pubs.acs.org/doi/full/10.1021/acs.jproteome.1c00827</umod:url>
 			</umod:xref>
 			<umod:misc_notes>Phospho Decoy can be used to compute FLR in phospho proteomics experiments, the method is called pAla</umod:misc_notes>
+		</umod:mod>
+		<umod:mod title="TMTpro_Ox"
+        full_name="TMTpro 16plex + Oxidation combined"
+        username_of_poster="OpenMS developer team"
+        group_of_poster=""
+        date_time_posted="2026-04-01 12:00:00"
+        date_time_modified="2026-04-01 12:00:00"
+        approved="0"
+        record_id="99914">
+			<umod:specificity hidden="0" site="K" position="Anywhere" classification="Chemical derivative" spec_group="1"/>
+			<umod:delta mono_mass="320.202061" avge_mass="320.3121"
+          composition="H(25) C(8) 13C(7) N 15N(2) O(4)">
+				<umod:element symbol="H" number="25"/>
+				<umod:element symbol="C" number="8"/>
+				<umod:element symbol="13C" number="7"/>
+				<umod:element symbol="N" number="1"/>
+				<umod:element symbol="15N" number="2"/>
+				<umod:element symbol="O" number="4"/>
+			</umod:delta>
+			<umod:misc_notes>Combined modification: TMTpro (UNIMOD:2016, 304.207146 Da) + Oxidation (UNIMOD:35, 15.994915 Da) on lysine</umod:misc_notes>
 		</umod:mod>
 	</umod:modifications>
 </umod:unimod>


### PR DESCRIPTION
## Summary
- Adds `TMTpro_Ox` (record 99914) to `share/OpenMS/CHEMISTRY/custom_mods.xml`
- Combined modification: TMTpro (UNIMOD:2016, 304.207146 Da) + Oxidation (UNIMOD:35, 15.994915 Da) = 320.202061 Da
- Specificity: lysine (K), anywhere
- Composition: `H(25) C(8) 13C(7) N 15N(2) O(4)`

## Test plan
- [ ] CI passes (XML is well-formed and loaded by ModificationsDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TMTpro_Ox modification entry enabling lysine residue analysis with combined TMTpro labeling and oxidation chemistry. The new modification includes precise mass delta calculations and comprehensive elemental composition specifications. This expansion of the chemistry database supports advanced proteomics applications requiring this specialized combined chemical modification approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->