### PR TITLE
fix: remove unused arrow/csv and arrow/ipc dependencies from Arrow_test (#9065)

### DIFF
--- a/src/tests/class_tests/openms/source/Arrow_test.cpp
+++ b/src/tests/class_tests/openms/source/Arrow_test.cpp
@@ -2,332 +2,97 @@
 #include <OpenMS/test_config.h>
 
 #include <arrow/api.h>
-
-#include <arrow/csv/api.h>
-
 #include <arrow/io/api.h>
-
 #include <arrow/ipc/api.h>
-
 #include <parquet/arrow/reader.h>
-
 #include <parquet/arrow/writer.h>
 #include <iostream>
 #include <vector>
 #include <memory>
 #include <arrow/status.h>
-#include <arrow/csv/reader.h>
 
 using namespace OpenMS;
 
-//example code used here can be found at: https://arrow.apache.org/docs/cpp/tutorials/io_tutorial.html
-
+// Adapted from https://arrow.apache.org/docs/cpp/tutorials/io_tutorial.html
+// Tests IPC and Parquet I/O — the formats OpenMS actually uses.
 
 static ::arrow::Status GenInitialFile()
 {
-
-  // Make a couple 8-bit integer arrays and a 16-bit integer array -- just like
-
-  // basic Arrow example.
-
   arrow::Int8Builder int8builder;
 
   int8_t days_raw[5] = {1, 12, 17, 23, 28};
-
   ARROW_RETURN_NOT_OK(int8builder.AppendValues(days_raw, 5));
-
   std::shared_ptr<arrow::Array> days;
-
   ARROW_ASSIGN_OR_RAISE(days, int8builder.Finish());
 
-
   int8_t months_raw[5] = {1, 3, 5, 7, 1};
-
   ARROW_RETURN_NOT_OK(int8builder.AppendValues(months_raw, 5));
-
   std::shared_ptr<arrow::Array> months;
-
   ARROW_ASSIGN_OR_RAISE(months, int8builder.Finish());
 
-
   arrow::Int16Builder int16builder;
-
   int16_t years_raw[5] = {1990, 2000, 1995, 2000, 1995};
-
   ARROW_RETURN_NOT_OK(int16builder.AppendValues(years_raw, 5));
-
   std::shared_ptr<arrow::Array> years;
-
   ARROW_ASSIGN_OR_RAISE(years, int16builder.Finish());
-
-
-  // Get a vector of our Arrays
 
   std::vector<std::shared_ptr<arrow::Array>> columns = {days, months, years};
 
+  auto field_day = arrow::field("Day", arrow::int8());
+  auto field_month = arrow::field("Month", arrow::int8());
+  auto field_year = arrow::field("Year", arrow::int16());
+  auto schema = arrow::schema({field_day, field_month, field_year});
 
-  // Make a schema to initialize the Table with
+  auto table = arrow::Table::Make(schema, columns);
 
-  std::shared_ptr<arrow::Field> field_day, field_month, field_year;
-
-  std::shared_ptr<arrow::Schema> schema;
-
-
-  field_day = arrow::field("Day", arrow::int8());
-
-  field_month = arrow::field("Month", arrow::int8());
-
-  field_year = arrow::field("Year", arrow::int16());
-
-
-  schema = arrow::schema({field_day, field_month, field_year});
-
-  // With the schema and data, create a Table
-
-  std::shared_ptr<arrow::Table> table;
-
-  table = arrow::Table::Make(schema, columns);
-
-
-  // Write out test files in IPC, CSV, and Parquet for the example to use.
-
+  // Write IPC file
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-
   ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_in.arrow"));
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc_writer,
-
-                        arrow::ipc::MakeFileWriter(outfile, schema));
-
+  ARROW_ASSIGN_OR_RAISE(auto ipc_writer, arrow::ipc::MakeFileWriter(outfile, schema));
   ARROW_RETURN_NOT_OK(ipc_writer->WriteTable(*table));
-
   ARROW_RETURN_NOT_OK(ipc_writer->Close());
 
-
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_in.csv"));
-
-  ARROW_ASSIGN_OR_RAISE(auto csv_writer,
-
-                        arrow::csv::MakeCSVWriter(outfile, table->schema()));
-
-  ARROW_RETURN_NOT_OK(csv_writer->WriteTable(*table));
-
-  ARROW_RETURN_NOT_OK(csv_writer->Close());
-
-
+  // Write Parquet file
   ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_in.parquet"));
-
   PARQUET_THROW_NOT_OK(
-
       parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, 5));
 
