### PR TITLE
perf: fast FragmentIndex build with bitmask modification enumeration

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
@@ -37,8 +38,10 @@ namespace OpenMS
      *
      * Field semantics and how they relate to the braced initializer lists used in tests {a, b, {c, d}, e}:
      *  - protein_idx .......... 'a' Index into the FASTA entries vector passed to build(); identifies the source protein.
-     *  - modification_idx_ .... 'b' Index into the list of generated modification variants for the given unmodified subsequence.
-     *                             In tests, this maps to mod_peptides[modification_idx_] created by ModifiedPeptideGenerator.
+     *  - mod_bitmask_ ......... 'b' Bitmask encoding which variable modification slots are active.
+     *                             Each bit corresponds to a (position, mod_type) pair found by scanning
+     *                             the sequence left-to-right against the variable modification config.
+     *                             0 = unmodified (or fixed-only). Supports up to 32 variable mod slots.
      *  - sequence_ ............ '{c, d}' 0-based start offset and length (in residues) of the peptide subsequence within the protein.
      *                             Note: length (d) is used like std::string::substr(start, length).
      *  - precursor_mz_ ........ 'e' Mono-isotopic m/z at charge 1 (M+H)+; used for ordering/slicing in the index.
@@ -47,15 +50,15 @@ namespace OpenMS
     struct Peptide {
 
       // We need a constructor in order to emplace back
-      Peptide(UInt32 protein_idx, UInt32 modification_idx, std::pair<uint16_t , uint16_t> sequence, float precursor_mz):
+      Peptide(UInt32 protein_idx, uint32_t mod_bitmask, std::pair<uint16_t , uint16_t> sequence, float precursor_mz):
           protein_idx(protein_idx),
-        modification_idx_(modification_idx),
+        mod_bitmask_(mod_bitmask),
         sequence_(sequence),
         precursor_mz_(precursor_mz)
         {}
 
         UInt32 protein_idx;            ///< 0-based index into FASTA entries provided to build(); identifies the source protein
-        UInt32 modification_idx_;      ///< Index into variant list produced by ModifiedPeptideGenerator for this subsequence (0 = unmodified)
+        uint32_t mod_bitmask_;         ///< Bitmask of active variable mod slots (0 = unmodified/fixed-only; up to 32 slots)
         std::pair<uint16_t , uint16_t> sequence_; ///< {start, length} within the source protein sequence (start is 0-based; length in residues)
         float precursor_mz_;           ///< Mono-isotopic m/z at charge 1 (M+H)+ of this peptide; used for sorting/filtering
     };
@@ -226,6 +229,19 @@ namespace OpenMS
     void querySpectrum(const MSSpectrum& spectrum,
                        SpectrumMatchesTopN& sms);
 
+    /** @brief Reconstruct a fully modified AASequence from a Peptide's bitmask.
+     *
+     * Used for result output — only called for final hits (not in the build hot path).
+     * Applies fixed modifications, then uses the bitmask to determine which variable
+     * modifications are active at which positions.
+     *
+     * @param[in] peptide   The Peptide descriptor with mod_bitmask_
+     * @param[in] fasta_entries The FASTA database used during build()
+     * @return The fully modified AASequence
+     */
+    AASequence reconstructModifiedSequence(const Peptide& peptide,
+                                           const std::vector<FASTAFile::FASTAEntry>& fasta_entries) const;
+
 protected:
 
 
@@ -252,6 +268,57 @@ protected:
      * @param[in] fasta_entries
      */
     void generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries);
+
+    /// Entry in the per-AA variable modification lookup table.
+    struct VarModEntry
+    {
+      double delta_mass;                    ///< mass delta from this modification
+      const ResidueModification* mod_ptr;   ///< pointer to the modification (for AASequence reconstruction)
+      ResidueModification::TermSpecificity term_spec; ///< where this mod can be applied
+    };
+
+    /// A candidate modification slot for a specific peptide.
+    /// Slots are built by scanning a peptide sequence left-to-right against the variable mod config.
+    /// The slot index determines its bit position in mod_bitmask_.
+    struct ModSlot
+    {
+      uint16_t position;                    ///< residue index, or NTERM_SLOT/CTERM_SLOT
+      double delta_mass;                    ///< mass delta
+      const ResidueModification* mod_ptr;   ///< for AASequence reconstruction
+
+      static constexpr uint16_t NTERM_SLOT = UINT16_MAX - 1;
+      static constexpr uint16_t CTERM_SLOT = UINT16_MAX;
+    };
+
+    static constexpr size_t MAX_MOD_SLOTS = 32; ///< max variable mod slots per peptide (uint32_t bitmask)
+
+    /// Build per-AA modification lookup tables from modifications_fixed_ and modifications_variable_.
+    /// Called once at the start of generatePeptides().
+    void initModificationTables_();
+
+    /// Scan a peptide sequence to find all variable modification slots.
+    /// Returns the number of slots written to out_slots (at most MAX_MOD_SLOTS).
+    /// Deterministic ordering: N-term pure-terminal mods, then left-to-right residue mods
+    /// (ANYWHERE + position-specific terminal), then C-term pure-terminal mods.
+    size_t buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots) const;
+
+    /// Per-AA fixed modification delta mass (0.0 if no fixed mod applies)
+    std::array<double, 128> fixed_mod_deltas_{};
+    /// Per-AA fixed modification pointer (nullptr if none)
+    std::array<const ResidueModification*, 128> fixed_mod_ptrs_{};
+    double fixed_nterm_delta_{0.0};   ///< Fixed N-terminal mod delta (0 if none)
+    double fixed_cterm_delta_{0.0};   ///< Fixed C-terminal mod delta (0 if none)
+    const ResidueModification* fixed_nterm_mod_ptr_{nullptr};
+    const ResidueModification* fixed_cterm_mod_ptr_{nullptr};
+
+    /// Per-AA variable modification table: for each ASCII char, list of possible variable mods
+    std::array<std::vector<VarModEntry>, 128> variable_mod_table_{};
+    /// Pure N-terminal variable mods (not residue-specific)
+    std::vector<VarModEntry> variable_nterm_mods_;
+    /// Pure C-terminal variable mods (not residue-specific)
+    std::vector<VarModEntry> variable_cterm_mods_;
+
+    bool mod_tables_initialized_{false};
 
     /// Precomputed residue mass lookup table: ASCII char -> internal monoisotopic mass (Da).
     /// Indexed by single-letter amino acid code (e.g., 'A'=65). Entries for non-AA chars are 0.

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -214,6 +214,11 @@ namespace OpenMS
                            const std::pair<size_t,size_t>& peptide_idx_range,
                            uint16_t peak_charge);
 
+    /// Scalar (non-SIMD) query for benchmarking comparison
+    std::vector<Hit> queryScalar(const Peak1D& peak,
+                                 const std::pair<size_t,size_t>& peptide_idx_range,
+                                 uint16_t peak_charge);
+
     /**
      * @brief: queries one complete experimental spectra against the Database. Loops over all precursor charges
      * Starts at min_precursor_charge and iteratively goes to max_precursor_charge. We query all peaks multiple times with all the

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -227,8 +227,7 @@ namespace OpenMS
 protected:
 
 
-#ifdef DEBUG_FRAGMENT_INDEX
-  /**@brief One entry in the fragment index (debug only — SoA layout used in production)
+  /**@brief One entry in the fragment index
    */
   struct Fragment
   {
@@ -236,10 +235,9 @@ protected:
           peptide_idx_(peptide_idx),
           fragment_mz_(fragment_mz)
       {}
-      UInt32 peptide_idx_;
+      UInt32 peptide_idx_; // 32 bit in sage
       float fragment_mz_;
   };
-#endif
 
     bool is_build_{false};              ///< true, if the database has been populated with fragments
 
@@ -253,9 +251,8 @@ protected:
      */
     void generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries);
 
-    std::vector<Peptide> fi_peptides_;           ///< vector of all (digested) peptides
-    std::vector<float>  fi_fragment_mzs_;        ///< SoA: fragment m/z values (parallel with fi_fragment_peptide_idxs_)
-    std::vector<UInt32> fi_fragment_peptide_idxs_; ///< SoA: peptide index for each fragment (parallel with fi_fragment_mzs_)
+    std::vector<Peptide> fi_peptides_;   ///< vector of all (digested) peptides
+    std::vector<Fragment> fi_fragments_; ///< vector of all theoretical fragments (b- and y- ions)
 
     float fragment_min_mz_;  ///< smallest fragment mz
     float fragment_max_mz_;  ///< largest fragment mz    

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -214,11 +214,6 @@ namespace OpenMS
                            const std::pair<size_t,size_t>& peptide_idx_range,
                            uint16_t peak_charge);
 
-    /// Scalar (non-SIMD) query for benchmarking comparison
-    std::vector<Hit> queryScalar(const Peak1D& peak,
-                                 const std::pair<size_t,size_t>& peptide_idx_range,
-                                 uint16_t peak_charge);
-
     /**
      * @brief: queries one complete experimental spectra against the Database. Loops over all precursor charges
      * Starts at min_precursor_charge and iteratively goes to max_precursor_charge. We query all peaks multiple times with all the

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -369,7 +369,8 @@ protected:
     std::vector<Fragment> fi_fragments_; ///< vector of all theoretical fragments (b- and y- ions)
 
     float fragment_min_mz_;  ///< smallest fragment mz
-    float fragment_max_mz_;  ///< largest fragment mz    
+    float fragment_max_mz_;  ///< largest fragment mz
+    size_t min_ion_index_{0}; ///< skip ions below this index (0=all, 2=skip b1/b2/y1/y2)
     size_t bucketsize_;       ///< number of fragments per outer node
     std::vector<float> bucket_min_mz_;  ///< vector of the smalles fragment mz of each bucket
     float precursor_mz_tolerance_;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -227,7 +227,8 @@ namespace OpenMS
 protected:
 
 
-  /**@brief One entry in the fragment index
+#ifdef DEBUG_FRAGMENT_INDEX
+  /**@brief One entry in the fragment index (debug only — SoA layout used in production)
    */
   struct Fragment
   {
@@ -235,9 +236,10 @@ protected:
           peptide_idx_(peptide_idx),
           fragment_mz_(fragment_mz)
       {}
-      UInt32 peptide_idx_; // 32 bit in sage
+      UInt32 peptide_idx_;
       float fragment_mz_;
   };
+#endif
 
     bool is_build_{false};              ///< true, if the database has been populated with fragments
 
@@ -251,8 +253,9 @@ protected:
      */
     void generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries);
 
-    std::vector<Peptide> fi_peptides_;   ///< vector of all (digested) peptides
-    std::vector<Fragment> fi_fragments_; ///< vector of all theoretical fragments (b- and y- ions)
+    std::vector<Peptide> fi_peptides_;           ///< vector of all (digested) peptides
+    std::vector<float>  fi_fragment_mzs_;        ///< SoA: fragment m/z values (parallel with fi_fragment_peptide_idxs_)
+    std::vector<UInt32> fi_fragment_peptide_idxs_; ///< SoA: peptide index for each fragment (parallel with fi_fragment_mzs_)
 
     float fragment_min_mz_;  ///< smallest fragment mz
     float fragment_max_mz_;  ///< largest fragment mz    

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -16,6 +16,7 @@
 
 
 #include <array>
+#include <mutex>
 #include <vector>
 #include <functional>
 
@@ -255,7 +256,7 @@ protected:
     /// Precomputed residue mass lookup table: ASCII char -> internal monoisotopic mass (Da).
     /// Indexed by single-letter amino acid code (e.g., 'A'=65). Entries for non-AA chars are 0.
     static std::array<double, 128> residue_mass_table_;
-    static bool mass_table_initialized_;
+    static std::once_flag mass_table_once_flag_;
     static void initResidueMassTable_();
 
     /// Precomputed ion-type mass offsets (from Residue::getInternalTo*Ion formulas)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -300,7 +300,10 @@ protected:
     /// Returns the number of slots written to out_slots (at most MAX_MOD_SLOTS).
     /// Deterministic ordering: N-term pure-terminal mods, then left-to-right residue mods
     /// (ANYWHERE + position-specific terminal), then C-term pure-terminal mods.
-    size_t buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots) const;
+    /// @param is_protein_nterm true if this peptide starts at protein position 0
+    /// @param is_protein_cterm true if this peptide ends at the last protein residue
+    size_t buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots,
+                          bool is_protein_nterm = false, bool is_protein_cterm = false) const;
 
     /// Per-AA fixed modification delta mass (0.0 if no fixed mod applies)
     std::array<double, 128> fixed_mod_deltas_{};

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -231,7 +231,7 @@ namespace OpenMS
 
     /** @brief Reconstruct a fully modified AASequence from a Peptide's bitmask.
      *
-     * Used for result output — only called for final hits (not in the build hot path).
+     * Used for result output - only called for final hits (not in the build hot path).
      * Applies fixed modifications, then uses the bitmask to determine which variable
      * modifications are active at which positions.
      *
@@ -249,12 +249,13 @@ protected:
    */
   struct Fragment
   {
+      Fragment() = default;
       Fragment(UInt32 peptide_idx, float fragment_mz):
           peptide_idx_(peptide_idx),
           fragment_mz_(fragment_mz)
       {}
-      UInt32 peptide_idx_; // 32 bit in sage
-      float fragment_mz_;
+      UInt32 peptide_idx_{}; // 32 bit in sage
+      float fragment_mz_{};
   };
 
     bool is_build_{false};              ///< true, if the database has been populated with fragments
@@ -269,7 +270,7 @@ protected:
      */
     void generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries);
 
-    /// Entry in the per-AA variable modification lookup table.
+    /** @brief Entry in the per-AA variable modification lookup table. */
     struct VarModEntry
     {
       double delta_mass;                    ///< mass delta from this modification
@@ -277,17 +278,19 @@ protected:
       ResidueModification::TermSpecificity term_spec; ///< where this mod can be applied
     };
 
-    /// A candidate modification slot for a specific peptide.
-    /// Slots are built by scanning a peptide sequence left-to-right against the variable mod config.
-    /// The slot index determines its bit position in mod_bitmask_.
+    /** @brief A candidate modification slot for a specific peptide.
+     *
+     * Slots are built by scanning a peptide sequence left-to-right against the variable mod config.
+     * The slot index determines its bit position in mod_bitmask_.
+     */
     struct ModSlot
     {
       uint16_t position;                    ///< residue index, or NTERM_SLOT/CTERM_SLOT
       double delta_mass;                    ///< mass delta
       const ResidueModification* mod_ptr;   ///< for AASequence reconstruction
 
-      static constexpr uint16_t NTERM_SLOT = UINT16_MAX - 1;
-      static constexpr uint16_t CTERM_SLOT = UINT16_MAX;
+      static constexpr uint16_t NTERM_SLOT = UINT16_MAX - 1; ///< sentinel for pure N-terminal mod slot
+      static constexpr uint16_t CTERM_SLOT = UINT16_MAX;      ///< sentinel for pure C-terminal mod slot
     };
 
     static constexpr size_t MAX_MOD_SLOTS = 32; ///< max variable mod slots per peptide (uint32_t bitmask)
@@ -300,6 +303,9 @@ protected:
     /// Returns the number of slots written to out_slots (at most MAX_MOD_SLOTS).
     /// Deterministic ordering: N-term pure-terminal mods, then left-to-right residue mods
     /// (ANYWHERE + position-specific terminal), then C-term pure-terminal mods.
+    /// @param sequence raw amino acid character array
+    /// @param seq_len length of the sequence
+    /// @param out_slots output array for modification slots (must have space for MAX_MOD_SLOTS entries)
     /// @param is_protein_nterm true if this peptide starts at protein position 0
     /// @param is_protein_cterm true if this peptide ends at the last protein residue
     size_t buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots,

--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -15,6 +15,7 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 
 
+#include <array>
 #include <vector>
 #include <functional>
 
@@ -250,6 +251,42 @@ protected:
      * @param[in] fasta_entries
      */
     void generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries);
+
+    /// Precomputed residue mass lookup table: ASCII char -> internal monoisotopic mass (Da).
+    /// Indexed by single-letter amino acid code (e.g., 'A'=65). Entries for non-AA chars are 0.
+    static std::array<double, 128> residue_mass_table_;
+    static bool mass_table_initialized_;
+    static void initResidueMassTable_();
+
+    /// Precomputed ion-type mass offsets (from Residue::getInternalTo*Ion formulas)
+    struct IonOffsets
+    {
+      double b_offset{0.0};
+      double y_offset{0.0};
+      double a_offset{0.0};
+      double c_offset{0.0};
+      double x_offset{0.0};
+      double z_offset{0.0};
+    };
+    static IonOffsets ion_offsets_;
+
+    /// Lightweight fragment generation: compute b/y ion m/z directly from amino acid chars.
+    /// Bypasses AASequence::fromString and TheoreticalSpectrumGenerator.
+    /// @param[out] fragments  Output vector to append Fragment entries to
+    /// @param[in]  sequence   Raw amino acid string (no modifications)
+    /// @param[in]  seq_len    Length of sequence
+    /// @param[in]  peptide_idx Index of this peptide in fi_peptides_
+    /// @param[in]  n_term_mod_mass  Mass delta from N-terminal modification (0 if none)
+    /// @param[in]  c_term_mod_mass  Mass delta from C-terminal modification (0 if none)
+    /// @param[in]  residue_mod_masses  Per-residue modification mass deltas (nullptr if none; array of seq_len doubles)
+    void generateFragmentsLightweight_(
+      std::vector<Fragment>& fragments,
+      const char* sequence,
+      size_t seq_len,
+      UInt32 peptide_idx,
+      double n_term_mod_mass,
+      double c_term_mod_mass,
+      const double* residue_mod_masses) const;
 
     std::vector<Peptide> fi_peptides_;   ///< vector of all (digested) peptides
     std::vector<Fragment> fi_fragments_; ///< vector of all theoretical fragments (b- and y- ions)

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -37,6 +37,7 @@
 #include <bit>
 #include <functional>
 #include <mutex>
+#include <boost/sort/sort.hpp>
 
 
 using namespace std;
@@ -749,8 +750,8 @@ namespace OpenMS
 
       OPENMS_LOG_INFO << "Sorting fragments..." << std::endl;
 
-      /// 1.) First all Fragments are sorted by their own mass!
-      sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)
+      /// 1.) First all Fragments are sorted by their own mass (parallel via Boost.Sort)
+      boost::sort::block_indirect_sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)
       {
         return std::tie(a.fragment_mz_, a.peptide_idx_) < std::tie(b.fragment_mz_, b.peptide_idx_);
       });

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -52,12 +52,14 @@ namespace OpenMS
     if (mass_table_initialized_) return;
 
     residue_mass_table_.fill(0.0);
-    const string aa_codes = "ACDEFGHIKLMNPQRSTVWY";
     const ResidueDB* rdb = ResidueDB::getInstance();
-    for (char c : aa_codes)
+    for (char c = 'A'; c <= 'Z'; ++c)
     {
       const Residue* r = rdb->getResidue(static_cast<unsigned char>(c));
-      residue_mass_table_[static_cast<size_t>(c)] = r->getMonoWeight(Residue::Internal);
+      if (r != nullptr)
+      {
+        residue_mass_table_[static_cast<size_t>(c)] = r->getMonoWeight(Residue::Internal);
+      }
     }
 
     // Precompute ion-type offsets
@@ -92,7 +94,7 @@ namespace OpenMS
         double base_mass = proton * z + n_term_mod_mass;
         double cumulative = base_mass;
 
-        for (size_t i = 0; i < seq_len; ++i)
+        for (size_t i = 0; i + 1 < seq_len; ++i)
         {
           double res_mass = table[static_cast<unsigned char>(sequence[i])];
           if (residue_mod_masses) res_mass += residue_mod_masses[i];
@@ -128,7 +130,7 @@ namespace OpenMS
         double base_mass = proton * z + c_term_mod_mass;
         double cumulative = base_mass;
 
-        for (size_t j = seq_len; j >= 1; --j)
+        for (size_t j = seq_len; j > 1; --j)
         {
           double res_mass = table[static_cast<unsigned char>(sequence[j - 1])];
           if (residue_mod_masses) res_mass += residue_mod_masses[j - 1];
@@ -239,12 +241,15 @@ namespace OpenMS
 
         for (const pair<size_t, size_t>& digested_peptide : digested_peptides)
         {
-          // skip peptides containing unknown AA
-          if (protein.sequence.substr(digested_peptide.first, digested_peptide.second).find('X') != string::npos)
+          // skip peptides containing unknown or ambiguous AA codes (X, B, Z, J)
           {
-            #pragma omp atomic
-            skipped_peptides++;
-            continue;
+            const auto sub = protein.sequence.substr(digested_peptide.first, digested_peptide.second);
+            if (sub.find_first_of("XBZJ") != string::npos)
+            {
+              #pragma omp atomic
+              skipped_peptides++;
+              continue;
+            }
           }
 
           const char* seq_ptr = protein.sequence.c_str() + digested_peptide.first;
@@ -292,7 +297,7 @@ namespace OpenMS
       }
       if (skipped_peptides > 0)
       {
-        OPENMS_LOG_WARN << skipped_peptides << " peptides skipped due to unkown AA \n";
+        OPENMS_LOG_WARN << skipped_peptides << " peptides skipped due to unknown or ambiguous AA (X/B/Z/J)\n";
       }
 
       // Merge per-thread peptide vectors

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -31,7 +31,6 @@
 #include <OpenMS/QC/QCBase.h>
 #include <omp.h>
 #include <functional>
-#include <numeric>
 
 
 using namespace std;
@@ -42,12 +41,12 @@ namespace OpenMS
 {
 
 #ifdef DEBUG_FRAGMENT_INDEX
-    static void print_slice(const std::vector<float>& mzs, size_t low, size_t high)
+    static void print_slice(const std::vector<FragmentIndex::Fragment>& slice, size_t low, size_t high)
     {
       cout << "Slice: ";
       for(size_t i = low; i <= high; i++)
       {
-        cout << mzs[i] << " ";
+        cout << slice[i].fragment_mz_ << " ";
       }
       cout << endl;
     }
@@ -62,8 +61,7 @@ namespace OpenMS
 
   void FragmentIndex::clear()
   {
-    fi_fragment_mzs_.clear();
-    fi_fragment_peptide_idxs_.clear();
+    fi_fragments_.clear();
     fi_peptides_.clear();
     bucket_min_mz_.clear();
     is_build_ = false;
@@ -188,16 +186,13 @@ namespace OpenMS
 
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
-      // Per-thread fragment vectors to avoid omp critical serialization.
-      // Each thread accumulates into its own pair of vectors, then we merge.
+      // Per-thread fragment vectors to avoid omp critical serialization
       const int num_threads = omp_get_max_threads();
       const size_t est_per_thread = (fi_peptides_.size() * 2 * peptide_min_length_) / num_threads + 1;
-      vector<vector<float>> thread_mzs(num_threads);
-      vector<vector<UInt32>> thread_idxs(num_threads);
+      vector<vector<Fragment>> thread_fragments(num_threads);
       for (int t = 0; t < num_threads; ++t)
       {
-        thread_mzs[t].reserve(est_per_thread);
-        thread_idxs[t].reserve(est_per_thread);
+        thread_fragments[t].reserve(est_per_thread);
       }
 
       vector<AASequence> mod_peptides;
@@ -227,84 +222,51 @@ namespace OpenMS
         for (const float& frag : b_y_ions)
         {
           if (fragment_min_mz_ > frag || frag > fragment_max_mz_) continue;
-          thread_mzs[tid].push_back(static_cast<float>(frag));
-          thread_idxs[tid].push_back(static_cast<UInt32>(peptide_idx));
+          thread_fragments[tid].emplace_back(static_cast<UInt32>(peptide_idx), frag);
         }
       }
 
-      // Merge per-thread vectors into global SoA arrays
+      // Merge per-thread vectors into global fragment array
       size_t total_fragments = 0;
-      for (int t = 0; t < num_threads; ++t) total_fragments += thread_mzs[t].size();
-      fi_fragment_mzs_.reserve(total_fragments);
-      fi_fragment_peptide_idxs_.reserve(total_fragments);
+      for (int t = 0; t < num_threads; ++t) total_fragments += thread_fragments[t].size();
+      fi_fragments_.reserve(total_fragments);
       for (int t = 0; t < num_threads; ++t)
       {
-        fi_fragment_mzs_.insert(fi_fragment_mzs_.end(), thread_mzs[t].begin(), thread_mzs[t].end());
-        fi_fragment_peptide_idxs_.insert(fi_fragment_peptide_idxs_.end(), thread_idxs[t].begin(), thread_idxs[t].end());
-        // Free thread-local memory immediately
-        vector<float>().swap(thread_mzs[t]);
-        vector<UInt32>().swap(thread_idxs[t]);
+        fi_fragments_.insert(fi_fragments_.end(), thread_fragments[t].begin(), thread_fragments[t].end());
+        vector<Fragment>().swap(thread_fragments[t]);
       }
 
       std::cout << "Sorting fragments..." << std::endl;
 
-      /// 1.) First all Fragments are sorted by their own mass via index permutation (SoA)
-      const size_t n = fi_fragment_mzs_.size();
-      std::vector<size_t> perm(n);
-      std::iota(perm.begin(), perm.end(), 0);
-      std::sort(perm.begin(), perm.end(), [&](size_t a, size_t b) {
-        return std::tie(fi_fragment_mzs_[a], fi_fragment_peptide_idxs_[a])
-             < std::tie(fi_fragment_mzs_[b], fi_fragment_peptide_idxs_[b]);
-      });
+      /// 1.) First all Fragments are sorted by their own mass!
+      sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)
       {
-        std::vector<float> sorted_mzs(n);
-        std::vector<UInt32> sorted_idxs(n);
-        for (size_t i = 0; i < n; ++i)
-        {
-          sorted_mzs[i] = fi_fragment_mzs_[perm[i]];
-          sorted_idxs[i] = fi_fragment_peptide_idxs_[perm[i]];
-        }
-        fi_fragment_mzs_ = std::move(sorted_mzs);
-        fi_fragment_peptide_idxs_ = std::move(sorted_idxs);
-      }
-      perm.clear(); // free permutation memory
+        return std::tie(a.fragment_mz_, a.peptide_idx_) < std::tie(b.fragment_mz_, b.peptide_idx_);
+      });
 
       /// Calculate the bucket size
-      bucketsize_ = sqrt(n);
+      bucketsize_ = sqrt(fi_fragments_.size()); //Todo: MSFragger uses a different approach, which might be better
       OPENMS_LOG_INFO << "Creating DB with bucket_size " << bucketsize_ << endl;
 
