### PR TITLE
fix(ProSE): honor ions:add_* parameters in scoring path

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -436,6 +436,13 @@ class OPENMS_DLLAPI ProSEAlgorithm :
 
     Size report_top_hits_;
 
+    bool add_a_ions_{false};
+    bool add_b_ions_{true};
+    bool add_c_ions_{false};
+    bool add_x_ions_{false};
+    bool add_y_ions_{true};
+    bool add_z_ions_{false};
+
     bool calibration_enabled_{false};
     double calibration_subset_ratio_{0.1};
     Size calibration_min_psms_{50};

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -270,6 +270,13 @@ namespace OpenMS
 
     // Open search mode is automatically determined based on precursor tolerance in isOpenSearchMode_()
 
+    add_a_ions_ = param_.getValue("ions:add_a_ions").toBool();
+    add_b_ions_ = param_.getValue("ions:add_b_ions").toBool();
+    add_c_ions_ = param_.getValue("ions:add_c_ions").toBool();
+    add_x_ions_ = param_.getValue("ions:add_x_ions").toBool();
+    add_y_ions_ = param_.getValue("ions:add_y_ions").toBool();
+    add_z_ions_ = param_.getValue("ions:add_z_ions").toBool();
+
     calibration_enabled_ = param_.getValue("calibration:enabled") == "true";
     calibration_subset_ratio_ = param_.getValue("calibration:subset_ratio");
     calibration_min_psms_ = param_.getValue("calibration:min_psms");
@@ -824,11 +831,19 @@ namespace OpenMS
     // call sites below read from this field instead of re-computing.
     last_mod_match_tolerance_used_ = computeModMatchTolerance_();
 
-    // create spectrum generator
+    // create spectrum generator — forward the ion-series toggles so scoring
+    // uses the same ion types as the FragmentIndex (which already reads them
+    // via setParameters in prepareContext).
     TheoreticalSpectrumGenerator spectrum_generator;
     Param param(spectrum_generator.getParameters());
     param.setValue("add_first_prefix_ion", "true");
     param.setValue("add_metainfo", "true");
+    param.setValue("add_a_ions", add_a_ions_ ? "true" : "false");
+    param.setValue("add_b_ions", add_b_ions_ ? "true" : "false");
+    param.setValue("add_c_ions", add_c_ions_ ? "true" : "false");
+    param.setValue("add_x_ions", add_x_ions_ ? "true" : "false");
+    param.setValue("add_y_ions", add_y_ions_ ? "true" : "false");
+    param.setValue("add_z_ions", add_z_ions_ ? "true" : "false");
     spectrum_generator.setParameters(param);
 
     // preallocate storage for PSMs


### PR DESCRIPTION
## Summary

Fix a silent bug where ProSE's `ions:add_a/b/c/x/y/z_ions` parameters were declared but never read — making the index and scoring paths inconsistent for non-default ion types (ETD, EThcD).

Closes item 12 in #9108.

## The bug

`ProSEAlgorithm` constructor (line 185-196) declares 6 ion-series toggle parameters with defaults (b/y on, a/c/x/z off). However:

- `updateMembers_()` **never reads them** — no `param_.getValue("ions:add_*")` calls
- `FragmentIndex` receives the params via `setParameters()` and correctly builds the index with the user's ion selection ✅
- `TheoreticalSpectrumGenerator` in the scoring loop (line 828-832) only sets `add_first_prefix_ion` and `add_metainfo` — **always generates b/y regardless** of user config ❌

**Result:** User sets `-Search:ions:add_c_ions true` for ETD data → index contains c-ion fragments → scorer generates b/y theoretical peaks → c-ions in the index never match → worse scores than expected. Silent data-quality issue.

## The fix

- Add 6 `bool` members to `ProSEAlgorithm` (header)
- Read them in `updateMembers_()` (6 lines)
- Forward to `TheoreticalSpectrumGenerator` in `search()` (6 lines)

Total: +23 lines, 2 files.

## Usage after fix

```bash
# ETD search (c/z ions)
ProSE -in etd_data.mzML -database db.fasta -out_idxml etd.idXML \
  -Search:ions:add_c_ions true -Search:ions:add_z_ions true \
  -Search:ions:add_b_ions false -Search:ions:add_y_ions false

# EThcD search (all ion types)
ProSE -in ethcd_data.mzML -database db.fasta -out_idxml ethcd.idXML \
  -Search:ions:add_c_ions true -Search:ions:add_z_ions true

# Default (HCD/CID, unchanged behavior)
ProSE -in hcd_data.mzML -database db.fasta -out_idxml hcd.idXML
```

## Test plan

- [x] Build clean on Linux
- [x] `ProSE --helphelp` shows all 6 `ions:add_*` params under `-Search:ions:` subsection
- [x] Default behavior unchanged (b/y on, a/c/x/z off — same as before the fix)
- [ ] Regression: run ProSE with default params on existing test fixture, verify idXML output is identical to pre-fix (manual; no ion-series-specific test fixture in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ion series selection in the ProSE algorithm, allowing users to control which ion types (a, b, c, x, y, z ions) are used during spectral analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->