### PR TITLE
Fix/opentims system install fallback

### DIFF
--- a/cmake/Modules/FindOpentims.cmake
+++ b/cmake/Modules/FindOpentims.cmake
@@ -1,0 +1,64 @@
+# - Try to find opentims (Bruker TimsTOF .d file reading library)
+# Once done this will define:
+#
+#  Opentims_FOUND        - system has opentims
+#  Opentims_INCLUDE_DIR  - the opentims include directory (parent of opentims++/)
+#  Opentims_LIBRARIES    - link these to use opentims
+#
+# And the imported target:
+#  opentims::opentims_cpp
+#
+# Hints:
+#  Set Opentims_ROOT_DIR to the root of a custom installation.
+
+# Prefer a CMake config package produced by opentims's own install rules.
+find_package(opentims CONFIG QUIET
+  HINTS
+    "${Opentims_ROOT_DIR}"
+    "${Opentims_ROOT_DIR}/lib/cmake/opentims"
+)
+if(opentims_FOUND)
+  if(NOT TARGET opentims::opentims_cpp)
+    message(FATAL_ERROR "opentims config package found but target opentims::opentims_cpp is missing")
+  endif()
+  set(Opentims_FOUND TRUE)
+  get_target_property(Opentims_INCLUDE_DIR opentims::opentims_cpp INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(Opentims_LIBRARIES   opentims::opentims_cpp IMPORTED_LOCATION)
+  return()
+endif()
+
+# Fall back to manual search when no config package is present.
+find_path(Opentims_INCLUDE_DIR
+  NAMES opentims++/opentims.h
+  HINTS
+    "${Opentims_ROOT_DIR}/include"
+    "${Opentims_ROOT_DIR}"
+  DOC "opentims include directory (parent of opentims++/)"
+)
+
+find_library(Opentims_LIBRARY
+  NAMES opentims_cpp
+  HINTS
+    "${Opentims_ROOT_DIR}/lib"
+    "${Opentims_ROOT_DIR}"
+  DOC "opentims static library"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Opentims
+  REQUIRED_VARS Opentims_LIBRARY Opentims_INCLUDE_DIR
+)
+
+if(Opentims_FOUND)
+  set(Opentims_LIBRARIES "${Opentims_LIBRARY}")
+
+  if(NOT TARGET opentims::opentims_cpp)
+    add_library(opentims::opentims_cpp STATIC IMPORTED)
+    set_target_properties(opentims::opentims_cpp PROPERTIES
+      IMPORTED_LOCATION             "${Opentims_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Opentims_INCLUDE_DIR}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(Opentims_INCLUDE_DIR Opentims_LIBRARY)

--- a/cmake/Modules/FindOpentims.cmake
+++ b/cmake/Modules/FindOpentims.cmake
@@ -27,7 +27,7 @@ if(opentims_FOUND)
   # configuration-specific locations before giving up.
   get_target_property(Opentims_LIBRARIES opentims::opentims_cpp IMPORTED_LOCATION)
   if(Opentims_LIBRARIES MATCHES "NOTFOUND")
-    foreach(_cfg Release Debug RelWithDebInfo MinSizeRel)
+    foreach(_cfg RELEASE DEBUG RELWITHDEBINFO MINSIZEREL)
       get_target_property(_loc opentims::opentims_cpp "IMPORTED_LOCATION_${_cfg}")
       if(_loc AND NOT _loc MATCHES "NOTFOUND")
         set(Opentims_LIBRARIES "${_loc}")

--- a/cmake/Modules/FindOpentims.cmake
+++ b/cmake/Modules/FindOpentims.cmake
@@ -23,7 +23,21 @@ if(opentims_FOUND)
   endif()
   set(Opentims_FOUND TRUE)
   get_target_property(Opentims_INCLUDE_DIR opentims::opentims_cpp INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(Opentims_LIBRARIES   opentims::opentims_cpp IMPORTED_LOCATION)
+  # IMPORTED_LOCATION is not set on interface-only or alias targets; try
+  # configuration-specific locations before giving up.
+  get_target_property(Opentims_LIBRARIES opentims::opentims_cpp IMPORTED_LOCATION)
+  if(Opentims_LIBRARIES MATCHES "NOTFOUND")
+    foreach(_cfg Release Debug RelWithDebInfo MinSizeRel)
+      get_target_property(_loc opentims::opentims_cpp "IMPORTED_LOCATION_${_cfg}")
+      if(_loc AND NOT _loc MATCHES "NOTFOUND")
+        set(Opentims_LIBRARIES "${_loc}")
+        break()
+      endif()
+    endforeach()
+    if(Opentims_LIBRARIES MATCHES "NOTFOUND")
+      set(Opentims_LIBRARIES "")
+    endif()
+  endif()
   return()
 endif()
 
@@ -53,10 +67,20 @@ if(Opentims_FOUND)
   set(Opentims_LIBRARIES "${Opentims_LIBRARY}")
 
   if(NOT TARGET opentims::opentims_cpp)
+    # NOTE: This manual-import path does not know whether the library was built
+    # with OPENTIMS_LINK_SQLITE_STATICALLY (which requires the caller to supply
+    # sqlite3 headers via Opentims_INCLUDE_DIR and link sqlite3).
+    # INTERFACE_COMPILE_DEFINITIONS is intentionally set to an empty list so
+    # that downstream consumers (e.g. cmake_findExternalLibs.cmake) can
+    # distinguish "property not set at all" (CONFIG target) from "property set
+    # but empty" (manual target) when deciding whether to inject sqlite3.
+    # If OPENTIMS_LINK_SQLITE_STATICALLY is required, override this property or
+    # pass -DOpentims_ROOT_DIR pointing to an installation with a config package.
     add_library(opentims::opentims_cpp STATIC IMPORTED)
     set_target_properties(opentims::opentims_cpp PROPERTIES
       IMPORTED_LOCATION             "${Opentims_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${Opentims_INCLUDE_DIR}"
+      INTERFACE_COMPILE_DEFINITIONS ""
     )
   endif()
 endif()

--- a/cmake/Modules/FindOpentims.cmake
+++ b/cmake/Modules/FindOpentims.cmake
@@ -8,10 +8,17 @@
 # And the imported target:
 #  opentims::opentims_cpp
 #
-# Hints:
-#  Set Opentims_ROOT_DIR to the root of a custom installation.
+# Standard CMake mechanisms (all honoured automatically):
+#  opentims_DIR          - directory containing opentimsConfig.cmake
+#  opentims_ROOT         - root of the opentims installation (CMake 3.12+ / CMP0074)
+#  CMAKE_PREFIX_PATH     - list of installation prefixes to search
+#
+# Legacy OpenMS hint (kept for backwards compatibility):
+#  Opentims_ROOT_DIR     - same role as opentims_ROOT
 
 # Prefer a CMake config package produced by opentims's own install rules.
+# opentims_ROOT / opentims_DIR / CMAKE_PREFIX_PATH are checked automatically
+# by CMake (CMP0074); Opentims_ROOT_DIR is the legacy OpenMS-specific hint.
 find_package(opentims CONFIG QUIET
   HINTS
     "${Opentims_ROOT_DIR}"
@@ -45,6 +52,8 @@ endif()
 find_path(Opentims_INCLUDE_DIR
   NAMES opentims++/opentims.h
   HINTS
+    "${opentims_ROOT}/include"
+    "${opentims_ROOT}"
     "${Opentims_ROOT_DIR}/include"
     "${Opentims_ROOT_DIR}"
   DOC "opentims include directory (parent of opentims++/)"
@@ -53,9 +62,11 @@ find_path(Opentims_INCLUDE_DIR
 find_library(Opentims_LIBRARY
   NAMES opentims_cpp
   HINTS
+    "${opentims_ROOT}/lib"
+    "${opentims_ROOT}"
     "${Opentims_ROOT_DIR}/lib"
     "${Opentims_ROOT_DIR}"
-  DOC "opentims static library"
+  DOC "opentims library"
 )
 
 include(FindPackageHandleStandardArgs)
@@ -76,7 +87,7 @@ if(Opentims_FOUND)
     # but empty" (manual target) when deciding whether to inject sqlite3.
     # If OPENTIMS_LINK_SQLITE_STATICALLY is required, override this property or
     # pass -DOpentims_ROOT_DIR pointing to an installation with a config package.
-    add_library(opentims::opentims_cpp STATIC IMPORTED)
+    add_library(opentims::opentims_cpp UNKNOWN IMPORTED)
     set_target_properties(opentims::opentims_cpp PROPERTIES
       IMPORTED_LOCATION             "${Opentims_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${Opentims_INCLUDE_DIR}"

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -402,4 +402,75 @@ if (WITH_GUI)
   endforeach()
 
 endif()
+
+#------------------------------------------------------------------------------
+# opentims (Bruker TimsTOF .d file reading)
+if (WITH_OPENTIMS)
+  # Enable C language for bundled ZSTD fallback (zstddeclib.c)
+  enable_language(C)
+
+  find_package(Opentims QUIET)
+
+  if(Opentims_FOUND)
+    message(STATUS "opentims: using system installation (${Opentims_LIBRARIES})")
+
+    # If the installed library was built with OPENTIMS_LINK_SQLITE_STATICALLY,
+    # that compile definition is propagated via the imported target's
+    # INTERFACE_COMPILE_DEFINITIONS. OpenMS must then supply sqlite3 headers
+    # and the library, just as it does in the FetchContent path.
+    get_target_property(_opentims_defs opentims::opentims_cpp INTERFACE_COMPILE_DEFINITIONS)
+    if(_opentims_defs MATCHES "OPENTIMS_LINK_SQLITE_STATICALLY")
+      target_include_directories(opentims::opentims_cpp INTERFACE
+        "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
+      target_link_libraries(opentims::opentims_cpp INTERFACE sqlite3)
+      message(STATUS "opentims: injecting OpenMS sqlite3 (library was built with static sqlite)")
+    endif()
+  else()
+    # No system install found — fetch and build from source.
+    message(STATUS "opentims: system installation not found, fetching from git")
+    include(FetchContent)
+
+    FetchContent_Declare(
+      opentims
+      GIT_REPOSITORY https://github.com/michalsta/opentims.git
+      GIT_TAG        v1.2.0b1
+    )
+
+    # Build opentims as a C++ static library, not a Python module.
+    # Use OpenMS's own sqlite3 instead of opentims's runtime dlopen.
+    set(OPENTIMS_BUILD_PYTHON       OFF CACHE BOOL "" FORCE)
+    set(OPENTIMS_BUILD_CPP_LIB      ON  CACHE BOOL "" FORCE)
+    set(OPENTIMS_LINK_SQLITE_STATICALLY ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(opentims)
+
+    # Provide OpenMS's sqlite3 headers and library to opentims
+    target_include_directories(opentims_cpp PRIVATE
+      "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
+    target_link_libraries(opentims_cpp PRIVATE sqlite3)
+
+    # ZSTD: prefer system; fall back to opentims's bundled decoder.
+    set(_OPENTIMS_SRC "${opentims_SOURCE_DIR}/src/opentims++")
+    find_package(zstd QUIET)
+    if(TARGET zstd::libzstd_shared)
+      target_link_libraries(opentims_cpp PRIVATE zstd::libzstd_shared)
+      message(STATUS "opentims: using system zstd (shared)")
+    elseif(TARGET zstd::libzstd_static)
+      target_link_libraries(opentims_cpp PRIVATE zstd::libzstd_static)
+      message(STATUS "opentims: using system zstd (static)")
+    else()
+      target_sources(opentims_cpp PRIVATE "${_OPENTIMS_SRC}/zstd/zstddeclib.c")
+      target_include_directories(opentims_cpp PRIVATE "${_OPENTIMS_SRC}/zstd")
+      message(STATUS "opentims: using bundled zstd decoder (system zstd not found)")
+    endif()
+
+    # Suppress warnings from third-party code
+    target_compile_options(opentims_cpp PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,/w,-w>)
+
+    # Expose a namespaced alias so downstream CMakeLists always use
+    # opentims::opentims_cpp regardless of how the library was obtained.
+    add_library(opentims::opentims_cpp ALIAS opentims_cpp)
+
+    message(STATUS "opentims: built from source (${opentims_SOURCE_DIR})")
+  endif()
+endif()
 #------------------------------------------------------------------------------

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -418,8 +418,12 @@ if (WITH_OPENTIMS)
     # that compile definition is propagated via the imported target's
     # INTERFACE_COMPILE_DEFINITIONS. OpenMS must then supply sqlite3 headers
     # and the library, just as it does in the FetchContent path.
+    # When the library was found via the manual search path (no CMake config
+    # package), INTERFACE_COMPILE_DEFINITIONS may not be set; in that case we
+    # conservatively inject sqlite3 because we cannot know how it was built.
     get_target_property(_opentims_defs opentims::opentims_cpp INTERFACE_COMPILE_DEFINITIONS)
-    if(_opentims_defs MATCHES "OPENTIMS_LINK_SQLITE_STATICALLY")
+    if(_opentims_defs MATCHES "OPENTIMS_LINK_SQLITE_STATICALLY"
+       OR (_opentims_defs MATCHES "NOTFOUND" AND NOT opentims_FOUND))
       target_include_directories(opentims::opentims_cpp INTERFACE
         "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
       target_link_libraries(opentims::opentims_cpp INTERFACE sqlite3)
@@ -433,7 +437,7 @@ if (WITH_OPENTIMS)
     FetchContent_Declare(
       opentims
       GIT_REPOSITORY https://github.com/michalsta/opentims.git
-      GIT_TAG        v1.2.0b1
+      GIT_TAG        v1.2.0b3
     )
 
     # Build opentims as a C++ static library, not a Python module.

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -398,12 +398,31 @@ if (WITH_OPENTIMS)
     set(OPENTIMS_BUILD_LIB              ON  CACHE BOOL "" FORCE)
     set(OPENTIMS_BUILD_PYTHON           OFF CACHE BOOL "" FORCE)
     set(OPENTIMS_LINK_SQLITE_STATICALLY ON  CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(opentims)
 
-    # Provide OpenMS's sqlite3 headers and library to opentims
+    # OpenMS sets BUILD_SHARED_LIBS=true (to build libOpenMS.so). Without this
+    # override, opentims's CMakeLists.txt would build libopentims_cpp.so instead
+    # of libopentims_cpp.a. A shared opentims would land in _deps/opentims-build/
+    # rather than the system lib path, so the build-time linker would fail with
+    # "undefined reference to TimsDataHandle" when linking test binaries against
+    # libOpenMS.so (because libopentims_cpp.so's directory is not in the test's
+    # -L search path). Force static so all opentims symbols get absorbed into
+    # libOpenMS.so at link time.
+    set(_openms_saved_build_shared_libs ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS OFF)
+    FetchContent_MakeAvailable(opentims)
+    set(BUILD_SHARED_LIBS ${_openms_saved_build_shared_libs})
+
+    # Provide OpenMS's sqlite3 headers to opentims so it compiles with
+    # OPENTIMS_LINK_SQLITE_STATICALLY (direct sqlite3 calls vs. dlopen).
+    # We intentionally do NOT call target_link_libraries(opentims_cpp PRIVATE sqlite3)
+    # here: adding the CMake sqlite3 target as a PRIVATE dep of a STATIC library
+    # would require sqlite3 to appear in the CMake export sets, which creates
+    # conflicts with SQLiteCpp's own sqlite3 export. The sqlite3 symbols are
+    # resolved at final link time through OpenMS's own SQLiteCpp dependency
+    # (SQLiteCpp PUBLIC-links sqlite3, so libsqlite3.a already appears in
+    # libOpenMS.so's link command after libopentims_cpp.a).
     target_include_directories(opentims_cpp PRIVATE
       "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
-    target_link_libraries(opentims_cpp PRIVATE sqlite3)
 
     # ZSTD: prefer system; fall back to opentims's bundled decoder.
     set(_OPENTIMS_SRC "${opentims_SOURCE_DIR}/src/opentims++")

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -427,6 +427,12 @@ if (WITH_OPENTIMS)
     # opentims::opentims_cpp regardless of how the library was obtained.
     add_library(opentims::opentims_cpp ALIAS opentims_cpp)
 
+    # Add opentims_cpp to the OpenMSTargets export set (same as Evergreen,
+    # SQLiteCpp, and other bundled deps).  CMake requires all targets linked
+    # by an exported target to be either imported or in an export set — even
+    # for PRIVATE deps of a shared library.
+    install_library(opentims_cpp)
+
     message(STATUS "opentims: built from source (${opentims_SOURCE_DIR})")
   endif()
 endif()

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -376,7 +376,7 @@ if (WITH_OPENTIMS)
     # conservatively inject sqlite3 because we cannot know how it was built.
     get_target_property(_opentims_defs opentims::opentims_cpp INTERFACE_COMPILE_DEFINITIONS)
     if(_opentims_defs MATCHES "OPENTIMS_LINK_SQLITE_STATICALLY"
-       OR (_opentims_defs MATCHES "NOTFOUND" AND NOT opentims_FOUND))
+       OR ((_opentims_defs MATCHES "NOTFOUND" OR _opentims_defs STREQUAL "") AND NOT opentims_FOUND))
       target_include_directories(opentims::opentims_cpp INTERFACE
         "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
       target_link_libraries(opentims::opentims_cpp INTERFACE sqlite3)

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -427,11 +427,12 @@ if (WITH_OPENTIMS)
     # opentims::opentims_cpp regardless of how the library was obtained.
     add_library(opentims::opentims_cpp ALIAS opentims_cpp)
 
-    # Add opentims_cpp to the OpenMSTargets export set (same as Evergreen,
-    # SQLiteCpp, and other bundled deps).  CMake requires all targets linked
-    # by an exported target to be either imported or in an export set — even
-    # for PRIVATE deps of a shared library.
+    # Add opentims_cpp to both the install-tree and build-tree export sets
+    # (same pattern as Evergreen, IsoSpec, and other bundled deps).
+    # install_library() → OpenMSTargets install export
+    # openms_register_export_target() → _OPENMS_EXPORT_TARGETS build-tree export()
     install_library(opentims_cpp)
+    openms_register_export_target(opentims_cpp)
 
     message(STATUS "opentims: built from source (${opentims_SOURCE_DIR})")
   endif()

--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -279,53 +279,6 @@ if(ArrowDataset_FOUND)
 endif()
 
 #------------------------------------------------------------------------------
-# opentims (Bruker TimsTOF .d file reading)
-if (WITH_OPENTIMS)
-  # Enable C language for bundled ZSTD fallback (zstddeclib.c)
-  enable_language(C)
-  include(FetchContent)
-
-  FetchContent_Declare(
-    opentims
-    GIT_REPOSITORY https://github.com/michalsta/opentims.git
-    GIT_TAG v1.2.0b1
-  )
-
-  # Build opentims as a C++ static library, not a Python module.
-  # Use OpenMS's own sqlite3 instead of opentims's runtime dlopen.
-  set(OPENTIMS_BUILD_PYTHON OFF CACHE BOOL "" FORCE)
-  set(OPENTIMS_BUILD_CPP_LIB ON CACHE BOOL "" FORCE)
-  set(OPENTIMS_LINK_SQLITE_STATICALLY ON CACHE BOOL "" FORCE)
-  FetchContent_MakeAvailable(opentims)
-
-  # Provide OpenMS's sqlite3 headers and library to opentims
-  target_include_directories(opentims_cpp PRIVATE "${CMAKE_SOURCE_DIR}/src/openms/extern/SQLiteCpp/sqlite3")
-  target_link_libraries(opentims_cpp PRIVATE sqlite3)
-
-  # ZSTD: opentims uses ZSTD for TDF frame decompression.
-  # Prefer system/package-managed zstd; fall back to opentims's bundled decoder.
-  set(_OPENTIMS_SRC "${opentims_SOURCE_DIR}/src/opentims++")
-  find_package(zstd QUIET)
-  if(TARGET zstd::libzstd_shared)
-    target_link_libraries(opentims_cpp PRIVATE zstd::libzstd_shared)
-    message(STATUS "opentims: using system zstd (shared)")
-  elseif(TARGET zstd::libzstd_static)
-    target_link_libraries(opentims_cpp PRIVATE zstd::libzstd_static)
-    message(STATUS "opentims: using system zstd (static)")
-  else()
-    # Compile opentims's bundled ZSTD decompression-only amalgamation
-    target_sources(opentims_cpp PRIVATE "${_OPENTIMS_SRC}/zstd/zstddeclib.c")
-    target_include_directories(opentims_cpp PRIVATE "${_OPENTIMS_SRC}/zstd")
-    message(STATUS "opentims: using bundled zstd decoder (system zstd not found)")
-  endif()
-
-  # Suppress warnings from third-party code
-  target_compile_options(opentims_cpp PRIVATE $<IF:$<CXX_COMPILER_ID:MSVC>,/w,-w>)
-
-  message(STATUS "Built opentims_cpp from source: ${opentims_SOURCE_DIR}")
-endif()
-
-#------------------------------------------------------------------------------
 # Done finding contrib libraries
 #------------------------------------------------------------------------------
 
@@ -437,14 +390,14 @@ if (WITH_OPENTIMS)
     FetchContent_Declare(
       opentims
       GIT_REPOSITORY https://github.com/michalsta/opentims.git
-      GIT_TAG        v1.2.0b3
+      GIT_TAG        v1.2.0b4
     )
 
     # Build opentims as a C++ static library, not a Python module.
     # Use OpenMS's own sqlite3 instead of opentims's runtime dlopen.
-    set(OPENTIMS_BUILD_PYTHON       OFF CACHE BOOL "" FORCE)
-    set(OPENTIMS_BUILD_CPP_LIB      ON  CACHE BOOL "" FORCE)
-    set(OPENTIMS_LINK_SQLITE_STATICALLY ON CACHE BOOL "" FORCE)
+    set(OPENTIMS_BUILD_LIB              ON  CACHE BOOL "" FORCE)
+    set(OPENTIMS_BUILD_PYTHON           OFF CACHE BOOL "" FORCE)
+    set(OPENTIMS_LINK_SQLITE_STATICALLY ON  CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(opentims)
 
     # Provide OpenMS's sqlite3 headers and library to opentims

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -97,7 +97,7 @@ if (OPENMS_ARROW_DATASET_TARGET)
 endif()
 
 if (WITH_OPENTIMS)
-  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES opentims_cpp)
+  list(APPEND OPENMS_DEP_PRIVATE_LIBRARIES opentims::opentims_cpp)
 endif()
 
 if (ENABLE_TDL)

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -147,7 +147,7 @@ if (TARGET ArrowSchemaRegistry_test)
 endif()
 
 if (TARGET BrukerTimsFile_test AND WITH_OPENTIMS)
-  target_link_libraries(BrukerTimsFile_test opentims_cpp sqlite3)
+  target_link_libraries(BrukerTimsFile_test opentims::opentims_cpp sqlite3)
 endif()
 
 if (TARGET BrukerTimsFile_test AND OPENTIMS_DDA_TEST_DATA)


### PR DESCRIPTION
Use standard CMake mechanisms to find OpenTIMS package already installed on system, fall back to git fetch+build from source (previous mechanism) if not present. Needs OpenTIMS 1.2.0b4 installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better OpenTIMS integration: automatic detection of system installs with a robust fallback build and consistent namespaced linking so Bruker TimsTOF .d file support is more reliable.

* **Chores**
  * More consistent handling of compression and SQLite linkage to reduce build issues and improve runtime reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->