-
- return ::arrow::Status::OK();
+  return ::arrow::Status::OK();
 }
 
-static ::arrow::Status RunMain() 
+static ::arrow::Status RunMain()
 {
-    // (Doc section: RunMain)
+  ARROW_RETURN_NOT_OK(GenInitialFile());
 
-  // (Doc section: Gen Files)
-
-  // Generate initial files for each format with a helper function -- don't worry,
-
-  // we'll also write a table in this example.
-
-  ARROW_RETURN_NOT_OK(GenInitialFile()); //adapted a bit to the test
-
-std::shared_ptr<arrow::io::ReadableFile> infile;
-
-  // (Doc section: ReadableFile Definition)
-
-  // (Doc section: Arrow ReadableFile Open)
-
-  // Get "test_in.arrow" into our file pointer
-
+  // --- IPC read/write ---
+  std::shared_ptr<arrow::io::ReadableFile> infile;
   ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(
-
                                     "test_in.arrow", arrow::default_memory_pool()));
-
-  // (Doc section: Arrow ReadableFile Open)
-
-  // (Doc section: Arrow Read Open)
-
-  // Open up the file with the IPC features of the library, gives us a reader object.
-
   ARROW_ASSIGN_OR_RAISE(auto ipc_reader, arrow::ipc::RecordBatchFileReader::Open(infile));
 
-  // (Doc section: Arrow Read Open)
-
-  // (Doc section: Arrow Read)
-
-  // Using the reader, we can read Record Batches. Note that this is specific to IPC;
-
-  // for other formats, we focus on Tables, but here, RecordBatches are used.
-
   std::shared_ptr<arrow::RecordBatch> rbatch;
-
   ARROW_ASSIGN_OR_RAISE(rbatch, ipc_reader->ReadRecordBatch(0));
 
-  // (Doc section: Arrow Read)
-
-
-  // (Doc section: Arrow Write Open)
-
-  // Just like with input, we get an object for the output file.
-
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-
-  // Bind it to "test_out.arrow"
-
   ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_out.arrow"));
-
-  // (Doc section: Arrow Write Open)
-
-  // (Doc section: Arrow Writer)
-
-  // Set up a writer with the output file -- and the schema! We're defining everything
-
-  // here, loading to fire.
-
-  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc_writer,
-
+  ARROW_ASSIGN_OR_RAISE(auto ipc_writer,
                         arrow::ipc::MakeFileWriter(outfile, rbatch->schema()));
-
-  // (Doc section: Arrow Writer)
-
-  // (Doc section: Arrow Write)
-
-  // Write the record batch.
-
   ARROW_RETURN_NOT_OK(ipc_writer->WriteRecordBatch(*rbatch));
-
-  // (Doc section: Arrow Write)
-
-  // (Doc section: Arrow Close)
-
-  // Specifically for IPC, the writer needs to be explicitly closed.
-
   ARROW_RETURN_NOT_OK(ipc_writer->Close());
 
