### PR TITLE
feat: semi-tryptic and non-specific digestion (FragmentIndex / SimpleSearchEngine)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/FragmentIndex.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
@@ -422,6 +423,7 @@ private:
 
     // SpectrumGenerator independend member variables
     std::string digestion_enzyme_;
+    EnzymaticDigestion::Specificity enzyme_specificity_{EnzymaticDigestion::SPEC_FULL}; ///< 'full' (default), 'semi' (semi-tryptic), or 'none' (e.g. immunopeptidomics)
 
     size_t missed_cleavages_; ///< number of missed cleavages
     float peptide_min_mass_;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -13,6 +13,7 @@
 
 #include <OpenMS/ANALYSIS/ID/FragmentIndex.h>
 #include <OpenMS/ANALYSIS/ID/OpenSearchModificationAnalysis.h>
+#include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/DATASTRUCTURES/StringView.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
@@ -419,6 +420,7 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     Size peptide_min_size_;
     Size peptide_max_size_;
     Size peptide_missed_cleavages_;
+    EnzymaticDigestion::Specificity peptide_enzyme_specificity_{EnzymaticDigestion::SPEC_FULL};
 
     String peptide_motif_;
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -9,6 +9,7 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 
+#include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/CHEMISTRY/ModifiedPeptideGenerator.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/DATASTRUCTURES/StringView.h>
@@ -120,6 +121,7 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
     Size peptide_min_size_;
     Size peptide_max_size_;
     Size peptide_missed_cleavages_;
+    EnzymaticDigestion::Specificity peptide_enzyme_specificity_{EnzymaticDigestion::SPEC_FULL};
 
     String peptide_motif_;
 

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -453,6 +453,7 @@ namespace OpenMS
       ProteaseDigestion digestor;
       digestor.setEnzyme(digestion_enzyme_);
       digestor.setMissedCleavages(missed_cleavages_);
+      digestor.setSpecificity(enzyme_specificity_);
 
       OPENMS_LOG_INFO << "Generating peptides..." << std::endl;
 
@@ -763,6 +764,18 @@ namespace OpenMS
       {
         return std::tie(a.fragment_mz_, a.peptide_idx_) < std::tie(b.fragment_mz_, b.peptide_idx_);
       });
+
+      // Empty database (no peptide passed length / mass / motif filters): nothing to bucket.
+      // Mark as built and return — guards against the OMP loop below dividing by zero
+      // when bucketsize_ becomes 0. This is a real risk for immunopeptidomics FASTAs that
+      // contain entries shorter than peptide:min_size.
+      if (fi_fragments_.empty())
+      {
+        bucketsize_ = 0;
+        OPENMS_LOG_INFO << "[FragmentIndex] No fragments generated — index is empty." << std::endl;
+        is_build_ = true;
+        return;
+      }
 
       /// Calculate the bucket size
       bucketsize_ = sqrt(fi_fragments_.size()); //Todo: MSFragger uses a different approach, which might be better
@@ -1104,6 +1117,15 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
 
 
     defaults_.setValue("peptide:missed_cleavages", 1, "Missed cleavages for digestion");
+    defaults_.setValue("peptide:enzyme_specificity", "full",
+      "Enzyme cleavage specificity required for both peptide termini.\n"
+      "  'full' : both termini must be enzyme-specific (canonical, e.g. tryptic).\n"
+      "  'semi' : only one terminus needs to be enzyme-specific (semi-tryptic).\n"
+      "  'none' : no enzyme constraint at either terminus; every substring of length\n"
+      "           [min_size, max_size] is enumerated. This is the canonical setting for\n"
+      "           immunopeptidomics (e.g. HLA peptides 8..12mers). For very large search\n"
+      "           spaces consider tightening 'peptide:min_size'/'peptide:max_size'.");
+    defaults_.setValidStrings("peptide:enzyme_specificity", {"full", "semi", "none"});
     defaults_.setValue("peptide:min_size", 7, "Minimal peptide length for database");
     defaults_.setValue("peptide:max_size", 40, "Maximal peptide length for database");
 
