### PR TITLE
feat: runtime search diagnostics and tolerance estimation in PeptideSearchEngineFI

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -432,6 +432,11 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     void logModificationAnalysisSummary_(const SearchResult& result,
                                          const String& output_base_name) const;
 
+    /// Helper: log search summary statistics and per-run tolerance estimation
+    void logSearchDiagnostics_(const PeakMap& spectra,
+                               const std::vector<ProteinIdentification>& protein_ids,
+                               const PeptideIdentificationList& peptide_ids) const;
+
     /// Helper function to determine if open search should be used based on tolerance
     bool isOpenSearchMode_() const
     {

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1289,7 +1289,7 @@ namespace OpenMS
 
     OPENMS_LOG_INFO << "\n[PDBS-FI] ============ Search Summary ============" << std::endl;
     OPENMS_LOG_INFO << "[PDBS-FI]   MS2 spectra:          " << num_ms2 << std::endl;
-    OPENMS_LOG_INFO << "[PDBS-FI]   PSMs:                 " << num_identified << std::endl;
+    OPENMS_LOG_INFO << "[PDBS-FI]   Matched spectra:      " << num_identified << std::endl;
     if (num_ms2 > 0)
     {
       OPENMS_LOG_INFO << "[PDBS-FI]   MS2 ID rate:          "

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1277,9 +1277,13 @@ namespace OpenMS
 
       // Precursor error: always compute inline (cheap) so tolerance estimation
       // does not depend on the annotate:PSM setting.
-      double theo_mz = top.getSequence().getMZ(top.getCharge());
-      double prec_error_ppm = Math::getPPM(pid.getMZ(), theo_mz);
-      precursor_errors.push_back(fabs(prec_error_ppm));
+      // Skip hits with unresolved charge (0) — getMZ() would throw.
+      if (top.getCharge() > 0)
+      {
+        double theo_mz = top.getSequence().getMZ(top.getCharge());
+        double prec_error_ppm = Math::getPPM(pid.getMZ(), theo_mz);
+        precursor_errors.push_back(fabs(prec_error_ppm));
+      }
 
       // Fragment error: use annotation metavalue if available (computing it
       // inline would require spectrum alignment which is expensive).

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1275,10 +1275,14 @@ namespace OpenMS
         unique_proteins.insert(ev.getProteinAccession());
       }
 
-      if (top.metaValueExists(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))
-      {
-        precursor_errors.push_back(fabs(static_cast<double>(top.getMetaValue(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))));
-      }
+      // Precursor error: always compute inline (cheap) so tolerance estimation
+      // does not depend on the annotate:PSM setting.
+      double theo_mz = top.getSequence().getMZ(top.getCharge());
+      double prec_error_ppm = Math::getPPM(pid.getMZ(), theo_mz);
+      precursor_errors.push_back(fabs(prec_error_ppm));
+
+      // Fragment error: use annotation metavalue if available (computing it
+      // inline would require spectrum alignment which is expensive).
       if (top.metaValueExists(Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM))
       {
         fragment_errors.push_back(static_cast<double>(top.getMetaValue(Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM)));

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -888,6 +888,8 @@ namespace OpenMS
       OPENMS_LOG_WARN << "FDR:PSM is set but decoys are disabled. Skipping FDR filtering." << endl;
     }
 
+    logSearchDiagnostics_(spectra, protein_ids, peptide_ids);
+
     return ExitCodes::EXECUTION_OK;
   }
 
@@ -1235,6 +1237,109 @@ namespace OpenMS
     }
 
     return std::move(mfres.per_file[0]);
