### PR TITLE
feat(PeptideDataBaseSearchFI): multi-file search with shared fragment index

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -11,12 +11,13 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 
+#include <OpenMS/ANALYSIS/ID/FragmentIndex.h>
+#include <OpenMS/ANALYSIS/ID/OpenSearchModificationAnalysis.h>
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
+#include <OpenMS/DATASTRUCTURES/StringView.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/DATASTRUCTURES/StringView.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
-#include <OpenMS/ANALYSIS/ID/OpenSearchModificationAnalysis.h>
 
 #include <vector>
 
@@ -69,6 +70,35 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
       PeptideIdentificationList peptide_ids;
       OpenSearchModificationAnalysis::OpenSearchAnalysisResult modification_analysis;
       bool is_open_search = false;
+    };
+
+    /**
+     * @brief Multi-file search result bundle.
+     *
+     * Returned by the file-list searchWithModificationAnalysis() overloads. Holds
+     * one SearchResult per input mzML (in @p per_file, in input order) and a
+     * single @p aggregate result whose peptide_ids are the concatenation of all
+     * per-file PSMs and whose modification_analysis is computed once on the
+     * pooled set of PSMs.
+     */
+    struct MultiFileSearchResult
+    {
+      std::vector<SearchResult> per_file;
+      SearchResult aggregate;
+    };
+
+    /**
+     * @brief Prepared per-database state shared across multiple spectrum files.
+     *
+     * Holds the (decoy-augmented) protein database and the built FragmentIndex
+     * so that searching N spectrum files against the same FASTA pays the index
+     * build cost only once. Construct via prepareContext() and pass to the
+     * context-taking search() overload.
+     */
+    struct SearchContext
+    {
+      std::vector<FASTAFile::FASTAEntry> db;
+      FragmentIndex fragment_index;
     };
 
     /**
@@ -156,9 +186,59 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
      * @param[out] prot_ids  Output protein-level identifications.
      * @param[out] pep_ids   Output spectrum-level peptide identifications (PSMs).
      * @return ExitCodes indicating success or error.
+     *
+     * Internally this is a thin wrapper around prepareContext() + the
+     * context-taking search() overload, so the FragmentIndex is rebuilt on every
+     * call. For repeated searches against the same database, prefer calling
+     * prepareContext() once and reusing the resulting SearchContext.
      */
     ExitCodes search(PeakMap& spectra,
                      const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+                     std::vector<ProteinIdentification>& prot_ids,
+                     PeptideIdentificationList& pep_ids) const;
+
+    /**
+     * @brief Build a SearchContext (decoy-augmented database + FragmentIndex) for reuse.
+     *
+     * Performs the database preparation and FragmentIndex construction steps so
+     * that subsequent calls to search(spectra, ctx, ...) can reuse the same
+     * index across many spectrum files. If decoy generation is enabled
+     * (parameter "decoys"), decoys are generated and shuffled into the
+     * returned context's db member exactly once here.
+     *
+     * @param[in] fasta_db Protein sequence database as FASTA entries.
+     * @return Prepared SearchContext containing the (possibly decoy-augmented)
+     *         database and the built FragmentIndex.
+     *
+     * Thread-safety: the returned context's FragmentIndex is read-only during
+     * subsequent search() calls; concurrent search() calls reading the same
+     * SearchContext are safe (per FragmentIndex query thread-safety contract).
+     * Do not call prepareContext() concurrently on the same algorithm instance.
+     */
+    SearchContext prepareContext(const std::vector<FASTAFile::FASTAEntry>& fasta_db) const;
+
+    /**
+     * @brief In-memory search using a pre-built SearchContext.
+     *
+     * Searches @p spectra against the database and FragmentIndex held in @p ctx.
+     * The fragment index build cost (decoy generation, peptide/fragment
+     * generation, sorting, bucketing) is paid by prepareContext() and is not
+     * repeated here, making this overload the right choice when searching many
+     * spectrum files against the same database.
+     *
+     * @param[in,out] spectra MS/MS spectra to search (preprocessed in-place).
+     * @param[in,out] ctx Pre-built SearchContext from prepareContext(). Taken
+     *            by non-const reference because the underlying FragmentIndex
+     *            query API is non-const, even though the index content is not
+     *            modified during the search; the @c db member is also handed
+     *            non-const to the downstream PeptideIndexing step (which
+     *            requires a non-const reference).
+     * @param[out] prot_ids Output protein-level identifications.
+     * @param[out] pep_ids  Output spectrum-level peptide identifications (PSMs).
+     * @return ExitCodes indicating success or error.
+     */
+    ExitCodes search(PeakMap& spectra,
+                     SearchContext& ctx,
                      std::vector<ProteinIdentification>& prot_ids,
                      PeptideIdentificationList& pep_ids) const;
 
@@ -175,6 +255,54 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     SearchResult searchWithModificationAnalysis(PeakMap& spectra,
                                                 const std::vector<FASTAFile::FASTAEntry>& fasta_db,
                                                 const String& output_base_name = "") const;
+
+    /**
+     * @brief Multi-file search with modification analysis (in-memory FASTA).
+     *
+     * Builds a single SearchContext (decoy generation + FragmentIndex) from
+     * @p fasta_db and reuses it across all input spectrum files. Each input
+     * file produces its own SearchResult including a per-file modification
+     * analysis (TSV written if a non-empty per-file base name is provided). An
+     * additional aggregate SearchResult is computed by pooling all per-file
+     * peptide identifications and running modification analysis once on the
+     * pooled set.
+     *
+     * @param[in] in_spectra_files Spectrum file paths (mzML or Bruker .d).
+     * @param[in] fasta_db Protein sequence database as FASTA entries.
+     * @param[in] output_base_names Optional per-file base names for
+     *            modification-analysis TSV outputs. Must be empty or have the
+     *            same length as @p in_spectra_files. Empty entries skip TSV
+     *            writing for that file.
+     * @param[in] aggregate_base_name Optional base name for the aggregate
+     *            modification-analysis TSV output. Empty disables aggregate
+     *            TSV writing (the aggregate analysis is still computed).
+     * @return MultiFileSearchResult bundling per-file results and aggregate.
+     *
+     * Errors:
+     *  - Throws Exception::InvalidParameter if @p output_base_names is
+     *    non-empty and its size differs from @p in_spectra_files.
+     */
+    MultiFileSearchResult searchWithModificationAnalysis(
+        const std::vector<String>& in_spectra_files,
+        const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+        const std::vector<String>& output_base_names = {},
+        const String& aggregate_base_name = "") const;
+
+    /**
+     * @brief Multi-file search with modification analysis (FASTA file path).
+     *
+     * Convenience overload that loads the FASTA database from @p in_db and
+     * delegates to the in-memory multi-file overload. The database file path
+     * is recorded in each per-file ProteinIdentification's SearchParameters
+     * (and on the aggregate result).
+     *
+     * @see searchWithModificationAnalysis(const std::vector<String>&, const std::vector<FASTAFile::FASTAEntry>&, const std::vector<String>&, const String&) const
+     */
+    MultiFileSearchResult searchWithModificationAnalysis(
+        const std::vector<String>& in_spectra_files,
+        const String& in_db,
+        const std::vector<String>& output_base_names = {},
+        const String& aggregate_base_name = "") const;
 
   protected:
     void updateMembers_() override;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -30,7 +30,7 @@ namespace OpenMS
   Provides a self-contained search engine that matches MS/MS spectra against a protein
   database using an FI (Fragment Index). Typical usage:
   - Configure parameters via DefaultParamHandler (mass tolerances, enzyme, charges, etc.)
