### PR TITLE
docs: add source build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Building OpenMS
 
 For developers who want to build OpenMS from source:
 
+- OpenMS requires CMake 3.21 or newer and a compiler with C++20 support.
 - [Build on Linux](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_linux.html) - Build instructions for Linux.
 - [Build on Windows](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_win.html) - Build instructions for Windows.
 - [Build on macOS](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html) - Build instructions for macOS.

--- a/doc/openms/docs/about/installation/installation-on-gnu-linux.md
+++ b/doc/openms/docs/about/installation/installation-on-gnu-linux.md
@@ -72,4 +72,6 @@ If you encounter errors with unavailable packages, troubleshoot using the follow
 
 ## Build OpenMS from source
 
+Before configuring a source build, make sure CMake 3.21 or newer is installed and that your GCC or Clang toolchain provides C++20 support.
+
 To build OpenMS from source, follow the build instructions for [Linux](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_linux.html).

--- a/doc/openms/docs/about/installation/installation-on-macos.md
+++ b/doc/openms/docs/about/installation/installation-on-macos.md
@@ -114,7 +114,8 @@ To use {term}`TOPP` as regular app in the shell, add the following lines to the 
 
 ## Build OpenMS from source
 
-To build OpenMS from source, follow the build instructions for [macOS](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html).
+Before configuring a source build, make sure CMake 3.21 or newer is installed and that your compiler toolchain provides C++20 support.
 
+To build OpenMS from source, follow the build instructions for [macOS](https://abibuilder.cs.uni-tuebingen.de/archive/openms/Documentation/release/latest/html/install_mac.html).
 
 


### PR DESCRIPTION
## Description

Document the baseline requirements for building OpenMS from source in the README and the GNU/Linux and macOS installation pages. This makes the CMake 3.21 and C++20 expectations visible in the remaining build instructions mentioned in #5195.

Refs #5195.

## Checklist
- [x] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [x] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build requirements information in README and installation guides for Linux and macOS.
  * Added prerequisites for CMake 3.21 or newer and C++20 compiler support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->