+  }
+
+  // =====================================================================
+  // Helper: log search summary statistics and per-run tolerance estimation
+  // =====================================================================
+  void PeptideSearchEngineFIAlgorithm::logSearchDiagnostics_(
+      const PeakMap& spectra,
+      const std::vector<ProteinIdentification>& /*protein_ids*/,
+      const PeptideIdentificationList& peptide_ids) const
+  {
+    // -- Search summary --
+    Size num_ms2 = std::count_if(spectra.begin(), spectra.end(),
+                                 [](const MSSpectrum& s) { return s.getMSLevel() == 2; });
+    Size num_identified = peptide_ids.size();
+
+    set<String> unique_peptides;
+    set<String> unique_proteins;
+
+    // Collect per-PSM error values for tolerance estimation (top-ranked hits only)
+    vector<double> precursor_errors;
+    vector<double> fragment_errors;
+
+    // Missed cleavages
+    EnzymaticDigestion digestor;
+    digestor.setEnzyme(ProteaseDB::getInstance()->getEnzyme(enzyme_));
+    map<Size, Size> mc_counts;
+
+    for (const auto& pid : peptide_ids)
+    {
+      if (pid.getHits().empty()) continue;
+      const PeptideHit& top = pid.getHits().front();
+      unique_peptides.insert(top.getSequence().toString());
+
+      for (const auto& ev : top.getPeptideEvidences())
+      {
+        unique_proteins.insert(ev.getProteinAccession());
+      }
+
+      if (top.metaValueExists(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))
+      {
+        precursor_errors.push_back(fabs(static_cast<double>(top.getMetaValue(Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM))));
+      }
+      if (top.metaValueExists(Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM))
+      {
+        fragment_errors.push_back(static_cast<double>(top.getMetaValue(Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM)));
+      }
+
+      mc_counts[digestor.countInternalCleavageSites(top.getSequence().toUnmodifiedString())]++;
+    }
+
+    OPENMS_LOG_INFO << "\n[PDBS-FI] ============ Search Summary ============" << std::endl;
+    OPENMS_LOG_INFO << "[PDBS-FI]   MS2 spectra:          " << num_ms2 << std::endl;
+    OPENMS_LOG_INFO << "[PDBS-FI]   PSMs:                 " << num_identified << std::endl;
+    if (num_ms2 > 0)
+    {
+      OPENMS_LOG_INFO << "[PDBS-FI]   MS2 ID rate:          "
+                      << std::fixed << std::setprecision(1) << (100.0 * num_identified / num_ms2) << "%" << std::endl;
+    }
+    OPENMS_LOG_INFO << "[PDBS-FI]   Unique peptides:      " << unique_peptides.size() << std::endl;
+    OPENMS_LOG_INFO << "[PDBS-FI]   Unique proteins:      " << unique_proteins.size() << std::endl;
+
+    // Missed cleavages distribution
+    if (!mc_counts.empty())
+    {
+      std::ostringstream mc_oss;
+      for (const auto& [mc, count] : mc_counts)
+      {
+        if (mc_oss.tellp() > 0) mc_oss << ", ";
+        mc_oss << mc << ": " << count;
+      }
+      OPENMS_LOG_INFO << "[PDBS-FI]   Missed cleavages:    " << mc_oss.str() << std::endl;
+    }
+
+    // -- Per-run tolerance estimation --
+    const Size min_psms_for_estimation = 10;
+    if (precursor_errors.size() >= min_psms_for_estimation || fragment_errors.size() >= min_psms_for_estimation)
+    {
+      OPENMS_LOG_INFO << "[PDBS-FI] -------- Tolerance Estimation --------" << std::endl;
+    }
+
+    if (precursor_errors.size() >= min_psms_for_estimation)
+    {
+      double med = Math::median(precursor_errors.begin(), precursor_errors.end());
+      double mad = Math::MAD(precursor_errors.begin(), precursor_errors.end(), med);
+      double recommended = std::ceil(med + 3.0 * mad);
+      OPENMS_LOG_INFO << "[PDBS-FI]   Precursor error: median=" << std::fixed << std::setprecision(2) << med
+                      << " ppm, MAD=" << mad << " ppm"
+                      << " -> recommended: " << static_cast<int>(recommended) << " ppm" << std::endl;
+    }
+
+    if (fragment_errors.size() >= min_psms_for_estimation)
+    {
+      double med = Math::median(fragment_errors.begin(), fragment_errors.end());
+      double mad = Math::MAD(fragment_errors.begin(), fragment_errors.end(), med);
+      double recommended = std::ceil(med + 3.0 * mad);
+      OPENMS_LOG_INFO << "[PDBS-FI]   Fragment error:  median=" << std::fixed << std::setprecision(2) << med
+                      << " ppm, MAD=" << mad << " ppm"
+                      << " -> recommended: " << static_cast<int>(recommended) << " ppm" << std::endl;
+    }
+
+    OPENMS_LOG_INFO << "[PDBS-FI]   (configured: precursor=" << precursor_mass_tolerance_ << " " << precursor_mass_tolerance_unit_
+                    << ", fragment=" << fragment_mass_tolerance_ << " " << fragment_mass_tolerance_unit_ << ")" << std::endl;
+    OPENMS_LOG_INFO << "[PDBS-FI] ============================================\n" << std::endl;
   }
 
   // =====================================================================


### PR DESCRIPTION
## Summary

- Log a **search summary** after every search: MS2 spectra count, PSM count, MS2 ID rate, unique peptides/proteins, missed cleavages distribution
- Log **per-run tolerance estimation**: median + MAD of precursor and fragment errors (ppm), with recommended tolerance (`ceil(median + 3*MAD)`), plus configured tolerance for comparison. Requires ≥10 PSMs (skipped otherwise). Follows the `InternalCalibration.cpp` pattern.
- Addresses items **\#\10** (runtime summary statistics) and **\#\11** (per-run tolerance estimation) from #9108

## Test plan

- [x] All 11 PeptideDataBaseSearchFI / PeptideSearchEngineFIAlgorithm tests pass
- [x] Smoke test: diagnostics output verified with test data (3 PSMs → summary shown, tolerance estimation correctly skipped due to <10 PSMs)
- [ ] Verify with real-world data that tolerance estimation produces sensible recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced search diagnostics: detailed logging of spectrum and identification summaries (MS2 count, PSMs, unique peptides/proteins).
  * Missed-cleavage distribution reporting based on configured enzyme specificity.
  * Per-run tolerance estimation with robust-statistic recommendations for precursor and fragment errors when sufficient data; current tolerances are also reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->