### PR TITLE
fix: use repo-root-relative paths in ReadTheDocs configs

### DIFF
--- a/doc/openms/.readthedocs.yaml
+++ b/doc/openms/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 
 # Build from the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: doc/openms/docs/conf.py
 
 build:
   os: ubuntu-24.04
@@ -21,7 +21,7 @@ build:
 
 python:
   install:
-    - requirements: requirements.txt
+    - requirements: doc/openms/requirements.txt
 
 formats:
     - pdf

--- a/doc/pyopenms/.readthedocs.yaml
+++ b/doc/pyopenms/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 
 # Build from the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/source/conf.py
+  configuration: doc/pyopenms/docs/source/conf.py
 
 build:
   os: ubuntu-24.04
@@ -19,8 +19,8 @@ build:
           exit 183;
         fi
     post_install:
-      - python docs/install_pyopenms.py
+      - python doc/pyopenms/docs/install_pyopenms.py
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: doc/pyopenms/docs/requirements.txt


### PR DESCRIPTION
## Summary

- ReadTheDocs monorepo builds run from the repository root, not the config file's directory
- All paths in `.readthedocs.yaml` (sphinx config, requirements, scripts) must be relative to the repo root
- Fixes RTD build failure: `Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'`

### Changes
- `doc/openms/.readthedocs.yaml`: `docs/conf.py` → `doc/openms/docs/conf.py`, `requirements.txt` → `doc/openms/requirements.txt`
- `doc/pyopenms/.readthedocs.yaml`: `docs/source/conf.py` → `doc/pyopenms/docs/source/conf.py`, `docs/install_pyopenms.py` → `doc/pyopenms/docs/install_pyopenms.py`, `docs/requirements.txt` → `doc/pyopenms/docs/requirements.txt`

## Test plan
- [ ] ReadTheDocs build succeeds for openms docs
- [ ] ReadTheDocs build succeeds for pyopenms docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Read the Docs configuration paths to reference documentation files in their new directory locations.
  * Updated Python dependency installation sources for documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->