### PR TITLE
feat: ProteomicsLFQ MBRFilter to remove unreliable RT-outlier transfers

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/OpenMSConfig.h>
+
+#include <map>
+#include <utility>
+
+namespace OpenMS
+{
+  class ConsensusMap;
+
+  /**
+    @brief Post-link filter that removes unreliable match-between-runs (MBR) transferred
+           feature handles from a ConsensusMap based on pairwise RT residual statistics.
+
+    For each ConsensusFeature, handles whose source feature carries a peptide
+    identification act as "anchors". Pairs of handles in the same ConsensusFeature
+    that share the same modified peptide sequence and charge are used to populate
+    a per-map-pair distribution of RT residuals (median + robust sigma derived from MAD).
+
+    In a second pass, every handle that does NOT carry a peptide identification
+    (typical MBR transfer) is checked against all ID-bearing handles in its
+    ConsensusFeature: if its RT is statistically inconsistent with the per-pair
+    anchor distribution for the corresponding map pair, the handle is removed
+    and the consensus position is recomputed.
+
+    A pooled global distribution is used as fallback for map pairs with too few
+    anchors.
+
+    The filter operates strictly post-link and does not require access to the
+    source FeatureMaps: peptide identifications carry a "map_index" MetaValue
+    that ConsensusFeature::insert(map_index, BaseFeature) attaches at link time.
+
+    @ingroup FeatureGrouping
+  */
+  class OPENMS_DLLAPI ConsensusMapMBRFilter :
+    public DefaultParamHandler
+  {
+public:
+    /// Unordered pair of map indices, smaller index first
+    using PairKey = std::pair<UInt64, UInt64>;
+
+    /// Per-pair RT residual statistics
+    struct PairStats
+    {
+      Size   n         = 0;
+      double median    = 0.0;        ///< signed: rt(map_a) - rt(map_b), with a < b
+      double mad_sigma = 0.0;        ///< 1.4826 * MAD, floored to min_pair_sigma
+      Size   removals  = 0;          ///< number of unidentified handles removed in this pair
+    };
+
+    /// Per-map-pair report
+    struct Report
+    {
+      std::map<PairKey, PairStats> pair_stats;
+      PairStats                    pooled;
+      Size                         handles_removed = 0;
+    };
+
+    /// Default constructor; registers parameters via defaults_
+    ConsensusMapMBRFilter();
+
+    /// Destructor
+    ~ConsensusMapMBRFilter() override = default;
+
+    /**
+      @brief Run the filter on a ConsensusMap.
+
+      Mutates @p cmap by removing unreliable transferred FeatureHandles and
+      recomputing the consensus position of affected ConsensusFeatures.
+
+      @param[in,out] cmap ConsensusMap to be filtered
+      @return Report containing per-pair stats and removal counts
+    */
+    Report filter(ConsensusMap& cmap);
+  };
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/sources.cmake
@@ -5,6 +5,7 @@ set(directory include/OpenMS/ANALYSIS/MAPMATCHING)
 set(sources_list_h
 BaseGroupFinder.h
 BaseSuperimposer.h
+ConsensusMapMBRFilter.h
 ConsensusMapNormalizerAlgorithmThreshold.h
 ConsensusMapNormalizerAlgorithmMedian.h
 ConsensusMapNormalizerAlgorithmQuantile.h

--- a/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.cpp
@@ -1,0 +1,307 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h>
+
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/FeatureHandle.h>
+#include <OpenMS/MATH/StatisticFunctions.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace OpenMS
+{
+  namespace
+  {
+    /// Identity key derived from a peptide hit: modified sequence + charge.
+    using IdKey = std::pair<String, Int>;
+
+    /// Returns the highest-scoring PeptideHit from a PeptideIdentification (score-direction aware).
+    /// Caller must ensure pid.getHits() is not empty.
+    const PeptideHit& bestHit_(const PeptideIdentification& pid)
+    {
+      const auto& hits = pid.getHits();
+      if (pid.isHigherScoreBetter())
+      {
+        return *std::max_element(hits.begin(), hits.end(), PeptideHit::ScoreLess());
+      }
+      else
+      {
+        return *std::min_element(hits.begin(), hits.end(), PeptideHit::ScoreLess());
+      }
+    }
+
+    /// True if @p a is "better" than @p b under the PID's score direction.
+    bool scoreBetter_(double a, double b, bool higher_is_better)
+    {
+      return higher_is_better ? (a > b) : (a < b);
+    }
+
+    /// Build map<map_index, (modified_seq, charge)> for a ConsensusFeature.
+    /// For map indices that appear in multiple PIDs, retains the best-scoring hit.
+    /// Skips PIDs with no map_index meta value or no hits.
+    std::map<UInt64, IdKey>
+    buildMapIndexToIdKey_(const ConsensusFeature& cf)
+    {
+      std::map<UInt64, IdKey> result;
+      // remember the score of the currently-stored best hit per map_index
+      std::map<UInt64, std::pair<double, bool>> best_score;
+
+      for (const PeptideIdentification& pid : cf.getPeptideIdentifications())
+      {
+        if (pid.getHits().empty()) { continue; }
+        if (!pid.metaValueExists("map_index")) { continue; }
+        const UInt64 map_index = static_cast<UInt64>(pid.getMetaValue("map_index"));
+
+        const PeptideHit& hit = bestHit_(pid);
+        const double score = hit.getScore();
+        const bool higher = pid.isHigherScoreBetter();
+
+        auto it = best_score.find(map_index);
+        if (it == best_score.end() || scoreBetter_(score, it->second.first, higher))
+        {
+          result[map_index] = std::make_pair(hit.getSequence().toString(), hit.getCharge());
+          best_score[map_index] = std::make_pair(score, higher);
+        }
+      }
+      return result;
+    }
+  } // unnamed namespace
+
+  ConsensusMapMBRFilter::ConsensusMapMBRFilter() :
+    DefaultParamHandler("ConsensusMapMBRFilter")
+  {
+    defaults_.setValue("k_sigma", 3.0,
+                       "Multiplier on the per-pair robust sigma (1.4826*MAD) for the rejection threshold.");
+    defaults_.setMinFloat("k_sigma", 0.0);
+
+    defaults_.setValue("min_anchors_per_pair", 5,
+                       "Minimum number of anchor pairs (same modified sequence + charge) required to use a per-pair distribution. "
+                       "Pairs below this threshold use the pooled fallback if enabled.");
+    defaults_.setMinInt("min_anchors_per_pair", 2);
+
+    defaults_.setValue("reject_fraction", 0.5,
+                       "Fraction of ID-bearing handles in the same ConsensusFeature that must reject the unidentified handle "
+                       "for it to be removed.");
+    defaults_.setMinFloat("reject_fraction", 0.0);
+    defaults_.setMaxFloat("reject_fraction", 1.0);
+
+    defaults_.setValue("min_pair_sigma", 1.0,
+                       "Floor (in seconds) for the per-pair sigma derived from MAD. Avoids zero-MAD pathologies.");
+    defaults_.setMinFloat("min_pair_sigma", 0.0);
+
+    defaults_.setValue("use_pooled_fallback", "true",
+                       "If 'true', map pairs with fewer than 'min_anchors_per_pair' anchors fall back to the pooled distribution.");
+    defaults_.setValidStrings("use_pooled_fallback", {"true", "false"});
+
+    defaultsToParam_();
+  }
+
+  ConsensusMapMBRFilter::Report ConsensusMapMBRFilter::filter(ConsensusMap& cmap)
+  {
+    Report report;
+
+    const double k_sigma              = (double)param_.getValue("k_sigma");
+    const Size   min_anchors_per_pair = (Size)(int)param_.getValue("min_anchors_per_pair");
+    const double reject_fraction      = (double)param_.getValue("reject_fraction");
+    const double min_pair_sigma       = (double)param_.getValue("min_pair_sigma");
+    const bool   use_pooled_fallback  = param_.getValue("use_pooled_fallback").toBool();
+
+    constexpr double MAD_TO_SIGMA = 1.4826;
+
+    // Cache map_index → (mod_seq, charge) per ConsensusFeature so both passes share the same lookup.
+    std::vector<std::map<UInt64, IdKey>> cf_id_maps;
+    cf_id_maps.reserve(cmap.size());
+    for (const ConsensusFeature& cf : cmap)
+    {
+      cf_id_maps.push_back(buildMapIndexToIdKey_(cf));
+    }
+
+    // Computes median + robust sigma (1.4826 * MAD, floored to min_pair_sigma) on @p vec (modified in-place).
+    auto computeStats = [&](std::vector<double>& vec, PairStats& s)
+    {
+      s.n        = vec.size();
+      s.median   = Math::median(vec.begin(), vec.end(), false);
+      const double mad = Math::MAD(vec.begin(), vec.end(), s.median);
+      s.mad_sigma = std::max(min_pair_sigma, MAD_TO_SIGMA * mad);
+    };
+
+    // ----- Pass 1: collect anchor residuals per (smaller, larger) map pair -----
+    std::map<PairKey, std::vector<double>> raw_residuals;
+
+    for (Size cf_idx = 0; cf_idx < cmap.size(); ++cf_idx)
+    {
+      const ConsensusFeature& cf = cmap[cf_idx];
+      if (cf.size() < 2) { continue; }
+      const auto& map_to_idkey = cf_id_maps[cf_idx];
+      if (map_to_idkey.size() < 2) { continue; }
+
+      // The handle set is ordered by IndexLess (map_index ascending), so the
+      // outer/inner double-loop with j>i naturally gives map_i <= map_j.
+      const auto& handles = cf.getFeatures();
+      for (auto it_i = handles.begin(); it_i != handles.end(); ++it_i)
+      {
+        const UInt64 mi = it_i->getMapIndex();
+        auto k_i = map_to_idkey.find(mi);
+        if (k_i == map_to_idkey.end()) { continue; }
+
+        auto it_j = it_i;
+        ++it_j;
+        for (; it_j != handles.end(); ++it_j)
+        {
+          const UInt64 mj = it_j->getMapIndex();
+          if (mj <= mi) { continue; } // belt-and-braces: equal map_index would be a duplicate handle
+          auto k_j = map_to_idkey.find(mj);
+          if (k_j == map_to_idkey.end()) { continue; }
+          if (k_i->second != k_j->second) { continue; }
+
+          // signed: rt(map_i) - rt(map_j), with map_i < map_j
+          raw_residuals[{mi, mj}].push_back(it_i->getRT() - it_j->getRT());
+        }
+      }
+    }
+
+    // Compute per-pair stats
+    for (auto& kv : raw_residuals)
+    {
+      PairStats s;
+      computeStats(kv.second, s);
+      report.pair_stats[kv.first] = s;
+    }
+
+    // Compute pooled stats from pairs that already have enough anchors. Centering each
+    // residual by its own pair median measures spread independent of per-pair bias.
+    {
+      std::vector<double> pooled_centered;
+      for (const auto& kv : raw_residuals)
+      {
+        if (kv.second.size() < min_anchors_per_pair) { continue; }
+        const double pm = report.pair_stats[kv.first].median;
+        for (double r : kv.second)
+        {
+          pooled_centered.push_back(r - pm);
+        }
+      }
+      if (!pooled_centered.empty())
+      {
+        computeStats(pooled_centered, report.pooled);
+      }
+    }
+
+    // ----- Pass 2: filter unidentified handles -----
+    for (Size cf_idx = 0; cf_idx < cmap.size(); ++cf_idx)
+    {
+      ConsensusFeature& cf = cmap[cf_idx];
+      if (cf.size() < 2) { continue; }
+      const auto& map_to_idkey = cf_id_maps[cf_idx];
+      if (map_to_idkey.empty()) { continue; }
+
+      auto isAnchor = [&](UInt64 mi) { return map_to_idkey.find(mi) != map_to_idkey.end(); };
+
+      Size id_count = 0;
+      for (const auto& fh : cf.getFeatures())
+      {
+        if (isAnchor(fh.getMapIndex())) { ++id_count; }
+      }
+      if (id_count == 0) { continue; }
+      if (id_count == cf.size()) { continue; }
+
+      std::set<UInt64> remove_map_indices;
+      std::map<PairKey, Size> per_pair_remove;
+
+      for (const auto& h_t : cf.getFeatures())
+      {
+        const UInt64 mt = h_t.getMapIndex();
+        if (isAnchor(mt)) { continue; }
+
+        Size rejections = 0;
+        Size comparisons = 0;
+        PairKey worst_pair{0, 0};
+        double  worst_z = -std::numeric_limits<double>::infinity();
+
+        for (const auto& h_a : cf.getFeatures())
+        {
+          const UInt64 ma = h_a.getMapIndex();
+          if (!isAnchor(ma)) { continue; }
+
+          PairKey key = (mt < ma) ? PairKey{mt, ma} : PairKey{ma, mt};
+          // signed_dt aligned to (smaller, larger): rt(smaller) - rt(larger)
+          double signed_dt = (mt < ma) ? (h_t.getRT() - h_a.getRT())
+                                       : (h_a.getRT() - h_t.getRT());
+
+          double median = 0.0;
+          double sigma  = 0.0;
+          auto it = report.pair_stats.find(key);
+          if (it != report.pair_stats.end() && it->second.n >= min_anchors_per_pair)
+          {
+            median = it->second.median;
+            sigma  = it->second.mad_sigma;
+          }
+          else if (use_pooled_fallback && report.pooled.n >= min_anchors_per_pair)
+          {
+            median = 0.0;
+            sigma  = report.pooled.mad_sigma;
+          }
+          else
+          {
+            continue;
+          }
+
+          ++comparisons;
+          const double z = std::abs(signed_dt - median) / sigma;
+          if (z > k_sigma) { ++rejections; }
+          if (z > worst_z) { worst_z = z; worst_pair = key; }
+        }
+
+        if (comparisons == 0) { continue; }
+        const double frac = static_cast<double>(rejections) / static_cast<double>(comparisons);
+        if (frac >= reject_fraction && rejections > 0)
+        {
+          remove_map_indices.insert(mt);
+          per_pair_remove[worst_pair] += 1;
+        }
+      }
+
+      if (remove_map_indices.empty()) { continue; }
+
+      ConsensusFeature::HandleSetType kept;
+      for (const auto& fh : cf.getFeatures())
+      {
+        if (remove_map_indices.find(fh.getMapIndex()) == remove_map_indices.end())
+        {
+          kept.insert(fh);
+        }
+      }
+      // Should never become empty (id_count >= 1 always survives)
+      if (kept.empty()) { continue; }
+
+      cf.setFeatures(std::move(kept));
+      cf.computeConsensus();
+
+      report.handles_removed += remove_map_indices.size();
+      for (const auto& kv : per_pair_remove)
+      {
+        report.pair_stats[kv.first].removals += kv.second;
+      }
+    }
+
+    return report;
+  }
+
+} // namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/sources.cmake
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/sources.cmake
@@ -5,6 +5,7 @@ set(directory source/ANALYSIS/MAPMATCHING)
 set(sources_list
 BaseGroupFinder.cpp
 BaseSuperimposer.cpp
+ConsensusMapMBRFilter.cpp
 ConsensusMapNormalizerAlgorithmThreshold.cpp
 ConsensusMapNormalizerAlgorithmMedian.cpp
 ConsensusMapNormalizerAlgorithmQuantile.cpp

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -484,6 +484,7 @@ set(analysis_executables_list
   FalseDiscoveryRate_test
   FeatureDeconvolution_test
   FeatureDistance_test
+  ConsensusMapMBRFilter_test
   FeatureGroupingAlgorithmKD_test
   FeatureGroupingAlgorithmLabeled_test
   FeatureGroupingAlgorithmQT_test

--- a/src/tests/class_tests/openms/source/ConsensusMapMBRFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMapMBRFilter_test.cpp
@@ -1,0 +1,395 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h>
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/Feature.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+
+using namespace OpenMS;
+using namespace std;
+
+namespace
+{
+  /// Build a Feature with a unique id, RT, m/z, intensity, optional ID (sequence + charge).
+  Feature makeFeature(UInt64 unique_id, double rt, double mz, double intensity,
+                      const String& sequence = "", Int charge = 0)
+  {
+    Feature f;
+    f.setUniqueId(unique_id);
+    f.setRT(rt);
+    f.setMZ(mz);
+    f.setIntensity(intensity);
+    f.setCharge(charge);
+    if (!sequence.empty())
+    {
+      PeptideIdentification pid;
+      pid.setScoreType("score");
+      pid.setHigherScoreBetter(true);
+      PeptideHit hit;
+      hit.setSequence(AASequence::fromString(sequence));
+      hit.setCharge(charge);
+      hit.setScore(1.0);
+      pid.setHits({hit});
+      f.setPeptideIdentifications({pid});
+    }
+    return f;
+  }
+
+  /// Make a 4-map column header set on a ConsensusMap.
+  void setupHeaders(ConsensusMap& cmap, Size n_maps)
+  {
+    auto& headers = cmap.getColumnHeaders();
+    for (Size i = 0; i < n_maps; ++i)
+    {
+      ConsensusMap::ColumnHeader h;
+      h.filename = "map_" + String(i) + ".mzML";
+      h.label = "label_" + String(i);
+      h.size = 0;
+      h.unique_id = i + 1;
+      headers[i] = h;
+    }
+  }
+
+  /// Build a ConsensusFeature from features in maps. Each entry is (map_index, Feature).
+  /// Uses the ConsensusFeature::insert(map_index, BaseFeature) path so map_index gets
+  /// stamped onto every PID exactly as the linker does.
+  ConsensusFeature makeCF(const std::vector<std::pair<UInt64, Feature>>& items)
+  {
+    ConsensusFeature cf;
+    cf.setUniqueId(items.front().second.getUniqueId() * 1000ULL + items.size());
+    for (const auto& kv : items)
+    {
+      cf.insert(kv.first, kv.second);
+    }
+    cf.computeConsensus();
+    return cf;
+  }
+}
+
+START_TEST(ConsensusMapMBRFilter, "$Id$")
+
+ConsensusMapMBRFilter* ptr = nullptr;
+ConsensusMapMBRFilter* nullPointer = nullptr;
+START_SECTION((ConsensusMapMBRFilter()))
+{
+  ptr = new ConsensusMapMBRFilter();
+  TEST_NOT_EQUAL(ptr, nullPointer)
+}
+END_SECTION
+
+START_SECTION((~ConsensusMapMBRFilter()))
+{
+  delete ptr;
+}
+END_SECTION
+
+START_SECTION([EXTRA] CF with all handles ID-bearing is left untouched)
+{
+  ConsensusMap cmap;
+  setupHeaders(cmap, 2);
+  ConsensusFeature cf = makeCF({
+    {0, makeFeature(1, 100.0, 500.0, 1e5, "PEPTIDEK", 2)},
+    {1, makeFeature(2, 200.0, 500.0, 1e5, "PEPTIDEK", 2)} // both have IDs => no transfer to filter
+  });
+  cmap.push_back(cf);
+
+  ConsensusMapMBRFilter f;
+  auto rep = f.filter(cmap);
+  TEST_EQUAL(rep.handles_removed, 0)
+  TEST_EQUAL(cmap[0].size(), 2)
+}
+END_SECTION
+
+START_SECTION((Report filter(ConsensusMap& cmap)))
+{
+  ConsensusMap cmap;
+  setupHeaders(cmap, 4);
+
+  // -------- 12 clean anchor CFs across all map pairs --------
+  // Inject per-pair RT bias: rt(map_i) = base_rt + bias[i] + jitter
+  // bias[0]=0.0, bias[1]=0.5, bias[2]=-0.3, bias[3]=0.7
+  std::vector<double> bias = {0.0, 0.5, -0.3, 0.7};
+  std::vector<double> jitters = {-0.4, -0.2, 0.0, 0.2, 0.4, -0.3, 0.1, -0.1, 0.3, 0.0, -0.2, 0.2};
+  // distinct valid amino-acid sequences for the 12 anchor CFs
+  const char* anchor_seqs[12] = {
+    "PEPTIDEAK", "PEPTIDECK", "PEPTIDEDK", "PEPTIDEEK", "PEPTIDEFK", "PEPTIDEGK",
+    "PEPTIDEHK", "PEPTIDEIK", "PEPTIDELK", "PEPTIDEMK", "PEPTIDENK", "PEPTIDEQK"};
+  UInt64 uid = 100;
+  for (Size i = 0; i < 12; ++i)
+  {
+    const double base_rt = 100.0 + 50.0 * i;
+    const String seq = anchor_seqs[i];
+    std::vector<std::pair<UInt64, Feature>> items;
+    for (Size m = 0; m < 4; ++m)
+    {
+      items.emplace_back(m, makeFeature(uid++, base_rt + bias[m] + jitters[i], 500.0 + i, 1e5, seq, 2));
+    }
+    cmap.push_back(makeCF(items));
+  }
+
+  // -------- 5 CFs with consistent transfer (3 IDs + 1 ID-less, RT consistent) --------
+  // The unidentified handle in map 3 has RT consistent with the per-pair bias.
+  const char* consistent_seqs[5] = {"AAAAAAK", "AAAAACK", "AAAAADK", "AAAAAEK", "AAAAAFK"};
+  for (Size i = 0; i < 5; ++i)
+  {
+    const double base_rt = 1000.0 + 50.0 * i;
+    const String seq = consistent_seqs[i];
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(0, makeFeature(uid++, base_rt + bias[0], 600.0 + i, 1e5, seq, 2));
+    items.emplace_back(1, makeFeature(uid++, base_rt + bias[1], 600.0 + i, 1e5, seq, 2));
+    items.emplace_back(2, makeFeature(uid++, base_rt + bias[2], 600.0 + i, 1e5, seq, 2));
+    // ID-less in map 3, but RT close to the expected bias
+    items.emplace_back(3, makeFeature(uid++, base_rt + bias[3] + 0.1, 600.0 + i, 5e4));
+    cmap.push_back(makeCF(items));
+  }
+
+  // -------- 5 CFs with outlier transfer (3 IDs + 1 ID-less far away) --------
+  const char* outlier_seqs[5] = {"GGGGGGK", "GGGGGAK", "GGGGGCK", "GGGGGDK", "GGGGGEK"};
+  for (Size i = 0; i < 5; ++i)
+  {
+    const double base_rt = 2000.0 + 50.0 * i;
+    const String seq = outlier_seqs[i];
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(0, makeFeature(uid++, base_rt + bias[0], 700.0 + i, 1e5, seq, 2));
+    items.emplace_back(1, makeFeature(uid++, base_rt + bias[1], 700.0 + i, 1e5, seq, 2));
+    items.emplace_back(2, makeFeature(uid++, base_rt + bias[2], 700.0 + i, 1e5, seq, 2));
+    // ID-less in map 3, but 30 seconds off the expected RT
+    items.emplace_back(3, makeFeature(uid++, base_rt + bias[3] + 30.0, 700.0 + i, 5e4));
+    cmap.push_back(makeCF(items));
+  }
+
+  // -------- Edge case: singleton CF (1 handle) --------
+  cmap.push_back(makeCF({{0, makeFeature(uid++, 5000.0, 800.0, 1e5, "SOLO", 2)}}));
+
+  // -------- Edge case: all-no-ID CF --------
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    for (Size m = 0; m < 4; ++m)
+    {
+      items.emplace_back(m, makeFeature(uid++, 6000.0 + m, 900.0, 1e5));
+    }
+    cmap.push_back(makeCF(items));
+  }
+
+  // -------- Edge case: all-IDs CF (no transfers to filter) --------
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    for (Size m = 0; m < 4; ++m)
+    {
+      items.emplace_back(m, makeFeature(uid++, 7000.0 + bias[m], 1000.0, 1e5, "ALLID", 2));
+    }
+    cmap.push_back(makeCF(items));
+  }
+
+  // ---- run filter ----
+  ConsensusMapMBRFilter f;
+  Param p = f.getParameters();
+  p.setValue("k_sigma", 3.0);
+  p.setValue("min_anchors_per_pair", 5);
+  p.setValue("reject_fraction", 0.5);
+  p.setValue("min_pair_sigma", 0.5);
+  p.setValue("use_pooled_fallback", "true");
+  f.setParameters(p);
+
+  auto rep = f.filter(cmap);
+
+  // Pair (0,1) anchors: 12 clean CFs + 5 consistent-transfer (both maps 0/1 have IDs)
+  // + 5 outlier-transfer (also both have IDs) + 1 all-IDs CF = 23 anchors.
+  // Median: rt(0) - rt(1) = -bias[1] = -0.5.
+  const ConsensusMapMBRFilter::PairKey k01(0, 1);
+  TEST_EQUAL(rep.pair_stats.count(k01), 1)
+  const ConsensusMapMBRFilter::PairStats& s01 = rep.pair_stats[k01];
+  TEST_EQUAL(s01.n, 23)
+  TEST_REAL_SIMILAR(s01.median, -0.5)
+  // sigma should be small but positive (floored at min_pair_sigma)
+  const bool sigma_ok = (s01.mad_sigma >= 0.5);
+  TEST_EQUAL(sigma_ok, true)
+
+  // All 12 anchor CFs untouched
+  for (Size i = 0; i < 12; ++i)
+  {
+    TEST_EQUAL(cmap[i].size(), 4)
+  }
+  // 5 consistent transfer CFs untouched
+  for (Size i = 12; i < 17; ++i)
+  {
+    TEST_EQUAL(cmap[i].size(), 4)
+  }
+  // 5 outlier transfer CFs each lost their map-3 handle
+  for (Size i = 17; i < 22; ++i)
+  {
+    TEST_EQUAL(cmap[i].size(), 3)
+    // The remaining handles are exactly maps 0..2
+    Size mask = 0;
+    for (const auto& fh : cmap[i].getFeatures()) { mask |= (1u << fh.getMapIndex()); }
+    const Size expected_mask = 0b0111u;
+    TEST_EQUAL(mask, expected_mask)
+    // PIDs are intact
+    const bool pids_ok = (cmap[i].getPeptideIdentifications().size() >= 3);
+    TEST_EQUAL(pids_ok, true)
+  }
+  // Singleton CF untouched
+  TEST_EQUAL(cmap[22].size(), 1)
+  // All-no-ID CF untouched
+  TEST_EQUAL(cmap[23].size(), 4)
+  // All-IDs CF untouched
+  TEST_EQUAL(cmap[24].size(), 4)
+
+  // 5 handles removed in total
+  TEST_EQUAL(rep.handles_removed, 5)
+}
+END_SECTION
+
+START_SECTION([EXTRA] anchors require matching charge)
+{
+  // Two CFs of the same modified sequence but different charges should NOT be paired as anchors.
+  ConsensusMap cmap;
+  setupHeaders(cmap, 2);
+  UInt64 uid = 1;
+  // 6 CFs where map 0 is charge 2 and map 1 is charge 3 — same sequence, different precursors.
+  // No anchors should be collected because the (mod_seq, charge) keys differ.
+  for (Size i = 0; i < 6; ++i)
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(0, makeFeature(uid++, 100.0 + 50.0 * i, 500.0 + i, 1e5, "PEPTIDEAK", 2));
+    items.emplace_back(1, makeFeature(uid++, 100.0 + 50.0 * i + 0.3, 500.0 + i, 1e5, "PEPTIDEAK", 3));
+    cmap.push_back(makeCF(items));
+  }
+  ConsensusMapMBRFilter f;
+  auto rep = f.filter(cmap);
+  // pair (0,1) should not exist in the stats because no anchors matched
+  TEST_EQUAL(rep.pair_stats.empty(), true)
+  TEST_EQUAL(rep.handles_removed, 0)
+}
+END_SECTION
+
+START_SECTION([EXTRA] PIDs with no hits or no map_index meta value are ignored)
+{
+  // Build a CF where one of the contributing features has a PID with empty hits.
+  // The filter should not crash and should treat that handle as ID-less.
+  ConsensusMap cmap;
+  setupHeaders(cmap, 2);
+
+  Feature f0;
+  f0.setUniqueId(1);
+  f0.setRT(100.0); f0.setMZ(500.0); f0.setIntensity(1e5); f0.setCharge(2);
+  PeptideIdentification empty_pid; // no hits set
+  empty_pid.setScoreType("score");
+  empty_pid.setHigherScoreBetter(true);
+  f0.setPeptideIdentifications({empty_pid});
+
+  Feature f1 = makeFeature(2, 200.0, 500.0, 1e5, "PEPTIDEAK", 2);
+
+  ConsensusFeature cf;
+  cf.setUniqueId(42);
+  cf.insert(0, f0);
+  cf.insert(1, f1);
+  cf.computeConsensus();
+  cmap.push_back(cf);
+
+  ConsensusMapMBRFilter f;
+  auto rep = f.filter(cmap);
+  // f0's empty PID should not produce an anchor; f1 has a real ID, f0 looks ID-less.
+  // With only 1 ID-bearing handle and no anchors at all, no per-pair stats exist;
+  // the pooled fallback is also empty, so f0 is left alone.
+  TEST_EQUAL(rep.handles_removed, 0)
+  TEST_EQUAL(cmap[0].size(), 2)
+}
+END_SECTION
+
+START_SECTION([EXTRA] under-anchored pair uses pooled fallback)
+{
+  ConsensusMap cmap;
+  setupHeaders(cmap, 3);
+
+  // 10 clean anchors for pair (0,1) and (0,2) but only 1 for pair (1,2).
+  const char* foo_seqs[10] = {
+    "AAAFOOAK", "AAAFOOCK", "AAAFOODK", "AAAFOOEK", "AAAFOOFK",
+    "AAAFOOGK", "AAAFOOHK", "AAAFOOIK", "AAAFOOLK", "AAAFOOMK"};
+  const char* bar_seqs[10] = {
+    "BARAAAAK", "BARAACAK", "BARAADAK", "BARAAEAK", "BARAAFAK",
+    "BARAAGAK", "BARAAHAK", "BARAAIAK", "BARAALAK", "BARAAMAK"};
+  UInt64 uid = 1;
+  for (Size i = 0; i < 10; ++i)
+  {
+    const double base_rt = 100.0 + 50.0 * i;
+    const String seq = foo_seqs[i];
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(0, makeFeature(uid++, base_rt + 0.0, 500.0 + i, 1e5, seq, 2));
+    items.emplace_back(1, makeFeature(uid++, base_rt + 0.3, 500.0 + i, 1e5, seq, 2));
+    cmap.push_back(makeCF(items));
+  }
+  for (Size i = 0; i < 10; ++i)
+  {
+    const double base_rt = 1000.0 + 50.0 * i;
+    const String seq = bar_seqs[i];
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(0, makeFeature(uid++, base_rt + 0.0, 600.0 + i, 1e5, seq, 2));
+    items.emplace_back(2, makeFeature(uid++, base_rt - 0.2, 600.0 + i, 1e5, seq, 2));
+    cmap.push_back(makeCF(items));
+  }
+  // single anchor for pair (1,2)
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(1, makeFeature(uid++, 2000.0, 700.0, 1e5, "SINGLE", 2));
+    items.emplace_back(2, makeFeature(uid++, 2000.0 + 0.4, 700.0, 1e5, "SINGLE", 2));
+    cmap.push_back(makeCF(items));
+  }
+
+  // CF with map 1 ID + map 2 ID-less, 0.4 sec offset (consistent with pooled distribution)
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(1, makeFeature(uid++, 3000.0, 800.0, 1e5, "TRANSFERAK", 2));
+    items.emplace_back(2, makeFeature(uid++, 3000.4, 800.0, 5e4));
+    cmap.push_back(makeCF(items));
+  }
+  const Size idx_consistent = cmap.size() - 1;
+
+  // CF with map 1 ID + map 2 ID-less, 50 sec offset (clear outlier under any pooled stat)
+  {
+    std::vector<std::pair<UInt64, Feature>> items;
+    items.emplace_back(1, makeFeature(uid++, 4000.0, 900.0, 1e5, "TRANSFERCK", 2));
+    items.emplace_back(2, makeFeature(uid++, 4050.0, 900.0, 5e4));
+    cmap.push_back(makeCF(items));
+  }
+  const Size idx_outlier = cmap.size() - 1;
+
+  ConsensusMapMBRFilter f;
+  Param p = f.getParameters();
+  p.setValue("k_sigma", 3.0);
+  p.setValue("min_anchors_per_pair", 5);
+  p.setValue("reject_fraction", 0.5);
+  p.setValue("min_pair_sigma", 0.5);
+  p.setValue("use_pooled_fallback", "true");
+  f.setParameters(p);
+
+  auto rep = f.filter(cmap);
+
+  // Pooled distribution should be populated from pairs (0,1) and (0,2)
+  const bool pooled_ok = (rep.pooled.n >= 20);
+  TEST_EQUAL(pooled_ok, true)
+
+  // Consistent transfer CF unchanged
+  TEST_EQUAL(cmap[idx_consistent].size(), 2)
+  // Outlier transfer CF lost its map-2 handle
+  TEST_EQUAL(cmap[idx_outlier].size(), 1)
+  TEST_EQUAL(rep.handles_removed, 1)
+}
+END_SECTION
+
+END_TEST