-  // (Doc section: Arrow Close)
-
-
-  // (Doc section: CSV Read Open)
-
-  // Bind our input file to "test_in.csv"
-
-  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open("test_in.csv"));
-
-  // (Doc section: CSV Read Open)
-
-  // (Doc section: CSV Table Declare)
-
-  std::shared_ptr<arrow::Table> csv_table;
-
-  // (Doc section: CSV Table Declare)
-
-  // (Doc section: CSV Reader Make)
-
-  // The CSV reader has several objects for various options. For now, we'll use defaults.
-
-  ARROW_ASSIGN_OR_RAISE(
-
-      auto csv_reader,
-
-      arrow::csv::TableReader::Make(
-
-          arrow::io::default_io_context(), infile, arrow::csv::ReadOptions::Defaults(),
-
-          arrow::csv::ParseOptions::Defaults(), arrow::csv::ConvertOptions::Defaults()));
-
-  // (Doc section: CSV Reader Make)
-
-  // (Doc section: CSV Read)
-
-  // Read the table.
-
-  ARROW_ASSIGN_OR_RAISE(csv_table, csv_reader->Read())
-
-  // (Doc section: CSV Read)
-
-
-  // (Doc section: CSV Write)
-
-  // Bind our output file to "test_out.csv"
-
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_out.csv"));
-
-  // The CSV writer has simpler defaults, review API documentation for more complex usage.
-
-  ARROW_ASSIGN_OR_RAISE(auto csv_writer,
-
-                        arrow::csv::MakeCSVWriter(outfile, csv_table->schema()));
-
-  ARROW_RETURN_NOT_OK(csv_writer->WriteTable(*csv_table));
-
-  // Not necessary, but a safe practice.
-
-  ARROW_RETURN_NOT_OK(csv_writer->Close());
-
-  // (Doc section: CSV Write)
-
-
-  // (Doc section: Parquet Read Open)
-
-  // Bind our input file to "test_in.parquet"
-
+  // --- Parquet read/write ---
   ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open("test_in.parquet"));
-
-  // (Doc section: Parquet Read Open)
-
-  // (Doc section: Parquet FileReader)
-
   std::unique_ptr<parquet::arrow::FileReader> reader;
-
-  // (Doc section: Parquet FileReader)
-
-  // (Doc section: Parquet OpenFile)
-
-  // Note that Parquet's OpenFile() takes the reader by reference, rather than returning
-
-  // a reader.
-
   PARQUET_ASSIGN_OR_THROW(reader,
-
                           parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
-  // (Doc section: Parquet OpenFile)
-
-
-  // (Doc section: Parquet Read)
-
   std::shared_ptr<arrow::Table> parquet_table;
-
-  // Read the table.
-
   PARQUET_THROW_NOT_OK(reader->ReadTable(&parquet_table));
 
-  // (Doc section: Parquet Read)
-
-
-  // (Doc section: Parquet Write)
-
-  // Parquet writing does not need a declared writer object. Just get the output
-
-  // file bound, then pass in the table, memory pool, output, and chunk size for
-
-  // breaking up the Table on-disk.
-
   ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_out.parquet"));
-
   PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(
-
       *parquet_table, arrow::default_memory_pool(), outfile, 5));
 
-  // (Doc section: Parquet Write)
-
-  // (Doc section: Return)
   return ::arrow::Status::OK();
 }
 

--- a/src/tests/class_tests/openms/source/Arrow_test.cpp
+++ b/src/tests/class_tests/openms/source/Arrow_test.cpp
@@ -3,7 +3,6 @@
 
 #include <arrow/api.h>
 #include <arrow/io/api.h>
-#include <arrow/ipc/api.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <memory>
@@ -11,12 +10,12 @@
 
 using namespace OpenMS;
 
-// Adapted from https://arrow.apache.org/docs/cpp/tutorials/io_tutorial.html
-// Tests IPC and Parquet I/O — the formats OpenMS actually uses.
+// Tests Arrow/Parquet I/O — the format OpenMS actually uses.
 
-static ::arrow::Status GenInitialFile(const std::string& ipc_path,
-                                      const std::string& parquet_path)
+static ::arrow::Status RunParquetRoundtrip(const std::string& in_path,
+                                           const std::string& out_path)
 {
+  // Build a small table
   arrow::Int8Builder int8builder;
 
   int8_t days_raw[5] = {1, 12, 17, 23, 28};
@@ -44,79 +43,38 @@ static ::arrow::Status GenInitialFile(const std::string& ipc_path,
 
   auto table = arrow::Table::Make(schema, columns);
 
-  // Write IPC file
+  // Write Parquet
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(ipc_path));
-  ARROW_ASSIGN_OR_RAISE(auto ipc_writer, arrow::ipc::MakeFileWriter(outfile, schema));
-  ARROW_RETURN_NOT_OK(ipc_writer->WriteTable(*table));
-  ARROW_RETURN_NOT_OK(ipc_writer->Close());
-
-  // Write Parquet file
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(parquet_path));
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(in_path));
   PARQUET_THROW_NOT_OK(
       parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, 5));
 
