### PR TITLE
ProSE: multi-format Parquet output (idXML + QPX + internal)

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/FORMAT/MSExperimentArrowExport.h>  // for ParquetWriteConfig
+
+#include <memory>
+#include <vector>
+
+// Forward declarations
+namespace arrow
+{
+  class Table;
+}
+
+namespace OpenMS
+{
+
+/**
+  @brief Public helpers for writing and concatenating Arrow tables to Parquet files
+
+  TOPP tools link against libOpenMS (which exports these helpers) but not directly
+  against Arrow/Parquet. These wrappers keep all Arrow/Parquet API calls inside
+  libOpenMS so downstream binaries don't need to import Arrow symbols.
+
+  @ingroup FileIO
+*/
+namespace ArrowIOHelpers
+{
+  /**
+    @brief Write an Arrow table to a Parquet file
+
+    @param[in] table The Arrow table to write (must not be null)
+    @param[in] filename Output file path
+    @param[in] config Parquet writer configuration (compression, row group size, ...)
+    @return true on success, false on error (errors are logged)
+  */
+  OPENMS_DLLAPI bool writeTableToParquet(
+    const std::shared_ptr<arrow::Table>& table,
+    const String& filename,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  /**
+    @brief Concatenate a vector of Arrow tables and write the result to a Parquet file
+
+    All tables must share the same schema. An empty input vector is a no-op
+    (returns true without writing).
+
+    @param[in] tables Vector of Arrow tables to concatenate (must share schema)
+    @param[in] filename Output file path
+    @param[in] config Parquet writer configuration
+    @return true on success (or if @p tables is empty), false on error
+  */
+  OPENMS_DLLAPI bool concatenateAndWriteToParquet(
+    const std::vector<std::shared_ptr<arrow::Table>>& tables,
+    const String& filename,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
+}
+
+} // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowIOHelpers.h
@@ -36,6 +36,15 @@ namespace OpenMS
 namespace ArrowIOHelpers
 {
   /**
+    @brief Generate a lowercase hyphenated RFC 4122 version-4 UUID string
+
+    Used by QPX Parquet exporters when attaching file metadata.
+
+    @return UUID string, e.g. "550e8400-e29b-41d4-a716-446655440000"
+  */
+  OPENMS_DLLAPI String generateUuidV4();
+
+  /**
     @brief Write an Arrow table to a Parquet file
 
     @param[in] table The Arrow table to write (must not be null)

--- a/src/openms/include/OpenMS/FORMAT/ArrowSchemaRegistry.h
+++ b/src/openms/include/OpenMS/FORMAT/ArrowSchemaRegistry.h
@@ -302,6 +302,52 @@ namespace OpenMS
     static std::shared_ptr<arrow::Schema> schema();
   };
 
+  /// @brief Schema for QPX protein group export (quantms Parquet eXchange format, pg table)
+  ///
+  /// Defines column names, nested Arrow types, and the complete schema for
+  /// protein group data in the QPX format. Supports both quantified (ConsensusMap)
+  /// and identification-only (search engine) output — quantification columns are nullable.
+  struct OPENMS_DLLAPI QPXPgSchema
+  {
+    static constexpr const char* PG_ACCESSIONS = "pg_accessions";
+    static constexpr const char* PG_NAMES = "pg_names";
+    static constexpr const char* GG_ACCESSIONS = "gg_accessions";
+    static constexpr const char* GG_NAMES = "gg_names";
+    static constexpr const char* GG_QVALUE = "gg_qvalue";
+    static constexpr const char* ANCHOR_PROTEIN = "anchor_protein";
+    static constexpr const char* RUN_FILE_NAME = "run_file_name";
+    static constexpr const char* GLOBAL_QVALUE = "global_qvalue";
+    static constexpr const char* PG_QVALUE = "pg_qvalue";
+    static constexpr const char* INTENSITIES = "intensities";
+    static constexpr const char* ADDITIONAL_INTENSITIES = "additional_intensities";
+    static constexpr const char* IS_DECOY = "is_decoy";
+    static constexpr const char* CONTAMINANT = "contaminant";
+    static constexpr const char* PEPTIDES = "peptides";
+    static constexpr const char* PEPTIDE_COUNTS = "peptide_counts";
+    static constexpr const char* FEATURE_COUNTS = "feature_counts";
+    static constexpr const char* SEQUENCE_COVERAGE = "sequence_coverage";
+    static constexpr const char* MOLECULAR_WEIGHT = "molecular_weight";
+    static constexpr const char* ADDITIONAL_SCORES = "additional_scores";
+    static constexpr const char* CV_PARAMS = "cv_params";
+
+    /// @brief Arrow type for intensities: list<struct{label, intensity}> (nullable for search-engine output)
+    static std::shared_ptr<arrow::DataType> intensitiesType();
+    /// @brief Arrow type for additional intensities: list<struct{label, intensities: list<struct{...}>}>
+    static std::shared_ptr<arrow::DataType> additionalIntensitiesType();
+    /// @brief Arrow type for peptides: list<struct{protein_name, peptide_count}>
+    static std::shared_ptr<arrow::DataType> peptidesType();
+    /// @brief Arrow type for peptide_counts: struct{unique_sequences, total_sequences}
+    static std::shared_ptr<arrow::DataType> peptideCountsType();
+    /// @brief Arrow type for feature_counts: struct{unique_features, total_features}
+    static std::shared_ptr<arrow::DataType> featureCountsType();
+    /// @brief Arrow type for additional scores (delegates to QPXPSMSchema::additionalScoresType)
+    static std::shared_ptr<arrow::DataType> additionalScoresType();
+    /// @brief Arrow type for CV params (delegates to QPXPSMSchema::cvParamsType)
+    static std::shared_ptr<arrow::DataType> cvParamsType();
+    /// @brief Complete Arrow schema for QPX pg table (20 fields)
+    static std::shared_ptr<arrow::Schema> schema();
+  };
+
   /// @brief Schema for spectra in long (one row per peak) format
   struct OPENMS_DLLAPI SpectraLongSchema
   {

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -13,14 +13,21 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/FORMAT/MSExperimentArrowExport.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
 
 #include <memory>
 #include <string>
+#include <vector>
 
 // Forward declarations
 namespace arrow
 {
   class Table;
+}
+
+namespace OpenMS
+{
+  class ProteinIdentification;
 }
 
 namespace OpenMS
@@ -64,6 +71,36 @@ public:
   */
   static bool exportToParquet(
     const ConsensusMap& cmap,
+    const String& filename,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  /**
+    @brief Export protein group data to Arrow table from identification data (no quantification)
+
+    For search-engine output where no ConsensusMap is available. Populates required
+    QPX pg fields (pg_accessions, anchor_protein, run_file_name, is_decoy, peptides)
+    and sets quantification columns (intensities, additional_intensities) to null.
+
+    @param[in] protein_identifications Protein identifications with protein groups
+    @param[in] peptide_identifications Peptide identifications (for peptide-per-protein counts)
+    @return Shared pointer to Arrow Table (empty table if no groups, never nullptr)
+  */
+  static std::shared_ptr<arrow::Table> exportToArrow(
+    const std::vector<ProteinIdentification>& protein_identifications,
+    const PeptideIdentificationList& peptide_identifications);
+
+  /**
+    @brief Export protein group data to Parquet file from identification data (no quantification)
+
+    @param[in] protein_identifications Protein identifications with protein groups
+    @param[in] peptide_identifications Peptide identifications (for peptide-per-protein counts)
+    @param[in] filename Output file path
+    @param[in] config Parquet writing options
+    @return true on success, false on error
+  */
+  static bool exportToParquet(
+    const std::vector<ProteinIdentification>& protein_identifications,
+    const PeptideIdentificationList& peptide_identifications,
     const String& filename,
     const ParquetWriteConfig& config = ParquetWriteConfig{});
 };

--- a/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
+++ b/src/openms/include/OpenMS/FORMAT/ProteinGroupArrowExport.h
@@ -103,6 +103,24 @@ public:
     const PeptideIdentificationList& peptide_identifications,
     const String& filename,
     const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  /**
+    @brief Write a pre-built QPX protein group Arrow table to a Parquet file
+
+    The table is expected to follow QPXPgSchema (e.g., from exportToArrow).
+    Attaches QPX file metadata (qpx_version, file_type="pg", UUID, creation_date)
+    before writing. Use this overload when the caller already has the table built
+    (e.g., for merged output) to avoid rebuilding it.
+
+    @param[in] table QPX pg Arrow table (must not be null)
+    @param[in] filename Output file path
+    @param[in] config Parquet writing options
+    @return true on success, false on error
+  */
+  static bool exportToParquet(
+    const std::shared_ptr<arrow::Table>& table,
+    const String& filename,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
 };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/QPXFile.h
+++ b/src/openms/include/OpenMS/FORMAT/QPXFile.h
@@ -87,6 +87,24 @@ public:
     const String& filename,
     bool export_all_psms = false,
     const ParquetWriteConfig& config = ParquetWriteConfig{});
+
+  /**
+    @brief Write a pre-built QPX PSM Arrow table to a Parquet file
+
+    The table is expected to follow QPXPSMSchema (e.g., from exportPSMsToQPXArrow).
+    Attaches QPX file metadata (qpx_version, file_type="psm", UUID, creation_date)
+    before writing. Use this overload when the caller already has the table built
+    (e.g., for merged output) to avoid rebuilding it.
+
+    @param[in] table QPX PSM Arrow table (must not be null)
+    @param[in] filename Output file path
+    @param[in] config Parquet writing options
+    @return true on success, false on error
+  */
+  static bool exportToParquet(
+    const std::shared_ptr<arrow::Table>& table,
+    const String& filename,
+    const ParquetWriteConfig& config = ParquetWriteConfig{});
 };
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -16,10 +16,38 @@
 #include <parquet/arrow/writer.h>
 #include <parquet/properties.h>
 
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+
 namespace OpenMS
 {
 namespace ArrowIOHelpers
 {
+
+String generateUuidV4()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<uint32_t> dist;
+  uint8_t bytes[16];
+  for (int i = 0; i < 4; ++i)
+  {
+    uint32_t r = dist(gen);
+    std::memcpy(bytes + i * 4, &r, 4);
+  }
+  bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
+  char buf[37];
+  std::snprintf(buf, sizeof(buf),
+    "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+    bytes[0], bytes[1], bytes[2], bytes[3],
+    bytes[4], bytes[5], bytes[6], bytes[7],
+    bytes[8], bytes[9], bytes[10], bytes[11],
+    bytes[12], bytes[13], bytes[14], bytes[15]);
+  return String(buf);
+}
 
 namespace
 {

--- a/src/openms/source/FORMAT/ArrowIOHelpers.cpp
+++ b/src/openms/source/FORMAT/ArrowIOHelpers.cpp
@@ -1,0 +1,119 @@
+// Copyright (c) 2002-present, OpenMS Inc. -- EKU Tuebingen, ETH Zurich, and FU Berlin
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
+
+#include <OpenMS/CONCEPT/LogStream.h>
+
+#include <arrow/api.h>
+#include <arrow/io/file.h>
+#include <arrow/table.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/properties.h>
+
+namespace OpenMS
+{
+namespace ArrowIOHelpers
+{
+
+namespace
+{
+  arrow::Compression::type toArrowCompression(ParquetWriteConfig::Compression c)
+  {
+    switch (c)
+    {
+      case ParquetWriteConfig::Compression::NONE:   return arrow::Compression::UNCOMPRESSED;
+      case ParquetWriteConfig::Compression::SNAPPY: return arrow::Compression::SNAPPY;
+      case ParquetWriteConfig::Compression::GZIP:   return arrow::Compression::GZIP;
+      case ParquetWriteConfig::Compression::LZ4:    return arrow::Compression::LZ4;
+      case ParquetWriteConfig::Compression::ZSTD:   return arrow::Compression::ZSTD;
+    }
+    return arrow::Compression::ZSTD;
+  }
+}
+
+bool writeTableToParquet(
+  const std::shared_ptr<arrow::Table>& table,
+  const String& filename,
+  const ParquetWriteConfig& config)
+{
+  if (!table)
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: null table passed to writeTableToParquet (" << filename << ")" << std::endl;
+    return false;
+  }
+
+  auto file_result = arrow::io::FileOutputStream::Open(filename);
+  if (!file_result.ok())
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: Failed to open " << filename
+                     << " for writing: " << file_result.status().ToString() << std::endl;
+    return false;
+  }
+  const auto& outfile = file_result.ValueOrDie();
+
+  auto builder = parquet::WriterProperties::Builder();
+  builder.compression(toArrowCompression(config.compression));
+  if (config.compression == ParquetWriteConfig::Compression::ZSTD ||
+      config.compression == ParquetWriteConfig::Compression::GZIP)
+  {
+    builder.compression_level(config.compression_level);
+  }
+  builder.data_pagesize(config.data_page_size);
+  if (config.write_statistics) { builder.enable_statistics(); }
+  else                         { builder.disable_statistics(); }
+
+  auto writer_properties = builder.build();
+  auto arrow_properties = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
+  auto status = parquet::arrow::WriteTable(
+    *table,
+    arrow::default_memory_pool(),
+    outfile,
+    config.row_group_size,
+    writer_properties,
+    arrow_properties);
+
+  if (!status.ok())
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: Failed to write " << filename
+                     << ": " << status.ToString() << std::endl;
+    return false;
+  }
+
+  auto close_status = outfile->Close();
+  if (!close_status.ok())
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: Failed to close " << filename
+                     << ": " << close_status.ToString() << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+bool concatenateAndWriteToParquet(
+  const std::vector<std::shared_ptr<arrow::Table>>& tables,
+  const String& filename,
+  const ParquetWriteConfig& config)
+{
+  if (tables.empty()) { return true; }
+
+  auto concat_result = arrow::ConcatenateTables(tables);
+  if (!concat_result.ok())
+  {
+    OPENMS_LOG_ERROR << "ArrowIOHelpers: Failed to concatenate tables for " << filename
+                     << ": " << concat_result.status().ToString() << std::endl;
+    return false;
+  }
+
+  return writeTableToParquet(concat_result.ValueOrDie(), filename, config);
+}
+
+} // namespace ArrowIOHelpers
+} // namespace OpenMS

--- a/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
+++ b/src/openms/source/FORMAT/ArrowSchemaRegistry.cpp
@@ -482,6 +482,88 @@ namespace OpenMS
     });
   }
 
