### PR TITLE
feat: NumMatchedPeaks, longest ion run, fragment annotations

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -332,13 +332,14 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
       SignedSize peptide_mod_index; ///< enumeration index of the non-RNA peptide modification
       */
       double score = 0; ///< main score
-      std::vector<PeptideHit::PeakAnnotation> fragment_annotations;
       double prefix_fraction = 0; ///< fraction of annotated b-ions
       double suffix_fraction = 0; ///< fraction of annotated y-ions
       double mean_error = 0.0; ///< mean absolute fragment mass error
       int isotope_error = 0; ///< isotope offset used for this PSM
       uint16_t applied_charge = 0; ///< precursor charge used for this PSM
       double delta_mass = 0.0; ///< mass difference for open search (Da)
+      uint16_t matched_b_ions = 0; ///< number of matched b-ions
+      uint16_t matched_y_ions = 0; ///< number of matched y-ions
 
       static bool hasBetterScore(const AnnotatedHit_& a, const AnnotatedHit_& b)
       {

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -331,13 +331,14 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
       StringView sequence;
       SignedSize peptide_mod_index; ///< enumeration index of the non-RNA peptide modification
       */
+      // Layout: doubles first, then floats, then int, then uint16_t — minimizes padding (40 bytes excluding AASequence)
       double score = 0; ///< main score
-      double prefix_fraction = 0; ///< fraction of annotated b-ions
-      double suffix_fraction = 0; ///< fraction of annotated y-ions
-      double mean_error = 0.0; ///< mean absolute fragment mass error
+      double delta_mass = 0.0; ///< mass difference for open search (Da)
+      float prefix_fraction = 0; ///< fraction of annotated b-ions
+      float suffix_fraction = 0; ///< fraction of annotated y-ions
+      float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0; ///< isotope offset used for this PSM
       uint16_t applied_charge = 0; ///< precursor charge used for this PSM
-      double delta_mass = 0.0; ///< mass difference for open search (Da)
       uint16_t matched_b_ions = 0; ///< number of matched b-ions
       uint16_t matched_y_ions = 0; ///< number of matched y-ions
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -50,10 +50,11 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
     {
       StringView sequence;
       SignedSize peptide_mod_index; ///< enumeration index of the non-RNA peptide modification
+      // Layout: doubles first, then floats, then int, then uint16_t — minimizes padding
       double score = 0; ///< main score
-      double prefix_fraction = 0; ///< fraction of annotated b-ions
-      double suffix_fraction = 0; ///< fraction of annotated y-ions
-      double mean_error = 0.0; ///< mean absolute fragment mass error
+      float prefix_fraction = 0; ///< fraction of annotated b-ions
+      float suffix_fraction = 0; ///< fraction of annotated y-ions
+      float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0;
       uint16_t matched_b_ions = 0; ///< number of matched b-ions
       uint16_t matched_y_ions = 0; ///< number of matched y-ions

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -55,13 +55,12 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       double suffix_fraction = 0; ///< fraction of annotated y-ions
       double mean_error = 0.0; ///< mean absolute fragment mass error
       int isotope_error = 0;
-      std::vector<PeptideHit::PeakAnnotation> fragment_annotations;
+      uint16_t matched_b_ions = 0; ///< number of matched b-ions
+      uint16_t matched_y_ions = 0; ///< number of matched y-ions
 
       static bool hasBetterScore(const AnnotatedHit_& a, const AnnotatedHit_& b)
       {
         if (a.score != b.score) return a.score > b.score;
-        // compare the mod_index first, as it is cheaper than the strncmp() of the sequences
-        // there doesn't have to be a certain ordering (that makes sense), we just need it to be thread-safe
         if (b.peptide_mod_index != a.peptide_mod_index) return a.peptide_mod_index < b.peptide_mod_index;
         return a.sequence < b.sequence;
       }

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -344,6 +344,18 @@ namespace OpenMS
       // User parameter name for the fraction of suffix ions that have been matched
       inline const std::string MATCHED_SUFFIX_IONS_FRACTION = "matched_suffix_ions_fraction";
 
+      // User parameter name for the number of matched b-ions (absolute count)
+      inline const std::string MATCHED_B_IONS = "matched_b_ions";
+
+      // User parameter name for the number of matched y-ions (absolute count)
+      inline const std::string MATCHED_Y_IONS = "matched_y_ions";
+
+      // User parameter name for the total number of matched fragment ions
+      inline const std::string NUM_MATCHED_PEAKS = "num_matched_peaks";
+
+      // User parameter name for the longest consecutive b- or y-ion series
+      inline const std::string LONGEST_PEPTIDE_ION_SEQUENCE = "longest_peptide_ion_sequence";
+
       /** User parameter name for the spectrum reference in PeptideIdentification (it is not yet treated as a class attribute)
               String
       */

--- a/src/openms/include/OpenMS/FORMAT/ArrowSchemaRegistry.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowSchemaRegistry.h
@@ -192,6 +192,10 @@ namespace OpenMS
     static constexpr const char* PSM_METAVALUES = "psm_metavalues";
     static constexpr const char* SPECTRUM_METAVALUES = "spectrum_metavalues";
     static constexpr const char* RUN_IDENTIFIER = "run_identifier";
+    static constexpr const char* MZ_ARRAY = "mz_array";
+    static constexpr const char* INTENSITY_ARRAY = "intensity_array";
+    static constexpr const char* CHARGE_ARRAY = "charge_array";
+    static constexpr const char* ION_TYPE_ARRAY = "ion_type_array";
 
     static std::shared_ptr<arrow::DataType> modificationsType();
     static std::shared_ptr<arrow::DataType> additionalScoresType();

--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -771,7 +771,7 @@ namespace OpenMS
       // contain entries shorter than peptide:min_size.
       if (fi_fragments_.empty())
       {
-        bucketsize_ = 0;
+        bucketsize_ = 1; // keep non-zero to preserve bucket-walking loop invariants
         OPENMS_LOG_INFO << "[FragmentIndex] No fragments generated — index is empty." << std::endl;
         is_build_ = true;
         return;

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -671,6 +671,8 @@ namespace OpenMS
         ah.prefix_fraction = (double)detail.matched_b_ions/seq_length;
         ah.suffix_fraction = (double)detail.matched_y_ions/seq_length;
         ah.mean_error = detail.mean_error;
+        ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
+        ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
 
         ah.isotope_error = sms.isotope_error_;
         ah.applied_charge = sms.precursor_charge_;

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -775,9 +775,9 @@ namespace OpenMS
         ah.sequence = std::move(mod_candidate);
         ah.score = score;
         double seq_length = (double)ah.sequence.size();
-        ah.prefix_fraction = (double)detail.matched_b_ions/seq_length;
-        ah.suffix_fraction = (double)detail.matched_y_ions/seq_length;
-        ah.mean_error = detail.mean_error;
+        ah.prefix_fraction = static_cast<float>(detail.matched_b_ions / seq_length);
+        ah.suffix_fraction = static_cast<float>(detail.matched_y_ions / seq_length);
+        ah.mean_error = static_cast<float>(detail.mean_error);
         ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
         ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -115,13 +115,18 @@ namespace OpenMS
     defaults_.setValidStrings("decoys", {"true","false"} );
 
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
-    defaults_.setValidStrings("annotate:PSM", 
+    defaults_.setValidStrings("annotate:PSM",
       std::vector<std::string>{
         "ALL",
-        Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM, 
+        Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM,
         Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM,
         Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
-        Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION}
+        Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION,
+        Constants::UserParam::NUM_MATCHED_PEAKS,
+        Constants::UserParam::MATCHED_B_IONS,
+        Constants::UserParam::MATCHED_Y_IONS,
+        Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
+        Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
@@ -320,6 +325,11 @@ namespace OpenMS
     bool annotation_fragment_error_ppm = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM) != annotate_psm_.end();
     bool annotation_prefix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_suffix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION) != annotate_psm_.end();
+    bool annotation_num_matched_peaks = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::NUM_MATCHED_PEAKS) != annotate_psm_.end();
+    bool annotation_matched_b_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_B_IONS) != annotate_psm_.end();
+    bool annotation_matched_y_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_Y_IONS) != annotate_psm_.end();
+    bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
+    bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -328,7 +338,15 @@ namespace OpenMS
       annotation_fragment_error_ppm = true;
       annotation_prefix_fraction = true;
       annotation_suffix_fraction = true;