@@ -1158,6 +1180,8 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     add_x_ions_ = param_.getValue("ions:add_x_ions").toBool();
     add_z_ions_ = param_.getValue("ions:add_z_ions").toBool();
     digestion_enzyme_ = param_.getValue("enzyme").toString();
+    enzyme_specificity_ = EnzymaticDigestion::getSpecificityByName(
+      param_.getValue("peptide:enzyme_specificity").toString());
     missed_cleavages_ = param_.getValue("peptide:missed_cleavages");
     peptide_min_mass_ = param_.getValue("peptide:min_mass");
     peptide_max_mass_ = param_.getValue("peptide:max_mass");

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -533,7 +533,16 @@ namespace OpenMS
       for (size_t i = 0; i != old_size; ++i)
       {
         FASTAFile::FASTAEntry e = ctx.db[i];
-        e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
+        // Non-specific search: plain reverse (no enzyme boundaries to preserve).
+        // Enzyme-specific search: reverse within enzymatic peptide boundaries.
+        if (peptide_enzyme_specificity_ == EnzymaticDigestion::SPEC_NONE)
+        {
+          e.sequence = decoy_generator.reverseProtein(AASequence::fromString(e.sequence)).toString();
+        }
+        else
+        {
+          e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
+        }
         e.identifier = "DECOY_" + e.identifier;
         ctx.db.push_back(std::move(e));
       }

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -129,6 +129,15 @@ namespace OpenMS
     defaults_.setValue("peptide:min_size", 7, "Minimum size a peptide must have after digestion to be considered in the search.");
     defaults_.setValue("peptide:max_size", 40, "Maximum size a peptide must have after digestion to be considered in the search (0 = disabled).");
     defaults_.setValue("peptide:missed_cleavages", 1, "Number of missed cleavages.");
+    defaults_.setValue("peptide:enzyme_specificity", "full",
+      "Enzyme cleavage specificity required for both peptide termini.\n"
+      "  'full' : both termini must be enzyme-specific (canonical, e.g. tryptic).\n"
+      "  'semi' : only one terminus needs to be enzyme-specific (semi-tryptic).\n"
+      "  'none' : no enzyme constraint at either terminus; every substring of length\n"
+      "           [min_size, max_size] is enumerated. Use this for immunopeptidomics\n"
+      "           (e.g. HLA peptides 8..12mers). For very large search spaces consider\n"
+      "           tightening 'peptide:min_size'/'peptide:max_size'.");
+    defaults_.setValidStrings("peptide:enzyme_specificity", {"full", "semi", "none"});
     defaults_.setValue("peptide:motif", "", "If set, only peptides that contain this motif (provided as RegEx) will be considered.");
     defaults_.setSectionDescription("peptide", "Peptide Options");
 
@@ -215,6 +224,8 @@ namespace OpenMS
     peptide_min_size_ = param_.getValue("peptide:min_size");
     peptide_max_size_ = param_.getValue("peptide:max_size");
     peptide_missed_cleavages_ = param_.getValue("peptide:missed_cleavages");
+    peptide_enzyme_specificity_ = EnzymaticDigestion::getSpecificityByName(
+      param_.getValue("peptide:enzyme_specificity").toString());
     peptide_motif_ = param_.getValue("peptide:motif").toString(); // TODO: remove unused parameters
 
     report_top_hits_ = param_.getValue("report:top_hits");
@@ -481,7 +492,7 @@ namespace OpenMS
     // record whether open-search mode was used
     search_parameters.setMetaValue("open_search", isOpenSearchMode_() ? "true" : "false");
 
-    search_parameters.enzyme_term_specificity = EnzymaticDigestion::SPEC_FULL;
+    search_parameters.enzyme_term_specificity = peptide_enzyme_specificity_;
     protein_ids[0].setSearchParameters(std::move(search_parameters));
 
     // Annotate IM unit on ProteinIdentification if all PeptideIdentifications have IM
@@ -711,13 +722,17 @@ namespace OpenMS
       endProgress();
     }
 
