### PR TITLE
docs: update pyOpenMS wrapping guide from Cython/autowrap to nanobind

### DIFF
--- a/doc/pyopenms/docs/source/community/index.rst
+++ b/doc/pyopenms/docs/source/community/index.rst
@@ -17,9 +17,9 @@ If you are unsure how to do that or want to discuss questions
 pyopenms sources
 ----------------
 
-pyopenms mostly consists of Cython wrappers around the OpenMS C++ library. Below
+pyopenms uses nanobind to wrap the OpenMS C++ library for Python. Below
 you will find information on how to build pyopenms from source and how to wrap
-new classes. You can of course also contribute classesa and functionality in pure python.
+new classes. You can of course also contribute classes and functionality in pure Python.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/pyopenms/docs/source/community/wrapping_workflows_new_classes.rst
+++ b/doc/pyopenms/docs/source/community/wrapping_workflows_new_classes.rst
@@ -4,71 +4,110 @@ Wrapping Workflows and New Classes
 How pyOpenMS Wraps C++ Classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-General concept of how the wrapping is done (all files are in ``src/pyOpenMS/``): 
+pyOpenMS uses `nanobind <https://github.com/wjakob/nanobind>`_ to expose OpenMS
+C++ classes to Python. The binding code is hand-maintained in C++ source files
+under ``src/pyOpenMS/bindings/``.
 
-- Step 1: The author declares which C++ classes and which functions of these
-  classes she/he wants to wrap (expose to Python). This is done by writing the
-  class and function declaration in a ``.pxd`` file in the ``pxds/`` folder.
-- Step 2: The Python tool "autowrap" (developed for this project) creates the
-  wrapping code automatically from the function declaration - see
-  https://github.com/OpenMS/autowrap for an explanation of the autowrap
-  tool. 
-  Since not all code can be wrapped automatically using the pxd file, manual 
-  Cython code sometimes need to be written in the ``addons/`` folder.
-  Autowrap will create an output file at ``pyopenms/pyopenms.pyx`` 
-  which can be interpreted by Cython.
-- Step 3: Cython "cythonizes", i.e., translates the ``pyopenms/pyopenms.pyx`` to C++ code at
-  ``pyopenms/pyopenms.cpp`` that contains everything to build a Python module.
-- Step 4: A compiler, nowadays driven by CMake in OpenMS, compiles the C++ code to a Python
-  extension module (pyopenms.so/dylib/dll/pyd) which is then importable in Python with
-  ``import pyopenms``
+The wrapping process works as follows:
 
-Maintaining existing wrappers
+- **Step 1:** The developer writes nanobind binding code in the appropriate
+  ``bind_<domain>.cpp`` file under ``src/pyOpenMS/bindings/``. Each file
+  corresponds to a domain of the OpenMS library (e.g., ``bind_kernel.cpp``
+  for kernel classes, ``bind_format.cpp`` for file format classes).
+- **Step 2:** CMake compiles each binding file into a separate Python extension
+  module (e.g., ``_pyopenms_kernel.so``). All modules share type information
+  via the ``NB_DOMAIN "pyopenms"`` mechanism.
+- **Step 3:** The top-level ``pyopenms/__init__.py`` imports and re-exports all
+  classes, so users simply write ``import pyopenms``.
+
+In addition to the C++ bindings, pure Python convenience methods can be added
+via the **addon system** in ``pyopenms/addons/``. These are injected into the
+wrapped classes at import time.
+
+
+Binding File Organization
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each binding file covers a domain of the OpenMS C++ library:
+
+.. list-table::
+   :header-rows: 1
+
+   * - C++ Header Path
+     - Binding File
+   * - ``KERNEL/``
+     - ``bind_kernel.cpp``
+   * - ``KERNEL/MSSpectrum.h``
+     - ``bind_spectrum.cpp``
+   * - ``KERNEL/MSChromatogram.h``
+     - ``bind_chromatogram.cpp``
+   * - ``KERNEL/MSExperiment.h``
+     - ``bind_experiment.cpp``
+   * - ``FORMAT/``
+     - ``bind_format.cpp``
+   * - ``ANALYSIS/``
+     - ``bind_analysis.cpp``
+   * - ``CHEMISTRY/``
+     - ``bind_chemistry.cpp``
+   * - ``METADATA/``
+     - ``bind_metadata.cpp``
+   * - ``PROCESSING/``
+     - ``bind_processing.cpp``
+   * - ``FEATUREFINDER/``
+     - ``bind_featurefinder.cpp``
+   * - ``DATASTRUCTURES/``, ``MATH/``, ``CONCEPT/``
+     - ``bind_datastructures.cpp``
+   * - ``ML/``
+     - ``bind_ml.cpp``
+   * - Everything else
+     - ``bind_misc.cpp``
+
+Each class in a binding file is preceded by a section comment for navigation:
+
+.. code-block:: cpp
+
+   // --- ClassName ---
+
+
+Maintaining Existing Wrappers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the C++ API is changed, then pyOpenMS will
-not build any more.  Thus, find the corresponding file in the ``pyOpenMS/pxds/``
-folder and adjust the function declaration accordingly.
+If the C++ API of a wrapped class changes (e.g., a method is renamed, removed,
+or has its signature changed), the corresponding binding code in
+``src/pyOpenMS/bindings/bind_<domain>.cpp`` must be updated to match.
+
 
 How to Wrap New Methods in Existing Classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Lets say you have written a new method for an existing OpenMS class and you
