### PR TITLE
fix: mark Bruker TDF spectra as CENTROID so downstream tools accept them

### DIFF
--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -911,6 +911,9 @@ namespace OpenMS
     spec.setRT(frame.time);
     spec.setMSLevel(ms_level);
     spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+    // TDF peaks are detector-centroided in m/z (peak-list format); label as
+    // centroid so downstream tools (e.g. CometAdapter) don't reject as profile.
+    spec.setType(SpectrumSettings::SpectrumType::CENTROID);
     spec.setNativeID("frame=" + String(frame.id));
 
     if (frame.num_peaks == 0) return;
@@ -1203,6 +1206,7 @@ namespace OpenMS
           spec.setRT(frame.time);
           spec.setMSLevel(2);
           spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+          spec.setType(SpectrumSettings::SpectrumType::CENTROID);
           spec.setNativeID("frame=" + String(frame.id) + " windowGroup=" + String(win->window_group) + " scan=" + String(win->scan_begin));
 
           Precursor prec;
@@ -1699,6 +1703,7 @@ namespace OpenMS
       spec.setMSLevel(2);
       spec.setDriftTime(scalar_im);
       spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+      spec.setType(SpectrumSettings::SpectrumType::CENTROID);
       spec.setNativeID("scan=" + String(prec_id));
 
       // Copy sorted peak data
@@ -1873,6 +1878,7 @@ namespace OpenMS
             spec.setRT(center_frame.time);
             spec.setMSLevel(2);
             spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+            spec.setType(SpectrumSettings::SpectrumType::CENTROID);
             spec.setNativeID("frame=" + String(center_frame.id) + " windowGroup=" + String(win->window_group) + " scan=" + String(win->scan_begin));
 
             Precursor prec;
@@ -1937,6 +1943,7 @@ namespace OpenMS
             spec.setRT(frame.time);
             spec.setMSLevel(2);
             spec.setDriftTimeUnit(DriftTimeUnit::VSSC);
+            spec.setType(SpectrumSettings::SpectrumType::CENTROID);
             spec.setNativeID("frame=" + String(frame.id) + " windowGroup=" + String(win->window_group) + " scan=" + String(win->scan_begin));
 
             Precursor prec;

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -248,6 +248,9 @@ START_SECTION(DDA loading integration test)
       TEST_NOT_EQUAL(spec.getDriftTime(), 0.0);
       TEST_EQUAL(spec.getDriftTimeUnit(), DriftTimeUnit::VSSC);
       TEST_NOT_EQUAL(spec.getPrecursors()[0].getMZ(), 0.0);
+      // TDF MS2 peaks are detector-centroided; must be labelled CENTROID so
+      // downstream tools (e.g. CometAdapter) don't reject them as profile.
+      TEST_EQUAL(spec.getType(), SpectrumSettings::SpectrumType::CENTROID);
       break;
     }
   }
@@ -313,6 +316,8 @@ START_SECTION(DDA frame-level loading test)
     if (!spec.empty())
     {
       TEST_EQUAL(spec.containsIMData(), true);
+      // frameToSpectrum emits detector-centroided peaks; label as CENTROID.
+      TEST_EQUAL(spec.getType(), SpectrumSettings::SpectrumType::CENTROID);
       break;
     }
   }
@@ -505,6 +510,8 @@ START_SECTION(DIA loading integration test)
     {
       TEST_EQUAL(spec.containsIMData(), true);
       TEST_NOT_EQUAL(spec.getPrecursors().size(), 0);
+      // TDF MS2 peaks are detector-centroided; must be labelled CENTROID.
+      TEST_EQUAL(spec.getType(), SpectrumSettings::SpectrumType::CENTROID);
       break;
     }
   }


### PR DESCRIPTION
@timosachsenberg does https://github.com/OpenMS/OpenMS/pull/9152/changes fixes this issue already?

## Summary
- `BrukerTimsFile` currently writes TDF spectra into `MSExperiment` without setting `SpectrumSettings::SpectrumType`, so spectra default to `UNKNOWN`. When the experiment is written to mzML, only the parent CV term `MS:1000525` (\"spectrum representation\") is emitted and not the child `MS:1000127` (\"centroid spectrum\") / `MS:1000128` (\"profile spectrum\").
- Downstream tools that strictly validate the CV term — notably `CometAdapter` — reject the mzML with `Profile data provided but centroided MS2 spectra required` and force users to add `-force` (which taints results).
- TDF peak data is already detector-centroided in m/z (it is stored as a peak list, not a profile trace), so the correct label is `CENTROID`. This PR sets the type in the five spectrum-emission paths so the CV term lands correctly in the mzML.

## Changes
- `src/openms/source/FORMAT/BrukerTimsFile.cpp`: add `spec.setType(SpectrumSettings::SpectrumType::CENTROID)` in:
  - `frameToSpectrum` (raw MS1 / MS2 via `loadFrames_`)
  - streaming DIA MS2
  - DDA MS2
  - DIA MS2 aggregated/denoised
  - DIA MS2 raw per-WindowGroup
- `src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp`: add `TEST_EQUAL(spec.getType(), CENTROID)` in the DDA loading, DDA frame-level, and DIA loading integration tests, mirroring the existing MS1 CENTROID assertion in the DDA MS1 centroiding test.

## Test plan
- [x] `BrukerTimsFile_test` — all 22 sections pass locally with `ENABLE_OPENTIMS_TESTS=ON` (exit 0).
- [x] End-to-end: the patched `FileConverter` run on a real timsTOF `.d` file produces mzML whose MS2 spectra now carry `<cvParam accession=\"MS:1000127\" name=\"centroid spectrum\"/>`. `CometAdapter` accepts it without `-force`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes & Tests

* **Bug Fixes**
  * Spectra from TDF/TIMS data now explicitly include correct spectrum type classification, improving data quality metadata for multiple spectrum construction pathways including frame conversion and DIA/DDA analysis modes.

* **Tests**
  * Added comprehensive assertions to verify spectrum type metadata is correctly set across TDF MS2 spectra and frame-level data loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->