+      annotation_num_matched_peaks = true;
+      annotation_matched_b_ions = true;
+      annotation_matched_y_ions = true;
+      annotation_longest_ion_run = true;
+      annotation_fragment_annotations = true;
     }
+
+    // Alignment is needed for fragment error, fragment annotations, and longest ion run
+    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run;
 
 #pragma omp parallel for
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
@@ -365,17 +383,26 @@ namespace OpenMS
           ph.setScore(ah.score);
           ph.setSequence(ah.sequence);
 
-          if (annotation_fragment_error_ppm)
+          // Generate theoretical spectrum + alignment for annotations that need it
+          std::vector<std::pair<Size, Size>> alignment;
+          MSSpectrum theoretical_spec;
+          if (need_alignment)
           {
             TheoreticalSpectrumGenerator tsg;
-            vector<pair<Size, Size> > alignment;
-            MSSpectrum theoretical_spec;
+            Param tsg_param(tsg.getParameters());
+            tsg_param.setValue("add_metainfo", "true");
+            tsg_param.setValue("add_first_prefix_ion", "true");
+            tsg.setParameters(tsg_param);
+
             const int max_frag_z = (charge >= 2) ? std::min<int>(charge - 1, 2) : 1;
             tsg.getSpectrum(theoretical_spec, ah.sequence, 1, max_frag_z);
             SpectrumAlignment sa;
             sa.getSpectrumAlignment(alignment, theoretical_spec, spec);
+          }
 