-      /// 2.) Per-bucket sort by peptide_idx and record bucket_min_mz_
-      std::vector<size_t> bperm; // reusable per-bucket permutation
-      #pragma omp parallel for private(bperm)
-      for (SignedSize i = 0; i < (SignedSize)n; i += bucketsize_)
+      /// 2.) next sort after precursor mass and save the min_mz of each bucket
+      #pragma omp parallel for
+      for (SignedSize i = 0; i < (SignedSize)fi_fragments_.size(); i += bucketsize_)
       {
+
         #pragma omp critical
-        bucket_min_mz_.emplace_back(fi_fragment_mzs_[i]);
+        bucket_min_mz_.emplace_back(fi_fragments_[i].fragment_mz_);
 
-        const size_t bucket_start = static_cast<size_t>(i);
-        const size_t bucket_end = std::min(bucket_start + bucketsize_, n);
-        const size_t bucket_len = bucket_end - bucket_start;
+        auto bucket_start = fi_fragments_.begin() + i;
+        auto bucket_end = (i + bucketsize_) > fi_fragments_.size() ? fi_fragments_.end() : bucket_start + bucketsize_;
 
-        bperm.resize(bucket_len);
-        std::iota(bperm.begin(), bperm.end(), size_t(0));
-        std::sort(bperm.begin(), bperm.end(), [&](size_t a, size_t b) {
-          return fi_fragment_peptide_idxs_[bucket_start + a]
-               < fi_fragment_peptide_idxs_[bucket_start + b];
+//TODO: is this thread safe????
+        sort(bucket_start, bucket_end, [](const Fragment& a, const Fragment& b) {
+          return a.peptide_idx_ < b.peptide_idx_; // we don´t need a tie, because the idx are unique
         });
-
-        std::vector<float> tmp_mzs(bucket_len);
-        std::vector<UInt32> tmp_idxs(bucket_len);
-        for (size_t k = 0; k < bucket_len; ++k)
-        {
-          tmp_mzs[k] = fi_fragment_mzs_[bucket_start + bperm[k]];
-          tmp_idxs[k] = fi_fragment_peptide_idxs_[bucket_start + bperm[k]];
-        }
-        std::copy(tmp_mzs.begin(), tmp_mzs.end(), fi_fragment_mzs_.begin() + bucket_start);
-        std::copy(tmp_idxs.begin(), tmp_idxs.end(), fi_fragment_peptide_idxs_.begin() + bucket_start);
       }
       OPENMS_LOG_INFO << "Sorting by bucket min m/z:" << bucketsize_ << endl;
-      // Resort in case the parallelization block above messed something up
-      std::sort(bucket_min_mz_.begin(), bucket_min_mz_.end());
+      //Resort in case the parallelization block above messed something up TODO: check if this can happen
+      std::sort( bucket_min_mz_.begin(), bucket_min_mz_.end());
       is_build_ = true;
       OPENMS_LOG_INFO << "Fragment index built!" << endl;
   }
@@ -323,48 +285,47 @@ namespace OpenMS
                                                   const pair<size_t, size_t>& peptide_idx_range,
                                                   uint16_t peak_charge)
   {
-      const float adjusted_mass = peak.getMZ() * static_cast<float>(peak_charge) - ((peak_charge - 1) * Constants::PROTON_MASS_U);
-      const float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
-      const float lo_bound = adjusted_mass - frag_tol;
-      const float hi_bound = adjusted_mass + frag_tol;
+      float adjusted_mass = peak.getMZ() * (float)peak_charge -((peak_charge-1) * Constants::PROTON_MASS_U);
 
-      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), lo_bound);
-      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), hi_bound);
+      float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
+
+      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), adjusted_mass - frag_tol);
+      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), adjusted_mass + frag_tol);
+
       if (left_it != bucket_min_mz_.begin()) --left_it;
 
-      const auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it),
-                                              std::distance(bucket_min_mz_.begin(), right_it));
+      auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it), std::distance(bucket_min_mz_.begin(), right_it));
 
       vector<FragmentIndex::Hit> hits;
       hits.reserve(peptide_idx_range.second - peptide_idx_range.first);
 
-      const float* mz_data = fi_fragment_mzs_.data();
-      const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
-      const UInt32 pidx_limit = static_cast<UInt32>(peptide_idx_range.second); // exclusive upper bound
 
-      for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
+      for (UInt32 j = in_range_buckets.first; j < in_range_buckets.second; j++)
       {
-        const size_t slice_begin = j * bucketsize_;
-        const size_t slice_end = std::min((j + 1) * bucketsize_, fi_fragment_mzs_.size());
+        auto slice_begin = fi_fragments_.begin() + (j*bucketsize_);
+        auto slice_end = ((j+1) * bucketsize_) >= fi_fragments_.size() ? fi_fragments_.end() : (fi_fragments_.begin() + ((j+1) * bucketsize_)) ;
 
-        // Binary search on peptide_idx within this bucket
-        auto lb = std::lower_bound(pidx_data + slice_begin, pidx_data + slice_end,
-                                   static_cast<UInt32>(peptide_idx_range.first));
-        size_t i = static_cast<size_t>(lb - pidx_data);
+        auto left_iter = std::lower_bound(slice_begin, slice_end, peptide_idx_range.first, [](Fragment a, UInt32 b) { return a.peptide_idx_ < b;} );
 
-        for (; i < slice_end; ++i)
+        while (left_iter != slice_end) // sequential scan
         {
-          if (pidx_data[i] >= pidx_limit) break;
-          if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
+          if(left_iter->peptide_idx_ > peptide_idx_range.second) break;
+
+          if ((adjusted_mass >= left_iter->fragment_mz_ - frag_tol ) && adjusted_mass <= (left_iter->fragment_mz_+ frag_tol))
           {
-            hits.emplace_back(pidx_data[i], mz_data[i]);
+
+            hits.emplace_back(left_iter->peptide_idx_, left_iter->fragment_mz_);
+            #ifdef DEBUG_FRAGMENT_INDEX
+            if (left_iter->peptide_idx_ < peptide_idx_range.first || left_iter->peptide_idx_ > peptide_idx_range.second)
+              OPENMS_LOG_WARN << "idx out of range" << endl;
+            #endif
           }
+          ++left_iter;
         }
       }
 
       return hits;
   }
-
 
   void FragmentIndex::queryPeaks(SpectrumMatchesTopN& candidates, const MSSpectrum& spectrum,
                                 const std::pair<size_t, size_t>& candidates_range,

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -29,7 +29,6 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/QCBase.h>
-#include <OpenMS/SYSTEM/SIMDe.h>
 #include <functional>
 #include <numeric>
 
@@ -321,10 +320,6 @@ namespace OpenMS
       vector<FragmentIndex::Hit> hits;
       hits.reserve(peptide_idx_range.second - peptide_idx_range.first);
 
-      // Broadcast tolerance bounds for SIMD (4 x float)
-      const simde__m128 v_lo = simde_mm_set1_ps(lo_bound);
-      const simde__m128 v_hi = simde_mm_set1_ps(hi_bound);
-
       const float* mz_data = fi_fragment_mzs_.data();
       const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
       const UInt32 pidx_limit = static_cast<UInt32>(peptide_idx_range.second); // exclusive upper bound
@@ -335,83 +330,6 @@ namespace OpenMS
         const size_t slice_end = std::min((j + 1) * bucketsize_, fi_fragment_mzs_.size());
 
         // Binary search on peptide_idx within this bucket
-        auto lb = std::lower_bound(pidx_data + slice_begin, pidx_data + slice_end,
-                                   static_cast<UInt32>(peptide_idx_range.first));
-        size_t pos = static_cast<size_t>(lb - pidx_data);
-
-        // --- SIMD loop: process 4 fragments at a time ---
-        size_t i = pos;
-        for (; i + 4 <= slice_end; i += 4)
-        {
-          // Early exit: peptide_idxs are sorted, so if first >= limit, all subsequent are too
-          if (pidx_data[i] >= pidx_limit) break;
-
-          // Load 4 consecutive m/z values
-          simde__m128 v_mz = simde_mm_loadu_ps(mz_data + i);
-
-          // Vectorized range check: mz >= lo AND mz <= hi
-          simde__m128 cmp_ge = simde_mm_cmpge_ps(v_mz, v_lo);
-          simde__m128 cmp_le = simde_mm_cmple_ps(v_mz, v_hi);
-          int mask = simde_mm_movemask_ps(simde_mm_and_ps(cmp_ge, cmp_le));
-
-          if (mask != 0)
-          {
-            for (int k = 0; k < 4; ++k)
-            {
-              if ((mask & (1 << k)) && pidx_data[i + k] < pidx_limit)
-              {
-                hits.emplace_back(pidx_data[i + k], mz_data[i + k]);
-              }
-            }
-          }
-
-          // If last element exceeded peptide range, no point continuing this bucket.
-          // Advance i past this group so the scalar remainder doesn't re-process it.
-          if (pidx_data[i + 3] >= pidx_limit) { i += 4; break; }
-        }
-
-        // --- Scalar remainder: last 0-3 elements ---
-        for (; i < slice_end; ++i)
-        {
-          if (pidx_data[i] >= pidx_limit) break;
-          if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
-          {
-            hits.emplace_back(pidx_data[i], mz_data[i]);
-          }
-        }
-      }
-
-      return hits;
-  }
-
-  vector<FragmentIndex::Hit> FragmentIndex::queryScalar(const OpenMS::Peak1D& peak,
-                                                        const pair<size_t, size_t>& peptide_idx_range,
-                                                        uint16_t peak_charge)
-  {
-      const float adjusted_mass = peak.getMZ() * static_cast<float>(peak_charge) - ((peak_charge - 1) * Constants::PROTON_MASS_U);
-      const float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
-      const float lo_bound = adjusted_mass - frag_tol;
-      const float hi_bound = adjusted_mass + frag_tol;
-
-      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), lo_bound);
-      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), hi_bound);
-      if (left_it != bucket_min_mz_.begin()) --left_it;
-
-      const auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it),
-                                              std::distance(bucket_min_mz_.begin(), right_it));
-
-      vector<FragmentIndex::Hit> hits;
-      hits.reserve(peptide_idx_range.second - peptide_idx_range.first);
-
-      const float* mz_data = fi_fragment_mzs_.data();
-      const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
-      const UInt32 pidx_limit = static_cast<UInt32>(peptide_idx_range.second); // exclusive upper bound
-
-      for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
-      {
-        const size_t slice_begin = j * bucketsize_;
-        const size_t slice_end = std::min((j + 1) * bucketsize_, fi_fragment_mzs_.size());
-
         auto lb = std::lower_bound(pidx_data + slice_begin, pidx_data + slice_end,
                                    static_cast<UInt32>(peptide_idx_range.first));
         size_t i = static_cast<size_t>(lb - pidx_data);
@@ -428,6 +346,7 @@ namespace OpenMS
 
       return hits;
   }
+
 
   void FragmentIndex::queryPeaks(SpectrumMatchesTopN& candidates, const MSSpectrum& spectrum,
                                 const std::pair<size_t, size_t>& candidates_range,

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -31,8 +31,11 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/QCBase.h>
-#include <omp.h>
+#ifdef _OPENMP
+  #include <omp.h>
+#endif
 #include <functional>
+#include <mutex>
 
 
 using namespace std;
@@ -44,33 +47,31 @@ namespace OpenMS
 
   // Static member definitions
   std::array<double, 128> FragmentIndex::residue_mass_table_{};
-  bool FragmentIndex::mass_table_initialized_{false};
+  std::once_flag FragmentIndex::mass_table_once_flag_;
   FragmentIndex::IonOffsets FragmentIndex::ion_offsets_{};
 
   void FragmentIndex::initResidueMassTable_()
   {
-    if (mass_table_initialized_) return;
-
-    residue_mass_table_.fill(0.0);
-    const ResidueDB* rdb = ResidueDB::getInstance();
-    for (char c = 'A'; c <= 'Z'; ++c)
-    {
-      const Residue* r = rdb->getResidue(static_cast<unsigned char>(c));
-      if (r != nullptr)
+    std::call_once(mass_table_once_flag_, []() {
+      residue_mass_table_.fill(0.0);
+      const ResidueDB* rdb = ResidueDB::getInstance();
+      for (char c = 'A'; c <= 'Z'; ++c)
       {
-        residue_mass_table_[static_cast<size_t>(c)] = r->getMonoWeight(Residue::Internal);
+        const Residue* r = rdb->getResidue(static_cast<unsigned char>(c));
+        if (r != nullptr)
+        {
+          residue_mass_table_[static_cast<size_t>(c)] = r->getMonoWeight(Residue::Internal);
+        }
       }
-    }
 
-    // Precompute ion-type offsets
-    ion_offsets_.b_offset = Residue::getInternalToBIon().getMonoWeight();
-    ion_offsets_.y_offset = Residue::getInternalToYIon().getMonoWeight();
-    ion_offsets_.a_offset = Residue::getInternalToAIon().getMonoWeight();
-    ion_offsets_.c_offset = Residue::getInternalToCIon().getMonoWeight();
-    ion_offsets_.x_offset = Residue::getInternalToXIon().getMonoWeight();
-    ion_offsets_.z_offset = Residue::getInternalToZIon().getMonoWeight();
-
-    mass_table_initialized_ = true;
+      // Precompute ion-type offsets
+      ion_offsets_.b_offset = Residue::getInternalToBIon().getMonoWeight();
+      ion_offsets_.y_offset = Residue::getInternalToYIon().getMonoWeight();
+      ion_offsets_.a_offset = Residue::getInternalToAIon().getMonoWeight();
+      ion_offsets_.c_offset = Residue::getInternalToCIon().getMonoWeight();
+      ion_offsets_.x_offset = Residue::getInternalToXIon().getMonoWeight();
+      ion_offsets_.z_offset = Residue::getInternalToZIon().getMonoWeight();
+    });
   }
 
   void FragmentIndex::generateFragmentsLightweight_(
@@ -189,7 +190,7 @@ namespace OpenMS
 
   /// Compute precursor m/z at charge 1 (M+H)+ directly from amino acid chars.
   /// Formula: (sum_of_internal_masses + H2O + proton) / 1
-  static float computePrecursorMzFromChars_(const char* seq, size_t len, const std::array<double, 128>& table)
+  static float computePrecursorMzFromChars(const char* seq, size_t len, const std::array<double, 128>& table)
   {
     // M+H = sum(internal masses) + H2O + proton
     static const double water = Residue::getInternalToFull().getMonoWeight(); // 18.0105646834
@@ -221,10 +222,14 @@ namespace OpenMS
       digestor.setEnzyme(digestion_enzyme_);
       digestor.setMissedCleavages(missed_cleavages_);
 
-      std::cout << "Generating peptides..." << std::endl;
+      OPENMS_LOG_INFO << "Generating peptides..." << std::endl;
 
       // Per-thread peptide vectors to avoid omp critical
+#ifdef _OPENMP
       const int num_threads = omp_get_max_threads();
+#else
+      const int num_threads = 1;
+#endif
       vector<vector<Peptide>> thread_peptides(num_threads);
       const size_t est_per_thread = (fasta_entries.size() * 5) / num_threads + 1;
       for (int t = 0; t < num_threads; ++t)
@@ -234,17 +239,21 @@ namespace OpenMS
       #pragma omp parallel for private(digested_peptides)
       for (SignedSize protein_idx = 0; protein_idx < (SignedSize)fasta_entries.size(); ++protein_idx)
       {
+#ifdef _OPENMP
         const int tid = omp_get_thread_num();
+#else
+        const int tid = 0;
+#endif
         digested_peptides.clear();
         const FASTAFile::FASTAEntry& protein = fasta_entries[protein_idx];
         digestor.digestUnmodified(StringView(protein.sequence), digested_peptides, peptide_min_length_, peptide_max_length_);
 
         for (const pair<size_t, size_t>& digested_peptide : digested_peptides)
         {
-          // skip peptides containing unknown or ambiguous AA codes (X, B, Z, J)
+          // skip peptides containing unknown or ambiguous AA codes (X, B, Z)
           {
             const auto sub = protein.sequence.substr(digested_peptide.first, digested_peptide.second);
-            if (sub.find_first_of("XBZJ") != string::npos)
+            if (sub.find_first_of("XBZ") != string::npos)
             {
               #pragma omp atomic
               skipped_peptides++;
@@ -284,7 +293,7 @@ namespace OpenMS
           else
           {
             // Unmodified path: compute precursor m/z directly from lookup table
-            float unmodified_mz = computePrecursorMzFromChars_(seq_ptr, seq_len, residue_mass_table_);
+            float unmodified_mz = computePrecursorMzFromChars(seq_ptr, seq_len, residue_mass_table_);
             if (peptide_min_mass_ <= unmodified_mz && unmodified_mz <= peptide_max_mass_)
             {
               thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), 0,
@@ -297,7 +306,7 @@ namespace OpenMS
       }
       if (skipped_peptides > 0)
       {
-        OPENMS_LOG_WARN << skipped_peptides << " peptides skipped due to unknown or ambiguous AA (X/B/Z/J)\n";
+        OPENMS_LOG_WARN << skipped_peptides << " peptides skipped due to unknown or ambiguous AA (X/B/Z)\n";
       }
 
       // Merge per-thread peptide vectors
@@ -310,20 +319,17 @@ namespace OpenMS
         vector<Peptide>().swap(thread_peptides[t]);
       }
 
-      std::cout << "Sorting peptides..." << std::endl;
+      OPENMS_LOG_INFO << "Sorting peptides..." << std::endl;
       sort(fi_peptides_.begin(), fi_peptides_.end(), [](const Peptide& a, const Peptide& b)
            {
         return std::tie(a.precursor_mz_, a.protein_idx) < std::tie(b.precursor_mz_, b.protein_idx);
            });
-      std::cout << "done." << std::endl;
+      OPENMS_LOG_INFO << "done." << std::endl;
   }
 
   void FragmentIndex::build(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
-      // Initialize residue mass lookup table (once, thread-safe via static flag)
-      initResidueMassTable_();
-
-      /// generate all Peptides
+      /// generate all Peptides (also initializes residue mass table)
       generatePeptides(fasta_entries);
 
       const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
@@ -340,7 +346,11 @@ namespace OpenMS
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
       // Per-thread fragment vectors to avoid omp critical serialization
+#ifdef _OPENMP
       const int num_threads = omp_get_max_threads();
+#else
+      const int num_threads = 1;
+#endif
       const size_t est_per_thread = (fi_peptides_.size() * 2 * peptide_min_length_) / num_threads + 1;
       vector<vector<Fragment>> thread_fragments(num_threads);
       for (int t = 0; t < num_threads; ++t)
@@ -357,7 +367,11 @@ namespace OpenMS
         #pragma omp parallel for private(mod_peptides)
         for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
         {
+#ifdef _OPENMP
           const int tid = omp_get_thread_num();
+#else
+          const int tid = 0;
+#endif
           const Peptide& pep = fi_peptides_[peptide_idx];
           mod_peptides.clear();
 
@@ -407,7 +421,11 @@ namespace OpenMS
         #pragma omp parallel for
         for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
         {
+#ifdef _OPENMP
           const int tid = omp_get_thread_num();
+#else
+          const int tid = 0;
+#endif
           const Peptide& pep = fi_peptides_[peptide_idx];
           const char* seq_ptr = fasta_entries[pep.protein_idx].sequence.c_str() + pep.sequence_.first;
           size_t seq_len = pep.sequence_.second;
@@ -428,7 +446,7 @@ namespace OpenMS
         vector<Fragment>().swap(thread_fragments[t]);
       }
 
-      std::cout << "Sorting fragments..." << std::endl;
+      OPENMS_LOG_INFO << "Sorting fragments..." << std::endl;
 
       /// 1.) First all Fragments are sorted by their own mass!
       sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -252,6 +252,7 @@ namespace OpenMS
 
     // Generate prefix ions (b, a, c) - left to right cumulative sum
     // Fragment charge is always 1 for the index (matching original TSG call)
+    // Ion index is 1-based: i=0 produces ion 1 (b1/a1/c1), so skip when (i+1) < min_ion_index_
     if (add_b_ions_ || add_a_ions_ || add_c_ions_)
     {
       {
@@ -264,6 +265,8 @@ namespace OpenMS
           double res_mass = table[static_cast<unsigned char>(sequence[i])];
           if (residue_mod_masses) res_mass += residue_mod_masses[i];
           cumulative += res_mass;
+
+          if (i + 1 <= min_ion_index_) continue; // skip ions below min_ion_index
 
           if (add_b_ions_)
           {
@@ -288,18 +291,23 @@ namespace OpenMS
     }
 
     // Generate suffix ions (y, x, z) - right to left cumulative sum
+    // Suffix ion index: first iteration produces y1, second y2, etc.
     if (add_y_ions_ || add_x_ions_ || add_z_ions_)
     {
       {
         constexpr int z = 1;
         double base_mass = proton * z + c_term_mod_mass;
         double cumulative = base_mass;
+        size_t suffix_ion_num = 0;
 
         for (size_t j = seq_len; j > 1; --j)
         {
           double res_mass = table[static_cast<unsigned char>(sequence[j - 1])];
           if (residue_mod_masses) res_mass += residue_mod_masses[j - 1];
           cumulative += res_mass;
+          ++suffix_ion_num;
+
+          if (suffix_ion_num <= min_ion_index_) continue; // skip ions below min_ion_index
 
           if (add_y_ions_)
           {
@@ -1078,6 +1086,8 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
     defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
+    defaults_.setValue("fragment:min_ion_index", 0, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2 like Sage). Ions below this index are not added to the fragment index.");
+    defaults_.setMinInt("fragment:min_ion_index", 0);
 
     vector<String> all_mods;
     ModificationsDB::getInstance()->getAllSearchModifications(all_mods);
@@ -1155,6 +1165,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     peptide_max_length_ = param_.getValue("peptide:max_size");
     fragment_min_mz_ = param_.getValue("fragment:min_mz");
     fragment_max_mz_ = param_.getValue("fragment:max_mz");
+    min_ion_index_ = param_.getValue("fragment:min_ion_index");
     
     precursor_mz_tolerance_ = param_.getValue("precursor:mass_tolerance");
     fragment_mz_tolerance_ = param_.getValue("fragment:mass_tolerance");

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -29,7 +29,9 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/QCBase.h>
+#include <OpenMS/SYSTEM/SIMDe.h>
 #include <functional>
+#include <numeric>
 
 
 using namespace std;
@@ -40,12 +42,12 @@ namespace OpenMS
 {
 
 #ifdef DEBUG_FRAGMENT_INDEX
-    static void print_slice(const std::vector<FragmentIndex::Fragment>& slice, size_t low, size_t high)
+    static void print_slice(const std::vector<float>& mzs, size_t low, size_t high)
     {
       cout << "Slice: ";
       for(size_t i = low; i <= high; i++)
       {
-        cout << slice[i].fragment_mz_ << " ";
+        cout << mzs[i] << " ";
       }
       cout << endl;
     }
@@ -60,7 +62,8 @@ namespace OpenMS
 
   void FragmentIndex::clear()
   {
-    fi_fragments_.clear();
+    fi_fragment_mzs_.clear();
+    fi_fragment_peptide_idxs_.clear();
     fi_peptides_.clear();
     bucket_min_mz_.clear();
     is_build_ = false;
@@ -162,8 +165,10 @@ namespace OpenMS
 
   void FragmentIndex::build(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
-      // reserve some memory for fi_fragments_: Each Peptide can approx give rise to up to #AA*2 fragments
-      fi_fragments_.reserve(fi_peptides_.size() * 2 * peptide_min_length_); //TODO: Does this make senese?
+      // reserve some memory: Each Peptide can approx give rise to up to #AA*2 fragments
+      const size_t est_fragments = fi_peptides_.size() * 2 * peptide_min_length_;
+      fi_fragment_mzs_.reserve(est_fragments);
+      fi_fragment_peptide_idxs_.reserve(est_fragments);
 
       // get the spectrum generator and set the ion-types
       //TheoreticalSpectrumGenerator tsg;
@@ -221,41 +226,72 @@ namespace OpenMS
           if (fragment_min_mz_ > frag || frag > fragment_max_mz_  ) continue;
 
          #pragma omp critical (CreateFragment)
-          fi_fragments_.emplace_back(static_cast<UInt32>(peptide_idx),(float) frag);
-        }        
+          {
+            fi_fragment_mzs_.push_back(static_cast<float>(frag));
+            fi_fragment_peptide_idxs_.push_back(static_cast<UInt32>(peptide_idx));
+          }
+        }
       }
 
       std::cout << "Sorting fragments..." << std::endl;
 
-      /// 1.) First all Fragments are sorted by their own mass!
-      sort(fi_fragments_.begin(), fi_fragments_.end(), [](const Fragment& a, const Fragment& b)
-      {
-        return std::tie(a.fragment_mz_, a.peptide_idx_) < std::tie(b.fragment_mz_, b.peptide_idx_);
+      /// 1.) First all Fragments are sorted by their own mass via index permutation (SoA)
+      const size_t n = fi_fragment_mzs_.size();
+      std::vector<size_t> perm(n);
+      std::iota(perm.begin(), perm.end(), 0);
+      std::sort(perm.begin(), perm.end(), [&](size_t a, size_t b) {
+        return std::tie(fi_fragment_mzs_[a], fi_fragment_peptide_idxs_[a])
+             < std::tie(fi_fragment_mzs_[b], fi_fragment_peptide_idxs_[b]);
       });
+      {
+        std::vector<float> sorted_mzs(n);
+        std::vector<UInt32> sorted_idxs(n);
+        for (size_t i = 0; i < n; ++i)
+        {
+          sorted_mzs[i] = fi_fragment_mzs_[perm[i]];
+          sorted_idxs[i] = fi_fragment_peptide_idxs_[perm[i]];
+        }
+        fi_fragment_mzs_ = std::move(sorted_mzs);
+        fi_fragment_peptide_idxs_ = std::move(sorted_idxs);
+      }
+      perm.clear(); // free permutation memory
 
       /// Calculate the bucket size
-      bucketsize_ = sqrt(fi_fragments_.size()); //Todo: MSFragger uses a different approach, which might be better
+      bucketsize_ = sqrt(n);
       OPENMS_LOG_INFO << "Creating DB with bucket_size " << bucketsize_ << endl;
 
-      /// 2.) next sort after precursor mass and save the min_mz of each bucket
-      #pragma omp parallel for
-      for (SignedSize i = 0; i < (SignedSize)fi_fragments_.size(); i += bucketsize_)
+      /// 2.) Per-bucket sort by peptide_idx and record bucket_min_mz_
+      std::vector<size_t> bperm; // reusable per-bucket permutation
+      #pragma omp parallel for private(bperm)
+      for (SignedSize i = 0; i < (SignedSize)n; i += bucketsize_)
       {
-
         #pragma omp critical
-        bucket_min_mz_.emplace_back(fi_fragments_[i].fragment_mz_);
+        bucket_min_mz_.emplace_back(fi_fragment_mzs_[i]);
 
-        auto bucket_start = fi_fragments_.begin() + i;
-        auto bucket_end = (i + bucketsize_) > fi_fragments_.size() ? fi_fragments_.end() : bucket_start + bucketsize_;
+        const size_t bucket_start = static_cast<size_t>(i);
+        const size_t bucket_end = std::min(bucket_start + bucketsize_, n);
+        const size_t bucket_len = bucket_end - bucket_start;
 
-//TODO: is this thread safe????
-        sort(bucket_start, bucket_end, [](const Fragment& a, const Fragment& b) {
-          return a.peptide_idx_ < b.peptide_idx_; // we don´t need a tie, because the idx are unique
+        bperm.resize(bucket_len);
+        std::iota(bperm.begin(), bperm.end(), size_t(0));
+        std::sort(bperm.begin(), bperm.end(), [&](size_t a, size_t b) {
+          return fi_fragment_peptide_idxs_[bucket_start + a]
+               < fi_fragment_peptide_idxs_[bucket_start + b];
         });
+
+        std::vector<float> tmp_mzs(bucket_len);
+        std::vector<UInt32> tmp_idxs(bucket_len);
+        for (size_t k = 0; k < bucket_len; ++k)
+        {
+          tmp_mzs[k] = fi_fragment_mzs_[bucket_start + bperm[k]];
+          tmp_idxs[k] = fi_fragment_peptide_idxs_[bucket_start + bperm[k]];
+        }
+        std::copy(tmp_mzs.begin(), tmp_mzs.end(), fi_fragment_mzs_.begin() + bucket_start);
+        std::copy(tmp_idxs.begin(), tmp_idxs.end(), fi_fragment_peptide_idxs_.begin() + bucket_start);
       }
       OPENMS_LOG_INFO << "Sorting by bucket min m/z:" << bucketsize_ << endl;
-      //Resort in case the parallelization block above messed something up TODO: check if this can happen
-      std::sort( bucket_min_mz_.begin(), bucket_min_mz_.end());
+      // Resort in case the parallelization block above messed something up
+      std::sort(bucket_min_mz_.begin(), bucket_min_mz_.end());
       is_build_ = true;
       OPENMS_LOG_INFO << "Fragment index built!" << endl;
   }
@@ -274,42 +310,77 @@ namespace OpenMS
                                                   const pair<size_t, size_t>& peptide_idx_range,
                                                   uint16_t peak_charge)
   {
-      float adjusted_mass = peak.getMZ() * (float)peak_charge -((peak_charge-1) * Constants::PROTON_MASS_U);
+      const float adjusted_mass = peak.getMZ() * static_cast<float>(peak_charge) - ((peak_charge - 1) * Constants::PROTON_MASS_U);
+      const float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
+      const float lo_bound = adjusted_mass - frag_tol;
+      const float hi_bound = adjusted_mass + frag_tol;
 
-      float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
-
-      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), adjusted_mass - frag_tol);
-      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), adjusted_mass + frag_tol);
-
+      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), lo_bound);
+      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), hi_bound);
       if (left_it != bucket_min_mz_.begin()) --left_it;
 
-      auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it), std::distance(bucket_min_mz_.begin(), right_it));
+      const auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it),
+                                              std::distance(bucket_min_mz_.begin(), right_it));
 
       vector<FragmentIndex::Hit> hits;
       hits.reserve(peptide_idx_range.second - peptide_idx_range.first);
 
+      // Broadcast tolerance bounds for SIMD (4 x float)
+      const simde__m128 v_lo = simde_mm_set1_ps(lo_bound);
+      const simde__m128 v_hi = simde_mm_set1_ps(hi_bound);
 
-      for (UInt32 j = in_range_buckets.first; j < in_range_buckets.second; j++)
+      const float* mz_data = fi_fragment_mzs_.data();
+      const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
+      const UInt32 pidx_max = static_cast<UInt32>(peptide_idx_range.second);
+
+      for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
       {
-        auto slice_begin = fi_fragments_.begin() + (j*bucketsize_);
-        auto slice_end = ((j+1) * bucketsize_) >= fi_fragments_.size() ? fi_fragments_.end() : (fi_fragments_.begin() + ((j+1) * bucketsize_)) ;
+        const size_t slice_begin = j * bucketsize_;
+        const size_t slice_end = std::min((j + 1) * bucketsize_, fi_fragment_mzs_.size());
 
-        auto left_iter = std::lower_bound(slice_begin, slice_end, peptide_idx_range.first, [](Fragment a, UInt32 b) { return a.peptide_idx_ < b;} );
+        // Binary search on peptide_idx within this bucket
+        auto lb = std::lower_bound(pidx_data + slice_begin, pidx_data + slice_end,
+                                   static_cast<UInt32>(peptide_idx_range.first));
+        size_t pos = static_cast<size_t>(lb - pidx_data);
 
-        while (left_iter != slice_end) // sequential scan
+        // --- SIMD loop: process 4 fragments at a time ---
+        size_t i = pos;
+        for (; i + 4 <= slice_end; i += 4)
         {
-          if(left_iter->peptide_idx_ > peptide_idx_range.second) break;
+          // Early exit: peptide_idxs are sorted, so if first > max, all subsequent are too
+          if (pidx_data[i] > pidx_max) break;
 
-          if ((adjusted_mass >= left_iter->fragment_mz_ - frag_tol ) && adjusted_mass <= (left_iter->fragment_mz_+ frag_tol))
+          // Load 4 consecutive m/z values
+          simde__m128 v_mz = simde_mm_loadu_ps(mz_data + i);
+
+          // Vectorized range check: mz >= lo AND mz <= hi
+          simde__m128 cmp_ge = simde_mm_cmpge_ps(v_mz, v_lo);
+          simde__m128 cmp_le = simde_mm_cmple_ps(v_mz, v_hi);
+          int mask = simde_mm_movemask_ps(simde_mm_and_ps(cmp_ge, cmp_le));
+
+          if (mask != 0)
           {
-
-            hits.emplace_back(left_iter->peptide_idx_, left_iter->fragment_mz_);
-            #ifdef DEBUG_FRAGMENT_INDEX
-            if (left_iter->peptide_idx_ < peptide_idx_range.first || left_iter->peptide_idx_ > peptide_idx_range.second)
-              OPENMS_LOG_WARN << "idx out of range" << endl;
-            #endif
+            for (int k = 0; k < 4; ++k)
+            {
+              if ((mask & (1 << k)) && pidx_data[i + k] <= pidx_max)
+              {
+                hits.emplace_back(pidx_data[i + k], mz_data[i + k]);
+              }
+            }
           }
-          ++left_iter;
+
+          // If last element exceeded peptide range, no point continuing this bucket
+          if (pidx_data[i + 3] > pidx_max) break;
+        }
+
+        // --- Scalar remainder: last 0-3 elements ---
+        for (; i < slice_end; ++i)
+        {
+          if (pidx_data[i] > pidx_max) break;
+          if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
+          {
+            hits.emplace_back(pidx_data[i], mz_data[i]);
+          }
         }
       }
 

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -387,6 +387,51 @@ namespace OpenMS
       return hits;
   }
 
+  vector<FragmentIndex::Hit> FragmentIndex::queryScalar(const OpenMS::Peak1D& peak,
+                                                        const pair<size_t, size_t>& peptide_idx_range,
+                                                        uint16_t peak_charge)
+  {
+      const float adjusted_mass = peak.getMZ() * static_cast<float>(peak_charge) - ((peak_charge - 1) * Constants::PROTON_MASS_U);
+      const float frag_tol = fragment_mz_tolerance_unit_ppm_ ? Math::ppmToMass(fragment_mz_tolerance_, adjusted_mass) : fragment_mz_tolerance_;
+      const float lo_bound = adjusted_mass - frag_tol;
+      const float hi_bound = adjusted_mass + frag_tol;
+
+      auto left_it = std::lower_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), lo_bound);
+      auto right_it = std::upper_bound(bucket_min_mz_.begin(), bucket_min_mz_.end(), hi_bound);
+      if (left_it != bucket_min_mz_.begin()) --left_it;
+
+      const auto in_range_buckets = make_pair(std::distance(bucket_min_mz_.begin(), left_it),
+                                              std::distance(bucket_min_mz_.begin(), right_it));
+
+      vector<FragmentIndex::Hit> hits;
+      hits.reserve(peptide_idx_range.second - peptide_idx_range.first);
+
+      const float* mz_data = fi_fragment_mzs_.data();
+      const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
+      const UInt32 pidx_max = static_cast<UInt32>(peptide_idx_range.second);
+
+      for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
+      {
+        const size_t slice_begin = j * bucketsize_;
+        const size_t slice_end = std::min((j + 1) * bucketsize_, fi_fragment_mzs_.size());
+
+        auto lb = std::lower_bound(pidx_data + slice_begin, pidx_data + slice_end,
+                                   static_cast<UInt32>(peptide_idx_range.first));
+        size_t i = static_cast<size_t>(lb - pidx_data);
+
+        for (; i < slice_end; ++i)
+        {
+          if (pidx_data[i] > pidx_max) break;
+          if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
+          {
+            hits.emplace_back(pidx_data[i], mz_data[i]);
+          }
+        }
+      }
+
+      return hits;
+  }
+
   void FragmentIndex::queryPeaks(SpectrumMatchesTopN& candidates, const MSSpectrum& spectrum,
                                 const std::pair<size_t, size_t>& candidates_range,
                                 const int16_t isotope_error,

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -170,13 +170,17 @@ namespace OpenMS
     mod_tables_initialized_ = true;
   }
 
-  size_t FragmentIndex::buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots) const
+  size_t FragmentIndex::buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots,
+                                       bool is_protein_nterm, bool is_protein_cterm) const
   {
     size_t n_slots = 0;
 
-    // 1. Pure N-terminal variable mods (not residue-specific)
+    // 1. Pure N-terminal variable mods (not residue-specific, origin='X')
     for (const auto& entry : variable_nterm_mods_)
     {
+      // PROTEIN_N_TERM: only for peptides at protein start
+      // N_TERM: for any peptide's N-terminus
+      if (entry.term_spec == ResidueModification::PROTEIN_N_TERM && !is_protein_nterm) continue;
       if (n_slots >= MAX_MOD_SLOTS) break;
       out_slots[n_slots++] = {ModSlot::NTERM_SLOT, entry.delta_mass, entry.mod_ptr};
     }
@@ -189,22 +193,43 @@ namespace OpenMS
       for (const auto& entry : var_mods)
       {
         if (n_slots >= MAX_MOD_SLOTS) break;
-        // Check term specificity: ANYWHERE applies everywhere,
-        // N_TERM only at position 0, C_TERM only at last position
-        if (entry.term_spec == ResidueModification::ANYWHERE ||
-            (entry.term_spec == ResidueModification::N_TERM && i == 0) ||
-            (entry.term_spec == ResidueModification::PROTEIN_N_TERM && i == 0) ||
-            (entry.term_spec == ResidueModification::C_TERM && i == seq_len - 1) ||
-            (entry.term_spec == ResidueModification::PROTEIN_C_TERM && i == seq_len - 1))
+        // ANYWHERE: any position
+        // N_TERM: peptide N-term (position 0)
+        // PROTEIN_N_TERM: only position 0 AND peptide is at protein start
+        // C_TERM: peptide C-term (last position)
+        // PROTEIN_C_TERM: only last position AND peptide is at protein end
+        bool applies = false;
+        if (entry.term_spec == ResidueModification::ANYWHERE)
+        {
+          applies = true;
+        }
+        else if (entry.term_spec == ResidueModification::N_TERM && i == 0)
+        {
+          applies = true;
+        }
+        else if (entry.term_spec == ResidueModification::PROTEIN_N_TERM && i == 0 && is_protein_nterm)
+        {
+          applies = true;
+        }
+        else if (entry.term_spec == ResidueModification::C_TERM && i == seq_len - 1)
+        {
+          applies = true;
+        }
+        else if (entry.term_spec == ResidueModification::PROTEIN_C_TERM && i == seq_len - 1 && is_protein_cterm)
+        {
+          applies = true;
+        }
+        if (applies)
         {
           out_slots[n_slots++] = {static_cast<uint16_t>(i), entry.delta_mass, entry.mod_ptr};
         }
       }
     }
 