-  - Call search() with an input mzML file and a FASTA database to populate identification
+  - Call search() with an input spectrum file (mzML or Bruker .d) and a FASTA database to populate identification
     outputs (ProteinIdentification and PeptideIdentificationList)
   - Intended for educational/prototyping use and to demonstrate FI-backed searching
 
@@ -76,7 +76,7 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
      * @brief Multi-file search result bundle.
      *
      * Returned by the file-list searchWithModificationAnalysis() overloads. Holds
-     * one SearchResult per input mzML (in @p per_file, in input order) and a
+     * one SearchResult per input file (in @p per_file, in input order) and a
      * single @p aggregate result whose peptide_ids are the concatenation of all
      * per-file PSMs and whose modification_analysis is computed once on the
      * pooled set of PSMs.
@@ -117,7 +117,7 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     };
 
     /**
-     * @brief Search spectra in an mzML file against a protein database using an FI-backed workflow.
+     * @brief Search spectra in a spectrum file (mzML or Bruker .d) against a protein database using an FI-backed workflow.
      *
      * Populates protein and peptide identifications, including search meta data, PSM hits,
      * and search engine annotations. Parameters are taken from this instance (DefaultParamHandler).

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -80,6 +80,21 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
      * single @p aggregate result whose peptide_ids are the concatenation of all
      * per-file PSMs and whose modification_analysis is computed once on the
      * pooled set of PSMs.
+     *
+     * Special cases for @p aggregate:
+     *  - When the input list contains exactly one file, @p aggregate is left
+     *    almost-empty (only @c is_open_search and @c exit_code are set) — the
+     *    single-file pooled aggregate would just duplicate @c per_file[0] and
+     *    re-run modification analysis on the same PSMs. Callers should use
+     *    @c per_file[0] for the result in this case.
+     *  - When every per-file run failed, @p aggregate.exit_code is set to the
+     *    first non-OK per-file exit code (so callers can inspect it without
+     *    walking the @p per_file vector).
+     *
+     * The aggregate's @c protein_ids template is taken from the first
+     * successful per-file result (search parameters are identical across files
+     * by construction), with the primary MS run path overwritten to list every
+     * input file.
      */
     struct MultiFileSearchResult
     {

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -415,16 +415,17 @@ namespace OpenMS
           }
         }
 
-// Debug: log spectrum-level top hit details before storing PeptideIdentification
-if (!pi.getHits().empty())
-{
-  const PeptideHit& top_hit = pi.getHits().front();
-  OPENMS_LOG_INFO << "[PDBS-FI] scan_index=" << scan_index
-                    << " top_ln(hyperscore)=" << top_hit.getScore()
-                    << " top_charge=" << top_hit.getCharge()
-                    << " top_isotope_error=" << (int)top_hit.getMetaValue("isotope_error")
-                    << std::endl;
-}
+        // Debug: log spectrum-level top hit details before storing PeptideIdentification.
+        // DEBUG (not INFO) because multi-file mode would emit one line per scan per input.
+        if (!pi.getHits().empty())
+        {
+          const PeptideHit& top_hit = pi.getHits().front();
+          OPENMS_LOG_DEBUG << "[PDBS-FI] scan_index=" << scan_index
+                           << " top_ln(hyperscore)=" << top_hit.getScore()
+                           << " top_charge=" << top_hit.getCharge()
+                           << " top_isotope_error=" << (int)top_hit.getMetaValue("isotope_error")
+                           << std::endl;
+        }
 #pragma omp critical (peptide_ids_access)
         {
           //clang-tidy: seems to be a false-positive in combination with omp
@@ -950,6 +951,9 @@ if (!pi.getHits().empty())
     }
 
     // Build the aggregate result by pooling per-file PSMs.
+    // If every per-file run failed, propagate the first non-OK exit code into the
+    // aggregate (rather than overloading UNEXPECTED_RESULT, which has a specific
+    // meaning - PeptideIndexing failure).
     bool any_ok = false;
     for (const auto& pf : mfres.per_file)
     {
@@ -958,16 +962,24 @@ if (!pi.getHits().empty())
 
     if (!any_ok)
     {
-      mfres.aggregate.exit_code = ExitCodes::UNEXPECTED_RESULT;
+      for (const auto& pf : mfres.per_file)
+      {
+        if (pf.exit_code != ExitCodes::EXECUTION_OK)
+        {
+          mfres.aggregate.exit_code = pf.exit_code;
+          break;
+        }
+      }
       return mfres;
     }
 
     // Single-file fast path: the aggregate would just duplicate the only per-file
-    // result. Copy it across (so callers can rely on aggregate being populated)
-    // and skip the redundant pooled modification analysis.
+    // result and re-run modification analysis on the same PSMs. Skip the pooling
+    // and analysis entirely. The aggregate is left with only @c is_open_search
+    // and @c exit_code populated; callers should use @c per_file[0] for the
+    // actual identifications. This is documented on @c MultiFileSearchResult.
     if (mfres.per_file.size() == 1 && mfres.per_file[0].exit_code == ExitCodes::EXECUTION_OK)
     {
-      mfres.aggregate = mfres.per_file[0];
       return mfres;
     }
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -499,11 +499,71 @@ if (!pi.getHits().empty())
   }
 
   // =====================================================================
