### PR TITLE
[WIP] perf: hoist scoring objects in MRMFeatureFinderScoring

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -616,6 +616,15 @@ namespace OpenMS
     std::transform(precursor_chroms.begin(), precursor_chroms.end(), precursor_ids.begin(),
                    [](const auto& ch) { return ch.getNativeID(); });
 
+    // Copy params once per transition group, outside the OpenMP loop
+    Param dia_param = param_.copy("DIAScoring:", true);
+    DIAScoring local_diascoring;
+    local_diascoring.setParameters(dia_param);
+
+    Param emg_param = param_.copy("EMGScoring:", true);
+    EmgScoring local_emgscoring;
+    local_emgscoring.setFitterParam(emg_param);
+
     // Go through all peak groups (found MRM features) and score them
     #ifdef _OPENMP
     int in_parallel = omp_in_parallel();
@@ -702,7 +711,7 @@ namespace OpenMS
         // full spectra scores
         if (ms1_map_ && ms1_map_->getNrSpectra() > 0 && mrmfeature.getMZ() > 0)
         {
-          scorer.calculatePrecursorDIAScores(ms1_map_, diascoring_, precursor_mz, imrmfeature->getRT(), *pep, im_range, scores);
+          scorer.calculatePrecursorDIAScores(ms1_map_, local_diascoring, precursor_mz, imrmfeature->getRT(), *pep, im_range, scores);
         }
         if (su_.use_ms1_fullscan)
         {
@@ -742,7 +751,7 @@ namespace OpenMS
           std::vector<double> masserror_ppm;
           scorer.calculateDIAScores(imrmfeature,
                                     transition_group_detection.getTransitions(),
-                                    swath_maps, ms1_map_, diascoring_, *pep, scores, masserror_ppm,
+                                    swath_maps, ms1_map_, local_diascoring, *pep, scores, masserror_ppm,
                                     drift_target, im_range, mobilogram_consumer, feature_id);
           mrmfeature.setMetaValue("masserror_ppm", masserror_ppm);
         }
@@ -862,7 +871,7 @@ namespace OpenMS
         {
           //TODO wouldn't a weighted elution model score be much better? lower intensity traces usually will not have
           // a nice profile
-          scores.elution_model_fit_score = emgscoring_.calcElutionFitScore(mrmfeature, transition_group_detection);
+          scores.elution_model_fit_score = local_emgscoring.calcElutionFitScore(mrmfeature, transition_group_detection);
           mrmfeature.addScore("var_elution_model_fit_score", scores.elution_model_fit_score);
         }
 


### PR DESCRIPTION
## Description

Tried hoisting DIAScoring and EmgScoring to cut down on Param::copy overhead, but the Mtb benchmark (5.3GB) actually slowed down (User time: 35m 46s -> 41m 57s).

im wondering if sharing one object across OpenMP threads is causing cache contention or false sharing that offsets the parameter saving. in the original code, these were stack-allocated per feature.

does the team prefer thread-local storage here, or is there a better pattern in OpenMS for sharing these scorers safely?

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scoring calculations in MRM feature detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->