### PR TITLE
authors check: Only post PR comments when the script exits with 100

### DIFF
--- a/.github/workflows/check-authors-file.yml
+++ b/.github/workflows/check-authors-file.yml
@@ -23,7 +23,10 @@ jobs:
           path: ci-tools
       - name: Check the AUTHORS File
         run: |
-          if ! ci-tools/scripts/authors.sh "$GITHUB_BASE_REF" "HEAD"; then
+          exit_code=0
+          ci-tools/scripts/authors.sh "$GITHUB_BASE_REF" "HEAD" || exit_code=$?
+
+          if [ "$exit_code" -eq 100 ]; then
             ci-tools/scripts/authors.sh -p "$ACTOR" "$GITHUB_BASE_REF" "HEAD" |
               gh pr comment "$PR" --body-file -
           fi


### PR DESCRIPTION
I changed the script to distinguish between failure and when the `AUTHORS` file is out of date.  For the latter case it exits with status 100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to refine script exit code handling.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->