-    // 3. Pure C-terminal variable mods (not residue-specific)
+    // 3. Pure C-terminal variable mods (not residue-specific, origin='X')
     for (const auto& entry : variable_cterm_mods_)
     {
+      if (entry.term_spec == ResidueModification::PROTEIN_C_TERM && !is_protein_cterm) continue;
       if (n_slots >= MAX_MOD_SLOTS) break;
       out_slots[n_slots++] = {ModSlot::CTERM_SLOT, entry.delta_mass, entry.mod_ptr};
     }
@@ -360,8 +385,10 @@ namespace OpenMS
     {
       const char* seq_ptr = protein_seq.c_str() + peptide.sequence_.first;
       size_t seq_len = peptide.sequence_.second;
+      bool is_prot_nterm = (peptide.sequence_.first == 0);
+      bool is_prot_cterm = (peptide.sequence_.first + seq_len == protein_seq.size());
       ModSlot slots[MAX_MOD_SLOTS];
-      size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
+      size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots, is_prot_nterm, is_prot_cterm);
 
       for (size_t s = 0; s < n_slots; ++s)
       {
@@ -472,8 +499,10 @@ namespace OpenMS
           if (has_variable_mods)
           {
             // Bitmask-based variable modification enumeration
+            bool is_prot_nterm = (digested_peptide.first == 0);
+            bool is_prot_cterm = (digested_peptide.first + seq_len == protein.sequence.size());
             ModSlot slots[MAX_MOD_SLOTS];
-            size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
+            size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots, is_prot_nterm, is_prot_cterm);
 
             if (n_slots == 0)
             {
@@ -677,8 +706,11 @@ namespace OpenMS
           }
 
           // Rebuild mod slots and apply variable mods from bitmask
+          const string& prot_seq = fasta_entries[pep.protein_idx].sequence;
+          bool is_prot_nterm = (pep.sequence_.first == 0);
+          bool is_prot_cterm = (pep.sequence_.first + seq_len == prot_seq.size());
           ModSlot slots[MAX_MOD_SLOTS];
-          size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
+          size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots, is_prot_nterm, is_prot_cterm);
           for (size_t s = 0; s < n_slots; ++s)
           {
             if (!(pep.mod_bitmask_ & (1u << s))) continue;

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -17,6 +17,8 @@
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/SimpleTSGXLMS.h>
 
+#include <OpenMS/CHEMISTRY/Residue.h>
+#include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
@@ -39,6 +41,121 @@ using namespace std;
 
 namespace OpenMS
 {
+
+  // Static member definitions
+  std::array<double, 128> FragmentIndex::residue_mass_table_{};
+  bool FragmentIndex::mass_table_initialized_{false};
+  FragmentIndex::IonOffsets FragmentIndex::ion_offsets_{};
+
+  void FragmentIndex::initResidueMassTable_()
+  {
+    if (mass_table_initialized_) return;
+
+    residue_mass_table_.fill(0.0);
+    const string aa_codes = "ACDEFGHIKLMNPQRSTVWY";
+    const ResidueDB* rdb = ResidueDB::getInstance();
+    for (char c : aa_codes)
+    {
+      const Residue* r = rdb->getResidue(static_cast<unsigned char>(c));
+      residue_mass_table_[static_cast<size_t>(c)] = r->getMonoWeight(Residue::Internal);
+    }
+
+    // Precompute ion-type offsets
+    ion_offsets_.b_offset = Residue::getInternalToBIon().getMonoWeight();
+    ion_offsets_.y_offset = Residue::getInternalToYIon().getMonoWeight();
+    ion_offsets_.a_offset = Residue::getInternalToAIon().getMonoWeight();
+    ion_offsets_.c_offset = Residue::getInternalToCIon().getMonoWeight();
+    ion_offsets_.x_offset = Residue::getInternalToXIon().getMonoWeight();
+    ion_offsets_.z_offset = Residue::getInternalToZIon().getMonoWeight();
+
+    mass_table_initialized_ = true;
+  }
+
+  void FragmentIndex::generateFragmentsLightweight_(
+    std::vector<Fragment>& fragments,
+    const char* sequence,
+    size_t seq_len,
+    UInt32 peptide_idx,
+    double n_term_mod_mass,
+    double c_term_mod_mass,
+    const double* residue_mod_masses) const
+  {
+    const double proton = Constants::PROTON_MASS_U;
+    const auto& table = residue_mass_table_;
+
+    // Generate prefix ions (b, a, c) - left to right cumulative sum
+    // Fragment charge is always 1 for the index (matching original TSG call)
+    if (add_b_ions_ || add_a_ions_ || add_c_ions_)
+    {
+      {
+        constexpr int z = 1;
+        double base_mass = proton * z + n_term_mod_mass;
+        double cumulative = base_mass;
+
+        for (size_t i = 0; i < seq_len; ++i)
+        {
+          double res_mass = table[static_cast<unsigned char>(sequence[i])];
+          if (residue_mod_masses) res_mass += residue_mod_masses[i];
+          cumulative += res_mass;
+
+          if (add_b_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.b_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+          if (add_a_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.a_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+          if (add_c_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.c_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+        }
+      }
+    }
+
+    // Generate suffix ions (y, x, z) - right to left cumulative sum
+    if (add_y_ions_ || add_x_ions_ || add_z_ions_)
+    {
+      {
+        constexpr int z = 1;
+        double base_mass = proton * z + c_term_mod_mass;
+        double cumulative = base_mass;
+
+        for (size_t j = seq_len; j >= 1; --j)
+        {
+          double res_mass = table[static_cast<unsigned char>(sequence[j - 1])];
+          if (residue_mod_masses) res_mass += residue_mod_masses[j - 1];
+          cumulative += res_mass;
+
+          if (add_y_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.y_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+          if (add_x_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.x_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+          if (add_z_ions_)
+          {
+            float mz = static_cast<float>((cumulative + ion_offsets_.z_offset) / z);
+            if (mz >= fragment_min_mz_ && mz <= fragment_max_mz_)
+              fragments.emplace_back(peptide_idx, mz);
+          }
+        }
+      }
+    }
+  }
 
 #ifdef DEBUG_FRAGMENT_INDEX
     static void print_slice(const std::vector<FragmentIndex::Fragment>& slice, size_t low, size_t high)
@@ -68,13 +185,34 @@ namespace OpenMS
   }
 
 
-  // TODO: check if it makes sense to stream fasta from disc (we have some code for that... would safe memory but might have other drawbacks)
+  /// Compute precursor m/z at charge 1 (M+H)+ directly from amino acid chars.
+  /// Formula: (sum_of_internal_masses + H2O + proton) / 1
+  static float computePrecursorMzFromChars_(const char* seq, size_t len, const std::array<double, 128>& table)
+  {
+    // M+H = sum(internal masses) + H2O + proton
+    static const double water = Residue::getInternalToFull().getMonoWeight(); // 18.0105646834
+    double mass = water + Constants::PROTON_MASS_U;
+    for (size_t i = 0; i < len; ++i)
+    {
+      mass += table[static_cast<unsigned char>(seq[i])];
+    }
+    return static_cast<float>(mass);
+  }
+
   void FragmentIndex::generatePeptides(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
+      initResidueMassTable_();
 
-      fi_peptides_.reserve(fasta_entries.size() * 5 * modifications_variable_.size()); //TODO: Calculate the average cleavage site number for the most important model organisms
-      ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-      ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+      const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
+
+      ModifiedPeptideGenerator::MapToResidueType fixed_modifications;
+      ModifiedPeptideGenerator::MapToResidueType variable_modifications;
+      if (has_modifications)
+      {
+        fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
+        variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+      }
+
       size_t skipped_peptides = 0;
 
       ProteaseDigestion digestor;
@@ -82,19 +220,26 @@ namespace OpenMS
       digestor.setMissedCleavages(missed_cleavages_);
 
       std::cout << "Generating peptides..." << std::endl;
-      
-      vector<pair<size_t, size_t>> digested_peptides; // every thread gets it own copy that is only cleared, not destructed (prevents frequent reallocations)
+
+      // Per-thread peptide vectors to avoid omp critical
+      const int num_threads = omp_get_max_threads();
+      vector<vector<Peptide>> thread_peptides(num_threads);
+      const size_t est_per_thread = (fasta_entries.size() * 5) / num_threads + 1;
+      for (int t = 0; t < num_threads; ++t)
+        thread_peptides[t].reserve(est_per_thread);
+
+      vector<pair<size_t, size_t>> digested_peptides;
       #pragma omp parallel for private(digested_peptides)
       for (SignedSize protein_idx = 0; protein_idx < (SignedSize)fasta_entries.size(); ++protein_idx)
       {
+        const int tid = omp_get_thread_num();
         digested_peptides.clear();
         const FASTAFile::FASTAEntry& protein = fasta_entries[protein_idx];
-        /// DIGEST (if bottom-up)
         digestor.digestUnmodified(StringView(protein.sequence), digested_peptides, peptide_min_length_, peptide_max_length_);
 
         for (const pair<size_t, size_t>& digested_peptide : digested_peptides)
         {
-          //remove peptides containing unknown AA
+          // skip peptides containing unknown AA
           if (protein.sequence.substr(digested_peptide.first, digested_peptide.second).find('X') != string::npos)
           {
             #pragma omp atomic
@@ -102,14 +247,15 @@ namespace OpenMS
             continue;
           }
 
-          /// MODIFY (if modifications are specified)
-          AASequence unmod_peptide = AASequence::fromString(protein.sequence.substr(digested_peptide.first, digested_peptide.second));
-          float unmodified_mz = unmod_peptide.getMZ(1);
+          const char* seq_ptr = protein.sequence.c_str() + digested_peptide.first;
+          size_t seq_len = digested_peptide.second;
 
-          if (!(modifications_fixed_.empty() && modifications_variable_.empty()))
+          if (has_modifications)
           {
+            // Modified path: still needs AASequence for modification application
+            AASequence unmod_peptide = AASequence::fromString(protein.sequence.substr(digested_peptide.first, seq_len));
             vector<AASequence> modified_peptides;
-            AASequence mod_peptide = AASequence(unmod_peptide); // copy the peptide
+            AASequence mod_peptide = AASequence(unmod_peptide);
 
             ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
             ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, modified_peptides);
@@ -118,32 +264,28 @@ namespace OpenMS
             for (const AASequence& modified_peptide : modified_peptides)
             {
               float modified_mz = modified_peptide.getMZ(1);
-              if (modified_mz < peptide_min_mass_ || modified_mz > peptide_max_mass_) // exclude peptides that are not in the min-max window
+              if (modified_mz < peptide_min_mass_ || modified_mz > peptide_max_mass_)
               {
-                continue;   //TODO: Integrate this check in ModPepGen from #6859
+                continue;
               }
-              #pragma omp critical (FIIndex)
-              {
-                fi_peptides_.emplace_back(static_cast<UInt32>(protein_idx),
-                                        modification_idx,
-                                        std::make_pair(static_cast<uint16_t>(digested_peptide.first),
-                                                       static_cast<uint16_t>(digested_peptide.second)),
-                                        modified_mz);
-                ++modification_idx;
-              }
+              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx),
+                                      modification_idx,
+                                      std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                                                     static_cast<uint16_t>(seq_len)),
+                                      modified_mz);
+              ++modification_idx;
             }
           }
           else
           {
+            // Unmodified path: compute precursor m/z directly from lookup table
+            float unmodified_mz = computePrecursorMzFromChars_(seq_ptr, seq_len, residue_mass_table_);
             if (peptide_min_mass_ <= unmodified_mz && unmodified_mz <= peptide_max_mass_)
             {
-              #pragma omp critical (FIIndex)
-              {
-                fi_peptides_.emplace_back(static_cast<UInt32>(protein_idx), 0,
-                                        std::make_pair(static_cast<uint16_t>(digested_peptide.first),
-                                                       static_cast<uint16_t>(digested_peptide.second)),
-                                        unmodified_mz);
-              }
+              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), 0,
+                                      std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                                                     static_cast<uint16_t>(seq_len)),
+                                      unmodified_mz);
             }
           }
         }
@@ -152,37 +294,43 @@ namespace OpenMS
       {
         OPENMS_LOG_WARN << skipped_peptides << " peptides skipped due to unkown AA \n";
       }
-      std::cout << "Sorting peptides..." << std::endl;        
-      // sort the peptide vector, critical for following steps
+
+      // Merge per-thread peptide vectors
+      size_t total_peptides = 0;
+      for (int t = 0; t < num_threads; ++t) total_peptides += thread_peptides[t].size();
+      fi_peptides_.reserve(total_peptides);
+      for (int t = 0; t < num_threads; ++t)
+      {
+        fi_peptides_.insert(fi_peptides_.end(), thread_peptides[t].begin(), thread_peptides[t].end());
+        vector<Peptide>().swap(thread_peptides[t]);
+      }
+
+      std::cout << "Sorting peptides..." << std::endl;
       sort(fi_peptides_.begin(), fi_peptides_.end(), [](const Peptide& a, const Peptide& b)
            {
         return std::tie(a.precursor_mz_, a.protein_idx) < std::tie(b.precursor_mz_, b.protein_idx);
            });
-      std::cout << "done." << std::endl;        
+      std::cout << "done." << std::endl;
   }
 
   void FragmentIndex::build(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
-      // get the spectrum generator and set the ion-types
-      TheoreticalSpectrumGenerator tsg;
-
-      auto tsg_params = tsg.getParameters();
-      auto this_params = getParameters();
-      tsg_params.setValue("add_a_ions", this_params.getValue("ions:add_a_ions"));
-      tsg_params.setValue("add_b_ions", this_params.getValue("ions:add_b_ions"));
-      tsg_params.setValue("add_c_ions", this_params.getValue("ions:add_c_ions"));
-      tsg_params.setValue("add_x_ions", this_params.getValue("ions:add_x_ions"));
-      tsg_params.setValue("add_y_ions", this_params.getValue("ions:add_y_ions"));
-      tsg_params.setValue("add_z_ions", this_params.getValue("ions:add_z_ions"));
-      tsg.setParameters(tsg_params);
+      // Initialize residue mass lookup table (once, thread-safe via static flag)
+      initResidueMassTable_();
 
       /// generate all Peptides
       generatePeptides(fasta_entries);
 
-      /// Since we (the new) Peptide struct does not store the AASequence, we must reconstruct the modified ones
-      /// therefore we need the modificationGenerators:
-      ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-      ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+      const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
+
+      // Only needed for the modified path
+      ModifiedPeptideGenerator::MapToResidueType fixed_modifications;
+      ModifiedPeptideGenerator::MapToResidueType variable_modifications;
+      if (has_modifications)
+      {
+        fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
+        variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+      }
 
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
@@ -195,34 +343,73 @@ namespace OpenMS
         thread_fragments[t].reserve(est_per_thread);
       }
 
-      vector<AASequence> mod_peptides;
-      std::vector<float> b_y_ions;
-
-      #pragma omp parallel for private(mod_peptides, b_y_ions)
-      for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
+      if (has_modifications)
       {
-        const int tid = omp_get_thread_num();
-        const Peptide& pep = fi_peptides_[peptide_idx];
-        mod_peptides.clear();
-        b_y_ions.clear();
-        AASequence unmod_peptide = AASequence::fromString(fasta_entries[pep.protein_idx].sequence.substr(pep.sequence_.first, pep.sequence_.second));
+        // Modified path: reconstruct AASequence to apply modifications,
+        // then extract per-residue mass deltas for lightweight generation
+        vector<AASequence> mod_peptides;
 
-        if (!(modifications_fixed_.empty() && modifications_variable_.empty()))
+        #pragma omp parallel for private(mod_peptides)
+        for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
         {
+          const int tid = omp_get_thread_num();
+          const Peptide& pep = fi_peptides_[peptide_idx];
+          mod_peptides.clear();
+
+          const string& protein_seq = fasta_entries[pep.protein_idx].sequence;
+          const char* seq_ptr = protein_seq.c_str() + pep.sequence_.first;
+          size_t seq_len = pep.sequence_.second;
+
+          AASequence unmod_peptide = AASequence::fromString(protein_seq.substr(pep.sequence_.first, seq_len));
           AASequence mod_peptide = AASequence(unmod_peptide);
           ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
           ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, mod_peptides);
-          tsg.getPrefixAndSuffixIonsMZ(b_y_ions, mod_peptides[pep.modification_idx_], 1);
-        }
-        else
-        {
-          tsg.getPrefixAndSuffixIonsMZ(b_y_ions, unmod_peptide, 1);
-        }
 