-  // In-memory search: core logic without file I/O
+  // Build a SearchContext (decoys + FragmentIndex) from a FASTA database.
+  // Hoisted out of the in-memory search() body so callers can build the
+  // index once and reuse it across many spectrum files.
+  // =====================================================================
+  PeptideSearchEngineFIAlgorithm::SearchContext
+  PeptideSearchEngineFIAlgorithm::prepareContext(
+      const std::vector<FASTAFile::FASTAEntry>& fasta_db) const
+  {
+    SearchContext ctx;
+    // Always work with a mutable local copy (PeptideIndexing::run requires non-const ref)
+    ctx.db = fasta_db;
+
+    if (decoys_)
+    {
+      startProgress(0, 1, "Generate decoys...");
+      DecoyGenerator decoy_generator;
+
+      const size_t old_size = ctx.db.size();
+      ctx.db.reserve(ctx.db.size() * 2);
+      for (size_t i = 0; i != old_size; ++i)
+      {
+        FASTAFile::FASTAEntry e = ctx.db[i];
+        e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
+        e.identifier = "DECOY_" + e.identifier;
+        ctx.db.push_back(std::move(e));
+      }
+      Math::RandomShuffler shuffler;
+      shuffler.portable_random_shuffle(ctx.db.begin(), ctx.db.end());
+      endProgress();
+    }
+
+    // build fragment index
+    startProgress(0, 1, "Building fragment index...");
+    auto this_params = getParameters();
+    ctx.fragment_index.setParameters(this_params);
+    ctx.fragment_index.build(ctx.db);
+    endProgress();
+
+    return ctx;
+  }
+
+  // =====================================================================
+  // In-memory search: thin wrapper that builds a fresh SearchContext per call.
+  // For repeated searches against the same database, prefer the
+  // context-taking overload below.
   // =====================================================================
   PeptideSearchEngineFIAlgorithm::ExitCodes PeptideSearchEngineFIAlgorithm::search(
       PeakMap& spectra,
       const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+      vector<ProteinIdentification>& protein_ids,
+      PeptideIdentificationList& peptide_ids) const
+  {
+    SearchContext ctx = prepareContext(fasta_db);
+    return search(spectra, ctx, protein_ids, peptide_ids);
+  }
+
+  // =====================================================================
+  // In-memory search using a pre-built SearchContext (no index rebuild).
+  // Takes the context by non-const reference because the underlying
+  // FragmentIndex::querySpectrum() and PeptideIndexing::run() APIs are both
+  // non-const, even though neither conceptually mutates shared state.
+  // =====================================================================
+  PeptideSearchEngineFIAlgorithm::ExitCodes PeptideSearchEngineFIAlgorithm::search(
+      PeakMap& spectra,
+      SearchContext& ctx,
       vector<ProteinIdentification>& protein_ids,
       PeptideIdentificationList& peptide_ids) const
   {
@@ -538,35 +598,11 @@ if (!pi.getHits().empty())
     vector<vector<AnnotatedHit_> > annotated_hits(spectra.size(), vector<AnnotatedHit_>());
     for (auto & a : annotated_hits) { a.reserve(report_top_hits_); }
 
-    // Always work with a mutable local copy (PeptideIndexing::run requires non-const ref)
-    vector<FASTAFile::FASTAEntry> db(fasta_db);
-
-    if (decoys_)
-    {
-      startProgress(0, 1, "Generate decoys...");
-      DecoyGenerator decoy_generator;
-
-      const size_t old_size = db.size();
-      db.reserve(db.size() * 2);
-      for (size_t i = 0; i != old_size; ++i)
-      {
-        FASTAFile::FASTAEntry e = db[i];
-        e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
-        e.identifier = "DECOY_" + e.identifier;
-        db.push_back(std::move(e));
-      }
-      Math::RandomShuffler shuffler;
-      shuffler.portable_random_shuffle(db.begin(), db.end());
-      endProgress();
-    }
-
-    // build fragment index
-    startProgress(0, 1, "Building fragment index...");
-    FragmentIndex fragment_index_;
-    auto this_params = getParameters();
-    fragment_index_.setParameters(this_params);
-    fragment_index_.build(db);
-    endProgress();
+    // Reference the prepared (decoy-augmented) database and prebuilt fragment index from the context.
+    // The fragment index is queried (not mutated) during scoring; the database is handed to
+    // PeptideIndexing::run() below which requires a non-const reference.
+    std::vector<FASTAFile::FASTAEntry>& db = ctx.db;
+    FragmentIndex& fragment_index_ = ctx.fragment_index;
 
     startProgress(0, spectra.size(), "Scoring peptide models against spectra...");
     size_t count_spectra{};
@@ -808,37 +844,252 @@ if (!pi.getHits().empty())
   }
 
   // =====================================================================
