### PR TITLE
fix: segfault in OpenSwathWorkflow with use_consensus=false

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -482,6 +482,20 @@ public:
         double peak_integral = pa.area;
         double peak_apex_int = pa.height;
         f.setMetaValue("peak_apex_position", pa.apex_pos);
+
+        // In non-consensus mode, override hull_points with the full resampled
+        // chromatogram so all transitions produce equal-sized intensity vectors
+        // for cross-correlation scoring. Area/height/apex are already correct
+        // from the per-transition integration above.
+        if (!use_consensus_)
+        {
+          pa.hull_points.clear();
+          for (const auto& p : used_chromatogram)
+          {
+            pa.hull_points.push_back(DPosition<2>(p.getPos(), p.getIntensity()));
+          }
+        }
+
         if (background_subtraction_ != "none")
         {
           double background{0};
@@ -625,6 +639,18 @@ public:
         PeakIntegrator::PeakArea pa = pi_.integratePeak(used_chromatogram, local_left, local_right);
         double peak_integral = pa.area;
         double peak_apex_int = pa.height;
+
+        // In non-consensus mode, override hull_points with the full resampled
+        // chromatogram so all precursors produce equal-sized intensity vectors
+        // for cross-correlation scoring (see pickFragmentChromatograms).
+        if (!use_consensus_)
+        {
+          pa.hull_points.clear();
+          for (const auto& p : used_chromatogram)
+          {
+            pa.hull_points.push_back(DPosition<2>(p.getPos(), p.getIntensity()));
+          }
+        }
 
         if (background_subtraction_ != "none")
         {

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -456,6 +456,16 @@ START_SECTION((template < typename SpectrumT, typename TransitionT > void pickTr
       TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getMetaValue("peak_apex_position"), 14);
       TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getMetaValue("peak_apex_position"), 16); // consensus = 7
       TEST_REAL_SIMILAR(mrmfeature.getFeature("3").getMetaValue("peak_apex_position"), 7);
+
+      // Hull points must be equal-sized across all transitions so that
+      // cross-correlation scoring receives consistent intensity vectors
+      // (regression test for GitHub issue #9138).
+      Size hp1 = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size();
+      Size hp2 = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size();
+      Size hp3 = mrmfeature.getFeature("3").getConvexHulls()[0].getHullPoints().size();
+      TEST_EQUAL(hp1, hp2)
+      TEST_EQUAL(hp1, hp3)
+      TEST_TRUE(hp1 > 0)
     }
 
     {

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -18,6 +18,8 @@
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/MRMScoring.h>
 
 #include <boost/assign/std/vector.hpp>
 
@@ -457,15 +459,29 @@ START_SECTION((template < typename SpectrumT, typename TransitionT > void pickTr
       TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getMetaValue("peak_apex_position"), 16); // consensus = 7
       TEST_REAL_SIMILAR(mrmfeature.getFeature("3").getMetaValue("peak_apex_position"), 7);
 
-      // Hull points must be equal-sized across all transitions so that
-      // cross-correlation scoring receives consistent intensity vectors
-      // (regression test for GitHub issue #9138).
+      // Regression test for GitHub issue #9138: with use_consensus=false,
+      // hull_points must be equal-sized so cross-correlation scoring does
+      // not read past the end of the shorter vector (segfault in release).
       Size hp1 = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size();
       Size hp2 = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size();
       Size hp3 = mrmfeature.getFeature("3").getConvexHulls()[0].getHullPoints().size();
       TEST_EQUAL(hp1, hp2)
       TEST_EQUAL(hp1, hp3)
       TEST_TRUE(hp1 > 0)
+
+      // Exercise the actual crash path: wrap in MRMFeatureOpenMS and run
+      // cross-correlation scoring (this segfaulted before the fix).
+      {
+        OpenSwath::IMRMFeature* imrmfeature = new MRMFeatureOpenMS(mrmfeature);
+        std::vector<std::string> native_ids = {"1", "2", "3"};
+        OpenSwath::MRMScoring mrmscore;
+        mrmscore.initializeXCorrMatrix(imrmfeature, native_ids);
+        // If we get here without crashing, the fix works.
+        // Verify scores are finite.
+        TEST_TRUE(std::isfinite(mrmscore.calcXcorrCoelutionScore()))
+        TEST_TRUE(std::isfinite(mrmscore.calcXcorrShapeScore()))
+        delete imrmfeature;
+      }
     }
 
     {


### PR DESCRIPTION
## Summary

Fixes #9138 — OpenSwathWorkflow segfaults when `use_consensus=false` with `detecting=1` and `quantifying=1`.

- **Root cause**: In non-consensus mode, `PeakIntegrator::integratePeak` produces hull_points of different sizes per transition (each clipped to its own peak boundaries). These become intensity vectors for `Scoring::calculateCrossCorrelation`, which assumes equal-sized vectors and reads past the end of the shorter one via `Eigen::Map`.
- **Fix**: After `integratePeak`, override hull_points with the full resampled chromatogram (always `master_peak_container`-sized) in non-consensus mode. Area, height, and apex position remain computed with per-transition boundaries (unchanged behavior).
- **Also explains**: Case 1 from the issue (detecting=1, quantifying=0 → empty results) is expected behavior — at least one quantifying transition is required for non-zero feature intensity.

Bug has been latent since the `use_consensus=false` feature was introduced in April 2018.

## Test plan

- [x] `MRMTransitionGroupPicker_test` passes (existing values unchanged)
- [x] TOPP `MRMTransitionGroupPicker` integration tests pass (FuzzyDiff output match)
- [x] New regression test verifies hull_points are equal-sized across transitions in non-consensus mode
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where peak boundaries could be incorrect when consensus mode was off; peak intensity samples are now used to build peak shapes for accurate chromatogram analysis.
  * Added checks to ensure peak boundary sizes are consistent across related transitions and restored stability for cross-correlation scoring paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->