+  // -- QPXPgSchema (quantms Parquet eXchange format, protein group table) --
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::intensitiesType()
+  {
+    return arrow::list(arrow::struct_({
+      arrow::field("label", arrow::utf8(), /*nullable=*/false),
+      arrow::field("intensity", arrow::float32(), /*nullable=*/false)
+    }));
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::additionalIntensitiesType()
+  {
+    auto int_pair_type = arrow::struct_({
+      arrow::field("intensity_name", arrow::utf8(), /*nullable=*/false),
+      arrow::field("intensity_value", arrow::float32(), /*nullable=*/false)
+    });
+    return arrow::list(arrow::struct_({
+      arrow::field("label", arrow::utf8(), /*nullable=*/false),
+      arrow::field("intensities", arrow::list(int_pair_type), /*nullable=*/false)
+    }));
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::peptidesType()
+  {
+    return arrow::list(arrow::struct_({
+      arrow::field("protein_name", arrow::utf8(), /*nullable=*/false),
+      arrow::field("peptide_count", arrow::int32(), /*nullable=*/false)
+    }));
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::peptideCountsType()
+  {
+    return arrow::struct_({
+      arrow::field("unique_sequences", arrow::int32(), /*nullable=*/false),
+      arrow::field("total_sequences", arrow::int32(), /*nullable=*/false)
+    });
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::featureCountsType()
+  {
+    return arrow::struct_({
+      arrow::field("unique_features", arrow::int32(), /*nullable=*/false),
+      arrow::field("total_features", arrow::int32(), /*nullable=*/false)
+    });
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::additionalScoresType()
+  {
+    return QPXPSMSchema::additionalScoresType();
+  }
+
+  std::shared_ptr<arrow::DataType> QPXPgSchema::cvParamsType()
+  {
+    return QPXPSMSchema::cvParamsType();
+  }
+
+  std::shared_ptr<arrow::Schema> QPXPgSchema::schema()
+  {
+    return arrow::schema({
+      arrow::field(PG_ACCESSIONS, arrow::list(arrow::utf8()), /*nullable=*/false),
+      arrow::field(PG_NAMES, arrow::list(arrow::utf8())),
+      arrow::field(GG_ACCESSIONS, arrow::list(arrow::utf8())),
+      arrow::field(GG_NAMES, arrow::list(arrow::utf8())),
+      arrow::field(GG_QVALUE, arrow::float64()),
+      arrow::field(ANCHOR_PROTEIN, arrow::utf8(), /*nullable=*/false),
+      arrow::field(RUN_FILE_NAME, arrow::utf8(), /*nullable=*/false),
+      arrow::field(GLOBAL_QVALUE, arrow::float64()),
+      arrow::field(PG_QVALUE, arrow::float64()),
+      arrow::field(INTENSITIES, intensitiesType()),
+      arrow::field(ADDITIONAL_INTENSITIES, additionalIntensitiesType()),
+      arrow::field(IS_DECOY, arrow::boolean(), /*nullable=*/false),
+      arrow::field(CONTAMINANT, arrow::boolean()),
+      arrow::field(PEPTIDES, peptidesType(), /*nullable=*/false),
+      arrow::field(PEPTIDE_COUNTS, peptideCountsType()),
+      arrow::field(FEATURE_COUNTS, featureCountsType()),
+      arrow::field(SEQUENCE_COVERAGE, arrow::float32()),
+      arrow::field(MOLECULAR_WEIGHT, arrow::float32()),
+      arrow::field(ADDITIONAL_SCORES, additionalScoresType()),
+      arrow::field(CV_PARAMS, cvParamsType()),
+    });
+  }
+
   // -- QPXFeatureSchema (quantms Parquet eXchange format) --
   // Shared types delegate to QPXPSMSchema to avoid duplication
 

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -14,18 +14,13 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <arrow/api.h>
 #include <arrow/builder.h>
-#include <arrow/io/file.h>
-#include <parquet/arrow/writer.h>
-#include <parquet/properties.h>
 
-#include <cstdio>
-#include <cstring>
 #include <map>
-#include <random>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -468,6 +463,23 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(const Conse
 }
 
 
+namespace
+{
+  /// Attach the canonical QPX "pg" file metadata to a table's schema.
+  std::shared_ptr<arrow::Table> attachQPXPgMetadata(const std::shared_ptr<arrow::Table>& table)
+  {
+    auto metadata = arrow::key_value_metadata({
+      {"qpx_version", "1.0"},
+      {"creator", "OpenMS"},
+      {"file_type", "pg"},
+      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
+      {"uuid", std::string(ArrowIOHelpers::generateUuidV4())},
+      {"software_provider", "OpenMS"}
+    });
+    return table->ReplaceSchemaMetadata(metadata);
+  }
+}
+
 bool ProteinGroupArrowExport::exportToParquet(
   const ConsensusMap& cmap,
   const String& filename,
@@ -479,99 +491,7 @@ bool ProteinGroupArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport: Failed to create Arrow table" << std::endl;
     return false;
   }
-
-  // Add QPX metadata to schema
-  {
-    // Generate RFC 4122 version-4 UUID
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint32_t> dist;
-    uint8_t bytes[16];
-    for (int i = 0; i < 4; ++i)
-    {
-      uint32_t r = dist(gen);
-      std::memcpy(bytes + i * 4, &r, 4);
-    }
-    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
-    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
-    char buf[37];
-    std::snprintf(buf, sizeof(buf),
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      bytes[0], bytes[1], bytes[2], bytes[3],
-      bytes[4], bytes[5], bytes[6], bytes[7],
-      bytes[8], bytes[9], bytes[10], bytes[11],
-      bytes[12], bytes[13], bytes[14], bytes[15]);
-
-    auto metadata = arrow::key_value_metadata({
-      {"qpx_version", "1.0"},
-      {"creator", "OpenMS"},
-      {"file_type", "pg"},
-      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
-      {"uuid", std::string(buf)},
-      {"software_provider", "OpenMS"}
-    });
-    table = table->ReplaceSchemaMetadata(metadata);
-  }
-
-  // Open output file
-  auto result = arrow::io::FileOutputStream::Open(filename);
-  if (!result.ok())
-  {
-    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: Failed to open file: " << filename << std::endl;
-    return false;
-  }
-  const auto& outfile = *result;
-
-  // Configure Parquet writer
-  auto builder = parquet::WriterProperties::Builder();
-
-  switch (config.compression)
-  {
-    case ParquetWriteConfig::Compression::NONE:
-      builder.compression(arrow::Compression::UNCOMPRESSED);
-      break;
-    case ParquetWriteConfig::Compression::SNAPPY:
-      builder.compression(arrow::Compression::SNAPPY);
-      break;
-    case ParquetWriteConfig::Compression::GZIP:
-      builder.compression(arrow::Compression::GZIP);
-      builder.compression_level(config.compression_level);
-      break;
-    case ParquetWriteConfig::Compression::LZ4:
-      builder.compression(arrow::Compression::LZ4);
-      break;
-    case ParquetWriteConfig::Compression::ZSTD:
-      builder.compression(arrow::Compression::ZSTD);
-      builder.compression_level(config.compression_level);
-      break;
-  }
-
-  builder.data_pagesize(config.data_page_size);
-
-  if (config.write_statistics)
-  {
-    builder.enable_statistics();
-  }
-  else
-  {
-    builder.disable_statistics();
-  }
-
-  auto writer_props = builder.build();
-  auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-
-  auto write_status = parquet::arrow::WriteTable(
-    *table, arrow::default_memory_pool(), outfile,
-    config.row_group_size, writer_props, arrow_props);
-
-  if (!write_status.ok())
-  {
-    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: Failed to write Parquet: "
-                     << write_status.ToString() << std::endl;
-    return false;
-  }
-
-  return true;
+  return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
 }
 
 
@@ -767,22 +687,18 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       }
     }
 
-    // gg_accessions, gg_names (gene groups — populate if meta values available)
+    // gg_accessions, gg_names (gene groups — one entry per group member, keep
+    // parallel to pg_accessions so consumers can zip positionally; empty string
+    // when the meta value is missing).
     (void)gg_accessions_builder.Append();
     (void)gg_names_builder.Append();
     for (const auto& acc : group.accessions)
     {
       auto it = hit_lookup.find(acc);
-      if (it != hit_lookup.end())
-      {
-        bool has_ga = it->second->metaValueExists("gene_accession");
-        bool has_gn = it->second->metaValueExists("gene_name");
-        if (has_ga || has_gn)
-        {
-          (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
-          (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
-        }
-      }
+      bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
+      bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
+      (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
+      (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
     }
 
     // gg_qvalue - not available
@@ -814,9 +730,10 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
     // contaminant - not tracked
     (void)contaminant_builder.AppendNull();
 
-    // peptides — populate from peptide evidence counts
+    // peptides — one {protein_name, peptide_count} per group member
     (void)peptides_builder.Append();
-    int total_unique = 0;
+    int total_sequences = 0;
+    std::unordered_set<std::string> group_unique_peptides;
     for (const auto& acc : group.accessions)
     {
       auto pit = acc_to_peptides.find(acc);
@@ -824,16 +741,19 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
       (void)pep_struct_b->Append();
       (void)pep_name_b->Append(acc);
       (void)pep_count_b->Append(count);
-      total_unique += count;
+      total_sequences += count;
+      if (pit != acc_to_peptides.end())
+      {
+        group_unique_peptides.insert(pit->second.begin(), pit->second.end());
+      }
     }
 
-    // peptide_counts — unique across all group members (use anchor as proxy for unique)
+    // peptide_counts — unique sequences across the union of group members,
+    // total_sequences is the sum of per-protein counts (double-counts shared peptides).
     {
-      auto pit = acc_to_peptides.find(anchor);
-      int unique_count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
       (void)peptide_counts_builder.Append();
-      (void)pc_unique_b->Append(unique_count);
-      (void)pc_total_b->Append(total_unique);
+      (void)pc_unique_b->Append(static_cast<int>(group_unique_peptides.size()));
+      (void)pc_total_b->Append(total_sequences);
     }
 
     // feature_counts - not available for id-only
@@ -944,99 +864,7 @@ bool ProteinGroupArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to create Arrow table" << std::endl;
     return false;
   }
-
-  // Add QPX metadata to schema
-  {
-    // Generate RFC 4122 version-4 UUID
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint32_t> dist;
-    uint8_t bytes[16];
-    for (int i = 0; i < 4; ++i)
-    {
-      uint32_t r = dist(gen);
-      std::memcpy(bytes + i * 4, &r, 4);
-    }
-    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
-    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
-    char buf[37];
-    std::snprintf(buf, sizeof(buf),
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      bytes[0], bytes[1], bytes[2], bytes[3],
-      bytes[4], bytes[5], bytes[6], bytes[7],
-      bytes[8], bytes[9], bytes[10], bytes[11],
-      bytes[12], bytes[13], bytes[14], bytes[15]);
-
-    auto metadata = arrow::key_value_metadata({
-      {"qpx_version", "1.0"},
-      {"creator", "OpenMS"},
-      {"file_type", "pg"},
-      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
-      {"uuid", std::string(buf)},
-      {"software_provider", "OpenMS"}
-    });
-    table = table->ReplaceSchemaMetadata(metadata);
-  }
-
-  // Open output file
-  auto result = arrow::io::FileOutputStream::Open(filename);
-  if (!result.ok())
-  {
-    OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to open file: " << filename << std::endl;
-    return false;
-  }
-  const auto& outfile = *result;
-
-  // Configure Parquet writer
-  auto builder = parquet::WriterProperties::Builder();
-
-  switch (config.compression)
-  {
-    case ParquetWriteConfig::Compression::NONE:
-      builder.compression(arrow::Compression::UNCOMPRESSED);
-      break;
-    case ParquetWriteConfig::Compression::SNAPPY:
-      builder.compression(arrow::Compression::SNAPPY);
-      break;
-    case ParquetWriteConfig::Compression::GZIP:
-      builder.compression(arrow::Compression::GZIP);
-      builder.compression_level(config.compression_level);
-      break;
-    case ParquetWriteConfig::Compression::LZ4:
-      builder.compression(arrow::Compression::LZ4);
-      break;
-    case ParquetWriteConfig::Compression::ZSTD:
-      builder.compression(arrow::Compression::ZSTD);
-      builder.compression_level(config.compression_level);
-      break;
-  }
-
-  builder.data_pagesize(config.data_page_size);
-
-  if (config.write_statistics)
-  {
-    builder.enable_statistics();
-  }
-  else
-  {
-    builder.disable_statistics();
-  }
-
-  auto writer_props = builder.build();
-  auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-
-  auto write_status = parquet::arrow::WriteTable(
-    *table, arrow::default_memory_pool(), outfile,
-    config.row_group_size, writer_props, arrow_props);
-
-  if (!write_status.ok())
-  {
-    OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to write Parquet: "
-                     << write_status.ToString() << std::endl;
-    return false;
-  }
-
-  return true;
+  return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
 }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -10,8 +10,10 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 
 #include <arrow/api.h>
@@ -565,6 +567,471 @@ bool ProteinGroupArrowExport::exportToParquet(
   if (!write_status.ok())
   {
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport: Failed to write Parquet: "
+                     << write_status.ToString() << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+
+std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
+  const std::vector<ProteinIdentification>& protein_identifications,
+  const PeptideIdentificationList& peptide_identifications)
+{
+  auto target_schema = QPXPgSchema::schema();
+
+  if (protein_identifications.empty())
+  {
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): No protein identifications found" << std::endl;
+    return arrow::Table::MakeEmpty(target_schema).ValueOrDie();
+  }
+
+  const auto& prot_id = protein_identifications[0];
+  const auto& groups = prot_id.getIndistinguishableProteins();
+
+  if (groups.empty())
+  {
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): No indistinguishable protein groups found" << std::endl;
+    return arrow::Table::MakeEmpty(target_schema).ValueOrDie();
+  }
+
+  // Derive run file name from primary MS run path
+  StringList run_paths;
+  prot_id.getPrimaryMSRunPath(run_paths);
+  std::string run_file = run_paths.empty() ? "" : std::string(run_paths[0]);
+
+  // Build accession -> ProteinHit lookup
+  std::unordered_map<std::string, const ProteinHit*> hit_lookup;
+  for (const auto& hit : prot_id.getHits())
+  {
+    hit_lookup[hit.getAccession()] = &hit;
+  }
+
+  // Build per-protein peptide counts from PeptideIdentificationList
+  // Only count best hit per spectrum (first hit after assuming sorted by score)
+  std::unordered_map<std::string, std::unordered_set<std::string>> acc_to_peptides;
+  for (const auto& pep_id : peptide_identifications)
+  {
+    if (pep_id.getHits().empty()) continue;
+    // Use the best hit (first after sorting)
+    const auto& best_hit = pep_id.getHits()[0];
+    std::string seq = best_hit.getSequence().toString();
+    for (const auto& ev : best_hit.getPeptideEvidences())
+    {
+      const std::string& acc = ev.getProteinAccession();
+      if (!acc.empty())
+      {
+        acc_to_peptides[acc].insert(seq);
+      }
+    }
+  }
+
+  Size estimated_rows = groups.size();
+
+  // -- Simple column builders --
+  arrow::StringBuilder anchor_protein_builder, run_file_name_builder;
+  arrow::DoubleBuilder global_qvalue_builder, pg_qvalue_builder, gg_qvalue_builder;
+  arrow::FloatBuilder sequence_coverage_builder, molecular_weight_builder;
+  arrow::BooleanBuilder is_decoy_builder, contaminant_builder;
+
+  // -- list<utf8> builders --
+  auto pg_acc_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder pg_accessions_builder(arrow::default_memory_pool(), pg_acc_vb);
+
+  auto pg_names_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder pg_names_builder(arrow::default_memory_pool(), pg_names_vb);
+
+  auto gg_acc_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder gg_accessions_builder(arrow::default_memory_pool(), gg_acc_vb);
+
+  auto gg_names_vb = std::make_shared<arrow::StringBuilder>();
+  arrow::ListBuilder gg_names_builder(arrow::default_memory_pool(), gg_names_vb);
+
+  // -- intensities: null (not available for id-only) --
+  // We still need a properly typed builder to match schema; append nulls per row
+  auto intensities_value_type = std::dynamic_pointer_cast<arrow::ListType>(QPXPgSchema::intensitiesType())->value_type();
+  auto int_label_b = std::make_shared<arrow::StringBuilder>();
+  auto int_value_b = std::make_shared<arrow::FloatBuilder>();
+  auto int_struct_b = std::make_shared<arrow::StructBuilder>(
+    intensities_value_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{int_label_b, int_value_b});
+  arrow::ListBuilder intensities_builder(arrow::default_memory_pool(), int_struct_b, QPXPgSchema::intensitiesType());
+
+  // -- additional_intensities: null (not available for id-only) --
+  auto add_int_value_type = std::dynamic_pointer_cast<arrow::ListType>(QPXPgSchema::additionalIntensitiesType())->value_type();
+  // inner list type for the "intensities" field of the struct
+  auto int_pair_type = arrow::struct_({
+    arrow::field("intensity_name", arrow::utf8(), /*nullable=*/false),
+    arrow::field("intensity_value", arrow::float32(), /*nullable=*/false)
+  });
+  auto ip_name_b = std::make_shared<arrow::StringBuilder>();
+  auto ip_value_b = std::make_shared<arrow::FloatBuilder>();
+  auto ip_struct_b = std::make_shared<arrow::StructBuilder>(
+    int_pair_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{ip_name_b, ip_value_b});
+  auto ip_list_b = std::make_shared<arrow::ListBuilder>(arrow::default_memory_pool(), ip_struct_b, arrow::list(int_pair_type));
+  auto ai_label_b = std::make_shared<arrow::StringBuilder>();
+  auto ai_struct_b = std::make_shared<arrow::StructBuilder>(
+    add_int_value_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{ai_label_b, ip_list_b});
+  arrow::ListBuilder additional_intensities_builder(arrow::default_memory_pool(), ai_struct_b, QPXPgSchema::additionalIntensitiesType());
+
+  // -- peptides: list<struct{protein_name: utf8, peptide_count: int32}> --
+  auto pep_value_type = std::dynamic_pointer_cast<arrow::ListType>(QPXPgSchema::peptidesType())->value_type();
+  auto pep_name_b = std::make_shared<arrow::StringBuilder>();
+  auto pep_count_b = std::make_shared<arrow::Int32Builder>();
+  auto pep_struct_b = std::make_shared<arrow::StructBuilder>(
+    pep_value_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{pep_name_b, pep_count_b});
+  arrow::ListBuilder peptides_builder(arrow::default_memory_pool(), pep_struct_b, QPXPgSchema::peptidesType());
+
+  // -- peptide_counts: struct{unique_sequences, total_sequences} --
+  auto pep_counts_type = QPXPgSchema::peptideCountsType();
+  auto pc_unique_b = std::make_shared<arrow::Int32Builder>();
+  auto pc_total_b = std::make_shared<arrow::Int32Builder>();
+  arrow::StructBuilder peptide_counts_builder(
+    pep_counts_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{pc_unique_b, pc_total_b});
+
+  // -- feature_counts: null (not available for id-only) --
+  auto feat_counts_type = QPXPgSchema::featureCountsType();
+  auto fc_unique_b = std::make_shared<arrow::Int32Builder>();
+  auto fc_total_b = std::make_shared<arrow::Int32Builder>();
+  arrow::StructBuilder feature_counts_builder(
+    feat_counts_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{fc_unique_b, fc_total_b});
+
+  // -- additional_scores: list<struct{score_name, score_value, higher_better}> --
+  auto as_type = QPXPgSchema::additionalScoresType();
+  auto as_value_type = std::dynamic_pointer_cast<arrow::ListType>(as_type)->value_type();
+  auto as_name_b = std::make_shared<arrow::StringBuilder>();
+  auto as_value_b = std::make_shared<arrow::DoubleBuilder>();
+  auto as_hb_b = std::make_shared<arrow::BooleanBuilder>();
+  auto as_struct_b = std::make_shared<arrow::StructBuilder>(
+    as_value_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{as_name_b, as_value_b, as_hb_b});
+  arrow::ListBuilder additional_scores_builder(arrow::default_memory_pool(), as_struct_b, as_type);
+
+  // -- cv_params: list<struct{cv_name, cv_value}> --
+  auto cv_type = QPXPgSchema::cvParamsType();
+  auto cv_value_type = std::dynamic_pointer_cast<arrow::ListType>(cv_type)->value_type();
+  auto cv_name_b = std::make_shared<arrow::StringBuilder>();
+  auto cv_value_b = std::make_shared<arrow::StringBuilder>();
+  auto cv_struct_b = std::make_shared<arrow::StructBuilder>(
+    cv_value_type, arrow::default_memory_pool(),
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>>{cv_name_b, cv_value_b});
+  arrow::ListBuilder cv_params_builder(arrow::default_memory_pool(), cv_struct_b, cv_type);
+
+  // Reserve capacity
+  arrow::Status status;
+  status = anchor_protein_builder.Reserve(estimated_rows);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = run_file_name_builder.Reserve(estimated_rows);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = global_qvalue_builder.Reserve(estimated_rows);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = is_decoy_builder.Reserve(estimated_rows);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+
+  // Iterate protein groups and emit rows
+  for (const auto& group : groups)
+  {
+    const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
+
+    // anchor_protein
+    (void)anchor_protein_builder.Append(anchor);
+
+    // run_file_name
+    (void)run_file_name_builder.Append(run_file);
+
+    // pg_accessions
+    (void)pg_accessions_builder.Append();
+    for (const auto& acc : group.accessions)
+    {
+      (void)pg_acc_vb->Append(acc);
+    }
+
+    // pg_names
+    (void)pg_names_builder.Append();
+    for (const auto& acc : group.accessions)
+    {
+      auto it = hit_lookup.find(acc);
+      if (it != hit_lookup.end())
+      {
+        (void)pg_names_vb->Append(it->second->getDescription());
+      }
+      else
+      {
+        (void)pg_names_vb->Append("");
+      }
+    }
+
+    // gg_accessions, gg_names (gene groups — populate if meta values available)
+    (void)gg_accessions_builder.Append();
+    (void)gg_names_builder.Append();
+    for (const auto& acc : group.accessions)
+    {
+      auto it = hit_lookup.find(acc);
+      if (it != hit_lookup.end())
+      {
+        bool has_ga = it->second->metaValueExists("gene_accession");
+        bool has_gn = it->second->metaValueExists("gene_name");
+        if (has_ga || has_gn)
+        {
+          (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
+          (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
+        }
+      }
+    }
+
+    // gg_qvalue - not available
+    (void)gg_qvalue_builder.AppendNull();
+
+    // global_qvalue — use group probability
+    (void)global_qvalue_builder.Append(group.probability);
+
+    // pg_qvalue - not available for id-only
+    (void)pg_qvalue_builder.AppendNull();
+
+    // intensities — null for id-only
+    (void)intensities_builder.AppendNull();
+
+    // additional_intensities — null for id-only
+    (void)additional_intensities_builder.AppendNull();
+
+    // is_decoy
+    auto anchor_it = hit_lookup.find(anchor);
+    if (anchor_it != hit_lookup.end())
+    {
+      (void)is_decoy_builder.Append(anchor_it->second->isDecoy());
+    }
+    else
+    {
+      (void)is_decoy_builder.Append(false);
+    }
+
+    // contaminant - not tracked
+    (void)contaminant_builder.AppendNull();
+
+    // peptides — populate from peptide evidence counts
+    (void)peptides_builder.Append();
+    int total_unique = 0;
+    for (const auto& acc : group.accessions)
+    {
+      auto pit = acc_to_peptides.find(acc);
+      int count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
+      (void)pep_struct_b->Append();
+      (void)pep_name_b->Append(acc);
+      (void)pep_count_b->Append(count);
+      total_unique += count;
+    }
+
+    // peptide_counts — unique across all group members (use anchor as proxy for unique)
+    {
+      auto pit = acc_to_peptides.find(anchor);
+      int unique_count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
+      (void)peptide_counts_builder.Append();
+      (void)pc_unique_b->Append(unique_count);
+      (void)pc_total_b->Append(total_unique);
+    }
+
+    // feature_counts - not available for id-only
+    (void)feature_counts_builder.AppendNull();
+
+    // sequence_coverage
+    if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
+    {
+      (void)sequence_coverage_builder.Append(static_cast<float>(anchor_it->second->getCoverage()));
+    }
+    else
+    {
+      (void)sequence_coverage_builder.AppendNull();
+    }
+
+    // molecular_weight - not available
+    (void)molecular_weight_builder.AppendNull();
+
+    // additional_scores — anchor protein score
+    (void)additional_scores_builder.Append();
+    if (anchor_it != hit_lookup.end())
+    {
+      (void)as_struct_b->Append();
+      (void)as_name_b->Append(prot_id.getScoreType());
+      (void)as_value_b->Append(anchor_it->second->getScore());
+      (void)as_hb_b->Append(prot_id.isHigherScoreBetter());
+    }
+
+    // cv_params - empty for now
+    (void)cv_params_builder.Append();
+  }
+
+  // Finalize all arrays
+  std::shared_ptr<arrow::Array> arr_pg_acc, arr_pg_names, arr_gg_acc, arr_gg_names;
+  std::shared_ptr<arrow::Array> arr_gg_qval, arr_anchor, arr_run_file;
+  std::shared_ptr<arrow::Array> arr_global_qval, arr_pg_qval;
+  std::shared_ptr<arrow::Array> arr_intensities, arr_add_intensities;
+  std::shared_ptr<arrow::Array> arr_is_decoy, arr_contaminant;
+  std::shared_ptr<arrow::Array> arr_peptides, arr_pep_counts, arr_feat_counts;
+  std::shared_ptr<arrow::Array> arr_seq_cov, arr_mol_weight;
+  std::shared_ptr<arrow::Array> arr_add_scores, arr_cv_params;
+
+  status = pg_accessions_builder.Finish(&arr_pg_acc);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_accessions Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = pg_names_builder.Finish(&arr_pg_names);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_names Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = gg_accessions_builder.Finish(&arr_gg_acc);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_accessions Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = gg_names_builder.Finish(&arr_gg_names);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_names Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = gg_qvalue_builder.Finish(&arr_gg_qval);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = anchor_protein_builder.Finish(&arr_anchor);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = run_file_name_builder.Finish(&arr_run_file);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = global_qvalue_builder.Finish(&arr_global_qval);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = pg_qvalue_builder.Finish(&arr_pg_qval);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = intensities_builder.Finish(&arr_intensities);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): intensities Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = additional_intensities_builder.Finish(&arr_add_intensities);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_intensities Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = is_decoy_builder.Finish(&arr_is_decoy);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = contaminant_builder.Finish(&arr_contaminant);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): contaminant Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = peptides_builder.Finish(&arr_peptides);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptides Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = peptide_counts_builder.Finish(&arr_pep_counts);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptide_counts Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = feature_counts_builder.Finish(&arr_feat_counts);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): feature_counts Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = sequence_coverage_builder.Finish(&arr_seq_cov);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): sequence_coverage Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = molecular_weight_builder.Finish(&arr_mol_weight);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): molecular_weight Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = additional_scores_builder.Finish(&arr_add_scores);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_scores Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  status = cv_params_builder.Finish(&arr_cv_params);
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): cv_params Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+
+  auto table = arrow::Table::Make(target_schema, {
+    arr_pg_acc, arr_pg_names, arr_gg_acc, arr_gg_names,
+    arr_gg_qval, arr_anchor, arr_run_file,
+    arr_global_qval, arr_pg_qval,
+    arr_intensities, arr_add_intensities,
+    arr_is_decoy, arr_contaminant,
+    arr_peptides, arr_pep_counts, arr_feat_counts,
+    arr_seq_cov, arr_mol_weight,
+    arr_add_scores, arr_cv_params,
+  });
+
+  return table;
+}
+
+
+bool ProteinGroupArrowExport::exportToParquet(
+  const std::vector<ProteinIdentification>& protein_identifications,
+  const PeptideIdentificationList& peptide_identifications,
+  const String& filename,
+  const ParquetWriteConfig& config)
+{
+  auto table = exportToArrow(protein_identifications, peptide_identifications);
+  if (!table)
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to create Arrow table" << std::endl;
+    return false;
+  }
+
+  // Add QPX metadata to schema
+  {
+    // Generate RFC 4122 version-4 UUID
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint32_t> dist;
+    uint8_t bytes[16];
+    for (int i = 0; i < 4; ++i)
+    {
+      uint32_t r = dist(gen);
+      std::memcpy(bytes + i * 4, &r, 4);
+    }
+    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
+    char buf[37];
+    std::snprintf(buf, sizeof(buf),
+      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+      bytes[0], bytes[1], bytes[2], bytes[3],
+      bytes[4], bytes[5], bytes[6], bytes[7],
+      bytes[8], bytes[9], bytes[10], bytes[11],
+      bytes[12], bytes[13], bytes[14], bytes[15]);
+
+    auto metadata = arrow::key_value_metadata({
+      {"qpx_version", "1.0"},
+      {"creator", "OpenMS"},
+      {"file_type", "pg"},
+      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
+      {"uuid", std::string(buf)},
+      {"software_provider", "OpenMS"}
+    });
+    table = table->ReplaceSchemaMetadata(metadata);
+  }
+
+  // Open output file
+  auto result = arrow::io::FileOutputStream::Open(filename);
+  if (!result.ok())
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to open file: " << filename << std::endl;
+    return false;
+  }
+  const auto& outfile = *result;
+
+  // Configure Parquet writer
+  auto builder = parquet::WriterProperties::Builder();
+
+  switch (config.compression)
+  {
+    case ParquetWriteConfig::Compression::NONE:
+      builder.compression(arrow::Compression::UNCOMPRESSED);
+      break;
+    case ParquetWriteConfig::Compression::SNAPPY:
+      builder.compression(arrow::Compression::SNAPPY);
+      break;
+    case ParquetWriteConfig::Compression::GZIP:
+      builder.compression(arrow::Compression::GZIP);
+      builder.compression_level(config.compression_level);
+      break;
+    case ParquetWriteConfig::Compression::LZ4:
+      builder.compression(arrow::Compression::LZ4);
+      break;
+    case ParquetWriteConfig::Compression::ZSTD:
+      builder.compression(arrow::Compression::ZSTD);
+      builder.compression_level(config.compression_level);
+      break;
+  }
+
+  builder.data_pagesize(config.data_page_size);
+
+  if (config.write_statistics)
+  {
+    builder.enable_statistics();
+  }
+  else
+  {
+    builder.disable_statistics();
+  }
+
+  auto writer_props = builder.build();
+  auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+
+  auto write_status = parquet::arrow::WriteTable(
+    *table, arrow::default_memory_pool(), outfile,
+    config.row_group_size, writer_props, arrow_props);
+
+  if (!write_status.ok())
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to write Parquet: "
                      << write_status.ToString() << std::endl;
     return false;
   }

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -491,6 +491,19 @@ bool ProteinGroupArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport: Failed to create Arrow table" << std::endl;
     return false;
   }