-        for (const float& frag : b_y_ions)
+          const AASequence& final_peptide = mod_peptides[pep.modification_idx_];
+
+          // Extract per-residue modification mass deltas
+          vector<double> mod_masses(seq_len, 0.0);
+          bool has_residue_mods = false;
+          for (size_t i = 0; i < seq_len; ++i)
+          {
+            double modified_mass = final_peptide[i].getMonoWeight(Residue::Internal);
+            double unmodified_mass = residue_mass_table_[static_cast<unsigned char>(seq_ptr[i])];
+            double delta = modified_mass - unmodified_mass;
+            if (delta != 0.0)
+            {
+              mod_masses[i] = delta;
+              has_residue_mods = true;
+            }
+          }
+
+          double n_term_mod = 0.0;
+          if (final_peptide.hasNTerminalModification())
+            n_term_mod = final_peptide.getNTerminalModification()->getDiffMonoMass();
+
+          double c_term_mod = 0.0;
+          if (final_peptide.hasCTerminalModification())
+            c_term_mod = final_peptide.getCTerminalModification()->getDiffMonoMass();
+
+          generateFragmentsLightweight_(
+            thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
+            n_term_mod, c_term_mod, has_residue_mods ? mod_masses.data() : nullptr);
+        }
+      }
+      else
+      {
+        // Unmodified path: compute fragments directly from protein sequence chars.
+        // No AASequence parsing, no TheoreticalSpectrumGenerator needed.
+        #pragma omp parallel for
+        for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
         {
-          if (fragment_min_mz_ > frag || frag > fragment_max_mz_) continue;
-          thread_fragments[tid].emplace_back(static_cast<UInt32>(peptide_idx), frag);
+          const int tid = omp_get_thread_num();
+          const Peptide& pep = fi_peptides_[peptide_idx];
+          const char* seq_ptr = fasta_entries[pep.protein_idx].sequence.c_str() + pep.sequence_.first;
+          size_t seq_len = pep.sequence_.second;
+
+          generateFragmentsLightweight_(
+            thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
+            0.0, 0.0, nullptr);
         }
       }
 

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -331,7 +331,7 @@ namespace OpenMS
 
       const float* mz_data = fi_fragment_mzs_.data();
       const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
-      const UInt32 pidx_max = static_cast<UInt32>(peptide_idx_range.second);
+      const UInt32 pidx_limit = static_cast<UInt32>(peptide_idx_range.second); // exclusive upper bound
 
       for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
       {
@@ -347,8 +347,8 @@ namespace OpenMS
         size_t i = pos;
         for (; i + 4 <= slice_end; i += 4)
         {
-          // Early exit: peptide_idxs are sorted, so if first > max, all subsequent are too
-          if (pidx_data[i] > pidx_max) break;
+          // Early exit: peptide_idxs are sorted, so if first >= limit, all subsequent are too
+          if (pidx_data[i] >= pidx_limit) break;
 
           // Load 4 consecutive m/z values
           simde__m128 v_mz = simde_mm_loadu_ps(mz_data + i);
@@ -362,7 +362,7 @@ namespace OpenMS
           {
             for (int k = 0; k < 4; ++k)
             {
-              if ((mask & (1 << k)) && pidx_data[i + k] <= pidx_max)
+              if ((mask & (1 << k)) && pidx_data[i + k] < pidx_limit)
               {
                 hits.emplace_back(pidx_data[i + k], mz_data[i + k]);
               }
@@ -370,13 +370,13 @@ namespace OpenMS
           }
 
           // If last element exceeded peptide range, no point continuing this bucket
-          if (pidx_data[i + 3] > pidx_max) break;
+          if (pidx_data[i + 3] >= pidx_limit) break;
         }
 
         // --- Scalar remainder: last 0-3 elements ---
         for (; i < slice_end; ++i)
         {
-          if (pidx_data[i] > pidx_max) break;
+          if (pidx_data[i] >= pidx_limit) break;
           if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
           {
             hits.emplace_back(pidx_data[i], mz_data[i]);
@@ -408,7 +408,7 @@ namespace OpenMS
 
       const float* mz_data = fi_fragment_mzs_.data();
       const UInt32* pidx_data = fi_fragment_peptide_idxs_.data();
-      const UInt32 pidx_max = static_cast<UInt32>(peptide_idx_range.second);
+      const UInt32 pidx_limit = static_cast<UInt32>(peptide_idx_range.second); // exclusive upper bound
 
       for (size_t j = static_cast<size_t>(in_range_buckets.first); j < static_cast<size_t>(in_range_buckets.second); ++j)
       {
@@ -421,7 +421,7 @@ namespace OpenMS
 
         for (; i < slice_end; ++i)
         {
-          if (pidx_data[i] > pidx_max) break;
+          if (pidx_data[i] >= pidx_limit) break;
           if (mz_data[i] >= lo_bound && mz_data[i] <= hi_bound)
           {
             hits.emplace_back(pidx_data[i], mz_data[i]);

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -369,8 +369,9 @@ namespace OpenMS
             }
           }
 
-          // If last element exceeded peptide range, no point continuing this bucket
-          if (pidx_data[i + 3] >= pidx_limit) break;
+          // If last element exceeded peptide range, no point continuing this bucket.
+          // Advance i past this group so the scalar remainder doesn't re-process it.
+          if (pidx_data[i + 3] >= pidx_limit) { i += 4; break; }
         }
 
         // --- Scalar remainder: last 0-3 elements ---

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -34,6 +34,7 @@
 #ifdef _OPENMP
   #include <omp.h>
 #endif
+#include <bit>
 #include <functional>
 #include <mutex>
 
@@ -509,7 +510,7 @@ namespace OpenMS
               for (uint32_t bitmask = 0; bitmask < max_bitmask; ++bitmask)
               {
                 // Check max variable mods constraint
-                unsigned int popcount = __builtin_popcount(bitmask);
+                unsigned int popcount = std::popcount(bitmask);
                 if (popcount > max_variable_mods_per_peptide_) continue;
 
                 // Check position conflicts: no two set bits can map to the same position

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -165,14 +165,7 @@ namespace OpenMS
 
   void FragmentIndex::build(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
-      // reserve some memory: Each Peptide can approx give rise to up to #AA*2 fragments
-      const size_t est_fragments = fi_peptides_.size() * 2 * peptide_min_length_;
-      fi_fragment_mzs_.reserve(est_fragments);
-      fi_fragment_peptide_idxs_.reserve(est_fragments);
-
       // get the spectrum generator and set the ion-types
-      //TheoreticalSpectrumGenerator tsg;
-      //SimpleTSGXLMS tsg;
       TheoreticalSpectrumGenerator tsg;
 
       auto tsg_params = tsg.getParameters();
@@ -183,12 +176,15 @@ namespace OpenMS
       tsg_params.setValue("add_x_ions", this_params.getValue("ions:add_x_ions"));
       tsg_params.setValue("add_y_ions", this_params.getValue("ions:add_y_ions"));
       tsg_params.setValue("add_z_ions", this_params.getValue("ions:add_z_ions"));
-      //tsg_params.setValue("add_first_prefix_ion", "true");
       tsg.setParameters(tsg_params);
-
 
       /// generate all Peptides
       generatePeptides(fasta_entries);
+
+      // reserve memory after peptide generation (each peptide gives ~#AA*2 fragments)
+      const size_t est_fragments = fi_peptides_.size() * 2 * peptide_min_length_;
+      fi_fragment_mzs_.reserve(est_fragments);
+      fi_fragment_peptide_idxs_.reserve(est_fragments);
 
       /// Since we (the new) Peptide struct does not store the AASequence, we must reconstruct the modified ones
       /// therefore we need the modificationGenerators:

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -29,6 +29,7 @@
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/MATH/MathFunctions.h>
 #include <OpenMS/QC/QCBase.h>
+#include <omp.h>
 #include <functional>
 #include <numeric>
 
@@ -180,25 +181,32 @@ namespace OpenMS
       /// generate all Peptides
       generatePeptides(fasta_entries);
 
-      // reserve memory after peptide generation (each peptide gives ~#AA*2 fragments)
-      const size_t est_fragments = fi_peptides_.size() * 2 * peptide_min_length_;
-      fi_fragment_mzs_.reserve(est_fragments);
-      fi_fragment_peptide_idxs_.reserve(est_fragments);
-
       /// Since we (the new) Peptide struct does not store the AASequence, we must reconstruct the modified ones
       /// therefore we need the modificationGenerators:
       ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
       ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
 
+      OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
+
+      // Per-thread fragment vectors to avoid omp critical serialization.
+      // Each thread accumulates into its own pair of vectors, then we merge.
+      const int num_threads = omp_get_max_threads();
+      const size_t est_per_thread = (fi_peptides_.size() * 2 * peptide_min_length_) / num_threads + 1;
+      vector<vector<float>> thread_mzs(num_threads);
+      vector<vector<UInt32>> thread_idxs(num_threads);
+      for (int t = 0; t < num_threads; ++t)
+      {
+        thread_mzs[t].reserve(est_per_thread);
+        thread_idxs[t].reserve(est_per_thread);
+      }
 
       vector<AASequence> mod_peptides;
       std::vector<float> b_y_ions;
 
-      OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
-
-     #pragma omp parallel for private(mod_peptides, b_y_ions)
-      for(SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
+      #pragma omp parallel for private(mod_peptides, b_y_ions)
+      for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
       {
+        const int tid = omp_get_thread_num();
         const Peptide& pep = fi_peptides_[peptide_idx];
         mod_peptides.clear();
         b_y_ions.clear();
@@ -206,7 +214,7 @@ namespace OpenMS
 
         if (!(modifications_fixed_.empty() && modifications_variable_.empty()))
         {
-          AASequence mod_peptide = AASequence(unmod_peptide); // copy the peptide
+          AASequence mod_peptide = AASequence(unmod_peptide);
           ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
           ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, mod_peptides);
           tsg.getPrefixAndSuffixIonsMZ(b_y_ions, mod_peptides[pep.modification_idx_], 1);
@@ -218,14 +226,24 @@ namespace OpenMS
 
         for (const float& frag : b_y_ions)
         {
-          if (fragment_min_mz_ > frag || frag > fragment_max_mz_  ) continue;
-
-         #pragma omp critical (CreateFragment)
-          {
-            fi_fragment_mzs_.push_back(static_cast<float>(frag));
-            fi_fragment_peptide_idxs_.push_back(static_cast<UInt32>(peptide_idx));
-          }
+          if (fragment_min_mz_ > frag || frag > fragment_max_mz_) continue;
+          thread_mzs[tid].push_back(static_cast<float>(frag));
+          thread_idxs[tid].push_back(static_cast<UInt32>(peptide_idx));
         }
+      }
+
+      // Merge per-thread vectors into global SoA arrays
+      size_t total_fragments = 0;
+      for (int t = 0; t < num_threads; ++t) total_fragments += thread_mzs[t].size();
+      fi_fragment_mzs_.reserve(total_fragments);
+      fi_fragment_peptide_idxs_.reserve(total_fragments);
+      for (int t = 0; t < num_threads; ++t)
+      {
+        fi_fragment_mzs_.insert(fi_fragment_mzs_.end(), thread_mzs[t].begin(), thread_mzs[t].end());
+        fi_fragment_peptide_idxs_.insert(fi_fragment_peptide_idxs_.end(), thread_idxs[t].begin(), thread_idxs[t].end());
+        // Free thread-local memory immediately
+        vector<float>().swap(thread_mzs[t]);
+        vector<UInt32>().swap(thread_idxs[t]);
       }
 
       std::cout << "Sorting fragments..." << std::endl;

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -74,6 +74,143 @@ namespace OpenMS
     });
   }
 
+  void FragmentIndex::initModificationTables_()
+  {
+    if (mod_tables_initialized_) return;
+
+    fixed_mod_deltas_.fill(0.0);
+    fixed_mod_ptrs_.fill(nullptr);
+    for (auto& v : variable_mod_table_) v.clear();
+    variable_nterm_mods_.clear();
+    variable_cterm_mods_.clear();
+    fixed_nterm_delta_ = 0.0;
+    fixed_cterm_delta_ = 0.0;
+    fixed_nterm_mod_ptr_ = nullptr;
+    fixed_cterm_mod_ptr_ = nullptr;
+
+    // Build fixed modification lookup
+    if (!modifications_fixed_.empty())
+    {
+      auto fixed_map = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
+      for (const auto& [mod_ptr, residue_ptr] : fixed_map.val)
+      {
+        auto term_spec = mod_ptr->getTermSpecificity();
+        double delta = mod_ptr->getDiffMonoMass();
+        char origin = mod_ptr->getOrigin();
+
+        if (origin == 'X' || origin == '.') // terminal-only, no specific AA
+        {
+          if (term_spec == ResidueModification::N_TERM || term_spec == ResidueModification::PROTEIN_N_TERM)
+          {
+            fixed_nterm_delta_ = delta;
+            fixed_nterm_mod_ptr_ = mod_ptr;
+          }
+          else if (term_spec == ResidueModification::C_TERM || term_spec == ResidueModification::PROTEIN_C_TERM)
+          {
+            fixed_cterm_delta_ = delta;
+            fixed_cterm_mod_ptr_ = mod_ptr;
+          }
+        }
+        else
+        {
+          // Residue-specific fixed mod (e.g., Carbamidomethyl on C)
+          // For ANYWHERE: applies at all matching positions
+          // For N_TERM/C_TERM: only at terminal positions (handled during enumeration)
+          if (term_spec == ResidueModification::ANYWHERE)
+          {
+            fixed_mod_deltas_[static_cast<unsigned char>(origin)] = delta;
+            fixed_mod_ptrs_[static_cast<unsigned char>(origin)] = mod_ptr;
+          }
+          else if (term_spec == ResidueModification::N_TERM || term_spec == ResidueModification::PROTEIN_N_TERM)
+          {
+            fixed_nterm_delta_ = delta;
+            fixed_nterm_mod_ptr_ = mod_ptr;
+          }
+          else if (term_spec == ResidueModification::C_TERM || term_spec == ResidueModification::PROTEIN_C_TERM)
+          {
+            fixed_cterm_delta_ = delta;
+            fixed_cterm_mod_ptr_ = mod_ptr;
+          }
+        }
+      }
+    }
+
+    // Build variable modification lookup
+    if (!modifications_variable_.empty())
+    {
+      auto var_map = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+      for (const auto& [mod_ptr, residue_ptr] : var_map.val)
+      {
+        auto term_spec = mod_ptr->getTermSpecificity();
+        double delta = mod_ptr->getDiffMonoMass();
+        char origin = mod_ptr->getOrigin();
+        VarModEntry entry{delta, mod_ptr, term_spec};
+
+        if (origin == 'X' || origin == '.')
+        {
+          // Pure terminal mod (no specific AA)
+          if (term_spec == ResidueModification::N_TERM || term_spec == ResidueModification::PROTEIN_N_TERM)
+          {
+            variable_nterm_mods_.push_back(entry);
+          }
+          else if (term_spec == ResidueModification::C_TERM || term_spec == ResidueModification::PROTEIN_C_TERM)
+          {
+            variable_cterm_mods_.push_back(entry);
+          }
+        }
+        else
+        {
+          // Residue-specific variable mod — add to the table for this AA
+          variable_mod_table_[static_cast<unsigned char>(origin)].push_back(entry);
+        }
+      }
+    }
+
+    mod_tables_initialized_ = true;
+  }
+
+  size_t FragmentIndex::buildModSlots_(const char* sequence, size_t seq_len, ModSlot* out_slots) const
+  {
+    size_t n_slots = 0;
+
+    // 1. Pure N-terminal variable mods (not residue-specific)
+    for (const auto& entry : variable_nterm_mods_)
+    {
+      if (n_slots >= MAX_MOD_SLOTS) break;
+      out_slots[n_slots++] = {ModSlot::NTERM_SLOT, entry.delta_mass, entry.mod_ptr};
+    }
+
+    // 2. Per-residue variable mods, left-to-right
+    for (size_t i = 0; i < seq_len; ++i)
+    {
+      unsigned char aa = static_cast<unsigned char>(sequence[i]);
+      const auto& var_mods = variable_mod_table_[aa];
+      for (const auto& entry : var_mods)
+      {
+        if (n_slots >= MAX_MOD_SLOTS) break;
+        // Check term specificity: ANYWHERE applies everywhere,
+        // N_TERM only at position 0, C_TERM only at last position
+        if (entry.term_spec == ResidueModification::ANYWHERE ||
+            (entry.term_spec == ResidueModification::N_TERM && i == 0) ||
+            (entry.term_spec == ResidueModification::PROTEIN_N_TERM && i == 0) ||
+            (entry.term_spec == ResidueModification::C_TERM && i == seq_len - 1) ||
+            (entry.term_spec == ResidueModification::PROTEIN_C_TERM && i == seq_len - 1))
+        {
+          out_slots[n_slots++] = {static_cast<uint16_t>(i), entry.delta_mass, entry.mod_ptr};
+        }
+      }
+    }
+
+    // 3. Pure C-terminal variable mods (not residue-specific)
+    for (const auto& entry : variable_cterm_mods_)
+    {
+      if (n_slots >= MAX_MOD_SLOTS) break;
+      out_slots[n_slots++] = {ModSlot::CTERM_SLOT, entry.delta_mass, entry.mod_ptr};
+    }
+
+    return n_slots;
+  }
+
   void FragmentIndex::generateFragmentsLightweight_(
     std::vector<Fragment>& fragments,
     const char* sequence,
@@ -185,6 +322,66 @@ namespace OpenMS
     fi_peptides_.clear();
     bucket_min_mz_.clear();
     is_build_ = false;
+    mod_tables_initialized_ = false;
+  }
+
+  AASequence FragmentIndex::reconstructModifiedSequence(
+    const Peptide& peptide,
+    const std::vector<FASTAFile::FASTAEntry>& fasta_entries) const
+  {
+    const string& protein_seq = fasta_entries[peptide.protein_idx].sequence;
+    AASequence seq = AASequence::fromString(protein_seq.substr(peptide.sequence_.first, peptide.sequence_.second));
+
+    const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
+    if (!has_modifications) return seq;
+
+    // Apply fixed modifications at each residue
+    for (size_t i = 0; i < seq.size(); ++i)
+    {
+      unsigned char aa = static_cast<unsigned char>(protein_seq[peptide.sequence_.first + i]);
+      if (fixed_mod_ptrs_[aa] != nullptr)
+      {
+        seq.setModification(i, fixed_mod_ptrs_[aa]);
+      }
+    }
+    // Apply fixed terminal modifications
+    if (fixed_nterm_mod_ptr_ != nullptr)
+    {
+      seq.setNTerminalModification(fixed_nterm_mod_ptr_);
+    }
+    if (fixed_cterm_mod_ptr_ != nullptr)
+    {
+      seq.setCTerminalModification(fixed_cterm_mod_ptr_);
+    }
+
+    // Apply variable modifications from bitmask
+    if (peptide.mod_bitmask_ != 0)
+    {
+      const char* seq_ptr = protein_seq.c_str() + peptide.sequence_.first;
+      size_t seq_len = peptide.sequence_.second;
+      ModSlot slots[MAX_MOD_SLOTS];
+      size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
+
+      for (size_t s = 0; s < n_slots; ++s)
+      {
+        if (!(peptide.mod_bitmask_ & (1u << s))) continue;
+
+        if (slots[s].position == ModSlot::NTERM_SLOT)
+        {
+          seq.setNTerminalModification(slots[s].mod_ptr);
+        }
+        else if (slots[s].position == ModSlot::CTERM_SLOT)
+        {
+          seq.setCTerminalModification(slots[s].mod_ptr);
+        }
+        else
+        {
+          seq.setModification(slots[s].position, slots[s].mod_ptr);
+        }
+      }
+    }
+
+    return seq;
   }
 
 
@@ -207,13 +404,11 @@ namespace OpenMS
       initResidueMassTable_();
 
       const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
+      const bool has_variable_mods = !modifications_variable_.empty();
 
-      ModifiedPeptideGenerator::MapToResidueType fixed_modifications;
-      ModifiedPeptideGenerator::MapToResidueType variable_modifications;
       if (has_modifications)
       {
-        fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-        variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
+        initModificationTables_();
       }
 
       size_t skipped_peptides = 0;
@@ -264,42 +459,110 @@ namespace OpenMS
           const char* seq_ptr = protein.sequence.c_str() + digested_peptide.first;
           size_t seq_len = digested_peptide.second;
 
-          if (has_modifications)
+          // Compute base precursor mass from lookup table (includes fixed mod deltas)
+          static const double water = Residue::getInternalToFull().getMonoWeight();
+          double base_mass = water + Constants::PROTON_MASS_U + fixed_nterm_delta_ + fixed_cterm_delta_;
+          for (size_t i = 0; i < seq_len; ++i)
           {
-            // Modified path: still needs AASequence for modification application
-            AASequence unmod_peptide = AASequence::fromString(protein.sequence.substr(digested_peptide.first, seq_len));
-            vector<AASequence> modified_peptides;
-            AASequence mod_peptide = AASequence(unmod_peptide);
+            base_mass += residue_mass_table_[static_cast<unsigned char>(seq_ptr[i])]
+                       + fixed_mod_deltas_[static_cast<unsigned char>(seq_ptr[i])];
+          }
 
-            ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
-            ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, modified_peptides);
+          if (has_variable_mods)
+          {
+            // Bitmask-based variable modification enumeration
+            ModSlot slots[MAX_MOD_SLOTS];
+            size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
 
-            UInt32 modification_idx = 0;
-            for (const AASequence& modified_peptide : modified_peptides)
+            if (n_slots == 0)
             {
-              float modified_mz = modified_peptide.getMZ(1);
-              if (modified_mz < peptide_min_mass_ || modified_mz > peptide_max_mass_)
+              // No variable mod sites on this peptide — just the fixed-mod version
+              float mz = static_cast<float>(base_mass);
+              if (peptide_min_mass_ <= mz && mz <= peptide_max_mass_)
               {
-                continue;
+                thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), uint32_t(0),
+                  std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                                 static_cast<uint16_t>(seq_len)), mz);
               }
-              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx),
-                                      modification_idx,
-                                      std::make_pair(static_cast<uint16_t>(digested_peptide.first),
-                                                     static_cast<uint16_t>(seq_len)),
-                                      modified_mz);
-              ++modification_idx;
+            }
+            else
+            {
+              // Pre-compute which slots share a position (conflict groups)
+              // Build position-to-slot mapping for conflict detection
+              // Two slots conflict if they map to the same residue position
+              // (mutually exclusive: at most one variable mod per position)
+              uint32_t conflict_mask[MAX_MOD_SLOTS] = {};
+              for (size_t a = 0; a < n_slots; ++a)
+              {
+                for (size_t b = a + 1; b < n_slots; ++b)
+                {
+                  if (slots[a].position == slots[b].position)
+                  {
+                    conflict_mask[a] |= (1u << b);
+                    conflict_mask[b] |= (1u << a);
+                  }
+                }
+              }
+
+              // Enumerate all valid bitmask subsets
+              uint32_t max_bitmask = (1u << n_slots);
+              for (uint32_t bitmask = 0; bitmask < max_bitmask; ++bitmask)
+              {
+                // Check max variable mods constraint
+                unsigned int popcount = __builtin_popcount(bitmask);
+                if (popcount > max_variable_mods_per_peptide_) continue;
+
+                // Check position conflicts: no two set bits can map to the same position
+                bool conflict = false;
+                for (size_t s = 0; s < n_slots && !conflict; ++s)
+                {
+                  if ((bitmask & (1u << s)) && (bitmask & conflict_mask[s] & ~(1u << s)))
+                  {
+                    conflict = true;
+                  }
+                }
+                if (conflict) continue;
+
+                // Compute variant precursor mass
+                double variant_mass = base_mass;
+                for (size_t s = 0; s < n_slots; ++s)
+                {
+                  if (bitmask & (1u << s))
+                  {
+                    variant_mass += slots[s].delta_mass;
+                  }
+                }
+
+                float mz = static_cast<float>(variant_mass);
+                if (peptide_min_mass_ <= mz && mz <= peptide_max_mass_)
+                {
+                  thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), bitmask,
+                    std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                                   static_cast<uint16_t>(seq_len)), mz);
+                }
+              }
+            }
+          }
+          else if (has_modifications)
+          {
+            // Fixed mods only — no variable mods to enumerate
+            float mz = static_cast<float>(base_mass);
+            if (peptide_min_mass_ <= mz && mz <= peptide_max_mass_)
+            {
+              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), uint32_t(0),
+                std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                               static_cast<uint16_t>(seq_len)), mz);
             }
           }
           else
           {
-            // Unmodified path: compute precursor m/z directly from lookup table
-            float unmodified_mz = computePrecursorMzFromChars(seq_ptr, seq_len, residue_mass_table_);
+            // No modifications at all
+            float unmodified_mz = static_cast<float>(base_mass);
             if (peptide_min_mass_ <= unmodified_mz && unmodified_mz <= peptide_max_mass_)
             {
-              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), 0,
-                                      std::make_pair(static_cast<uint16_t>(digested_peptide.first),
-                                                     static_cast<uint16_t>(seq_len)),
-                                      unmodified_mz);
+              thread_peptides[tid].emplace_back(static_cast<UInt32>(protein_idx), uint32_t(0),
+                std::make_pair(static_cast<uint16_t>(digested_peptide.first),
+                               static_cast<uint16_t>(seq_len)), unmodified_mz);
             }
           }
         }
@@ -329,19 +592,10 @@ namespace OpenMS
 
   void FragmentIndex::build(const std::vector<FASTAFile::FASTAEntry>& fasta_entries)
   {
-      /// generate all Peptides (also initializes residue mass table)
+      /// generate all Peptides (also initializes residue mass table and mod tables)
       generatePeptides(fasta_entries);
 
       const bool has_modifications = !(modifications_fixed_.empty() && modifications_variable_.empty());
-
-      // Only needed for the modified path
-      ModifiedPeptideGenerator::MapToResidueType fixed_modifications;
-      ModifiedPeptideGenerator::MapToResidueType variable_modifications;
-      if (has_modifications)
-      {
-        fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-        variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
-      }
 
       OPENMS_LOG_INFO << "Generating fragments..." << std::endl;
 
@@ -358,42 +612,62 @@ namespace OpenMS
         thread_fragments[t].reserve(est_per_thread);
       }
 
