### PR TITLE
Add top-level install overview file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,22 @@
+OpenMS Installation Guide
+=========================
+
+If you want to install or build OpenMS, start with these entry points:
+
+- Binary installers and packages: see the "Installation" section in the main README and the platform-specific guides in `doc/openms/docs/about/installation/`.
+- Build from source on GNU/Linux: `doc/openms/docs/about/installation/installation-on-gnu-linux.md`
+- Build from source on macOS: `doc/openms/docs/about/installation/installation-on-macos.md`
+- Build from source on Windows: `doc/openms/docs/about/installation/installation-on-windows.md`
+- Build and development notes: `doc/openms/docs/manual/develop.md`
+
+Online documentation:
+
+- Stable documentation: https://openms.readthedocs.io/en/latest/
+- Development documentation: https://openms.readthedocs.io/en/develop/
+
+Quick links:
+
+- Installation overview: https://openms.readthedocs.io/en/latest/about/installation.html
+- GNU/Linux build instructions: https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_linux.html
+- macOS build instructions: https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html
+- Windows build instructions: https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_win.html

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Building OpenMS
 
 For developers who want to build OpenMS from source:
 
+- See [INSTALL](INSTALL) for a compact overview of installation and build entry points.
+
 - [Build on Linux](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_linux.html) - Build instructions for Linux.
 - [Build on Windows](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_win.html) - Build instructions for Windows.
 - [Build on macOS](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html) - Build instructions for macOS.


### PR DESCRIPTION
## Description

Add a top-level `INSTALL` file that points contributors to the existing installation and build documentation, and surface that file from the README build section.

Fixes #4577.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new INSTALL documentation page consolidating installation and build guidance for GNU/Linux, macOS, and Windows platforms.
  * Includes links to binary installer guidance, platform-specific source build instructions, and development documentation.
  * Updated README with reference to INSTALL page for streamlined access to installation overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->