-  return ::arrow::Status::OK();
-}
-
-static ::arrow::Status RunMain(const std::string& in_ipc_path,
-                                const std::string& in_parquet_path,
-                                const std::string& out_ipc_path,
-                                const std::string& out_parquet_path)
-{
-  ARROW_RETURN_NOT_OK(GenInitialFile(in_ipc_path, in_parquet_path));
-
-  // --- IPC read/write ---
+  // Read Parquet
   std::shared_ptr<arrow::io::ReadableFile> infile;
-  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(
-                                    in_ipc_path, arrow::default_memory_pool()));
-  ARROW_ASSIGN_OR_RAISE(auto ipc_reader, arrow::ipc::RecordBatchFileReader::Open(infile));
-
-  std::shared_ptr<arrow::RecordBatch> rbatch;
-  ARROW_ASSIGN_OR_RAISE(rbatch, ipc_reader->ReadRecordBatch(0));
-
-  std::shared_ptr<arrow::io::FileOutputStream> outfile;
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(out_ipc_path));
-  ARROW_ASSIGN_OR_RAISE(auto ipc_writer,
-                        arrow::ipc::MakeFileWriter(outfile, rbatch->schema()));
-  ARROW_RETURN_NOT_OK(ipc_writer->WriteRecordBatch(*rbatch));
-  ARROW_RETURN_NOT_OK(ipc_writer->Close());
-
-  // --- Parquet read/write ---
-  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(in_parquet_path));
+  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(in_path));
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_ASSIGN_OR_THROW(reader,
                           parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
 
-  std::shared_ptr<arrow::Table> parquet_table;
-  PARQUET_THROW_NOT_OK(reader->ReadTable(&parquet_table));
+  std::shared_ptr<arrow::Table> read_table;
+  PARQUET_THROW_NOT_OK(reader->ReadTable(&read_table));
 
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(out_parquet_path));
+  // Write back out to verify roundtrip
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(out_path));
   PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(
-      *parquet_table, arrow::default_memory_pool(), outfile, 5));
+      *read_table, arrow::default_memory_pool(), outfile, 5));
 
   return ::arrow::Status::OK();
 }
 
 START_TEST(Arrow, "$Id$")
 
-START_SECTION(GenInitialFile())
+START_SECTION(RunParquetRoundtrip())
 {
-  String in_ipc, in_parquet;
-  NEW_TMP_FILE(in_ipc);
+  String in_parquet, out_parquet;
   NEW_TMP_FILE(in_parquet);
-  TEST_EQUAL(GenInitialFile(in_ipc, in_parquet).ok(), true)
-}
-END_SECTION
-
-START_SECTION(RunMain())
-{
-  String in_ipc, in_parquet, out_ipc, out_parquet;
-  NEW_TMP_FILE(in_ipc);
-  NEW_TMP_FILE(in_parquet);
-  NEW_TMP_FILE(out_ipc);
   NEW_TMP_FILE(out_parquet);
-  TEST_EQUAL(RunMain(in_ipc, in_parquet, out_ipc, out_parquet).ok(), true)
+  TEST_EQUAL(RunParquetRoundtrip(in_parquet, out_parquet).ok(), true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Arrow_test.cpp
+++ b/src/tests/class_tests/openms/source/Arrow_test.cpp
@@ -6,8 +6,6 @@
 #include <arrow/ipc/api.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
-#include <iostream>
-#include <vector>
 #include <memory>
 #include <arrow/status.h>
 
@@ -16,7 +14,8 @@ using namespace OpenMS;
 // Adapted from https://arrow.apache.org/docs/cpp/tutorials/io_tutorial.html
 // Tests IPC and Parquet I/O — the formats OpenMS actually uses.
 
-static ::arrow::Status GenInitialFile()
+static ::arrow::Status GenInitialFile(const std::string& ipc_path,
+                                      const std::string& parquet_path)
 {
   arrow::Int8Builder int8builder;
 
@@ -47,41 +46,44 @@ static ::arrow::Status GenInitialFile()
 
   // Write IPC file
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_in.arrow"));
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(ipc_path));
   ARROW_ASSIGN_OR_RAISE(auto ipc_writer, arrow::ipc::MakeFileWriter(outfile, schema));
   ARROW_RETURN_NOT_OK(ipc_writer->WriteTable(*table));
   ARROW_RETURN_NOT_OK(ipc_writer->Close());
 
   // Write Parquet file
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_in.parquet"));
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(parquet_path));
   PARQUET_THROW_NOT_OK(
       parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), outfile, 5));
 
   return ::arrow::Status::OK();
 }
 