-      if (has_modifications)
+      // Unified fragment generation path for all cases.
+      // For modified peptides: reconstruct per-residue deltas from bitmask + mod tables.
+      // No AASequence construction, no ModifiedPeptideGenerator.
+      #pragma omp parallel for
+      for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
       {
-        // Modified path: reconstruct AASequence to apply modifications,
-        // then extract per-residue mass deltas for lightweight generation
-        vector<AASequence> mod_peptides;
-
-        #pragma omp parallel for private(mod_peptides)
-        for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
-        {
 #ifdef _OPENMP
-          const int tid = omp_get_thread_num();
+        const int tid = omp_get_thread_num();
 #else
-          const int tid = 0;
+        const int tid = 0;
 #endif
-          const Peptide& pep = fi_peptides_[peptide_idx];
-          mod_peptides.clear();
+        const Peptide& pep = fi_peptides_[peptide_idx];
+        const char* seq_ptr = fasta_entries[pep.protein_idx].sequence.c_str() + pep.sequence_.first;
+        size_t seq_len = pep.sequence_.second;
 
-          const string& protein_seq = fasta_entries[pep.protein_idx].sequence;
-          const char* seq_ptr = protein_seq.c_str() + pep.sequence_.first;
-          size_t seq_len = pep.sequence_.second;
-
-          AASequence unmod_peptide = AASequence::fromString(protein_seq.substr(pep.sequence_.first, seq_len));
-          AASequence mod_peptide = AASequence(unmod_peptide);
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide, max_variable_mods_per_peptide_, mod_peptides);
-
-          const AASequence& final_peptide = mod_peptides[pep.modification_idx_];
-
-          // Extract per-residue modification mass deltas
+        if (!has_modifications || pep.mod_bitmask_ == 0)
+        {
+          // No modifications or unmodified variant: just fixed mod deltas (if any)
+          if (!has_modifications)
+          {
+            generateFragmentsLightweight_(
+              thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
+              0.0, 0.0, nullptr);
+          }
+          else
+          {
+            // Fixed mods only — build delta array from fixed_mod_deltas_
+            vector<double> mod_masses(seq_len, 0.0);
+            bool has_residue_mods = false;
+            for (size_t i = 0; i < seq_len; ++i)
+            {
+              double delta = fixed_mod_deltas_[static_cast<unsigned char>(seq_ptr[i])];
+              if (delta != 0.0)
+              {
+                mod_masses[i] = delta;
+                has_residue_mods = true;
+              }
+            }
+            generateFragmentsLightweight_(
+              thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
+              fixed_nterm_delta_, fixed_cterm_delta_,
+              has_residue_mods ? mod_masses.data() : nullptr);
+          }
+        }
+        else
+        {
+          // Variable modifications active: reconstruct delta array from bitmask
           vector<double> mod_masses(seq_len, 0.0);
           bool has_residue_mods = false;
+          double n_term_mod = fixed_nterm_delta_;
+          double c_term_mod = fixed_cterm_delta_;
+
+          // Apply fixed mod deltas first
           for (size_t i = 0; i < seq_len; ++i)
           {
-            double modified_mass = final_peptide[i].getMonoWeight(Residue::Internal);
-            double unmodified_mass = residue_mass_table_[static_cast<unsigned char>(seq_ptr[i])];
-            double delta = modified_mass - unmodified_mass;
+            double delta = fixed_mod_deltas_[static_cast<unsigned char>(seq_ptr[i])];
             if (delta != 0.0)
             {
               mod_masses[i] = delta;
@@ -401,38 +675,32 @@ namespace OpenMS
             }
           }
 
-          double n_term_mod = 0.0;
-          if (final_peptide.hasNTerminalModification())
-            n_term_mod = final_peptide.getNTerminalModification()->getDiffMonoMass();
+          // Rebuild mod slots and apply variable mods from bitmask
+          ModSlot slots[MAX_MOD_SLOTS];
+          size_t n_slots = buildModSlots_(seq_ptr, seq_len, slots);
+          for (size_t s = 0; s < n_slots; ++s)
+          {
+            if (!(pep.mod_bitmask_ & (1u << s))) continue;
 
-          double c_term_mod = 0.0;
-          if (final_peptide.hasCTerminalModification())
-            c_term_mod = final_peptide.getCTerminalModification()->getDiffMonoMass();
-
-          generateFragmentsLightweight_(
-            thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
-            n_term_mod, c_term_mod, has_residue_mods ? mod_masses.data() : nullptr);
-        }
-      }
-      else
-      {
-        // Unmodified path: compute fragments directly from protein sequence chars.
-        // No AASequence parsing, no TheoreticalSpectrumGenerator needed.
-        #pragma omp parallel for
-        for (SignedSize peptide_idx = 0; peptide_idx < (SignedSize)fi_peptides_.size(); peptide_idx++)
-        {
-#ifdef _OPENMP
-          const int tid = omp_get_thread_num();
-#else
-          const int tid = 0;
-#endif
-          const Peptide& pep = fi_peptides_[peptide_idx];
-          const char* seq_ptr = fasta_entries[pep.protein_idx].sequence.c_str() + pep.sequence_.first;
-          size_t seq_len = pep.sequence_.second;
+            if (slots[s].position == ModSlot::NTERM_SLOT)
+            {
+              n_term_mod += slots[s].delta_mass;
+            }
+            else if (slots[s].position == ModSlot::CTERM_SLOT)
+            {
+              c_term_mod += slots[s].delta_mass;
+            }
+            else
+            {
+              mod_masses[slots[s].position] += slots[s].delta_mass;
+              has_residue_mods = true;
+            }
+          }
 
           generateFragmentsLightweight_(
             thread_fragments[tid], seq_ptr, seq_len, static_cast<UInt32>(peptide_idx),
-            0.0, 0.0, nullptr);
+            n_term_mod, c_term_mod,
+            has_residue_mods ? mod_masses.data() : nullptr);
         }
       }
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -590,23 +590,8 @@ if (!pi.getHits().empty())
 
       for (const auto& sms : top_sms.hits_)
       {
-        FragmentIndex::Peptide sms_pep = fragment_index_.getPeptides()[sms.peptide_idx_];
-        pair<size_t, size_t> candidate_snippet = sms_pep.sequence_;
-        AASequence unmod_candidate = AASequence::fromString(db[sms_pep.protein_idx].sequence.substr(candidate_snippet.first, candidate_snippet.second));
-        AASequence mod_candidate;
-        if (!(modifications_variable_.empty() && modifications_fixed_.empty()))
-        {
-          vector<AASequence> mod_candidates;
-          ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-          ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, unmod_candidate);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, unmod_candidate, modifications_max_variable_mods_per_peptide_, mod_candidates);
-          mod_candidate = mod_candidates[sms_pep.modification_idx_];
-        }
-        else
-        {
-          mod_candidate = unmod_candidate;
-        }
+        const FragmentIndex::Peptide& sms_pep = fragment_index_.getPeptides()[sms.peptide_idx_];
+        AASequence mod_candidate = fragment_index_.reconstructModifiedSequence(sms_pep, db);
 
         PeakSpectrum theo_spectrum;
         spectrum_generator.getSpectrum(theo_spectrum, mod_candidate, 1, 1);

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -79,6 +79,10 @@ namespace OpenMS
                                        )
   {
 #ifdef _OPENMP
+    if (num_threads <= 0)
+    {
+      num_threads = omp_get_num_procs();
+    }
     omp_set_num_threads(num_threads);
 #endif
   }
@@ -151,7 +155,7 @@ namespace OpenMS
     registerStringOption_("log", "<file>", "", "Name of log file (created only when specified)", false, true);
     registerIntOption_("instance", "<n>", 1, "Instance number for the TOPP INI file", false, true);
     registerIntOption_("debug", "<n>", 0, "Sets the debug level", false, true);
-    registerIntOption_("threads", "<n>", 1, "Sets the number of threads allowed to be used by the TOPP tool", false);
+    registerIntOption_("threads", "<n>", 1, "Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)", false);
     registerStringOption_("write_ini", "<file>", "", "Writes the default configuration file", false);
     registerStringOption_("write_ctd", "<out_dir>", "", "Writes the common tool description file(s) (Toolname(s).ctd) to <out_dir>", false, true);
     registerStringOption_("write_nested_cwl", "<out_dir>", "", "Writes the Common Workflow Language file(s) (Toolname(s).cwl) to <out_dir>", false, true);

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -79,10 +79,6 @@ namespace OpenMS
                                        )
   {
 #ifdef _OPENMP
-    if (num_threads <= 0)
-    {
-      num_threads = omp_get_num_procs();
-    }
     omp_set_num_threads(num_threads);
 #endif
   }
@@ -155,7 +151,7 @@ namespace OpenMS
     registerStringOption_("log", "<file>", "", "Name of log file (created only when specified)", false, true);
     registerIntOption_("instance", "<n>", 1, "Instance number for the TOPP INI file", false, true);
     registerIntOption_("debug", "<n>", 0, "Sets the debug level", false, true);
-    registerIntOption_("threads", "<n>", 1, "Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)", false);
+    registerIntOption_("threads", "<n>", 1, "Sets the number of threads allowed to be used by the TOPP tool", false);
     registerStringOption_("write_ini", "<file>", "", "Writes the default configuration file", false);
     registerStringOption_("write_ctd", "<out_dir>", "", "Writes the common tool description file(s) (Toolname(s).ctd) to <out_dir>", false, true);
     registerStringOption_("write_nested_cwl", "<out_dir>", "", "Writes the Common Workflow Language file(s) (Toolname(s).cwl) to <out_dir>", false, true);

--- a/src/tests/class_tests/openms/data/FeatureFinderMultiplex_1_parameters.ini
+++ b/src/tests/class_tests/openms/data/FeatureFinderMultiplex_1_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/class_tests/openms/data/FileHandler_toppas.toppas
+++ b/src/tests/class_tests/openms/data/FileHandler_toppas.toppas
@@ -36,7 +36,7 @@
         <ITEM name="out_type" value="consensusXML" type="string" description="output file type -- default: determined from file extension or content#br#" restrictions="mzData,mzXML,mzML,DTA2D,mgf,featureXML,consensusXML" />
         <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       </NODE>

--- a/src/tests/class_tests/openms/data/Param_post16_update.ini
+++ b/src/tests/class_tests/openms/data/Param_post16_update.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
     </NODE>

--- a/src/tests/class_tests/openms/data/Param_pre16_update.ini
+++ b/src/tests/class_tests/openms/data/Param_pre16_update.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="string" description="output file " tags="output file,required" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
     </NODE>

--- a/src/tests/class_tests/openms/data/TOPPBaseCmdParseSubsectionsTest.ini
+++ b/src/tests/class_tests/openms/data/TOPPBaseCmdParseSubsectionsTest.ini
@@ -6,7 +6,7 @@
       <ITEM name="stringoption" value="" type="string" description="string description" tags="required" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_out.ini
+++ b/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_out.ini
@@ -39,7 +39,7 @@
       </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_subsec_out.ini
+++ b/src/tests/class_tests/openms/data/TOPPBase_test_write_ini_subsec_out.ini
@@ -6,7 +6,7 @@
       <ITEM name="stringoption" value="" type="string" description="string description" required="true" advanced="false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -551,6 +551,7 @@ set(analysis_executables_list
   PeptideProteinResolution_test
   PeakGroup_test
   PScore_test
+  FragmentIndex_test
   HyperScore_test
   MorpheusScore_test
   OpenPepXLAlgorithm_test

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -454,6 +454,15 @@ START_SECTION(lightweight_fragment_count)
   size_t expected_fragments = 2 * (seq.size() - 1);
   size_t actual_fragments = fcTest.fragmentCountForPeptide(0);
   TEST_EQUAL(actual_fragments, expected_fragments)
+
+  // With min_ion_index=2, skip b1/b2/y1/y2 → 2*(n-1-2) = 2*5 = 10 fragments
+  fcTest.clear();
+  params.setValue("fragment:min_ion_index", 2);
+  fcTest.setParameters(params);
+  fcTest.build(entries);
+  TEST_EQUAL(fcTest.getPeptides().size(), 1)
+  size_t expected_with_skip = 2 * (seq.size() - 1 - 2); // skip 2 from each series
+  TEST_EQUAL(fcTest.fragmentCountForPeptide(0), expected_with_skip)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -536,4 +536,157 @@ START_SECTION(fixed_plus_variable_mods)
 }
 END_SECTION
 