-    // reindex peptides to proteins
+    // reindex peptides to proteins.
+    // The PeptideIndexer drops peptides whose termini do not match the configured
+    // specificity, so it must agree with the search-time setting — otherwise
+    // semi-specific / non-specific PSMs would be silently filtered out here.
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
     param_pi.setValue("decoy_string", "DECOY_");
     param_pi.setValue("decoy_string_position", "prefix");
     param_pi.setValue("enzyme:name", enzyme_);
-    param_pi.setValue("enzyme:specificity", "full");
+    param_pi.setValue("enzyme:specificity",
+                      EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
     param_pi.setValue("missing_decoy_action", "silent");
     indexer.setParameters(param_pi);
 

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -119,6 +119,15 @@ namespace OpenMS
     defaults_.setValue("peptide:min_size", 7, "Minimum size a peptide must have after digestion to be considered in the search.");
     defaults_.setValue("peptide:max_size", 40, "Maximum size a peptide must have after digestion to be considered in the search (0 = disabled).");
     defaults_.setValue("peptide:missed_cleavages", 1, "Number of missed cleavages.");
+    defaults_.setValue("peptide:enzyme_specificity", "full",
+      "Enzyme cleavage specificity required for both peptide termini.\n"
+      "  'full' : both termini must be enzyme-specific (canonical, e.g. tryptic).\n"
+      "  'semi' : only one terminus needs to be enzyme-specific (semi-tryptic).\n"
+      "  'none' : no enzyme constraint at either terminus; every substring of length\n"
+      "           [min_size, max_size] is enumerated. Use this for immunopeptidomics\n"
+      "           (e.g. HLA peptides 8..12mers). For very large search spaces consider\n"
+      "           tightening 'peptide:min_size'/'peptide:max_size'.");
+    defaults_.setValidStrings("peptide:enzyme_specificity", {"full", "semi", "none"});
     defaults_.setValue("peptide:motif", "", "If set, only peptides that contain this motif (provided as RegEx) will be considered.");
     defaults_.setSectionDescription("peptide", "Peptide Options");
 
@@ -170,6 +179,8 @@ namespace OpenMS
     peptide_min_size_ = param_.getValue("peptide:min_size");
     peptide_max_size_ = param_.getValue("peptide:max_size");
     peptide_missed_cleavages_ = param_.getValue("peptide:missed_cleavages");
+    peptide_enzyme_specificity_ = EnzymaticDigestion::getSpecificityByName(
+      param_.getValue("peptide:enzyme_specificity").toString());
     peptide_motif_ = param_.getValue("peptide:motif").toString();
 
     report_top_hits_ = param_.getValue("report:top_hits");
@@ -412,7 +423,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
 
     search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));
 
-    search_parameters.enzyme_term_specificity = EnzymaticDigestion::SPEC_FULL;
+    search_parameters.enzyme_term_specificity = peptide_enzyme_specificity_;
     protein_ids[0].setSearchParameters(std::move(search_parameters));
 
     // Annotate IM unit on ProteinIdentification if all PeptideIdentifications have IM
@@ -549,6 +560,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     ProteaseDigestion digestor;
     digestor.setEnzyme(enzyme_);
     digestor.setMissedCleavages(peptide_missed_cleavages_);
+    digestor.setSpecificity(peptide_enzyme_specificity_);
     startProgress(0, fasta_db.size(), "Scoring peptide models against spectra...");
 
     // lookup for processed peptides. must be defined outside of omp section and synchronized
@@ -723,13 +735,17 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     // add meta data on spectra file
     protein_ids[0].setPrimaryMSRunPath({in_spectra}, spectra);
 
-    // reindex peptides to proteins
+    // reindex peptides to proteins.
+    // The PeptideIndexer uses isValidProduct() to drop peptides whose termini do not
+    // match the configured specificity, so it must agree with the search-time setting —
+    // otherwise semi/non-specific hits would be silently filtered out here.
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
     param_pi.setValue("decoy_string", "DECOY_");
     param_pi.setValue("decoy_string_position", "prefix");
     param_pi.setValue("enzyme:name", enzyme_);
