### PR TITLE
feat: protein-level FDR (picked-protein) in PeptideSearchEngineFI

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -416,8 +416,8 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     bool decoys_;
     String decoy_prefix_;
 
-    double fdr_psm_;
-    double fdr_protein_;
+    double fdr_psm_{0.0};
+    double fdr_protein_{0.0};
 
     StringList annotate_psm_;
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -416,6 +416,7 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     bool decoys_;
 
     double fdr_psm_;
+    double fdr_protein_;
 
     StringList annotate_psm_;
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h
@@ -414,6 +414,7 @@ class OPENMS_DLLAPI PeptideSearchEngineFIAlgorithm :
     String enzyme_;
 
     bool decoys_;
+    String decoy_prefix_;
 
     double fdr_psm_;
     double fdr_protein_;

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -115,6 +115,8 @@ namespace OpenMS
     defaults_.setValue("decoys", "false", "Should decoys be generated?");
     defaults_.setValidStrings("decoys", {"true","false"} );
 
+    defaults_.setValue("decoy_prefix", "DECOY_", "Accession prefix used for decoy proteins. When decoy generation is enabled (-decoys), this prefix is added to generated decoy accessions. When decoy generation is disabled, the FASTA database may already contain decoy proteins with this prefix (e.g., from DecoyDatabase) and FDR can still be applied.", {"advanced"});
+
     defaults_.setValue("annotate:PSM",  std::vector<std::string>{"ALL"}, "Annotations added to each PSM.");
     defaults_.setValidStrings("annotate:PSM",
       std::vector<std::string>{
@@ -259,6 +261,7 @@ namespace OpenMS
     report_top_hits_ = param_.getValue("report:top_hits");
 
     decoys_ = param_.getValue("decoys") == "true";
+    decoy_prefix_ = param_.getValue("decoy_prefix").toString();
     annotate_psm_ = ListUtils::toStringList<std::string>(param_.getValue("annotate:PSM"));
     fdr_psm_ = param_.getValue("FDR:PSM");
     fdr_protein_ = param_.getValue("FDR:protein");
@@ -677,7 +680,7 @@ namespace OpenMS
         {
           e.sequence = decoy_generator.reversePeptides(AASequence::fromString(e.sequence), enzyme_).toString();
         }
-        e.identifier = "DECOY_" + e.identifier;
+        e.identifier = decoy_prefix_ + e.identifier;
         ctx.db.push_back(std::move(e));
       }
       Math::RandomShuffler shuffler;
@@ -902,7 +905,7 @@ namespace OpenMS
     // semi-specific / non-specific PSMs would be silently filtered out here.
     PeptideIndexing indexer;
     Param param_pi = indexer.getParameters();
-    param_pi.setValue("decoy_string", "DECOY_");
+    param_pi.setValue("decoy_string", decoy_prefix_);
     param_pi.setValue("decoy_string_position", "prefix");
     param_pi.setValue("enzyme:name", enzyme_);
     param_pi.setValue("enzyme:specificity",
@@ -941,11 +944,13 @@ namespace OpenMS
       }
     }
 