+// Cross-validate bitmask enumeration against ModifiedPeptideGenerator.
+// For each test case: build FragmentIndex with bitmask path, also run
+// ModifiedPeptideGenerator independently, then compare:
+//   1. Same number of modification variants
+//   2. Same set of precursor masses (within float tolerance)
+//   3. Reconstructed AASequences match the ModifiedPeptideGenerator output
+START_SECTION(cross_validate_vs_ModifiedPeptideGenerator)
+{
+  // Helper lambda: run ModifiedPeptideGenerator on a peptide string and return
+  // sorted vector of (precursor_mz_charge1, AASequence_string) pairs
+  auto run_modpepgen = [](const std::string& pep_str,
+                          const std::vector<std::string>& fixed_mod_names,
+                          const std::vector<std::string>& var_mod_names,
+                          size_t max_var_mods) -> std::vector<std::pair<float, std::string>>
+  {
+    AASequence unmod = AASequence::fromString(pep_str);
+    AASequence mod = AASequence(unmod);
+
+    ModifiedPeptideGenerator::MapToResidueType fixed_mods;
+    ModifiedPeptideGenerator::MapToResidueType var_mods;
+    if (!fixed_mod_names.empty())
+    {
+      StringList sl(fixed_mod_names.begin(), fixed_mod_names.end());
+      fixed_mods = ModifiedPeptideGenerator::getModifications(sl);
+      ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, mod);
+    }
+    std::vector<AASequence> variants;
+    if (!var_mod_names.empty())
+    {
+      StringList sl(var_mod_names.begin(), var_mod_names.end());
+      var_mods = ModifiedPeptideGenerator::getModifications(sl);
+      ModifiedPeptideGenerator::applyVariableModifications(var_mods, mod, max_var_mods, variants);
+    }
+    else
+    {
+      variants.push_back(mod);
+    }
+
+    std::vector<std::pair<float, std::string>> result;
+    for (const auto& v : variants)
+    {
+      result.emplace_back(static_cast<float>(v.getMZ(1)), v.toString());
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // Helper: build FragmentIndex, collect sorted (precursor_mz, reconstructed_string) pairs
+  auto run_fragment_index = [](const std::string& seq,
+                               const std::vector<std::string>& fixed_mod_names,
+                               const std::vector<std::string>& var_mod_names,
+                               size_t max_var_mods) -> std::vector<std::pair<float, std::string>>
+  {
+    std::vector<FASTAFile::FASTAEntry> entries {{"p", "p", seq}};
+    FragmentIndex fi;
+    auto params = fi.getParameters();
+    params.setValue("enzyme", "no cleavage");
+    params.setValue("peptide:min_size", 0);
+    params.setValue("peptide:max_size", 100);
+    params.setValue("peptide:min_mass", 0);
+    params.setValue("peptide:max_mass", 50000);
+    params.setValue("fragment:min_mz", 0);
+    params.setValue("fragment:max_mz", 50000);
+    params.setValue("modifications:variable_max_per_peptide", static_cast<int>(max_var_mods));
+    params.setValue("modifications:variable", std::vector<std::string>(var_mod_names.begin(), var_mod_names.end()));
+    params.setValue("modifications:fixed", std::vector<std::string>(fixed_mod_names.begin(), fixed_mod_names.end()));
+    fi.setParameters(params);
+    fi.build(entries);
+
+    std::vector<std::pair<float, std::string>> result;
+    for (const auto& pep : fi.getPeptides())
+    {
+      AASequence reconstructed = fi.reconstructModifiedSequence(pep, entries);
+      result.emplace_back(pep.precursor_mz_, reconstructed.toString());
+    }
+    std::sort(result.begin(), result.end());
+    return result;
+  };
+
+  // --- Test case 1: Simple Oxidation(M) + Carbamidomethyl(C) ---
+  {
+    auto mpg = run_modpepgen("ACMACK", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 2);
+    auto fi  = run_fragment_index("ACMACK", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 2);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+
+  // --- Test case 2: Multiple M sites ---
+  {
+    auto mpg = run_modpepgen("DFDMDMDM", {}, {"Oxidation (M)"}, 2);
+    auto fi  = run_fragment_index("DFDMDMDM", {}, {"Oxidation (M)"}, 2);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+
+  // --- Test case 3: N-terminal variable mod (Carbamyl) + residue mod (Oxidation) ---
+  {
+    auto mpg = run_modpepgen("KAAAAAAAMA", {}, {"Carbamyl (N-term)", "Oxidation (M)"}, 2);
+    auto fi  = run_fragment_index("KAAAAAAAMA", {}, {"Carbamyl (N-term)", "Oxidation (M)"}, 2);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+
+  // --- Test case 4: Two different variable mods on same AA (C) ---
+  {
+    auto mpg = run_modpepgen("ACAACAACA", {}, {"Glutathione (C)", "Carbamidomethyl (C)"}, 1);
+    auto fi  = run_fragment_index("ACAACAACA", {}, {"Glutathione (C)", "Carbamidomethyl (C)"}, 1);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+
+  // --- Test case 5: No modifiable sites ---
+  {
+    auto mpg = run_modpepgen("AAAAAAAAA", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 2);
+    auto fi  = run_fragment_index("AAAAAAAAA", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 2);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+
+  // --- Test case 6: Fixed + variable mods, max_var_mods=3, multiple site types ---
+  {
+    auto mpg = run_modpepgen("ACMACMACA", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 3);
+    auto fi  = run_fragment_index("ACMACMACA", {"Carbamidomethyl (C)"}, {"Oxidation (M)"}, 3);
+    TEST_EQUAL(fi.size(), mpg.size())
+    for (size_t i = 0; i < std::min(fi.size(), mpg.size()); ++i)
+    {
+      TEST_REAL_SIMILAR(fi[i].first, mpg[i].first)
+      TEST_EQUAL(fi[i].second, mpg[i].second)
+    }
+  }
+}
+END_SECTION
+
 END_TEST

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -18,7 +18,6 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
-#include <chrono>
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <limits>
 
@@ -195,44 +194,6 @@ FragmentIndex_test buildTestIndex(const std::string& protein_seq,
   entries.push_back({"sp|TEST", "test protein", protein_seq});
   fi.build(entries);
   return fi;
-}
-
-// Helper: compare SIMD vs scalar query results for every peak in a spectrum.
-// Checks both hit count AND hit content (peptide_idx + fragment_mz).
-bool simdScalarMatch(FragmentIndex_test& fi, const MSSpectrum& spec,
-                     const std::pair<size_t,size_t>& range, uint16_t charge,
-                     size_t& simd_count, size_t& scalar_count)
-{
-  auto hitSortKey = [](const FragmentIndex::Hit& a, const FragmentIndex::Hit& b) {
-    return std::tie(a.peptide_idx, a.fragment_mz) < std::tie(b.peptide_idx, b.fragment_mz);
-  };
-
-  bool match = true;
-  for (const auto& peak : spec)
-  {
-    auto simd_hits = fi.query(peak, range, charge);
-    auto scalar_hits = fi.queryScalar(peak, range, charge);
-    simd_count += simd_hits.size();
-    scalar_count += scalar_hits.size();
-    if (simd_hits.size() != scalar_hits.size())
-    {
-      match = false;
-      continue;
-    }
-    // Sort both and compare element-wise
-    std::sort(simd_hits.begin(), simd_hits.end(), hitSortKey);
-    std::sort(scalar_hits.begin(), scalar_hits.end(), hitSortKey);
-    for (size_t h = 0; h < simd_hits.size(); ++h)
-    {
-      if (simd_hits[h].peptide_idx != scalar_hits[h].peptide_idx ||
-          simd_hits[h].fragment_mz != scalar_hits[h].fragment_mz)
-      {
-        match = false;
-        break;
-      }
-    }
-  }
-  return match;
 }
 
 //////////////////////////////
@@ -500,99 +461,27 @@ START_SECTION(tolerance)
 }
 END_SECTION
 
-START_SECTION(simd_scalar_equivalence_basic)
+
+START_SECTION(query_edge_empty_range)
 {
-  // Test SIMD vs scalar equivalence with a standard protein
-  auto fi = buildTestIndex(
-    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIERIHFHTYRQVKAFPAYQLDKK"
-    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  // Test with multiple peptides at different charges
-  std::vector<std::string> test_peptides = {
-    "EVAEAATGEDASSPPPK", "MDAILR", "GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER",
-    "AFPAYQLDKK", "DYTRIVFVEDPTFHQIITSLENYR"
-  };
-
-  for (const auto& pep_str : test_peptides)
-  {
-    AASequence pep = AASequence::fromString(pep_str);
-    for (int charge = 1; charge <= 3; ++charge)
-    {
-      MSSpectrum spec;
-      tsg.getSpectrum(spec, pep, charge, charge);
-      float prec_mz = pep.getMZ(charge);
-      auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-      size_t simd_n = 0, scalar_n = 0;
-      TEST_TRUE(simdScalarMatch(fi, spec, range, charge, simd_n, scalar_n))
-      TEST_EQUAL(simd_n, scalar_n)
-    }
-  }
-}
-END_SECTION
-
-START_SECTION(simd_scalar_equivalence_real_fasta)
-{
-  // Use the SSE/Comet test FASTA (real protein sequences)
-  auto fi = buildTestIndex(
-    // proteins.fasta test sequence
-    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV"
-    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV"
-    "AXXSTFDFYQRRLVTLAESPRAPSP"
-    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV",
-    0.05, "Da", 10.0, "ppm", 2); // 2 missed cleavages for more peptides
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  // Query with multiple known peptides from this sequence
-  std::vector<std::string> peps = {"GSMTVDMQEIGSTEMPYEVPTQPNATSA", "GWFDGPSFK", "VPSVPTR",
-                                    "PSGIFR", "EKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQR"};
-  for (const auto& p : peps)
-  {
-    AASequence pep = AASequence::fromString(p);
-    MSSpectrum spec;
-    tsg.getSpectrum(spec, pep, 1, 1);
-    float prec_mz = pep.getMZ(1);
-    auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-    size_t simd_n = 0, scalar_n = 0;
-    TEST_TRUE(simdScalarMatch(fi, spec, range, 1, simd_n, scalar_n))
-    TEST_EQUAL(simd_n, scalar_n)
-  }
-}
-END_SECTION
-
-START_SECTION(simd_scalar_edge_empty_range)
-{
-  // Edge case: empty peptide range [k, k) — should produce 0 hits in both
+  // Edge case: empty peptide range [k, k) — should produce 0 hits
   auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR");
 
   Peak1D peak;
   peak.setMZ(500.0);
   peak.setIntensity(1.0);
 
-  // Use a precursor mass that doesn't match anything
   auto range = fi.getPeptidesInPrecursorRange(99999.0f, {0.0f, 0.0f});
-  TEST_EQUAL(range.first, range.second) // empty range
+  TEST_EQUAL(range.first, range.second)
 
-  auto simd_hits = fi.query(peak, range, 1);
-  auto scalar_hits = fi.queryScalar(peak, range, 1);
-  TEST_EQUAL(simd_hits.size(), 0)
-  TEST_EQUAL(scalar_hits.size(), 0)
+  auto hits = fi.query(peak, range, 1);
+  TEST_EQUAL(hits.size(), 0)
 }
 END_SECTION
 
-START_SECTION(simd_scalar_edge_single_fragment_bucket)
+START_SECTION(query_edge_small_bucket)
 {
-  // Edge case: very short protein producing < 4 fragments (tests scalar remainder path only)
+  // Edge case: very short protein producing few fragments
   auto fi = buildTestIndex("AAAAAKR", 0.05, "Da", 10.0, "ppm", 0, 5, 7);
 
   Peak1D peak;
@@ -600,18 +489,16 @@ START_SECTION(simd_scalar_edge_single_fragment_bucket)
   peak.setIntensity(1.0);
   auto range = fi.getPeptidesInPrecursorRange(300.0f, {-300.0f, 300.0f});
 
-  auto simd_hits = fi.query(peak, range, 1);
-  auto scalar_hits = fi.queryScalar(peak, range, 1);
-  TEST_EQUAL(simd_hits.size(), scalar_hits.size())
+  auto hits = fi.query(peak, range, 1);
+  (void)hits;
 }
 END_SECTION
 
-START_SECTION(simd_scalar_edge_ppm_tolerance)
+START_SECTION(query_edge_ppm_tolerance)
 {
-  // Edge case: ppm tolerance instead of Da
   auto fi = buildTestIndex(
     "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER",
-    20.0, "ppm"); // 20 ppm fragment tolerance
+    20.0, "ppm");
 
   TheoreticalSpectrumGenerator tsg;
   auto tp = tsg.getParameters();
@@ -621,19 +508,19 @@ START_SECTION(simd_scalar_edge_ppm_tolerance)
 
   AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
   MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 2, 2);
-  float prec_mz = pep.getMZ(2);
+  tsg.getSpectrum(spec, pep, 1, 1);
+  float prec_mz = pep.getMZ(1);
   auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
 
-  size_t simd_n = 0, scalar_n = 0;
-  TEST_TRUE(simdScalarMatch(fi, spec, range, 2, simd_n, scalar_n))
-  TEST_EQUAL(simd_n, scalar_n)
+  size_t total_hits = 0;
+  for (const auto& peak : spec)
+    total_hits += fi.query(peak, range, 1).size();
+  TEST_TRUE(total_hits > 0)
 }
 END_SECTION
 
-START_SECTION(simd_scalar_edge_tolerance_boundary)
+START_SECTION(query_edge_tolerance_boundary)
 {
-  // Edge case: peaks right at tolerance boundary
   auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR", 0.01, "Da");
 
   TheoreticalSpectrumGenerator tsg;
@@ -645,79 +532,46 @@ START_SECTION(simd_scalar_edge_tolerance_boundary)
   AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
   MSSpectrum spec;
   tsg.getSpectrum(spec, pep, 1, 1);
-
-  // Shift all peaks by exactly the tolerance (0.01 Da) — should still match
-  MSSpectrum shifted_spec;
-  for (const auto& peak : spec)
-  {
-    Peak1D p;
-    p.setMZ(peak.getMZ() + 0.009); // just inside tolerance
-    p.setIntensity(peak.getIntensity());
-    shifted_spec.push_back(p);
-  }
-
   float prec_mz = pep.getMZ(1);
   auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
 
-  size_t simd_n = 0, scalar_n = 0;
-  TEST_TRUE(simdScalarMatch(fi, shifted_spec, range, 1, simd_n, scalar_n))
-  TEST_EQUAL(simd_n, scalar_n)
-
-  // Shift peaks just outside tolerance — should produce 0 hits
-  MSSpectrum outside_spec;
+  // Peaks shifted just inside tolerance
+  MSSpectrum shifted;
   for (const auto& peak : spec)
   {
     Peak1D p;
-    p.setMZ(peak.getMZ() + 0.02); // outside 0.01 Da tolerance
+    p.setMZ(peak.getMZ() + 0.009);
     p.setIntensity(peak.getIntensity());
-    outside_spec.push_back(p);
+    shifted.push_back(p);
   }
+  size_t inside_hits = 0;
+  for (const auto& peak : shifted)
+    inside_hits += fi.query(peak, range, 1).size();
+  TEST_TRUE(inside_hits > 0)
 
-  size_t simd_n2 = 0, scalar_n2 = 0;
-  TEST_TRUE(simdScalarMatch(fi, outside_spec, range, 1, simd_n2, scalar_n2))
-  TEST_EQUAL(simd_n2, scalar_n2)
-  TEST_EQUAL(simd_n2, 0)
-}
-END_SECTION
-
-START_SECTION(simd_scalar_edge_multi_charge)
-{
-  // Edge case: multiple fragment charges
-  auto fi = buildTestIndex(
-    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER"
-    "IHFHTYRQVKAFPAYQLDKKMGKDYTRIVFVEDPTFHQIITSLENYR");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  AASequence pep = AASequence::fromString("GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
-  MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 1, 3); // generate ions at charges 1-3
-
-  float prec_mz = pep.getMZ(3);
-  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-
-  // Test with fragment charges 1, 2, and 3
-  for (uint16_t fc = 1; fc <= 3; ++fc)
+  // Peaks shifted outside tolerance
+  MSSpectrum outside;
+  for (const auto& peak : spec)
   {
-    size_t simd_n = 0, scalar_n = 0;
-    TEST_TRUE(simdScalarMatch(fi, spec, range, fc, simd_n, scalar_n))
-    TEST_EQUAL(simd_n, scalar_n)
+    Peak1D p;
+    p.setMZ(peak.getMZ() + 0.02);
+    p.setIntensity(peak.getIntensity());
+    outside.push_back(p);
   }
+  size_t outside_hits = 0;
+  for (const auto& peak : outside)
+    outside_hits += fi.query(peak, range, 1).size();
+  TEST_EQUAL(outside_hits, 0)
 }
 END_SECTION
 
-START_SECTION(simd_scalar_edge_wide_precursor_window)
+START_SECTION(query_edge_wide_precursor_window)
 {
-  // Edge case: wide precursor window (many candidates spanning multiple buckets)
   auto fi = buildTestIndex(
     "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER"
     "IHFHTYRQVKAFPAYQLDKKMGKDYTRIVFVEDPTFHQIITSLENYR"
     "SMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR",
-    0.05, "Da", 500.0, "Da"); // very wide precursor tolerance
+    0.05, "Da", 500.0, "Da");
 
   TheoreticalSpectrumGenerator tsg;
   auto tp = tsg.getParameters();
@@ -728,79 +582,21 @@ START_SECTION(simd_scalar_edge_wide_precursor_window)
   AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
   MSSpectrum spec;
   tsg.getSpectrum(spec, pep, 1, 1);
-
   float prec_mz = pep.getMZ(1);
   auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
 
-  size_t simd_n = 0, scalar_n = 0;
-  TEST_TRUE(simdScalarMatch(fi, spec, range, 1, simd_n, scalar_n))
-  TEST_EQUAL(simd_n, scalar_n)
-  TEST_TRUE(simd_n > 0) // wide window should produce hits
+  size_t total_hits = 0;
+  for (const auto& peak : spec)
+    total_hits += fi.query(peak, range, 1).size();
+  TEST_TRUE(total_hits > 0)
 }
 END_SECTION
 
-START_SECTION(simd_scalar_edge_soa_invariants)
+START_SECTION(query_edge_soa_invariants)
 {
-  // Verify SoA buffer alignment invariant (via fragmentsSorted which accesses both arrays)
   auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
   TEST_TRUE(fi.fragmentsSorted())
   TEST_TRUE(fi.peptidesSorted())
-}
-END_SECTION
-
-START_SECTION(benchmark_simd_vs_scalar)
-{
-  auto fi = buildTestIndex(
-    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIERIHFHTYRQVKAFPAYQLDKK"
-    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  AASequence pep = AASequence::fromString("GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
-  MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 1, 1);
-  float prec_mz = pep.getMZ(1);
-  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-
-  // Warm up
-  for (int w = 0; w < 10; ++w)
-    for (const auto& peak : spec)
-    {
-      fi.query(peak, range, 1);
-      fi.queryScalar(peak, range, 1);
-    }
-
-  const int ITERATIONS = 1000;
-
-  auto t0 = std::chrono::high_resolution_clock::now();
-  size_t simd_total = 0;
-  for (int iter = 0; iter < ITERATIONS; ++iter)
-    for (const auto& peak : spec)
-      simd_total += fi.query(peak, range, 1).size();
-  auto t1 = std::chrono::high_resolution_clock::now();
-
-  size_t scalar_total = 0;
-  auto t2 = std::chrono::high_resolution_clock::now();
-  for (int iter = 0; iter < ITERATIONS; ++iter)
-    for (const auto& peak : spec)
-      scalar_total += fi.queryScalar(peak, range, 1).size();
-  auto t3 = std::chrono::high_resolution_clock::now();
-
-  double simd_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-  double scalar_ms = std::chrono::duration<double, std::milli>(t3 - t2).count();
-
-  std::cout << "\n=== FragmentIndex Query Benchmark ===" << std::endl;
-  std::cout << "Iterations: " << ITERATIONS << " x " << spec.size() << " peaks" << std::endl;
-  std::cout << "SIMD:   " << simd_ms << " ms (hits: " << simd_total << ")" << std::endl;
-  std::cout << "Scalar: " << scalar_ms << " ms (hits: " << scalar_total << ")" << std::endl;
-  std::cout << "Speedup: " << (scalar_ms / simd_ms) << "x" << std::endl;
-  std::cout << "======================================\n" << std::endl;
-
-  TEST_EQUAL(simd_total, scalar_total)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -18,6 +18,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <chrono>
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <limits>
 
@@ -422,6 +423,108 @@ START_SECTION(tolerance)
     }
   }
   TEST_TRUE(found);
+}
+END_SECTION
+
+START_SECTION(benchmark_simd_vs_scalar)
+{
+  // Build a moderately sized index for benchmarking
+  FragmentIndex_test benchFI;
+  Param p = benchFI.getParameters();
+  p.setValue("ions:add_b_ions", "true");
+  p.setValue("ions:add_y_ions", "true");
+  p.setValue("ions:add_a_ions", "false");
+  p.setValue("ions:add_c_ions", "false");
+  p.setValue("ions:add_x_ions", "false");
+  p.setValue("ions:add_z_ions", "false");
+  p.setValue("peptide:min_size", (UInt)5);
+  p.setValue("peptide:max_size", (UInt)40);
+  p.setValue("peptide:missed_cleavages", (UInt)1);
+  p.setValue("peptide:min_mass", 0.0);
+  p.setValue("peptide:max_mass", 5000.0);
+  p.setValue("fragment:min_mz", 0.0);
+  p.setValue("fragment:max_mz", 90000.0);
+  p.setValue("fragment:tolerance", 0.05);
+  p.setValue("fragment:tolerance_unit", "Da");
+  p.setValue("precursor:tolerance", 10.0);
+  p.setValue("precursor:tolerance_unit", "ppm");
+  p.setValue("precursor:min_charge", (UInt)1);
+  p.setValue("precursor:max_charge", (UInt)1);
+  p.setValue("search:max_fragment_charge", (UInt)1);
+  benchFI.setParameters(p);
+
+  // Use a larger protein for more fragments
+  std::vector<FASTAFile::FASTAEntry> bench_entries;
+  bench_entries.push_back({"sp|BENCH", "Benchmark protein",
+    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIERIHFHTYRQVKAFPAYQLDKK"
+    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR"});
+
+  benchFI.build(bench_entries);
+
+  // Generate a test spectrum from the first peptide
+  TheoreticalSpectrumGenerator tsg;
+  auto tsg_params = tsg.getParameters();
+  tsg_params.setValue("add_b_ions", "true");
+  tsg_params.setValue("add_y_ions", "true");
+  tsg.setParameters(tsg_params);
+
+  AASequence test_pep = AASequence::fromString("EVAEAATGEDASSPPPK");
+  MSSpectrum theo_spec;
+  tsg.getSpectrum(theo_spec, test_pep, 1, 1);
+
+  float precursor_mz = test_pep.getMonoWeight(Residue::Full, 1) + Constants::PROTON_MASS_U;
+  auto candidates_range = benchFI.getPeptidesInPrecursorRange(precursor_mz, {0.0f, 0.0f});
+
+  // Warm up
+  for (int w = 0; w < 10; ++w)
+  {
+    for (const auto& peak : theo_spec)
+    {
+      benchFI.query(peak, candidates_range, 1);
+      benchFI.queryScalar(peak, candidates_range, 1);
+    }
+  }
+
+  const int ITERATIONS = 1000;
+
+  // Benchmark SIMD
+  auto t0 = std::chrono::high_resolution_clock::now();
+  size_t simd_total_hits = 0;
+  for (int iter = 0; iter < ITERATIONS; ++iter)
+  {
+    for (const auto& peak : theo_spec)
+    {
+      auto hits = benchFI.query(peak, candidates_range, 1);
+      simd_total_hits += hits.size();
+    }
+  }
+  auto t1 = std::chrono::high_resolution_clock::now();
+
+  // Benchmark Scalar
+  auto t2 = std::chrono::high_resolution_clock::now();
+  size_t scalar_total_hits = 0;
+  for (int iter = 0; iter < ITERATIONS; ++iter)
+  {
+    for (const auto& peak : theo_spec)
+    {
+      auto hits = benchFI.queryScalar(peak, candidates_range, 1);
+      scalar_total_hits += hits.size();
+    }
+  }
+  auto t3 = std::chrono::high_resolution_clock::now();
+
+  double simd_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+  double scalar_ms = std::chrono::duration<double, std::milli>(t3 - t2).count();
+
+  std::cout << "\n=== FragmentIndex Query Benchmark ===" << std::endl;
+  std::cout << "Iterations: " << ITERATIONS << " x " << theo_spec.size() << " peaks" << std::endl;
+  std::cout << "SIMD:   " << simd_ms << " ms (hits: " << simd_total_hits << ")" << std::endl;
+  std::cout << "Scalar: " << scalar_ms << " ms (hits: " << scalar_total_hits << ")" << std::endl;
+  std::cout << "Speedup: " << (scalar_ms / simd_ms) << "x" << std::endl;
+  std::cout << "======================================\n" << std::endl;
+
+  // Verify both produce identical results
+  TEST_EQUAL(simd_total_hits, scalar_total_hits)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -437,20 +437,20 @@ START_SECTION(benchmark_simd_vs_scalar)
   p.setValue("ions:add_c_ions", "false");
   p.setValue("ions:add_x_ions", "false");
   p.setValue("ions:add_z_ions", "false");
-  p.setValue("peptide:min_size", (UInt)5);
-  p.setValue("peptide:max_size", (UInt)40);
-  p.setValue("peptide:missed_cleavages", (UInt)1);
-  p.setValue("peptide:min_mass", 0.0);
-  p.setValue("peptide:max_mass", 5000.0);
-  p.setValue("fragment:min_mz", 0.0);
-  p.setValue("fragment:max_mz", 90000.0);
-  p.setValue("fragment:tolerance", 0.05);
-  p.setValue("fragment:tolerance_unit", "Da");
-  p.setValue("precursor:tolerance", 10.0);
-  p.setValue("precursor:tolerance_unit", "ppm");
-  p.setValue("precursor:min_charge", (UInt)1);
-  p.setValue("precursor:max_charge", (UInt)1);
-  p.setValue("search:max_fragment_charge", (UInt)1);
+  p.setValue("peptide:min_size", 5);
+  p.setValue("peptide:max_size", 40);
+  p.setValue("peptide:missed_cleavages", 1);
+  p.setValue("peptide:min_mass", 0);
+  p.setValue("peptide:max_mass", 5000);
+  p.setValue("fragment:min_mz", 0);
+  p.setValue("fragment:max_mz", 90000);
+  p.setValue("fragment:mass_tolerance", 0.05);
+  p.setValue("fragment:mass_tolerance_unit", "Da");
+  p.setValue("precursor:mass_tolerance", 10.0);
+  p.setValue("precursor:mass_tolerance_unit", "ppm");
+  p.setValue("precursor:min_charge", 1);
+  p.setValue("precursor:max_charge", 1);
+  p.setValue("search:max_fragment_charge", 1);
   benchFI.setParameters(p);
 
   // Use a larger protein for more fragments

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -80,14 +80,14 @@ public:
   // This captures the two-dimensional ordering constraint of the index.
   bool fragmentsSorted()
   {
-    for (size_t fi_idx = 0; fi_idx < fi_fragments_.size(); fi_idx += bucketsize_)
+    for (size_t fi_idx = 0; fi_idx < fi_fragment_mzs_.size(); fi_idx += bucketsize_)
     {
       UInt32 last_idx = 0;
-      const size_t end = (fi_idx + bucketsize_ > fi_fragments_.size()) ? fi_fragments_.size() : (fi_idx + bucketsize_);
+      const size_t end = std::min(fi_idx + bucketsize_, fi_fragment_mzs_.size());
       for (size_t bucket_idx = fi_idx; bucket_idx < end; ++bucket_idx)
       {
-        if (fi_fragments_[bucket_idx].peptide_idx_ < last_idx) return false;
-        last_idx = fi_fragments_[bucket_idx].peptide_idx_;
+        if (fi_fragment_peptide_idxs_[bucket_idx] < last_idx) return false;
+        last_idx = fi_fragment_peptide_idxs_[bucket_idx];
       }
     }
     return true;

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -45,7 +45,7 @@ class FragmentIndex_test : public FragmentIndex
 {
 public:
   // Verifies that the generated peptide set matches the expected set exactly
-  // (by subsequence window and modification index).
+  // (by subsequence window and mod bitmask).
   bool testDigestion(const std::vector<FragmentIndex::Peptide>& expected)
   {
     if (expected.size() != fi_peptides_.size()) return false;
@@ -54,7 +54,7 @@ public:
       bool found = false;
       for (const auto& act : fi_peptides_)
       {
-        if ((exp.sequence_ == act.sequence_) && (exp.modification_idx_ == act.modification_idx_))
+        if ((exp.sequence_ == act.sequence_) && (exp.mod_bitmask_ == act.mod_bitmask_))
         {
           found = true;
           break;
@@ -108,16 +108,8 @@ public:
 
   bool testQuery(const UInt32 charge, const bool precursor_mz_known, const std::vector<FASTAFile::FASTAEntry>& entries)
   {
-    // fetch parameters for modification generation
-    auto params = getParameters();
-    const StringList modifications_fixed_ = ListUtils::toStringList<std::string>(params.getValue("modifications:fixed"));
-    const StringList modifications_variable_ = ListUtils::toStringList<std::string>(params.getValue("modifications:variable"));
-    const ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
-    const ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
-
     // Create theoretical spectra for different charges
     TheoreticalSpectrumGenerator tsg;
-    std::vector<AASequence> mod_peptides;
     PeakSpectrum b_y_ions;
     MSSpectrum spec_theo;
     Precursor prec_theo;
@@ -134,16 +126,10 @@ public:
     {
       FragmentIndex::SpectrumMatchesTopN sms;
       b_y_ions.clear(true);
-      mod_peptides.clear();
       spec_theo.clear(true);
 
       prec_theo.clearMetaInfo();
-      const AASequence unmod_peptide = AASequence::fromString(entries[0].sequence.substr(pep.sequence_.first, pep.sequence_.second));
-      AASequence mod_peptide = AASequence(unmod_peptide); // copy the peptide
-      ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, mod_peptide);
-      ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, mod_peptide,
-                                                           params.getValue("modifications:variable_max_per_peptide"), mod_peptides);
-      mod_peptide = mod_peptides[pep.modification_idx_];
+      AASequence mod_peptide = reconstructModifiedSequence(pep, entries);
       tsg.getSpectrum(b_y_ions, mod_peptide, charge, charge);
       prec_theo.setMZ(mod_peptide.getMZ(charge));
       if (precursor_mz_known) { prec_theo.setCharge(charge); }
@@ -184,18 +170,18 @@ START_SECTION(build())
   // Test proteins used to generate expected peptides for multiple parameterizations
   /*
     Format of expected peptide descriptors below and their mapping to FragmentIndex::Peptide fields:
-      { protein_idx, modification_idx_, { start, length }, precursor_mz_ }
+      { protein_idx, mod_bitmask_, { start, length }, precursor_mz_ }
 
     Where:
     - protein_idx: 0-based index into the FASTA entries vector passed to build(); selects the source protein.
-    - modification_idx_: index into mod_peptides returned by ModifiedPeptideGenerator for the given unmodified subsequence
-                        (0 = unmodified; higher values enumerate concrete variable-mod combinations).
+    - mod_bitmask_: bitmask of active variable modification slots. Each bit corresponds to a (position, mod_type) pair
+                   found by scanning the sequence left-to-right (0 = unmodified/fixed-only).
     - start: 0-based start offset within the selected protein sequence.
     - length: number of residues for the peptide (used as std::string::substr(start, length)).
     - precursor_mz_: mono-isotopic m/z at charge 1 (M+H)+. In these tests we often use a dummy value, as only ordering
                     invariants on peptides/fragment buckets are asserted.
 
-    Note: testDigestion() compares expected vs. built peptides only by {sequence_, modification_idx_}.
+    Note: testDigestion() compares expected vs. built peptides only by {sequence_, mod_bitmask_}.
   */
   const std::vector<FASTAFile::FASTAEntry> entries0 {{"t", "t", "ARGEPADSSRKDFDMDMDM"}, {"t2", "t2", "HALLORTSCHSM"}};
   // Expected peptides when enabling fixed Carbamidomethyl (C) and variable Oxidation (M)
@@ -468,6 +454,85 @@ START_SECTION(lightweight_fragment_count)
   size_t expected_fragments = 2 * (seq.size() - 1);
   size_t actual_fragments = fcTest.fragmentCountForPeptide(0);
   TEST_EQUAL(actual_fragments, expected_fragments)
+}
+END_SECTION
+
+// Test multi-mod-per-site: two different variable mods targeting the same AA (C)
+// and fragment count correctness with modifications
+START_SECTION(multi_mod_per_site)
+{
+  // Peptide with 2 C sites — both Glutathione(C) and Carbamidomethyl(C) are variable
+  const std::vector<FASTAFile::FASTAEntry> entries {{"p", "p", "ACACK"}};
+
+  FragmentIndex_test mmTest;
+  auto params = mmTest.getParameters();
+  params.setValue("enzyme", "no cleavage");
+  params.setValue("peptide:min_size", 0);
+  params.setValue("peptide:max_size", 100);
+  params.setValue("peptide:min_mass", 0);
+  params.setValue("peptide:max_mass", 50000);
+  params.setValue("fragment:min_mz", 0);
+  params.setValue("fragment:max_mz", 50000);
+  params.setValue("modifications:variable_max_per_peptide", 2);
+  params.setValue("modifications:variable", std::vector<std::string> {"Oxidation (M)"});
+  params.setValue("modifications:fixed", std::vector<std::string> {"Carbamidomethyl (C)"});
+  mmTest.setParameters(params);
+
+  mmTest.build(entries);
+
+  // "ACACK" has no M, so no variable mod sites → only 1 peptide (fixed C mods only)
+  TEST_EQUAL(mmTest.getPeptides().size(), 1)
+  // All peptides should have bitmask 0 (no variable mods)
+  TEST_EQUAL(mmTest.getPeptides()[0].mod_bitmask_, 0u)
+  TEST_TRUE(mmTest.peptidesSorted())
+  TEST_TRUE(mmTest.fragmentsSorted())
+  // Fragment count: 2*(5-1) = 8 for b+y ions
+  TEST_EQUAL(mmTest.fragmentCountForPeptide(0), 8)
+}
+END_SECTION
+
+// Test variable mods on M with fixed mods on C — verifies bitmask enumeration
+START_SECTION(fixed_plus_variable_mods)
+{
+  const std::vector<FASTAFile::FASTAEntry> entries {{"p", "p", "ACMK"}};
+
+  FragmentIndex_test fvTest;
+  auto params = fvTest.getParameters();
+  params.setValue("enzyme", "no cleavage");
+  params.setValue("peptide:min_size", 0);
+  params.setValue("peptide:max_size", 100);
+  params.setValue("peptide:min_mass", 0);
+  params.setValue("peptide:max_mass", 50000);
+  params.setValue("fragment:min_mz", 0);
+  params.setValue("fragment:max_mz", 50000);
+  params.setValue("modifications:variable_max_per_peptide", 2);
+  params.setValue("modifications:variable", std::vector<std::string> {"Oxidation (M)"});
+  params.setValue("modifications:fixed", std::vector<std::string> {"Carbamidomethyl (C)"});
+  fvTest.setParameters(params);
+
+  fvTest.build(entries);
+
+  // "ACMK": 1 M site → 2 peptides (bitmask 0 = no Ox, bitmask 1 = Ox on M)
+  TEST_EQUAL(fvTest.getPeptides().size(), 2)
+  TEST_TRUE(fvTest.peptidesSorted())
+  TEST_TRUE(fvTest.fragmentsSorted())
+
+  // Both variants should produce 2*(4-1) = 6 fragments each
+  for (size_t i = 0; i < fvTest.getPeptides().size(); ++i)
+  {
+    TEST_EQUAL(fvTest.fragmentCountForPeptide(static_cast<UInt32>(i)), 6)
+  }
+
+  // Verify reconstructModifiedSequence produces valid sequences
+  for (const auto& pep : fvTest.getPeptides())
+  {
+    AASequence reconstructed = fvTest.reconstructModifiedSequence(pep, entries);
+    TEST_EQUAL(reconstructed.size(), 4)
+    // C at position 1 should always have Carbamidomethyl (fixed mod)
+    TEST_TRUE(reconstructed[1].isModified())
+    // M at position 2: modified only when bitmask bit 0 is set
+    TEST_EQUAL(reconstructed[2].isModified(), (pep.mod_bitmask_ & 1u) != 0)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -93,6 +93,19 @@ public:
     return true;
   }
 
+  // Returns the total number of fragments generated for a given peptide index.
+  size_t fragmentCountForPeptide(UInt32 peptide_idx) const
+  {
+    size_t count = 0;
+    for (const auto& f : fi_fragments_)
+    {
+      if (f.peptide_idx_ == peptide_idx) ++count;
+    }
+    return count;
+  }
+
+  const std::vector<Fragment>& getFragments() const { return fi_fragments_; }
+
   bool testQuery(const UInt32 charge, const bool precursor_mz_known, const std::vector<FASTAFile::FASTAEntry>& entries)
   {
     // fetch parameters for modification generation
@@ -422,6 +435,39 @@ START_SECTION(tolerance)
     }
   }
   TEST_TRUE(found);
+}
+END_SECTION
+
+// Verify that the lightweight fragment generator produces the expected number of
+// b/y ions: 2*(n-1) for an n-residue peptide with default b+y ion types,
+// consistent with standard fragment indexing (b1..b(n-1), y1..y(n-1)).
+START_SECTION(lightweight_fragment_count)
+{
+  const std::string seq = "PEPTIDER";  // 8 residues
+  const std::vector<FASTAFile::FASTAEntry> entries {{"p", "p", seq}};
+
+  FragmentIndex_test fcTest;
+  auto params = fcTest.getParameters();
+  params.setValue("enzyme", "no cleavage");
+  params.setValue("peptide:min_size", 0);
+  params.setValue("peptide:max_size", 100);
+  params.setValue("peptide:min_mass", 0);
+  params.setValue("peptide:max_mass", 50000);
+  params.setValue("fragment:min_mz", 0);
+  params.setValue("fragment:max_mz", 50000);
+  params.setValue("modifications:variable", std::vector<std::string> {});
+  params.setValue("modifications:fixed", std::vector<std::string> {});
+  fcTest.setParameters(params);
+
+  fcTest.build(entries);
+
+  // Should produce exactly one peptide
+  TEST_EQUAL(fcTest.getPeptides().size(), 1)
+
+  // For b+y ions (default): 2 * (n-1) = 2 * 7 = 14 fragments
+  size_t expected_fragments = 2 * (seq.size() - 1);
+  size_t actual_fragments = fcTest.fragmentCountForPeptide(0);
+  TEST_EQUAL(actual_fragments, expected_fragments)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -161,6 +161,58 @@ public:
   }
 };
 
+// Helper: build a FragmentIndex with given params and protein sequence
+FragmentIndex_test buildTestIndex(const std::string& protein_seq,
+                                  double frag_tol = 0.05,
+                                  const std::string& frag_unit = "Da",
+                                  double prec_tol = 10.0,
+                                  const std::string& prec_unit = "ppm",
+                                  int missed_cleavages = 1,
+                                  int min_size = 5,
+                                  int max_size = 40)
+{
+  FragmentIndex_test fi;
+  Param p = fi.getParameters();
+  p.setValue("ions:add_b_ions", "true");
+  p.setValue("ions:add_y_ions", "true");
+  p.setValue("peptide:min_size", min_size);
+  p.setValue("peptide:max_size", max_size);
+  p.setValue("peptide:missed_cleavages", missed_cleavages);
+  p.setValue("peptide:min_mass", 0);
+  p.setValue("peptide:max_mass", 9000);
+  p.setValue("fragment:min_mz", 0);
+  p.setValue("fragment:max_mz", 90000);
+  p.setValue("fragment:mass_tolerance", frag_tol);
+  p.setValue("fragment:mass_tolerance_unit", frag_unit);
+  p.setValue("precursor:mass_tolerance", prec_tol);
+  p.setValue("precursor:mass_tolerance_unit", prec_unit);
+  p.setValue("precursor:min_charge", 1);
+  p.setValue("precursor:max_charge", 3);
+  fi.setParameters(p);
+
+  std::vector<FASTAFile::FASTAEntry> entries;
+  entries.push_back({"sp|TEST", "test protein", protein_seq});
+  fi.build(entries);
+  return fi;
+}
+
+// Helper: compare SIMD vs scalar query results for every peak in a spectrum
+bool simdScalarMatch(FragmentIndex_test& fi, const MSSpectrum& spec,
+                     const std::pair<size_t,size_t>& range, uint16_t charge,
+                     size_t& simd_count, size_t& scalar_count)
+{
+  bool match = true;
+  for (const auto& peak : spec)
+  {
+    auto simd_hits = fi.query(peak, range, charge);
+    auto scalar_hits = fi.queryScalar(peak, range, charge);
+    simd_count += simd_hits.size();
+    scalar_count += scalar_hits.size();
+    if (simd_hits.size() != scalar_hits.size()) match = false;
+  }
+  return match;
+}
+
 //////////////////////////////
 START_TEST(FragmentIndex, "$Id")
 
@@ -426,105 +478,307 @@ START_SECTION(tolerance)
 }
 END_SECTION
 
+START_SECTION(simd_scalar_equivalence_basic)
+{
+  // Test SIMD vs scalar equivalence with a standard protein
+  auto fi = buildTestIndex(
+    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIERIHFHTYRQVKAFPAYQLDKK"
+    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR");
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  // Test with multiple peptides at different charges
+  std::vector<std::string> test_peptides = {
+    "EVAEAATGEDASSPPPK", "MDAILR", "GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER",
+    "AFPAYQLDKK", "DYTRIVFVEDPTFHQIITSLENYR"
+  };
+
+  for (const auto& pep_str : test_peptides)
+  {
+    AASequence pep = AASequence::fromString(pep_str);
+    for (int charge = 1; charge <= 3; ++charge)
+    {
+      MSSpectrum spec;
+      tsg.getSpectrum(spec, pep, charge, charge);
+      float prec_mz = pep.getMZ(charge);
+      auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+      size_t simd_n = 0, scalar_n = 0;
+      TEST_TRUE(simdScalarMatch(fi, spec, range, charge, simd_n, scalar_n))
+      TEST_EQUAL(simd_n, scalar_n)
+    }
+  }
+}
+END_SECTION
+
+START_SECTION(simd_scalar_equivalence_real_fasta)
+{
+  // Use the SSE/Comet test FASTA (real protein sequences)
+  auto fi = buildTestIndex(
+    // proteins.fasta test sequence
+    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV"
+    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV"
+    "AXXSTFDFYQRRLVTLAESPRAPSP"
+    "GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFKVPSVPTRPSGIFRRPSRIKPEFSFKEKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQRTFKSDFQSV",
+    0.05, "Da", 10.0, "ppm", 2); // 2 missed cleavages for more peptides
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  // Query with multiple known peptides from this sequence
+  std::vector<std::string> peps = {"GSMTVDMQEIGSTEMPYEVPTQPNATSA", "GWFDGPSFK", "VPSVPTR",
+                                    "PSGIFR", "EKVSELVSPAVYTFGLFVQNASESLTSDDPSDVPTQR"};
+  for (const auto& p : peps)
+  {
+    AASequence pep = AASequence::fromString(p);
+    MSSpectrum spec;
+    tsg.getSpectrum(spec, pep, 1, 1);
+    float prec_mz = pep.getMZ(1);
+    auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+    size_t simd_n = 0, scalar_n = 0;
+    TEST_TRUE(simdScalarMatch(fi, spec, range, 1, simd_n, scalar_n))
+    TEST_EQUAL(simd_n, scalar_n)
+  }
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_empty_range)
+{
+  // Edge case: empty peptide range [k, k) — should produce 0 hits in both
+  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR");
+
+  Peak1D peak;
+  peak.setMZ(500.0);
+  peak.setIntensity(1.0);
+
+  // Use a precursor mass that doesn't match anything
+  auto range = fi.getPeptidesInPrecursorRange(99999.0f, {0.0f, 0.0f});
+  TEST_EQUAL(range.first, range.second) // empty range
+
+  auto simd_hits = fi.query(peak, range, 1);
+  auto scalar_hits = fi.queryScalar(peak, range, 1);
+  TEST_EQUAL(simd_hits.size(), 0)
+  TEST_EQUAL(scalar_hits.size(), 0)
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_single_fragment_bucket)
+{
+  // Edge case: very short protein producing < 4 fragments (tests scalar remainder path only)
+  auto fi = buildTestIndex("AAAAAKR", 0.05, "Da", 10.0, "ppm", 0, 5, 7);
+
+  Peak1D peak;
+  peak.setMZ(300.0);
+  peak.setIntensity(1.0);
+  auto range = fi.getPeptidesInPrecursorRange(300.0f, {-300.0f, 300.0f});
+
+  auto simd_hits = fi.query(peak, range, 1);
+  auto scalar_hits = fi.queryScalar(peak, range, 1);
+  TEST_EQUAL(simd_hits.size(), scalar_hits.size())
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_ppm_tolerance)
+{
+  // Edge case: ppm tolerance instead of Da
+  auto fi = buildTestIndex(
+    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER",
+    20.0, "ppm"); // 20 ppm fragment tolerance
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
+  MSSpectrum spec;
+  tsg.getSpectrum(spec, pep, 2, 2);
+  float prec_mz = pep.getMZ(2);
+  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+
+  size_t simd_n = 0, scalar_n = 0;
+  TEST_TRUE(simdScalarMatch(fi, spec, range, 2, simd_n, scalar_n))
+  TEST_EQUAL(simd_n, scalar_n)
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_tolerance_boundary)
+{
+  // Edge case: peaks right at tolerance boundary
+  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR", 0.01, "Da");
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
+  MSSpectrum spec;
+  tsg.getSpectrum(spec, pep, 1, 1);
+
+  // Shift all peaks by exactly the tolerance (0.01 Da) — should still match
+  MSSpectrum shifted_spec;
+  for (const auto& peak : spec)
+  {
+    Peak1D p;
+    p.setMZ(peak.getMZ() + 0.009); // just inside tolerance
+    p.setIntensity(peak.getIntensity());
+    shifted_spec.push_back(p);
+  }
+
+  float prec_mz = pep.getMZ(1);
+  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+
+  size_t simd_n = 0, scalar_n = 0;
+  TEST_TRUE(simdScalarMatch(fi, shifted_spec, range, 1, simd_n, scalar_n))
+  TEST_EQUAL(simd_n, scalar_n)
+
+  // Shift peaks just outside tolerance — should produce 0 hits
+  MSSpectrum outside_spec;
+  for (const auto& peak : spec)
+  {
+    Peak1D p;
+    p.setMZ(peak.getMZ() + 0.02); // outside 0.01 Da tolerance
+    p.setIntensity(peak.getIntensity());
+    outside_spec.push_back(p);
+  }
+
+  size_t simd_n2 = 0, scalar_n2 = 0;
+  TEST_TRUE(simdScalarMatch(fi, outside_spec, range, 1, simd_n2, scalar_n2))
+  TEST_EQUAL(simd_n2, scalar_n2)
+  TEST_EQUAL(simd_n2, 0)
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_multi_charge)
+{
+  // Edge case: multiple fragment charges
+  auto fi = buildTestIndex(
+    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER"
+    "IHFHTYRQVKAFPAYQLDKKMGKDYTRIVFVEDPTFHQIITSLENYR");
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  AASequence pep = AASequence::fromString("GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
+  MSSpectrum spec;
+  tsg.getSpectrum(spec, pep, 1, 3); // generate ions at charges 1-3
+
+  float prec_mz = pep.getMZ(3);
+  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+
+  // Test with fragment charges 1, 2, and 3
+  for (uint16_t fc = 1; fc <= 3; ++fc)
+  {
+    size_t simd_n = 0, scalar_n = 0;
+    TEST_TRUE(simdScalarMatch(fi, spec, range, fc, simd_n, scalar_n))
+    TEST_EQUAL(simd_n, scalar_n)
+  }
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_wide_precursor_window)
+{
+  // Edge case: wide precursor window (many candidates spanning multiple buckets)
+  auto fi = buildTestIndex(
+    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER"
+    "IHFHTYRQVKAFPAYQLDKKMGKDYTRIVFVEDPTFHQIITSLENYR"
+    "SMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR",
+    0.05, "Da", 500.0, "Da"); // very wide precursor tolerance
+
+  TheoreticalSpectrumGenerator tsg;
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
+
+  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
+  MSSpectrum spec;
+  tsg.getSpectrum(spec, pep, 1, 1);
+
+  float prec_mz = pep.getMZ(1);
+  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
+
+  size_t simd_n = 0, scalar_n = 0;
+  TEST_TRUE(simdScalarMatch(fi, spec, range, 1, simd_n, scalar_n))
+  TEST_EQUAL(simd_n, scalar_n)
+  TEST_TRUE(simd_n > 0) // wide window should produce hits
+}
+END_SECTION
+
+START_SECTION(simd_scalar_edge_soa_invariants)
+{
+  // Verify SoA buffer alignment invariant (via fragmentsSorted which accesses both arrays)
+  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
+  TEST_TRUE(fi.fragmentsSorted())
+  TEST_TRUE(fi.peptidesSorted())
+}
+END_SECTION
+
 START_SECTION(benchmark_simd_vs_scalar)
 {
-  // Build a moderately sized index for benchmarking
-  FragmentIndex_test benchFI;
-  Param p = benchFI.getParameters();
-  p.setValue("ions:add_b_ions", "true");
-  p.setValue("ions:add_y_ions", "true");
-  p.setValue("ions:add_a_ions", "false");
-  p.setValue("ions:add_c_ions", "false");
-  p.setValue("ions:add_x_ions", "false");
-  p.setValue("ions:add_z_ions", "false");
-  p.setValue("peptide:min_size", 5);
-  p.setValue("peptide:max_size", 40);
-  p.setValue("peptide:missed_cleavages", 1);
-  p.setValue("peptide:min_mass", 0);
-  p.setValue("peptide:max_mass", 5000);
-  p.setValue("fragment:min_mz", 0);
-  p.setValue("fragment:max_mz", 90000);
-  p.setValue("fragment:mass_tolerance", 0.05);
-  p.setValue("fragment:mass_tolerance_unit", "Da");
-  p.setValue("precursor:mass_tolerance", 10.0);
-  p.setValue("precursor:mass_tolerance_unit", "ppm");
-  p.setValue("precursor:min_charge", 1);
-  p.setValue("precursor:max_charge", 1);
-  p.setValue("search:max_fragment_charge", 1);
-  benchFI.setParameters(p);
-
-  // Use a larger protein for more fragments
-  std::vector<FASTAFile::FASTAEntry> bench_entries;
-  bench_entries.push_back({"sp|BENCH", "Benchmark protein",
+  auto fi = buildTestIndex(
     "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIERIHFHTYRQVKAFPAYQLDKK"
-    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR"});
+    "MGKDYTRIVFVEDPTFHQIITSLENYRSMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR");
 
-  benchFI.build(bench_entries);
-
-  // Generate a test spectrum from the first peptide
   TheoreticalSpectrumGenerator tsg;
-  auto tsg_params = tsg.getParameters();
-  tsg_params.setValue("add_b_ions", "true");
-  tsg_params.setValue("add_y_ions", "true");
-  tsg.setParameters(tsg_params);
+  auto tp = tsg.getParameters();
+  tp.setValue("add_b_ions", "true");
+  tp.setValue("add_y_ions", "true");
+  tsg.setParameters(tp);
 
-  AASequence test_pep = AASequence::fromString("EVAEAATGEDASSPPPK");
-  MSSpectrum theo_spec;
-  tsg.getSpectrum(theo_spec, test_pep, 1, 1);
-
-  float precursor_mz = test_pep.getMonoWeight(Residue::Full, 1) + Constants::PROTON_MASS_U;
-  auto candidates_range = benchFI.getPeptidesInPrecursorRange(precursor_mz, {0.0f, 0.0f});
+  AASequence pep = AASequence::fromString("GLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
+  MSSpectrum spec;
+  tsg.getSpectrum(spec, pep, 1, 1);
+  float prec_mz = pep.getMZ(1);
+  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
 
   // Warm up
   for (int w = 0; w < 10; ++w)
-  {
-    for (const auto& peak : theo_spec)
+    for (const auto& peak : spec)
     {
-      benchFI.query(peak, candidates_range, 1);
-      benchFI.queryScalar(peak, candidates_range, 1);
+      fi.query(peak, range, 1);
+      fi.queryScalar(peak, range, 1);
     }
-  }
 
   const int ITERATIONS = 1000;
 
-  // Benchmark SIMD
   auto t0 = std::chrono::high_resolution_clock::now();
-  size_t simd_total_hits = 0;
+  size_t simd_total = 0;
   for (int iter = 0; iter < ITERATIONS; ++iter)
-  {
-    for (const auto& peak : theo_spec)
-    {
-      auto hits = benchFI.query(peak, candidates_range, 1);
-      simd_total_hits += hits.size();
-    }
-  }
+    for (const auto& peak : spec)
+      simd_total += fi.query(peak, range, 1).size();
   auto t1 = std::chrono::high_resolution_clock::now();
 
-  // Benchmark Scalar
+  size_t scalar_total = 0;
   auto t2 = std::chrono::high_resolution_clock::now();
-  size_t scalar_total_hits = 0;
   for (int iter = 0; iter < ITERATIONS; ++iter)
-  {
-    for (const auto& peak : theo_spec)
-    {
-      auto hits = benchFI.queryScalar(peak, candidates_range, 1);
-      scalar_total_hits += hits.size();
-    }
-  }
+    for (const auto& peak : spec)
+      scalar_total += fi.queryScalar(peak, range, 1).size();
   auto t3 = std::chrono::high_resolution_clock::now();
 
   double simd_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
   double scalar_ms = std::chrono::duration<double, std::milli>(t3 - t2).count();
 
   std::cout << "\n=== FragmentIndex Query Benchmark ===" << std::endl;
-  std::cout << "Iterations: " << ITERATIONS << " x " << theo_spec.size() << " peaks" << std::endl;
-  std::cout << "SIMD:   " << simd_ms << " ms (hits: " << simd_total_hits << ")" << std::endl;
-  std::cout << "Scalar: " << scalar_ms << " ms (hits: " << scalar_total_hits << ")" << std::endl;
+  std::cout << "Iterations: " << ITERATIONS << " x " << spec.size() << " peaks" << std::endl;
+  std::cout << "SIMD:   " << simd_ms << " ms (hits: " << simd_total << ")" << std::endl;
+  std::cout << "Scalar: " << scalar_ms << " ms (hits: " << scalar_total << ")" << std::endl;
   std::cout << "Speedup: " << (scalar_ms / simd_ms) << "x" << std::endl;
   std::cout << "======================================\n" << std::endl;
 
-  // Verify both produce identical results
-  TEST_EQUAL(simd_total_hits, scalar_total_hits)
+  TEST_EQUAL(simd_total, scalar_total)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -80,15 +80,14 @@ public:
   // This captures the two-dimensional ordering constraint of the index.
   bool fragmentsSorted()
   {
-    if (fi_fragment_mzs_.size() != fi_fragment_peptide_idxs_.size()) return false;
-    for (size_t fi_idx = 0; fi_idx < fi_fragment_mzs_.size(); fi_idx += bucketsize_)
+    for (size_t fi_idx = 0; fi_idx < fi_fragments_.size(); fi_idx += bucketsize_)
     {
       UInt32 last_idx = 0;
-      const size_t end = std::min(fi_idx + bucketsize_, fi_fragment_mzs_.size());
+      const size_t end = (fi_idx + bucketsize_ > fi_fragments_.size()) ? fi_fragments_.size() : (fi_idx + bucketsize_);
       for (size_t bucket_idx = fi_idx; bucket_idx < end; ++bucket_idx)
       {
-        if (fi_fragment_peptide_idxs_[bucket_idx] < last_idx) return false;
-        last_idx = fi_fragment_peptide_idxs_[bucket_idx];
+        if (fi_fragments_[bucket_idx].peptide_idx_ < last_idx) return false;
+        last_idx = fi_fragments_[bucket_idx].peptide_idx_;
       }
     }
     return true;
@@ -160,41 +159,6 @@ public:
     return test;
   }
 };
-
-// Helper: build a FragmentIndex with given params and protein sequence
-FragmentIndex_test buildTestIndex(const std::string& protein_seq,
-                                  double frag_tol = 0.05,
-                                  const std::string& frag_unit = "Da",
-                                  double prec_tol = 10.0,
-                                  const std::string& prec_unit = "ppm",
-                                  int missed_cleavages = 1,
-                                  int min_size = 5,
-                                  int max_size = 40)
-{
-  FragmentIndex_test fi;
-  Param p = fi.getParameters();
-  p.setValue("ions:add_b_ions", "true");
-  p.setValue("ions:add_y_ions", "true");
-  p.setValue("peptide:min_size", min_size);
-  p.setValue("peptide:max_size", max_size);
-  p.setValue("peptide:missed_cleavages", missed_cleavages);
-  p.setValue("peptide:min_mass", 0);
-  p.setValue("peptide:max_mass", 9000);
-  p.setValue("fragment:min_mz", 0);
-  p.setValue("fragment:max_mz", 90000);
-  p.setValue("fragment:mass_tolerance", frag_tol);
-  p.setValue("fragment:mass_tolerance_unit", frag_unit);
-  p.setValue("precursor:mass_tolerance", prec_tol);
-  p.setValue("precursor:mass_tolerance_unit", prec_unit);
-  p.setValue("precursor:min_charge", 1);
-  p.setValue("precursor:max_charge", 3);
-  fi.setParameters(p);
-
-  std::vector<FASTAFile::FASTAEntry> entries;
-  entries.push_back({"sp|TEST", "test protein", protein_seq});
-  fi.build(entries);
-  return fi;
-}
 
 //////////////////////////////
 START_TEST(FragmentIndex, "$Id")
@@ -458,145 +422,6 @@ START_SECTION(tolerance)
     }
   }
   TEST_TRUE(found);
-}
-END_SECTION
-
-
-START_SECTION(query_edge_empty_range)
-{
-  // Edge case: empty peptide range [k, k) — should produce 0 hits
-  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR");
-
-  Peak1D peak;
-  peak.setMZ(500.0);
-  peak.setIntensity(1.0);
-
-  auto range = fi.getPeptidesInPrecursorRange(99999.0f, {0.0f, 0.0f});
-  TEST_EQUAL(range.first, range.second)
-
-  auto hits = fi.query(peak, range, 1);
-  TEST_EQUAL(hits.size(), 0)
-}
-END_SECTION
-
-START_SECTION(query_edge_small_bucket)
-{
-  // Edge case: very short protein producing few fragments
-  auto fi = buildTestIndex("AAAAAKR", 0.05, "Da", 10.0, "ppm", 0, 5, 7);
-
-  Peak1D peak;
-  peak.setMZ(300.0);
-  peak.setIntensity(1.0);
-  auto range = fi.getPeptidesInPrecursorRange(300.0f, {-300.0f, 300.0f});
-
-  auto hits = fi.query(peak, range, 1);
-  (void)hits;
-}
-END_SECTION
-
-START_SECTION(query_edge_ppm_tolerance)
-{
-  auto fi = buildTestIndex(
-    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER",
-    20.0, "ppm");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
-  MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 1, 1);
-  float prec_mz = pep.getMZ(1);
-  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-
-  size_t total_hits = 0;
-  for (const auto& peak : spec)
-    total_hits += fi.query(peak, range, 1).size();
-  TEST_TRUE(total_hits > 0)
-}
-END_SECTION
-
-START_SECTION(query_edge_tolerance_boundary)
-{
-  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILR", 0.01, "Da");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
-  MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 1, 1);
-  float prec_mz = pep.getMZ(1);
-  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-
-  // Peaks shifted just inside tolerance
-  MSSpectrum shifted;
-  for (const auto& peak : spec)
-  {
-    Peak1D p;
-    p.setMZ(peak.getMZ() + 0.009);
-    p.setIntensity(peak.getIntensity());
-    shifted.push_back(p);
-  }
-  size_t inside_hits = 0;
-  for (const auto& peak : shifted)
-    inside_hits += fi.query(peak, range, 1).size();
-  TEST_TRUE(inside_hits > 0)
-
-  // Peaks shifted outside tolerance
-  MSSpectrum outside;
-  for (const auto& peak : spec)
-  {
-    Peak1D p;
-    p.setMZ(peak.getMZ() + 0.02);
-    p.setIntensity(peak.getIntensity());
-    outside.push_back(p);
-  }
-  size_t outside_hits = 0;
-  for (const auto& peak : outside)
-    outside_hits += fi.query(peak, range, 1).size();
-  TEST_EQUAL(outside_hits, 0)
-}
-END_SECTION
-
-START_SECTION(query_edge_wide_precursor_window)
-{
-  auto fi = buildTestIndex(
-    "EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER"
-    "IHFHTYRQVKAFPAYQLDKKMGKDYTRIVFVEDPTFHQIITSLENYR"
-    "SMKARASNFKSARLAKYGVDLEKELVARFAQHTAIKNPNFTKLQGSR",
-    0.05, "Da", 500.0, "Da");
-
-  TheoreticalSpectrumGenerator tsg;
-  auto tp = tsg.getParameters();
-  tp.setValue("add_b_ions", "true");
-  tp.setValue("add_y_ions", "true");
-  tsg.setParameters(tp);
-
-  AASequence pep = AASequence::fromString("EVAEAATGEDASSPPPK");
-  MSSpectrum spec;
-  tsg.getSpectrum(spec, pep, 1, 1);
-  float prec_mz = pep.getMZ(1);
-  auto range = fi.getPeptidesInPrecursorRange(prec_mz, {0.0f, 0.0f});
-
-  size_t total_hits = 0;
-  for (const auto& peak : spec)
-    total_hits += fi.query(peak, range, 1).size();
-  TEST_TRUE(total_hits > 0)
-}
-END_SECTION
-
-START_SECTION(query_edge_soa_invariants)
-{
-  auto fi = buildTestIndex("EVAEAATGEDASSPPPKMDAILRGLNFEQLEEVIQTLHNAFSKENEPQLYPAIER");
-  TEST_TRUE(fi.fragmentsSorted())
-  TEST_TRUE(fi.peptidesSorted())
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -81,6 +81,7 @@ public:
   // This captures the two-dimensional ordering constraint of the index.
   bool fragmentsSorted()
   {
+    if (fi_fragment_mzs_.size() != fi_fragment_peptide_idxs_.size()) return false;
     for (size_t fi_idx = 0; fi_idx < fi_fragment_mzs_.size(); fi_idx += bucketsize_)
     {
       UInt32 last_idx = 0;
@@ -196,11 +197,16 @@ FragmentIndex_test buildTestIndex(const std::string& protein_seq,
   return fi;
 }
 
-// Helper: compare SIMD vs scalar query results for every peak in a spectrum
+// Helper: compare SIMD vs scalar query results for every peak in a spectrum.
+// Checks both hit count AND hit content (peptide_idx + fragment_mz).
 bool simdScalarMatch(FragmentIndex_test& fi, const MSSpectrum& spec,
                      const std::pair<size_t,size_t>& range, uint16_t charge,
                      size_t& simd_count, size_t& scalar_count)
 {
+  auto hitSortKey = [](const FragmentIndex::Hit& a, const FragmentIndex::Hit& b) {
+    return std::tie(a.peptide_idx, a.fragment_mz) < std::tie(b.peptide_idx, b.fragment_mz);
+  };
+
   bool match = true;
   for (const auto& peak : spec)
   {
@@ -208,7 +214,23 @@ bool simdScalarMatch(FragmentIndex_test& fi, const MSSpectrum& spec,
     auto scalar_hits = fi.queryScalar(peak, range, charge);
     simd_count += simd_hits.size();
     scalar_count += scalar_hits.size();
-    if (simd_hits.size() != scalar_hits.size()) match = false;
+    if (simd_hits.size() != scalar_hits.size())
+    {
+      match = false;
+      continue;
+    }
+    // Sort both and compare element-wise
+    std::sort(simd_hits.begin(), simd_hits.end(), hitSortKey);
+    std::sort(scalar_hits.begin(), scalar_hits.end(), hitSortKey);
+    for (size_t h = 0; h < simd_hits.size(); ++h)
+    {
+      if (simd_hits[h].peptide_idx != scalar_hits[h].peptide_idx ||
+          simd_hits[h].fragment_mz != scalar_hits[h].fragment_mz)
+      {
+        match = false;
+        break;
+      }
+    }
   }
   return match;
 }

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -509,7 +509,7 @@ START_SECTION(([EXTRA]String getStringOption_(const String& name) const))
 	p2.setValue("TOPPBaseTest:1:flag","false","flag description");
   p2.setValue("TOPPBaseTest:1:log","","Name of log file (created only when specified)");
 	p2.setValue("TOPPBaseTest:1:debug",0,"Sets the debug level");
-	p2.setValue("TOPPBaseTest:1:threads",1, "Sets the number of threads allowed to be used by the TOPP tool");
+	p2.setValue("TOPPBaseTest:1:threads",1, "Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)");
 	p2.setValue("TOPPBaseTest:1:no_progress","false","Disables progress logging to command line");
 	p2.setValue("TOPPBaseTest:1:force","false","Overwrite tool specific checks.");
 	p2.setValue("TOPPBaseTest:1:test","false","Enables the test mode (needed for software testing only)");

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2951,7 +2951,8 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys)
+    -Search:decoys
+    -threads 4)
 
   # SageAdapter DDA test: generate decoys externally (SageAdapter sets generate_decoys=false),
   # then search with Sage, then apply FDR filtering on hyperscore via FalseDiscoveryRate.

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2951,8 +2951,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:enzyme Trypsin/P
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
-    -Search:decoys
-    -threads 4)
+    -Search:decoys)
 
   # SageAdapter DDA test: generate decoys externally (SageAdapter sets generate_decoys=false),
   # then search with Sage, then apply FDR filtering on hyperscore via FalseDiscoveryRate.

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2992,7 +2992,8 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
       "-variable_modifications" "Oxidation (M)" "Acetyl (Protein N-term)"
       -chimera false
       -predict_rt false
-      -deisotope false)
+      -deisotope false
+      -min_ion_index 0)
     set_tests_properties("TOPP_SageAdapter_DDA" PROPERTIES DEPENDS "TOPP_DecoyDatabase_DDA")
 
     add_test("TOPP_FalseDiscoveryRate_SageDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2940,6 +2940,13 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:decoys
     -threads 4)
 
+  add_test("TOPP_FalseDiscoveryRate_SimpleSearchEngineDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
+    -in ${TESTS_TEMP_DIR}/SimpleSearchEngine_DDA_out.tmp.idXML
+    -out ${TESTS_TEMP_DIR}/SimpleSearchEngine_DDA_fdr.tmp.idXML
+    -FDR:PSM 0.01
+    -protein false)
+  set_tests_properties("TOPP_FalseDiscoveryRate_SimpleSearchEngineDDA" PROPERTIES DEPENDS "TOPP_SimpleSearchEngine_DDA")
+
   add_test("TOPP_PeptideDataBaseSearchFI_DDA" ${TOPP_BIN_PATH}/PeptideDataBaseSearchFI -test
     -in ${OPENTIMS_DDA_SYMLINK}
     -database ${OPENTIMS_TEST_FASTA}
@@ -2952,6 +2959,13 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
     -Search:peptide:missed_cleavages 2
     "-Search:modifications:variable" "Oxidation (M)" "Acetyl (Protein N-term)"
     -Search:decoys)
+
+  add_test("TOPP_FalseDiscoveryRate_PeptideDataBaseSearchFIDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test
+    -in ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_DDA_out.tmp.idXML
+    -out ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_DDA_fdr.tmp.idXML
+    -FDR:PSM 0.01
+    -protein false)
+  set_tests_properties("TOPP_FalseDiscoveryRate_PeptideDataBaseSearchFIDDA" PROPERTIES DEPENDS "TOPP_PeptideDataBaseSearchFI_DDA")
 
   # SageAdapter DDA test: generate decoys externally (SageAdapter sets generate_decoys=false),
   # then search with Sage, then apply FDR filtering on hyperscore via FalseDiscoveryRate.

--- a/src/tests/topp/Decharger_input.ini
+++ b/src/tests/topp/Decharger_input.ini
@@ -9,7 +9,7 @@
       <ITEM name="outpairs" value="" type="string" description="output file" tags="output file" restrictions="*.ConsensusXML" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Feature decharging algorithm section">

--- a/src/tests/topp/FeatureFinderCentroided_1_parameters.ini
+++ b/src/tests/topp/FeatureFinderCentroided_1_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="seeds" value="" type="string" description="User-specified seed list. This feature is not supported by all algorithms! (valid formats: &apos;featureXML&apos;)" tags="input file" />
       <ITEM name="log" value="TOPP.log" type="string" description="Location of the log file" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for software testing only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm section">

--- a/src/tests/topp/FeatureFinderMetabo.ini
+++ b/src/tests/topp/FeatureFinderMetabo.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="FeatureXML file with metabolite features" required="true" advanced="false" supported_formats="*.featureXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMetabo_2_noEPD.ini
+++ b/src/tests/topp/FeatureFinderMetabo_2_noEPD.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="FeatureXML file with metabolite features" required="true" advanced="false" supported_formats="*.featureXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMetabo_3.ini
+++ b/src/tests/topp/FeatureFinderMetabo_3.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_chrom" value="" type="output-file" description="Optional mzML file with chromatograms" required="false" advanced="false" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMetabo_4.ini
+++ b/src/tests/topp/FeatureFinderMetabo_4.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_chrom" value="" type="output-file" description="Optional mzML file with chromatograms" required="false" advanced="false" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMetabo_6.ini
+++ b/src/tests/topp/FeatureFinderMetabo_6.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="FeatureXML file with metabolite features" required="true" advanced="false" supported_formats="*.featureXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_10_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_10_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="out_blacklist" value="" type="output-file" description="Optional output file containing all peaks which have been associated with a peptide feature (and subsequently blacklisted)." required="false" advanced="true" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_11_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_11_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="out_blacklist" value="" type="output-file" description="Optional output file containing all peaks which have been associated with a peptide feature (and subsequently blacklisted)." required="false" advanced="true" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_1_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_1_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_2_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_2_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_3_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_3_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_4_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_4_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_5_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_5_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_6_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_6_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_7_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_7_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_8_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_8_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureFinderMultiplex_9_parameters.ini
+++ b/src/tests/topp/FeatureFinderMultiplex_9_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_multiplets" value="" type="output-file" description="Optional output file conatining all detected peptide groups (i.e. peptide pairs or triplets or singlets or ..). The m/z-RT positions correspond to the lightest peptide in each group." required="false" advanced="true" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerLabeled_1_parameters.ini
+++ b/src/tests/topp/FeatureLinkerLabeled_1_parameters.ini
@@ -7,7 +7,7 @@
        <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML" />
        <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
        <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
        <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
        <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerLabeled_2_parameters.ini
+++ b/src/tests/topp/FeatureLinkerLabeled_2_parameters.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="Output file" required="true" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_1_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_1_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_2_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_2_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="true" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_3_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_3_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerUnlabeledKD_4_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledKD_4_parameters.ini
@@ -10,7 +10,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_1_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_1_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_2_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_2_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="true" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_3_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_3_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeled_1_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeled_1_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeled_2_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeled_2_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeled_3_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeled_3_parameters.ini
@@ -10,7 +10,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FeatureLinkerUnlabeled_4_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeled_4_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/FuzzyDiff.ini
+++ b/src/tests/topp/FuzzyDiff.ini
@@ -17,7 +17,7 @@
       <ITEM name="first_column" value="1" type="int" description="number of first column, used for calculation of column numbers" required="false" advanced="false" restrictions="0:" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/GNPSExport_1_mostint.ini
+++ b/src/tests/topp/GNPSExport_1_mostint.ini
@@ -14,7 +14,7 @@
       <ITEM name="output_type" value="most_intense" type="string" description="specificity of mgf output information" required="false" advanced="false" restrictions="full_spectra,merged_spectra,most_intense" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/GNPSExport_2_merged.ini
+++ b/src/tests/topp/GNPSExport_2_merged.ini
@@ -14,7 +14,7 @@
       <ITEM name="output_type" value="merged_spectra" type="string" description="specificity of mgf output information" required="false" advanced="false" restrictions="full_spectra,merged_spectra,most_intense" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/GNPSExport_3_binsize.ini
+++ b/src/tests/topp/GNPSExport_3_binsize.ini
@@ -14,7 +14,7 @@
       <ITEM name="output_type" value="most_intense" type="string" description="specificity of mgf output information" required="false" advanced="false" restrictions="full_spectra,merged_spectra,most_intense" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/IDFileConverter_5_parameters.ini
+++ b/src/tests/topp/IDFileConverter_5_parameters.ini
@@ -14,7 +14,7 @@
       <ITEM name="scan_regex" value="scan=(?&lt;SCAN&gt;\d+)" type="string" description="[Mascot, pepXML, Percolator only] Regular expression used to extract the scan number or retention time. See documentation for details." required="false" advanced="true" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="true" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -32,7 +32,7 @@
         <ITEM name="faims_merge_features" value="true" type="string" description="For FAIMS data with multiple compensation voltages: Merge features representing the same analyte detected at different CV values into a single feature. Only features with DIFFERENT FAIMS CV values are merged (same CV = different analytes). Has no effect on non-FAIMS data." required="false" advanced="false" restrictions="true,false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
@@ -114,7 +114,7 @@
         <ITEM name="ignore_charge" value="false" type="bool" description="For feature/consensus maps: Assign an ID independently of whether its charge state matches that of the (consensus) feature." required="false" advanced="true" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
@@ -146,7 +146,7 @@
         <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/INIUpdater_2_broken.toppas
+++ b/src/tests/topp/INIUpdater_2_broken.toppas
@@ -31,7 +31,7 @@
         <ITEM name="seeds" value="" type="string" description="User-specified seed list. This feature is not supported by all algorithms!" tags="input file" restrictions="*.featureXML" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm section">
@@ -113,7 +113,7 @@
         <ITEM name="use_subelements" value="false" type="string" description="Match using RT and m/z of sub-features instead of consensus RT and m/z. A consensus feature matches if any of its sub-features matches." restrictions="true,false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       </NODE>
@@ -132,7 +132,7 @@
         <ITEM name="keep_subelements" value="false" type="string" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." restrictions="true,false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/INIUpdater_3_old.toppas
+++ b/src/tests/topp/INIUpdater_3_old.toppas
@@ -30,7 +30,7 @@
         <ITEM name="type" value="centroided" type="string" description="FeatureFinder algorithm type" restrictions="centroided,isotope_wavelet,mrm" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm section">
@@ -111,7 +111,7 @@
         <ITEM name="use_subelements" value="false" type="string" description="Match using RT and m/z of sub-features instead of consensus RT and m/z. A consensus feature matches if any of its sub-features matches." restrictions="true,false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       </NODE>
@@ -130,7 +130,7 @@
         <ITEM name="type" value="unlabeled" type="string" description="Feature grouping algorithm type" restrictions="labeled,unlabeled,unlabeled_qt" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -30,7 +30,7 @@
         <ITEM name="faims_merge_features" value="true" type="string" description="For FAIMS data with multiple compensation voltages: Merge features representing the same analyte detected at different CV values into a single feature. Only features with DIFFERENT FAIMS CV values are merged (same CV = different analytes). Has no effect on non-FAIMS data." required="false" advanced="false" restrictions="true,false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
@@ -112,7 +112,7 @@
         <ITEM name="ignore_charge" value="false" type="bool" description="For feature/consensus maps: Assign an ID independently of whether its charge state matches that of the (consensus) feature." required="false" advanced="true" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />
@@ -144,7 +144,7 @@
         <ITEM name="keep_subelements" value="false" type="bool" description="For consensusXML input only: If set, the sub-features of the inputs are transferred to the output." required="false" advanced="false" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
         <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
         <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/IsobaricAnalyzer.ini
+++ b/src/tests/topp/IsobaricAnalyzer.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output consensusXML file with quantitative information" required="true" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MapAlignerIdentification_parameters.ini
+++ b/src/tests/topp/MapAlignerIdentification_parameters.ini
@@ -11,7 +11,7 @@
       </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MapAlignerPoseClustering_1_parameters.ini
+++ b/src/tests/topp/MapAlignerPoseClustering_1_parameters.ini
@@ -11,7 +11,7 @@
       </ITEMLIST>
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MapAlignerPoseClustering_2_parameters.ini
+++ b/src/tests/topp/MapAlignerPoseClustering_2_parameters.ini
@@ -11,7 +11,7 @@
       </ITEMLIST>
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MapAlignerSpectrum_parameters.ini
+++ b/src/tests/topp/MapAlignerSpectrum_parameters.ini
@@ -11,7 +11,7 @@
       </ITEMLIST>
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/MapAlignerTreeGuided_parameters.ini
+++ b/src/tests/topp/MapAlignerTreeGuided_parameters.ini
@@ -12,7 +12,7 @@
       <ITEM name="copy_data" value="false" type="string" description="When aligning a large dataset with many files, load the input files twice and bypass copying." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/MapAlignerTreeGuided_parameters2.ini
+++ b/src/tests/topp/MapAlignerTreeGuided_parameters2.ini
@@ -12,7 +12,7 @@
       <ITEM name="copy_data" value="true" type="string" description="When aligning a large dataset with many files, load the input files twice and bypass copying." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overwrite tool specific checks." required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/MassTraceExtractor.ini
+++ b/src/tests/topp/MassTraceExtractor.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_type" value="" type="string" description="output file type -- default: determined from file extension or content" required="false" advanced="false" restrictions="featureXML,consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MassTraceExtractor_2.ini
+++ b/src/tests/topp/MassTraceExtractor_2.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="string" description="output featureXML file with mass traces" tags="output file,required" supported_formats="*.featureXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/MassTraceExtractor_3_expected.ini
+++ b/src/tests/topp/MassTraceExtractor_3_expected.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_type" value="" type="string" description="output file type -- default: determined from file extension or content" required="false" advanced="false" restrictions="featureXML,consensusXML" />
       <ITEM name="log" value="/some/path/to/log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="2" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="2" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/MassTraceExtractor_4.ini
+++ b/src/tests/topp/MassTraceExtractor_4.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_type" value="" type="string" description="output file type -- default: determined from file extension or content" required="false" advanced="false" restrictions="featureXML,consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/MultiplexResolver_1_parameters.ini
+++ b/src/tests/topp/MultiplexResolver_1_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_conflicts" value="" type="output-file" description="Optional output containing peptide multiplets without ID annotation or with conflicting quant/ID information." required="false" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MultiplexResolver_2_parameters.ini
+++ b/src/tests/topp/MultiplexResolver_2_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_conflicts" value="" type="output-file" description="Optional output containing peptide multiplets without ID annotation or with conflicting quant/ID information." required="false" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MultiplexResolver_3_parameters.ini
+++ b/src/tests/topp/MultiplexResolver_3_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="out_conflicts" value="" type="output-file" description="Optional output containing peptide multiplets without ID annotation or with conflicting quant/ID information." required="false" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/MultiplexResolver_4_parameters.ini
+++ b/src/tests/topp/MultiplexResolver_4_parameters.ini
@@ -9,7 +9,7 @@
       <ITEM name="out_conflicts" value="" type="output-file" description="Optional output containing peptide multiplets without ID annotation or with conflicting quant/ID information." required="false" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/NoiseFilterGaussian_2_parameters.ini
+++ b/src/tests/topp/NoiseFilterGaussian_2_parameters.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="string" description="output raw data file " tags="output file,required" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/NoiseFilterSGolay_2_parameters.ini
+++ b/src/tests/topp/NoiseFilterSGolay_2_parameters.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="string" description="output raw data file " tags="output file,required" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/NucleicAcidSearchEngine_1.ini
+++ b/src/tests/topp/NucleicAcidSearchEngine_1.ini
@@ -13,7 +13,7 @@
       <ITEM name="decharge_ms2" value="false" type="string" description="Decharge the MS2 spectra for scoring" required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/OpenNuXL_1_parameters.ini
+++ b/src/tests/topp/OpenNuXL_1_parameters.ini
@@ -19,7 +19,7 @@
       <ITEM name="peak_count" value="20" type="int" description="Retained peaks in peak window." required="false" advanced="true" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/OpenPepXL_input.ini
+++ b/src/tests/topp/OpenPepXL_input.ini
@@ -15,7 +15,7 @@
       <ITEM name="out_xquest_specxml" value="" type="output-file" description="Matched spectra in the xQuest .spec.xml format for spectra visualization in the xQuest results manager." required="false" advanced="false" supported_formats="*.spec.xml" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/OpenSwathAnalyzer_5.ini
+++ b/src/tests/topp/OpenSwathAnalyzer_5.ini
@@ -13,7 +13,7 @@
       <ITEM name="min_upper_edge_dist" value="0" type="double" description="[applies only if you have full MS2 spectra maps] Minimal distance to the edge to still consider a precursor, in Thomson (only in SWATH)" required="false" advanced="false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/OpenSwathAnalyzer_7_backgroundSubtraction.ini
+++ b/src/tests/topp/OpenSwathAnalyzer_7_backgroundSubtraction.ini
@@ -13,7 +13,7 @@
       <ITEM name="min_upper_edge_dist" value="0" type="double" description="[applies only if you have full MS2 spectra maps] Minimal distance to the edge to still consider a precursor, in Thomson (only in SWATH)" required="false" advanced="false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/PeakPickerHiRes_6.ini
+++ b/src/tests/topp/PeakPickerHiRes_6.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="inmemory" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="true" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/PeakPickerHiRes_parameters.ini
+++ b/src/tests/topp/PeakPickerHiRes_parameters.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="inmemory" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/PeakPickerIM_parameters_1.ini
+++ b/src/tests/topp/PeakPickerIM_parameters_1.ini
@@ -9,7 +9,7 @@
       <ITEM name="method" value="mobilogram" type="string" description="Method to pick peaks in IM dimension" required="false" advanced="true" restrictions="mobilogram,cluster,traces" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/PeakPickerIM_parameters_2.ini
+++ b/src/tests/topp/PeakPickerIM_parameters_2.ini
@@ -9,7 +9,7 @@
       <ITEM name="method" value="cluster" type="string" description="Method to pick peaks in IM dimension" required="false" advanced="true" restrictions="mobilogram,cluster,traces" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/PeakPickerIM_parameters_3.ini
+++ b/src/tests/topp/PeakPickerIM_parameters_3.ini
@@ -9,7 +9,7 @@
       <ITEM name="method" value="traces" type="string" description="Method to pick peaks in IM dimension" required="false" advanced="true" restrictions="mobilogram,cluster,traces" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/PeakPickerIterative_1.ini
+++ b/src/tests/topp/PeakPickerIterative_1.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="output file" required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/PeakPickerIterative_2.ini
+++ b/src/tests/topp/PeakPickerIterative_2.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="output file" required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/PeptideDataBaseSearchFI_1.ini
+++ b/src/tests/topp/PeptideDataBaseSearchFI_1.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="Search" description="">

--- a/src/tests/topp/PeptideDataBaseSearchFI_2.ini
+++ b/src/tests/topp/PeptideDataBaseSearchFI_2.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/SimpleSearchEngine_1.ini
+++ b/src/tests/topp/SimpleSearchEngine_1.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="Search" description="">

--- a/src/tests/topp/SimpleSearchEngine_2.ini
+++ b/src/tests/topp/SimpleSearchEngine_2.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_1.ini
@@ -57,7 +57,7 @@
       <ITEM name="require_variable_mod" value="false" type="bool" description="If true, requires at least one variable modification per peptide" required="false" advanced="true" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="true" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_3.ini
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_3.ini
@@ -63,7 +63,7 @@
       <ITEM name="require_variable_mod" value="false" type="bool" description="If true, requires at least one variable modification per peptide" required="false" advanced="true" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/THIRDPARTY/CometAdapter_5.ini
+++ b/src/tests/topp/THIRDPARTY/CometAdapter_5.ini
@@ -60,7 +60,7 @@
       <ITEM name="reindex" value="true" type="string" description="Recalculate peptide to protein association using OpenMS. Annotates target-decoy information." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1.ini
@@ -32,7 +32,7 @@
       <ITEM name="java_permgen" value="0" type="int" description="Maximum Java permanent generation space (in MB); only for Java 7 and below" required="false" advanced="true" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
     </NODE>

--- a/src/tests/topp/THIRDPARTY/MaRaClusterAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/MaRaClusterAdapter_1.ini
@@ -17,7 +17,7 @@
       <ITEM name="precursor_tolerance_units" value="ppm" type="string" description="tolerance_mass_units 0=ppm, 1=Da" required="false" advanced="true" restrictions="ppm,Da" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/THIRDPARTY/MaRaClusterAdapter_2.ini
+++ b/src/tests/topp/THIRDPARTY/MaRaClusterAdapter_2.ini
@@ -17,7 +17,7 @@
       <ITEM name="precursor_tolerance_units" value="ppm" type="string" description="tolerance_mass_units 0=ppm, 1=Da" required="false" advanced="true" restrictions="ppm,Da" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/THIRDPARTY/MascotAdapterOnline_1.ini
+++ b/src/tests/topp/THIRDPARTY/MascotAdapterOnline_1.ini
@@ -7,7 +7,7 @@
       <ITEM name="out" value="" type="output-file" description="output file in idXML format.#br#" required="true" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_1.ini
@@ -38,7 +38,7 @@
       <ITEM name="post_processing_tdc" value="false" type="string" description="Use target-decoy competition to assign q-values and PEPs." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/THIRDPARTY/SageAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/SageAdapter_1.ini
@@ -46,7 +46,7 @@
       <ITEM name="predict_rt" value="false" type="string" description="Sets predict_rt option (true or false), default: false" required="false" advanced="false" />
       <ITEM name="wide_window" value="false" type="string" description="Sets wide_window option (true or false), default: false" required="false" advanced="false" />
       <ITEM name="smoothing" value="false" type="string" description="Should the PTM histogram be smoothed and local maxima be picked. If false, uses raw data, default: false" required="false" advanced="false" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="reindex" value="true" type="string" description="Recalculate peptide to protein association using OpenMS. Annotates target-decoy information." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />

--- a/src/tests/topp/TMTElevenPlexMethod_test.ini
+++ b/src/tests/topp/TMTElevenPlexMethod_test.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output consensusXML file with quantitative information" required="true" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/TMTTenPlexMethod_test.ini
+++ b/src/tests/topp/TMTTenPlexMethod_test.ini
@@ -8,7 +8,7 @@
       <ITEM name="out" value="" type="output-file" description="output consensusXML file with quantitative information" required="true" advanced="false" supported_formats="*.consensusXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/TextExporter_2_parameters.ini
+++ b/src/tests/topp/TextExporter_2_parameters.ini
@@ -11,7 +11,7 @@
       <ITEM name="no_ids" value="true" type="string" description="Supresses output of identification data." restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="feature" description="Options for featureXML input files">

--- a/src/tests/topp/TextExporter_7_parameters.ini
+++ b/src/tests/topp/TextExporter_7_parameters.ini
@@ -11,7 +11,7 @@
       <ITEM name="no_ids" value="false" type="string" description="Suppresses output of identification data." required="false" advanced="false" restrictions="true,false" />
       <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/WRITE_INI_IN.ini
+++ b/src/tests/topp/WRITE_INI_IN.ini
@@ -8,7 +8,7 @@
       <ITEM name="write_peak_meta_data" value="false" type="string" description="Write additional information about the picked peaks (maximal intensity, left and right area...) into the mzML-file.Attention: this can blow up files,as 7 arrays are stored per spectrum!" tags="advanced" restrictions="true,false" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
       <ITEM name="debug" value="4" type="int" description=" -- should be updated" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="inmemory" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="4" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="bool" description="Disables progress logging to command line" required="false" advanced="true" />
       <ITEM name="force" value="false" type="bool" description="Overrides tool-specific checks" required="false" advanced="true" />
       <ITEM name="test" value="false" type="bool" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" />

--- a/src/tests/topp/degenerate_cases/PPHiRes_invalidParamName.ini
+++ b/src/tests/topp/degenerate_cases/PPHiRes_invalidParamName.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="inmemory" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="INVALIDPARAMNAME_BASE" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="INVALIDPARAMNAME_BASE" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/degenerate_cases/PPHiRes_invalidValue.ini
+++ b/src/tests/topp/degenerate_cases/PPHiRes_invalidValue.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="THISVALUEISINVALID" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/topp/degenerate_cases/PPHiRes_invalidValueSection.ini
+++ b/src/tests/topp/degenerate_cases/PPHiRes_invalidValueSection.ini
@@ -8,7 +8,7 @@
       <ITEM name="processOption" value="inmemory" type="string" description="Whether to load all data and process them in-memory or whether to process the data on the fly (lowmemory) without loading the whole file into memory first" required="false" advanced="true" restrictions="inmemory,lowmemory" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
       <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/tests/toppas/ExecutePipeline_1.toppas
+++ b/src/tests/toppas/ExecutePipeline_1.toppas
@@ -58,7 +58,7 @@
         <ITEM name="i" value="false" type="string" description="Check whether a given mzML file contains valid indices (conforming to the indexedmzML standard)" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
@@ -85,7 +85,7 @@
         <ITEM name="i" value="false" type="string" description="Check whether a given mzML file contains valid indices (conforming to the indexedmzML standard)" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
@@ -106,7 +106,7 @@
         <ITEM name="annotate_file_origin" value="false" type="string" description="Store the original filename in each feature using meta value &quot;file_origin&quot; (for featureXML and consensusXML only)." required="false" advanced="false" restrictions="true,false" />
         <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
-        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+        <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />
         <ITEM name="no_progress" value="true" type="string" description="Disables progress logging to command line" required="false" advanced="false" restrictions="true,false" />
         <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -87,6 +87,12 @@ class PeptideDataBaseSearchFI :
 
     ExitCodes main_(int, const char**) override
     {
+      // Use all available cores by default (like Sage), unless user explicitly set threads > 1
+      if (getIntOption_("threads") <= 1)
+      {
+        TOPPBase::setMaxNumberOfThreads(0);
+      }
+
       String in = getStringOption_("in");
       String database = getStringOption_("database");
       String out = getStringOption_("out");

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -87,12 +87,6 @@ class PeptideDataBaseSearchFI :
 
     ExitCodes main_(int, const char**) override
     {
-      // Use all available cores by default (like Sage), unless user explicitly set threads > 1
-      if (getIntOption_("threads") <= 1)
-      {
-        TOPPBase::setMaxNumberOfThreads(0);
-      }
-
       String in = getStringOption_("in");
       String database = getStringOption_("database");
       String out = getStringOption_("out");

--- a/src/topp/SimpleSearchEngine.cpp
+++ b/src/topp/SimpleSearchEngine.cpp
@@ -92,6 +92,12 @@ class SimpleSearchEngine :
 
     ExitCodes main_(int, const char**) override
     {
+      // Use all available cores by default (like Sage), unless user explicitly set threads > 1
+      if (getIntOption_("threads") <= 1)
+      {
+        TOPPBase::setMaxNumberOfThreads(0);
+      }
+
       String in = getStringOption_("in");
       String database = getStringOption_("database");
       String out = getStringOption_("out");

--- a/src/topp/SimpleSearchEngine.cpp
+++ b/src/topp/SimpleSearchEngine.cpp
@@ -92,12 +92,6 @@ class SimpleSearchEngine :
 
     ExitCodes main_(int, const char**) override
     {
-      // Use all available cores by default (like Sage), unless user explicitly set threads > 1
-      if (getIntOption_("threads") <= 1)
-      {
-        TOPPBase::setMaxNumberOfThreads(0);
-      }
-
       String in = getStringOption_("in");
       String database = getStringOption_("database");
       String out = getStringOption_("out");


### PR DESCRIPTION
## Summary

Overhaul of FragmentIndex build pipeline for dramatically faster peptide/fragment generation:

### Build performance
- **Per-thread vectors** replacing `#pragma omp critical` in peptide and fragment generation — eliminates serialization bottleneck
- **Residue mass lookup table** (`std::array<double, 128>`) populated from ResidueDB — replaces `AASequence::fromString` + `TheoreticalSpectrumGenerator` in the hot path
- `generateFragmentsLightweight_()` computes b/y/a/c/x/z ion m/z via cumulative sum — no string parsing, no object allocation
- **Parallel fragment sort** via `boost::sort::block_indirect_sort` — 4.6x speedup on global m/z sort (45s → 10s)

### Bitmask modification enumeration
- **Replaces `AASequence` + `ModifiedPeptideGenerator`** with direct bitmask enumeration of variable modification combinations
- Per-AA modification lookup tables built once from the config
- Scans peptide sequences to find variable mod slots `(position, mod_type, delta_mass)` — deterministic left-to-right ordering
- Enumerates valid `uint32_t` bitmask subsets with conflict detection (mutually exclusive bits for same-position mods)
- Computes precursor m/z as `base_mass + sum(selected deltas)` — pure arithmetic, no objects
- Fragment generation reconstructs per-residue delta arrays from bitmask on the fly
- `reconstructModifiedSequence()` for AASequence recovery at output time only (~1000 hits, not millions)
- Correctly handles `PROTEIN_N_TERM`/`PROTEIN_C_TERM` modifications based on peptide position in protein (improvement over `ModifiedPeptideGenerator` which silently skips these)

### Infrastructure
- `threads=0` support at TOPPBase level (`-threads 0` = all available cores)
- Thread-safe static initialization via `std::call_once`
- `#ifdef _OPENMP` guards on all OpenMP API calls (non-OpenMP build support)
- `std::popcount` instead of `__builtin_popcount` (MSVC compat)
- FDR filtering tests for SSE and FI DDA benchmarks
- Sage DDA test uses `min_ion_index 0` for fair comparison (match all ions like OpenMS engines)

## Benchmark

DDA TimsTOF HeLa + Human SwissProt (with decoys), Trypsin/P, 2 missed cleavages, Oxidation(M) + Acetyl(Protein N-term) variable, matched settings:

| Engine | Wall time | PSMs @ 1% FDR | Peak memory |
|--------|-----------|---------------|-------------|
| **PeptideDataBaseSearchFI** (this PR) | **59s** | **4,339** | **4,283 MB** |
| Sage 0.14.6 | 57s | 3,756 | 6,681 MB |

**45% faster** than the baseline (1m47s → 59s). Wall time now matches Sage. Identifies **15% more PSMs** with **36% less memory**.

Per-phase breakdown (this PR):

| Phase | Duration |
|-------|----------|
| Generate peptides | 2.5s |
| Sort peptides | 1.2s |
| Generate fragments | 6.6s |
| Sort fragments (Boost parallel) | 10.0s |
| Query/Score | 32s |
| **Total** | **59s** |

Note: Sage memory measured with `/usr/bin/time -v` on the actual process (SageAdapter reports only the 128 MB wrapper). Sage's `min_ion_index` was set to 0 for fair comparison (default 2 skips b1/b2/y1/y2 but only affects preliminary scoring — final PSM count is unchanged at 3,756).

## Test plan

- [x] All existing FragmentIndex tests pass (build, clear, querySpectrum, isotope_error, tolerance)
- [x] New `lightweight_fragment_count` test validates 2*(n-1) fragment count
- [x] New `multi_mod_per_site` and `fixed_plus_variable_mods` edge case tests
- [x] Cross-validation test comparing bitmask enumeration against `ModifiedPeptideGenerator` for 6 scenarios (terminal mods, multi-mod-per-site, mixed sites, no sites)
- [x] DDA benchmark results match baseline target/decoy ratio
- [x] FDR filtering tests for all three search engines
- [x] cppcheck passes
- [x] openms-ci-full passes (Linux gcc/clang/arm + macOS confirmed, Windows in progress)
- [ ] pyopenms-wheels build (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)