-            vector<double> err;
+          if (annotation_fragment_error_ppm)
+          {
+            std::vector<double> err;
             for (const auto& match : alignment)
             {
               double fragment_error = fabs(Math::getPPM(spec[match.second].getMZ(), theoretical_spec[match.first].getMZ()));
@@ -401,6 +428,86 @@ namespace OpenMS
           if (annotation_suffix_fraction)
           {
             ph.setMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION, ah.suffix_fraction);
+          }
+
+          // Matched ion counts (from scoring, no alignment needed)
+          if (annotation_num_matched_peaks)
+          {
+            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_b_ions + ah.matched_y_ions));
+          }
+          if (annotation_matched_b_ions)
+          {
+            ph.setMetaValue(Constants::UserParam::MATCHED_B_IONS, static_cast<int>(ah.matched_b_ions));
+          }
+          if (annotation_matched_y_ions)
+          {
+            ph.setMetaValue(Constants::UserParam::MATCHED_Y_IONS, static_cast<int>(ah.matched_y_ions));
+          }
+
+          // Fragment annotations and longest ion run (both need alignment + ion names)
+          if (annotation_fragment_annotations || annotation_longest_ion_run)
+          {
+            const auto& ion_names = theoretical_spec.getStringDataArrays()[0];
+            const auto& ion_charges = theoretical_spec.getIntegerDataArrays()[0];
+
+            // Build PeakAnnotation vector + collect ion ordinals for longest run
+            std::vector<PeptideHit::PeakAnnotation> peak_annotations;
+            std::vector<int> b_ordinals, y_ordinals;
+            peak_annotations.reserve(alignment.size());
+
+            for (const auto& [theo_idx, exp_idx] : alignment)
+            {
+              if (annotation_fragment_annotations)
+              {
+                PeptideHit::PeakAnnotation pa;
+                pa.mz = spec[exp_idx].getMZ();
+                pa.intensity = spec[exp_idx].getIntensity();
+                pa.annotation = ion_names[theo_idx];
+                pa.charge = ion_charges[theo_idx];
+                peak_annotations.push_back(pa);
+              }
+
+              if (annotation_longest_ion_run)
+              {
+                const String& name = ion_names[theo_idx];
+                if (name.size() >= 2 && (name[0] == 'b' || name[0] == 'y'))
+                {
+                  // Extract ordinal: "b5", "y3-H2O1+", "b12++" -> 5, 3, 12
+                  Size pos = 1;
+                  while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9') ++pos;
+                  if (pos > 1)
+                  {
+                    int ordinal = String(name.substr(1, pos - 1)).toInt();
+                    if (name[0] == 'b') b_ordinals.push_back(ordinal);
+                    else y_ordinals.push_back(ordinal);
+                  }
+                }
+              }
+            }
+
+            if (annotation_fragment_annotations)
+            {
+              ph.setPeakAnnotations(std::move(peak_annotations));
+            }
+
+            if (annotation_longest_ion_run)
+            {
+              // Compute longest consecutive run across b and y series
+              auto longestRun = [](std::vector<int>& v) -> int {
+                if (v.empty()) return 0;
+                std::sort(v.begin(), v.end());
+                v.erase(std::unique(v.begin(), v.end()), v.end());
+                int best = 1, run = 1;
+                for (Size i = 1; i < v.size(); ++i)
+                {
+                  if (v[i] == v[i - 1] + 1) { ++run; if (run > best) best = run; }
+                  else run = 1;
+                }
+                return best;
+              };
+              int longest = std::max(longestRun(b_ordinals), longestRun(y_ordinals));
+              ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, longest);
+            }
           }
 
           // Add isotope error metavalue (always)

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -795,9 +795,9 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
             ah.sequence = c;
             ah.peptide_mod_index = mod_pep_idx;
             ah.score = score;
-            ah.prefix_fraction = (double)detail.matched_b_ions/(double)c.size();
-            ah.suffix_fraction = (double)detail.matched_y_ions/(double)c.size();
-            ah.mean_error = detail.mean_error;
+            ah.prefix_fraction = static_cast<float>((double)detail.matched_b_ions / (double)c.size());
+            ah.suffix_fraction = static_cast<float>((double)detail.matched_y_ions / (double)c.size());
+            ah.mean_error = static_cast<float>(detail.mean_error);
             ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
             ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
             ah.isotope_error = low_it->second.second;

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -105,13 +105,18 @@ namespace OpenMS
     defaults_.setValidStrings("decoys", {"true","false"} );
 
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
-    defaults_.setValidStrings("annotate:PSM", 
+    defaults_.setValidStrings("annotate:PSM",
       std::vector<std::string>{
         "ALL",
-        Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM, 
+        Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM,
         Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM,
         Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
-        Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION}
+        Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION,
+        Constants::UserParam::NUM_MATCHED_PEAKS,
+        Constants::UserParam::MATCHED_B_IONS,
+        Constants::UserParam::MATCHED_Y_IONS,
+        Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
+        Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
 
     defaults_.setSectionDescription("annotate", "Annotation Options");
@@ -272,6 +277,11 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     bool annotation_fragment_error_ppm = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM) != annotate_psm_.end();
     bool annotation_prefix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_suffix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION) != annotate_psm_.end();
+    bool annotation_num_matched_peaks = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::NUM_MATCHED_PEAKS) != annotate_psm_.end();
+    bool annotation_matched_b_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_B_IONS) != annotate_psm_.end();
+    bool annotation_matched_y_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_Y_IONS) != annotate_psm_.end();
+    bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
+    bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
     // "ALL" adds all annotations
     if (std::find(annotate_psm_.begin(), annotate_psm_.end(), "ALL") != annotate_psm_.end())
@@ -280,7 +290,15 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       annotation_fragment_error_ppm = true;
       annotation_prefix_fraction = true;
       annotation_suffix_fraction = true;
+      annotation_num_matched_peaks = true;
+      annotation_matched_b_ions = true;
+      annotation_matched_y_ions = true;
+      annotation_longest_ion_run = true;
+      annotation_fragment_annotations = true;
     }
+
+    // Alignment is needed for fragment error, fragment annotations, and longest ion run
+    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run;
 
 #pragma omp parallel for
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
@@ -327,16 +345,26 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
           ph.setScore(ah.score);
           ph.setSequence(fixed_and_variable_modified_peptide);
 
-          if (annotation_fragment_error_ppm)
+          // Generate theoretical spectrum + alignment for annotations that need it
+          std::vector<std::pair<Size, Size>> alignment;
+          MSSpectrum theoretical_spec;
+          if (need_alignment)
           {
             TheoreticalSpectrumGenerator tsg;
-            vector<pair<Size, Size> > alignment;
-            MSSpectrum theoretical_spec;
-            tsg.getSpectrum(theoretical_spec, fixed_and_variable_modified_peptide, 1, std::min((int)charge - 1, 2));
+            Param tsg_param(tsg.getParameters());
+            tsg_param.setValue("add_metainfo", "true");
+            tsg_param.setValue("add_first_prefix_ion", "true");
+            tsg.setParameters(tsg_param);
+
+            const int max_frag_z = (charge >= 2) ? std::min<int>(charge - 1, 2) : 1;
+            tsg.getSpectrum(theoretical_spec, fixed_and_variable_modified_peptide, 1, max_frag_z);
             SpectrumAlignment sa;
             sa.getSpectrumAlignment(alignment, theoretical_spec, spec);
+          }
 
