### PR TITLE
fix: correct m/z for b/a neutral-loss ions in TheoreticalSpectrumGenerator

### DIFF
--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -830,7 +830,19 @@ namespace OpenMS
             fx_losses.insert(EmpiricalFormula("H2O")); // HCD water loss at N-term
           }
 
-          for (i = Size(!add_first_prefix_ion_); i < peptide.size() - 1; ++i)
+          // Re-apply preamble for peptide[0] (same as plain-ion loop above)
+          // so that the running mass includes the first residue. (#9078)
+          i = Size(!add_first_prefix_ion_);
+          if (i == 1)
+          {
+            mono_weight += peptide[0].getMonoWeight(Residue::Internal);
+            if (peptide[0].hasNeutralLoss())
+            {
+              for (const auto& formula : peptide[0].getLossFormulas()) fx_losses.insert(formula);
+            }
+          }
+
+          for (; i < peptide.size() - 1; ++i)
           {
             mono_weight += peptide[i].getMonoWeight(Residue::Internal); // standard internal residue including named modifications: c
 


### PR DESCRIPTION
## Summary
- Fixes #9078
- The neutral-loss loop for prefix ions (b/a) reset the running mass accumulator but did not re-add `peptide[0]`'s residue mass, unlike the plain-ion loop above it
- This caused all b/a neutral-loss fragments (`b-H2O`, `b-NH3`, `a-H2O`, `a-NH3`) to be too low by exactly the first residue's internal mass divided by charge
- Plain b/a/y ions and y-ion neutral losses were unaffected

## Root cause
In `TheoreticalSpectrumGenerator::addPeaks_()`, the plain-ion loop has a preamble that adds `peptide[0].getMonoWeight(Residue::Internal)` before entering the loop at `i = 1`. After the plain-ion loop, `mono_weight` is reset to `initial_mono_weight`, but the neutral-loss loop never re-applies the preamble — so `peptide[0]`'s mass is missing from all neutral-loss m/z calculations.

## Fix
Add the same preamble (residue 0 mass + loss formulas) to the neutral-loss loop, mirroring the plain-ion loop structure.

## Test plan
- [ ] CI passes
- [ ] Existing `TheoreticalSpectrumGenerator_test` passes
- [ ] Reproducer from issue (b/a neutral-loss ions for `HRLEDMEQALSPSVFK`) now matches expected values

Credit to @karstensuhre for reporting and locating the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected neutral loss calculation logic in theoretical spectrum generation to ensure accurate mass accumulation and loss formula handling for peptide residues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->