### PR TITLE
TOPPView: default plugins path to executable directory

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -79,6 +79,14 @@ namespace OpenMS
 
   const std::string user_section = "preferences:user:";
 
+  namespace
+  {
+    String getDefaultPluginPath_()
+    {
+      return File::getExecutablePath() + "OpenMS_Plugins";
+    }
+  } // namespace
+
   /// supported types which can be opened with File-->Open
   const FileTypeList supported_types({ FileTypes::MZML, FileTypes::MZXML, FileTypes::MZDATA, FileTypes::SQMASS,
                                        FileTypes::FEATUREXML, FileTypes::CONSENSUSXML, FileTypes::IDXML,
@@ -437,7 +445,7 @@ namespace OpenMS
     defaults_.setValue(user_section + "default_path", ".", "Default path for loading and storing files.");
     defaults_.setValue(user_section + "default_path_current", "true", "If the current path is preferred over the default path.");
     defaults_.setValidStrings(user_section + "default_path_current", {"true","false"});
-    defaults_.setValue(user_section + "plugins_path", File::getUserDirectory() + "OpenMS_Plugins", "Default path for loading Plugins");
+    defaults_.setValue(user_section + "plugins_path", getDefaultPluginPath_(), "Default path for loading Plugins");
     defaults_.setValue(user_section + "intensity_cutoff", "off", "Low intensity cutoff for maps.");
     defaults_.setValidStrings(user_section + "intensity_cutoff", {"on","off"});
     defaults_.setValue(user_section + "on_file_change", "ask", "What action to take, when a data file changes. Do nothing, update automatically or ask the user.");
@@ -1542,7 +1550,7 @@ namespace OpenMS
         if (!tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString()))
         {
           // reset it to the default
-          param_.setValue(user_section + "plugins_path", File::getUserDirectory() + "OpenMS_Plugins");
+          param_.setValue(user_section + "plugins_path", getDefaultPluginPath_());
         }
       }
     }
@@ -1580,7 +1588,7 @@ namespace OpenMS
     if (!tool_scanner_.setPluginPath(param_.getValue(user_section + "plugins_path").toString()))
     {
       // reset if it does not
-      param_.setValue(user_section + "plugins_path", tool_scanner_.getPluginPath());
+      param_.setValue(user_section + "plugins_path", getDefaultPluginPath_());
     }
 
     // save only the subsection that begins with "preferences:" and all tool params ("tool_params:")


### PR DESCRIPTION
## Description

Change TOPPView's default plugin directory from the user home directory to the executable directory, so the plugin folder is created next to the shipped binaries instead of cluttering the user's home directory.

Fixes #6233.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Plugin path resolution has been updated. The application now searches for plugins relative to the executable installation directory by default, with automatic fallback to configured locations when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->