### PR TITLE
fix: BrukerTimsFile::loadDIAStreaming must sort peaks by m/z (#9134)

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
@@ -604,7 +604,6 @@ namespace OpenMS
           "Common causes:\n"
           "  - Too few iRT/CiRT peptides in the transition library for the LC gradient\n"
           "  - Low data quality (check the 'Detected N empty chromatograms' warnings above)\n"
-          "  - Input spectra with unsorted m/z peaks (e.g. Bruker .d loaded via streaming)\n"
           "  - Wrong SWATH window boundaries (precursor m/z mismatch between library and data)");
       }
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/CalibrationWorkflow.cpp
@@ -392,6 +392,32 @@ namespace OpenMS
       irt_chromatograms = provider->collectIrtChromatogramsForIrt(swath_maps, irt_transitions, mrm_mapping_param, cp_irt, TransformationDescription(), pasef, load_into_memory);
     }
 
+    // Summarize chromatogram extraction quality — empty chromatograms are a leading
+    // indicator that downstream calibration will fail (insufficient RT bin coverage).
+    // The per-batch "Detected N empty chromatograms" warnings from DIAChromHandler
+    // scroll past easily; this one-line summary is the aggregated view.
+    {
+      Size nr_empty = std::count_if(irt_chromatograms.begin(), irt_chromatograms.end(),
+        [](const MSChromatogram& c) { return c.empty(); });
+      Size nr_total = irt_chromatograms.size();
+      Size nr_nonempty = nr_total - nr_empty;
+      if (nr_total > 0 && nr_empty > nr_total / 2)
+      {
+        OPENMS_LOG_WARN << "[OpenSwath] iRT chromatogram extraction: " << nr_nonempty << "/"
+                        << nr_total << " non-empty (" << std::fixed << std::setprecision(1)
+                        << (100.0 * nr_nonempty / nr_total) << "%). "
+                        << "Over half are empty - iRT calibration may fail. "
+                        << "Common causes: wrong SWATH boundaries, poor data quality, "
+                        << "or unsorted m/z peaks in the input spectra." << std::endl;
+      }
+      else if (nr_total > 0)
+      {
+        OPENMS_LOG_INFO << "[OpenSwath] iRT chromatogram extraction: " << nr_nonempty << "/"
+                        << nr_total << " non-empty (" << std::fixed << std::setprecision(1)
+                        << (100.0 * nr_nonempty / nr_total) << "%)" << std::endl;
+      }
+    }
+
     // debug output of the iRT chromatograms
     String irt_mzml_out_local = irt_mzml_out;
     if (irt_mzml_out_local.empty() && debug_level > 1)
@@ -564,14 +590,31 @@ namespace OpenMS
 
       if (!enoughPeptides)
       {
+        const int nr_bins = irt_detection_param.getValue("NrRTBins");
+        const int min_pep = irt_detection_param.getValue("MinPeptidesPerBin");
+        const int min_filled = irt_detection_param.getValue("MinBinsFilled");
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-          "There were not enough bins with the minimal number of peptides");
+          String("iRT calibration failed: insufficient RT coverage after outlier removal.\n") +
+          "  Chromatograms extracted:    " + String(chromatograms.size()) + "\n" +
+          "  iRT peptides matched:       " + String(pairs.size()) + " (before outlier removal)\n" +
+          "  After outlier removal:      " + String(pairs_corrected.size()) + " (exp_RT, theor_RT) pairs\n" +
+          "  Binning requires:           " + String(min_filled) + "/" + String(nr_bins) + " RT bins "
+          "with >= " + String(min_pep) + " peptides each\n" +
+          "  RT range:                   " + String(RTRange.first, 1) + " - " + String(RTRange.second, 1) + " s\n" +
+          "Common causes:\n"
+          "  - Too few iRT/CiRT peptides in the transition library for the LC gradient\n"
+          "  - Low data quality (check the 'Detected N empty chromatograms' warnings above)\n"
+          "  - Input spectra with unsorted m/z peaks (e.g. Bruker .d loaded via streaming)\n"
+          "  - Wrong SWATH window boundaries (precursor m/z mismatch between library and data)");
       }
     }
     if (pairs_corrected.size() < 2)
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-        "There are less than 2 iRT normalization peptides, not enough for an RT correction.");
+        String("Less than 2 iRT normalization peptides after outlier removal (have ") +
+        String(pairs_corrected.size()) + " from " + String(pairs.size()) + " initial matches, " +
+        String(chromatograms.size()) + " chromatograms extracted). "
+        "Not enough for an RT correction.");
     }
 
     // 7. Select the "correct" peaks for m/z (and IM) correction (e.g. remove those not

--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -1130,6 +1130,14 @@ namespace OpenMS
         centroidMS1Frame(frame, spec, config, centroider);
       else
         frameToSpectrum(frame, spec, 1);