--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
+#include <OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.h>
 #include <OpenMS/ANALYSIS/ID/ConsensusMapMergerAlgorithm.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmQT.h>
@@ -319,6 +320,21 @@ protected:
     pq_defaults.setValue("top:include_all", "true");
     pq_defaults.addTag("top:include_all", "advanced");
 
+    // post-link MBR filter: gating flag is registered as a top-level string option
+    // (kept out of the Param block below to avoid the "false"/"true" → FLAG auto-conversion).
+    registerStringOption_("MBRFilter:enabled", "<option>", "false",
+                          "Filter unreliable match-between-runs transferred handles after linking, "
+                          "based on pairwise RT residual statistics from identified anchors.",
+                          false, true);
+    setValidStrings_("MBRFilter:enabled", ListUtils::create<String>("true,false"));
+
+    // The remaining MBRFilter parameters live inside the helper's defaults.
+    Param mbrf_defaults = ConsensusMapMBRFilter().getDefaults();
+    for (auto it = mbrf_defaults.begin(); it != mbrf_defaults.end(); ++it)
+    {
+      mbrf_defaults.addTag(it.getName(), "advanced");
+    }
+
     Param bio_defaults = Biosaur2Algorithm().getDefaults();
     bio_defaults.setValue("mini", 500.0);   // filter low-intensity noise peaks (default 1.0 too permissive)
     bio_defaults.setValue("minlh", 3);      // require hills spanning >= 3 scans (default 2 keeps transient noise)
