### PR TITLE
Reduced Memory Overhead in FeatureFinderCentroided

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,6 +115,7 @@ the authors tag in the respective file header.
  - Timo Sachsenberg
  - Tinatin Kasradze
  - Till Englert
+ - Tilman Aurich
  - Tom David Müller
  - Tom Lukas Lankenau
  - Tom Waschischeck

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,8 @@ TOPP tools:
     MetaProSIP:
       - Added detailed documentation of CSV output column formats (#4400)
         Flags with trailing arguments now produce clearer warnings instead of cryptic "trailing text arguments" errors.
+    FeatureFinderCentroided:
+      - Reworked the underlying algorithm to omit a RAM-costly copy statement. RAM usage is now significantly reduced.
 
 PyOpenMS:
   - BREAKING: Binding backend replaced from Autowrap/Cython to hand-maintained nanobind C++ bindings (#8699)

--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
@@ -110,7 +110,7 @@ public:
 
     void setSeeds(const FeatureMap& seeds);
 
-    void setData(const MSExperiment& map, FeatureMap& features);
+    void setData(MSExperiment& map, FeatureMap& features);
 
     /**
       @brief Main method of the FeatureFinderAlgorithmPicked.
@@ -121,7 +121,7 @@ public:
 
       @note: The algorithm will not work on data with negative m/z values and throw an exception.
 
-      @note: the input data will be copied internally (leading to a memory overhead).
+      @note: the input data is modified internally (no memory overhead from copying).
 
       @param[in] input_map The input map of centroided spectra with MS level 1.
       @param[out] features The output feature map.
@@ -141,8 +141,8 @@ public:
 protected:
     void run();
 
-    /// editable copy of the map
-    MapType map_;
+    /// pointer to the editable map
+    MapType* map_;
 
     FeatureMap* features_;
 

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -131,9 +131,9 @@ namespace OpenMS
     seeds_ = seeds;
   }
 
-  void FeatureFinderAlgorithmPicked::setData(const MSExperiment& map, FeatureMap& features)
+  void FeatureFinderAlgorithmPicked::setData(MSExperiment& map, FeatureMap& features)
   {
-    map_ = map;
+    map_ = &map;
     features_ = &features;
   }
 
@@ -198,7 +198,7 @@ namespace OpenMS
 
     //reserve space for calculated scores
     UInt charge_count = charge_high - charge_low + 1;
-    for (auto& s : map_)
+    for (auto& s : (*map_))
     {
       Size scan_size = s.size();
       s.getFloatDataArrays().resize(3 + 2 * charge_count);
@@ -242,10 +242,10 @@ namespace OpenMS
     //new scope to make local variables disappear
     {
       startProgress(0, intensity_bins_ * intensity_bins_, "Precalculating intensity scores");
-      double rt_start = map_.spectrumRanges().byMSLevel(1).getMinRT();
-      double mz_start = map_.spectrumRanges().byMSLevel(1).getMinMZ();
-      intensity_rt_step_ = (map_.spectrumRanges().byMSLevel(1).getMaxRT() - rt_start) / (double)intensity_bins_;
-      intensity_mz_step_ = (map_.spectrumRanges().byMSLevel(1).getMaxMZ() - mz_start) / (double)intensity_bins_;
+      double rt_start = map_->spectrumRanges().byMSLevel(1).getMinRT();
+      double mz_start = map_->spectrumRanges().byMSLevel(1).getMinMZ();
+      intensity_rt_step_ = (map_->spectrumRanges().byMSLevel(1).getMaxRT() - rt_start) / (double)intensity_bins_;
+      intensity_mz_step_ = (map_->spectrumRanges().byMSLevel(1).getMaxMZ() - mz_start) / (double)intensity_bins_;
       intensity_thresholds_.resize(intensity_bins_);
       for (Size rt = 0; rt < intensity_bins_; ++rt)
       {
@@ -261,7 +261,7 @@ namespace OpenMS
           //std::cout << "rt range: " << min_rt << " - " << max_rt << '\n';
           //std::cout << "mz range: " << min_mz << " - " << max_mz << '\n';
           tmp.clear();
-          for (MapType::ConstAreaIterator it = map_.areaBeginConst(min_rt, max_rt, min_mz, max_mz); it != map_.areaEndConst(); ++it)
+          for (MapType::ConstAreaIterator it = map_->areaBeginConst(min_rt, max_rt, min_mz, max_mz); it != map_->areaEndConst(); ++it)
           {
             tmp.push_back(it->getIntensity());
           }
@@ -281,11 +281,11 @@ namespace OpenMS
       }
 
       //store intensity score in PeakInfo
-      for (Size s = 0; s < map_.size(); ++s)
+      for (Size s = 0; s < map_->size(); ++s)
       {
-        for (Size p = 0; p < map_[s].size(); ++p)
+        for (Size p = 0; p < (*map_)[s].size(); ++p)
         {
-          map_[s].getFloatDataArrays()[1][p] = intensityScore_(s, p);
+          (*map_)[s].getFloatDataArrays()[1][p] = intensityScore_(s, p);
         }
       }
       endProgress();
@@ -297,13 +297,13 @@ namespace OpenMS
     //---------------------------------------------------------------------------
     //new scope to make local variables disappear
     {
-      Size end_iteration = map_.size() - std::min((Size)min_spectra_, map_.size());
+      Size end_iteration = map_->size() - std::min((Size)min_spectra_, map_->size());
       startProgress(min_spectra_, end_iteration, "Precalculating mass trace scores");
       // skip first and last scans since we cannot extend the mass traces there
       for (Size s = min_spectra_; s < end_iteration; ++s)
       {
         setProgress(s);
-        SpectrumType& spectrum = map_[s];
+        SpectrumType& spectrum = (*map_)[s];
         //iterate over all peaks of the scan
         for (Size p = 0; p < spectrum.size(); ++p)
         {
@@ -316,7 +316,7 @@ namespace OpenMS
           bool is_max_peak = true; // checking the maximum intensity peaks -> use them later as feature seeds.
           for (Size i = 1; i <= min_spectra_; ++i)
           {
-            SpectrumType& next_spectrum = map_[s + i];
+            SpectrumType& next_spectrum = (*map_)[s + i];
             if (!next_spectrum.empty()) // There are peaks in the spectrum
             {
               Size spec_index = next_spectrum.findNearest(pos);
@@ -327,7 +327,7 @@ namespace OpenMS
           }
           for (Size i = 1; i <= min_spectra_; ++i)
           {
-            SpectrumType& next_spectrum = map_[s - i];
+            SpectrumType& next_spectrum = (*map_)[s - i];
             if (!next_spectrum.empty()) // There are peaks in the spectrum
             {
               Size spec_index = next_spectrum.findNearest(pos);
@@ -356,7 +356,7 @@ namespace OpenMS
     //---------------------------------------------------------------------------
     //new scope to make local variables disappear
     {
-      double max_mass = map_.spectrumRanges().byMSLevel(1).getMaxMZ() * charge_high;
+      double max_mass = map_->spectrumRanges().byMSLevel(1).getMaxMZ() * charge_high;
       Size num_isotopes = std::ceil(max_mass / mass_window_width_) + 1;
       startProgress(0, num_isotopes, "Precalculating isotope distributions");
 
@@ -449,11 +449,11 @@ namespace OpenMS
       //-----------------------------------------------------------
       // Step 3.1: Precalculate IsotopePattern score
       //-----------------------------------------------------------
-      startProgress(0, map_.size(), String("Calculating isotope pattern scores for charge ") + String(c));
-      for (Size s = 0; s < map_.size(); ++s)
+      startProgress(0, map_->size(), String("Calculating isotope pattern scores for charge ") + String(c));
+      for (Size s = 0; s < map_->size(); ++s)
       {
         setProgress(s);
-        const SpectrumType& spectrum = map_[s];
+        const SpectrumType& spectrum = (*map_)[s];
         for (Size p = 0; p < spectrum.size(); ++p)
         {
           double mz = spectrum[p].getMZ();
@@ -479,9 +479,9 @@ namespace OpenMS
           {
             for (Size i = 0; i < pattern.peak.size(); ++i)
             {
-              if (pattern.peak[i] >= 0 && pattern_score > map_[pattern.spectrum[i]].getFloatDataArrays()[meta_index_isotope][pattern.peak[i]])
+              if (pattern.peak[i] >= 0 && pattern_score > (*map_)[pattern.spectrum[i]].getFloatDataArrays()[meta_index_isotope][pattern.peak[i]])
               {
-                map_[pattern.spectrum[i]].getFloatDataArrays()[meta_index_isotope][pattern.peak[i]] = pattern_score;
+                (*map_)[pattern.spectrum[i]].getFloatDataArrays()[meta_index_isotope][pattern.peak[i]] = pattern_score;
               }
             }
           }
@@ -492,7 +492,7 @@ namespace OpenMS
       // Step 3.2:
       // Find seeds for this charge
       //-----------------------------------------------------------
-      Size end_of_iteration = map_.size() - std::min((Size)min_spectra_, map_.size());
+      Size end_of_iteration = map_->size() - std::min((Size)min_spectra_, map_->size());
       startProgress(min_spectra_, end_of_iteration, String("Finding seeds for charge ") + String(c));
 
       double min_seed_score = param_.getValue("seed:min_score");
@@ -502,9 +502,9 @@ namespace OpenMS
         setProgress(s);
 
         //iterate over peaks
-        for (Size p = 0; p < map_[s].size(); ++p)
+        for (Size p = 0; p < (*map_)[s].size(); ++p)
         {
-          FloatDataArrays& meta = map_[s].getFloatDataArrays();
+          FloatDataArrays& meta = (*map_)[s].getFloatDataArrays();
           double overall_score = std::pow(meta[0][p] * meta[1][p] * meta[meta_index_isotope][p], 1.0f / 3.0f);
           meta[meta_index_overall][p] = overall_score;
 
@@ -517,7 +517,7 @@ namespace OpenMS
               Seed seed;
               seed.spectrum = s;
               seed.peak = p;
-              seed.intensity = map_[s][p].getIntensity();
+              seed.intensity = (*map_)[s][p].getIntensity();
               seeds.push_back(seed);
             }
             //user-specified seeds: overall score greater than USER min seed score
@@ -525,19 +525,19 @@ namespace OpenMS
             {
               //only consider seeds, if they are near a user-specified seed
               Feature tmp;
-              tmp.setMZ(map_[s][p].getMZ() - user_mz_tol);
+              tmp.setMZ((*map_)[s][p].getMZ() - user_mz_tol);
               for (FeatureMap::const_iterator it = std::lower_bound(seeds_.begin(), seeds_.end(), tmp, Feature::MZLess()); it < seeds_.end(); ++it)
               {
-                if (it->getMZ() > map_[s][p].getMZ() + user_mz_tol)
+                if (it->getMZ() > (*map_)[s][p].getMZ() + user_mz_tol)
                 {
                   break;
                 }
-                if (fabs(it->getMZ() - map_[s][p].getMZ()) < user_mz_tol && fabs(it->getRT() - map_[s].getRT()) < user_rt_tol)
+                if (fabs(it->getMZ() - (*map_)[s][p].getMZ()) < user_mz_tol && fabs(it->getRT() - (*map_)[s].getRT()) < user_rt_tol)
                 {
                   Seed seed;
                   seed.spectrum = s;
                   seed.peak = p;
-                  seed.intensity = map_[s][p].getIntensity();
+                  seed.intensity = (*map_)[s][p].getIntensity();
                   seeds.push_back(seed);
                   break;
                 }
@@ -558,12 +558,12 @@ namespace OpenMS
         {
           Size spectrum = seed.spectrum;
           Size peak = seed.peak;
-          const FloatDataArrays& meta = map_[spectrum].getFloatDataArrays();
+          const FloatDataArrays& meta = (*map_)[spectrum].getFloatDataArrays();
           Feature tmp;
           tmp.setIntensity(seed.intensity);
           tmp.setOverallQuality(meta[meta_index_overall][peak]);
-          tmp.setRT(map_[spectrum].getRT());
-          tmp.setMZ(map_[spectrum][peak].getMZ());
+          tmp.setRT((*map_)[spectrum].getRT());
+          tmp.setMZ((*map_)[spectrum][peak].getMZ());
           tmp.setMetaValue("intensity_score", meta[1][peak]);
           tmp.setMetaValue("pattern_score", meta[meta_index_isotope][peak]);
           tmp.setMetaValue("trace_score", meta[0][peak]);
@@ -602,7 +602,7 @@ namespace OpenMS
         // Extend all mass traces
         //------------------------------------------------------------------
 
-        const SpectrumType& spectrum = map_[seeds[i].spectrum];
+        const SpectrumType& spectrum = (*map_)[seeds[i].spectrum];
         const PeakType& peak = spectrum[seeds[i].peak];
 
         IF_MASTERTHREAD
@@ -635,7 +635,7 @@ namespace OpenMS
         extendMassTraces_(best_pattern, traces, meta_index_overall);
 
         //check if the traces are still valid
-        double seed_mz = map_[seeds[i].spectrum][seeds[i].peak].getMZ();
+        double seed_mz = (*map_)[seeds[i].spectrum][seeds[i].peak].getMZ();
 
         if (!traces.isValid(seed_mz, trace_tolerance_))
         {
@@ -807,8 +807,8 @@ namespace OpenMS
         DBoundingBox<2> bb = f.getConvexHull().getBoundingBox();
         for (Size j = i + 1; j < seeds.size(); ++j)
         {
-          double rt = map_[seeds[j].spectrum].getRT();
-          double mz = map_[seeds[j].spectrum][seeds[j].peak].getMZ();
+          double rt = (*map_)[seeds[j].spectrum].getRT();
+          double mz = (*map_)[seeds[j].spectrum][seeds[j].peak].getMZ();
           if (bb.encloses(rt, mz) && f.encloses(rt, mz))
           {
 #pragma omp critical(FeatureFinderAlgorithmPicked_SEEDSINFEATURES)
@@ -1012,9 +1012,9 @@ namespace OpenMS
       for (std::map<Seed, String>::iterator it2 = abort_reasons_.begin(); it2 != abort_reasons_.end(); ++it2, ++counter)
       {
         Feature f;
-        f.setRT(map_[it2->first.spectrum].getRT());
-        f.setMZ(map_[it2->first.spectrum][it2->first.peak].getMZ());
-        f.setIntensity(map_[it2->first.spectrum][it2->first.peak].getIntensity());
+        f.setRT((*map_)[it2->first.spectrum].getRT());
+        f.setMZ((*map_)[it2->first.spectrum][it2->first.peak].getMZ());
+        f.setIntensity((*map_)[it2->first.spectrum][it2->first.peak].getIntensity());
         f.setMetaValue("label", it2->second);
         f.setUniqueId(counter); // ID = index
         abort_map.push_back(f);
@@ -1023,11 +1023,11 @@ namespace OpenMS
       FileHandler().storeFeatures("debug/abort_reasons.featureXML", abort_map);
 
       //store input map with calculated scores (without overall score)
-      for (auto& s : map_)
+      for (auto& s : (*map_))
       {
         s.getFloatDataArrays().erase(s.getFloatDataArrays().begin() + 2);
       }
-      FileHandler().storeExperiment("debug/input.mzML", map_, {FileTypes::MZML});
+      FileHandler().storeExperiment("debug/input.mzML", (*map_), {FileTypes::MZML});
     }
 
   }
@@ -1211,7 +1211,7 @@ namespace OpenMS
     {
       log_ << "Testing isotope patterns for charge " << charge << ": \n";
     }
-    const SpectrumType& spectrum = map_[center.spectrum];
+    const SpectrumType& spectrum = (*map_)[center.spectrum];
     const TheoreticalIsotopePattern& isotopes = getIsotopeDistribution_(spectrum[center.peak].getMZ() * charge);
     if (debug_)
     {
@@ -1334,25 +1334,25 @@ namespace OpenMS
       {
         continue; //skip missing and removed traces
       }
-      if (map_[pattern.spectrum[p]][pattern.peak[p]].getIntensity() > max_int)
+      if ((*map_)[pattern.spectrum[p]][pattern.peak[p]].getIntensity() > max_int)
       {
-        max_int = map_[pattern.spectrum[p]][pattern.peak[p]].getIntensity();
+        max_int = (*map_)[pattern.spectrum[p]][pattern.peak[p]].getIntensity();
         max_trace_index = p;
       }
     }
 
     //extend the maximum intensity trace to determine the boundaries in RT dimension
     Size start_index = pattern.spectrum[max_trace_index];
-    const PeakType* start_peak = &(map_[pattern.spectrum[max_trace_index]][pattern.peak[max_trace_index]]);
+    const PeakType* start_peak = &((*map_)[pattern.spectrum[max_trace_index]][pattern.peak[max_trace_index]]);
     double start_mz = start_peak->getMZ();
-    double start_rt = map_[start_index].getRT();
+    double start_rt = (*map_)[start_index].getRT();
     if (debug_)
     {
       log_ << " - Trace " << max_trace_index << " (maximum intensity)\n";
     }
     if (debug_)
     {
-      log_ << "   - extending from: " << map_[start_index].getRT() << " / " << start_mz << " (int: " << start_peak->getIntensity() << ")\n";
+      log_ << "   - extending from: " << (*map_)[start_index].getRT() << " / " << start_mz << " (int: " << start_peak->getIntensity() << ")\n";
     }
     //initialize the trace and extend
     MassTrace max_trace;
@@ -1411,26 +1411,26 @@ namespace OpenMS
         }
         continue;
       }
-      starting_peak.intensity = map_[starting_peak.spectrum][starting_peak.peak].getIntensity();
-      if (debug_) log_ << "   - trace seed: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")\n";
+      starting_peak.intensity = (*map_)[starting_peak.spectrum][starting_peak.peak].getIntensity();
+      if (debug_) log_ << "   - trace seed: " << (*map_)[starting_peak.spectrum].getRT() << " / " << (*map_)[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << (*map_)[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")\n";
 
       //search for nearby maximum of the mass trace as the extension assumes that it starts at the maximum
       Size begin = std::max((Size)0, starting_peak.spectrum - min_spectra_);
-      Size end = std::min(starting_peak.spectrum + min_spectra_, (Size)map_.size());
-      double mz = map_[starting_peak.spectrum][starting_peak.peak].getMZ();
-      double inte = map_[starting_peak.spectrum][starting_peak.peak].getIntensity();
+      Size end = std::min(starting_peak.spectrum + min_spectra_, (Size)map_->size());
+      double mz = (*map_)[starting_peak.spectrum][starting_peak.peak].getMZ();
+      double inte = (*map_)[starting_peak.spectrum][starting_peak.peak].getIntensity();
       for (Size spectrum_index = begin; spectrum_index < end; ++spectrum_index)
       {
         //find better seeds (no-empty scan/low mz diff/higher intensity)
         SignedSize peak_index = -1;
-        if (!map_[spectrum_index].empty())
+        if (!(*map_)[spectrum_index].empty())
         {
-          peak_index = map_[spectrum_index].findNearest(map_[starting_peak.spectrum][starting_peak.peak].getMZ());
+          peak_index = (*map_)[spectrum_index].findNearest((*map_)[starting_peak.spectrum][starting_peak.peak].getMZ());
         }
 
         if (peak_index < 0 ||
-            map_[spectrum_index][peak_index].getIntensity() <= inte ||
-            std::fabs(mz - map_[spectrum_index][peak_index].getMZ()) >= pattern_tolerance_
+            (*map_)[spectrum_index][peak_index].getIntensity() <= inte ||
+            std::fabs(mz - (*map_)[spectrum_index][peak_index].getMZ()) >= pattern_tolerance_
             )
         {
           continue;
@@ -1438,18 +1438,18 @@ namespace OpenMS
 
         starting_peak.spectrum = spectrum_index;
         starting_peak.peak = peak_index;
-        inte = map_[spectrum_index][peak_index].getIntensity();
+        inte = (*map_)[spectrum_index][peak_index].getIntensity();
       }
       if (debug_)
       {
-        log_ << "   - extending from: " << map_[starting_peak.spectrum].getRT() << " / " << map_[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << map_[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")\n";
+        log_ << "   - extending from: " << (*map_)[starting_peak.spectrum].getRT() << " / " << (*map_)[starting_peak.spectrum][starting_peak.peak].getMZ() << " (int: " << (*map_)[starting_peak.spectrum][starting_peak.peak].getIntensity() << ")\n";
       }
       //------------------------------------------------------------------
       //Extend seed to a mass trace
       MassTrace trace;
-      const PeakType* seed = &(map_[starting_peak.spectrum][starting_peak.peak]);
+      const PeakType* seed = &((*map_)[starting_peak.spectrum][starting_peak.peak]);
       //initialize trace with seed data and extend
-      trace.peaks.emplace_back(map_[starting_peak.spectrum].getRT(), seed);
+      trace.peaks.emplace_back((*map_)[starting_peak.spectrum].getRT(), seed);
       extendMassTrace_(trace, starting_peak.spectrum, seed->getMZ(), false, meta_index_overall, rt_min, rt_max);
       extendMassTrace_(trace, starting_peak.spectrum, seed->getMZ(), true, meta_index_overall, rt_min, rt_max);
 
@@ -1508,11 +1508,11 @@ namespace OpenMS
     Size peaks_before_extension = trace.peaks.size();
     String abort_reason = "";
 
-    while ((!increase_rt && spectrum_index >= 0) || (increase_rt && spectrum_index < (SignedSize)map_.size()))
+    while ((!increase_rt && spectrum_index >= 0) || (increase_rt && spectrum_index < (SignedSize)map_->size()))
     {
       if (boundaries &&
-          ((!increase_rt && map_[spectrum_index].getRT() < min_rt) ||
-           (increase_rt && map_[spectrum_index].getRT() > max_rt))
+          ((!increase_rt && (*map_)[spectrum_index].getRT() < min_rt) ||
+           (increase_rt && (*map_)[spectrum_index].getRT() > max_rt))
           )
       {
         abort_reason = "Hit upper/lower boundary";
@@ -1521,16 +1521,16 @@ namespace OpenMS
 
       SignedSize peak_index = -1;
 
-      if (!map_[spectrum_index].empty())
+      if (!(*map_)[spectrum_index].empty())
       {
-        peak_index = map_[spectrum_index].findNearest(mz);
+        peak_index = (*map_)[spectrum_index].findNearest(mz);
       }
 
       // check if the peak is "missing"
       if (
         peak_index < 0 // no peak found
-         || map_[spectrum_index].getFloatDataArrays()[meta_index_overall][peak_index] < 0.01 // overall score is to low
-         || positionScore_(mz, map_[spectrum_index][peak_index].getMZ(), trace_tolerance_) == 0.0 // deviation of mz is too big
+         || (*map_)[spectrum_index].getFloatDataArrays()[meta_index_overall][peak_index] < 0.01 // overall score is to low
+         || positionScore_(mz, (*map_)[spectrum_index][peak_index].getMZ(), trace_tolerance_) == 0.0 // deviation of mz is too big
         )
       {
         ++missing_peaks;
@@ -1546,11 +1546,11 @@ namespace OpenMS
         missing_peaks = 0;
 
         //add found peak to trace
-        trace.peaks.emplace_back(map_[spectrum_index].getRT(), &(map_[spectrum_index][peak_index]));
+        trace.peaks.emplace_back((*map_)[spectrum_index].getRT(), &((*map_)[spectrum_index][peak_index]));
 
         //update deltas and intensities
-        deltas.push_back((map_[spectrum_index][peak_index].getIntensity() - last_observed_intensity) / last_observed_intensity);
-        last_observed_intensity = map_[spectrum_index][peak_index].getIntensity();
+        deltas.push_back(((*map_)[spectrum_index][peak_index].getIntensity() - last_observed_intensity) / last_observed_intensity);
+        last_observed_intensity = (*map_)[spectrum_index][peak_index].getIntensity();
 
         //Abort if the average delta is too big (as intensity increases then)
         double average_delta = std::accumulate(deltas.end() - delta_count, deltas.end(), 0.0) / (double)delta_count;
@@ -1613,7 +1613,7 @@ namespace OpenMS
     UInt matches = 0;
 
     //search in the center spectrum
-    const SpectrumType& spectrum = map_[spectrum_index];
+    const SpectrumType& spectrum = (*map_)[spectrum_index];
     peak_index = nearest_(pos, spectrum, peak_index);
     double this_mz_score = positionScore_(pos, spectrum[peak_index].getMZ(), pattern_tolerance_);
     pattern.theoretical_mz[pattern_index] = pos;
@@ -1632,9 +1632,9 @@ namespace OpenMS
     }
 
     //previous spectrum
-    if (spectrum_index != 0 && !map_[spectrum_index - 1].empty())
+    if (spectrum_index != 0 && !(*map_)[spectrum_index - 1].empty())
     {
-      const SpectrumType& spectrum_before = map_[spectrum_index - 1];
+      const SpectrumType& spectrum_before = (*map_)[spectrum_index - 1];
       Size index_before = spectrum_before.findNearest(pos);
       double mz_score = positionScore_(pos, spectrum_before[index_before].getMZ(), pattern_tolerance_);
       if (mz_score != 0.0)
@@ -1653,9 +1653,9 @@ namespace OpenMS
     }
 
     //next spectrum
-    if (spectrum_index != map_.size() - 1 && !map_[spectrum_index + 1].empty())
+    if (spectrum_index != map_->size() - 1 && !(*map_)[spectrum_index + 1].empty())
     {
-      const SpectrumType& spectrum_after = map_[spectrum_index + 1];
+      const SpectrumType& spectrum_after = (*map_)[spectrum_index + 1];
       Size index_after = spectrum_after.findNearest(pos);
       double mz_score = positionScore_(pos, spectrum_after[index_after].getMZ(), pattern_tolerance_);
       if (mz_score != 0.0)
@@ -1826,11 +1826,11 @@ namespace OpenMS
   double FeatureFinderAlgorithmPicked::intensityScore_(Size spectrum, Size peak) const
   {
     // calculate (half) bin numbers
-    double intensity  = map_[spectrum][peak].getIntensity();
-    double rt = map_[spectrum].getRT();
-    double mz = map_[spectrum][peak].getMZ();
-    double rt_min = map_.spectrumRanges().byMSLevel(1).getMinRT();
-    double mz_min = map_.spectrumRanges().byMSLevel(1).getMinMZ();
+    double intensity  = (*map_)[spectrum][peak].getIntensity();
+    double rt = (*map_)[spectrum].getRT();
+    double mz = (*map_)[spectrum][peak].getMZ();
+    double rt_min = map_->spectrumRanges().byMSLevel(1).getMinRT();
+    double mz_min = map_->spectrumRanges().byMSLevel(1).getMinMZ();
     UInt rt_bin = std::min(2 * intensity_bins_ - 1, (UInt) std::floor((rt - rt_min) / intensity_rt_step_ * 2.0));
     UInt mz_bin = std::min(2 * intensity_bins_ - 1, (UInt) std::floor((mz - mz_min) / intensity_mz_step_ * 2.0));
     // determine mz bins


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

FeatureFinderCentroided uses FeatureFinderAlgorithmPicked to find two-dimensional features in given LC-MS data.
The underlying algorithm currently copies the whole MSExperiment into map_ which, as commented in the code already, creates massive memory overhead. By replacing the copy with a reference and adjusting the following process to still work as intended, I was able to achieve the following RAM reduction on my M2 MacBook Pro with MacOS Tahoe 26.4 (25E246):

Testfile, reduced to only level 1 with FileFilter TOPP tool as thats the only relevant data for the algorithm:

https://abibuilder.cs.uni-tuebingen.de/archive/openms/Tutorials/Data/MzMLTestFiles/ThermoQExactiveDDA-LFQ2.mzML


**----- FileInfo of the testfile: -----**


-- General information --

File name: filter_2021MQ001_MEGI_010_01_2ug.raw.mzML
File type: mzML

Instrument: Thermo Fisher Scientific instrument model
  Mass Analyzer: Fourier transform ion cyclotron resonance mass spectrometer (resolution: 0)

MS levels: 1
Total number of peaks: 18404402
Number of spectra: 9753

Combined Ranges (spectra + chromatograms):
  retention time: 0.06 .. 6599.78 sec (110.0 min)
  mass-to-charge: 0.00 .. 1399.99
  ion mobility: <none> .. <none>
  intensity: 0.00 .. 11202306048.00

Spectrum Ranges:
  retention time: 0.06 .. 6599.69 sec (110.0 min)
  mass-to-charge: 350.01 .. 1399.99
  ion mobility: <none> .. <none>
  intensity: 1584.91 .. 11202306048.00

MS Level 1 Ranges:
  retention time: 0.06 .. 6599.69 sec (110.0 min)
  mass-to-charge: 350.01 .. 1399.99
  ion mobility: <none> .. <none>
  intensity: 1584.91 .. 11202306048.00

Chromatogram Ranges:
  retention time: 0.06 .. 6599.78 sec (110.0 min)
  mass-to-charge: 0.00 .. 0.00
  intensity: 0.00 .. 11202306048.00

Number of spectra per MS level:
  level 1: 9753

Peak type from metadata (or estimated from data)
  level 1: Centroid (Centroid)

Activation methods

Precursor charge distribution:

Number of chromatograms: 1
Number of chromatographic peaks: 250675

Number of chromatograms per type: 
  total ion current chromatogram:                         1


FileInfo took 0.88 s (wall), 0.87 s (CPU), 0.14 s (system), 0.73 s (user); Peak Memory Usage: 411 MB.



**----- FeatureFinderCentroided single core // output before the adjustment: -----**

Progress of 'loading mzML':
  Progress of 'loading spectra list':
  -- done [took 0.73 s (CPU), 0.83 s (Wall)] -- 
  Progress of 'loading chromatogram list':
  -- done [took 0.00 s (CPU), 0.00 s (Wall)] -- 
-- done [took 0.74 s (CPU), 0.84 s (Wall) @ 369.6 MiB/s] -- 
Not FAIMS compensation voltages found in the data. Returning PeakMap as CV NaN.
Found 317593 seeds for charge 1.
Found 27144 feature candidates for charge 1.
Found 231331 seeds for charge 2.
Found 22954 feature candidates for charge 2.
Found 110027 seeds for charge 3.
Found 6246 feature candidates for charge 3.
Found 25639 seeds for charge 4.
Found 833 feature candidates for charge 4.
Removed 22180 overlapping features.

Info: reasons for not finalizing a feature during its construction:
 - Could not extend seed: 222203 times
 - Could not find good enough isotope pattern containing the seed: 31435 times
 - Feature quality too low after fit: 4981 times
 - Invalid feature after fit - too few traces or peaks left: 86827 times
 - Invalid fit: Center outside of feature bounds: 9227 times
 - Invalid fit: Fitted model is bigger than 'max_rt_span': 189851 times
 - Invalid fit: Less than 'min_rt_span' left after fit: 61 times

34997 features found.
FeatureFinderCentroided took 07:02 m (wall), 06:58 m (CPU), 5.41 s (system), 06:53 m (user); Peak Memory Usage: 1565 MB.

**----- FeatureFinderCentroided single core // output after the adjustment: -----**

Progress of 'loading mzML':
  Progress of 'loading spectra list':
  -- done [took 0.74 s (CPU), 0.76 s (Wall)] -- 
  Progress of 'loading chromatogram list':
  -- done [took 0.01 s (CPU), 0.01 s (Wall)] -- 
-- done [took 0.75 s (CPU), 0.77 s (Wall) @ 400.9 MiB/s] -- 
Not FAIMS compensation voltages found in the data. Returning PeakMap as CV NaN.
Found 317593 seeds for charge 1.
Found 27144 feature candidates for charge 1.
Found 231331 seeds for charge 2.
Found 22954 feature candidates for charge 2.
Found 110027 seeds for charge 3.
Found 6246 feature candidates for charge 3.
Found 25639 seeds for charge 4.
Found 833 feature candidates for charge 4.
Removed 22180 overlapping features.

Info: reasons for not finalizing a feature during its construction:
 - Could not extend seed: 222203 times
 - Could not find good enough isotope pattern containing the seed: 31435 times
 - Feature quality too low after fit: 4981 times
 - Invalid feature after fit - too few traces or peaks left: 86827 times
 - Invalid fit: Center outside of feature bounds: 9227 times
 - Invalid fit: Fitted model is bigger than 'max_rt_span': 189851 times
 - Invalid fit: Less than 'min_rt_span' left after fit: 61 times

34997 features found.
FeatureFinderCentroided took 06:54 m (wall), 06:53 m (CPU), 4.26 s (system), 06:48 m (user); Peak Memory Usage: 1292 MB.

**----- Summary -----**

The peak memory usage was reduced by roughly 270mb which equals to around 18% peak memory reduction.
I also watched the lower memory peaks which where reduced around 20% as well.
The FileInfo of the output files was also checked and is exactly the same as the output files prior to the change.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [x] Add relevant changes and new features to the CHANGELOG file
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * FeatureFinderCentroided now uses significantly less RAM during processing.

* **API Changes**
  * Feature finder methods updated to work directly with mutable input data instead of copying internally.

* **Chores**
  * Added new contributor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->