+  return exportToParquet(table, filename, config);
+}
+
+bool ProteinGroupArrowExport::exportToParquet(
+  const std::shared_ptr<arrow::Table>& table,
+  const String& filename,
+  const ParquetWriteConfig& config)
+{
+  if (!table)
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: null table passed to exportToParquet (" << filename << ")" << std::endl;
+    return false;
+  }
   return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
 }
 
@@ -864,7 +877,7 @@ bool ProteinGroupArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): Failed to create Arrow table" << std::endl;
     return false;
   }
-  return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
+  return exportToParquet(table, filename, config);
 }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
+++ b/src/openms/source/FORMAT/ProteinGroupArrowExport.cpp
@@ -504,6 +504,17 @@ bool ProteinGroupArrowExport::exportToParquet(
     OPENMS_LOG_ERROR << "ProteinGroupArrowExport: null table passed to exportToParquet (" << filename << ")" << std::endl;
     return false;
   }
+
+  // Guard: this overload stamps file_type="pg", so the caller must pass a
+  // QPXPgSchema table.
+  auto validation = ArrowSchemaValidation::validate(table, QPXPgSchema::schema(), ArrowSchemaValidation::Mode::Strict);
+  if (!validation.valid)
+  {
+    OPENMS_LOG_ERROR << "ProteinGroupArrowExport: table schema does not match QPXPgSchema ("
+                     << filename << "): " << validation.toString() << std::endl;
+    return false;
+  }
+
   return ArrowIOHelpers::writeTableToParquet(attachQPXPgMetadata(table), filename, config);
 }
 