-    param_pi.setValue("enzyme:specificity", "full");
+    param_pi.setValue("enzyme:specificity",
+                      EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
     param_pi.setValue("missing_decoy_action", "silent");
     indexer.setParameters(param_pi);
 

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -547,7 +547,16 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       for (size_t i = 0; i != old_size; ++i)
       {
         FASTAFile::FASTAEntry e = fasta_db[i];
-        e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
+        // Non-specific search: plain reverse (no enzyme boundaries to preserve).
+        // Enzyme-specific search: reverse within enzymatic peptide boundaries.
+        if (peptide_enzyme_specificity_ == EnzymaticDigestion::SPEC_NONE)
+        {
+          e.sequence = decoy_generator.reverseProtein(AASequence::fromString(e.sequence)).toString();
+        }
+        else
+        {
+          e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
+        }
         e.identifier = "DECOY_" + e.identifier;
         fasta_db.push_back(std::move(e));
       }

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -145,7 +145,9 @@ namespace OpenMS
     const int last_c = cleavage_positions.back(); // Last cleavage
     const int lgth = last_c - first_c;
 
-    // Lambda checking min & max conditions and adding to output
+    // Lambda checking min & max conditions and adding to output as (start, end) pairs.
+    // NOTE: ProteaseDigestion::digest also calls semiSpecificDigestion_ and uses (start, end).
+    // EnzymaticDigestion::digestUnmodified callers convert to their own convention at the call site.
     auto variant = [&output, &wrong, min_length, max_length](Size x, Size y)
     {
       if (min_length <= y - x &&
@@ -485,7 +487,7 @@ namespace OpenMS
 
     // Semi-specific: in addition to the fully-specific products above, generate variants
     // where one terminus is a non-cleavage site. semiSpecificDigestion_() returns pair<Size,Size>
-    // (start, length) which we then materialize as StringView sub-views into the same backing string.
+    // as (start, end) which we convert to substr(start, length) for StringView sub-views.
     if (specificity_ == SPEC_SEMI)
     {
       fragment_positions.push_back(static_cast<int>(sequence.size()));
@@ -493,7 +495,7 @@ namespace OpenMS
       wrong_size += semiSpecificDigestion_(fragment_positions, semi_pairs, min_length, max_length);
       for (const auto& p : semi_pairs)
       {
-        output.emplace_back(sequence.substr(p.first, p.second));
+        output.emplace_back(sequence.substr(p.first, p.second - p.first));
       }
     }
 
@@ -544,12 +546,18 @@ namespace OpenMS
     Size wrong_size = digestAfterTokenize_(fragment_positions, sequence, output, min_length, max_length);
 
     // Semi-specific: in addition to the fully-specific products above, generate variants
-    // where one terminus is a non-cleavage site. semiSpecificDigestion_() expects a positions
-    // vector that includes both sequence termini, so append the past-the-end position.
+    // where one terminus is a non-cleavage site. semiSpecificDigestion_() returns (start, end)
+    // pairs (matching ProteaseDigestion convention), so convert to (start, length) to match
+    // digestAfterTokenize_'s convention used in this overload.
     if (specificity_ == SPEC_SEMI)
     {
       fragment_positions.push_back(static_cast<int>(sequence.size()));
-      wrong_size += semiSpecificDigestion_(fragment_positions, output, min_length, max_length);
+      std::vector<std::pair<Size, Size>> semi_pairs;
+      wrong_size += semiSpecificDigestion_(fragment_positions, semi_pairs, min_length, max_length);
+      for (const auto& p : semi_pairs)
+      {
+        output.emplace_back(p.first, p.second - p.first);
+      }
     }
 
     return wrong_size;

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -453,10 +453,19 @@ namespace OpenMS
       max_length = sequence.size();
     }
 
-    // Unspecific cleavage:
-    // For unspecific cleavage every site is a cutting position.
-    // All substrings of length min_size..max_size are generated.
-    if (enzyme_->getName() == UnspecificCleavage)
+    // Sequence too short to yield any peptides — also guards against unsigned underflow below.
+    if (sequence.size() < min_length)
+    {
+      return 0;
+    }
+
+    // Non-specific / unspecific cleavage:
+    // Every site is a cutting position. All substrings of length min_length..max_length are generated.
+    // This is the canonical immunopeptidomics path (e.g. HLA-I 8..12mers).
+    // Two equivalent ways to enable it:
+    //   - enzyme set to "unspecific cleavage" (any specificity), or
+    //   - any enzyme with specificity_ == SPEC_NONE.
+    if (enzyme_->getName() == UnspecificCleavage || specificity_ == SPEC_NONE)
     {
       output.reserve(sequence.size() * (max_length - min_length + 1));
       for (Size i = 0; i <= sequence.size() - min_length; ++i)
@@ -470,9 +479,25 @@ namespace OpenMS
       return 0;
     }
 
-    // naive cleavage sites
+    // naive cleavage sites — fully-specific products + missed cleavages
     std::vector<int> fragment_positions = tokenize_(sequence.getString());
-    return digestAfterTokenize_(fragment_positions, sequence, output, min_length, max_length);
+    Size wrong_size = digestAfterTokenize_(fragment_positions, sequence, output, min_length, max_length);
+
+    // Semi-specific: in addition to the fully-specific products above, generate variants
+    // where one terminus is a non-cleavage site. semiSpecificDigestion_() returns pair<Size,Size>
+    // (start, length) which we then materialize as StringView sub-views into the same backing string.
+    if (specificity_ == SPEC_SEMI)
+    {
+      fragment_positions.push_back(static_cast<int>(sequence.size()));
+      std::vector<std::pair<Size, Size>> semi_pairs;
+      wrong_size += semiSpecificDigestion_(fragment_positions, semi_pairs, min_length, max_length);
+      for (const auto& p : semi_pairs)
+      {
+        output.emplace_back(sequence.substr(p.first, p.second));
+      }
+    }
+
+    return wrong_size;
   }
 
   Size EnzymaticDigestion::digestUnmodified(const StringView& sequence, std::vector<std::pair<Size, Size>>& output, Size min_length, Size max_length) const
@@ -486,10 +511,21 @@ namespace OpenMS
       max_length = sequence.size();
     }
 
