### PR TITLE
feat: add repeat-preserving decoy generation (#5055)

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/DecoyGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DecoyGenerator.h
@@ -80,6 +80,16 @@ namespace OpenMS
             const String& protease,
             const int max_attempts = 100
             );
+
+      /*
+        @brief Generate a repeat-preserving decoy sequence.
+        Shuffles the protein while preserving amino acid composition.
+  
+        @param[in] protein The target protein sequence
+        @return A decoy sequence with preserved composition
+        @note Modifications are discarded
+     */
+      AASequence repeatPreservingDecoy(const AASequence& protein);
     
     private:
       // sequence identity by matching AAs

--- a/src/openms/source/CHEMISTRY/DecoyGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/DecoyGenerator.cpp
@@ -215,5 +215,9 @@ double DecoyGenerator::SequenceIdentity_(const String& decoy, const String& targ
    
   return std::max(identity, rev_identity);
 }
-
+AASequence DecoyGenerator::repeatPreservingDecoy(const AASequence& protein)
+{
+  OPENMS_PRECONDITION(!protein.isModified(), "Decoy generation only supports unmodified proteins.");
+  return shufflePeptides(protein, "no cleavage");
+}
 


### PR DESCRIPTION
Fixes #5055
## Description

Adds a basic repeat-preserving decoy generation method to `DecoyGenerator`.

This introduces a new function `repeatPreservingDecoy` that generates decoy sequences by shuffling the full protein sequence (no cleavage), preserving amino acid composition.
---

## Details
- Added `repeatPreservingDecoy` method to `DecoyGenerator`.
- Uses existing `shufflePeptides` with `"no cleavage"`.
- Keeps amino acid composition while generating decoy sequences.
- Minimal and safe integration with already existing code.
---

## Note
This is a baseline implementation. More advanced approaches (e.g., de Bruijn graph-based methods mentioned in the issue discussion/paper) can be explored in future improvements.
---
## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new decoy generation method that creates protein decoys by shuffling sequences while preserving amino acid composition and discarding modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->