@@ -520,47 +531,12 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
     return arrow::Table::MakeEmpty(target_schema).ValueOrDie();
   }
 
-  const auto& prot_id = protein_identifications[0];
-  const auto& groups = prot_id.getIndistinguishableProteins();
-
-  if (groups.empty())
+  // Compute total estimated rows across all protein identifications
+  Size estimated_rows = 0;
+  for (const auto& pid : protein_identifications)
   {
-    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): No indistinguishable protein groups found" << std::endl;
-    return arrow::Table::MakeEmpty(target_schema).ValueOrDie();
+    estimated_rows += pid.getIndistinguishableProteins().size();
   }
-
-  // Derive run file name from primary MS run path
-  StringList run_paths;
-  prot_id.getPrimaryMSRunPath(run_paths);
-  std::string run_file = run_paths.empty() ? "" : std::string(run_paths[0]);
-
-  // Build accession -> ProteinHit lookup
-  std::unordered_map<std::string, const ProteinHit*> hit_lookup;
-  for (const auto& hit : prot_id.getHits())
-  {
-    hit_lookup[hit.getAccession()] = &hit;
-  }
-
-  // Build per-protein peptide counts from PeptideIdentificationList
-  // Only count best hit per spectrum (first hit after assuming sorted by score)
-  std::unordered_map<std::string, std::unordered_set<std::string>> acc_to_peptides;
-  for (const auto& pep_id : peptide_identifications)
-  {
-    if (pep_id.getHits().empty()) continue;
-    // Use the best hit (first after sorting)
-    const auto& best_hit = pep_id.getHits()[0];
-    std::string seq = best_hit.getSequence().toString();
-    for (const auto& ev : best_hit.getPeptideEvidences())
-    {
-      const std::string& acc = ev.getProteinAccession();
-      if (!acc.empty())
-      {
-        acc_to_peptides[acc].insert(seq);
-      }
-    }
-  }
-
-  Size estimated_rows = groups.size();
 
   // -- Simple column builders --
   arrow::StringBuilder anchor_protein_builder, run_file_name_builder;
@@ -659,144 +635,192 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   // Reserve capacity
   arrow::Status status;
   status = anchor_protein_builder.Reserve(estimated_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = run_file_name_builder.Reserve(estimated_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = global_qvalue_builder.Reserve(estimated_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Reserve failed: " << status.ToString() << std::endl; return nullptr; }
   status = is_decoy_builder.Reserve(estimated_rows);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Reserve failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Reserve failed: " << status.ToString() << std::endl; return nullptr; }
 
-  // Iterate protein groups and emit rows
-  for (const auto& group : groups)
+  // Iterate over all protein identifications; for each, build scoped lookup
+  // structures and append one row per indistinguishable protein group.
+  Size total_groups_found = 0;
+  for (const auto& prot_id : protein_identifications)
   {
-    const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
+    const auto& groups = prot_id.getIndistinguishableProteins();
+    if (groups.empty()) continue;
+    total_groups_found += groups.size();
 
-    // anchor_protein
-    (void)anchor_protein_builder.Append(anchor);
+    // Derive run file name from primary MS run path for this prot_id
+    StringList run_paths;
+    prot_id.getPrimaryMSRunPath(run_paths);
+    std::string run_file = run_paths.empty() ? "" : std::string(run_paths[0]);
 
-    // run_file_name
-    (void)run_file_name_builder.Append(run_file);
-
-    // pg_accessions
-    (void)pg_accessions_builder.Append();
-    for (const auto& acc : group.accessions)
+    // Build accession -> ProteinHit lookup scoped to this prot_id
+    std::unordered_map<std::string, const ProteinHit*> hit_lookup;
+    for (const auto& hit : prot_id.getHits())
     {
-      (void)pg_acc_vb->Append(acc);
+      hit_lookup[hit.getAccession()] = &hit;
     }
 
-    // pg_names
-    (void)pg_names_builder.Append();
-    for (const auto& acc : group.accessions)
+    // Build per-protein peptide counts from peptide_identifications whose
+    // identifier matches this prot_id's identifier
+    std::unordered_map<std::string, std::unordered_set<std::string>> acc_to_peptides;
+    for (const auto& pep_id : peptide_identifications)
     {
-      auto it = hit_lookup.find(acc);
-      if (it != hit_lookup.end())
+      if (pep_id.getIdentifier() != prot_id.getIdentifier()) continue;
+      if (pep_id.getHits().empty()) continue;
+      // Use the best hit (first after assuming sorted by score)
+      const auto& best_hit = pep_id.getHits()[0];
+      std::string seq = best_hit.getSequence().toString();
+      for (const auto& ev : best_hit.getPeptideEvidences())
       {
-        (void)pg_names_vb->Append(it->second->getDescription());
+        const std::string& acc = ev.getProteinAccession();
+        if (!acc.empty())
+        {
+          acc_to_peptides[acc].insert(seq);
+        }
+      }
+    }
+
+    // Iterate protein groups for this prot_id and emit rows
+    for (const auto& group : groups)
+    {
+      const std::string& anchor = group.accessions.empty() ? "" : group.accessions[0];
+
+      // anchor_protein
+      (void)anchor_protein_builder.Append(anchor);
+
+      // run_file_name
+      (void)run_file_name_builder.Append(run_file);
+
+      // pg_accessions
+      (void)pg_accessions_builder.Append();
+      for (const auto& acc : group.accessions)
+      {
+        (void)pg_acc_vb->Append(acc);
+      }
+
+      // pg_names
+      (void)pg_names_builder.Append();
+      for (const auto& acc : group.accessions)
+      {
+        auto it = hit_lookup.find(acc);
+        if (it != hit_lookup.end())
+        {
+          (void)pg_names_vb->Append(it->second->getDescription());
+        }
+        else
+        {
+          (void)pg_names_vb->Append("");
+        }
+      }
+
+      // gg_accessions, gg_names (gene groups — one entry per group member, keep
+      // parallel to pg_accessions so consumers can zip positionally; empty string
+      // when the meta value is missing).
+      (void)gg_accessions_builder.Append();
+      (void)gg_names_builder.Append();
+      for (const auto& acc : group.accessions)
+      {
+        auto it = hit_lookup.find(acc);
+        bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
+        bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
+        (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
+        (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
+      }
+
+      // gg_qvalue - not available
+      (void)gg_qvalue_builder.AppendNull();
+
+      // global_qvalue — use group probability
+      (void)global_qvalue_builder.Append(group.probability);
+
+      // pg_qvalue - not available for id-only
+      (void)pg_qvalue_builder.AppendNull();
+
+      // intensities — null for id-only
+      (void)intensities_builder.AppendNull();
+
+      // additional_intensities — null for id-only
+      (void)additional_intensities_builder.AppendNull();
+
+      // is_decoy
+      auto anchor_it = hit_lookup.find(anchor);
+      if (anchor_it != hit_lookup.end())
+      {
+        (void)is_decoy_builder.Append(anchor_it->second->isDecoy());
       }
       else
       {
-        (void)pg_names_vb->Append("");
+        (void)is_decoy_builder.Append(false);
       }
-    }
 
-    // gg_accessions, gg_names (gene groups — one entry per group member, keep
-    // parallel to pg_accessions so consumers can zip positionally; empty string
-    // when the meta value is missing).
-    (void)gg_accessions_builder.Append();
-    (void)gg_names_builder.Append();
-    for (const auto& acc : group.accessions)
-    {
-      auto it = hit_lookup.find(acc);
-      bool has_ga = (it != hit_lookup.end()) && it->second->metaValueExists("gene_accession");
-      bool has_gn = (it != hit_lookup.end()) && it->second->metaValueExists("gene_name");
-      (void)gg_acc_vb->Append(has_ga ? it->second->getMetaValue("gene_accession").toString() : "");
-      (void)gg_names_vb->Append(has_gn ? it->second->getMetaValue("gene_name").toString() : "");
-    }
+      // contaminant - not tracked
+      (void)contaminant_builder.AppendNull();
 
-    // gg_qvalue - not available
-    (void)gg_qvalue_builder.AppendNull();
-
-    // global_qvalue — use group probability
-    (void)global_qvalue_builder.Append(group.probability);
-
-    // pg_qvalue - not available for id-only
-    (void)pg_qvalue_builder.AppendNull();
-
-    // intensities — null for id-only
-    (void)intensities_builder.AppendNull();
-
-    // additional_intensities — null for id-only
-    (void)additional_intensities_builder.AppendNull();
-
-    // is_decoy
-    auto anchor_it = hit_lookup.find(anchor);
-    if (anchor_it != hit_lookup.end())
-    {
-      (void)is_decoy_builder.Append(anchor_it->second->isDecoy());
-    }
-    else
-    {
-      (void)is_decoy_builder.Append(false);
-    }
-
-    // contaminant - not tracked
-    (void)contaminant_builder.AppendNull();
-
-    // peptides — one {protein_name, peptide_count} per group member
-    (void)peptides_builder.Append();
-    int total_sequences = 0;
-    std::unordered_set<std::string> group_unique_peptides;
-    for (const auto& acc : group.accessions)
-    {
-      auto pit = acc_to_peptides.find(acc);
-      int count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
-      (void)pep_struct_b->Append();
-      (void)pep_name_b->Append(acc);
-      (void)pep_count_b->Append(count);
-      total_sequences += count;
-      if (pit != acc_to_peptides.end())
+      // peptides — one {protein_name, peptide_count} per group member
+      (void)peptides_builder.Append();
+      int total_sequences = 0;
+      std::unordered_set<std::string> group_unique_peptides;
+      for (const auto& acc : group.accessions)
       {
-        group_unique_peptides.insert(pit->second.begin(), pit->second.end());
+        auto pit = acc_to_peptides.find(acc);
+        int count = (pit != acc_to_peptides.end()) ? static_cast<int>(pit->second.size()) : 0;
+        (void)pep_struct_b->Append();
+        (void)pep_name_b->Append(acc);
+        (void)pep_count_b->Append(count);
+        total_sequences += count;
+        if (pit != acc_to_peptides.end())
+        {
+          group_unique_peptides.insert(pit->second.begin(), pit->second.end());
+        }
       }
+
+      // peptide_counts — unique sequences across the union of group members,
+      // total_sequences is the sum of per-protein counts (double-counts shared peptides).
+      {
+        (void)peptide_counts_builder.Append();
+        (void)pc_unique_b->Append(static_cast<int>(group_unique_peptides.size()));
+        (void)pc_total_b->Append(total_sequences);
+      }
+
+      // feature_counts - not available for id-only
+      (void)feature_counts_builder.AppendNull();
+
+      // sequence_coverage
+      if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
+      {
+        (void)sequence_coverage_builder.Append(static_cast<float>(anchor_it->second->getCoverage()));
+      }
+      else
+      {
+        (void)sequence_coverage_builder.AppendNull();
+      }
+
+      // molecular_weight - not available
+      (void)molecular_weight_builder.AppendNull();
+
+      // additional_scores — anchor protein score
+      (void)additional_scores_builder.Append();
+      if (anchor_it != hit_lookup.end())
+      {
+        (void)as_struct_b->Append();
+        (void)as_name_b->Append(prot_id.getScoreType());
+        (void)as_value_b->Append(anchor_it->second->getScore());
+        (void)as_hb_b->Append(prot_id.isHigherScoreBetter());
+      }
+
+      // cv_params - empty for now
+      (void)cv_params_builder.Append();
     }
+  }
 
-    // peptide_counts — unique sequences across the union of group members,
-    // total_sequences is the sum of per-protein counts (double-counts shared peptides).
-    {
-      (void)peptide_counts_builder.Append();
-      (void)pc_unique_b->Append(static_cast<int>(group_unique_peptides.size()));
-      (void)pc_total_b->Append(total_sequences);
-    }
-
-    // feature_counts - not available for id-only
-    (void)feature_counts_builder.AppendNull();
-
-    // sequence_coverage
-    if (anchor_it != hit_lookup.end() && anchor_it->second->getCoverage() != ProteinHit::COVERAGE_UNKNOWN)
-    {
-      (void)sequence_coverage_builder.Append(static_cast<float>(anchor_it->second->getCoverage()));
-    }
-    else
-    {
-      (void)sequence_coverage_builder.AppendNull();
-    }
-
-    // molecular_weight - not available
-    (void)molecular_weight_builder.AppendNull();
-
-    // additional_scores — anchor protein score
-    (void)additional_scores_builder.Append();
-    if (anchor_it != hit_lookup.end())
-    {
-      (void)as_struct_b->Append();
-      (void)as_name_b->Append(prot_id.getScoreType());
-      (void)as_value_b->Append(anchor_it->second->getScore());
-      (void)as_hb_b->Append(prot_id.isHigherScoreBetter());
-    }
-
-    // cv_params - empty for now
-    (void)cv_params_builder.Append();
+  if (total_groups_found == 0)
+  {
+    OPENMS_LOG_WARN << "ProteinGroupArrowExport (id-only): No indistinguishable protein groups found" << std::endl;
+    return arrow::Table::MakeEmpty(target_schema).ValueOrDie();
   }
 
   // Finalize all arrays
@@ -810,45 +834,45 @@ std::shared_ptr<arrow::Table> ProteinGroupArrowExport::exportToArrow(
   std::shared_ptr<arrow::Array> arr_add_scores, arr_cv_params;
 
   status = pg_accessions_builder.Finish(&arr_pg_acc);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_accessions Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_accessions Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = pg_names_builder.Finish(&arr_pg_names);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_names Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_names Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = gg_accessions_builder.Finish(&arr_gg_acc);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_accessions Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_accessions Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = gg_names_builder.Finish(&arr_gg_names);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_names Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_names Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = gg_qvalue_builder.Finish(&arr_gg_qval);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): gg_qvalue Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = anchor_protein_builder.Finish(&arr_anchor);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): anchor_protein Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = run_file_name_builder.Finish(&arr_run_file);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): run_file_name Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = global_qvalue_builder.Finish(&arr_global_qval);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): global_qvalue Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = pg_qvalue_builder.Finish(&arr_pg_qval);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_qvalue Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): pg_qvalue Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = intensities_builder.Finish(&arr_intensities);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): intensities Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): intensities Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = additional_intensities_builder.Finish(&arr_add_intensities);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_intensities Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_intensities Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = is_decoy_builder.Finish(&arr_is_decoy);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): is_decoy Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = contaminant_builder.Finish(&arr_contaminant);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): contaminant Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): contaminant Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = peptides_builder.Finish(&arr_peptides);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptides Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptides Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = peptide_counts_builder.Finish(&arr_pep_counts);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptide_counts Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): peptide_counts Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = feature_counts_builder.Finish(&arr_feat_counts);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): feature_counts Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): feature_counts Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = sequence_coverage_builder.Finish(&arr_seq_cov);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): sequence_coverage Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): sequence_coverage Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = molecular_weight_builder.Finish(&arr_mol_weight);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): molecular_weight Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): molecular_weight Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = additional_scores_builder.Finish(&arr_add_scores);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_scores Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): additional_scores Finish failed: " << status.ToString() << std::endl; return nullptr; }
   status = cv_params_builder.Finish(&arr_cv_params);
