### PR TITLE
perf: add sn_min_threshold_ member to MRMFeatureFinderScoring.h

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -292,6 +292,7 @@ private:
     double merge_spectra_by_peak_width_fraction_;
     double uis_threshold_sn_;
     double uis_threshold_peak_area_;
+    double sn_min_threshold_; ///< Minimum S/N ratio for tiered early-exit scoring (see #8959)
 
     double sn_win_len_;
     unsigned int sn_bin_count_;
@@ -311,4 +312,3 @@ private:
 }
 
 #undef run_identifier
-


### PR DESCRIPTION
## Description

Header-only companion to PR #9069.

Adds the `sn_min_threshold_` member variable declaration to
`MRMFeatureFinderScoring.h`, required for the tiered early-exit
scoring implemented in the `.cpp` file.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced signal-to-noise ratio threshold control in feature scoring, enabling improved performance optimization for feature detection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->