### PR TITLE
fix: allow RTD 'latest' and 'stable' versions through build guard

### DIFF
--- a/doc/openms/.readthedocs.yaml
+++ b/doc/openms/.readthedocs.yaml
@@ -12,10 +12,10 @@ build:
     post_checkout:
       # Reasons to cancel the documentation build (exit 183).
       #
-      # Only build docs on the `develop` branch, or one of the release
-      # branches.
+      # Only build docs on the `develop` branch, release branches,
+      # or RTD version names (latest, stable).
       - |
-        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qvE "^(develop|release)\b"; then
+        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qvE "^(develop|release|latest|stable)\b"; then
           exit 183;
         fi
 

--- a/doc/pyopenms/.readthedocs.yaml
+++ b/doc/pyopenms/.readthedocs.yaml
@@ -12,10 +12,10 @@ build:
     post_checkout:
       # Reasons to cancel the documentation build (exit 183).
       #
-      # Only build docs on the `develop` branch, or one of the release
-      # branches.
+      # Only build docs on the `develop` branch, release branches,
+      # or RTD version names (latest, stable).
       - |
-        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qvE "^(develop|release)\b"; then
+        if echo "$READTHEDOCS_GIT_IDENTIFIER" | grep -qvE "^(develop|release|latest|stable)\b"; then
           exit 183;
         fi
     post_install:


### PR DESCRIPTION
## Summary

RTD manual triggers and default version builds use `latest` or `stable` as `READTHEDOCS_GIT_IDENTIFIER`, not `develop`. The `post_checkout` guard in both `.readthedocs.yaml` configs was rejecting these, cancelling builds with exit 183.

Adds `latest` and `stable` to the allowed patterns in both `doc/openms/.readthedocs.yaml` and `doc/pyopenms/.readthedocs.yaml`.

## Test plan
- [ ] Manual RTD build trigger succeeds for pyopenms docs
- [ ] Manual RTD build trigger succeeds for openms docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ReadTheDocs configuration for both OpenMS and PyOpenMS to enable documentation builds for `latest` and `stable` version identifiers, in addition to previously supported branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->