+      // Sort peaks by m/z (and the associated IM float data array alongside).
+      // TIMS save_to_buffs returns peaks in (scan_id, m/z-within-scan) order,
+      // which is NOT globally m/z-sorted. Downstream consumers
+      // (OpenSwath's chromatogram extraction) assume sorted m/z for lower_bound /
+      // upper_bound range queries; without this sort, queries silently miss
+      // peaks, producing empty chromatograms and breaking iRT calibration.
+      // The non-streaming load() path gets this sort for free via exp.sortSpectra(true).
+      spec.sortByPosition();
       consumer.consumeSpectrum(spec);
       setProgress(i);
     }
@@ -1216,6 +1224,11 @@ namespace OpenMS
           {
             spec.getFloatDataArrays().push_back(std::move(im_array));
             spec.setIMPeakType(IMPeakType::IM_PROFILE);
+            // Sort peaks by m/z (and the IM float data array alongside).
+            // See the matching comment in the MS1 loop above — TIMS save_to_buffs
+            // returns peaks in (scan_id, m/z-within-scan) order; OpenSwath's
+            // chromatogram extraction assumes globally m/z-sorted input.
+            spec.sortByPosition();
             consumer.consumeSpectrum(spec);
           }
         }


### PR DESCRIPTION
Fixes #9134.

## Summary

OpenSwathWorkflow crashes on Bruker `.d` input with `Error: Unexpected internal error (There were not enough bins with the minimal number of peptides)` during iRT calibration, while the same dataset converted to `.mzML` works fine. The `.d` path produces only ~41% of the chromatograms the `.mzML` path does, with massive `Detected N empty chromatograms` warnings (thousands per SWATH window) during Linear Calibration.

## Root cause

`BrukerTimsFile::loadDIAStreaming()` (PR #9129) feeds spectra directly to `FullSwathFileConsumer::consumeSpectrum()` without sorting each spectrum's peaks by m/z. TIMS `save_to_buffs()` returns peaks in `(scan_id, m/z-within-scan)` order, which is **not** globally m/z-sorted — across scan_ids the m/z values oscillate.

OpenSwath's chromatogram extraction uses `lower_bound` / `upper_bound` on each spectrum's peak list to perform m/z-range queries (standard mzML convention assumes sorted peaks). Unsorted input silently returns no matches → empty chromatograms across iRT peptides → iRT calibration's minimum-bin check fails → crash.

### Why the other paths don't hit this

| Path | Sort step | Status |
|---|---|---|
| `load()` → `loadDIA_()` → in-memory `MSExperiment` | `exp.sortSpectra(true)` called at end of `load()` | ✅ sorted |
| `transform()` → `loadDIA_()` → consumer | `exp.sortSpectra(true)` called before feeding consumer | ✅ sorted |
| `loadBrukerTdf()` → **`loadDIAStreaming()`** → consumer | **no sort step** | ❌ unsorted — this bug |

`MSExperiment::sortSpectra(true)` at `MSExperiment.cpp:792-804` calls `sortByPosition()` on each spectrum, which sorts peaks by m/z **and** permutes the associated `FloatDataArray` (IM data) alongside — so the peak ↔ IM mapping is preserved.

## Fix

Call `spec.sortByPosition()` immediately before each `consumer.consumeSpectrum()` in `loadDIAStreaming()`, for both the MS1 and MS2 emission loops. Two one-line additions plus comments explaining why. Verified via `MSSpectrum.cpp:36-56` that `sortByPosition()` correctly permutes the `FloatDataArray` (IM data) alongside the peaks.

## Debugging trail

Observations from the user's logs:

| Metric | `.mzML` (works) | `.d` (crashes) | Ratio |
|---|---|---|---|
| MS1 spectra | 2512 | 2512 | 1.00 |
| SWATH windows | 24 | 24 | 1.00 |
| Chromatograms stored (Linear Calibration) | **37715** | **15467** | **0.41** |
| Peptides analyzed | 6287 | 4084 | 0.65 |
| Empty chromatograms per Linear Calibration batch | 1–2 | 54–1706 | ~1000× |

Same input file (both derived from the same acquisition), same iRT library, same SWATH boundaries, but the `.d` path loses ~59% of chromatograms because downstream m/z-range queries on unsorted spectra miss their targets. The spectrum COUNT is correct; each SwathMap receives its full complement of spectra. Only the peak ORDER inside each spectrum is wrong.

## Test plan

- [x] Local build clean on Linux x86_64
- [x] Existing `BrukerTimsFile_test` (exercising `load()` / `loadDIA_()`, not `loadDIAStreaming()`) still passes after the fix — 522 s runtime, no regressions
- [ ] End-to-end verification: user re-runs `OpenSwathWorkflow` on their `.d` dataset and confirms iRT calibration no longer fails (waiting on user to test)

## Follow-up

The existing `loadDIAStreaming` test (added in PR #9129) only checks spectrum counts and basic metadata, not m/z ordering — which is why this bug wasn't caught by CI. Worth adding a regression test that asserts spectrum peaks are monotonically m/z-sorted after streaming, but that's a small follow-up rather than a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent peak ordering in DIA streaming so spectra and associated ion-mobility data are position-sorted for reliable downstream range queries.

* **Improvements**
  * Added an aggregated QC log after iRT chromatogram extraction that warns when many chromatograms are empty and reports empty/non-empty ratios.
  * Improved iRT calibration failure messages to include detailed, actionable diagnostics and counts for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->