-            vector<double> err;
+          if (annotation_fragment_error_ppm)
+          {
+            std::vector<double> err;
             for (const auto& match : alignment)
             {
               double fragment_error = fabs(Math::getPPM(spec[match.second].getMZ(), theoretical_spec[match.first].getMZ()));
@@ -362,6 +390,86 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
           if (annotation_suffix_fraction)
           {
             ph.setMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION, ah.suffix_fraction);
+          }
+
+          // Matched ion counts (from scoring, no alignment needed)
+          if (annotation_num_matched_peaks)
+          {
+            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_b_ions + ah.matched_y_ions));
+          }
+          if (annotation_matched_b_ions)
+          {
+            ph.setMetaValue(Constants::UserParam::MATCHED_B_IONS, static_cast<int>(ah.matched_b_ions));
+          }
+          if (annotation_matched_y_ions)
+          {
+            ph.setMetaValue(Constants::UserParam::MATCHED_Y_IONS, static_cast<int>(ah.matched_y_ions));
+          }
+
+          // Fragment annotations and longest ion run (both need alignment + ion names)
+          if (annotation_fragment_annotations || annotation_longest_ion_run)
+          {
+            const auto& ion_names = theoretical_spec.getStringDataArrays()[0];
+            const auto& ion_charges = theoretical_spec.getIntegerDataArrays()[0];
+
+            // Build PeakAnnotation vector + collect ion ordinals for longest run
+            std::vector<PeptideHit::PeakAnnotation> peak_annotations;
+            std::vector<int> b_ordinals, y_ordinals;
+            peak_annotations.reserve(alignment.size());
+
+            for (const auto& [theo_idx, exp_idx] : alignment)
+            {
+              if (annotation_fragment_annotations)
+              {
+                PeptideHit::PeakAnnotation pa;
+                pa.mz = spec[exp_idx].getMZ();
+                pa.intensity = spec[exp_idx].getIntensity();
+                pa.annotation = ion_names[theo_idx];
+                pa.charge = ion_charges[theo_idx];
+                peak_annotations.push_back(pa);
+              }
+
+              if (annotation_longest_ion_run)
+              {
+                const String& name = ion_names[theo_idx];
+                if (name.size() >= 2 && (name[0] == 'b' || name[0] == 'y'))
+                {
+                  // Extract ordinal: "b5", "y3-H2O1+", "b12++" -> 5, 3, 12
+                  Size pos = 1;
+                  while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9') ++pos;
+                  if (pos > 1)
+                  {
+                    int ordinal = String(name.substr(1, pos - 1)).toInt();
+                    if (name[0] == 'b') b_ordinals.push_back(ordinal);
+                    else y_ordinals.push_back(ordinal);
+                  }
+                }
+              }
+            }
+
+            if (annotation_fragment_annotations)
+            {
+              ph.setPeakAnnotations(std::move(peak_annotations));
+            }
+
+            if (annotation_longest_ion_run)
+            {
+              // Compute longest consecutive run across b and y series
+              auto longestRun = [](std::vector<int>& v) -> int {
+                if (v.empty()) return 0;
+                std::sort(v.begin(), v.end());
+                v.erase(std::unique(v.begin(), v.end()), v.end());
+                int best = 1, run = 1;
+                for (Size i = 1; i < v.size(); ++i)
+                {
+                  if (v[i] == v[i - 1] + 1) { ++run; if (run > best) best = run; }
+                  else run = 1;
+                }
+                return best;
+              };
+              int longest = std::max(longestRun(b_ordinals), longestRun(y_ordinals));
+              ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, longest);
+            }
           }
 
           // store PSM

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -690,6 +690,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
             ah.prefix_fraction = (double)detail.matched_b_ions/(double)c.size();
             ah.suffix_fraction = (double)detail.matched_y_ions/(double)c.size();
             ah.mean_error = detail.mean_error;
+            ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
+            ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
             ah.isotope_error = low_it->second.second;
 
 #ifdef _OPENMP

--- a/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
+++ b/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
@@ -393,6 +393,10 @@ namespace OpenMS
       arrow::field(PSM_METAVALUES, metavaluesType()),
       arrow::field(SPECTRUM_METAVALUES, metavaluesType()),
       arrow::field(RUN_IDENTIFIER, arrow::utf8()),
+      arrow::field(MZ_ARRAY, arrow::list(arrow::float32())),
+      arrow::field(INTENSITY_ARRAY, arrow::list(arrow::float32())),
+      arrow::field(CHARGE_ARRAY, arrow::list(arrow::int32())),
+      arrow::field(ION_TYPE_ARRAY, arrow::list(arrow::utf8())),
     });
   }
 

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/FORMAT/QPXFile.h>
 
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
@@ -136,6 +137,16 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
     std::vector<std::shared_ptr<arrow::ArrayBuilder>>{smv_name_b, smv_value_b, smv_type_b});
   arrow::ListBuilder spectrum_metavalues_builder(arrow::default_memory_pool(), smv_struct_b);
 
+  // -- fragment annotation arrays: mz_array, intensity_array, charge_array, ion_type_array --
+  auto psm_mz_arr_vb = std::make_shared<arrow::FloatBuilder>();
+  arrow::ListBuilder psm_mz_array_builder(arrow::default_memory_pool(), psm_mz_arr_vb);
+  auto psm_int_arr_vb = std::make_shared<arrow::FloatBuilder>();
+  arrow::ListBuilder psm_intensity_array_builder(arrow::default_memory_pool(), psm_int_arr_vb);
+  auto psm_chg_arr_vb = std::make_shared<arrow::Int32Builder>();
+  arrow::ListBuilder psm_charge_array_builder(arrow::default_memory_pool(), psm_chg_arr_vb);
+  auto psm_ion_arr_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder psm_ion_type_array_builder(arrow::default_memory_pool(), psm_ion_arr_vb);
+
   // Estimate total rows for capacity reservation
   Size num_rows = 0;
   for (const auto& pep_id : peptide_identifications)