-  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): cv_params Finish failed: " << status.ToString() << std::endl; return arrow::Table::MakeEmpty(target_schema).ValueOrDie(); }
+  if (!status.ok()) { OPENMS_LOG_ERROR << "ProteinGroupArrowExport (id-only): cv_params Finish failed: " << status.ToString() << std::endl; return nullptr; }
 
   auto table = arrow::Table::Make(target_schema, {
     arr_pg_acc, arr_pg_names, arr_gg_acc, arr_gg_names,

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/ANALYSIS/ID/IDScoreSwitcherAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/Scores.h>
@@ -1318,6 +1319,25 @@ std::shared_ptr<arrow::Table> QPXFile::exportPSMsToQPXArrow(
 }
 
 
+namespace
+{
+  /// Attach the canonical QPX "psm" file metadata (qpx_version, file_type="psm",
+  /// UUID, creation date, scan_format, creator) to the schema of @p table.
+  std::shared_ptr<arrow::Table> attachQPXPsmMetadata(const std::shared_ptr<arrow::Table>& table)
+  {
+    auto metadata = arrow::key_value_metadata({
+      {"qpx_version", "1.0"},
+      {"creator", "OpenMS"},
+      {"file_type", "psm"},
+      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
+      {"uuid", std::string(ArrowIOHelpers::generateUuidV4())},
+      {"scan_format", "scan"},
+      {"software_provider", "OpenMS"}
+    });
+    return table->ReplaceSchemaMetadata(metadata);
+  }
+}
+
 bool QPXFile::exportToParquet(
   const std::vector<ProteinIdentification>& protein_identifications,
   const PeptideIdentificationList& peptide_identifications,
@@ -1331,103 +1351,20 @@ bool QPXFile::exportToParquet(
     OPENMS_LOG_ERROR << "QPXFile: Failed to create Arrow table" << std::endl;
     return false;
   }
+  return exportToParquet(table, filename, config);
+}
 
-  // Add QPX file metadata to the table schema (matches Python to_psm_qpx())
+bool QPXFile::exportToParquet(
+  const std::shared_ptr<arrow::Table>& table,
+  const String& filename,
+  const ParquetWriteConfig& config)
+{
+  if (!table)
   {
-    // Generate RFC 4122 version-4 UUID
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<uint32_t> dist;
-    uint8_t bytes[16];
-    for (int i = 0; i < 4; ++i)
-    {
-      uint32_t r = dist(gen);
-      std::memcpy(bytes + i * 4, &r, 4);
-    }
-    bytes[6] = (bytes[6] & 0x0F) | 0x40; // version 4
-    bytes[8] = (bytes[8] & 0x3F) | 0x80; // variant 1
-    char buf[37];
-    std::snprintf(buf, sizeof(buf),
-      "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-      bytes[0], bytes[1], bytes[2], bytes[3],
-      bytes[4], bytes[5], bytes[6], bytes[7],
-      bytes[8], bytes[9], bytes[10], bytes[11],
-      bytes[12], bytes[13], bytes[14], bytes[15]);
-    std::string uuid_str(buf);
-    
-    auto metadata = arrow::key_value_metadata({
-      {"qpx_version", "1.0"},
-      {"creator", "OpenMS"},
-      {"file_type", "psm"},
-      {"creation_date", DateTime::nowUTC().toString("yyyy-MM-ddThh:mm:ssZ")},
-      {"uuid", uuid_str},
-      {"scan_format", "scan"},
-      {"software_provider", "OpenMS"}
-    });
-    table = table->ReplaceSchemaMetadata(metadata);
-  }
-
-  // Open output file
-  auto result = arrow::io::FileOutputStream::Open(filename);
-  if (!result.ok())
-  {
-    OPENMS_LOG_ERROR << "QPXFile: Failed to open file: " << filename << std::endl;
+    OPENMS_LOG_ERROR << "QPXFile: null table passed to exportToParquet (" << filename << ")" << std::endl;
     return false;
   }
-  const auto& outfile = *result;
-
-  // Configure Parquet writer
-  auto builder = parquet::WriterProperties::Builder();
-
-  switch (config.compression)
-  {
-    case ParquetWriteConfig::Compression::NONE:
-      builder.compression(arrow::Compression::UNCOMPRESSED);
-      break;
-    case ParquetWriteConfig::Compression::SNAPPY:
-      builder.compression(arrow::Compression::SNAPPY);
-      break;
-    case ParquetWriteConfig::Compression::GZIP:
-      builder.compression(arrow::Compression::GZIP);
-      builder.compression_level(config.compression_level);
-      break;
-    case ParquetWriteConfig::Compression::LZ4:
-      builder.compression(arrow::Compression::LZ4);
-      break;
-    case ParquetWriteConfig::Compression::ZSTD:
-      builder.compression(arrow::Compression::ZSTD);
-      builder.compression_level(config.compression_level);
-      break;
-  }
-
-  builder.data_pagesize(config.data_page_size);
-
-  if (config.write_statistics)
-  {
-    builder.enable_statistics();
-  }
-  else
-  {
-    builder.disable_statistics();
-  }
-
-  auto writer_props = builder.build();
-
-  auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-
-  // Write
-  auto write_status = parquet::arrow::WriteTable(
-    *table, arrow::default_memory_pool(), outfile,
-    config.row_group_size, writer_props, arrow_props);
-
-  if (!write_status.ok())
-  {
-    OPENMS_LOG_ERROR << "QPXFile: Failed to write Parquet: "
-                     << write_status.ToString() << std::endl;
-    return false;
-  }
-
-  return true;
+  return ArrowIOHelpers::writeTableToParquet(attachQPXPsmMetadata(table), filename, config);
 }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -1364,6 +1364,18 @@ bool QPXFile::exportToParquet(
     OPENMS_LOG_ERROR << "QPXFile: null table passed to exportToParquet (" << filename << ")" << std::endl;
     return false;
   }
+
+  // Guard: the table-taking overload attaches file_type="psm" metadata, so the
+  // caller must actually pass a QPXPSMSchema table (not, e.g., the internal
+  // PSMSchema produced by exportToArrow).
+  auto validation = ArrowSchemaValidation::validate(table, QPXPSMSchema::schema(), ArrowSchemaValidation::Mode::Strict);
+  if (!validation.valid)
+  {
+    OPENMS_LOG_ERROR << "QPXFile: table schema does not match QPXPSMSchema ("
+                     << filename << "): " << validation.toString() << std::endl;
+    return false;
+  }
+
   return ArrowIOHelpers::writeTableToParquet(attachQPXPsmMetadata(table), filename, config);
 }
 

--- a/src/openms/source/FORMAT/sources.cmake
+++ b/src/openms/source/FORMAT/sources.cmake
@@ -122,6 +122,7 @@ list(APPEND sources_list ProteinIdentificationArrowIO.cpp)
 list(APPEND sources_list FeatureMapArrowIO.cpp)
 list(APPEND sources_list ConsensusMapArrowIO.cpp)
 list(APPEND sources_list ArrowSchemaRegistry.cpp)
+list(APPEND sources_list ArrowIOHelpers.cpp)
 
 if (WITH_OPENTIMS)
   list(APPEND sources_list BrukerTimsFile.cpp)

--- a/src/pyOpenMS/bindings/bind_format.cpp
+++ b/src/pyOpenMS/bindings/bind_format.cpp
@@ -2283,7 +2283,12 @@ or chromatograms only (SRM/MRM) and forwards to the appropriate loader.
     nb::class_<OpenMS::QPXFile>(m, "QPXFile",
         "Export PSM data to Apache Arrow/Parquet format following QPX PSM schema")
         .def(nb::init<>())
-        .def_static("exportToParquet", &OpenMS::QPXFile::exportToParquet,
+        .def_static("exportToParquet",
+            static_cast<bool (*)(const std::vector<OpenMS::ProteinIdentification>&,
+                                 const OpenMS::PeptideIdentificationList&,
+                                 const OpenMS::String&,
+                                 bool,
+                                 const OpenMS::ParquetWriteConfig&)>(&OpenMS::QPXFile::exportToParquet),
             "protein_identifications"_a, "peptide_identifications"_a,
             "filename"_a, "export_all_psms"_a = false,
             "config"_a = OpenMS::ParquetWriteConfig{},

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -462,6 +462,46 @@ START_SECTION(ProteinGroupArrowExport::exportToArrow(vector<ProteinIdentificatio
   // Verify intensities is null (no quantification)
   auto int_col = table->GetColumnByName("intensities")->chunk(0);
   TEST_EQUAL(int_col->IsNull(0), true)
+
+  // is_decoy
+  auto is_decoy_col = std::static_pointer_cast<arrow::BooleanArray>(
+    table->GetColumnByName("is_decoy")->chunk(0));
+  TEST_EQUAL(is_decoy_col->Value(0), false)
+
+  // global_qvalue carries group.probability
+  auto qv_col = std::static_pointer_cast<arrow::DoubleArray>(
+    table->GetColumnByName("global_qvalue")->chunk(0));
+  TEST_EQUAL(qv_col->IsNull(0), false)
+  TEST_REAL_SIMILAR(qv_col->Value(0), 0.01)
+
+  // peptides list: one entry per group accession (2 here: PROT_A and PROT_B)
+  auto peptides_list = std::static_pointer_cast<arrow::ListArray>(
+    table->GetColumnByName("peptides")->chunk(0));
+  TEST_EQUAL(peptides_list->value_length(0), 2)
+  auto peptides_struct = std::static_pointer_cast<arrow::StructArray>(peptides_list->values());
+  auto pep_name_arr = std::static_pointer_cast<arrow::StringArray>(peptides_struct->field(0));
+  auto pep_count_arr = std::static_pointer_cast<arrow::Int32Array>(peptides_struct->field(1));
+  TEST_STRING_EQUAL(pep_name_arr->GetString(0), "PROT_A")
+  TEST_EQUAL(pep_count_arr->Value(0), 1)   // one peptide evidence for PROT_A
+  TEST_STRING_EQUAL(pep_name_arr->GetString(1), "PROT_B")
+  TEST_EQUAL(pep_count_arr->Value(1), 0)   // no peptide evidence for PROT_B
+
+  // peptide_counts: unique sequences = 1 (the peptide is attributed to PROT_A only);
+  // total_sequences = 1 (sum of per-protein counts)
+  auto pc_struct = std::static_pointer_cast<arrow::StructArray>(
+    table->GetColumnByName("peptide_counts")->chunk(0));
+  auto pc_unique = std::static_pointer_cast<arrow::Int32Array>(pc_struct->field(0));
+  auto pc_total = std::static_pointer_cast<arrow::Int32Array>(pc_struct->field(1));
+  TEST_EQUAL(pc_unique->Value(0), 1)
+  TEST_EQUAL(pc_total->Value(0), 1)
+
+  // gg_accessions / gg_names must be parallel to pg_accessions (length 2, both empty strings)
+  auto gg_acc_list = std::static_pointer_cast<arrow::ListArray>(
+    table->GetColumnByName("gg_accessions")->chunk(0));
+  auto gg_names_list = std::static_pointer_cast<arrow::ListArray>(
+    table->GetColumnByName("gg_names")->chunk(0));
+  TEST_EQUAL(gg_acc_list->value_length(0), 2)
+  TEST_EQUAL(gg_names_list->value_length(0), 2)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/QPXFile_test.cpp
+++ b/src/tests/class_tests/openms/source/QPXFile_test.cpp
@@ -18,6 +18,9 @@
 #include <OpenMS/METADATA/PeptideHit.h>
 #include <OpenMS/METADATA/PeptideEvidence.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
+#include <OpenMS/METADATA/PeptideIdentificationList.h>
 
 #include <arrow/api.h>
 #include <arrow/io/api.h>
@@ -385,6 +388,93 @@ START_SECTION(Test modifications structured output)
   auto mod_col2 = table2->GetColumnByName("modifications");
   auto mod_list2 = std::static_pointer_cast<arrow::ListArray>(mod_col2->chunk(0));
   TEST_EQUAL(mod_list2->value_length(0), 0) // empty list for unmodified
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION(QPXPgSchema::schema())
+{
+  auto schema = QPXPgSchema::schema();
+  TEST_EQUAL(schema->num_fields(), 20)
+
+  // Required (non-nullable) fields
+  TEST_EQUAL(schema->GetFieldByName("pg_accessions")->nullable(), false)
+  TEST_EQUAL(schema->GetFieldByName("anchor_protein")->nullable(), false)
+  TEST_EQUAL(schema->GetFieldByName("run_file_name")->nullable(), false)
+  TEST_EQUAL(schema->GetFieldByName("is_decoy")->nullable(), false)
+  TEST_EQUAL(schema->GetFieldByName("peptides")->nullable(), false)
+
+  // Nullable (optional) fields
+  TEST_EQUAL(schema->GetFieldByName("intensities")->nullable(), true)
+  TEST_EQUAL(schema->GetFieldByName("additional_intensities")->nullable(), true)
+  TEST_EQUAL(schema->GetFieldByName("global_qvalue")->nullable(), true)
+  TEST_EQUAL(schema->GetFieldByName("pg_qvalue")->nullable(), true)
+}
+END_SECTION
+
+START_SECTION(ProteinGroupArrowExport::exportToArrow(vector<ProteinIdentification>, PeptideIdentificationList))
+{
+  // Set up minimal protein identification with one group
+  ProteinIdentification prot_id;
+  prot_id.setPrimaryMSRunPath({"test_run.mzML"});
+  ProteinHit hit1;
+  hit1.setAccession("PROT_A");
+  hit1.setScore(0.99);
+  hit1.setTargetDecoyType(ProteinHit::TargetDecoyType::TARGET);
+  ProteinHit hit2;
+  hit2.setAccession("PROT_B");
+  hit2.setScore(0.95);
+  hit2.setTargetDecoyType(ProteinHit::TargetDecoyType::TARGET);
+  prot_id.setHits({hit1, hit2});
+  prot_id.setScoreType("Mascot");
+  prot_id.setHigherScoreBetter(true);
+
+  ProteinIdentification::ProteinGroup group;
+  group.accessions = {"PROT_A", "PROT_B"};
+  group.probability = 0.01;
+  prot_id.insertIndistinguishableProteins(group);
+
+  // Set up peptide identifications
+  PeptideIdentification pep_id;
+  PeptideHit pep_hit;
+  pep_hit.setSequence(AASequence::fromString("PEPTIDE"));
+  PeptideEvidence ev;
+  ev.setProteinAccession("PROT_A");
+  pep_hit.setPeptideEvidences({ev});
+  pep_id.setHits({pep_hit});
+  PeptideIdentificationList pep_ids = {pep_id};
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, pep_ids);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 1)
+  TEST_EQUAL(table->num_columns(), 20)
+
+  // Verify run_file_name is derived from ProteinIdentification
+  auto run_col = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("run_file_name")->chunk(0));
+  TEST_STRING_EQUAL(run_col->GetString(0), "test_run.mzML")
+
+  // Verify anchor_protein
+  auto anchor_col = std::static_pointer_cast<arrow::StringArray>(table->GetColumnByName("anchor_protein")->chunk(0));
+  TEST_STRING_EQUAL(anchor_col->GetString(0), "PROT_A")
+
+  // Verify intensities is null (no quantification)
+  auto int_col = table->GetColumnByName("intensities")->chunk(0);
+  TEST_EQUAL(int_col->IsNull(0), true)
+}
+END_SECTION
+
+START_SECTION(ProteinGroupArrowExport::exportToArrow empty groups)
+{
+  ProteinIdentification prot_id;
+  prot_id.setPrimaryMSRunPath({"test.mzML"});
+  PeptideIdentificationList pep_ids;
+
+  auto table = ProteinGroupArrowExport::exportToArrow({prot_id}, pep_ids);
+  TEST_NOT_EQUAL(table, nullptr)
+  TEST_EQUAL(table->num_rows(), 0)
+  TEST_EQUAL(table->num_columns(), 20)
 }
 END_SECTION
 

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2902,7 +2902,7 @@ set_tests_properties("TOPP_SimpleSearchEngine_2_out" PROPERTIES DEPENDS
 # ProSE:
 add_test("TOPP_ProSE_1" ${TOPP_BIN_PATH}/ProSE -test
 -ini ${DATA_DIR_TOPP}/ProSE_1.ini -in
-${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML -out ${TESTS_TEMP_DIR}/ProSE_1_out.tmp.idXML
+${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML -out_idxml ${TESTS_TEMP_DIR}/ProSE_1_out.tmp.idXML
 -database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
 add_test("TOPP_ProSE_1_out" ${DIFF} -in1 ${TESTS_TEMP_DIR}/ProSE_1_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/ProSE_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=")
 set_tests_properties("TOPP_ProSE_1_out" PROPERTIES DEPENDS
@@ -2910,26 +2910,39 @@ set_tests_properties("TOPP_ProSE_1_out" PROPERTIES DEPENDS
 
 add_test("TOPP_ProSE_2" ${TOPP_BIN_PATH}/ProSE -test
 -ini ${DATA_DIR_TOPP}/ProSE_2.ini -in
-${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML -out ${TESTS_TEMP_DIR}/ProSE_2_out.tmp.idXML
+${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML -out_idxml ${TESTS_TEMP_DIR}/ProSE_2_out.tmp.idXML
 -database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
 add_test("TOPP_ProSE_2_out" ${DIFF} -in1 ${TESTS_TEMP_DIR}/ProSE_2_out.tmp.idXML -in2 ${DATA_DIR_TOPP}/ProSE_2_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=")
 set_tests_properties("TOPP_ProSE_2_out" PROPERTIES DEPENDS
 "TOPP_ProSE_2")
 
-# Multi-file test: search two mzML inputs (here the same file twice for simplicity)
-# against the same FASTA in a single invocation. The fragment index is built once
-# and reused. The first output is idXML (compared against the _1 reference), the
-# second output is QPX PSM parquet (smoke-tested via sha256sum which fails if the
-# file does not exist).
+# Multi-file test: single-file idXML output
 add_test("TOPP_ProSE_3_multi" ${TOPP_BIN_PATH}/ProSE -test
--ini ${DATA_DIR_TOPP}/ProSE_1.ini
--in ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML
--out ${TESTS_TEMP_DIR}/ProSE_3_multi_a.tmp.idXML ${TESTS_TEMP_DIR}/ProSE_3_multi_b.tmp.parquet
--database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
-add_test("TOPP_ProSE_3_multi_idXML_out" ${DIFF} -in1 ${TESTS_TEMP_DIR}/ProSE_3_multi_a.tmp.idXML -in2 ${DATA_DIR_TOPP}/ProSE_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=")
+  -ini ${DATA_DIR_TOPP}/ProSE_1.ini
+  -in ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML
+  -out_idxml ${TESTS_TEMP_DIR}/ProSE_3_multi_a.tmp.idXML
+  -database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
+add_test("TOPP_ProSE_3_multi_idXML_out" ${DIFF}
+  -in1 ${TESTS_TEMP_DIR}/ProSE_3_multi_a.tmp.idXML
+  -in2 ${DATA_DIR_TOPP}/ProSE_1_out.idXML
+  -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=")
 set_tests_properties("TOPP_ProSE_3_multi_idXML_out" PROPERTIES DEPENDS "TOPP_ProSE_3_multi")
-add_test(NAME "TOPP_ProSE_3_multi_parquet_out" COMMAND ${CMAKE_COMMAND} -E sha256sum ${TESTS_TEMP_DIR}/ProSE_3_multi_b.tmp.parquet)
-set_tests_properties("TOPP_ProSE_3_multi_parquet_out" PROPERTIES DEPENDS "TOPP_ProSE_3_multi")
+
+# Test 3b: QPX directory output (smoke test — check files exist)
+add_test("TOPP_ProSE_3_qpx" ${TOPP_BIN_PATH}/ProSE -test
+  -ini ${DATA_DIR_TOPP}/ProSE_1.ini
+  -in ${DATA_DIR_TOPP}/SimpleSearchEngine_1.mzML
+  -out_qpx ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir
+  -database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
+add_test(NAME "TOPP_ProSE_3_qpx_psm_exists" COMMAND ${CMAKE_COMMAND} -E sha256sum
+  ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir/SimpleSearchEngine_1.psm.parquet)
+set_tests_properties("TOPP_ProSE_3_qpx_psm_exists" PROPERTIES DEPENDS "TOPP_ProSE_3_qpx")
+add_test(NAME "TOPP_ProSE_3_qpx_pg_exists" COMMAND ${CMAKE_COMMAND} -E sha256sum
+  ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir/SimpleSearchEngine_1.pg.parquet)
+set_tests_properties("TOPP_ProSE_3_qpx_pg_exists" PROPERTIES DEPENDS "TOPP_ProSE_3_qpx")
+add_test(NAME "TOPP_ProSE_3_qpx_merged_exists" COMMAND ${CMAKE_COMMAND} -E sha256sum
+  ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir/quantms.psm.parquet)
+set_tests_properties("TOPP_ProSE_3_qpx_merged_exists" PROPERTIES DEPENDS "TOPP_ProSE_3_qpx")
 
 # Asymmetric precursor window + calibration bias preservation end-to-end test.
 # Uses SimpleSearchEngine_1_shifted_7ppm.mzML (all MS2 precursors multiplied by
@@ -2943,7 +2956,7 @@ set_tests_properties("TOPP_ProSE_3_multi_parquet_out" PROPERTIES DEPENDS "TOPP_P
 add_test("TOPP_ProSE_4" ${TOPP_BIN_PATH}/ProSE -test
   -ini ${DATA_DIR_TOPP}/ProSE_4.ini
   -in ${DATA_DIR_TOPP}/SimpleSearchEngine_1_shifted_7ppm.mzML
-  -out ${TESTS_TEMP_DIR}/ProSE_4_out.tmp.idXML
+  -out_idxml ${TESTS_TEMP_DIR}/ProSE_4_out.tmp.idXML
   -database ${DATA_DIR_TOPP}/SimpleSearchEngine_1.fasta)
 add_test("TOPP_ProSE_4_out" ${DIFF}
   -in1 ${TESTS_TEMP_DIR}/ProSE_4_out.tmp.idXML
@@ -2987,7 +3000,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
   add_test("TOPP_ProSE_DDA" ${TOPP_BIN_PATH}/ProSE -test
     -in ${OPENTIMS_DDA_SYMLINK}
     -database ${OPENTIMS_TEST_FASTA}
-    -out ${TESTS_TEMP_DIR}/ProSE_DDA_out.tmp.idXML
+    -out_idxml ${TESTS_TEMP_DIR}/ProSE_DDA_out.tmp.idXML
     -Search:precursor:mass_tolerance_lower 20
     -Search:precursor:mass_tolerance_upper 20
     -Search:precursor:mass_tolerance_unit ppm
@@ -3009,7 +3022,7 @@ if (WITH_OPENTIMS AND OPENTIMS_DDA_TEST_DATA)
   add_test("TOPP_ProSE_DDA_calibrated" ${TOPP_BIN_PATH}/ProSE -test
     -in ${OPENTIMS_DDA_SYMLINK}
     -database ${OPENTIMS_TEST_FASTA}
-    -out ${TESTS_TEMP_DIR}/ProSE_DDA_calibrated_out.tmp.idXML
+    -out_idxml ${TESTS_TEMP_DIR}/ProSE_DDA_calibrated_out.tmp.idXML
     -Search:precursor:mass_tolerance_lower 20
     -Search:precursor:mass_tolerance_upper 20
     -Search:precursor:mass_tolerance_unit ppm

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -2943,6 +2943,9 @@ set_tests_properties("TOPP_ProSE_3_qpx_pg_exists" PROPERTIES DEPENDS "TOPP_ProSE
 add_test(NAME "TOPP_ProSE_3_qpx_merged_exists" COMMAND ${CMAKE_COMMAND} -E sha256sum
   ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir/quantms.psm.parquet)
 set_tests_properties("TOPP_ProSE_3_qpx_merged_exists" PROPERTIES DEPENDS "TOPP_ProSE_3_qpx")
+add_test(NAME "TOPP_ProSE_3_qpx_merged_pg_exists" COMMAND ${CMAKE_COMMAND} -E sha256sum
+  ${TESTS_TEMP_DIR}/ProSE_3_qpx_dir/quantms.pg.parquet)
+set_tests_properties("TOPP_ProSE_3_qpx_merged_pg_exists" PROPERTIES DEPENDS "TOPP_ProSE_3_qpx")
 
 # Asymmetric precursor window + calibration bias preservation end-to-end test.
 # Uses SimpleSearchEngine_1_shifted_7ppm.mzML (all MS2 precursors multiplied by

--- a/src/tests/topp/ProSE_1.ini
+++ b/src/tests/topp/ProSE_1.ini
@@ -5,7 +5,7 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
+      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/tests/topp/ProSE_1.ini
+++ b/src/tests/topp/ProSE_1.ini
@@ -5,7 +5,8 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
+      <ITEMLIST name="out_idxml" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML">
+      </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/tests/topp/ProSE_2.ini
+++ b/src/tests/topp/ProSE_2.ini
@@ -5,7 +5,7 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
+      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/tests/topp/ProSE_2.ini
+++ b/src/tests/topp/ProSE_2.ini
@@ -5,7 +5,8 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
+      <ITEMLIST name="out_idxml" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML">
+      </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/tests/topp/ProSE_4.ini
+++ b/src/tests/topp/ProSE_4.ini
@@ -5,7 +5,7 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out" value="" type="output-file" description="output file " required="true" advanced="false" supported_formats="*.idXML" />
+      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/tests/topp/ProSE_4.ini
+++ b/src/tests/topp/ProSE_4.ini
@@ -5,7 +5,8 @@
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;ProSE&apos;">
       <ITEM name="in" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="database" value="" type="input-file" description="input file " required="true" advanced="false" supported_formats="*.fasta" />
-      <ITEM name="out_idxml" value="" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML" />
+      <ITEMLIST name="out_idxml" type="output-file" description="output file " required="false" advanced="false" supported_formats="*.idXML">
+      </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool (0 = all available cores)" required="false" advanced="false" />

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -17,12 +17,21 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
 #include <OpenMS/FORMAT/QPXFile.h>
+#include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
+#include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
+#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 
+#include <arrow/api.h>
+#include <arrow/io/file.h>
+#include <parquet/arrow/writer.h>
+#include <parquet/properties.h>
+
 #include <map>
+#include <set>
 
 using namespace OpenMS;
 using namespace std;
@@ -86,8 +95,12 @@ class ProSE :
       registerInputFile_("database", "<file>", "", "Input protein sequence database in FASTA format.");
       setValidFormats_("database", ListUtils::create<String>("fasta"));
 
-      registerOutputFileList_("out", "<files>", StringList(), "Output identification file(s). Must have the same number of entries as -in. Output format is auto-detected per file from the extension (.idXML or .parquet); a mix of formats within one run is allowed.");
-      setValidFormats_("out", ListUtils::create<String>("idXML,parquet"));
+      registerOutputFileList_("out_idxml", "<files>", StringList(), "Output idXML identification file(s). Must have the same number of entries as -in.", false);
+      setValidFormats_("out_idxml", ListUtils::create<String>("idXML"));
+
+      registerOutputDir_("out_qpx", "<dir>", "", "Output directory for QPX exchange format Parquet files. Writes per-input <basename>.psm.parquet and <basename>.pg.parquet, plus merged quantms.psm.parquet and quantms.pg.parquet.", false, true);
+
+      registerOutputDir_("out_parquet", "<dir>", "", "Output directory for OpenMS internal format Parquet files. Writes per-input <basename>.psm/proteins/pg/search_params.parquet, plus merged openms.* files.", false, true);
 
       registerOutputFile_("out_merged", "<file>", "", "Optional merged output file containing all PSMs pooled across input files with cross-file protein inference (BasicProteinInferenceAlgorithm) and optional picked-protein FDR (FDR:protein). Per-file outputs (-out) retain run-level information. Only useful with multiple -in files.", false);
       setValidFormats_("out_merged", ListUtils::create<String>("idXML"));
@@ -112,8 +125,10 @@ class ProSE :
     {
       const StringList in_list = getStringList_("in");
       const String database = getStringOption_("database");
-      const StringList out_list = getStringList_("out");
+      const StringList out_idxml_list = getStringList_("out_idxml");
       const String out_merged = getStringOption_("out_merged");
+      const String out_qpx_dir = getOutputDirOption("out_qpx");
+      const String out_parquet_dir = getOutputDirOption("out_parquet");
       // getOutputDirOption auto-creates the directory if it doesn't exist (and returns "" if unset).
       const String out_mod_analysis_dir = getOutputDirOption("out_mod_analysis_dir");
 
@@ -123,25 +138,34 @@ class ProSE :
         return ILLEGAL_PARAMETERS;
       }
 
-      if (in_list.size() != out_list.size())
+      // At least one output must be specified
+      if (out_idxml_list.empty() && out_qpx_dir.empty() && out_parquet_dir.empty())
       {
-        OPENMS_LOG_ERROR << "Number of output files (-out, " << out_list.size()
+        OPENMS_LOG_ERROR << "No output specified. Provide at least one of -out_idxml, -out_qpx, or -out_parquet." << endl;
+        return ILLEGAL_PARAMETERS;
+      }
+
+      // -out_idxml count must match -in count
+      if (!out_idxml_list.empty() && in_list.size() != out_idxml_list.size())
+      {
+        OPENMS_LOG_ERROR << "Number of output files (-out_idxml, " << out_idxml_list.size()
                          << ") must match number of input files (-in, " << in_list.size() << ")." << endl;
         return ILLEGAL_PARAMETERS;
       }
 
-      // Pre-flight validate every -out file extension before running the search,
-      // so the user learns about a typo (e.g. ".idxml" -> "idxml") before paying the
-      // index-build + search cost. registerOutputFileList_ does NOT validate per-entry
-      // formats at the CLI layer, so we have to do it here.
-      for (const String& out_file : out_list)
+      // Validate basenames are unique (for parquet directory output)
+      if (!out_qpx_dir.empty() || !out_parquet_dir.empty())
       {
-        const FileTypes::Type out_type = FileHandler::getTypeByFileName(out_file);
-        if (out_type != FileTypes::IDXML && out_type != FileTypes::PARQUET)
+        std::set<std::string> basenames;
+        for (const auto& in_file : in_list)
         {
-          OPENMS_LOG_ERROR << "Unsupported output format for '" << out_file
-                           << "' (expected .idXML or .parquet)." << endl;
-          return ILLEGAL_PARAMETERS;
+          std::string bn = File::stemName(in_file);
+          if (!basenames.insert(bn).second)
+          {
+            OPENMS_LOG_ERROR << "Duplicate input basename '" << bn
+                             << "'. Parquet directory output requires unique basenames." << endl;
+            return ILLEGAL_PARAMETERS;
+          }
         }
       }
 
@@ -368,11 +392,37 @@ class ProSE :
       }
 
       // Write per-file outputs and track failures.
+      // Accumulate Arrow tables for merged parquet output.
+      std::vector<std::shared_ptr<arrow::Table>> qpx_psm_tables, qpx_pg_tables;
+      std::vector<std::shared_ptr<arrow::Table>> oms_psm_tables, oms_prot_tables, oms_pg_tables, oms_sp_tables;
+
+      // Helper: write an Arrow table to a Parquet file with default settings
+      auto writeTableToParquet = [](const std::shared_ptr<arrow::Table>& table, const String& filename) -> bool
+      {
+        auto file_result = arrow::io::FileOutputStream::Open(filename);
+        if (!file_result.ok())
+        {
+          OPENMS_LOG_ERROR << "Failed to open " << filename << " for writing" << endl;
+          return false;
+        }
+        auto props = parquet::WriterProperties::Builder()
+          .compression(arrow::Compression::ZSTD)->compression_level(3)
+          ->enable_statistics()->data_pagesize(1024 * 1024)->build();
+        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
+        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(),
+          file_result.ValueOrDie(), 128 * 1024 * 1024, props, arrow_props);
+        if (!status.ok())
+        {
+          OPENMS_LOG_ERROR << "Failed to write parquet " << filename << ": " << status.ToString() << endl;
+          return false;
+        }
+        return true;
+      };
+
       Size failed_count = 0;
       for (Size i = 0; i < in_list.size(); ++i)
       {
         const String& in_file = in_list[i];
-        const String& out_file = out_list[i];
         ProSEAlgorithm::SearchResult& result = mfres.per_file[i];
 
         if (result.exit_code != ProSEAlgorithm::ExitCodes::EXECUTION_OK)
@@ -383,27 +433,121 @@ class ProSE :
           continue;
         }
 
+        const String basename = File::stemName(in_file);
+
         // In test mode, replace the absolute MS run path with file://<basename> for reproducible diffs.
         if (getFlag_("test") && !result.protein_ids.empty())
         {
           result.protein_ids[0].setPrimaryMSRunPath({"file://" + File::basename(in_file)});
         }
 
-        // Dispatch on output extension (already validated above to be IDXML or PARQUET).
-        const FileTypes::Type out_type = FileHandler::getTypeByFileName(out_file);
-        if (out_type == FileTypes::IDXML)
+        // -- idXML output --
+        if (!out_idxml_list.empty())
         {
-          FileHandler().storeIdentifications(out_file, result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+          FileHandler().storeIdentifications(out_idxml_list[i], result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
         }
-        else // FileTypes::PARQUET
+
+        // -- QPX directory output --
+        if (!out_qpx_dir.empty())
         {
-          if (!QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, out_file, /*export_all_psms=*/false))
+          // PSM
+          const String qpx_psm_file = out_qpx_dir + "/" + basename + ".psm.parquet";
+          if (!QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, qpx_psm_file, /*export_all_psms=*/false))
           {
-            OPENMS_LOG_ERROR << "Failed to write parquet output for " << in_file << " -> " << out_file << endl;
-            ++failed_count;
-            continue;
+            OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << endl;
+            ++failed_count; continue;
+          }
+          auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
+          if (qpx_psm_table) qpx_psm_tables.push_back(qpx_psm_table);
+
+          // Protein groups
+          const String qpx_pg_file = out_qpx_dir + "/" + basename + ".pg.parquet";
+          if (!ProteinGroupArrowExport::exportToParquet(result.protein_ids, result.peptide_ids, qpx_pg_file))
+          {
+            OPENMS_LOG_ERROR << "Failed to write QPX PG parquet for " << in_file << endl;
+            ++failed_count; continue;
+          }
+          auto qpx_pg_table = ProteinGroupArrowExport::exportToArrow(result.protein_ids, result.peptide_ids);
+          if (qpx_pg_table) qpx_pg_tables.push_back(qpx_pg_table);
+        }
+
+        // -- OpenMS internal directory output --
+        if (!out_parquet_dir.empty())
+        {
+          bool ok = true;
+
+          // PSM (internal schema)
+          const String oms_psm_file = out_parquet_dir + "/" + basename + ".psm.parquet";
+          auto oms_psm_table = QPXFile::exportToArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
+          if (oms_psm_table)
+          {
+            oms_psm_tables.push_back(oms_psm_table);
+            ok = writeTableToParquet(oms_psm_table, oms_psm_file) && ok;
+          }
+
+          // Proteins
+          auto prot_table = ProteinIdentificationArrowIO::exportProteinsToArrow(result.protein_ids);
+          if (prot_table)
+          {
+            oms_prot_tables.push_back(prot_table);
+            ok = ProteinIdentificationArrowIO::exportProteinsToParquet(
+              result.protein_ids, out_parquet_dir + "/" + basename + ".proteins.parquet") && ok;
+          }
+
+          // Protein groups
+          auto pg_table = ProteinIdentificationArrowIO::exportProteinGroupsToArrow(result.protein_ids);
+          if (pg_table)
+          {
+            oms_pg_tables.push_back(pg_table);
+            ok = ProteinIdentificationArrowIO::exportProteinGroupsToParquet(
+              result.protein_ids, out_parquet_dir + "/" + basename + ".pg.parquet") && ok;
+          }
+
+          // Search params
+          auto sp_table = ProteinIdentificationArrowIO::exportSearchParamsToArrow(result.protein_ids);
+          if (sp_table)
+          {
+            oms_sp_tables.push_back(sp_table);
+            ok = ProteinIdentificationArrowIO::exportSearchParamsToParquet(
+              result.protein_ids, out_parquet_dir + "/" + basename + ".search_params.parquet") && ok;
+          }
+
+          if (!ok)
+          {
+            OPENMS_LOG_ERROR << "Failed to write one or more internal parquet files for " << in_file << endl;
+            ++failed_count; continue;
           }
         }
+      }
+
+      // -- Write merged Parquet files --
+      auto concatAndWrite = [&writeTableToParquet](const std::vector<std::shared_ptr<arrow::Table>>& tables,
+                               const String& filename) -> bool
+      {
+        if (tables.empty()) return true;
+        auto concat_result = arrow::ConcatenateTables(tables);
+        if (!concat_result.ok())
+        {
+          OPENMS_LOG_ERROR << "Failed to concatenate tables for " << filename << ": "
+                           << concat_result.status().ToString() << endl;
+          return false;
+        }
+        return writeTableToParquet(concat_result.ValueOrDie(), filename);
+      };
+
+      // Always write merged files (even for single input — provides a canonical name).
+      if (!out_qpx_dir.empty())
+      {
+        concatAndWrite(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet");
+        concatAndWrite(qpx_pg_tables, out_qpx_dir + "/quantms.pg.parquet");
+      }
+
+      if (!out_parquet_dir.empty())
+      {
+        concatAndWrite(oms_psm_tables, out_parquet_dir + "/openms.psm.parquet");
+        concatAndWrite(oms_prot_tables, out_parquet_dir + "/openms.proteins.parquet");
+        concatAndWrite(oms_pg_tables, out_parquet_dir + "/openms.pg.parquet");
+        concatAndWrite(oms_sp_tables, out_parquet_dir + "/openms.search_params.parquet");
       }
 
       if (failed_count > 0)

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -99,7 +99,7 @@ class ProSE :
 
       registerOutputDir_("out_parquet", "<dir>", "", "Output directory for OpenMS internal format Parquet files. Writes per-input <basename>.psm/proteins/pg/search_params.parquet, plus merged openms.* files.", false, true);
 
-      registerOutputFile_("out_merged", "<file>", "", "Optional merged output file containing all PSMs pooled across input files with cross-file protein inference (BasicProteinInferenceAlgorithm) and optional picked-protein FDR (FDR:protein). Per-file outputs (-out) retain run-level information. Only useful with multiple -in files.", false);
+      registerOutputFile_("out_merged", "<file>", "", "Optional merged output file containing all PSMs pooled across input files with cross-file protein inference (BasicProteinInferenceAlgorithm) and optional picked-protein FDR (FDR:protein). Per-file outputs (-out_idxml / -out_qpx / -out_parquet) retain run-level information. Only useful with multiple -in files.", false);
       setValidFormats_("out_merged", ListUtils::create<String>("idXML"));
 
       registerOutputDir_("out_mod_analysis_dir", "<dir>", "", "Optional directory to write modification-analysis tables (delta-mass, PTM stats) when running in open-search mode. When set, per-file tables are written using each input file's basename and an additional aggregate table is written across all input files. Has no effect in closed-search mode.", false, true);
@@ -334,7 +334,7 @@ class ProSE :
 
       // Write merged output: pool all per-file PSMs (possibly Percolator-rescored),
       // run cross-file protein inference + optional protein FDR, write to -out_merged.
-      // Per-file outputs (-out) are NOT modified — they retain run-level information.
+      // Per-file outputs (-out_idxml/-out_qpx/-out_parquet) are NOT modified — they retain run-level information.
       if (!out_merged.empty() && in_list.size() > 1)
       {
         const String decoy_prefix = search_params.getValue("decoy_prefix").toString();
@@ -415,83 +415,132 @@ class ProSE :
           result.protein_ids[0].setPrimaryMSRunPath({"file://" + File::basename(in_file)});
         }
 
+        // Output modes are independent: a failure in one mode must not skip the
+        // sibling modes for the same input. Each mode contributes at most one
+        // failure to input_failed; the input counts as failed if any mode failed.
+        bool input_failed = false;
+
         // -- idXML output --
         if (!out_idxml_list.empty())
         {
-          FileHandler().storeIdentifications(out_idxml_list[i], result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+          try
+          {
+            FileHandler().storeIdentifications(out_idxml_list[i], result.protein_ids, result.peptide_ids, {FileTypes::IDXML});
+          }
+          catch (const Exception::BaseException& e)
+          {
+            OPENMS_LOG_ERROR << "Failed to write idXML output for " << in_file
+                             << " -> " << out_idxml_list[i] << ": " << e.what() << endl;
+            input_failed = true;
+          }
         }
 
         // -- QPX directory output --
         if (!out_qpx_dir.empty())
         {
-          // PSM
+          // PSM — write file and accumulate table for merge independently.
+          // Accumulation uses a freshly-built table (exportToParquet rebuilds internally).
           const String qpx_psm_file = out_qpx_dir + "/" + basename + ".psm.parquet";
-          if (!QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, qpx_psm_file, /*export_all_psms=*/false))
+          if (QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, qpx_psm_file, /*export_all_psms=*/false))
           {
-            OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << endl;
-            ++failed_count; continue;
+            auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
+            if (qpx_psm_table) { qpx_psm_tables.push_back(qpx_psm_table); }
+            else { OPENMS_LOG_WARN << "QPX PSM table build returned null for " << in_file << " (merged quantms.psm.parquet will not include this run)" << endl; }
           }
-          auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
-          if (qpx_psm_table) qpx_psm_tables.push_back(qpx_psm_table);
+          else
+          {
+            OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << " -> " << qpx_psm_file << endl;
+            input_failed = true;
+          }
 
-          // Protein groups
+          // Protein groups — independent of PSM result.
           const String qpx_pg_file = out_qpx_dir + "/" + basename + ".pg.parquet";
-          if (!ProteinGroupArrowExport::exportToParquet(result.protein_ids, result.peptide_ids, qpx_pg_file))
+          if (ProteinGroupArrowExport::exportToParquet(result.protein_ids, result.peptide_ids, qpx_pg_file))
           {
-            OPENMS_LOG_ERROR << "Failed to write QPX PG parquet for " << in_file << endl;
-            ++failed_count; continue;
+            auto qpx_pg_table = ProteinGroupArrowExport::exportToArrow(result.protein_ids, result.peptide_ids);
+            if (qpx_pg_table) { qpx_pg_tables.push_back(qpx_pg_table); }
+            else { OPENMS_LOG_WARN << "QPX PG table build returned null for " << in_file << " (merged quantms.pg.parquet will not include this run)" << endl; }
           }
-          auto qpx_pg_table = ProteinGroupArrowExport::exportToArrow(result.protein_ids, result.peptide_ids);
-          if (qpx_pg_table) qpx_pg_tables.push_back(qpx_pg_table);
+          else
+          {
+            OPENMS_LOG_ERROR << "Failed to write QPX PG parquet for " << in_file << " -> " << qpx_pg_file << endl;
+            input_failed = true;
+          }
         }
 
         // -- OpenMS internal directory output --
         if (!out_parquet_dir.empty())
         {
-          bool ok = true;
-
-          // PSM (internal schema)
+          // PSM (internal PSMSchema) — build once, write, accumulate for merge.
           const String oms_psm_file = out_parquet_dir + "/" + basename + ".psm.parquet";
           auto oms_psm_table = QPXFile::exportToArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
           if (oms_psm_table)
           {
             oms_psm_tables.push_back(oms_psm_table);
-            ok = ArrowIOHelpers::writeTableToParquet(oms_psm_table, oms_psm_file) && ok;
+            if (!ArrowIOHelpers::writeTableToParquet(oms_psm_table, oms_psm_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write internal PSM parquet for " << in_file << " -> " << oms_psm_file << endl;
+              input_failed = true;
+            }
+          }
+          else
+          {
+            OPENMS_LOG_WARN << "Internal PSM table build returned null for " << in_file << " — skipping " << oms_psm_file << endl;
           }
 
           // Proteins
+          const String oms_prot_file = out_parquet_dir + "/" + basename + ".proteins.parquet";
           auto prot_table = ProteinIdentificationArrowIO::exportProteinsToArrow(result.protein_ids);
           if (prot_table)
           {
             oms_prot_tables.push_back(prot_table);
-            ok = ProteinIdentificationArrowIO::exportProteinsToParquet(
-              result.protein_ids, out_parquet_dir + "/" + basename + ".proteins.parquet") && ok;
+            if (!ProteinIdentificationArrowIO::exportProteinsToParquet(result.protein_ids, oms_prot_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write proteins parquet for " << in_file << " -> " << oms_prot_file << endl;
+              input_failed = true;
+            }
+          }
+          else
+          {
+            OPENMS_LOG_WARN << "Proteins table build returned null for " << in_file << " — skipping " << oms_prot_file << endl;
           }
 
           // Protein groups
+          const String oms_pg_file = out_parquet_dir + "/" + basename + ".pg.parquet";
           auto pg_table = ProteinIdentificationArrowIO::exportProteinGroupsToArrow(result.protein_ids);
           if (pg_table)
           {
             oms_pg_tables.push_back(pg_table);
-            ok = ProteinIdentificationArrowIO::exportProteinGroupsToParquet(
-              result.protein_ids, out_parquet_dir + "/" + basename + ".pg.parquet") && ok;
+            if (!ProteinIdentificationArrowIO::exportProteinGroupsToParquet(result.protein_ids, oms_pg_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write protein groups parquet for " << in_file << " -> " << oms_pg_file << endl;
+              input_failed = true;
+            }
+          }
+          else
+          {
+            OPENMS_LOG_WARN << "Protein groups table build returned null for " << in_file << " — skipping " << oms_pg_file << endl;
           }
 
           // Search params
+          const String oms_sp_file = out_parquet_dir + "/" + basename + ".search_params.parquet";
           auto sp_table = ProteinIdentificationArrowIO::exportSearchParamsToArrow(result.protein_ids);
           if (sp_table)
           {
             oms_sp_tables.push_back(sp_table);
-            ok = ProteinIdentificationArrowIO::exportSearchParamsToParquet(
-              result.protein_ids, out_parquet_dir + "/" + basename + ".search_params.parquet") && ok;
+            if (!ProteinIdentificationArrowIO::exportSearchParamsToParquet(result.protein_ids, oms_sp_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write search params parquet for " << in_file << " -> " << oms_sp_file << endl;
+              input_failed = true;
+            }
           }
-
-          if (!ok)
+          else
           {
-            OPENMS_LOG_ERROR << "Failed to write one or more internal parquet files for " << in_file << endl;
-            ++failed_count; continue;
+            OPENMS_LOG_WARN << "Search params table build returned null for " << in_file << " — skipping " << oms_sp_file << endl;
           }
         }
+
+        if (input_failed) { ++failed_count; }
       }
 
       // -- Write merged Parquet files --

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // --------------------------------------------------------------------------
-// $Maintainer:  $
-// $Authors:  $
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/ID/ProSEAlgorithm.h>
@@ -19,16 +19,13 @@
 #include <OpenMS/FORMAT/QPXFile.h>
 #include <OpenMS/FORMAT/ProteinGroupArrowExport.h>
 #include <OpenMS/FORMAT/ProteinIdentificationArrowIO.h>
-#include <OpenMS/FORMAT/ArrowSchemaRegistry.h>
+#include <OpenMS/FORMAT/ArrowIOHelpers.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 
-#include <arrow/api.h>
-#include <arrow/io/file.h>
-#include <parquet/arrow/writer.h>
-#include <parquet/properties.h>
+#include <arrow/table.h>  // only for std::shared_ptr<arrow::Table> declarations
 
 #include <map>
 #include <set>
@@ -396,29 +393,6 @@ class ProSE :
       std::vector<std::shared_ptr<arrow::Table>> qpx_psm_tables, qpx_pg_tables;
       std::vector<std::shared_ptr<arrow::Table>> oms_psm_tables, oms_prot_tables, oms_pg_tables, oms_sp_tables;
 
-      // Helper: write an Arrow table to a Parquet file with default settings
-      auto writeTableToParquet = [](const std::shared_ptr<arrow::Table>& table, const String& filename) -> bool
-      {
-        auto file_result = arrow::io::FileOutputStream::Open(filename);
-        if (!file_result.ok())
-        {
-          OPENMS_LOG_ERROR << "Failed to open " << filename << " for writing" << endl;
-          return false;
-        }
-        auto props = parquet::WriterProperties::Builder()
-          .compression(arrow::Compression::ZSTD)->compression_level(3)
-          ->enable_statistics()->data_pagesize(1024 * 1024)->build();
-        auto arrow_props = parquet::ArrowWriterProperties::Builder().store_schema()->build();
-        auto status = parquet::arrow::WriteTable(*table, arrow::default_memory_pool(),
-          file_result.ValueOrDie(), 128 * 1024 * 1024, props, arrow_props);
-        if (!status.ok())
-        {
-          OPENMS_LOG_ERROR << "Failed to write parquet " << filename << ": " << status.ToString() << endl;
-          return false;
-        }
-        return true;
-      };
-
       Size failed_count = 0;
       for (Size i = 0; i < in_list.size(); ++i)
       {
@@ -482,7 +456,7 @@ class ProSE :
           if (oms_psm_table)
           {
             oms_psm_tables.push_back(oms_psm_table);
-            ok = writeTableToParquet(oms_psm_table, oms_psm_file) && ok;
+            ok = ArrowIOHelpers::writeTableToParquet(oms_psm_table, oms_psm_file) && ok;
           }
 
           // Proteins
@@ -521,33 +495,19 @@ class ProSE :
       }
 
       // -- Write merged Parquet files --
-      auto concatAndWrite = [&writeTableToParquet](const std::vector<std::shared_ptr<arrow::Table>>& tables,
-                               const String& filename) -> bool
-      {
-        if (tables.empty()) return true;
-        auto concat_result = arrow::ConcatenateTables(tables);
-        if (!concat_result.ok())
-        {
-          OPENMS_LOG_ERROR << "Failed to concatenate tables for " << filename << ": "
-                           << concat_result.status().ToString() << endl;
-          return false;
-        }
-        return writeTableToParquet(concat_result.ValueOrDie(), filename);
-      };
-
       // Always write merged files (even for single input — provides a canonical name).
       if (!out_qpx_dir.empty())
       {
-        concatAndWrite(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet");
-        concatAndWrite(qpx_pg_tables, out_qpx_dir + "/quantms.pg.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(qpx_pg_tables, out_qpx_dir + "/quantms.pg.parquet");
       }
 
       if (!out_parquet_dir.empty())
       {
-        concatAndWrite(oms_psm_tables, out_parquet_dir + "/openms.psm.parquet");
-        concatAndWrite(oms_prot_tables, out_parquet_dir + "/openms.proteins.parquet");
-        concatAndWrite(oms_pg_tables, out_parquet_dir + "/openms.pg.parquet");
-        concatAndWrite(oms_sp_tables, out_parquet_dir + "/openms.search_params.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(oms_psm_tables, out_parquet_dir + "/openms.psm.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(oms_prot_tables, out_parquet_dir + "/openms.proteins.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(oms_pg_tables, out_parquet_dir + "/openms.pg.parquet");
+        ArrowIOHelpers::concatenateAndWriteToParquet(oms_sp_tables, out_parquet_dir + "/openms.search_params.parquet");
       }
 
       if (failed_count > 0)

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -545,24 +545,30 @@ class ProSE :
 
       // -- Write merged Parquet files --
       // Always write merged files (even for single input — provides a canonical name).
+      bool merged_ok = true;
       if (!out_qpx_dir.empty())
       {
-        ArrowIOHelpers::concatenateAndWriteToParquet(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet");
-        ArrowIOHelpers::concatenateAndWriteToParquet(qpx_pg_tables, out_qpx_dir + "/quantms.pg.parquet");
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(qpx_psm_tables, out_qpx_dir + "/quantms.psm.parquet") && merged_ok;
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(qpx_pg_tables,  out_qpx_dir + "/quantms.pg.parquet")  && merged_ok;
       }
 
       if (!out_parquet_dir.empty())
       {
-        ArrowIOHelpers::concatenateAndWriteToParquet(oms_psm_tables, out_parquet_dir + "/openms.psm.parquet");
-        ArrowIOHelpers::concatenateAndWriteToParquet(oms_prot_tables, out_parquet_dir + "/openms.proteins.parquet");
-        ArrowIOHelpers::concatenateAndWriteToParquet(oms_pg_tables, out_parquet_dir + "/openms.pg.parquet");
-        ArrowIOHelpers::concatenateAndWriteToParquet(oms_sp_tables, out_parquet_dir + "/openms.search_params.parquet");
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(oms_psm_tables,  out_parquet_dir + "/openms.psm.parquet")           && merged_ok;
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(oms_prot_tables, out_parquet_dir + "/openms.proteins.parquet")      && merged_ok;
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(oms_pg_tables,   out_parquet_dir + "/openms.pg.parquet")            && merged_ok;
+        merged_ok = ArrowIOHelpers::concatenateAndWriteToParquet(oms_sp_tables,   out_parquet_dir + "/openms.search_params.parquet") && merged_ok;
       }
 
       if (failed_count > 0)
       {
         OPENMS_LOG_ERROR << "ProSE finished with " << failed_count
                          << " file(s) failing out of " << in_list.size() << "." << endl;
+        return INTERNAL_ERROR;
+      }
+      if (!merged_ok)
+      {
+        OPENMS_LOG_ERROR << "ProSE failed to write one or more merged Parquet files." << endl;
         return INTERNAL_ERROR;
       }
       return EXECUTION_OK;

--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -438,33 +438,38 @@ class ProSE :
         // -- QPX directory output --
         if (!out_qpx_dir.empty())
         {
-          // PSM — write file and accumulate table for merge independently.
-          // Accumulation uses a freshly-built table (exportToParquet rebuilds internally).
+          // PSM — build table once, write to file, accumulate same table for merge.
           const String qpx_psm_file = out_qpx_dir + "/" + basename + ".psm.parquet";
-          if (QPXFile::exportToParquet(result.protein_ids, result.peptide_ids, qpx_psm_file, /*export_all_psms=*/false))
+          auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
+          if (qpx_psm_table)
           {
-            auto qpx_psm_table = QPXFile::exportPSMsToQPXArrow(result.protein_ids, result.peptide_ids, /*export_all_psms=*/false);
-            if (qpx_psm_table) { qpx_psm_tables.push_back(qpx_psm_table); }
-            else { OPENMS_LOG_WARN << "QPX PSM table build returned null for " << in_file << " (merged quantms.psm.parquet will not include this run)" << endl; }
+            qpx_psm_tables.push_back(qpx_psm_table);
+            if (!QPXFile::exportToParquet(qpx_psm_table, qpx_psm_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << " -> " << qpx_psm_file << endl;
+              input_failed = true;
+            }
           }
           else
           {
-            OPENMS_LOG_ERROR << "Failed to write QPX PSM parquet for " << in_file << " -> " << qpx_psm_file << endl;
-            input_failed = true;
+            OPENMS_LOG_WARN << "QPX PSM table build returned null for " << in_file << " — skipping " << qpx_psm_file << endl;
           }
 
           // Protein groups — independent of PSM result.
           const String qpx_pg_file = out_qpx_dir + "/" + basename + ".pg.parquet";
-          if (ProteinGroupArrowExport::exportToParquet(result.protein_ids, result.peptide_ids, qpx_pg_file))
+          auto qpx_pg_table = ProteinGroupArrowExport::exportToArrow(result.protein_ids, result.peptide_ids);
+          if (qpx_pg_table)
           {
-            auto qpx_pg_table = ProteinGroupArrowExport::exportToArrow(result.protein_ids, result.peptide_ids);
-            if (qpx_pg_table) { qpx_pg_tables.push_back(qpx_pg_table); }
-            else { OPENMS_LOG_WARN << "QPX PG table build returned null for " << in_file << " (merged quantms.pg.parquet will not include this run)" << endl; }
+            qpx_pg_tables.push_back(qpx_pg_table);
+            if (!ProteinGroupArrowExport::exportToParquet(qpx_pg_table, qpx_pg_file))
+            {
+              OPENMS_LOG_ERROR << "Failed to write QPX PG parquet for " << in_file << " -> " << qpx_pg_file << endl;
+              input_failed = true;
+            }
           }
           else
           {
-            OPENMS_LOG_ERROR << "Failed to write QPX PG parquet for " << in_file << " -> " << qpx_pg_file << endl;
-            input_failed = true;
+            OPENMS_LOG_WARN << "QPX PG table build returned null for " << in_file << " — skipping " << qpx_pg_file << endl;
           }
         }
 


### PR DESCRIPTION
## Summary

Extends ProSE to support three independent output formats with per-input and merged Parquet files:

- **`-out_idxml`** (file list): per-input idXML output — replaces the old `-out` parameter (breaking change)
- **`-out_qpx`** (directory): QPX exchange format Parquet files (`<basename>.psm.parquet`, `<basename>.pg.parquet`, plus merged `quantms.*`)
- **`-out_parquet`** (directory): OpenMS internal format Parquet files (PSM + proteins + protein groups + search params, plus merged `openms.*`)

At least one output parameter must be specified. Directory outputs require unique input basenames.

## Changes

1. **`QPXPgSchema`** added to `ArrowSchemaRegistry` — matches quantms `pg.yaml` spec; quantification columns are nullable so search-engine-only output is valid (same approach as the quantms mzIdentML converter)
2. **`ProteinGroupArrowExport`** — new overload `exportToArrow/exportToParquet(vector<ProteinIdentification>, PeptideIdentificationList)` that writes QPX `pg.parquet` from search results without a `ConsensusMap`. Derives `run_file_name` from `ProteinIdentification::getPrimaryMSRunPath()`. Returns empty table (never `nullptr`) when no groups exist.
3. **`ProSE.cpp`** — parameter rewiring + per-file output dispatch + post-loop merged concatenation via `arrow::ConcatenateTables`
4. Tests updated: existing TOPP tests renamed to `-out_idxml`; new `TOPP_ProSE_3_qpx` smoke test for QPX directory output; unit tests for `QPXPgSchema` and the new `ProteinGroupArrowExport` overload

## Breaking Change

`-out` is removed (hard rename to `-out_idxml`, no deprecation alias). Downstream scripts and `.ini` files using `-out` will need to be updated.

## Test Plan

- [x] `ctest -R TOPP_ProSE` — all 14 tests pass (including new QPX directory test)
- [x] `ctest -R QPXFile_test` — 7/7 sections pass (including new QPXPgSchema and ProteinGroupArrowExport tests)
- [x] `ctest -R ProteinIdentificationArrowIO_test` — passes
- [ ] Manual verification: run ProSE with `-out_qpx` and `-out_parquet` on a real dataset, inspect Parquet files with pyarrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QPX protein-group schema and id-only export to Arrow/Parquet from identification inputs
  * Added direct export of pre-built QPX PSM/PG Arrow tables to Parquet
  * ProSE CLI: separate outputs for idXML, QPX Parquet (per-input + merged), and internal-schema Parquet; output validation and basename collision checks

* **Tests**
  * Added tests for the protein-group schema, id-only export content/nullability, and empty-group handling

* **Chores**
  * Added helpers to generate UUIDs and write/concatenate Arrow tables to Parquet; updated test/config wiring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->