### PR TITLE
feat: default fragment:min_ion_index=2 in FragmentIndex (skip b1/b2/y1/y2)

### DIFF
--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1086,7 +1086,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
     defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
-    defaults_.setValue("fragment:min_ion_index", 0, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2 like Sage). Ions below this index are not added to the fragment index.");
+    defaults_.setValue("fragment:min_ion_index", 2, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2). Ions below this index are not added to the fragment index — they are often noisy and unreliable.");
     defaults_.setMinInt("fragment:min_ion_index", 0);
 
     vector<String> all_mods;

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -252,7 +252,7 @@ namespace OpenMS
 
     // Generate prefix ions (b, a, c) - left to right cumulative sum
     // Fragment charge is always 1 for the index (matching original TSG call)
-    // Ion index is 1-based: i=0 produces ion 1 (b1/a1/c1), so skip when (i+1) < min_ion_index_
+    // Ion index is 1-based: i=0 produces ion 1 (b1/a1/c1), so skip when (i+1) <= min_ion_index_
     if (add_b_ions_ || add_a_ions_ || add_c_ions_)
     {
       {
@@ -1086,7 +1086,7 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
     defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
-    defaults_.setValue("fragment:min_ion_index", 2, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2). Ions below this index are not added to the fragment index — they are often noisy and unreliable.");
+    defaults_.setValue("fragment:min_ion_index", 2, "Ions with index less than or equal to this value are not added to the fragment index (use 0 to include all ions; 2 skips b1/b2/y1/y2). Low-index ions are often noisy and unreliable.");
     defaults_.setMinInt("fragment:min_ion_index", 0);
 
     vector<String> all_mods;

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -89,7 +89,9 @@ namespace OpenMS
 
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
-    defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");    
+    defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
+    defaults_.setValue("fragment:min_ion_index", 2, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2). Ions below this index are not added to the fragment index — they are often noisy and unreliable.");
+    defaults_.setMinInt("fragment:min_ion_index", 0);
 
     defaults_.setSectionDescription("fragment", "Fragments (Product Ion) Options");
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -90,7 +90,7 @@ namespace OpenMS
 
     defaults_.setValue("fragment:min_mz", 150, "Minimal fragment mz for database");
     defaults_.setValue("fragment:max_mz", 2000, "Maximal fragment mz for database");
-    defaults_.setValue("fragment:min_ion_index", 2, "Minimum ion index to consider (0 = include all ions, 2 = skip b1/b2/y1/y2). Ions below this index are not added to the fragment index — they are often noisy and unreliable.");
+    defaults_.setValue("fragment:min_ion_index", 2, "Ions with index less than or equal to this value are not added to the fragment index (use 0 to include all ions; 2 skips b1/b2/y1/y2). Low-index ions are often noisy and unreliable.");
     defaults_.setMinInt("fragment:min_ion_index", 0);
 
     defaults_.setSectionDescription("fragment", "Fragments (Product Ion) Options");

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -284,6 +284,7 @@ START_SECTION(void querySpectrum(const MSSpectrum& spectrum, SpectrumMatchesTopN
   params.setValue("fragment:min_mz", 0);
   // ensure all peptides/fragments are generated for exhaustive self-hit checks
   params.setValue("fragment:max_mz", 5000000);
+  params.setValue("fragment:min_ion_index", 0);
   queryTest.setParameters(params);
 
   queryTest.build(entries);
@@ -372,6 +373,7 @@ START_SECTION(tolerance)
   auto params = tolTest.getParameters();
   params.setValue("fragment:min_mz", 0);
   params.setValue("fragment:max_mz", 90000);
+  params.setValue("fragment:min_ion_index", 0); // index all ions to verify all theoretical peaks match
   params.setValue("fragment:mass_tolerance", 0.05);
   params.setValue("fragment:mass_tolerance_unit", "Da");
   params.setValue("precursor:mass_tolerance", 2.0);
@@ -441,6 +443,7 @@ START_SECTION(lightweight_fragment_count)
   params.setValue("peptide:max_mass", 50000);
   params.setValue("fragment:min_mz", 0);
   params.setValue("fragment:max_mz", 50000);
+  params.setValue("fragment:min_ion_index", 0); // include all ions for this test
   params.setValue("modifications:variable", std::vector<std::string> {});
   params.setValue("modifications:fixed", std::vector<std::string> {});
   fcTest.setParameters(params);
@@ -482,6 +485,7 @@ START_SECTION(multi_mod_per_site)
   params.setValue("peptide:max_mass", 50000);
   params.setValue("fragment:min_mz", 0);
   params.setValue("fragment:max_mz", 50000);
+  params.setValue("fragment:min_ion_index", 0); // include all ions for fragment count check
   params.setValue("modifications:variable_max_per_peptide", 2);
   params.setValue("modifications:variable", std::vector<std::string> {"Oxidation (M)"});
   params.setValue("modifications:fixed", std::vector<std::string> {"Carbamidomethyl (C)"});
@@ -514,6 +518,7 @@ START_SECTION(fixed_plus_variable_mods)
   params.setValue("peptide:max_mass", 50000);
   params.setValue("fragment:min_mz", 0);
   params.setValue("fragment:max_mz", 50000);
+  params.setValue("fragment:min_ion_index", 0); // include all ions for fragment count check
   params.setValue("modifications:variable_max_per_peptide", 2);
   params.setValue("modifications:variable", std::vector<std::string> {"Oxidation (M)"});
   params.setValue("modifications:fixed", std::vector<std::string> {"Carbamidomethyl (C)"});

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2993,7 +2993,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
       -chimera false
       -predict_rt false
       -deisotope false
-      -min_ion_index 0)
+      -min_ion_index 2)
     set_tests_properties("TOPP_SageAdapter_DDA" PROPERTIES DEPENDS "TOPP_DecoyDatabase_DDA")
 
     add_test("TOPP_FalseDiscoveryRate_SageDDA" ${TOPP_BIN_PATH}/FalseDiscoveryRate -test


### PR DESCRIPTION
## Summary

Change the default value of `fragment:min_ion_index` from 0 to 2 in the FragmentIndex / PeptideDataBaseSearchFI search engine. This matches Sage's default behavior of excluding the four shortest fragment ions (b1, b2, y1, y2) which are often noisy and unreliable.

## Motivation

Low-index fragment ions (b1, b2, y1, y2) tend to:
- Have lower signal-to-noise ratios
- Match many random peaks across decoys
- Inflate the candidate count without improving discrimination

Removing them improves both speed and identification rate.

## Benchmark

DDA TimsTOF HeLa + Human SwissProt (with decoys), Trypsin/P, 2 missed cleavages, Oxidation(M) + Acetyl(Protein N-term) variable:

| Setting | Wall time | PSMs @ 1% FDR | Peak memory |
|---------|-----------|---------------|-------------|
| `min_ion_index=0` (previous default) | 59s | 4,339 | 4,283 MB |
| **`min_ion_index=2` (new default)** | **48s** | **4,374** | **3,984 MB** |

- **+35 PSMs** at 1% FDR (improved discrimination)
- **-11s** wall time (-19%)
- **-300 MB** peak memory (-7%)

## Changes

- `FragmentIndex.cpp`: change default from 0 to 2
- `PeptideSearchEngineFIAlgorithm.cpp`: expose `fragment:min_ion_index` parameter and set default 2
- `FragmentIndex_test.cpp`: update tests that depend on full ion counts to set `min_ion_index=0` explicitly (`lightweight_fragment_count`, `multi_mod_per_site`, `fixed_plus_variable_mods`, `querySpectrum`, `tolerance`)
- `tests/topp/CMakeLists.txt`: update Sage DDA benchmark to use `-min_ion_index 2` (matching new FI default for fair comparison)

## Test plan

- [x] FragmentIndex unit tests pass
- [x] TOPP unit tests pass (PeptideDataBaseSearchFI_1/2, SimpleSearchEngine_1/2)
- [x] DDA benchmark validates improved PSM count + speed + memory
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * New configurable minimum fragment ion index (default: 2). Low-index ions (e.g., b1/b2/y1/y2) are now excluded by default; help text updated to describe inclusive "less than or equal" behavior.
* **Tests**
  * Test and CI test-invocation updates to cover both exhaustive (include all ions) and default (skip low-index ions) configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->