@@ -203,7 +214,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
   // Metavalue keys excluded from psm_metavalues (they have dedicated columns)
   static const std::unordered_set<std::string> excluded_hit_mvs_psm = {
     "target_decoy", "predicted_RT", "predicted_rt", "ion_mobility", "IM",
-    "scan", "reference_file_name"
+    "scan", "reference_file_name",
+    Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM  // dedicated mz/intensity/charge/ion_type arrays
   };
 
   IDScoreSwitcherAlgorithm idsa;
@@ -570,6 +582,30 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
           }
         }
       }
+
+      // === fragment annotation arrays (from PeakAnnotations) ===
+      const auto& psm_peak_annotations = hit.getPeakAnnotations();
+      if (!psm_peak_annotations.empty())
+      {
+        (void)psm_mz_array_builder.Append();
+        (void)psm_intensity_array_builder.Append();
+        (void)psm_charge_array_builder.Append();
+        (void)psm_ion_type_array_builder.Append();
+        for (const auto& pa : psm_peak_annotations)
+        {
+          (void)psm_mz_arr_vb->Append(static_cast<float>(pa.mz));
+          (void)psm_int_arr_vb->Append(static_cast<float>(pa.intensity));
+          (void)psm_chg_arr_vb->Append(pa.charge);
+          (void)psm_ion_arr_vb->Append(pa.annotation);
+        }
+      }
+      else
+      {
+        (void)psm_mz_array_builder.AppendNull();
+        (void)psm_intensity_array_builder.AppendNull();
+        (void)psm_charge_array_builder.AppendNull();
+        (void)psm_ion_type_array_builder.AppendNull();
+      }
     } // end hit loop
 
     ++p_id_index;
@@ -638,6 +674,15 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
   std::shared_ptr<arrow::Array> arr_run_identifier;
   status = run_identifier_builder.Finish(&arr_run_identifier);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: run_identifier_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  std::shared_ptr<arrow::Array> arr_psm_mz_array, arr_psm_intensity_array, arr_psm_charge_array, arr_psm_ion_type_array;
+  status = psm_mz_array_builder.Finish(&arr_psm_mz_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: psm_mz_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = psm_intensity_array_builder.Finish(&arr_psm_intensity_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: psm_intensity_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = psm_charge_array_builder.Finish(&arr_psm_charge_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: psm_charge_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = psm_ion_type_array_builder.Finish(&arr_psm_ion_type_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: psm_ion_type_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
 
   // Build schema from registry
   auto schema = PSMSchema::schema();
@@ -650,7 +695,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportToArrow(
     arr_cv_params, arr_scan, arr_rt, arr_ion_mobility,
     arr_spectrum_ref, arr_score, arr_score_type, arr_higher_score_better,
     arr_rank, arr_p_id, arr_psm_mvs, arr_spectrum_mvs,
-    arr_run_identifier
+    arr_run_identifier,
+    arr_psm_mz_array, arr_psm_intensity_array, arr_psm_charge_array, arr_psm_ion_type_array
   });
 
   // Validate table against registry schema (strict — write path must match exactly)
@@ -755,8 +801,17 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
   auto cross_links_type = QPXPSMSchema::crossLinksType();
   // We build a null array later
 
-  // -- mz_array, intensity_array, charge_array, ion_type_array, ion_mobility_array (null for now) --
-  // We build null arrays later
+  // -- mz_array list<float32>, intensity_array list<float32>, charge_array list<int32>, ion_type_array list<utf8> --
+  // Populated from PeptideHit::getPeakAnnotations() (fragment ion annotations).
+  auto mz_arr_vb = std::make_shared<arrow::FloatBuilder>();
+  arrow::ListBuilder mz_array_builder(arrow::default_memory_pool(), mz_arr_vb);
+  auto int_arr_vb = std::make_shared<arrow::FloatBuilder>();
+  arrow::ListBuilder intensity_array_builder(arrow::default_memory_pool(), int_arr_vb);
+  auto chg_arr_vb = std::make_shared<arrow::Int32Builder>();
+  arrow::ListBuilder charge_array_builder(arrow::default_memory_pool(), chg_arr_vb);
+  auto ion_arr_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder ion_type_array_builder(arrow::default_memory_pool(), ion_arr_vb);
+  // -- ion_mobility_array (null for now — no per-fragment IM data) --
 
   // Estimate total rows for capacity reservation
   Size num_rows = 0;
@@ -811,7 +866,8 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
   // Metavalue keys excluded from additional_scores (they have dedicated columns)
   static const std::unordered_set<std::string> excluded_hit_mvs = {
     "target_decoy", "predicted_RT", "predicted_rt", "ion_mobility", "IM",
-    "scan", "reference_file_name"
+    "scan", "reference_file_name",
+    Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM  // dedicated mz/intensity/charge/ion_type arrays
   };
 
   IDScoreSwitcherAlgorithm idsa;
@@ -1128,6 +1184,30 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
         (void)pa_vb->Append(ev.getProteinAccession());
       }
 
+      // === fragment annotation arrays (from PeakAnnotations) ===
+      const auto& peak_annotations = hit.getPeakAnnotations();
+      if (!peak_annotations.empty())
+      {
+        (void)mz_array_builder.Append();
+        (void)intensity_array_builder.Append();
+        (void)charge_array_builder.Append();
+        (void)ion_type_array_builder.Append();
+        for (const auto& pa : peak_annotations)
+        {
+          (void)mz_arr_vb->Append(static_cast<float>(pa.mz));
+          (void)int_arr_vb->Append(static_cast<float>(pa.intensity));
+          (void)chg_arr_vb->Append(pa.charge);
+          (void)ion_arr_vb->Append(pa.annotation);
+        }
+      }
+      else
+      {
+        (void)mz_array_builder.AppendNull();
+        (void)intensity_array_builder.AppendNull();
+        (void)charge_array_builder.AppendNull();
+        (void)ion_type_array_builder.AppendNull();
+      }
+
     } // end hit loop
 
   } // end peptide identification loop
