### PR TITLE
docs: mention OpenMP requirement for clang builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ The following authors contributed to OpenMS at some point. For the
 authors contributing to a specific piece of code, please refer to
 the authors tag in the respective file header.
  - Achal Bajpai
+ - Adithya Kammati
  - Aditya Muzumdar
  - Ahmed Khalil
  - Alen Saric

--- a/doc/openms/docs/manual/develop/custom-compilation.md
+++ b/doc/openms/docs/manual/develop/custom-compilation.md
@@ -13,6 +13,10 @@ cmake -DCMAKE_C_COMPILER=/path/to/c-compiler/binary/gcc -DCMAKE_CXX_COMPILER=/pa
 cmake -DCMAKE_C_COMPILER=/path/to/c-compiler/binary/clang -DCMAKE_CXX_COMPILER=/path/to/c++-compiler/binary/clang++
 ```
 
+```{note}
+When building OpenMS with `clang` on GNU/Linux, make sure the OpenMP runtime and development headers are installed as well. On Debian-based distributions this is typically provided by `libomp-dev`. Other distributions may use a different package name.
+```
+
 To compile OpenMS with clang and a specific GCC stdlib, instead of the system default one:
 
 Use this cmake option to specify an additional compiling option for clang:
@@ -30,5 +34,4 @@ This combination does not work for all versions of clang and gcc.
 - Clang 9.0.0 and GCC 8.3.0 stdlib compiles, but some tests fail.
 - Clang 6.0.0 and GCC 7.4.0 stdlib (Ubuntu 18.04 default versions) works
 ```
-
 


### PR DESCRIPTION
## Summary
- add a clang-specific note about installing OpenMP runtime and development headers on GNU/Linux
- mention the common Debian/Ubuntu package name without presenting it as universal
- add a pointer from the GNU/Linux source-build page to the compiler-specific notes

Closes #9040

## Testing
- not run locally (docs build tooling was not set up in this environment)
- verified the touched documentation files and internal doc reference targets manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced build documentation with additional guidance for GNU/Linux users compiling with clang, including OpenMP runtime and development headers requirements.
  * Updated contributors list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->