@@ -334,6 +350,7 @@ protected:
     combined.insert("PeptideQuantification:", ffi_defaults);
     combined.insert("Alignment:", ma_defaults);
     combined.insert("Linking:", fl_defaults);
+    combined.insert("MBRFilter:", mbrf_defaults);
     combined.insert("ProteinQuantification:", pq_defaults);
     combined.insert("Seeding:Biosaur2:", bio_defaults);
 
@@ -655,6 +672,33 @@ protected:
         median_fwhm,
         max_alignment_diff,
         consensus_fraction);
+
+      // Optional post-link MBR filter: removes unidentified handles whose RT
+      // is statistically inconsistent with per-pair anchor distributions.
+      if (getStringOption_("MBRFilter:enabled") == "true")
+      {
+        Param mbrf_param = getParam_().copy("MBRFilter:", true);
+        mbrf_param.remove("enabled"); // not part of the helper's defaults
+        ConsensusMapMBRFilter mbrf;
+        mbrf.setParameters(mbrf_param);
+        ConsensusMapMBRFilter::Report rep = mbrf.filter(consensus_fraction);
+
+        OPENMS_LOG_INFO << "MBRFilter: removed " << rep.handles_removed
+                        << " unreliable transferred handles." << endl;
+        OPENMS_LOG_INFO << "MBRFilter pooled fallback: n=" << rep.pooled.n
+                        << " sigma=" << rep.pooled.mad_sigma << endl;
+        for (const auto& kv : rep.pair_stats)
+        {
+          OPENMS_LOG_INFO << "  pair (" << kv.first.first << "," << kv.first.second << "): "
+                          << "n=" << kv.second.n
+                          << " median=" << kv.second.median
+                          << " sigma=" << kv.second.mad_sigma
+                          << " filtered=" << kv.second.removals << endl;
+        }
+
+        addDataProcessing_(consensus_fraction,
+                           getProcessingInfo_(DataProcessing::FILTERING));
+      }
     }
     else // only one feature map
     {


### PR DESCRIPTION
## Summary

Adds an optional post-link filter (off by default, enabled via `-MBRFilter:enabled true`) that uses pairwise RT-residual statistics from identified anchor handles to remove unreliable match-between-runs transfers from the linked `ConsensusMap`.

For each map pair the filter computes a robust median + MAD-derived sigma over anchors that share the same modified peptide sequence and charge, then drops unidentified handles in the same `ConsensusFeature` whose RT is inconsistent (`> k_sigma * sigma`) with the per-pair distribution. Map pairs with too few anchors fall back to a pooled distribution centered on each pair's own median.

The filter operates strictly post-link, takes only the `ConsensusMap` (no source `FeatureMap`s needed — anchors are detected via the existing `map_index` MetaValue stamped by `ConsensusFeature::insert(map_index, BaseFeature)`), and recomputes each affected ConsensusFeature's centroid via `computeConsensus()` so downstream consumers (`PeptideAndProteinQuant`, `MSstatsFile`, mzTab export, `IDConflictResolverAlgorithm`) see correctly-shrunk feature sets.

### New parameters (all advanced)

- `MBRFilter:enabled` (top-level flag, default `false`)
- `MBRFilter:k_sigma` (default `3.0`)
- `MBRFilter:min_anchors_per_pair` (default `5`)
- `MBRFilter:reject_fraction` (default `0.5`)
- `MBRFilter:min_pair_sigma` (default `1.0` sec floor for the per-pair sigma derived from MAD)
- `MBRFilter:use_pooled_fallback` (default `true`)

### History note

This branch was originally pushed directly to `develop` as `2fb89b14d1`, then reverted by `50ddb82ae3` so the work could go through normal PR review. The cherry-picked commit on this branch is functionally identical.

## Test plan

- [x] New unit test `ConsensusMapMBRFilter_test` (6 sections incl. anchor collection, outlier removal, charge-mismatch guard, pooled fallback, empty-PID safety)
- [x] All 54 existing `TOPP_ProteomicsLFQ_*` regression tests pass with the filter off by default
- [x] Smoke run on `share/OpenMS/examples/FRACTIONS/BSA*` with `-MBRFilter:enabled true` produces sensible per-pair stats and removes 1 unreliable transfer in fraction 1
- [ ] CI green

## Files

- New: `src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.h`
- New: `src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapMBRFilter.cpp`
- New: `src/tests/class_tests/openms/source/ConsensusMapMBRFilter_test.cpp`
- Modified: `src/topp/ProteomicsLFQ.cpp` (param wiring + call site in `alignAndLink_()`)
- Modified: 3× `sources.cmake` / `executables.cmake` for build registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MBR (Match Between Runs) filter to ProteomicsLFQ
  * Automatically removes unreliable transferred features after linking based on retention time consistency analysis
  * Configurable parameters enable fine-tuning of filtering sensitivity and fallback behavior across map pairs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->