-static ::arrow::Status RunMain()
+static ::arrow::Status RunMain(const std::string& in_ipc_path,
+                                const std::string& in_parquet_path,
+                                const std::string& out_ipc_path,
+                                const std::string& out_parquet_path)
 {
-  ARROW_RETURN_NOT_OK(GenInitialFile());
+  ARROW_RETURN_NOT_OK(GenInitialFile(in_ipc_path, in_parquet_path));
 
   // --- IPC read/write ---
   std::shared_ptr<arrow::io::ReadableFile> infile;
   ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(
-                                    "test_in.arrow", arrow::default_memory_pool()));
+                                    in_ipc_path, arrow::default_memory_pool()));
   ARROW_ASSIGN_OR_RAISE(auto ipc_reader, arrow::ipc::RecordBatchFileReader::Open(infile));
 
   std::shared_ptr<arrow::RecordBatch> rbatch;
   ARROW_ASSIGN_OR_RAISE(rbatch, ipc_reader->ReadRecordBatch(0));
 
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_out.arrow"));
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(out_ipc_path));
   ARROW_ASSIGN_OR_RAISE(auto ipc_writer,
                         arrow::ipc::MakeFileWriter(outfile, rbatch->schema()));
   ARROW_RETURN_NOT_OK(ipc_writer->WriteRecordBatch(*rbatch));
   ARROW_RETURN_NOT_OK(ipc_writer->Close());
 
   // --- Parquet read/write ---
-  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open("test_in.parquet"));
+  ARROW_ASSIGN_OR_RAISE(infile, arrow::io::ReadableFile::Open(in_parquet_path));
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_ASSIGN_OR_THROW(reader,
                           parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
@@ -89,7 +91,7 @@ static ::arrow::Status RunMain()
   std::shared_ptr<arrow::Table> parquet_table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(&parquet_table));
 
-  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open("test_out.parquet"));
+  ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(out_parquet_path));
   PARQUET_THROW_NOT_OK(parquet::arrow::WriteTable(
       *parquet_table, arrow::default_memory_pool(), outfile, 5));
 
@@ -100,13 +102,21 @@ START_TEST(Arrow, "$Id$")
 
 START_SECTION(GenInitialFile())
 {
-  TEST_EQUAL(GenInitialFile().ok(), true)
+  String in_ipc, in_parquet;
+  NEW_TMP_FILE(in_ipc);
+  NEW_TMP_FILE(in_parquet);
+  TEST_EQUAL(GenInitialFile(in_ipc, in_parquet).ok(), true)
 }
 END_SECTION
 
 START_SECTION(RunMain())
 {
-  TEST_EQUAL(RunMain().ok(), true)
+  String in_ipc, in_parquet, out_ipc, out_parquet;
+  NEW_TMP_FILE(in_ipc);
+  NEW_TMP_FILE(in_parquet);
+  NEW_TMP_FILE(out_ipc);
+  NEW_TMP_FILE(out_parquet);
+  TEST_EQUAL(RunMain(in_ipc, in_parquet, out_ipc, out_parquet).ok(), true)
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary
- Addresses #9065 — @w8jcik noted that `arrow/csv` can fail when Arrow lacks CSV support (`ARROW_CSV` is OFF by default upstream)
- Removes `arrow/csv` and `arrow/ipc` dependencies from `Arrow_test.cpp` — neither is used anywhere in the OpenMS library
- The original test was a copy of the [Arrow C++ I/O tutorial](https://arrow.apache.org/docs/cpp/tutorials/io_tutorial.html) testing Arrow itself, not OpenMS
- Replaced with a focused Parquet roundtrip test (write → read → write) covering the only Arrow format OpenMS uses
- Uses `NEW_TMP_FILE` for temp paths instead of hardcoded filenames

## Test plan
- [ ] CI passes on all platforms
- [ ] `Arrow_test` passes with Parquet-only coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test suite to focus on Parquet roundtrip validation, removed CSV and Arrow IPC I/O test flows, switched to temporary-path-based roundtrip checks, and applied small test formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->