### PR TITLE
fix: make enzyme configurable in MRMFeatureFinderScoring

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -282,6 +282,7 @@ private:
     bool use_ms1_ion_mobility_;
     bool apply_im_peak_picking_;
     String scoring_model_;
+    String enzyme_;
 
     // scoring parameters
     double rt_normalization_factor_;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -21,6 +21,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/SqliteConnector.h>
 
 #include <boost/range/adaptor/map.hpp>
@@ -99,7 +100,7 @@ namespace OpenMS
     std::vector<String> all_enzymes;
     ProteaseDB::getInstance()->getAllNames(all_enzymes);
     defaults_.setValue("enzyme", "Trypsin", "Enzyme used for counting missed cleavages in peptide sequences");
-    defaults_.setValidStrings("enzyme", all_enzymes);
+    defaults_.setValidStrings("enzyme", ListUtils::create<std::string>(all_enzymes));
 
     defaults_.insert("TransitionGroupPicker:", MRMTransitionGroupPicker().getDefaults());
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -19,6 +19,7 @@
 
 // Helpers
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ProteaseDigestion.h>
 #include <OpenMS/FORMAT/SqliteConnector.h>
 
@@ -93,6 +94,12 @@ namespace OpenMS
     defaults_.setValue("use_ms1_ion_mobility", "true", "Performs ion mobility extraction in MS1. Set to false if MS1 spectra do not contain ion mobility", {"advanced"});
     defaults_.setValue("apply_im_peak_picking", "false", "Perform peak picking on the extracted ion mobilograms. This is useful for reducing intefering signals from co-eluting analytes in the ion mobility dimension. The peak picking will take the highest peak and discard the remaining peaks for ion mobility scoring. ", {"advanced"});
     defaults_.setValidStrings("apply_im_peak_picking", {"true","false"});
+
+    // enzyme used for missed cleavage counting
+    std::vector<String> all_enzymes;
+    ProteaseDB::getInstance()->getAllNames(all_enzymes);
+    defaults_.setValue("enzyme", "Trypsin", "Enzyme used for counting missed cleavages in peptide sequences");
+    defaults_.setValidStrings("enzyme", all_enzymes);
 
     defaults_.insert("TransitionGroupPicker:", MRMTransitionGroupPicker().getDefaults());
 
@@ -595,7 +602,7 @@ namespace OpenMS
                       apply_im_peak_picking_);
 
     ProteaseDigestion pd;
-    pd.setEnzyme("Trypsin");
+    pd.setEnzyme(enzyme_);
 
     auto& mrmfeatures = transition_group_detection.getFeaturesMuteable();
 
@@ -1081,6 +1088,7 @@ namespace OpenMS
     strict_ = (bool)param_.getValue("strict").toBool();
     use_ms1_ion_mobility_ = (bool)param_.getValue("use_ms1_ion_mobility").toBool();
     apply_im_peak_picking_ = (bool)param_.getValue("apply_im_peak_picking").toBool();
+    enzyme_ = param_.getValue("enzyme").toString();
 
     su_.use_coelution_score_     = param_.getValue("Scores:use_coelution_score").toBool();
     su_.use_shape_score_         = param_.getValue("Scores:use_shape_score").toBool();


### PR DESCRIPTION
## Summary
- Fixes #9072
- Replaces hardcoded `"Trypsin"` enzyme in `MRMFeatureFinderScoring::scorePeakgroups()` with a user-configurable `enzyme` parameter
- Defaults to `"Trypsin"` for backward compatibility
- Valid values populated from `ProteaseDB`
- No TOPP tool changes needed — `MRMFeatureFinderScoring` parameters are already exposed in `OpenSwathWorkflow` via the `Scoring:` subsection

## Changes
- `MRMFeatureFinderScoring.h`: added `String enzyme_` member
- `MRMFeatureFinderScoring.cpp`: register `enzyme` param with `ProteaseDB` names, read in `updateMembers_()`, use in `scorePeakgroups()`

## Test plan
- [ ] CI passes on all platforms
- [ ] OpenSwathWorkflow exposes `Scoring:enzyme` parameter (verify with `-helphelp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MRM Feature Finder: added configurable protease/enzyme selection (defaults remain unchanged), so users can choose the enzyme used for digestion and missed-cleavage calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->