-    // PSM-level FDR filtering (requires decoys).
-    // Decoy hits are kept when protein FDR is requested — applyPickedProteinFDR
-    // needs both target and decoy proteins with scores. Decoy removal is
-    // deferred to the caller (file-based search or multi-file aggregate path).
-    if (fdr_psm_ > 0.0 && decoys_)
+    // PSM-level FDR filtering.
+    // Decoys may be generated internally (decoys_=true) or present in the
+    // input FASTA (external, identified by decoy_prefix_).
+    bool has_decoys = std::any_of(db.begin(), db.end(),
+        [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
+
+    if (fdr_psm_ > 0.0 && has_decoys)
     {
       FalseDiscoveryRate fdr;
       fdr.apply(peptide_ids);
@@ -959,9 +964,10 @@ namespace OpenMS
         IDFilter::removeUnreferencedProteins(protein_ids, peptide_ids);
       }
     }
-    else if (fdr_psm_ > 0.0 && !decoys_)
+    else if (fdr_psm_ > 0.0 && !has_decoys)
     {
-      OPENMS_LOG_WARN << "FDR:PSM is set but decoys are disabled. Skipping FDR filtering." << endl;
+      OPENMS_LOG_WARN << "FDR:PSM is set but no decoys found (decoy_prefix='" << decoy_prefix_
+                      << "'). Provide a FASTA with decoy proteins or enable '-decoys'. Skipping FDR filtering." << endl;
     }
 
     restore_fi_params();
@@ -1004,13 +1010,15 @@ namespace OpenMS
     // Protein inference + picked-protein FDR for single-file search.
     // Must run before decoy removal so both target and decoy proteins
     // receive aggregated scores from BPIA.
-    if (fdr_protein_ > 0.0 && decoys_)
+    bool has_decoys_single = std::any_of(fasta_db.begin(), fasta_db.end(),
+        [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
+    if (fdr_protein_ > 0.0 && has_decoys_single)
     {
       BasicProteinInferenceAlgorithm bpia;
       bpia.run(peptide_ids, protein_ids);
 
       FalseDiscoveryRate fdr;
-      fdr.applyPickedProteinFDR(protein_ids[0], "DECOY_", true);
+      fdr.applyPickedProteinFDR(protein_ids[0], decoy_prefix_, true);
       IDFilter::filterHitsByScore(protein_ids, fdr_protein_);
 
       // Now safe to remove decoys (deferred from search() above)
@@ -1268,7 +1276,7 @@ namespace OpenMS
       // from the database and maps all pooled PSMs to it.
       PeptideIndexing indexer;
       Param param_pi = indexer.getParameters();
-      param_pi.setValue("decoy_string", "DECOY_");
+      param_pi.setValue("decoy_string", decoy_prefix_);
       param_pi.setValue("decoy_string_position", "prefix");
       param_pi.setValue("enzyme:name", enzyme_);
       param_pi.setValue("enzyme:specificity",
@@ -1286,7 +1294,7 @@ namespace OpenMS
       bpia.run(mfres.aggregate.peptide_ids, mfres.aggregate.protein_ids);
 
       FalseDiscoveryRate fdr;
-      fdr.applyPickedProteinFDR(mfres.aggregate.protein_ids[0], "DECOY_", true);
+      fdr.applyPickedProteinFDR(mfres.aggregate.protein_ids[0], decoy_prefix_, true);
       IDFilter::filterHitsByScore(mfres.aggregate.protein_ids, fdr_protein_);
       IDFilter::removeDecoyHits(mfres.aggregate.peptide_ids);
       IDFilter::removeEmptyIdentifications(mfres.aggregate.peptide_ids);

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h>
 
+#include <OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
 #include <OpenMS/ANALYSIS/ID/FragmentIndex.h>
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
@@ -152,6 +153,9 @@ namespace OpenMS
     defaults_.setValue("FDR:PSM", 0.0, "Filter PSMs based on q-value (e.g., 0.05 = 5% FDR, set to 0 to disable filtering and report all PSMs with q-values). Requires '-decoys' to be set.");
     defaults_.setMinFloat("FDR:PSM", 0.0);
     defaults_.setMaxFloat("FDR:PSM", 1.0);
+    defaults_.setValue("FDR:protein", 0.0, "Filter proteins based on picked-protein FDR q-value (e.g., 0.01 = 1% protein FDR, set to 0 to disable). Applied after PSM-level FDR. Uses the picked-protein approach (Savitski et al. 2015) which pairs target and decoy proteins by accession. Requires '-decoys' to be set.");
+    defaults_.setMinFloat("FDR:protein", 0.0);
+    defaults_.setMaxFloat("FDR:protein", 1.0);
     defaults_.setSectionDescription("FDR", "False Discovery Rate control (requires decoys)");
 
     // Add parameters which are only used by FragmentIndex
@@ -257,6 +261,7 @@ namespace OpenMS
     decoys_ = param_.getValue("decoys") == "true";
     annotate_psm_ = ListUtils::toStringList<std::string>(param_.getValue("annotate:PSM"));
     fdr_psm_ = param_.getValue("FDR:PSM");
+    fdr_protein_ = param_.getValue("FDR:protein");
 
     // Open search mode is automatically determined based on precursor tolerance in isOpenSearchMode_()
 
@@ -936,15 +941,23 @@ namespace OpenMS
       }
     }
 
-    // PSM-level FDR filtering (requires decoys)
+    // PSM-level FDR filtering (requires decoys).
+    // Decoy hits are kept when protein FDR is requested — applyPickedProteinFDR
+    // needs both target and decoy proteins with scores. Decoy removal is
+    // deferred to the caller (file-based search or multi-file aggregate path).
     if (fdr_psm_ > 0.0 && decoys_)
     {
       FalseDiscoveryRate fdr;
       fdr.apply(peptide_ids);
       IDFilter::filterHitsByScore(peptide_ids, fdr_psm_);
-      IDFilter::removeDecoyHits(peptide_ids);
-      IDFilter::removeEmptyIdentifications(peptide_ids);
-      IDFilter::removeUnreferencedProteins(protein_ids, peptide_ids);
+
+      if (fdr_protein_ == 0.0)
+      {
+        // No protein FDR → safe to remove decoys now
+        IDFilter::removeDecoyHits(peptide_ids);
+        IDFilter::removeEmptyIdentifications(peptide_ids);
+        IDFilter::removeUnreferencedProteins(protein_ids, peptide_ids);
+      }
     }
     else if (fdr_psm_ > 0.0 && !decoys_)
     {
@@ -986,6 +999,24 @@ namespace OpenMS
     if (ec != ExitCodes::EXECUTION_OK)
     {
       return ec;
+    }
+
+    // Protein inference + picked-protein FDR for single-file search.
+    // Must run before decoy removal so both target and decoy proteins
+    // receive aggregated scores from BPIA.
+    if (fdr_protein_ > 0.0 && decoys_)
+    {
+      BasicProteinInferenceAlgorithm bpia;
+      bpia.run(peptide_ids, protein_ids);
+
+      FalseDiscoveryRate fdr;
+      fdr.applyPickedProteinFDR(protein_ids[0], "DECOY_", true);
+      IDFilter::filterHitsByScore(protein_ids, fdr_protein_);
+
+      // Now safe to remove decoys (deferred from search() above)
+      IDFilter::removeDecoyHits(peptide_ids);
+      IDFilter::removeEmptyIdentifications(peptide_ids);
+      IDFilter::removeUnreferencedProteins(protein_ids, peptide_ids);
     }
 
     // patch file-specific metadata
@@ -1212,6 +1243,54 @@ namespace OpenMS
       {
         mfres.aggregate.peptide_ids.push_back(pid);
       }
+    }
+
+    // Aggregate protein inference + picked-protein FDR on pooled PSMs (across
+    // all files). This is the correct level for protein inference — per-file
+    // protein FDR is too conservative because each file sees only a subset of
+    // the proteome. Mirrors the ProteomicsLFQ pattern.
+    if (fdr_protein_ > 0.0 && decoys_ && !mfres.aggregate.protein_ids.empty())
+    {
+      // Synchronize identifiers: pooled PSMs carry per-file identifiers
+      // but BasicProteinInferenceAlgorithm filters by identifier match.
+      // Set all PSMs to the aggregate protein run identifier (analogous to
+      // ConsensusMapMergerAlgorithm::mergeAllIDRuns setting "merged").
+      const String& agg_id = mfres.aggregate.protein_ids[0].getIdentifier();
+      for (auto& pid : mfres.aggregate.peptide_ids)
+      {
+        pid.setIdentifier(agg_id);
+      }
+
+      // Re-index pooled PSMs against the aggregate protein list
+      PeptideIndexing indexer;
+      Param param_pi = indexer.getParameters();
+      param_pi.setValue("decoy_string", "DECOY_");
+      param_pi.setValue("decoy_string_position", "prefix");
+      param_pi.setValue("enzyme:name", enzyme_);
+      param_pi.setValue("enzyme:specificity",
+                        EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
+      param_pi.setValue("missing_decoy_action", "silent");
+      indexer.setParameters(param_pi);
+      indexer.run(ctx.db, mfres.aggregate.protein_ids, mfres.aggregate.peptide_ids);
+
+      // Protein inference: aggregate best PSM score per peptide per protein.
+      // Uses BasicProteinInferenceAlgorithm (aggregation mode, default "best")
+      // which keeps the best PSM per peptidoform and assigns the aggregated
+      // score to each protein. This sets meaningful protein-level scores
+      // that applyPickedProteinFDR can work with.
+      BasicProteinInferenceAlgorithm bpia;
+      bpia.run(mfres.aggregate.peptide_ids, mfres.aggregate.protein_ids);
+
+      FalseDiscoveryRate fdr;
+      fdr.applyPickedProteinFDR(mfres.aggregate.protein_ids[0], "DECOY_", true);
+      IDFilter::filterHitsByScore(mfres.aggregate.protein_ids, fdr_protein_);
+      IDFilter::removeDecoyHits(mfres.aggregate.peptide_ids);
+      IDFilter::removeEmptyIdentifications(mfres.aggregate.peptide_ids);
+      IDFilter::removeUnreferencedProteins(mfres.aggregate.protein_ids, mfres.aggregate.peptide_ids);
+
+      OPENMS_LOG_INFO << "[PDBS-FI] Aggregate protein inference + FDR: "
+                      << mfres.aggregate.protein_ids[0].getHits().size() << " proteins at "
+                      << fdr_protein_ * 100 << "% FDR" << std::endl;
     }
 
     // Aggregate modification analysis on the pooled PSM set.

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
+#include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/FragmentIndex.h>
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
 #include <OpenMS/ANALYSIS/ID/HyperScore.h>
@@ -1222,78 +1223,32 @@ namespace OpenMS
       return mfres;
     }
 
-    // Use the first successful per-file result's protein metadata as the aggregate template.
-    for (const auto& pf : mfres.per_file)
-    {
-      if (pf.exit_code == ExitCodes::EXECUTION_OK)
-      {
-        mfres.aggregate.protein_ids = pf.protein_ids;
-        break;
-      }
-    }
-    // Overwrite the primary MS run path on the aggregate to point at all input files.
-    if (!mfres.aggregate.protein_ids.empty())
-    {
-      mfres.aggregate.protein_ids[0].setPrimaryMSRunPath(in_spectra_files);
-    }
-
-    // Pool peptide_ids across all successful per-file results.
-    Size pooled_count = 0;
-    for (const auto& pf : mfres.per_file)
-    {
-      if (pf.exit_code == ExitCodes::EXECUTION_OK) { pooled_count += pf.peptide_ids.size(); }
-    }
-    mfres.aggregate.peptide_ids.reserve(pooled_count);
+    // Merge per-file identifications into a single aggregate using
+    // IDMergerAlgorithm — the canonical OpenMS pattern for cross-file protein
+    // inference (mirrors ConsensusMapMergerAlgorithm::mergeAllIDRuns in
+    // ProteomicsLFQ). This deduplicates ProteinHits by accession (union) and
+    // remaps all PeptideIdentification identifiers to the merged run. No
+    // PeptideIndexing re-run needed: per-file searches already linked
+    // peptides to proteins.
+    IDMergerAlgorithm merger;
     for (const auto& pf : mfres.per_file)
     {
       if (pf.exit_code != ExitCodes::EXECUTION_OK) { continue; }
-      for (const auto& pid : pf.peptide_ids)
-      {
-        mfres.aggregate.peptide_ids.push_back(pid);
-      }
+      merger.insertRuns(pf.protein_ids, pf.peptide_ids);
     }
+    ProteinIdentification merged_proteins;
+    merger.returnResultsAndClear(merged_proteins, mfres.aggregate.peptide_ids);
+    mfres.aggregate.protein_ids = {std::move(merged_proteins)};
+    mfres.aggregate.protein_ids[0].setPrimaryMSRunPath(in_spectra_files);
 
-    // Aggregate protein inference + picked-protein FDR on pooled PSMs (across
-    // all files). This is the correct level for protein inference — per-file
-    // protein FDR is too conservative because each file sees only a subset of
-    // the proteome. Mirrors the ProteomicsLFQ pattern.
+    // Aggregate protein inference + picked-protein FDR on pooled PSMs.
     // Check for decoys: either generated internally (decoys_) or present in
     // the database (external decoys matching decoy_prefix_).
     bool has_decoys_agg = decoys_ || std::any_of(ctx.db.begin(), ctx.db.end(),
         [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
     if (fdr_protein_ > 0.0 && has_decoys_agg && !mfres.aggregate.protein_ids.empty())
     {
-      // Synchronize identifiers: pooled PSMs carry per-file identifiers
-      // but BasicProteinInferenceAlgorithm filters by identifier match.
-      // Set all PSMs to the aggregate protein run identifier (analogous to
-      // ConsensusMapMergerAlgorithm::mergeAllIDRuns setting "merged").
-      const String& agg_id = mfres.aggregate.protein_ids[0].getIdentifier();
-      for (auto& pid : mfres.aggregate.peptide_ids)
-      {
-        pid.setIdentifier(agg_id);
-      }
-
-      // Re-index pooled PSMs against the aggregate protein list.
-      // Necessary because the aggregate protein_ids is a template from one
-      // per-file result — its ProteinHits may not cover proteins identified
-      // only in other files. PeptideIndexing rebuilds the full protein list
-      // from the database and maps all pooled PSMs to it.
-      PeptideIndexing indexer;
-      Param param_pi = indexer.getParameters();
-      param_pi.setValue("decoy_string", decoy_prefix_);
-      param_pi.setValue("decoy_string_position", "prefix");
-      param_pi.setValue("enzyme:name", enzyme_);
-      param_pi.setValue("enzyme:specificity",
-                        EnzymaticDigestion::NamesOfSpecificity[peptide_enzyme_specificity_]);
-      param_pi.setValue("missing_decoy_action", "silent");
-      indexer.setParameters(param_pi);
-      indexer.run(ctx.db, mfres.aggregate.protein_ids, mfres.aggregate.peptide_ids);
-
       // Protein inference: aggregate best PSM score per peptide per protein.
-      // Uses BasicProteinInferenceAlgorithm (aggregation mode, default "best")
-      // which keeps the best PSM per peptidoform and assigns the aggregated
-      // score to each protein. This sets meaningful protein-level scores
-      // that applyPickedProteinFDR can work with.
       BasicProteinInferenceAlgorithm bpia;
       bpia.run(mfres.aggregate.peptide_ids, mfres.aggregate.protein_ids);
 

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1012,7 +1012,7 @@ namespace OpenMS
     // receive aggregated scores from BPIA.
     bool has_decoys_single = std::any_of(fasta_db.begin(), fasta_db.end(),
         [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
-    if (fdr_protein_ > 0.0 && has_decoys_single)
+    if (fdr_protein_ > 0.0 && (decoys_ || has_decoys_single))
     {
       BasicProteinInferenceAlgorithm bpia;
       bpia.run(peptide_ids, protein_ids);
@@ -1257,7 +1257,11 @@ namespace OpenMS
     // all files). This is the correct level for protein inference — per-file
     // protein FDR is too conservative because each file sees only a subset of
     // the proteome. Mirrors the ProteomicsLFQ pattern.
-    if (fdr_protein_ > 0.0 && decoys_ && !mfres.aggregate.protein_ids.empty())
+    // Check for decoys: either generated internally (decoys_) or present in
+    // the database (external decoys matching decoy_prefix_).
+    bool has_decoys_agg = decoys_ || std::any_of(ctx.db.begin(), ctx.db.end(),
+        [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
+    if (fdr_protein_ > 0.0 && has_decoys_agg && !mfres.aggregate.protein_ids.empty())
     {
       // Synchronize identifiers: pooled PSMs carry per-file identifiers
       // but BasicProteinInferenceAlgorithm filters by identifier match.

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1241,28 +1241,11 @@ namespace OpenMS
     mfres.aggregate.protein_ids = {std::move(merged_proteins)};
     mfres.aggregate.protein_ids[0].setPrimaryMSRunPath(in_spectra_files);
 
-    // Aggregate protein inference + picked-protein FDR on pooled PSMs.
-    // Check for decoys: either generated internally (decoys_) or present in
-    // the database (external decoys matching decoy_prefix_).
-    bool has_decoys_agg = decoys_ || std::any_of(ctx.db.begin(), ctx.db.end(),
-        [this](const FASTAFile::FASTAEntry& e) { return e.identifier.hasPrefix(decoy_prefix_); });
-    if (fdr_protein_ > 0.0 && has_decoys_agg && !mfres.aggregate.protein_ids.empty())
-    {
-      // Protein inference: aggregate best PSM score per peptide per protein.
-      BasicProteinInferenceAlgorithm bpia;
-      bpia.run(mfres.aggregate.peptide_ids, mfres.aggregate.protein_ids);
-
-      FalseDiscoveryRate fdr;
-      fdr.applyPickedProteinFDR(mfres.aggregate.protein_ids[0], decoy_prefix_, true);
-      IDFilter::filterHitsByScore(mfres.aggregate.protein_ids, fdr_protein_);
-      IDFilter::removeDecoyHits(mfres.aggregate.peptide_ids);
-      IDFilter::removeEmptyIdentifications(mfres.aggregate.peptide_ids);
-      IDFilter::removeUnreferencedProteins(mfres.aggregate.protein_ids, mfres.aggregate.peptide_ids);
-
-      OPENMS_LOG_INFO << "[PDBS-FI] Aggregate protein inference + FDR: "
-                      << mfres.aggregate.protein_ids[0].getHits().size() << " proteins at "
-                      << fdr_protein_ * 100 << "% FDR" << std::endl;
-    }
+    // Note: protein inference + FDR on the aggregate is left to the caller
+    // (e.g., the TOPP tool's -out_merged option) so that per-file outputs
+    // retain run-level information without being overwritten by aggregate
+    // protein lists. The aggregate here contains the merged (unfiltered)
+    // proteins + pooled PSMs for downstream use.
 
     // Aggregate modification analysis on the pooled PSM set.
     if (mfres.aggregate.is_open_search && !mfres.aggregate.peptide_ids.empty())

--- a/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.cpp
@@ -1261,7 +1261,11 @@ namespace OpenMS
         pid.setIdentifier(agg_id);
       }
 
-      // Re-index pooled PSMs against the aggregate protein list
+      // Re-index pooled PSMs against the aggregate protein list.
+      // Necessary because the aggregate protein_ids is a template from one
+      // per-file result — its ProteinHits may not cover proteins identified
+      // only in other files. PeptideIndexing rebuilds the full protein list
+      // from the database and maps all pooled PSMs to it.
       PeptideIndexing indexer;
       Param param_pi = indexer.getParameters();
       param_pi.setValue("decoy_string", "DECOY_");

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -9,6 +9,10 @@
 #include <OpenMS/ANALYSIS/ID/PeptideSearchEngineFIAlgorithm.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 
+#include <OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h>
+#include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
+#include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
+#include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
@@ -140,7 +144,18 @@ class PeptideDataBaseSearchFI :
       ProgressLogger progresslogger;
       progresslogger.setLogType(log_type_);
 
-      const Param search_params = getParam_().copy("Search:", true);
+      Param search_params = getParam_().copy("Search:", true);
+      const String percolator_executable = getStringOption_("percolator_executable");
+      const double user_protein_fdr = static_cast<double>(search_params.getValue("FDR:protein"));
+
+      // When Percolator rescoring is enabled, defer protein FDR to after rescoring
+      // so protein inference uses Percolator q-values, not raw HyperScores.
+      if (!percolator_executable.empty() && user_protein_fdr > 0.0)
+      {
+        OPENMS_LOG_INFO << "[PDBS-FI] Percolator rescoring enabled: deferring protein FDR to post-rescoring." << endl;
+        search_params.setValue("FDR:protein", 0.0);
+      }
+
       PeptideSearchEngineFIAlgorithm sse;
       sse.setParameters(search_params);
 
@@ -214,7 +229,6 @@ class PeptideDataBaseSearchFI :
 
       // Optional per-file Percolator rescoring (replaces HyperScore with
       // Percolator q-values for downstream FDR / protein inference).
-      const String percolator_executable = getStringOption_("percolator_executable");
       if (!percolator_executable.empty())
       {
         // Percolator requires decoys for target/decoy competition.
@@ -288,6 +302,69 @@ class PeptideDataBaseSearchFI :
           File::remove(tmp_in);
           File::remove(tmp_out);
           File::remove(tmp_weights);
+        }
+      }
+
+      // Post-rescoring protein inference + FDR on Percolator q-values.
+      // Only runs when both Percolator and protein FDR were requested.
+      if (!percolator_executable.empty() && user_protein_fdr > 0.0)
+      {
+        // Load FASTA for PeptideIndexing
+        vector<FASTAFile::FASTAEntry> fasta_db;
+        FASTAFile().load(database, fasta_db);
+        const String decoy_prefix = search_params.getValue("decoy_prefix").toString();
+        const String enzyme = search_params.getValue("enzyme").toString();
+
+        // Pool rescored PSMs across all files
+        vector<ProteinIdentification> agg_protein_ids;
+        PeptideIdentificationList agg_peptide_ids;
+        if (!mfres.per_file.empty() && mfres.per_file[0].exit_code == PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK)
+        {
+          agg_protein_ids = mfres.per_file[0].protein_ids;
+        }
+        const String& agg_id = agg_protein_ids.empty() ? String("merged") : agg_protein_ids[0].getIdentifier();
+        for (auto& pf : mfres.per_file)
+        {
+          if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
+          for (auto& pid : pf.peptide_ids)
+          {
+            pid.setIdentifier(agg_id);
+            agg_peptide_ids.push_back(pid);
+          }
+        }
+
+        if (!agg_protein_ids.empty() && !agg_peptide_ids.empty())
+        {
+          // Re-index and run protein inference on rescored PSMs
+          PeptideIndexing indexer;
+          Param param_pi = indexer.getParameters();
+          param_pi.setValue("decoy_string", decoy_prefix);
+          param_pi.setValue("decoy_string_position", "prefix");
+          param_pi.setValue("enzyme:name", enzyme);
+          param_pi.setValue("missing_decoy_action", "silent");
+          indexer.setParameters(param_pi);
+          indexer.run(fasta_db, agg_protein_ids, agg_peptide_ids);
+
+          BasicProteinInferenceAlgorithm bpia;
+          bpia.run(agg_peptide_ids, agg_protein_ids);
+
+          FalseDiscoveryRate fdr;
+          fdr.applyPickedProteinFDR(agg_protein_ids[0], decoy_prefix, true);
+          IDFilter::filterHitsByScore(agg_protein_ids, user_protein_fdr);
+          IDFilter::removeDecoyHits(agg_peptide_ids);
+          IDFilter::removeEmptyIdentifications(agg_peptide_ids);
+          IDFilter::removeUnreferencedProteins(agg_protein_ids, agg_peptide_ids);
+
+          OPENMS_LOG_INFO << "[PDBS-FI] Post-Percolator protein inference + FDR: "
+                          << agg_protein_ids[0].getHits().size() << " proteins at "
+                          << user_protein_fdr * 100 << "% FDR" << endl;
+
+          // Write back filtered protein list to each per-file result
+          for (auto& pf : mfres.per_file)
+          {
+            if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
+            pf.protein_ids = agg_protein_ids;
+          }
         }
       }
 

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -11,7 +11,7 @@
 
 #include <OpenMS/ANALYSIS/ID/BasicProteinInferenceAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
-#include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
+#include <OpenMS/ANALYSIS/ID/IDMergerAlgorithm.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
@@ -89,6 +89,9 @@ class PeptideDataBaseSearchFI :
       registerOutputFileList_("out", "<files>", StringList(), "Output identification file(s). Must have the same number of entries as -in. Output format is auto-detected per file from the extension (.idXML or .parquet); a mix of formats within one run is allowed.");
       setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
 
+      registerOutputFile_("out_merged", "<file>", "", "Optional merged output file containing all PSMs pooled across input files with cross-file protein inference (BasicProteinInferenceAlgorithm) and optional picked-protein FDR (FDR:protein). Per-file outputs (-out) retain run-level information. Only useful with multiple -in files.", false);
+      setValidFormats_("out_merged", ListUtils::create<String>("idXML"));
+
       registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input file's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
 
       registerInputFile_("percolator_executable", "<executable>",
@@ -110,6 +113,7 @@ class PeptideDataBaseSearchFI :
       const StringList in_list = getStringList_("in");
       const String database = getStringOption_("database");
       const StringList out_list = getStringList_("out");
+      const String out_merged = getStringOption_("out_merged");
       // getOutputDirOption auto-creates the directory if it doesn't exist (and returns "" if unset).
       const String out_mod_analysis_dir = getOutputDirOption("out_mod_analysis_dir");
 
@@ -227,20 +231,6 @@ class PeptideDataBaseSearchFI :
         return INTERNAL_ERROR;
       }
 
-      // If the algorithm ran aggregate protein FDR (multi-file, FDR:protein > 0),
-      // propagate the aggregate protein list to each per-file result so the
-      // per-file output files contain the cross-file protein inference result.
-      const double protein_fdr = static_cast<double>(search_params.getValue("FDR:protein"));
-      if (in_list.size() > 1 && protein_fdr > 0.0
-          && !mfres.aggregate.protein_ids.empty())
-      {
-        for (auto& pf : mfres.per_file)
-        {
-          if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
-          pf.protein_ids = mfres.aggregate.protein_ids;
-        }
-      }
-
       // Optional per-file Percolator rescoring (replaces HyperScore with
       // Percolator q-values for downstream FDR / protein inference).
       if (!percolator_executable.empty())
@@ -319,67 +309,60 @@ class PeptideDataBaseSearchFI :
         }
       }
 
-      // Post-rescoring protein inference + FDR on Percolator q-values.
-      // Only runs when both Percolator and protein FDR were requested.
-      if (!percolator_executable.empty() && user_protein_fdr > 0.0)
+      // Write merged output: pool all per-file PSMs (possibly Percolator-rescored),
+      // run cross-file protein inference + optional protein FDR, write to -out_merged.
+      // Per-file outputs (-out) are NOT modified — they retain run-level information.
+      if (!out_merged.empty() && in_list.size() > 1)
       {
-        // Load FASTA for PeptideIndexing
-        vector<FASTAFile::FASTAEntry> fasta_db;
-        FASTAFile().load(database, fasta_db);
         const String decoy_prefix = search_params.getValue("decoy_prefix").toString();
-        const String enzyme = search_params.getValue("enzyme").toString();
 
-        // Pool rescored PSMs across all files
-        vector<ProteinIdentification> agg_protein_ids;
-        PeptideIdentificationList agg_peptide_ids;
-        if (!mfres.per_file.empty() && mfres.per_file[0].exit_code == PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK)
-        {
-          agg_protein_ids = mfres.per_file[0].protein_ids;
-        }
-        const String& agg_id = agg_protein_ids.empty() ? String("merged") : agg_protein_ids[0].getIdentifier();
-        for (auto& pf : mfres.per_file)
+        // Merge per-file results via IDMergerAlgorithm (accession dedup + identifier remap)
+        IDMergerAlgorithm merger;
+        for (const auto& pf : mfres.per_file)
         {
           if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
-          for (auto& pid : pf.peptide_ids)
-          {
-            pid.setIdentifier(agg_id);
-            agg_peptide_ids.push_back(pid);
-          }
+          merger.insertRuns(pf.protein_ids, pf.peptide_ids);
         }
+        ProteinIdentification merged_proteins;
+        PeptideIdentificationList merged_peptides;
+        merger.returnResultsAndClear(merged_proteins, merged_peptides);
 
-        if (!agg_protein_ids.empty() && !agg_peptide_ids.empty())
+        vector<ProteinIdentification> merged_protein_ids = {std::move(merged_proteins)};
+        merged_protein_ids[0].setPrimaryMSRunPath(in_list);
+
+        // Protein inference: aggregate best PSM score per peptide per protein
+        BasicProteinInferenceAlgorithm bpia;
+        bpia.run(merged_peptides, merged_protein_ids);
+
+        // Optional picked-protein FDR
+        if (user_protein_fdr > 0.0)
         {
-          // Re-index and run protein inference on rescored PSMs
-          PeptideIndexing indexer;
-          Param param_pi = indexer.getParameters();
-          param_pi.setValue("decoy_string", decoy_prefix);
-          param_pi.setValue("decoy_string_position", "prefix");
-          param_pi.setValue("enzyme:name", enzyme);
-          param_pi.setValue("missing_decoy_action", "silent");
-          indexer.setParameters(param_pi);
-          indexer.run(fasta_db, agg_protein_ids, agg_peptide_ids);
-
-          BasicProteinInferenceAlgorithm bpia;
-          bpia.run(agg_peptide_ids, agg_protein_ids);
-
           FalseDiscoveryRate fdr;
-          fdr.applyPickedProteinFDR(agg_protein_ids[0], decoy_prefix, true);
-          IDFilter::filterHitsByScore(agg_protein_ids, user_protein_fdr);
-          IDFilter::removeDecoyHits(agg_peptide_ids);
-          IDFilter::removeEmptyIdentifications(agg_peptide_ids);
-          IDFilter::removeUnreferencedProteins(agg_protein_ids, agg_peptide_ids);
+          fdr.applyPickedProteinFDR(merged_protein_ids[0], decoy_prefix, true);
+          IDFilter::filterHitsByScore(merged_protein_ids, user_protein_fdr);
 
-          OPENMS_LOG_INFO << "[PDBS-FI] Post-Percolator protein inference + FDR: "
-                          << agg_protein_ids[0].getHits().size() << " proteins at "
+          OPENMS_LOG_INFO << "[PDBS-FI] Merged protein inference + FDR: "
+                          << merged_protein_ids[0].getHits().size() << " proteins at "
                           << user_protein_fdr * 100 << "% FDR" << endl;
-
-          // Write back filtered protein list to each per-file result
-          for (auto& pf : mfres.per_file)
-          {
-            if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
-            pf.protein_ids = agg_protein_ids;
-          }
         }
+
+        // Clean up decoys in merged output
+        IDFilter::removeDecoyHits(merged_peptides);
+        IDFilter::removeEmptyIdentifications(merged_peptides);
+        IDFilter::removeUnreferencedProteins(merged_protein_ids, merged_peptides);
+
+        if (getFlag_("test") && !merged_protein_ids.empty())
+        {
+          StringList basenames;
+          for (const auto& f : in_list) basenames.push_back("file://" + File::basename(f));
+          merged_protein_ids[0].setPrimaryMSRunPath(basenames);
+        }
+
+        FileHandler().storeIdentifications(out_merged, merged_protein_ids, merged_peptides, {FileTypes::IDXML});
+      }
+      else if (!out_merged.empty() && in_list.size() == 1)
+      {
+        OPENMS_LOG_WARN << "-out_merged is only useful with multiple -in files. Skipping merged output." << endl;
       }
 
       // Write per-file outputs and track failures.

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -11,6 +11,7 @@
 
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
+#include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
@@ -85,6 +86,14 @@ class PeptideDataBaseSearchFI :
       setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
 
       registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input file's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
+
+      registerInputFile_("percolator_executable", "<executable>",
+#ifdef OPENMS_WINDOWSPLATFORM
+        "",
+#else
+        "",
+#endif
+        "Path to the Percolator executable. If set, per-file PSMs are rescored with Percolator (via PercolatorAdapter) before output. Leave empty to skip rescoring.", false, true, ListUtils::create<String>("skipexists"));
 
       // put search algorithm parameters at Search: subtree of parameters
       Param search_algo_params_with_subsection;
@@ -201,6 +210,85 @@ class PeptideDataBaseSearchFI :
         OPENMS_LOG_ERROR << "Internal error: per-file result count (" << mfres.per_file.size()
                          << ") does not match input file count (" << in_list.size() << ")." << endl;
         return INTERNAL_ERROR;
+      }
+
+      // Optional per-file Percolator rescoring (replaces HyperScore with
+      // Percolator q-values for downstream FDR / protein inference).
+      const String percolator_executable = getStringOption_("percolator_executable");
+      if (!percolator_executable.empty())
+      {
+        // Percolator requires decoys for target/decoy competition.
+        // Check per-file results for target_decoy annotations.
+        bool has_decoys_for_percolator = false;
+        for (const auto& pf : mfres.per_file)
+        {
+          if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
+          for (const auto& ph : pf.protein_ids[0].getHits())
+          {
+            if (ph.metaValueExists("target_decoy") && ph.getMetaValue("target_decoy").toString() == "decoy")
+            {
+              has_decoys_for_percolator = true;
+              break;
+            }
+          }
+          if (has_decoys_for_percolator) break;
+        }
+
+        if (!has_decoys_for_percolator)
+        {
+          OPENMS_LOG_WARN << "Percolator rescoring requires decoys but none found in results. "
+                          << "Enable '-Search:decoys' or provide a FASTA with decoy proteins. "
+                          << "Skipping rescoring." << endl;
+        }
+        else
+        for (Size i = 0; i < in_list.size(); ++i)
+        {
+          auto& result = mfres.per_file[i];
+          if (result.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
+          if (result.peptide_ids.size() < 100)
+          {
+            OPENMS_LOG_WARN << "Skipping Percolator rescoring for " << in_list[i]
+                            << " (only " << result.peptide_ids.size() << " PSMs, need >= 100)." << endl;
+            continue;
+          }
+
+          // Write intermediate idXML for PercolatorAdapter input
+          String tmp_in = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_in.idXML";
+          String tmp_out = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc_out.idXML";
+          String tmp_weights = File::getTempDirectory() + "/" + File::stemName(in_list[i]) + "_perc.weights";
+          FileHandler().storeIdentifications(tmp_in, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+
+          std::vector<String> perc_params = {
+            "-in", tmp_in,
+            "-out", tmp_out,
+            "-percolator_executable", percolator_executable,
+            "-train_best_positive",
+            "-score_type", "q-value",
+            "-post_processing_tdc",
+            "-weights", tmp_weights
+          };
+
+          OPENMS_LOG_INFO << "[PDBS-FI] Rescoring " << in_list[i] << " with Percolator..." << endl;
+          TOPPBase::ExitCodes perc_ec = runExternalProcess_(String("PercolatorAdapter"), perc_params);
+
+          if (perc_ec != EXECUTION_OK)
+          {
+            OPENMS_LOG_WARN << "Percolator rescoring failed for " << in_list[i]
+                            << ". Using original HyperScore results." << endl;
+          }
+          else
+          {
+            result.protein_ids.clear();
+            result.peptide_ids.clear();
+            FileHandler().loadIdentifications(tmp_out, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+            IDFilter::keepNBestHits(result.peptide_ids, 1);
+          }
+
+          // Clean up temp files
+          File::remove(tmp_in);
+          File::remove(tmp_out);
+          File::remove(tmp_weights);
+        }
       }
 
       // Write per-file outputs and track failures.

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -50,6 +50,7 @@ using namespace std;
 
     @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
     @note Open-search mode is automatically determined by the precursor mass tolerance: enabled when tolerance exceeds 1 Da or 1000 ppm. No explicit open-search parameter is needed. This is logged at runtime and recorded in the output search parameters as UserParam 'open_search'.
+    @note Decoy generation uses an internal "DECOY_" prefix. FASTA databases with pre-existing decoys (external decoy prefix) are not supported — provide a target-only FASTA and enable '-Search:decoys' to let the tool generate decoys internally.
 
     <B>The command line parameters of this tool are:</B>
     @verbinclude TOPP_PeptideDataBaseSearchFI.cli

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -50,7 +50,7 @@ using namespace std;
 
     @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
     @note Open-search mode is automatically determined by the precursor mass tolerance: enabled when tolerance exceeds 1 Da or 1000 ppm. No explicit open-search parameter is needed. This is logged at runtime and recorded in the output search parameters as UserParam 'open_search'.
-    @note Decoy generation uses an internal "DECOY_" prefix. FASTA databases with pre-existing decoys (external decoy prefix) are not supported — provide a target-only FASTA and enable '-Search:decoys' to let the tool generate decoys internally.
+    @note Decoy handling: either enable '-Search:decoys' to generate decoys internally, or provide a FASTA database that already contains decoy proteins (e.g., from DecoyDatabase). In both cases, the decoy accession prefix must match '-Search:decoy_prefix' (default: "DECOY_").
 
     <B>The command line parameters of this tool are:</B>
     @verbinclude TOPP_PeptideDataBaseSearchFI.cli

--- a/src/topp/PeptideDataBaseSearchFI.cpp
+++ b/src/topp/PeptideDataBaseSearchFI.cpp
@@ -227,6 +227,20 @@ class PeptideDataBaseSearchFI :
         return INTERNAL_ERROR;
       }
 
+      // If the algorithm ran aggregate protein FDR (multi-file, FDR:protein > 0),
+      // propagate the aggregate protein list to each per-file result so the
+      // per-file output files contain the cross-file protein inference result.
+      const double protein_fdr = static_cast<double>(search_params.getValue("FDR:protein"));
+      if (in_list.size() > 1 && protein_fdr > 0.0
+          && !mfres.aggregate.protein_ids.empty())
+      {
+        for (auto& pf : mfres.per_file)
+        {
+          if (pf.exit_code != PeptideSearchEngineFIAlgorithm::ExitCodes::EXECUTION_OK) continue;
+          pf.protein_ids = mfres.aggregate.protein_ids;
+        }
+      }
+
       // Optional per-file Percolator rescoring (replaces HyperScore with
       // Percolator q-values for downstream FDR / protein inference).
       if (!percolator_executable.empty())


### PR DESCRIPTION
## Summary

- Add `FDR:protein` parameter for **picked-protein FDR** (Savitski et al. 2015) via existing `FalseDiscoveryRate::applyPickedProteinFDR()`
- Applied **after PSM-level FDR** in per-file search (protein scores derived from best PSM q-values)
- In the **multi-file aggregate path**, protein FDR is applied on pooled PSMs across all files — proper cross-file protein inference, matching the ProteomicsLFQ pattern
- Default: disabled (`FDR:protein = 0.0`), opt-in with e.g. `FDR:protein 0.01`

### Usage
```
PeptideDataBaseSearchFI -in spectra.mzML -database db.fasta -out results.idXML \
  -Search:decoys -Search:FDR:PSM 0.01 -Search:FDR:protein 0.01
```

Addresses item **#14** from #9108.

## Test plan

- [x] All 13 existing tests pass (protein FDR disabled by default)
- [ ] Validate on real-world data that protein FDR filtering produces expected protein counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable protein-level FDR filtering via new "FDR:protein" parameter (0.0–1.0, default 0.0). When enabled, protein inference and picked-protein FDR are applied in single-file and pooled workflows; decoy/empty/unreferenced entries are pruned after protein-level filtering and resulting protein counts are logged.

* **Documentation**
  * Clarified decoy behavior: decoys are generated with a fixed "DECOY_" prefix and input FASTA must be target-only when using internal decoy generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->