-would like to expose this method to pyOpenMS. First, identify the correct
-``.pxd`` file in the ``src/pyOpenMS/pxds`` folder (for example for
-:py:class:`~.Adduct` that would be `Adduct.pxd
-<https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/pxds/Adduct.pxd>`_).
-Open it and add your new function *with the correct indentation*:
+To expose a new C++ method to Python, find the class in the appropriate
+``bind_<domain>.cpp`` file and add a ``.def()`` call.
 
-- Place the full function declaration into the file (indented as the other functions)
-- Check whether you are using any classes that are not yet imported, if so add a corresponding ``cimport`` statement to the top of the file. E.g., if your method is using :py:class:`~.MSExperiment`, then add ``from MSExperiment cimport *`` to the top (note it's ``cimport``, not ``import``).
-- Most of the time it is clearer for a python user if you replace const-references with values in the function signature because the python function will always make a copy in
-  that case. You should add `nogil except +` to the end of the signature to indicate that it can be multithreaded and throw exceptions.
-  - Ex: ``void setType(Int a);`` becomes ``void setType(Int a) nogil except +`` 
-  - Ex: ``const T& getType() const;`` becomes ``T getType() nogil except +``
+For a simple method:
 
-- Remove any qualifiers (e.g. `const`) from the argument signatures, but leave reference and pointer indicators
+.. code-block:: cpp
 
-  - Ex: ``const T&`` becomes ``T``, preventing an additional copy operation
-  - Ex: ``T&`` will stay ``T&`` (indicating ``T`` needs to copied back to Python, make a note in the function docs that this argument may be changed)
-  - Ex: ``T*`` will stay ``T*`` (indicating ``T`` needs to copied back to Python, make a note in the function docs that this argument may be changed)
-  - One exception is ``OpenMS::String``. You can leave ``const String&`` as-is, since we have special handling for this.
-  
-- STL constructs are replaced with Cython constructs: ``std::vector<X>`` becomes ``libcpp_vector[ X ]`` etc. 
-- Most complex STL constructs can be wrapped even if they are nested, however mixing them with user-defined types does not always work, see `Limitations <#Limitations>`_ below. Nested ``std::vector`` constructs work well even with user-defined (OpenMS-defined) types. However, ``std::map<String, X>`` does not work (since ``String`` is user-defined, however a primitive C++ type such as ``std::map<std::string, X>`` would work).
-- Python cannot pass primitive data types by reference (therefore no ``int& res1``)
-- Python does not allow default values for parameters in C(++) functions. Therefore you either accept the fact that the "optional" value always needs to be specified in python
-  or you wrap it twice, once with and once without the optional parameter.
-- Replace ``boost::shared_ptr<X>`` with ``shared_ptr[X]`` and add ``from smart_ptr cimport shared_ptr`` to the top
-- Public members are simply added with ``Type member_name``. Private ones should be left out.
-- You can inject documentation that will be shown when calling ``help()`` in the function by adding ``wrap-doc:Your documentation`` as a comment after the function:
+   .def("methodName", &OpenMS::ClassName::methodName,
+        "Short description of the method")
 
-  - Ex: ``void modifyWidget() nogil except + # wrap-doc:This changes your widget``
-  - Warning: For a single-line comment, there should not be a space between wrap-doc and the following comment.
-  - Note: The space between the hash and wrap-doc (# wrap-doc) is not necessary, but used for consistency.
-  - Note: Please start the comment with a capital letter.
-  
-See the next section for a `simple example <#a-simple-example>`_ and a more `advanced example <#a-further-example>`_ of a wrapped class with several functions.
+For methods that need argument adaptation (e.g., filling output parameters by
+reference), use a lambda wrapper:
+
+.. code-block:: cpp
+
+   .def("getValues", [](const OpenMS::ClassName& self) {
+       std::vector<double> result;
+       self.getValues(result);
+       return result;
+   }, "Returns the values as a list")
+
+Use named arguments for clarity:
+
+.. code-block:: cpp
+
+   .def("setValue", &OpenMS::ClassName::setValue,
+        "value"_a, "Sets the value")
+
 
 How to Wrap New Classes
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,281 +115,217 @@ How to Wrap New Classes
 A Simple Example
 ----------------
 
-To wrap a new OpenMS class: Create a new ".pxd" file in the folder ``./pxds``. As
-a small example, look at the `Adduct.pxd 
-<https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/pxds/Adduct.pxd>`_ 
-to get you started. Start with the following structure:
+To wrap a new OpenMS class:
+
+1. **Choose the binding file** based on the C++ header location (see table above).
+2. **Add the include** for the C++ header.
+3. **Add the class binding** with constructors, copy support, and methods.
+
+.. code-block:: cpp
+
+   #include <OpenMS/MODULE/MyClass.h>
+
+   // --- MyClass ---
+   nb::class_<OpenMS::MyClass>(m, "MyClass", "Short class description")
+       .def(nb::init<>())
+       .def(nb::init<const OpenMS::MyClass &>())
+       .def("__copy__", [](const OpenMS::MyClass& self) {
+           return OpenMS::MyClass(self);
+       })
+       .def("__deepcopy__", [](const OpenMS::MyClass& self, nb::dict) {
+           return OpenMS::MyClass(self);
+       }, "memo"_a)
+       .def("getValue", &OpenMS::MyClass::getValue,
+            "Gets value (between 0 and 5)")
+       .def("setValue", &OpenMS::MyClass::setValue,
+            "v"_a, "Sets value (between 0 and 5)")
+       ;
+
+Key points:
+
+- Always provide both a default constructor and a copy constructor.
+- Always add ``__copy__`` and ``__deepcopy__`` methods.
+- Use ``"param"_a`` for named parameters.
+- Add a short docstring to each method. For longer docstrings, use raw strings:
+
+  .. code-block:: cpp
+
+     .def("myMethod", ..., R"doc(
+         Longer description of the method.
+
+         :param x: Description of x
+         :returns: Description of return value
+     )doc")
+
+
+Inheritance
+-----------
+
+**Simple inheritance (no virtual destructor mismatch):**
+
+If neither the class nor its base introduces a virtual destructor mismatch,
+declare the base class directly:
+
+.. code-block:: cpp
+
+   nb::class_<OpenMS::Acquisition, OpenMS::MetaInfoInterface>(
+       m, "Acquisition", "An acquisition")
+       .def(nb::init<>())
+       // ...
+       ;
+
+**Virtual destructor mismatch (critical):**
+
+If the derived class has a virtual destructor (``virtual ~ClassName()`` or
+``~ClassName() override``) but the base class (e.g., ``MetaInfoInterface``)
+does **not**, you must **not** declare the base in nanobind. Instead, use
+the helper templates from ``binding_utils.h``:
+
+.. code-block:: cpp
+
+   // WRONG - will segfault!
+   nb::class_<OpenMS::PeptideHit, OpenMS::MetaInfoInterface>(m, "PeptideHit", ...)
+
+   // CORRECT - use helper template
+   auto peptidehit = nb::class_<OpenMS::PeptideHit>(m, "PeptideHit", "A peptide hit")
+       .def(nb::init<>())
+       // ... other methods ...
+       ;
+   def_MetaInfoInterface<OpenMS::PeptideHit>(peptidehit);
+
+This pattern is required because nanobind computes incorrect pointer offsets
+when a derived class introduces a vtable pointer that the base class lacks.
+
+**How to check:** Look for ``virtual ~ClassName()`` or ``~ClassName() override``
+in the C++ header file. If present and the base class has no virtual destructor,
+use the helper template pattern.
+
+Helper Templates
+----------------
+
+Reusable helper templates in ``binding_utils.h`` bind common OpenMS interfaces:
+
+- ``def_MetaInfoInterface<T>(cls)`` -- binds ``getMetaValue``, ``setMetaValue``, ``isMetaEmpty``, etc.
+- ``def_UniqueIdInterface<T>(cls)`` -- binds ``getUniqueId``, ``setUniqueId``, etc.
+- ``def_CVTermList<T>(cls)`` -- binds ``addCVTerm``, ``getCVTerms``, ``hasCVTerm``, etc.
+- ``def_DefaultParamHandler<T>(cls)`` -- binds ``setParameters``, ``getParameters``, ``getDefaults``, etc.
+- ``def_ProgressLogger<T>(cls)`` -- binds ``setLogType``, ``startProgress``, ``endProgress``, etc.
+- ``def_DocumentIdentifier<T>(cls)`` -- binds ``setIdentifier``, ``getLoadedFilePath``, etc.
+
+Usage:
+
+.. code-block:: cpp
+
+   auto cls = nb::class_<OpenMS::MyAlgorithm>(m, "MyAlgorithm", "...")
+       .def(nb::init<>())
+       // ... class-specific methods ...
+       ;
+   def_DefaultParamHandler<OpenMS::MyAlgorithm>(cls);
+   def_ProgressLogger<OpenMS::MyAlgorithm>(cls);
+
+
+Enums
+-----
+
+Basic enum:
+
+.. code-block:: cpp
+
+   nb::enum_<OpenMS::MyEnum>(m, "MyEnum")
+       .value("VALUE1", OpenMS::MyEnum::VALUE1)
+       .value("VALUE2", OpenMS::MyEnum::VALUE2)
+       ;
+
+Enum supporting ``int()`` conversion (add ``nb::is_arithmetic()``):
+
+.. code-block:: cpp
+
+   nb::enum_<OpenMS::DriftTimeUnit>(m, "DriftTimeUnit", nb::is_arithmetic())
+       .value("NONE", OpenMS::DriftTimeUnit::NONE)
+       .value("MILLISECOND", OpenMS::DriftTimeUnit::MILLISECOND)
+       ;
+
+Nested enum (scoped under a class):
+
+.. code-block:: cpp
+
+   nb::enum_<OpenMS::MyClass::InnerEnum>(myclass, "InnerEnum")
+       .value("A", OpenMS::MyClass::InnerEnum::A)
+       ;
+
+
+Operator Overloading
+--------------------
+
+Common operators can be bound using nanobind's operator support:
+
+.. code-block:: cpp
+
+   .def(nb::self == nb::self)
+   .def(nb::self != nb::self)
+   .def(nb::self < nb::self)
+   .def(nb::self <= nb::self)
+   .def(nb::self > nb::self)
+   .def(nb::self >= nb::self)
+
+
+Methods Returning NumPy Arrays
+------------------------------
+
+For C++ methods that fill output vectors by reference, wrap them with a lambda
+that returns the data as numpy arrays:
+
+.. code-block:: cpp
+
+   .def("getData", [](const OpenMS::MyClass& self) {
+       std::vector<double> mz, intensity;
+       self.getData(mz, intensity);
+       // Return as numpy arrays using nanobind's ndarray support
+       // ...
+   }, "Returns (mz, intensity) arrays")
+
+
+Adding Pure Python Methods via Addons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For convenience methods that don't need C++ performance, use the addon system
+in ``pyopenms/addons/``. Addon methods are pure Python functions injected into
+wrapped classes at import time.
+
+Create a file ``pyopenms/addons/classname.py`` (snake_case filename):
+
+.. code-block:: python
+
+   from __future__ import annotations
+   from . import addon
+
+   @addon("ClassName")
+   def to_tuple(self) -> tuple:
+       """Return as a (mz, intensity) tuple."""
+       return (self.getMZ(), self.getIntensity())
+
+The ``@addon("ClassName")`` decorator (with PascalCase class name) attaches the
+function as a method on the specified class.
+
+Guidelines for addons:
+
+- Keep addons minimal -- only for non-performance-critical convenience methods.
+- Performance-critical methods should be C++ lambdas in the binding files.
+- Each addon file should document its methods with standard Python docstrings.
+
+
+Build and Test
+^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-  from xxx cimport *
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS":
-
-      cdef cppclass ClassName(DefaultParamHandler):
-          # wrap-inherits:
-          #    DefaultParamHandler
-
-          # default constructor
-          ClassName() nogil except +
-          # copy constructor
-          ClassName(ClassName &) nogil except +
-
-          Int getValue() nogil except + # wrap-doc:Gets value (between 0 and 5)
-          void setValue(Int v) nogil except + # wrap-doc:Sets value (between 0 and 5)
-
-
-- make sure to use ``ClassName:`` instead of ``ClassName(DefaultParamHandler):`` to
-  wrap a class that does not inherit from another class (e.g., DefaultParamHandler)
-  and also remove the two comments regarding inheritance below that line.
-- always use ``cimport`` and not Python ``import``
-- always add default constructor AND copy constructor to the code (note that the C++
-  compiler will add a default copy constructor to any class even if not 
-  specified in the header)
-  This will be wrapped as __copy__ and __deepcopy__ method in python:
-
-  .. code-block:: bash
-
-    def __copy__(self):
-     cdef ClassName rv = ClassName.__new__(ClassName)
-     rv.inst = shared_ptr[ClassName](new ClassName(deref(self.inst.get())))
-     return rv
-
-    def __deepcopy__(self, memo):
-       cdef ClassName rv = ClassName.__new__(ClassName)
-       rv.inst = shared_ptr[ClassName](new ClassName(deref(self.inst.get())))
-       return rv
-
-- Remember to include a copy constructor (even if none was declared in the C++
-  header file) since Cython will need it for certain operations. Otherwise you
-  might see error messages like ``item2.inst = shared_ptr[_ClassName](new _ClassName(deref(it_terms))) Call with wrong number of arguments``.
-- to expose a function to Python, copy the signature to your pxd file, e.g.
-  ``DataValue getValue()`` and make sure you ``cimport`` all corresponding classes.
-  Replace ``std::vector`` with the corresponding Cython vector, in this case
-  ``libcpp_vector`` (see for example `PepXMLFile.pxd
-  <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/pxds/PepXMLFile.pxd>`_)
-- you can add documentation that will show up in the interactive Python documentation (using ``help()``) using the ``wrap-doc`` qualifier
-
-A Further Example
------------------
-
-A slightly more complicated class could look like this, where we demonstrate
-how to handle a templated class with template ``T`` and static methods:
-
-.. code-block:: cython
-
-  from xxx cimport *
-  from AbstractBaseClass cimport *
-  from AbstractBaseClassImpl1 cimport *
-  from AbstractBaseClassImpl2 cimport *
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS":
-
-      cdef cppclass ClassName[T](DefaultParamHandler):
-          # wrap-inherits:
-          #    DefaultParamHandler
-          # 
-          # wrap-instances:
-          #   ClassName := ClassName[X]
-          #   ClassNameY := ClassName[Y]
-
-          ClassName() nogil except +
-          ClassName(ClassName[T] &) nogil except + # wrap-ignore
-
-          void method_name(int param1, double param2) nogil except +
-          T method_returns_template_param() nogil except +
-
-          size_t size() nogil except +
-          T operator[](int) nogil except + # wrap-upper-limit:size()
-
-          libcpp_vector[T].iterator begin() nogil except +  # wrap-iter-begin:__iter__(T)
-          libcpp_vector[T].iterator end()   nogil except +  # wrap-iter-end:__iter__(T)
-
-          void getWidgets(libcpp_vector[String] & keys) nogil except +
-          void getWidgets(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getWAsInt
-
-          # C++ signature: void process(AbstractBaseClass * widget)
-          void process(AbstractBaseClassImpl1 * widget) nogil except +
-          void process(AbstractBaseClassImpl2 * widget) nogil except +
-
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS::Classname<OpenMS::X>":
-
-      void static_method_name(int param1, double param2) nogil except + # wrap-attach:ClassName
-
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS::Classname<OpenMS::Y>":
-
-      void static_method_name(int param1, double param2) nogil except + # wrap-attach:ClassNameY
-
-
-Here the copy constructor will not be wrapped but the Cython parser will import
-it from C++ so that is is present (using ``wrap-ignore``). The ``operator[]``
-will return an object of type ``X`` or ``Y`` depending on the template
-argument ``T`` and contain a guard that the number may not be exceed ``size()``.
-
-The wrapping of iterators allows for iteration over the objects inside the
-``Classname`` container using the appropriate Python function (here
-``__iter__`` with the indicated return type ``T``).
-
-The ``wrap-as`` keyword allows the Python function to assume a different
-name. 
-
-Note that pointers to abstract base classes can be passed as arguments but the
-classes have to be known at compile time, e.g. the function ``process``
-takes a pointer to ``AbstractBaseClass`` which has two known
-implementations ``AbstractBaseClassImpl1`` and
-``AbstractBaseClassImpl2``. Then, the function needs to declared and
-overloaded with both implementations as arguments as shown above.
-
-An Example with Handwritten Addon Code
---------------------------------------
-
-A more complex examples requires some hand-written wrapper code
-(``pxds/Classname.pxd``), for example for singletons that implement a ``getInstance()``
-method that returns a pointer to the singleton resource. Note that in this case
-it is quite important to not let autowrap take over the pointer and possibly
-delete it when the lifetime of the Python object ends. This is done through
-``wrap-manual-memory`` and failing to doing so could lead to segmentation
-faults in the program.
-
-.. code-block:: cython
-
-  from xxx cimport *
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS":
-
-      cdef cppclass ModificationsDB "OpenMS::ModificationsDB":
-          # wrap-manual-memory
-          # wrap-hash:
-          #   getFullId().c_str()
-
-          ClassName(ClassName[T] &) nogil except + # wrap-ignore
-
-          void method_name(int param1, double param2) nogil except +
-
-          int process(libcpp_vector[Peak1D].iterator, libcpp_vector[Peak1D].iterator) nogil except + # wrap-ignore
-
-  cdef extern from "<OpenMS/path/to/header/Classname.h>" namespace "OpenMS::Classname":
-
-      const ClassName* getInstance() nogil except + # wrap-ignore
-
-
-Here the ``wrap-manual-memory`` keyword indicates that memory management
-will be handled manually and autowrap can assume that a member called
-``inst`` will be provided which implements a ``gets()`` method to
-obtain a pointer to an object of C++ type ``Classname``.
-
-We then have to provide such an object (``addons/Classname.pyx``):
-
-.. code-block:: cython
-
-    # This will go into the header (no empty lines below is *required*)
-    # NOTE: _Classname is the C++ class while Classname is the Python class
-    from Classname cimport Classname as _Classname
-    cdef class ClassnameWrapper:
-        # A small utility class holding a ptr and implementing get()
-        cdef const _Classname* wrapped
-        cdef setptr(self, const _Classname* wrapped): self.wrapped = wrapped
-        cdef const _Classname* get(self) except *: return self.wrapped
-
-        # This will go into the class (after the first empty line)
-        # NOTE: we use 4 spaces indent
-        # NOTE: using shared_ptr for a singleton will lead to segfaults, use raw ptr instead
-        cdef ClassnameWrapper inst
-
-        def __init__(self):
-          self.inst = ClassnameWrapper()
-          # the following require some knowledge of the internals of autowrap:
-          # we call the getInstance method to obtain raw ptr
-          self.inst.setptr(_getInstance_Classname())
-
-        def __dealloc__(self):
-          # Careful here, the wrapped ptr is a single instance and we should not
-          # reset it (which is why we used 'wrap-manual-dealloc')
-          pass
-
-        def process(self, Container c):
-          # An example function here (processing Container c):
-          return self.inst.get().process(c.inst.get().begin(), c.inst.get().end())
-
-
-Note how the manual wrapping of the process functions allows us to
-access the ``inst`` pointer of the argument as well as of the object
-itself, allowing us to call C++ functions on both pointers. This makes it easy
-to generate the required iterators and process the container efficiently.
-
-
-.. _Limitations Section:
-
-Considerations and Limitations
-------------------------------
-
-Further considerations and limitations:
-
-- Inheritance: there are some limitations, see for example ``Precursor.pxd``
-
-- Reference: arguments by reference may be copied under some circumstances. For
-  example, if they are in an array then not the original argument is handed
-  back, so comparisons might fail. Also, simple Python types like int, float
-  etc cannot be passed by reference.
-
-- operator+=: see for example ``AASequence.iadd`` in ``AASequence.pxd``
-
-- operator==, !=, <=, <, >=, > are wrapped automatically
-
-- Iterators: some limitations apply, see MSExperiment.pxd for an example
-
-- copy-constructor becomes __copy__/__deepcopy__ in Python
-
-- shared pointers: is handled automatically, check DataAccessHelper using ``shared_ptr[Spectrum]``. Use ``from smart_ptr cimport shared_ptr`` as import statement
-
-These hints can be given to autowrap classes (also check the autowrap documentation):
-
-- ``wrap-ignore`` is a hint for autowrap to not wrap the class (but the declaration might still be important for Cython to know about) 
-- ``wrap-instances:`` for templated classes (see MSSpectrum.pxd)
-- ``wrap-hash:`` hash function to use for ``__hash__`` (see Residue.pxd)
-- ``wrap-manual-memory:`` hint that memory management will be done manually
-
-These hints can be given to autowrap functions (also check the autowrap documentation):
-
-- ``wrap-ignore`` is a hint for autowrap to not wrap the function (but the declaration might still be important for Cython to know about) 
-- ``wrap-as:`` see for example AASequence
-- ``wrap-iter-begin:``, ``wrap-iter-end:`` (see ConsensusMap.pxd)
-- ``wrap-attach:`` enums, static methods (see for example VersionInfo.pxd)
-- ``wrap-upper-limit:size()`` (see MSSpectrum.pxd)
-
-
-Wrapping Code Yourself in ./addons
-----------------------------------
-
-Not all code can be wrapped automatically (yet). Place a file with the same (!)
-name in the addons folder (e.g. ``myClass.pxd`` in ``pxds/`` and ``myClass.pyx`` in ``addons/``)
-and leave two lines empty on the top (this is important). Start with 4 spaces
-of indent and write your additional wrapper functions, adding a wrap-ignore
-comment to the pxd file. See the example above, some additional examples, look into the ``src/pyOpenMS/addons/`` folder:
-
-- `IDRipper.pyx <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/addons/IDRipper.pyx>`_
-
-  - for an example of both input and output of a complex STL construct (``map< String, pair<vector<>, vector<> >`` )
-
-- `MSQuantifications.pyx <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/addons/MSQuantifications.pyx>`_
-
-  - for a ``vector< vector< pair <String,double > > >`` as input in registerExperiment
-  - for a ``map< String, Ratio>`` in getRatios to get returned
-
-- `QcMLFile.pyx <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/addons/QcMLFile.pyx>`_
-  - for a ``map< String, map< String,String> >`` as input
-
-- `SequestInfile.pyx <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/addons/SequestInfile.pyx>`_
-
-  - for a ``map< String, vector<String> >`` to get returned
-
-- `Attachment.pyx <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/addons/Attachment.pyx>`_
-
-  - for a ``vector< vector<String> >`` to get returned
-
-- `ChromatogramExtractorAlgorithm.pxd <https://github.com/OpenMS/OpenMS/blob/develop/src/pyOpenMS/pxds/ChromatogramExtractorAlgorithm.pxd>`_
-
-  - for an example of an abstract base class (``ISpectrumAccess``) in the function
-    ``extractChromatograms`` - this is solved by copy-pasting the function
-    multiple times for each possible implementation of the abstract base class.
-
-Make sure that you *always* declare your objects (all C++ and all Cython
-objects need to be declared) using ``cdef`` Type name. Otherwise you get ``Cannot
-convert ... to Python object`` errors.
+   # Build pyOpenMS
+   cmake --build OpenMS-build --target pyopenms -j$(nproc)
+
+   # Run tests (from /tmp to avoid import shadowing with source pyopenms/)
+   cd /tmp && PYTHONPATH=/path/to/OpenMS-build/pyOpenMS \
+       python3 -m pytest /path/to/src/pyOpenMS/tests/ -v
+
+   # Run a specific test file
+   PYTHONPATH=OpenMS-build/pyOpenMS \
+       python3 -m pytest src/pyOpenMS/tests/unittests/test_MyClass.py -v


### PR DESCRIPTION
## Summary

Closes #9113.

- Rewrites `wrapping_workflows_new_classes.rst` to document the current nanobind binding workflow, replacing all Cython/autowrap/`.pxd` content
- Covers: binding file organization, wrapping methods & classes, inheritance (including virtual destructor mismatch gotcha), helper templates, enums, operators, numpy arrays, addon system, build & test
- Updates `index.rst` description from "Cython wrappers" to "nanobind" and fixes a typo

## Test plan

- [ ] Verify RST renders correctly on ReadTheDocs preview
- [ ] Confirm no broken cross-references in the docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to accurately reflect nanobind-based binding architecture
  * Enhanced guidance for adding new classes and methods
  * Updated build and test instructions to reflect current project structure
  * Fixed minor typos and capitalization inconsistencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->