### PR TITLE
contrib: Treat as a submodule so we don't release it separately

### DIFF
--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -38,7 +38,60 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # NOTE: This job is temporary until we get rid of contrib.
+  prepare-contrib-for-windows:
+    runs-on: windows-2025
+    steps:
+      - name: Clone OpenMS
+        uses: actions/checkout@v6
+      - name: Set up Visual Studio shell
+        uses: egor-tensin/vs-shell@v2
+        with: { arch: x64 }
+
+      - name: Identify contrib submodule revision for cache key
+        id: contrib-rev
+        shell: bash
+        run: |
+          rev=$(git submodule status --cached -- contrib | sed -E 's/^-?//' | cut -d' ' -f1)
+          echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
+      - name: Cache contrib
+        id: cache-contrib
+        uses: actions/cache@v5
+        with:
+          path: contrib/build
+          key: ${{ runner.os }}-${{ steps.contrib-rev.outputs.rev }}
+
+      - name: Fetch contrib if not in cache
+        if: steps.cache-contrib.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git submodule update --init -- contrib
+          mkdir -p contrib/build
+
+      - name: Build contrib if not in cache
+        if: steps.cache-contrib.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $NPROC = $env:NUMBER_OF_PROCESSORS
+          if (-not $NPROC) { $NPROC = 4 }
+          $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
+          Set-Location "${{ github.workspace }}\contrib\build"
+          cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload Contrib
+        uses: actions/upload-artifact@v7
+        with:
+          name: contrib-${{ steps.contrib-rev.outputs.rev }}
+          path: |
+            contrib/build/lib/
+            contrib/build/bin/
+            contrib/build/include/
+          retention-days: 7
+
   build-and-test:
+    needs: prepare-contrib-for-windows
     strategy:
       fail-fast: false
       matrix:
@@ -326,28 +379,6 @@ jobs:
           echo "cmake_prefix=$(brew --prefix);$(brew --prefix libomp)" >>"$GITHUB_OUTPUT"
         fi
 
-    - name: Cache contrib (Windows)
-      if: startsWith(matrix.os, 'windows')
-      id: cache-contrib
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/OpenMS/contrib
-        key: ${{ runner.os }}-contrib4
-    
-    - name: Download contrib build from archive (Windows)
-      if: startsWith(matrix.os, 'windows') && steps.cache-contrib.outputs.cache-hit != 'true'
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-          cd OpenMS/contrib
-          # Download the file using the URL fetched from GitHub
-          gh release download -R OpenMS/contrib --pattern 'contrib_build-Windows.tar.gz'
-          # Extract the archive
-          7z x -so contrib_build-Windows.tar.gz | 7z x -si -ttar
-          rm contrib_build-Windows.tar.gz
-          ls -la
-
     - name: Build libcurl from source (Windows)
       if: startsWith(matrix.os, 'windows')
       shell: bash
@@ -378,6 +409,21 @@ jobs:
           ${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-ccache-develop
           ${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-ccache-
 
+    - name: Identify contrib submodule revision for cache key
+      id: contrib-rev
+      shell: bash
+      run: |
+        cd OpenMS
+        rev=$(git submodule status --cached -- contrib | sed -E 's/^-?//' | cut -d' ' -f1)
+        echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
+    - name: Download contrib artifact for Windows
+      if: runner.os == 'Windows'
+      uses: actions/download-artifact@v4
+      with:
+        name: contrib-${{ steps.contrib-rev.outputs.rev }}
+        path: OpenMS/contrib/build
+          
     - name: Add THIRDPARTY
       shell: bash
       run: |
@@ -453,7 +499,7 @@ jobs:
           PYOPENMS: "${{ startsWith(matrix.os, 'ubuntu') && matrix.compiler == 'g++' && 'ON' || 'OFF' }}"
           NO_DEPENDENCIES: "${{ startsWith(matrix.os, 'ubuntu') && matrix.compiler == 'g++' && 'OFF' || 'ON' }}"
           CMAKE_PREFIX_PATH: "${{ steps.tools-prefix.outputs.cmake_prefix }};${{ steps.conda-setup.outputs.cmake_prefix }}"
-          OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/OpenMS/contrib"
+          OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/OpenMS/contrib/build"
           CI_PROVIDER: "GitHub-Actions"
           CMAKE_GENERATOR: "Ninja"
           SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"


### PR DESCRIPTION
Instead of pulling pre-built releases of `contrib`, build it in CI from the associated submodule.

We want to use the submodule revision hash as the way to connect an OpenMS release to a version of contrib.  By doing this we make releasing OpenMS easier because we don't have to tag/release contrib and other external repositories.

Yes, this will add 45 minutes to the CI builds, **but** only when the `contrib` submodule is changed or the cached build of `contrib` is evicted from the cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the Windows build pipeline by adding a dedicated preparation job that caches and uploads a rebuilt dependency bundle with short-term (7-day) retention.
  * Updated the main Windows build to consume the prepared bundle instead of rebuilding or downloading archives, reducing duplicated work and build time.
  * Adjusted downstream build configuration to reference the prepared bundle layout for improved efficiency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->