-  // File-based searchWithModificationAnalysis: delegates to in-memory version
+  // Multi-file searchWithModificationAnalysis (in-memory FASTA).
+  //
+  // Builds the FragmentIndex once via prepareContext() and reuses it across
+  // all input spectrum files. Each input file produces its own SearchResult
+  // (with per-file modification analysis); a final aggregate SearchResult is
+  // computed by pooling all per-file PSMs and running modification analysis
+  // once on the pooled set.
+  // =====================================================================
+  PeptideSearchEngineFIAlgorithm::MultiFileSearchResult
+  PeptideSearchEngineFIAlgorithm::searchWithModificationAnalysis(
+      const std::vector<String>& in_spectra_files,
+      const std::vector<FASTAFile::FASTAEntry>& fasta_db,
+      const std::vector<String>& output_base_names,
+      const String& aggregate_base_name) const
+  {
+    if (!output_base_names.empty() && output_base_names.size() != in_spectra_files.size())
+    {
+      throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+        "output_base_names must be empty or have exactly one entry per spectrum file (got "
+        + String(output_base_names.size()) + " entries for " + String(in_spectra_files.size())
+        + " spectrum files).");
+    }
+
+    MultiFileSearchResult mfres;
+    mfres.aggregate.is_open_search = isOpenSearchMode_();
+
+    if (in_spectra_files.empty())
+    {
+      mfres.aggregate.exit_code = ExitCodes::INPUT_FILE_EMPTY;
+      return mfres;
+    }
+
+    // Build the (decoy-augmented) database and FragmentIndex exactly once.
+    SearchContext ctx = prepareContext(fasta_db);
+
+    mfres.per_file.reserve(in_spectra_files.size());
+
+    for (Size i = 0; i < in_spectra_files.size(); ++i)
+    {
+      const String& in_spectra = in_spectra_files[i];
+      const String per_file_base = (i < output_base_names.size()) ? output_base_names[i] : String("");
+
+      OPENMS_LOG_INFO << "[PDBS-FI] [" << (i + 1) << "/" << in_spectra_files.size()
+                      << "] Searching " << in_spectra << std::endl;
+
+      // load MS2 map
+      PeakMap spectra;
+      {
+        FileHandler f;
+        PeakFileOptions options;
+        options.clearMSLevels();
+        options.addMSLevel(2);
+        f.getOptions() = options;
+        f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
+      }
+      spectra.sortSpectra(true);
+
+      SearchResult result;
+      result.is_open_search = isOpenSearchMode_();
+      result.exit_code = search(spectra, ctx, result.protein_ids, result.peptide_ids);
+
+      if (result.exit_code != ExitCodes::EXECUTION_OK)
+      {
+        OPENMS_LOG_WARN << "[PDBS-FI] Search failed for " << in_spectra
+                        << " (exit code " << static_cast<int>(result.exit_code) << "). Continuing." << std::endl;
+        mfres.per_file.push_back(std::move(result));
+        continue;
+      }
+
+      // patch per-file metadata
+      if (!result.protein_ids.empty())
+      {
+        result.protein_ids[0].setPrimaryMSRunPath({in_spectra}, spectra);
+      }
+
+      // per-file modification analysis (only meaningful in open-search mode)
+      if (result.is_open_search)
+      {
+        OPENMS_LOG_INFO << "[PDBS-FI] Running detailed modification analysis for " << in_spectra << std::endl;
+
+        OpenSearchModificationAnalysis mod_analyzer;
+        String output_file = "";
+        if (!per_file_base.empty())
+        {
+          output_file = per_file_base + "_ModificationAnalysis.idXML";
+        }
+
+        result.modification_analysis = mod_analyzer.analyzeModificationsWithStatistics(
+          result.peptide_ids,
+          precursor_mass_tolerance_,
+          precursor_mass_tolerance_unit_ == "ppm",
+          false, // no smoothing
+          output_file
+        );
+
+        logModificationAnalysisSummary_(result, per_file_base);
+      }
+      else
+      {
+        OPENMS_LOG_INFO << "[PDBS-FI] Closed search mode - per-file modification analysis skipped" << std::endl;
+      }
+
+      mfres.per_file.push_back(std::move(result));
+    }
+
+    // Build the aggregate result by pooling per-file PSMs.
+    bool any_ok = false;
+    for (const auto& pf : mfres.per_file)
+    {
+      if (pf.exit_code == ExitCodes::EXECUTION_OK) { any_ok = true; break; }
+    }
+
+    if (!any_ok)
+    {
+      mfres.aggregate.exit_code = ExitCodes::UNEXPECTED_RESULT;
+      return mfres;
+    }
+
+    // Single-file fast path: the aggregate would just duplicate the only per-file
+    // result. Copy it across (so callers can rely on aggregate being populated)
+    // and skip the redundant pooled modification analysis.
+    if (mfres.per_file.size() == 1 && mfres.per_file[0].exit_code == ExitCodes::EXECUTION_OK)
+    {
+      mfres.aggregate = mfres.per_file[0];
+      return mfres;
+    }
+
+    // Use the first successful per-file result's protein metadata as the aggregate template.
+    for (const auto& pf : mfres.per_file)
+    {
+      if (pf.exit_code == ExitCodes::EXECUTION_OK)
+      {
+        mfres.aggregate.protein_ids = pf.protein_ids;
+        break;
+      }
+    }
+    // Overwrite the primary MS run path on the aggregate to point at all input files.
+    if (!mfres.aggregate.protein_ids.empty())
+    {
+      mfres.aggregate.protein_ids[0].setPrimaryMSRunPath(in_spectra_files);
+    }
+
+    // Pool peptide_ids across all successful per-file results.
+    Size pooled_count = 0;
+    for (const auto& pf : mfres.per_file)
+    {
+      if (pf.exit_code == ExitCodes::EXECUTION_OK) { pooled_count += pf.peptide_ids.size(); }
+    }
+    mfres.aggregate.peptide_ids.reserve(pooled_count);
+    for (const auto& pf : mfres.per_file)
+    {
+      if (pf.exit_code != ExitCodes::EXECUTION_OK) { continue; }
+      for (const auto& pid : pf.peptide_ids)
+      {
+        mfres.aggregate.peptide_ids.push_back(pid);
+      }
+    }
+
+    // Aggregate modification analysis on the pooled PSM set.
+    if (mfres.aggregate.is_open_search && !mfres.aggregate.peptide_ids.empty())
+    {
+      OPENMS_LOG_INFO << "[PDBS-FI] Running aggregate modification analysis on "
+                      << mfres.aggregate.peptide_ids.size() << " pooled PSM(s) from "
+                      << in_spectra_files.size() << " input file(s)." << std::endl;
+
+      OpenSearchModificationAnalysis mod_analyzer;
+      String agg_output_file = "";
+      if (!aggregate_base_name.empty())
+      {
+        agg_output_file = aggregate_base_name + "_ModificationAnalysis.idXML";
+      }
+
+      mfres.aggregate.modification_analysis = mod_analyzer.analyzeModificationsWithStatistics(
+        mfres.aggregate.peptide_ids,
+        precursor_mass_tolerance_,
+        precursor_mass_tolerance_unit_ == "ppm",
+        false, // no smoothing
+        agg_output_file
+      );
+
+      logModificationAnalysisSummary_(mfres.aggregate, aggregate_base_name);
+    }
+
+    return mfres;
+  }
+
+  // =====================================================================
+  // Multi-file searchWithModificationAnalysis (FASTA file path).
+  //
+  // Loads the FASTA from disk once, delegates to the in-memory multi-file
+  // overload, and patches the database file path on each per-file (and the
+  // aggregate) ProteinIdentification.
+  // =====================================================================
+  PeptideSearchEngineFIAlgorithm::MultiFileSearchResult
+  PeptideSearchEngineFIAlgorithm::searchWithModificationAnalysis(
+      const std::vector<String>& in_spectra_files,
+      const String& in_db,
+      const std::vector<String>& output_base_names,
+      const String& aggregate_base_name) const
+  {
+    // load FASTA once
+    vector<FASTAFile::FASTAEntry> fasta_db;
+    FASTAFile().load(in_db, fasta_db);
+
+    MultiFileSearchResult mfres = searchWithModificationAnalysis(
+      in_spectra_files, fasta_db, output_base_names, aggregate_base_name);
+
+    // Patch database file path into each per-file and aggregate ProteinIdentification.
+    for (auto& pf : mfres.per_file)
+    {
+      if (pf.exit_code == ExitCodes::EXECUTION_OK && !pf.protein_ids.empty())
+      {
+        pf.protein_ids[0].getSearchParameters().db = in_db;
+      }
+    }
+    if (mfres.aggregate.exit_code == ExitCodes::EXECUTION_OK && !mfres.aggregate.protein_ids.empty())
+    {
+      mfres.aggregate.protein_ids[0].getSearchParameters().db = in_db;
+    }
+
+    return mfres;
+  }
+
+  // =====================================================================
+  // File-based single-file searchWithModificationAnalysis: thin wrapper around
+  // the multi-file overload using a single-element list.
   // =====================================================================
   PeptideSearchEngineFIAlgorithm::SearchResult
   PeptideSearchEngineFIAlgorithm::searchWithModificationAnalysis(const String& in_spectra,
                                                                   const String& in_db,
                                                                   const String& output_base_name) const
   {
-    // load MS2 map
-    PeakMap spectra;
-    FileHandler f;
-    PeakFileOptions options;
-    options.clearMSLevels();
-    options.addMSLevel(2);
-    f.getOptions() = options;
-    f.loadExperiment(in_spectra, spectra, {FileTypes::MZML, FileTypes::BRUKER_TDF});
-    spectra.sortSpectra(true);
+    std::vector<String> in_files{in_spectra};
+    std::vector<String> base_names;
+    if (!output_base_name.empty()) { base_names.push_back(output_base_name); }
 
-    // load FASTA
-    vector<FASTAFile::FASTAEntry> fasta_db;
-    FASTAFile().load(in_db, fasta_db);
+    MultiFileSearchResult mfres = searchWithModificationAnalysis(in_files, in_db, base_names, "");
 
-    // delegate to in-memory version
-    SearchResult result = searchWithModificationAnalysis(spectra, fasta_db, output_base_name);
-
-    if (result.exit_code == ExitCodes::EXECUTION_OK && !result.protein_ids.empty())
+    if (mfres.per_file.empty())
     {
-      result.protein_ids[0].getSearchParameters().db = in_db;
-      result.protein_ids[0].setPrimaryMSRunPath({in_spectra}, spectra);
+      SearchResult empty_result;
+      empty_result.exit_code = ExitCodes::INPUT_FILE_EMPTY;
+      return empty_result;
     }
 
-    return result;
+    return std::move(mfres.per_file[0]);
   }
 
   // =====================================================================

