### PR TITLE
feat: allow Bruker DIA MS2 centroiding without denoising

### DIFF
--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -1860,14 +1860,14 @@ namespace OpenMS
               }
             }
 
-            // Denoise (skip if only 1 frame in range)
+            // Denoise (skip if only 1 frame in range, or caller disabled it via min_support <= 0)
             // TODO: This checks the index range, not the actual number of neighbor
             // frames that contributed peaks to the grid. If neighbor frames exist
             // but have zero peaks passing the IM filter for this window, the grid
             // contains only single-frame data yet denoising still runs — which may
             // remove valid isolated peaks. Consider counting actual contributing
             // frames if this becomes an issue in practice.
-            bool skip_denoise = (hi - lo) < 1;
+            bool skip_denoise = (hi - lo) < 1 || config.dia_ms2_min_support <= 0;
             auto peaks = config.dia_ms2_centroid
               ? aggregator.finalizeCentroided(config.dia_ms2_min_support, skip_denoise)
               : aggregator.finalize(config.dia_ms2_min_support, skip_denoise);

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -736,6 +736,67 @@ START_SECTION(DIA MS2 centroiding test)
 }
 END_SECTION
 
+START_SECTION(DIA MS2 centroiding without denoising (min_support=0))
+{
+  // Regression guard for the "centroid without noise filter" path exposed via
+  // Config::dia_ms2_min_support = 0. With min_support=0 the 3x3 neighbor filter
+  // in DIAFrameAggregator::finalize{,Centroided} is a no-op (`neighbors < 0` is
+  // always false), so every populated grid cell survives the denoise step.
+  // Under centroiding that means more local maxima → strictly more output peaks
+  // than the denoised (min_support=1) path, because denoising preferentially
+  // removes isolated cells that would otherwise become their own centroid.
+  BrukerTimsFile f;
+
+  BrukerTimsFile::Config cfg_denoise;
+  cfg_denoise.dia_ms2_n_neighbors = 1;
+  cfg_denoise.dia_ms2_min_support = 1;
+  cfg_denoise.dia_ms2_centroid = true;
+  MSExperiment exp_denoise;
+  f.load(OPENTIMS_DIA_TEST_DATA, exp_denoise, cfg_denoise);
+
+  BrukerTimsFile::Config cfg_no_denoise;
+  cfg_no_denoise.dia_ms2_n_neighbors = 1;
+  cfg_no_denoise.dia_ms2_min_support = 0;
+  cfg_no_denoise.dia_ms2_centroid = true;
+  MSExperiment exp_no_denoise;
+  f.load(OPENTIMS_DIA_TEST_DATA, exp_no_denoise, cfg_no_denoise);
+
+  Size denoise_peaks = 0, no_denoise_peaks = 0;
+  Size denoise_spectra = 0, no_denoise_spectra = 0;
+  for (const auto& spec : exp_denoise)
+    if (spec.getMSLevel() == 2) { ++denoise_spectra; denoise_peaks += spec.size(); }
+  for (const auto& spec : exp_no_denoise)
+    if (spec.getMSLevel() == 2) { ++no_denoise_spectra; no_denoise_peaks += spec.size(); }
+
+  // Without denoising, a few spectra that would become empty after denoising
+  // (and are dropped by the `if (peaks.empty()) continue;` guard in the
+  // BrukerTimsFile loader) are now retained. Count is >= denoised count.
+  TEST_EQUAL(no_denoise_spectra >= denoise_spectra, true);
+
+  // Without denoising the centroided output contains strictly more peaks:
+  // every populated grid cell becomes a centroid candidate instead of being
+  // dropped when isolated.
+  TEST_NOT_EQUAL(no_denoise_peaks, 0);
+  TEST_EQUAL(no_denoise_peaks > denoise_peaks, true);
+
+  // Output is still centroided in the IM dimension.
+  for (const auto& spec : exp_no_denoise)
+  {
+    if (spec.getMSLevel() == 2 && !spec.empty())
+    {
+      TEST_EQUAL(spec.containsIMData(), true);
+      TEST_EQUAL(spec.getIMPeakType() == IMPeakType::IM_CENTROIDED, true);
+      TEST_NOT_EQUAL(spec.getPrecursors().size(), 0);
+      break;
+    }
+  }
+
+  STATUS("DIA centroiding (no denoise): MS2 peaks=" << no_denoise_peaks
+         << " vs denoised=" << denoise_peaks
+         << " ratio=" << (static_cast<double>(no_denoise_peaks) / denoise_peaks));
+}
+END_SECTION
+
 START_SECTION(DIA readDIAMetadata test)
 {
   BrukerTimsFile f;

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -203,8 +203,9 @@ protected:
     setMinInt_("bruker:dia_ms2_n_neighbors", 0);
     registerIntOption_("bruker:dia_ms2_min_support", "<int>", 1,
       "DIA MS2 denoising: minimum occupied neighbor cells in a 3x3 (m/z x IM) grid to keep a point "
-      "(center cell excluded from count). Applied after frame aggregation. Only effective when dia_ms2_n_neighbors > 0.", false, true);
-    setMinInt_("bruker:dia_ms2_min_support", 1);
+      "(center cell excluded from count). Applied after frame aggregation. Only effective when dia_ms2_n_neighbors > 0. "
+      "Set to 0 to disable denoising (useful for pure centroiding without noise filtering).", false, true);
+    setMinInt_("bruker:dia_ms2_min_support", 0);
     registerStringOption_("bruker:dia_ms2_centroid", "<toggle>", "false",
       "Apply 2D Gaussian smoothing + local maxima peak picking to the denoised DIA MS2 grid. "
       "Produces IM_CENTROIDED spectra with sub-bin (m/z, IM) precision. Only effective when dia_ms2_n_neighbors > 0.", false, true);