-    // Unspecific cleavage:
-    // For unspecific cleavage every site is a cutting position.
-    // All substrings of length min_size..max_size are generated.
-    if (enzyme_->getName() == UnspecificCleavage)
+    // Sequence too short to yield any peptides — also guards against unsigned underflow below.
+    // Important for immunopeptidomics-style non-specific digestion of FASTA files that contain
+    // very short entries (signal peptides, fragments, ORF stubs).
+    if (sequence.size() < min_length)
+    {
+      return 0;
+    }
+
+    // Non-specific / unspecific cleavage:
+    // Every site is a cutting position. All substrings of length min_length..max_length are generated.
+    // This is the canonical immunopeptidomics path (e.g. HLA-I 8..12mers).
+    // Two equivalent ways to enable it:
+    //   - enzyme set to "unspecific cleavage" (any specificity), or
+    //   - any enzyme with specificity_ == SPEC_NONE.
+    if (enzyme_->getName() == UnspecificCleavage || specificity_ == SPEC_NONE)
     {
       output.reserve(sequence.size() * (max_length - min_length + 1));
       for (Size i = 0; i <= sequence.size() - min_length; ++i)
@@ -503,9 +539,20 @@ namespace OpenMS
       return 0;
     }
 
-    // naive cleavage sites
+    // naive cleavage sites — fully-specific products + missed cleavages
     std::vector<int> fragment_positions = tokenize_(sequence.getString());