--- a/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
@@ -819,6 +819,151 @@ START_SECTION((SearchResult searchWithModificationAnalysis(const String &, const
 }
 END_SECTION
 
+START_SECTION(([EXTRA] prepareContext + context-based search produces same IDs as single-shot search))
+{
+  // Build a tiny synthetic dataset where we know the search returns hits.
+  // Then verify that:
+  //   1. search(spectra, fasta_db, ...) (single-shot, builds index internally)
+  //   2. prepareContext(fasta_db) + search(spectra, ctx, ...) (context reuse)
+  // produce identical PSM counts (same internal pipeline).
+
+  vector<FASTAFile::FASTAEntry> fasta_db = {
+    {"P01", "Test01",
+     "MSDEREKVLGFHQRMPNASTICYWDLKEGFVRTHQPSANLDIKCMYKWTE"
+     "RHASGDFLKPIVEQNCTMYRGWSADELKHPFNQGTICMSYREWDAVLKPH"},
+    {"P02", "Test02",
+     "MKAILNHVGSTFREDWQCPYLKMISGDTFNHRVAWQECPLKYMTGISNHFR"
+     "DVEWAQCPLKTMIYGSNHFRDVEWAQCPKLIMTGSYNHFRDVEWAQCKPLIM"},
+  };
+
+  // Generate spectra from a few tryptic peptides (closed search, perfect matches).
+  ProteaseDigestion digester;
+  digester.setEnzyme("Trypsin");
+  digester.setMissedCleavages(1);
+
+  ModifiedPeptideGenerator::MapToResidueType fixed_mods =
+    ModifiedPeptideGenerator::getModifications({"Carbamidomethyl (C)"});
+
+  TheoreticalSpectrumGenerator tsg;
+  Param tsg_param = tsg.getParameters();
+  tsg_param.setValue("add_first_prefix_ion", "true");
+  tsg_param.setValue("add_metainfo", "true");
+  tsg.setParameters(tsg_param);
+
+  PeakMap spectra;
+  double rt = 100.0;
+  for (const auto& entry : fasta_db)
+  {
+    AASequence protein = AASequence::fromString(entry.sequence);
+    vector<AASequence> peptides;
+    digester.digest(protein, peptides, 7, 40);
+    for (auto& pep : peptides)
+    {
+      ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, pep);
+      if (pep.size() < 8) continue;
+
+      MSSpectrum spec;
+      tsg.getSpectrum(spec, pep, 1, 1);
+      spec.sortByPosition();
+      if (spec.size() < 10) continue;
+
+      spec.setMSLevel(2);
+      spec.setRT(rt);
+      rt += 0.1;
+
+      Precursor prec;
+      prec.setMZ(pep.getMZ(2));
+      prec.setCharge(2);
+      spec.setPrecursors({prec});
+      spec.setNativeID("spectrum=" + String(spectra.size()));
+
+      spectra.addSpectrum(std::move(spec));
+    }
+  }
+  TEST_TRUE(spectra.size() > 5)
+
+  PeptideSearchEngineFIAlgorithm algo;
+  Param p = algo.getParameters();
+  p.setValue("precursor:mass_tolerance", 20.0);
+  p.setValue("precursor:mass_tolerance_unit", "ppm");
+  p.setValue("fragment:mass_tolerance", 20.0);
+  p.setValue("fragment:mass_tolerance_unit", "ppm");
+  p.setValue("modifications:fixed", vector<string>{"Carbamidomethyl (C)"});
+  p.setValue("modifications:variable", vector<string>{});
+  p.setValue("decoys", "false");
+  algo.setParameters(p);
+
+  // Path A: single-shot search (builds + tears down the index internally).
+  PeakMap spectra_a = spectra; // search() preprocesses in place
+  vector<ProteinIdentification> prot_a;
+  PeptideIdentificationList pep_a;
+  auto ec_a = algo.search(spectra_a, fasta_db, prot_a, pep_a);
+  TEST_EQUAL(ec_a == PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK, true)
+  TEST_TRUE(pep_a.size() > 0)
+
+  // Path B: prepareContext + context-based search.
+  PeakMap spectra_b = spectra;
+  PeptideSearchEngineFIAlgorithm::SearchContext ctx = algo.prepareContext(fasta_db);
+  TEST_EQUAL(ctx.fragment_index.isBuild(), true)
+  vector<ProteinIdentification> prot_b;
+  PeptideIdentificationList pep_b;
+  auto ec_b = algo.search(spectra_b, ctx, prot_b, pep_b);
+  TEST_EQUAL(ec_b == PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK, true)
+
+  // Both paths must yield the same number of PSMs (the search engine itself is
+  // deterministic when decoys are disabled).
+  TEST_EQUAL(pep_a.size(), pep_b.size())
+
+  // Compare top-hit sequences spectrum-by-spectrum: they should match exactly.
+  TEST_EQUAL(prot_a.size(), prot_b.size())
+  for (Size i = 0; i < pep_a.size(); ++i)
+  {
+    TEST_EQUAL(pep_a[i].getHits().empty(), pep_b[i].getHits().empty())
+    if (!pep_a[i].getHits().empty() && !pep_b[i].getHits().empty())
+    {
+      TEST_STRING_EQUAL(pep_a[i].getHits()[0].getSequence().toString(),
+                        pep_b[i].getHits()[0].getSequence().toString())
+    }
+  }
+
+  // Reusing the same context for a second search must also work.
+  PeakMap spectra_c = spectra;
+  vector<ProteinIdentification> prot_c;
+  PeptideIdentificationList pep_c;
+  auto ec_c = algo.search(spectra_c, ctx, prot_c, pep_c);
+  TEST_EQUAL(ec_c == PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK, true)
+  TEST_EQUAL(pep_c.size(), pep_b.size())
+}
+END_SECTION
+
+START_SECTION((MultiFileSearchResult searchWithModificationAnalysis(const std::vector<String>&, const std::vector<FASTAFile::FASTAEntry>&, const std::vector<String>&, const String&) const))
+{
+  // Verify the multi-file in-memory FASTA overload validates input list lengths.
+  PeptideSearchEngineFIAlgorithm algo;
+  Param p = algo.getParameters();
+  p.setValue("decoys", "false");
+  algo.setParameters(p);
+
+  vector<FASTAFile::FASTAEntry> fasta_db = {{"P01", "Test", "MSDEREKVLGFHQRMPNASTICYWDLK"}};
+  vector<String> in_files = {"a.mzML", "b.mzML"};
+  vector<String> mismatched_base_names = {"a"}; // wrong size
+
+  TEST_EXCEPTION(Exception::InvalidParameter,
+                 algo.searchWithModificationAnalysis(in_files, fasta_db, mismatched_base_names, ""))
+
+  // Empty input file list returns INPUT_FILE_EMPTY (no exception).
+  auto empty_res = algo.searchWithModificationAnalysis(std::vector<String>{}, fasta_db, std::vector<String>{}, "");
+  TEST_EQUAL(empty_res.per_file.empty(), true)
+  TEST_EQUAL(empty_res.aggregate.exit_code == PeptideSearchEngineFIAlgorithm::ExitCodes::INPUT_FILE_EMPTY, true)
+}
+END_SECTION
+
+START_SECTION((MultiFileSearchResult searchWithModificationAnalysis(const std::vector<String>&, const String&, const std::vector<String>&, const String&) const))
+{
+  NOT_TESTABLE // tested via TOPP tool (multi-file integration test)
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2916,6 +2916,21 @@ add_test("TOPP_PeptideDataBaseSearchFI_2_out" ${DIFF} -in1 ${TESTS_TEMP_DIR}/Pep
 set_tests_properties("TOPP_PeptideDataBaseSearchFI_2_out" PROPERTIES DEPENDS
 "TOPP_PeptideDataBaseSearchFI_2")
 
+# Multi-file test: search two mzML inputs (here the same file twice for simplicity)
+# against the same FASTA in a single invocation. The fragment index is built once
+# and reused. The first output is idXML (compared against the _1 reference), the
+# second output is QPX PSM parquet (smoke-tested via sha256sum which fails if the
+# file does not exist).
+add_test("TOPP_PeptideDataBaseSearchFI_3_multi" ${TOPP_BIN_PATH}/PeptideDataBaseSearchFI -test
+-ini ${DATA_DIR_TOPP}/PeptideDataBaseSearchFI_1.ini
+-in ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML
+-out ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_3_multi_a.tmp.idXML ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_3_multi_b.tmp.parquet
+-database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
+add_test("TOPP_PeptideDataBaseSearchFI_3_multi_idXML_out" ${DIFF} -in1 ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_3_multi_a.tmp.idXML -in2 ${DATA_DIR_TOPP}/PeptideDataBaseSearchFI_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=")
+set_tests_properties("TOPP_PeptideDataBaseSearchFI_3_multi_idXML_out" PROPERTIES DEPENDS "TOPP_PeptideDataBaseSearchFI_3_multi")
+add_test(NAME "TOPP_PeptideDataBaseSearchFI_3_multi_parquet_out" COMMAND ${CMAKE_COMMAND} -E sha256sum ${TESTS_TEMP_DIR}/PeptideDataBaseSearchFI_3_multi_b.tmp.parquet)
+set_tests_properties("TOPP_PeptideDataBaseSearchFI_3_multi_parquet_out" PROPERTIES DEPENDS "TOPP_PeptideDataBaseSearchFI_3_multi")
+
 # Bruker .d input integration tests (DDA-PASEF with IM annotation)
 if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
   # Create a symlink with .d suffix so FileHandler recognizes the format

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -83,7 +83,7 @@ class PeptideDataBaseSearchFI :
       registerOutputFileList_("out", "<files>", StringList(), "Output identification file(s). Must have the same number of entries as -in. Output format is auto-detected per file from the extension (.idXML or .parquet); a mix of formats within one run is allowed.");
       setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
 
-      registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input mzML's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
+      registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input file's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
 
       // put search algorithm parameters at Search: subtree of parameters
       Param search_algo_params_with_subsection;
@@ -152,7 +152,7 @@ class PeptideDataBaseSearchFI :
       // Build per-file modification-analysis base names if -out_mod_analysis_dir is set.
       // Each per-file base name is "<dir>/<input_basename_without_ext>" so the algorithm
       // appends suffixes like _ModificationAnalysis_DeltaMassStats.tsv.
-      // Use a long, unlikely-to-collide aggregate stem so an input named "aggregate.mzML"
+      // Use a long, unlikely-to-collide aggregate stem so an input named "aggregate.mzML" (or "aggregate.d")
       // doesn't silently overwrite the aggregate output (or vice versa).
       static const String AGGREGATE_STEM = "_aggregate_across_files";
       std::vector<String> mod_analysis_base_names;

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -17,6 +17,8 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 
+#include <map>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -81,7 +83,7 @@ class PeptideDataBaseSearchFI :
       registerOutputFileList_("out", "<files>", StringList(), "Output identification file(s). Must have the same number of entries as -in. Output format is auto-detected per file from the extension (.idXML or .parquet); a mix of formats within one run is allowed.");
       setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
 
-      registerOutputPrefix_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input mzML's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
+      registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input mzML's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
 
       // put search algorithm parameters at Search: subtree of parameters
       Param search_algo_params_with_subsection;
@@ -94,7 +96,8 @@ class PeptideDataBaseSearchFI :
       const StringList in_list = getStringList_("in");
       const String database = getStringOption_("database");
       const StringList out_list = getStringList_("out");
-      const String out_mod_analysis_dir = getStringOption_("out_mod_analysis_dir");
+      // getOutputDirOption auto-creates the directory if it doesn't exist (and returns "" if unset).
+      const String out_mod_analysis_dir = getOutputDirOption("out_mod_analysis_dir");
 
       if (in_list.empty())
       {
@@ -109,26 +112,83 @@ class PeptideDataBaseSearchFI :
         return ILLEGAL_PARAMETERS;
       }
 
+      // Pre-flight validate every -out file extension before running the search,
+      // so the user learns about a typo (e.g. ".idxml" -> "idxml") before paying the
+      // index-build + search cost. registerOutputFileList_ does NOT validate per-entry
+      // formats at the CLI layer, so we have to do it here.
+      for (const String& out_file : out_list)
+      {
+        const FileTypes::Type out_type = FileHandler::getTypeByFileName(out_file);
+        if (out_type != FileTypes::IDXML && out_type != FileTypes::PARQUET)
+        {
+          OPENMS_LOG_ERROR << "Unsupported output format for '" << out_file
+                           << "' (expected .idXML or .parquet)." << endl;
+          return ILLEGAL_PARAMETERS;
+        }
+      }
+
       ProgressLogger progresslogger;
       progresslogger.setLogType(log_type_);
 
+      const Param search_params = getParam_().copy("Search:", true);
       PeptideSearchEngineFIAlgorithm sse;
-      sse.setParameters(getParam_().copy("Search:", true));
+      sse.setParameters(search_params);
+
+      // Determine open-search mode the same way the algorithm does, so we can give
+      // the user actionable feedback if -out_mod_analysis_dir is set in closed-search.
+      const double precursor_tol = static_cast<double>(search_params.getValue("precursor:mass_tolerance"));
+      const String precursor_tol_unit = search_params.getValue("precursor:mass_tolerance_unit").toString();
+      const bool open_search_mode = (precursor_tol_unit == "ppm")
+        ? (precursor_tol > 1000.0)
+        : (precursor_tol > 1.0);
+
+      if (!out_mod_analysis_dir.empty() && !open_search_mode)
+      {
+        OPENMS_LOG_WARN << "-out_mod_analysis_dir was set but the search is in CLOSED-search mode "
+                        << "(precursor tolerance " << precursor_tol << " " << precursor_tol_unit
+                        << "). Modification-analysis tables will NOT be written." << endl;
+      }
 
       // Build per-file modification-analysis base names if -out_mod_analysis_dir is set.
       // Each per-file base name is "<dir>/<input_basename_without_ext>" so the algorithm
       // appends suffixes like _ModificationAnalysis_DeltaMassStats.tsv.
+      // Use a long, unlikely-to-collide aggregate stem so an input named "aggregate.mzML"
+      // doesn't silently overwrite the aggregate output (or vice versa).
+      static const String AGGREGATE_STEM = "_aggregate_across_files";
       std::vector<String> mod_analysis_base_names;
       String aggregate_base_name;
-      if (!out_mod_analysis_dir.empty())
+      if (!out_mod_analysis_dir.empty() && open_search_mode)
       {
+        // Detect collisions: two inputs with the same File::stemName, OR an input whose
+        // stem matches the aggregate stem. We refuse to run rather than silently overwrite.
+        std::map<String, Size> stem_to_first_index;
+        for (Size i = 0; i < in_list.size(); ++i)
+        {
+          const String stem = File::stemName(in_list[i]);
+          if (stem == AGGREGATE_STEM)
+          {
+            OPENMS_LOG_ERROR << "Input file '" << in_list[i] << "' has basename '" << stem
+                             << "' which would collide with the reserved aggregate output name. "
+                             << "Rename the file or omit -out_mod_analysis_dir." << endl;
+            return ILLEGAL_PARAMETERS;
+          }
+          auto [it, inserted] = stem_to_first_index.emplace(stem, i);
+          if (!inserted)
+          {
+            OPENMS_LOG_ERROR << "Two -in files share basename '" << stem
+                             << "': '" << in_list[it->second] << "' and '" << in_list[i]
+                             << "'. Per-file modification-analysis TSVs would overwrite each other. "
+                             << "Rename one of them or omit -out_mod_analysis_dir." << endl;
+            return ILLEGAL_PARAMETERS;
+          }
+        }
+
         mod_analysis_base_names.reserve(in_list.size());
         for (const String& in_file : in_list)
         {
-          String stem = File::stemName(in_file);
-          mod_analysis_base_names.push_back(out_mod_analysis_dir + "/" + stem);
+          mod_analysis_base_names.push_back(out_mod_analysis_dir + "/" + File::stemName(in_file));
         }
-        aggregate_base_name = out_mod_analysis_dir + "/aggregate";
+        aggregate_base_name = out_mod_analysis_dir + "/" + AGGREGATE_STEM;
       }
 
       // Single-shot multi-file search: builds the fragment index once and iterates over -in.
@@ -143,7 +203,7 @@ class PeptideDataBaseSearchFI :
       }
 
       // Write per-file outputs and track failures.
-      bool any_failure = false;
+      Size failed_count = 0;
       for (Size i = 0; i < in_list.size(); ++i)
       {
         const String& in_file = in_list[i];
@@ -154,7 +214,7 @@ class PeptideDataBaseSearchFI :
         {
           OPENMS_LOG_ERROR << "Search failed for " << in_file
                            << " (algorithm exit code " << static_cast<int>(result.exit_code) << "). Skipping output." << endl;
-          any_failure = true;
+          ++failed_count;
           continue;
         }
 
@@ -164,31 +224,30 @@ class PeptideDataBaseSearchFI :
           result.protein_ids[0].setPrimaryMSRunPath({"file://" + File::basename(in_file)});
         }
 
-        // Dispatch on output extension: .idXML -> idXML; .parquet -> QPX PSM parquet.
+        // Dispatch on output extension (already validated above to be IDXML or PARQUET).
         const FileTypes::Type out_type = FileHandler::getTypeByFileName(out_file);
         if (out_type == FileTypes::IDXML)
         {
           FileHandler().storeIdentifications(out_file, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
         }
-        else if (out_type == FileTypes::PARQUET)
+        else // FileTypes::PARQUET
         {
           if (!QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, out_file, /*export_all_psms=*/false))
           {
             OPENMS_LOG_ERROR << "Failed to write parquet output for " << in_file << " -> " << out_file << endl;
-            any_failure = true;
+            ++failed_count;
             continue;
           }
         }
-        else
-        {
-          OPENMS_LOG_ERROR << "Unsupported output format for " << out_file
-                           << " (expected .idXML or .parquet)." << endl;
-          any_failure = true;
-          continue;
-        }
       }
 
-      return any_failure ? INTERNAL_ERROR : EXECUTION_OK;
+      if (failed_count > 0)
+      {
+        OPENMS_LOG_ERROR << "PeptideDataBaseSearchFI finished with " << failed_count
+                         << " file(s) failing out of " << in_list.size() << "." << endl;
+        return INTERNAL_ERROR;
+      }
+      return EXECUTION_OK;
     }
 };
 

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -10,6 +10,8 @@
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/FileTypes.h>
+#include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -70,14 +72,16 @@ class PeptideDataBaseSearchFI :
   protected:
     void registerOptionsAndFlags_() override
     {
-      registerInputFile_("in", "<file>", "", "input file ");
+      registerInputFileList_("in", "<files>", StringList(), "Input spectrum file(s). Multiple files are searched against the same database; the fragment index is built once and reused.");
       setValidFormats_("in", ListUtils::create<String>("mzML,d"));
 
-      registerInputFile_("database", "<file>", "", "input file ");
+      registerInputFile_("database", "<file>", "", "Input protein sequence database in FASTA format.");
       setValidFormats_("database", ListUtils::create<String>("fasta"));
 
-      registerOutputFile_("out", "<file>", "", "output file ");
-      setValidFormats_("out", ListUtils::create<String>("idXML"));
+      registerOutputFileList_("out", "<files>", StringList(), "Output identification file(s). Must have the same number of entries as -in. Output format is auto-detected per file from the extension (.idXML or .parquet); a mix of formats within one run is allowed.");
+      setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
+
+      registerOutputPrefix_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input mzML's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
 
       // put search algorithm parameters at Search: subtree of parameters
       Param search_algo_params_with_subsection;
@@ -87,35 +91,104 @@ class PeptideDataBaseSearchFI :
 
     ExitCodes main_(int, const char**) override
     {
-      String in = getStringOption_("in");
-      String database = getStringOption_("database");
-      String out = getStringOption_("out");
+      const StringList in_list = getStringList_("in");
+      const String database = getStringOption_("database");
+      const StringList out_list = getStringList_("out");
+      const String out_mod_analysis_dir = getStringOption_("out_mod_analysis_dir");
+
+      if (in_list.empty())
+      {
+        OPENMS_LOG_ERROR << "No input files provided (-in)." << endl;
+        return ILLEGAL_PARAMETERS;
+      }
+
+      if (in_list.size() != out_list.size())
+      {
+        OPENMS_LOG_ERROR << "Number of output files (-out, " << out_list.size()
+                         << ") must match number of input files (-in, " << in_list.size() << ")." << endl;
+        return ILLEGAL_PARAMETERS;
+      }
 
       ProgressLogger progresslogger;
       progresslogger.setLogType(log_type_);
 
-      vector<ProteinIdentification> protein_ids;
-      PeptideIdentificationList peptide_ids;
-
       PeptideSearchEngineFIAlgorithm sse;
       sse.setParameters(getParam_().copy("Search:", true));
-      // map algorithm exit code to application exit code
-      PeptideSearchEngineFIAlgorithm::ExitCodes e = sse.search(in, database, protein_ids, peptide_ids);
-      if (e != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK)
+
+      // Build per-file modification-analysis base names if -out_mod_analysis_dir is set.
+      // Each per-file base name is "<dir>/<input_basename_without_ext>" so the algorithm
+      // appends suffixes like _ModificationAnalysis_DeltaMassStats.tsv.
+      std::vector<String> mod_analysis_base_names;
+      String aggregate_base_name;
+      if (!out_mod_analysis_dir.empty())
       {
-        return TOPPBase::ExitCodes::INTERNAL_ERROR;
+        mod_analysis_base_names.reserve(in_list.size());
+        for (const String& in_file : in_list)
+        {
+          String stem = File::stemName(in_file);
+          mod_analysis_base_names.push_back(out_mod_analysis_dir + "/" + stem);
+        }
+        aggregate_base_name = out_mod_analysis_dir + "/aggregate";
       }
 
-      // MS path already set in algorithm. Overwrite here so we get something testable
-      if (getFlag_("test"))
+      // Single-shot multi-file search: builds the fragment index once and iterates over -in.
+      PeptideSearchEngineFIAlgorithm::MultiFileSearchResult mfres =
+        sse.searchWithModificationAnalysis(in_list, database, mod_analysis_base_names, aggregate_base_name);
+
+      if (mfres.per_file.size() != in_list.size())
       {
-        // if test mode set, add file without path so we can compare it
-        protein_ids[0].setPrimaryMSRunPath({"file://" + File::basename(in)});
+        OPENMS_LOG_ERROR << "Internal error: per-file result count (" << mfres.per_file.size()
+                         << ") does not match input file count (" << in_list.size() << ")." << endl;
+        return INTERNAL_ERROR;
       }
 
-      FileHandler().storeIdentifications(out, protein_ids, peptide_ids, {FileTypes::IDXML});
+      // Write per-file outputs and track failures.
+      bool any_failure = false;
+      for (Size i = 0; i < in_list.size(); ++i)
+      {
+        const String& in_file = in_list[i];
+        const String& out_file = out_list[i];
+        PeptideSearchEngineFIAlgorithm::SearchResult& result = mfres.per_file[i];
 
-      return EXECUTION_OK;
+        if (result.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK)
+        {
+          OPENMS_LOG_ERROR << "Search failed for " << in_file
+                           << " (algorithm exit code " << static_cast<int>(result.exit_code) << "). Skipping output." << endl;
+          any_failure = true;
+          continue;
+        }
+
+        // In test mode, replace the absolute MS run path with file://<basename> for reproducible diffs.
+        if (getFlag_("test") && !result.protein_ids.empty())
+        {
+          result.protein_ids[0].setPrimaryMSRunPath({"file://" + File::basename(in_file)});
+        }
+
+        // Dispatch on output extension: .idXML -> idXML; .parquet -> QPX PSM parquet.
+        const FileTypes::Type out_type = FileHandler::getTypeByFileName(out_file);
+        if (out_type == FileTypes::IDXML)
+        {
+          FileHandler().storeIdentifications(out_file, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+        }
+        else if (out_type == FileTypes::PARQUET)
+        {
+          if (!QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, out_file, /*export_all_psms=*/false))
+          {
+            OPENMS_LOG_ERROR << "Failed to write parquet output for " << in_file << " -> " << out_file << endl;
+            any_failure = true;
+            continue;
+          }
+        }
+        else
+        {
+          OPENMS_LOG_ERROR << "Unsupported output format for " << out_file
+                           << " (expected .idXML or .parquet)." << endl;
+          any_failure = true;
+          continue;
+        }
+      }
+
+      return any_failure ? INTERNAL_ERROR : EXECUTION_OK;
     }
 };
 


### PR DESCRIPTION
## Summary

`PeptideDataBaseSearchFI` can now process multiple spectrum files (mzML or Bruker .d) against the same FASTA in one invocation. The `FragmentIndex` is built once via a new `prepareContext()` step and reused across every input file, eliminating the redundant per-file index-build cost (peptide generation → fragment generation → sorting → bucketing) when batching searches.

Per-file output is written as either **idXML** or **QPX PSM parquet**, auto-detected from each `-out` entry's extension. Mixed formats within a single run are allowed.

Closes the FragmentIndex-reuse / multi-file batch use-case for this tool.

## Algorithm changes (`PeptideSearchEngineFIAlgorithm`)

- New `SearchContext` struct (decoy-augmented `db` + built `FragmentIndex`).
- New `prepareContext(fasta_db)` extracted from the existing `search()` body.
- New `search(PeakMap&, SearchContext&, ...)` overload reusing a pre-built context.
- New `MultiFileSearchResult` struct (per-file SearchResults + aggregate).
- Two new file-list `searchWithModificationAnalysis(...)` overloads (in-memory FASTA and FASTA file path) — build the index once, loop per file with per-file modification analysis, then run a single aggregate analysis on the pooled PSMs.
- Single-file fast-path skips the redundant aggregate computation (no wasted PSM deep-copy).
- Existing single-file `search(PeakMap&, fasta_db, ...)` and file-based `searchWithModificationAnalysis(in_spectra, in_db, ...)` refactored into thin wrappers — **no behavior change for existing callers** (verified by 10 byte-identical regression tests).
- Per-scan top-hit log demoted from INFO to DEBUG (multi-file mode would otherwise emit one line per scan per input).

## TOPP tool changes (`PeptideDataBaseSearchFI`)

- `-in` and `-out` are now lists; `-database` stays a single FASTA.
- Per-file extension dispatch: `.idXML` → `FileHandler::storeIdentifications`; `.parquet` → `QPXFile::exportToParquet`.
- New advanced `-out_mod_analysis_dir <dir>` writes per-file (basename-stemmed) and aggregate modification-analysis TSVs in open-search mode. Uses `registerOutputDir_` / `getOutputDirOption` so the directory is auto-created. When set, per-file tables use each input file's basename (works for both mzML and .d inputs).
- Pre-flight validation: matching `-in`/`-out` list lengths, recognised output extensions, basename-collision detection (refuses to overwrite when two inputs share a stem or collide with the reserved aggregate name).
- Explicit warning when `-out_mod_analysis_dir` is set in closed-search mode (precursor tolerance ≤ 1 Da / ≤ 1000 ppm).
- Per-file failures are logged but don't abort remaining files; final summary line + `INTERNAL_ERROR` exit code if any file failed.

## Tests

- **Class test:** new sections verifying (a) `prepareContext` + context-based `search()` produces the same PSMs as the single-shot `search()` and that the same context can be reused for a second search; (b) the multi-file overload's input-validation paths (`Exception::InvalidParameter` on length mismatch, `INPUT_FILE_EMPTY` on empty list).
- **TOPP integration test:** new `TOPP_PeptideDataBaseSearchFI_3_multi` runs the tool with two mzML inputs (the existing `SimpleSearchEngine_1.mzML` twice for simplicity) and one idXML + one parquet output. The idXML is diffed against the existing `_1` reference (same input → same output, proving the multi-file path is equivalent to single-file). The parquet output is smoke-tested with `cmake -E sha256sum` (fails if missing).
- All **10 pre-existing tests pass byte-identically** after the algorithm refactor (`_1`, `_2`, `_DDA`, `_FalseDiscoveryRate_DDA`, write-INI, write-CTD, class test, plus the 3 new ones → 13/13).

## Test plan

- [x] `cmake --build OpenMS-build -j$(nproc)` — clean
- [x] `ctest --test-dir OpenMS-build -R 'PeptideDataBaseSearchFI|PeptideSearchEngineFIAlgorithm'` — 13/13 pass
- [x] Existing single-file tests produce byte-identical idXML output as before the refactor
- [x] New `_3_multi` test produces matching idXML for the first input and a non-empty parquet for the second
- [ ] Manual sanity run on a non-trivial dataset to confirm "Building fragment index..." appears once and per-file scoring stages appear N times

## Notes / follow-ups (not in this PR)

- pyOpenMS bindings for the new `SearchContext` / `MultiFileSearchResult` / `prepareContext` / multi-file `searchWithModificationAnalysis` overloads (legacy single-file paths still bound).
- Framework-level fix in `TOPPBase::fileParamValidityCheck_` to add an `OUTPUT_FILE_LIST` branch (currently only `INPUT_FILE_LIST` is checked, so per-entry `setValidFormats_` validation is silently skipped for output lists). This tool's local pre-flight loop covers the gap for now; affects 4 other tools (`FileMerger`, `OpenSwathDIAPreScoring`, `QualityControl`, `SpectraSTSearchAdapter`).
- Class test parametrization over `decoys=true` to also exercise the decoy-generation path inside `prepareContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-file peptide search: batch processing of multiple spectrum files with per-file and pooled aggregate modification analysis.
  * Parquet output support alongside idXML; per-file output selection and optional modification-analysis output directory.
  * Reuse of prebuilt search context (database/index) to speed repeated searches; input/output count validation and output-name collision checks.

* **Tests**
  * Added tests for context reuse, multi-file search behavior, input validation, and empty-input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->