### PR DESCRIPTION
## Summary

- Lower CLI floor on `-bruker:dia_ms2_min_support` from `1` to `0` in `FileConverter`, so users can run frame-aggregated DIA MS2 centroiding without the 3×3 neighbor filter.
- Short-circuit the denoise step in `DIAFrameAggregator` when `min_support <= 0`, avoiding a wasteful 8-probe hashmap lookup per grid cell.
- Add regression-guard section in `BrukerTimsFile_test.cpp` that locks in the new contract.

## Motivation

The existing Bruker DIA MS2 path always applied spatial denoising (drop cells with no occupied 3×3 neighbors) even when the user wanted pure centroiding. The CLI clamped `min_support` to a minimum of `1`, leaving no way to disable the filter. This PR exposes the already-supported `min_support = 0` path through the CLI and adds a fast-path that skips the lookup loop when denoising is off.

## Usage

```
FileConverter -in foo.d -out foo.mzML \
  -bruker:dia_ms2_n_neighbors 1 \
  -bruker:dia_ms2_min_support 0 \
  -bruker:dia_ms2_centroid true
```

## Test Plan

- [x] `BrukerTimsFile_test` passes (13/13 sections, 770 s on OPENTIMS_DIA_TEST_DATA)
- [x] New `DIA MS2 centroiding without denoising (min_support=0)` section asserts:
  - `min_support=0` centroid run produces more peaks than `min_support=1` (fixture: 106.5 M vs 15.9 M, ~6.7× more centroids retained)
  - Spectrum count `>=` denoised count (empty-after-denoise drops are avoided)
  - Output spectra still `IM_CENTROIDED` with per-peak IM data and precursors
- [x] Existing `DIA MS2 aggregation` and `DIA MS2 centroiding` sections (min_support=1 default) still pass — no regression
- [x] `FileConverter --helphelp` shows `(default: '1') (min: '0')` for `-bruker:dia_ms2_min_support` and the updated help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DIA MS2 denoising behavior for Bruker TimsTOF data processing; denoising can now be disabled via configuration option, with the default setting changed.

* **Tests**
  * Added test coverage for MS2 centroiding without denoising.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->