### PR TITLE
build: bump minimum Boost version to 1.81

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ OpenMS/
 - Style checks: `ENABLE_STYLE_TESTING=ON` runs cpplint at `src/tests/coding/cpplint.py`.
 
 **Required dependencies:**
-- XercesC, Boost 1.78+ (date_time, regex, iostreams), Eigen3 (3.4.0+), libSVM (2.91+), COIN-OR or GLPK, ZLIB, BZip2, libcurl
+- XercesC, Boost 1.81+ (date_time, regex, iostreams), Eigen3 (3.4.0+), libSVM (2.91+), COIN-OR or GLPK, ZLIB, BZip2, libcurl
 - Qt6 (6.1.0+) — required for GUI (`openms_gui`); optional for TOPP tools, core library (`libOpenMS`), and pyOpenMS builds
 
 **Optional:** HDF5 (`-DWITH_HDF5=ON`)

--- a/cmake/build_system_macros.cmake
+++ b/cmake/build_system_macros.cmake
@@ -40,12 +40,9 @@ macro(find_boost)
     "1.84.1" "1.84.0" "1.84"
     "1.83.1" "1.83.0" "1.83"
     "1.82.1" "1.82.0" "1.82"
-    "1.81.1" "1.81.0" "1.81"
-    "1.80.1" "1.80.0" "1.80"
-    "1.79.1" "1.79.0" "1.79"
-    "1.78.1" "1.78.0" "1.78")
+    "1.81.1" "1.81.0" "1.81")
 
-  find_package(Boost 1.78.0 COMPONENTS ${ARGN} REQUIRED CONFIG)
+  find_package(Boost 1.81.0 COMPONENTS ${ARGN} REQUIRED CONFIG)
 
 endmacro(find_boost)
 

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -163,7 +163,7 @@ if (ENABLE_TDL)
 endif()
 
 # Use std::filesystem instead of boost::filesystem in boost::process (avoids linking boost_filesystem)
-# Requires Boost >= 1.78 (where BOOST_PROCESS_USE_STD_FS was introduced)
+# Requires Boost >= 1.81 (BOOST_PROCESS_USE_STD_FS was introduced in 1.78)
 target_compile_definitions(OpenMS PRIVATE BOOST_PROCESS_USE_STD_FS)
 
 if (WITH_OPENTIMS)


### PR DESCRIPTION
## Summary
1.81 offers very fast open addressing hash container.

- Raise the minimum required Boost version from 1.78 to 1.81 in `find_package(Boost ...)` and trim the `Boost_ADDITIONAL_VERSIONS` hint list accordingly
- Update the `AGENTS.md` dependency list and the explanatory comment next to `BOOST_PROCESS_USE_STD_FS`

## Test plan
- [ ] Configure and build OpenMS against Boost 1.81+ locally
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Boost library version requirement to 1.81 in build configuration and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->