@@ -1178,6 +1258,15 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: missed_cleavages_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = protein_accessions_builder.Finish(&arr_protein_acc);
   if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: protein_accessions_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  std::shared_ptr<arrow::Array> arr_mz_array, arr_intensity_array, arr_charge_array, arr_ion_type_array;
+  status = mz_array_builder.Finish(&arr_mz_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: mz_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = intensity_array_builder.Finish(&arr_intensity_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: intensity_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = charge_array_builder.Finish(&arr_charge_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: charge_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
+  status = ion_type_array_builder.Finish(&arr_ion_type_array);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "QPXFile: ion_type_array_builder Finish failed: " << status.ToString() << std::endl; return nullptr; }
 
   // Build null arrays for columns not yet populated.
   // Use actual row count from a finalized array to avoid coupling with the pre-loop estimate.
@@ -1194,10 +1283,6 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
   };
 
   auto arr_cross_links = make_null_array(QPXPSMSchema::crossLinksType());
-  auto arr_mz_array = make_null_array(arrow::list(arrow::float32()));
-  auto arr_intensity_array = make_null_array(arrow::list(arrow::float32()));
-  auto arr_charge_array = make_null_array(arrow::list(arrow::int32()));
-  auto arr_ion_type_array = make_null_array(arrow::list(arrow::utf8()));
   auto arr_ion_mobility_array = make_null_array(arrow::list(arrow::float32()));
 
   if (!arr_cross_links || !arr_mz_array || !arr_intensity_array ||

--- a/src/tests/class_tests/openms/source/ArrowSchemaRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/ArrowSchemaRegistry_test.cpp
@@ -761,7 +761,7 @@ START_SECTION(PSMSchema::schema() returns non-null with 25 fields)
 {
   auto s = PSMSchema::schema();
   TEST_NOT_EQUAL(s, nullptr)
-  TEST_EQUAL(s->num_fields(), 25)
+  TEST_EQUAL(s->num_fields(), 29)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
+++ b/src/tests/class_tests/openms/source/FragmentIndex_test.cpp
@@ -286,7 +286,6 @@ START_SECTION([EXTRA] peptide:enzyme_specificity (full / semi / none))
   }
 
   // ---------- semi: fully-tryptic + semi-tryptic variants ----------
-  size_t semi_count = 0;
   {
     FragmentIndex_test fi_semi;
     auto p = fi_semi.getParameters();
@@ -301,9 +300,8 @@ START_SECTION([EXTRA] peptide:enzyme_specificity (full / semi / none))
     p.setValue("modifications:fixed", std::vector<std::string>{});
     fi_semi.setParameters(p);
     fi_semi.build(entries);
-    semi_count = fi_semi.getPeptides().size();
     // semi must yield strictly more peptides than full (semi = full + semi-specific extras)
-    TEST_EQUAL(semi_count > 3, true)
+    TEST_EQUAL(fi_semi.getPeptides().size() > 3, true)
   }
 
   // ---------- none (immunopeptidomics): all substrings of [min,max] ----------
@@ -323,10 +321,26 @@ START_SECTION([EXTRA] peptide:enzyme_specificity (full / semi / none))
     fi_none.setParameters(p);
     fi_none.build(entries);
     TEST_EQUAL(fi_none.getPeptides().size(), 50)
-    // semi must produce fewer peptides than fully unconstrained (over the same length window).
-    // (We use a different length window above, so this is not directly comparable; just sanity-check
-    //  that none-mode produces a substantial multiple of full-mode.)
-    TEST_EQUAL(fi_none.getPeptides().size() > semi_count, true)
+  }
+
+  // ---------- none > semi when using same length window ----------
+  {
+    // Use same 8..12 window for both modes so the comparison is fair.
+    FragmentIndex_test fi_semi_8_12;
+    auto p = fi_semi_8_12.getParameters();
+    p.setValue("enzyme", "Trypsin");
+    p.setValue("peptide:missed_cleavages", 0);
+    p.setValue("peptide:enzyme_specificity", "semi");
+    p.setValue("peptide:min_size", 8);
+    p.setValue("peptide:max_size", 12);
+    p.setValue("peptide:min_mass", 0);
+    p.setValue("peptide:max_mass", 50000);
+    p.setValue("modifications:variable", std::vector<std::string>{});
+    p.setValue("modifications:fixed", std::vector<std::string>{});
+    fi_semi_8_12.setParameters(p);
+    fi_semi_8_12.build(entries);
+    // none (50 substrings) must exceed semi with the same length window
+    TEST_EQUAL(50 > fi_semi_8_12.getPeptides().size(), true)
   }
 
   // ---------- none with very short protein: must not crash ----------

--- a/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
@@ -819,6 +819,7 @@ START_SECTION((SearchResult searchWithModificationAnalysis(const String &, const
 }
 END_SECTION
 
+<<<<<<< HEAD
 START_SECTION(([EXTRA] prepareContext + context-based search produces same IDs as single-shot search))
 {
   // Build a tiny synthetic dataset where we know the search returns hits.
@@ -961,6 +962,101 @@ END_SECTION
 START_SECTION((MultiFileSearchResult searchWithModificationAnalysis(const std::vector<String>&, const String&, const std::vector<String>&, const String&) const))
 {
   NOT_TESTABLE // tested via TOPP tool (multi-file integration test)
+}
+END_SECTION
+
+START_SECTION(([EXTRA] PSM annotations - matched ion counts, longest run, fragment annotations))
+{
+  // Create a small FASTA database with one protein containing a single tryptic peptide
+  vector<FASTAFile::FASTAEntry> fasta_db = {
+    {"P01", "TestProtein", "PEPTIDEK"}
+  };
+
+  // Generate a synthetic MS2 spectrum from a known tryptic peptide
+  AASequence peptide = AASequence::fromString("PEPTIDEK");
+  TheoreticalSpectrumGenerator tsg;
+  Param tsg_param(tsg.getParameters());
+  tsg_param.setValue("add_metainfo", "true");
+  tsg_param.setValue("add_first_prefix_ion", "true");
+  tsg.setParameters(tsg_param);
+
+  PeakSpectrum theo;
+  tsg.getSpectrum(theo, peptide, 1, 1);
+
+  // Build a PeakMap with one MS2 spectrum
+  PeakMap exp;
+  MSSpectrum ms2;
+  ms2.setMSLevel(2);
+  ms2.setRT(100.0);
+  Precursor prec;
+  prec.setMZ(peptide.getMZ(2));  // charge 2
+  prec.setCharge(2);
+  ms2.setPrecursors({prec});
+
+  // Copy theoretical peaks to experimental (perfect match)
+  for (const auto& p : theo)
+  {
+    ms2.emplace_back(p.getMZ(), p.getIntensity());
+  }
+  ms2.sortByPosition();
+  exp.addSpectrum(std::move(ms2));
+
+  // Configure search engine
+  PeptideSearchEngineFIAlgorithm algo;
+  Param p = algo.getParameters();
+  p.setValue("precursor:mass_tolerance", 10.0);
+  p.setValue("precursor:mass_tolerance_unit", "ppm");
+  p.setValue("fragment:mass_tolerance", 10.0);
+  p.setValue("fragment:mass_tolerance_unit", "ppm");
+  p.setValue("enzyme", "Trypsin");
+  p.setValue("peptide:missed_cleavages", 0);
+  p.setValue("peptide:min_size", 5);
+  p.setValue("peptide:max_size", 40);
+  p.setValue("annotate:PSM", vector<string>{"ALL"});
+  p.setValue("modifications:fixed", vector<string>{});
+  p.setValue("modifications:variable", vector<string>{});
+  algo.setParameters(p);
+
+  vector<ProteinIdentification> prot_ids;
+  PeptideIdentificationList pep_ids;
+  algo.search(exp, fasta_db, prot_ids, pep_ids);
+
+  // Should have found our peptide
+  TEST_EQUAL(pep_ids.size(), 1)
+  TEST_EQUAL(pep_ids[0].getHits().size() >= 1, true)
+
+  const PeptideHit& hit = pep_ids[0].getHits()[0];
+  TEST_EQUAL(hit.getSequence(), peptide)
+
+  // Verify matched ion count annotations exist and are positive
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::NUM_MATCHED_PEAKS), true)
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_B_IONS), true)
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_Y_IONS), true)
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE), true)
+
+  int num_matched = hit.getMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS);
+  int b_ions = hit.getMetaValue(Constants::UserParam::MATCHED_B_IONS);
+  int y_ions = hit.getMetaValue(Constants::UserParam::MATCHED_Y_IONS);
+  int longest_run = hit.getMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE);
+
+  TEST_EQUAL(num_matched > 0, true)
+  TEST_EQUAL(num_matched, b_ions + y_ions)
+  TEST_EQUAL(b_ions > 0, true)
+  TEST_EQUAL(y_ions > 0, true)
+
+  // Perfect match: longest run should be substantial (peptide length - 1 for one series)
+  TEST_EQUAL(longest_run >= 3, true)
+
+  // Verify fragment annotations
+  const auto& annotations = hit.getPeakAnnotations();
+  TEST_EQUAL(annotations.empty(), false)
+  // Each annotation should have mz > 0, non-empty name, and charge >= 1
+  for (const auto& ann : annotations)
+  {
+    TEST_EQUAL(ann.mz > 0.0, true)
+    TEST_EQUAL(ann.annotation.empty(), false)
+    TEST_EQUAL(ann.charge >= 1, true)
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideSearchEngineFIAlgorithm_test.cpp
@@ -819,7 +819,6 @@ START_SECTION((SearchResult searchWithModificationAnalysis(const String &, const
 }
 END_SECTION
 
-<<<<<<< HEAD
 START_SECTION(([EXTRA] prepareContext + context-based search produces same IDs as single-shot search))
 {
   // Build a tiny synthetic dataset where we know the search returns hits.

--- a/src/tests/topp/PeptideDataBaseSearchFI_1_out.idXML
+++ b/src/tests/topp/PeptideDataBaseSearchFI_1_out.idXML
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-09-19T14:34:27" search_engine="PeptideDataBaseSearchFI" search_engine_version="3.5.0-pre-im-mtd-2025-08-04" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-09T11:11:27" search_engine="PeptideDataBaseSearchFI" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -34,10 +34,15 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="13.195273686121649" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="int" name="num_matched_peaks" value="11"/>
+				<UserParam type="int" name="matched_b_ions" value="3"/>
+				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -46,10 +51,15 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="47.256181302684936" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="int" name="num_matched_peaks" value="26"/>
+				<UserParam type="int" name="matched_b_ions" value="13"/>
+				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -58,10 +68,15 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="42.152939453592808" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="int" name="num_matched_peaks" value="24"/>
+				<UserParam type="int" name="matched_b_ions" value="12"/>
+				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/PeptideDataBaseSearchFI_2_out.idXML
+++ b/src/tests/topp/PeptideDataBaseSearchFI_2_out.idXML
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-09-19T14:34:27" search_engine="PeptideDataBaseSearchFI" search_engine_version="3.5.0-pre-im-mtd-2025-08-04" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-09T11:11:27" search_engine="PeptideDataBaseSearchFI" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -34,10 +34,15 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="13.195273686121649" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="int" name="num_matched_peaks" value="11"/>
+				<UserParam type="int" name="matched_b_ions" value="3"/>
+				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -46,10 +51,15 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="47.256181302684936" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="int" name="num_matched_peaks" value="26"/>
+				<UserParam type="int" name="matched_b_ions" value="13"/>
+				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -58,10 +68,15 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="42.152939453592808" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="int" name="num_matched_peaks" value="24"/>
+				<UserParam type="int" name="matched_b_ions" value="12"/>
+				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/SimpleSearchEngine_1_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_1_out.idXML
@@ -16,8 +16,8 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-01-22T10:24:48" search_engine="SimpleSearchEngine" search_engine_version="3.4.0-pre-feature-NuXL-2025-01-22" search_parameters_ref="SP_0" >
-		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+	<IdentificationRun date="2026-04-09T11:18:57" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
@@ -31,24 +31,34 @@
 			<UserParam type="stringList" name="spectra_data" value="[file://SimpleSearchEngine_1.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
-			<PeptideHit score="13.195273686121645" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
+			<PeptideHit score="13.195273686121649" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="int" name="num_matched_peaks" value="11"/>
+				<UserParam type="int" name="matched_b_ions" value="3"/>
+				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 			<UserParam type="int" name="scan_index" value="0"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
-			<PeptideHit score="47.256181302684944" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+			<PeptideHit score="47.256181302684936" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="int" name="num_matched_peaks" value="26"/>
+				<UserParam type="int" name="matched_b_ions" value="13"/>
+				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -56,11 +66,16 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="42.152939453592808" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="int" name="num_matched_peaks" value="24"/>
+				<UserParam type="int" name="matched_b_ions" value="12"/>
+				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>

--- a/src/tests/topp/SimpleSearchEngine_2_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_2_out.idXML
@@ -17,8 +17,8 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2025-01-21T14:31:29" search_engine="SimpleSearchEngine" search_engine_version="3.4.0-pre-nuxl-to-dev-2025-01-21" search_parameters_ref="SP_0" >
-		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+	<IdentificationRun date="2026-04-09T11:18:58" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</ProteinHit>
@@ -33,23 +33,33 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="16.841633986596268" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_0" >
+				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|312.17840576171875,0.130536571145058,1,&quot;y2+&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|562.32177734375,0.307607710361481,1,&quot;y4+&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|774.4742431640625,0.191590219736099,1,&quot;y6+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.731785331544976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857142857143"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.714285714285714"/>
+				<UserParam type="int" name="num_matched_peaks" value="12"/>
+				<UserParam type="int" name="matched_b_ions" value="2"/>
+				<UserParam type="int" name="matched_y_ions" value="10"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 			<UserParam type="int" name="scan_index" value="0"/>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.6689453125" spectrum_reference="spectrum=1" >
-			<PeptideHit score="42.21834054663703" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+			<PeptideHit score="42.218340546637023" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
+				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|540.3187255859375,0.676201343536377,2,&quot;b10++&quot;|541.35406494140625,0.121097505092621,1,&quot;b5+&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|796.43560791015625,0.201033338904381,2,&quot;b15++&quot;|844.9805908203125,0.01809080503881,2,&quot;b16++&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1024.443115234375,0.177698284387589,1,&quot;y8+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.303180368382511"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857142857143"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="int" name="num_matched_peaks" value="24"/>
+				<UserParam type="int" name="matched_b_ions" value="11"/>
+				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -57,11 +67,16 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="ln(hyperscore)" higher_score_better="true" significance_threshold="0.0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="34.936662112839578" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_2" >
+				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.391304347826087"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="int" name="num_matched_peaks" value="21"/>
+				<UserParam type="int" name="matched_b_ions" value="9"/>
+				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>


### PR DESCRIPTION
## Summary

- Per-PSM annotations: `num_matched_peaks`, `matched_b_ions`, `matched_y_ions`, `longest_peptide_ion_sequence`, and full `fragment_annotation` (PeakAnnotation vector for TOPPView visualization)
- Applied to both `PeptideSearchEngineFIAlgorithm` and `SimpleSearchEngineAlgorithm`
- Fragment annotations exported to PSM and QPX parquet formats via dedicated `mz_array`, `intensity_array`, `charge_array`, `ion_type_array` columns
- `fragment_annotation` metavalue excluded from parquet `psm_metavalues` bag to avoid duplication

Depends on #9112 (semi/non-specific digestion).

Addresses item #3 from #9108.

## Bugfixes included

- **Decoy generation**: use `reverseProtein()` (plain full reverse) when `enzyme_specificity=none` instead of enzyme-aware `reversePeptides()`, so decoy search space matches the non-specific target space
- **EnzymaticDigestion**: `semiSpecificDigestion_()` returns `(start, end)` pairs but two `digestUnmodified()` callers consumed them as `(start, length)` — fixed at the call sites

## Implementation details

- `HyperScore::PSMDetail` already computed matched b/y counts during scoring — now propagated to `AnnotatedHit_` as `uint16_t` fields
- Fragment annotations built in `postProcessHits_` for top-N hits only (not in the scoring hot loop) by reusing the existing `TheoreticalSpectrumGenerator` + `SpectrumAlignment` code path
- Longest consecutive ion run computed from alignment ion names (parses "b5", "y3-H2O1+" etc.)
- All new annotations gated behind the existing `annotate:PSM` parameter (included in "ALL")
- Removed dead `fragment_annotations` field from `AnnotatedHit_`; struct shrunk from 72 to 40 bytes via field reordering + `float` for fraction/error fields

## Test plan

- [x] New class test: synthetic spectrum from known peptide, verifies all new metavalues + PeakAnnotations
- [x] All 20 existing TOPP + class tests pass (reference files updated for new annotations)
- [x] ArrowSchemaRegistry test updated for new PSMSchema field count (25 → 29)
- [x] QPXFile test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detailed fragment ion matching metrics to peptide search results: matched b-ion and y-ion counts, total matched peaks, and longest consecutive ion series.
  * Introduced configurable enzyme specificity modes (full/semi/none) for controlling peptide generation during searches.
  * Fragment peak annotations now exported in search results with ion details.

* **Bug Fixes**
  * Improved robustness in handling empty fragment indexes and short input sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->