-    return digestAfterTokenize_(fragment_positions, sequence, output, min_length, max_length);
+    Size wrong_size = digestAfterTokenize_(fragment_positions, sequence, output, min_length, max_length);
+
+    // Semi-specific: in addition to the fully-specific products above, generate variants
+    // where one terminus is a non-cleavage site. semiSpecificDigestion_() expects a positions
+    // vector that includes both sequence termini, so append the past-the-end position.
+    if (specificity_ == SPEC_SEMI)
+    {
+      fragment_positions.push_back(static_cast<int>(sequence.size()));
+      wrong_size += semiSpecificDigestion_(fragment_positions, output, min_length, max_length);
+    }
+
+    return wrong_size;
   }
 
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
@@ -282,6 +282,70 @@ START_SECTION((Size digestUnmodified(const StringView sequence, std::vector<Stri
 }
 END_SECTION
 
+START_SECTION([EXTRA] digestUnmodified honors SPEC_NONE / SPEC_SEMI (pair output))
+{
+  // SPEC_NONE: any enzyme + specificity=none should enumerate all substrings of length [min,max]
+  // (canonical immunopeptidomics path: no enzyme constraint).
+  EnzymaticDigestion ed_none;
+  ed_none.setEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
+  ed_none.setSpecificity(EnzymaticDigestion::SPEC_NONE);
+
+  std::string s = "ABCDEFGHIJ"; // 10 aa, no internal K/R
+  std::vector<std::pair<size_t, size_t>> out_pairs;
+
+  // 8..10mers: 8mers=3, 9mers=2, 10mers=1 → 6 total
+  ed_none.digestUnmodified(StringView(s), out_pairs, 8, 10);
+  TEST_EQUAL(out_pairs.size(), 6)
+  for (const auto& p : out_pairs)
+  {
+    TEST_EQUAL(p.second >= 8 && p.second <= 10, true);
+  }
+
+  // Sequence shorter than min_length: must not crash, must return zero peptides
+  // (this used to underflow when sequence.size() < min_length).
+  std::string short_s = "ACD";
+  ed_none.digestUnmodified(StringView(short_s), out_pairs, 8, 12);
+  TEST_EQUAL(out_pairs.size(), 0)
+
+  // Empty sequence: defensive check.
+  std::string empty_s = "";
+  ed_none.digestUnmodified(StringView(empty_s), out_pairs, 1, 10);
+  TEST_EQUAL(out_pairs.size(), 0)
+
+  // SPEC_SEMI: in addition to fully-specific products, semi-specific (one terminus free) variants.
+  EnzymaticDigestion ed_semi;
+  ed_semi.setEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
+  ed_semi.setSpecificity(EnzymaticDigestion::SPEC_SEMI);
+
+  // "AKBCDEFG": Trypsin cuts after K (pos 2). Fully-specific products: "AK", "BCDEFG".
+  // Semi-specific adds: every prefix of "BCDEFG" of length >= min, plus every suffix of "AK"
+  // of length >= min, plus every prefix/suffix straddling the K cut, etc.
+  std::string s2 = "AKBCDEFG"; // length 8, single cleavage after K (pos 2)
+  ed_semi.digestUnmodified(StringView(s2), out_pairs, 1, 100);
+  // We don't pin an exact count (semiSpecificDigestion_ enumeration is well-tested elsewhere),
+  // but assert: (a) more peptides than fully-specific (which would yield 2), (b) the two
+  // fully-specific products are still present.
+  TEST_EQUAL(out_pairs.size() > 2, true)
+  bool found_AK = false;
+  bool found_BCDEFG = false;
+  for (const auto& p : out_pairs)
+  {
+    if (p.first == 0 && p.second == 2) found_AK = true;
+    if (p.first == 2 && p.second == 6) found_BCDEFG = true;
+  }
+  TEST_EQUAL(found_AK, true)
+  TEST_EQUAL(found_BCDEFG, true)
+
+  // SPEC_FULL (default) on the same input must NOT generate semi-specific variants —
+  // protect against accidental behaviour change.
+  EnzymaticDigestion ed_full;
+  ed_full.setEnzyme(ProteaseDB::getInstance()->getEnzyme("Trypsin"));
+  ed_full.setSpecificity(EnzymaticDigestion::SPEC_FULL); // default, but explicit
+  ed_full.digestUnmodified(StringView(s2), out_pairs, 1, 100);
+  TEST_EQUAL(out_pairs.size(), 2)
+}
+END_SECTION
+
 START_SECTION((Size semiSpecificDigestion_(const std::vector<int>& cleavage_positions, std::vector<std::pair<Size, Size>>& output, Size min_length, Size max_length) const))
 {
     class TempChild : public EnzymaticDigestion

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -251,6 +251,105 @@ START_SECTION(build())
 }
 END_SECTION
 
+// Verify that the new 'peptide:enzyme_specificity' parameter changes digestion behavior.
+// Three modes are tested:
+//   - "full" (default): both termini must be enzyme-specific (canonical, e.g. tryptic)
+//   - "semi": one terminus may be non-enzyme-specific (semi-tryptic)
+//   - "none": every substring of length [min,max] is enumerated, regardless of enzyme
+//             (the canonical immunopeptidomics path, e.g. HLA-I 8..12mers)
+START_SECTION([EXTRA] peptide:enzyme_specificity (full / semi / none))
+{
+  // 18-aa "protein" with two internal trypsin cuts (after K at pos 1, after R at pos 7).
+  // Sequence has no B/X/Z (which FragmentIndex filters out as ambiguous AAs).
+  // Tryptic products: "AK" (0..1), "ACDEFGR" (2..8), "HILMNPQSTV" (9..18).
+  const std::vector<FASTAFile::FASTAEntry> entries{
+    {"t", "t", "AKACDEFGRHILMNPQSTV"}};
+  // sanity: 19 aa total, no B/X/Z
+
+  // ---------- full (default): only fully-tryptic products ----------
+  {
+    FragmentIndex_test fi_full;
+    auto p = fi_full.getParameters();
+    p.setValue("enzyme", "Trypsin");
+    p.setValue("peptide:missed_cleavages", 0);
+    p.setValue("peptide:enzyme_specificity", "full");
+    p.setValue("peptide:min_size", 2);
+    p.setValue("peptide:max_size", 100);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    fi_full.setParameters(p);
+    fi_full.build(entries);
+    // 3 fully-tryptic products of length >= 2
+    TEST_EQUAL(fi_full.getPeptides().size(), 3)
+  }
+
+  // ---------- semi: fully-tryptic + semi-tryptic variants ----------
+  size_t semi_count = 0;
+  {
+    FragmentIndex_test fi_semi;
+    auto p = fi_semi.getParameters();
+    p.setValue("enzyme", "Trypsin");
+    p.setValue("peptide:missed_cleavages", 0);
+    p.setValue("peptide:enzyme_specificity", "semi");
+    p.setValue("peptide:min_size", 2);
+    p.setValue("peptide:max_size", 100);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    fi_semi.setParameters(p);
+    fi_semi.build(entries);
+    semi_count = fi_semi.getPeptides().size();
+    // semi must yield strictly more peptides than full (semi = full + semi-specific extras)
+    TEST_EQUAL(semi_count > 3, true)
+  }
+
+  // ---------- none (immunopeptidomics): all substrings of [min,max] ----------
+  // For 8..12mers from a 19-aa sequence: 8mers=12, 9mers=11, 10mers=10, 11mers=9, 12mers=8 → 50.
+  {
+    FragmentIndex_test fi_none;
+    auto p = fi_none.getParameters();
+    p.setValue("enzyme", "Trypsin"); // enzyme is irrelevant under specificity=none
+    p.setValue("peptide:missed_cleavages", 0);
+    p.setValue("peptide:enzyme_specificity", "none");
+    p.setValue("peptide:min_size", 8);
+    p.setValue("peptide:max_size", 12);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    fi_none.setParameters(p);
+    fi_none.build(entries);
+    TEST_EQUAL(fi_none.getPeptides().size(), 50)
+    // semi must produce fewer peptides than fully unconstrained (over the same length window).
+    // (We use a different length window above, so this is not directly comparable; just sanity-check
+    //  that none-mode produces a substantial multiple of full-mode.)
+    TEST_EQUAL(fi_none.getPeptides().size() > semi_count, true)
+  }
+
+  // ---------- none with very short protein: must not crash ----------
+  // FASTA databases often contain very short entries; pre-fix this would underflow.
+  {
+    const std::vector<FASTAFile::FASTAEntry> tiny{{"t", "t", "ABC"}}; // shorter than min_size
+    FragmentIndex_test fi_tiny;
+    auto p = fi_tiny.getParameters();
+    p.setValue("enzyme", "Trypsin");
+    p.setValue("peptide:enzyme_specificity", "none");
+    p.setValue("peptide:min_size", 8);
+    p.setValue("peptide:max_size", 12);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    fi_tiny.setParameters(p);
+    fi_tiny.build(tiny); // must not crash
+    TEST_EQUAL(fi_tiny.getPeptides().size(), 0)
+  }
+}
+END_SECTION
+
 // Verify that clear() resets the internal peptide container.
 START_SECTION(clear())
 {


### PR DESCRIPTION
## Summary
Implements item **#1** from #9108 — semi-tryptic and non-specific (immunopeptidomics) digestion — across `FragmentIndex`, `PeptideSearchEngineFIAlgorithm`, and (per discussion) `SimpleSearchEngineAlgorithm`.

- New parameter **`peptide:enzyme_specificity`** = `full` (default) / `semi` / `none`. Auto-exposed in `PeptideDataBaseSearchFI` and `SimpleSearchEngine` via the existing `registerFullParam_()` plumbing.
- `EnzymaticDigestion::digestUnmodified()` now honors `specificity_` in both the `vector<pair>` and `vector<StringView>` overloads — it previously silently ignored it, forcing callers to use the magic `\"unspecific cleavage\"` enzyme name for the non-specific path.
- Two hardcoded `SPEC_FULL` literals (per engine) replaced: the idXML `enzyme_term_specificity` field and the `PeptideIndexing` re-validation step. The latter would otherwise silently drop every semi-/non-specific PSM after the search.

## Bug fixes (uncovered while wiring this in)
- **Unsigned underflow** in `EnzymaticDigestion::digestUnmodified` when `sequence.size() < min_length`. Real risk for immunopeptidomics FASTAs containing entries shorter than `min_length` (signal peptides, ORF stubs).
- **SIGFPE in `FragmentIndex::build`** when no peptides survive filtering: `bucketsize_ = sqrt(0) = 0` divides by zero in the OMP bucket loop. Now early-returns with an empty index.

## Immunopeptidomics workflow
\`\`\`
PeptideDataBaseSearchFI -in spectra.mzML -database proteome.fasta -out hits.idXML \\
  -Search:peptide:enzyme_specificity none \\
  -Search:peptide:min_size 8 -Search:peptide:max_size 12
\`\`\`

## Test plan
- [x] \`EnzymaticDigestion_test\` — new section: SPEC_NONE substring enumeration, SPEC_SEMI extras, SPEC_FULL regression, short / empty sequence guards.
- [x] \`FragmentIndex_test\` — new section: \`full\` / \`semi\` / \`none\` parameter wiring on the same protein, plus a tiny-protein test that previously triggered the FPE crash.
- [x] \`PeptideSearchEngineFIAlgorithm_test\`, \`SimpleSearchEngineAlgorithm_test\` — pass.
- [x] \`TOPP_PeptideDataBaseSearchFI_1/2\`, \`TOPP_SimpleSearchEngine_1/2\` — pass.
- [x] End-to-end smoke test: \`PeptideDataBaseSearchFI -Search:peptide:enzyme_specificity semi\` produces 6 PSMs / 3 proteins on \`SimpleSearchEngine_1.{mzML,fasta}\` and the idXML records \`EnzymeTermSpecificity=semi\` + \`PeptideIndexer:enzyme_specificity=semi\`.
- [x] End-to-end smoke test: \`-Search:peptide:enzyme_specificity none -Search:peptide:min_size 8 -Search:peptide:max_size 12\` runs cleanly (empty result is just because the existing test data is tryptic-targeted).
- [x] CI on Linux/Windows/macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable enzyme specificity for peptide searches (full, semi, none); search, decoy generation and indexing now respect this setting.

* **Bug Fixes**
  * Early-exit when no fragments are generated to avoid downstream errors.
  * Guards to prevent integer underflow on very short sequences.

* **Tests**
  * Added tests covering all enzyme specificity modes and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->