### PR TITLE
feat(ProSE): delta score + rename ion counts + expanded Percolator features

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/HyperScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/HyperScore.h
@@ -46,8 +46,8 @@ struct OPENMS_DLLAPI HyperScore
    */
   struct PSMDetail
   {
-    size_t matched_b_ions = 0;
-    size_t matched_y_ions = 0;
+    size_t matched_prefix_ions = 0;  ///< N-terminal ions (a, b, c)
+    size_t matched_suffix_ions = 0;  ///< C-terminal ions (x, y, z)
     double mean_error = 0.0;
   };
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -336,8 +336,8 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       // Layout: doubles first, then floats, then int, then uint16_t — minimizes padding (40 bytes excluding AASequence)
       double score = 0; ///< main score
       double delta_mass = 0.0; ///< mass difference for open search (Da)
-      float prefix_fraction = 0; ///< fraction of annotated b-ions
-      float suffix_fraction = 0; ///< fraction of annotated y-ions
+      float prefix_fraction = 0; ///< fraction of annotated prefix ions (a/b/c)
+      float suffix_fraction = 0; ///< fraction of annotated suffix ions (x/y/z)
       float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0; ///< isotope offset used for this PSM
       uint16_t applied_charge = 0; ///< precursor charge used for this PSM

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ProSEAlgorithm.h
@@ -341,8 +341,8 @@ class OPENMS_DLLAPI ProSEAlgorithm :
       float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0; ///< isotope offset used for this PSM
       uint16_t applied_charge = 0; ///< precursor charge used for this PSM
-      uint16_t matched_b_ions = 0; ///< number of matched b-ions
-      uint16_t matched_y_ions = 0; ///< number of matched y-ions
+      uint16_t matched_prefix_ions = 0; ///< number of matched prefix ions (a/b/c)
+      uint16_t matched_suffix_ions = 0; ///< number of matched suffix ions (x/y/z)
 
       static bool hasBetterScore(const AnnotatedHit_& a, const AnnotatedHit_& b)
       {

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -56,8 +56,8 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       float suffix_fraction = 0; ///< fraction of annotated y-ions
       float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0;
-      uint16_t matched_b_ions = 0; ///< number of matched b-ions
-      uint16_t matched_y_ions = 0; ///< number of matched y-ions
+      uint16_t matched_prefix_ions = 0; ///< number of matched b-ions
+      uint16_t matched_suffix_ions = 0; ///< number of matched y-ions
 
       static bool hasBetterScore(const AnnotatedHit_& a, const AnnotatedHit_& b)
       {

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -52,12 +52,12 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       SignedSize peptide_mod_index; ///< enumeration index of the non-RNA peptide modification
       // Layout: doubles first, then floats, then int, then uint16_t — minimizes padding
       double score = 0; ///< main score
-      float prefix_fraction = 0; ///< fraction of annotated b-ions
-      float suffix_fraction = 0; ///< fraction of annotated y-ions
+      float prefix_fraction = 0; ///< fraction of annotated prefix ions (a/b/c)
+      float suffix_fraction = 0; ///< fraction of annotated suffix ions (x/y/z)
       float mean_error = 0.0f; ///< mean absolute fragment mass error
       int isotope_error = 0;
-      uint16_t matched_prefix_ions = 0; ///< number of matched b-ions
-      uint16_t matched_suffix_ions = 0; ///< number of matched y-ions
+      uint16_t matched_prefix_ions = 0; ///< number of matched prefix ions (a/b/c)
+      uint16_t matched_suffix_ions = 0; ///< number of matched suffix ions (x/y/z)
 
       static bool hasBetterScore(const AnnotatedHit_& a, const AnnotatedHit_& b)
       {

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -353,7 +353,7 @@ namespace OpenMS
       // User parameter name for the total number of matched fragment ions
       inline const std::string NUM_MATCHED_PEAKS = "num_matched_peaks";
 
-      // User parameter name for the longest consecutive b- or y-ion series
+      // User parameter name for the longest consecutive prefix (a/b/c) or suffix (x/y/z) ion series
       inline const std::string LONGEST_PEPTIDE_ION_SEQUENCE = "longest_peptide_ion_sequence";
 
       // User parameter name for the matched ion current (sum of experimental

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -344,11 +344,11 @@ namespace OpenMS
       // User parameter name for the fraction of suffix ions that have been matched
       inline const std::string MATCHED_SUFFIX_IONS_FRACTION = "matched_suffix_ions_fraction";
 
-      // User parameter name for the number of matched b-ions (absolute count)
-      inline const std::string MATCHED_B_IONS = "matched_b_ions";
+      // User parameter name for the number of matched prefix ions (a/b/c, absolute count)
+      inline const std::string MATCHED_PREFIX_IONS = "matched_prefix_ions";
 
-      // User parameter name for the number of matched y-ions (absolute count)
-      inline const std::string MATCHED_Y_IONS = "matched_y_ions";
+      // User parameter name for the number of matched suffix ions (x/y/z, absolute count)
+      inline const std::string MATCHED_SUFFIX_IONS = "matched_suffix_ions";
 
       // User parameter name for the total number of matched fragment ions
       inline const std::string NUM_MATCHED_PEAKS = "num_matched_peaks";

--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -356,6 +356,10 @@ namespace OpenMS
       // User parameter name for the longest consecutive b- or y-ion series
       inline const std::string LONGEST_PEPTIDE_ION_SEQUENCE = "longest_peptide_ion_sequence";
 
+      // User parameter name for the matched ion current (sum of experimental
+      // intensities over all matched fragment peaks, raw — not log-transformed)
+      inline const std::string MATCHED_ION_CURRENT = "matched_ion_current";
+
       /** User parameter name for the spectrum reference in PeptideIdentification (it is not yet treated as a class attribute)
               String
       */

--- a/src/openms/source/ANALYSIS/ID/HyperScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/HyperScore.cpp
@@ -127,30 +127,27 @@ namespace OpenMS
       return 0.0;
     }
 
-    int y_ion_count = 0;
-    int b_ion_count = 0;
+    int prefix_ion_count = 0;  // N-terminal: a, b, c
+    int suffix_ion_count = 0;  // C-terminal: x, y, z (incl. z., z')
     double dot_product = 0.0;
     double abs_error = 0.0;
-    if (fragment_mass_tolerance_unit_ppm) 
+
+    if (fragment_mass_tolerance_unit_ppm)
     {
       MatchedIterator<PeakSpectrum, PpmTrait, true> it(theo_spectrum, exp_spectrum, fragment_mass_tolerance);
       for (; it != it.end(); ++it)
       {
-        const double exp_mz{it.ref().getMZ()};
-        const double theo_mz{(*it).getMZ()};
-        const double exp_int{it.ref().getIntensity()};
-        const double theo_int{(*it).getIntensity()};
-        abs_error += Math::getPPMAbs(theo_mz, exp_mz);
-        dot_product += theo_int * exp_int; /* * mass_error */;
-        // fragment annotations in XL-MS data are more complex and do not start with the ion type, but the ion type always follows after a $
-        auto i = it.refIdx();
-        if ((*ion_names)[i][0] == 'y' || (*ion_names)[i].hasSubstring("$y"))
+        abs_error += Math::getPPMAbs((*it).getMZ(), it.ref().getMZ());
+        dot_product += (*it).getIntensity() * it.ref().getIntensity();
+        const String& name = (*ion_names)[it.refIdx()];
+        const char c = name[0];
+        if (c == 'a' || c == 'b' || c == 'c') ++prefix_ion_count;
+        else if (c == 'x' || c == 'y' || c == 'z') ++suffix_ion_count;
+        else if (auto p = name.find('$'); p != String::npos && p + 1 < name.size())
         {
-          ++y_ion_count;
-        }
-        else if ((*ion_names)[i][0] == 'b' || (*ion_names)[i].hasSubstring("$b"))
-        {
-          ++b_ion_count;
+          const char d = name[p + 1];
+          if (d == 'a' || d == 'b' || d == 'c') ++prefix_ion_count;
+          else if (d == 'x' || d == 'y' || d == 'z') ++suffix_ion_count;
         }
       }
     }
@@ -160,30 +157,26 @@ namespace OpenMS
       for (; it != it.end(); ++it)
       {
         abs_error += abs((*it).getMZ() - it.ref().getMZ());
-        dot_product += (*it).getIntensity() * it.ref().getIntensity(); /* * mass_error */;
-        // fragment annotations in XL-MS data are more complex and do not start with the ion type, but the ion type always follows after a $
-        auto i = it.refIdx();
-        if ((*ion_names)[i][0] == 'y' || (*ion_names)[i].hasSubstring("$y"))
+        dot_product += (*it).getIntensity() * it.ref().getIntensity();
+        const String& name = (*ion_names)[it.refIdx()];
+        const char c = name[0];
+        if (c == 'a' || c == 'b' || c == 'c') ++prefix_ion_count;
+        else if (c == 'x' || c == 'y' || c == 'z') ++suffix_ion_count;
+        else if (auto p = name.find('$'); p != String::npos && p + 1 < name.size())
         {
-          ++y_ion_count;
-        }
-        else if ((*ion_names)[i][0] == 'b' || (*ion_names)[i].hasSubstring("$b"))
-        {
-          ++b_ion_count;
+          const char d = name[p + 1];
+          if (d == 'a' || d == 'b' || d == 'c') ++prefix_ion_count;
+          else if (d == 'x' || d == 'y' || d == 'z') ++suffix_ion_count;
         }
       }
     }
-    // inefficient: calculates logs repeatedly
-    //const double yFact = logfactorial_(y_ion_count);
-    //const double bFact = logfactorial_(b_ion_count);
-    //const double hyperScore = log1p(dot_product) + yFact + bFact;
 
-    const int i_min = std::min(y_ion_count, b_ion_count);
-    const int i_max = std::max(y_ion_count, b_ion_count);
+    const int i_min = std::min(suffix_ion_count, prefix_ion_count);
+    const int i_max = std::max(suffix_ion_count, prefix_ion_count);
     const double hyperScore = log1p(dot_product) + 2*logfactorial_(i_min) + logfactorial_(i_max, i_min + 1);
-    d.matched_b_ions = b_ion_count;
-    d.matched_y_ions = y_ion_count;
-    d.mean_error = (b_ion_count + y_ion_count) > 0 ? abs_error / (double)(b_ion_count + y_ion_count) : 0.0;
+    d.matched_prefix_ions = prefix_ion_count;
+    d.matched_suffix_ions = suffix_ion_count;
+    d.mean_error = (prefix_ion_count + suffix_ion_count) > 0 ? abs_error / (double)(prefix_ion_count + suffix_ion_count) : 0.0;
     return hyperScore;
   }
 

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -131,8 +131,8 @@ namespace OpenMS
         Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
         Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION,
         Constants::UserParam::NUM_MATCHED_PEAKS,
-        Constants::UserParam::MATCHED_B_IONS,
-        Constants::UserParam::MATCHED_Y_IONS,
+        Constants::UserParam::MATCHED_PREFIX_IONS,
+        Constants::UserParam::MATCHED_SUFFIX_IONS,
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
         Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
@@ -342,15 +342,30 @@ namespace OpenMS
         const String& enzyme,
         const String& database_name) const
   {
-    // remove all but top n scoring TODO: use two parameters to distinguish between number of reported peptides and number of pre-scored peptides
-#pragma omp parallel for default(none) shared(annotated_hits, top_hits)
+    // remove all but top n scoring; compute delta_score (best - second-best)
+    // before truncation so it's available even when top_hits=1. Delta is stored
+    // in a side vector (one float per spectrum) to avoid adding a field to every
+    // AnnotatedHit_ candidate during scoring.
+    std::vector<float> delta_scores(annotated_hits.size(), 0.0f);
+#pragma omp parallel for default(none) shared(annotated_hits, top_hits, delta_scores)
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
     {
-      // sort and keeps n best elements according to score
-      Size topn = top_hits > annotated_hits[scan_index].size() ? annotated_hits[scan_index].size() : top_hits;
-      std::partial_sort(annotated_hits[scan_index].begin(), annotated_hits[scan_index].begin() + topn, annotated_hits[scan_index].end(), AnnotatedHit_::hasBetterScore);
-      annotated_hits[scan_index].resize(topn);
-      annotated_hits[scan_index].shrink_to_fit();
+      auto& hits = annotated_hits[scan_index];
+
+      // O(N) pass: find top-2 scores for delta. Leaves partial_sort unchanged.
+      double best_score = 0.0, second_best_score = 0.0;
+      for (const auto& h : hits)
+      {
+        if (h.score > best_score) { second_best_score = best_score; best_score = h.score; }
+        else if (h.score > second_best_score) { second_best_score = h.score; }
+      }
+      delta_scores[scan_index] = static_cast<float>(best_score - second_best_score);
+
+      // sort and keep n best elements according to score (unchanged)
+      Size topn = top_hits > hits.size() ? hits.size() : top_hits;
+      std::partial_sort(hits.begin(), hits.begin() + topn, hits.end(), AnnotatedHit_::hasBetterScore);
+      hits.resize(topn);
+      hits.shrink_to_fit();
     }
 
     bool annotation_precursor_error_ppm = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::PRECURSOR_ERROR_PPM_USERPARAM) != annotate_psm_.end();
@@ -358,8 +373,8 @@ namespace OpenMS
     bool annotation_prefix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_suffix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_num_matched_peaks = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::NUM_MATCHED_PEAKS) != annotate_psm_.end();
-    bool annotation_matched_b_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_B_IONS) != annotate_psm_.end();
-    bool annotation_matched_y_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_Y_IONS) != annotate_psm_.end();
+    bool annotation_matched_prefix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS) != annotate_psm_.end();
+    bool annotation_matched_suffix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS) != annotate_psm_.end();
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
@@ -371,8 +386,8 @@ namespace OpenMS
       annotation_prefix_fraction = true;
       annotation_suffix_fraction = true;
       annotation_num_matched_peaks = true;
-      annotation_matched_b_ions = true;
-      annotation_matched_y_ions = true;
+      annotation_matched_prefix_ions = true;
+      annotation_matched_suffix_ions = true;
       annotation_longest_ion_run = true;
       annotation_fragment_annotations = true;
     }
@@ -465,16 +480,18 @@ namespace OpenMS
           // Matched ion counts (from scoring, no alignment needed)
           if (annotation_num_matched_peaks)
           {
-            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_b_ions + ah.matched_y_ions));
+            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_prefix_ions + ah.matched_suffix_ions));
           }
-          if (annotation_matched_b_ions)
+          if (annotation_matched_prefix_ions)
           {
-            ph.setMetaValue(Constants::UserParam::MATCHED_B_IONS, static_cast<int>(ah.matched_b_ions));
+            ph.setMetaValue(Constants::UserParam::MATCHED_PREFIX_IONS, static_cast<int>(ah.matched_prefix_ions));
           }
-          if (annotation_matched_y_ions)
+          if (annotation_matched_suffix_ions)
           {
-            ph.setMetaValue(Constants::UserParam::MATCHED_Y_IONS, static_cast<int>(ah.matched_y_ions));
+            ph.setMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS, static_cast<int>(ah.matched_suffix_ions));
           }
+
+          ph.setMetaValue(Constants::UserParam::DELTA_SCORE, delta_scores[scan_index]);
 
           // Fragment annotations and longest ion run (both need alignment + ion names)
           if (annotation_fragment_annotations || annotation_longest_ion_run)
@@ -626,6 +643,10 @@ namespace OpenMS
     if (annotation_fragment_error_ppm) feature_set.push_back(Constants::UserParam::FRAGMENT_ERROR_MEDIAN_PPM_USERPARAM);
     if (annotation_prefix_fraction) feature_set.push_back(Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION);
     if (annotation_suffix_fraction) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION);
+    if (annotation_longest_ion_run) feature_set.push_back(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE);
+    if (annotation_matched_prefix_ions) feature_set.push_back(Constants::UserParam::MATCHED_PREFIX_IONS);
+    if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
+    feature_set.push_back(Constants::UserParam::DELTA_SCORE);
     // note: precursor error is calculated by percolator itself
     search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));
     // record whether open-search mode was used
@@ -878,11 +899,11 @@ namespace OpenMS
         ah.sequence = std::move(mod_candidate);
         ah.score = score;
         double seq_length = (double)ah.sequence.size();
-        ah.prefix_fraction = static_cast<float>(detail.matched_b_ions / seq_length);
-        ah.suffix_fraction = static_cast<float>(detail.matched_y_ions / seq_length);
+        ah.prefix_fraction = static_cast<float>(detail.matched_prefix_ions / seq_length);
+        ah.suffix_fraction = static_cast<float>(detail.matched_suffix_ions / seq_length);
         ah.mean_error = static_cast<float>(detail.mean_error);
-        ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
-        ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
+        ah.matched_prefix_ions = static_cast<uint16_t>(detail.matched_prefix_ions);
+        ah.matched_suffix_ions = static_cast<uint16_t>(detail.matched_suffix_ions);
 
         ah.isotope_error = sms.isotope_error_;
         ah.applied_charge = sms.precursor_charge_;

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -134,6 +134,7 @@ namespace OpenMS
         Constants::UserParam::MATCHED_PREFIX_IONS,
         Constants::UserParam::MATCHED_SUFFIX_IONS,
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
+        Constants::UserParam::MATCHED_ION_CURRENT,
         Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
 
@@ -376,6 +377,7 @@ namespace OpenMS
     bool annotation_matched_prefix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS) != annotate_psm_.end();
     bool annotation_matched_suffix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS) != annotate_psm_.end();
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
+    bool annotation_matched_ion_current = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
     // "ALL" adds all annotations
@@ -389,11 +391,12 @@ namespace OpenMS
       annotation_matched_prefix_ions = true;
       annotation_matched_suffix_ions = true;
       annotation_longest_ion_run = true;
+      annotation_matched_ion_current = true;
       annotation_fragment_annotations = true;
     }
 
-    // Alignment is needed for fragment error, fragment annotations, and longest ion run
-    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run;
+    // Alignment is needed for fragment error, fragment annotations, longest ion run, and MIC
+    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current;
 
 #pragma omp parallel for
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
@@ -493,15 +496,20 @@ namespace OpenMS
 
           ph.setMetaValue(Constants::UserParam::DELTA_SCORE, delta_scores[scan_index]);
 
-          // Fragment annotations and longest ion run (both need alignment + ion names)
-          if (annotation_fragment_annotations || annotation_longest_ion_run)
+          // Fragment annotations, longest ion run, and MIC all iterate the alignment + ion names
+          if (annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current)
           {
             const auto& ion_names = theoretical_spec.getStringDataArrays()[0];
             const auto& ion_charges = theoretical_spec.getIntegerDataArrays()[0];
 
-            // Build PeakAnnotation vector + collect ion ordinals for longest run
+            // Build PeakAnnotation vector + collect ion ordinals for longest run.
+            // Prefix = a/b/c (N-terminal), suffix = x/y/z (C-terminal). Ordinals
+            // for different ion types at the same cleavage position (e.g. a3 + b3)
+            // are merged via std::unique below — each ordinal is a backbone
+            // position, not an ion-type-specific identifier.
             std::vector<PeptideHit::PeakAnnotation> peak_annotations;
-            std::vector<int> b_ordinals, y_ordinals;
+            std::vector<int> prefix_ordinals, suffix_ordinals;
+            double matched_ion_current = 0.0;
             peak_annotations.reserve(alignment.size());
 
             for (const auto& [theo_idx, exp_idx] : alignment)
@@ -516,19 +524,30 @@ namespace OpenMS
                 peak_annotations.push_back(pa);
               }
 
-              if (annotation_longest_ion_run)
+              if (annotation_matched_ion_current)
+              {
+                // Safe: SpectrumAlignment's default Da path returns 1-to-1
+                // matches, so each exp_idx appears at most once. If ppm mode
+                // ever gets enabled here, one exp peak could match multiple
+                // theo peaks and this would double-count — revisit then.
+                matched_ion_current += spec[exp_idx].getIntensity();
+              }
+
+              if (annotation_longest_ion_run && ion_names[theo_idx].size() >= 2)
               {
                 const String& name = ion_names[theo_idx];
-                if (name.size() >= 2 && (name[0] == 'b' || name[0] == 'y'))
+                const char c = name[0];
+                const bool is_prefix = (c == 'a' || c == 'b' || c == 'c');
+                const bool is_suffix = (c == 'x' || c == 'y' || c == 'z');
+                if (is_prefix || is_suffix)
                 {
-                  // Extract ordinal: "b5", "y3-H2O1+", "b12++" -> 5, 3, 12
+                  // Extract ordinal: "b5", "y3-H2O1+", "c12++" -> 5, 3, 12
                   Size pos = 1;
                   while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9') ++pos;
                   if (pos > 1)
                   {
                     int ordinal = String(name.substr(1, pos - 1)).toInt();
-                    if (name[0] == 'b') b_ordinals.push_back(ordinal);
-                    else y_ordinals.push_back(ordinal);
+                    (is_prefix ? prefix_ordinals : suffix_ordinals).push_back(ordinal);
                   }
                 }
               }
@@ -539,9 +558,14 @@ namespace OpenMS
               ph.setPeakAnnotations(std::move(peak_annotations));
             }
 
+            if (annotation_matched_ion_current)
+            {
+              ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT, matched_ion_current);
+            }
+
             if (annotation_longest_ion_run)
             {
-              // Compute longest consecutive run across b and y series
+              // Compute longest consecutive run across prefix and suffix series
               auto longestRun = [](std::vector<int>& v) -> int {
                 if (v.empty()) return 0;
                 std::sort(v.begin(), v.end());
@@ -554,7 +578,7 @@ namespace OpenMS
                 }
                 return best;
               };
-              int longest = std::max(longestRun(b_ordinals), longestRun(y_ordinals));
+              int longest = std::max(longestRun(prefix_ordinals), longestRun(suffix_ordinals));
               ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, longest);
             }
           }
@@ -646,6 +670,7 @@ namespace OpenMS
     if (annotation_longest_ion_run) feature_set.push_back(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE);
     if (annotation_matched_prefix_ions) feature_set.push_back(Constants::UserParam::MATCHED_PREFIX_IONS);
     if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
+    if (annotation_matched_ion_current) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT);
     feature_set.push_back(Constants::UserParam::DELTA_SCORE);
     // note: precursor error is calculated by percolator itself
     search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -113,8 +113,8 @@ namespace OpenMS
         Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION,
         Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION,
         Constants::UserParam::NUM_MATCHED_PEAKS,
-        Constants::UserParam::MATCHED_B_IONS,
-        Constants::UserParam::MATCHED_Y_IONS,
+        Constants::UserParam::MATCHED_PREFIX_IONS,
+        Constants::UserParam::MATCHED_SUFFIX_IONS,
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
         Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
@@ -278,8 +278,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     bool annotation_prefix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_suffix_fraction = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS_FRACTION) != annotate_psm_.end();
     bool annotation_num_matched_peaks = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::NUM_MATCHED_PEAKS) != annotate_psm_.end();
-    bool annotation_matched_b_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_B_IONS) != annotate_psm_.end();
-    bool annotation_matched_y_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_Y_IONS) != annotate_psm_.end();
+    bool annotation_matched_prefix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS) != annotate_psm_.end();
+    bool annotation_matched_suffix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS) != annotate_psm_.end();
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
@@ -291,8 +291,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       annotation_prefix_fraction = true;
       annotation_suffix_fraction = true;
       annotation_num_matched_peaks = true;
-      annotation_matched_b_ions = true;
-      annotation_matched_y_ions = true;
+      annotation_matched_prefix_ions = true;
+      annotation_matched_suffix_ions = true;
       annotation_longest_ion_run = true;
       annotation_fragment_annotations = true;
     }
@@ -395,15 +395,15 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
           // Matched ion counts (from scoring, no alignment needed)
           if (annotation_num_matched_peaks)
           {
-            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_b_ions + ah.matched_y_ions));
+            ph.setMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS, static_cast<int>(ah.matched_prefix_ions + ah.matched_suffix_ions));
           }
-          if (annotation_matched_b_ions)
+          if (annotation_matched_prefix_ions)
           {
-            ph.setMetaValue(Constants::UserParam::MATCHED_B_IONS, static_cast<int>(ah.matched_b_ions));
+            ph.setMetaValue(Constants::UserParam::MATCHED_PREFIX_IONS, static_cast<int>(ah.matched_prefix_ions));
           }
-          if (annotation_matched_y_ions)
+          if (annotation_matched_suffix_ions)
           {
-            ph.setMetaValue(Constants::UserParam::MATCHED_Y_IONS, static_cast<int>(ah.matched_y_ions));
+            ph.setMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS, static_cast<int>(ah.matched_suffix_ions));
           }
 
           // Fragment annotations and longest ion run (both need alignment + ion names)
@@ -795,11 +795,11 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
             ah.sequence = c;
             ah.peptide_mod_index = mod_pep_idx;
             ah.score = score;
-            ah.prefix_fraction = static_cast<float>((double)detail.matched_b_ions / (double)c.size());
-            ah.suffix_fraction = static_cast<float>((double)detail.matched_y_ions / (double)c.size());
+            ah.prefix_fraction = static_cast<float>((double)detail.matched_prefix_ions / (double)c.size());
+            ah.suffix_fraction = static_cast<float>((double)detail.matched_suffix_ions / (double)c.size());
             ah.mean_error = static_cast<float>(detail.mean_error);
-            ah.matched_b_ions = static_cast<uint16_t>(detail.matched_b_ions);
-            ah.matched_y_ions = static_cast<uint16_t>(detail.matched_y_ions);
+            ah.matched_prefix_ions = static_cast<uint16_t>(detail.matched_prefix_ions);
+            ah.matched_suffix_ions = static_cast<uint16_t>(detail.matched_suffix_ions);
             ah.isotope_error = low_it->second.second;
 
 #ifdef _OPENMP

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -116,6 +116,7 @@ namespace OpenMS
         Constants::UserParam::MATCHED_PREFIX_IONS,
         Constants::UserParam::MATCHED_SUFFIX_IONS,
         Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE,
+        Constants::UserParam::MATCHED_ION_CURRENT,
         Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM}
       );
 
@@ -281,6 +282,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     bool annotation_matched_prefix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_PREFIX_IONS) != annotate_psm_.end();
     bool annotation_matched_suffix_ions = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_SUFFIX_IONS) != annotate_psm_.end();
     bool annotation_longest_ion_run = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE) != annotate_psm_.end();
+    bool annotation_matched_ion_current = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::MATCHED_ION_CURRENT) != annotate_psm_.end();
     bool annotation_fragment_annotations = std::find(annotate_psm_.begin(), annotate_psm_.end(), Constants::UserParam::FRAGMENT_ANNOTATION_USERPARAM) != annotate_psm_.end();
 
     // "ALL" adds all annotations
@@ -294,11 +296,12 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       annotation_matched_prefix_ions = true;
       annotation_matched_suffix_ions = true;
       annotation_longest_ion_run = true;
+      annotation_matched_ion_current = true;
       annotation_fragment_annotations = true;
     }
 
-    // Alignment is needed for fragment error, fragment annotations, and longest ion run
-    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run;
+    // Alignment is needed for fragment error, fragment annotations, longest ion run, and MIC
+    const bool need_alignment = annotation_fragment_error_ppm || annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current;
 
 #pragma omp parallel for
     for (SignedSize scan_index = 0; scan_index < (SignedSize)annotated_hits.size(); ++scan_index)
@@ -406,15 +409,19 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
             ph.setMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS, static_cast<int>(ah.matched_suffix_ions));
           }
 
-          // Fragment annotations and longest ion run (both need alignment + ion names)
-          if (annotation_fragment_annotations || annotation_longest_ion_run)
+          // Fragment annotations, longest ion run, and MIC all iterate the alignment + ion names
+          if (annotation_fragment_annotations || annotation_longest_ion_run || annotation_matched_ion_current)
           {
             const auto& ion_names = theoretical_spec.getStringDataArrays()[0];
             const auto& ion_charges = theoretical_spec.getIntegerDataArrays()[0];
 
-            // Build PeakAnnotation vector + collect ion ordinals for longest run
+            // Build PeakAnnotation vector + collect ion ordinals for longest run.
+            // Prefix = a/b/c (N-terminal), suffix = x/y/z (C-terminal). Ordinals
+            // at the same backbone position across ion types (e.g. a3 + b3) are
+            // merged via std::unique below.
             std::vector<PeptideHit::PeakAnnotation> peak_annotations;
-            std::vector<int> b_ordinals, y_ordinals;
+            std::vector<int> prefix_ordinals, suffix_ordinals;
+            double matched_ion_current = 0.0;
             peak_annotations.reserve(alignment.size());
 
             for (const auto& [theo_idx, exp_idx] : alignment)
@@ -429,19 +436,27 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
                 peak_annotations.push_back(pa);
               }
 
-              if (annotation_longest_ion_run)
+              if (annotation_matched_ion_current)
+              {
+                // See ProSEAlgorithm.cpp for the 1-to-1 alignment assumption.
+                matched_ion_current += spec[exp_idx].getIntensity();
+              }
+
+              if (annotation_longest_ion_run && ion_names[theo_idx].size() >= 2)
               {
                 const String& name = ion_names[theo_idx];
-                if (name.size() >= 2 && (name[0] == 'b' || name[0] == 'y'))
+                const char c = name[0];
+                const bool is_prefix = (c == 'a' || c == 'b' || c == 'c');
+                const bool is_suffix = (c == 'x' || c == 'y' || c == 'z');
+                if (is_prefix || is_suffix)
                 {
-                  // Extract ordinal: "b5", "y3-H2O1+", "b12++" -> 5, 3, 12
+                  // Extract ordinal: "b5", "y3-H2O1+", "c12++" -> 5, 3, 12
                   Size pos = 1;
                   while (pos < name.size() && name[pos] >= '0' && name[pos] <= '9') ++pos;
                   if (pos > 1)
                   {
                     int ordinal = String(name.substr(1, pos - 1)).toInt();
-                    if (name[0] == 'b') b_ordinals.push_back(ordinal);
-                    else y_ordinals.push_back(ordinal);
+                    (is_prefix ? prefix_ordinals : suffix_ordinals).push_back(ordinal);
                   }
                 }
               }
@@ -452,9 +467,14 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
               ph.setPeakAnnotations(std::move(peak_annotations));
             }
 
+            if (annotation_matched_ion_current)
+            {
+              ph.setMetaValue(Constants::UserParam::MATCHED_ION_CURRENT, matched_ion_current);
+            }
+
             if (annotation_longest_ion_run)
             {
-              // Compute longest consecutive run across b and y series
+              // Compute longest consecutive run across prefix (a/b/c) and suffix (x/y/z) series
               auto longestRun = [](std::vector<int>& v) -> int {
                 if (v.empty()) return 0;
                 std::sort(v.begin(), v.end());
@@ -467,7 +487,7 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
                 }
                 return best;
               };
-              int longest = std::max(longestRun(b_ordinals), longestRun(y_ordinals));
+              int longest = std::max(longestRun(prefix_ordinals), longestRun(suffix_ordinals));
               ph.setMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE, longest);
             }
           }

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1174,19 +1174,19 @@ START_SECTION(([EXTRA] PSM annotations - matched ion counts, longest run, fragme
 
   // Verify matched ion count annotations exist and are positive
   TEST_EQUAL(hit.metaValueExists(Constants::UserParam::NUM_MATCHED_PEAKS), true)
-  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_B_IONS), true)
-  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_Y_IONS), true)
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_PREFIX_IONS), true)
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_SUFFIX_IONS), true)
   TEST_EQUAL(hit.metaValueExists(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE), true)
 
   int num_matched = hit.getMetaValue(Constants::UserParam::NUM_MATCHED_PEAKS);
-  int b_ions = hit.getMetaValue(Constants::UserParam::MATCHED_B_IONS);
-  int y_ions = hit.getMetaValue(Constants::UserParam::MATCHED_Y_IONS);
+  int prefix_ions = hit.getMetaValue(Constants::UserParam::MATCHED_PREFIX_IONS);
+  int suffix_ions = hit.getMetaValue(Constants::UserParam::MATCHED_SUFFIX_IONS);
   int longest_run = hit.getMetaValue(Constants::UserParam::LONGEST_PEPTIDE_ION_SEQUENCE);
 
   TEST_EQUAL(num_matched > 0, true)
-  TEST_EQUAL(num_matched, b_ions + y_ions)
-  TEST_EQUAL(b_ions > 0, true)
-  TEST_EQUAL(y_ions > 0, true)
+  TEST_EQUAL(num_matched, prefix_ions + suffix_ions)
+  TEST_EQUAL(prefix_ions > 0, true)
+  TEST_EQUAL(suffix_ions > 0, true)
 
   // Perfect match: longest run should be substantial (peptide length - 1 for one series)
   TEST_EQUAL(longest_run >= 3, true)

--- a/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/ProSEAlgorithm_test.cpp
@@ -1191,6 +1191,23 @@ START_SECTION(([EXTRA] PSM annotations - matched ion counts, longest run, fragme
   // Perfect match: longest run should be substantial (peptide length - 1 for one series)
   TEST_EQUAL(longest_run >= 3, true)
 
+  // Delta score is emitted on every retained hit. With a single database peptide,
+  // there is no competing candidate, so delta = full score (same "no competition
+  // = maximum delta" convention as Sage/MSFragger).
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::DELTA_SCORE), true)
+  double delta = hit.getMetaValue(Constants::UserParam::DELTA_SCORE);
+  TEST_REAL_SIMILAR(delta, hit.getScore())
+
+  // MIC = sum of experimental intensities over matched peaks. The synthetic
+  // spectrum copies theoretical peaks into the experimental one, so MIC should
+  // equal the sum of theoretical peak intensities. Verifies the MIC code
+  // accumulates exactly once per matched peak (no double-counting).
+  TEST_EQUAL(hit.metaValueExists(Constants::UserParam::MATCHED_ION_CURRENT), true)
+  double expected_mic = 0.0;
+  for (const auto& p : theo) { expected_mic += p.getIntensity(); }
+  double mic = hit.getMetaValue(Constants::UserParam::MATCHED_ION_CURRENT);
+  TEST_REAL_SIMILAR(mic, expected_mic)
+
   // Verify fragment annotations
   const auto& annotations = hit.getPeakAnnotations();
   TEST_EQUAL(annotations.empty(), false)

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-09T11:11:27" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-17T14:55:16" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-percolator-features-2026-04-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -37,11 +37,13 @@
 				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285716414452"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428596973419"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
+				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
+				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -54,11 +56,13 @@
 				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.46428570151329"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.46428570151329"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
+				<UserParam type="float" name="delta_score" value="47.256179809570313"/>
+				<UserParam type="float" name="matched_ion_current" value="7.902573899365962"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -71,11 +75,13 @@
 				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.52173912525177"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.52173912525177"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
+				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -40,8 +40,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
-				<UserParam type="int" name="matched_b_ions" value="3"/>
-				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="matched_prefix_ions" value="3"/>
+				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -57,8 +57,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
-				<UserParam type="int" name="matched_b_ions" value="13"/>
-				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="matched_prefix_ions" value="13"/>
+				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -74,8 +74,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
-				<UserParam type="int" name="matched_b_ions" value="12"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="12"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-09T11:11:27" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-17T14:55:16" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-percolator-features-2026-04-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -37,11 +37,13 @@
 				<UserParam type="string" name="fragment_annotation" value="175.119094848632813,0.145235076546669,1,&quot;y1+&quot;|263.10302734375,0.269983410835266,1,&quot;b2+&quot;|281.664825439453125,0.045622423291206,2,&quot;y4++&quot;|334.140472412109375,0.038884554058313,1,&quot;b3+&quot;|338.206695556640625,0.036569740623236,2,&quot;y5++&quot;|387.74066162109375,0.041254211217165,2,&quot;y6++&quot;|425.263031005859375,0.154225364327431,1,&quot;y3+&quot;|469.2728271484375,0.031441166996956,2,&quot;y7++&quot;|497.783782958984375,0.041119836270809,2,&quot;y8++&quot;|526.29443359375,0.094272904098034,2,&quot;y9++&quot;|569.81048583984375,0.115230679512024,2,&quot;y10++&quot;|613.32598876953125,0.102093867957592,2,&quot;y11++&quot;|622.2730712890625,4.212265368551016e-03,1,&quot;b7+&quot;|648.84503173828125,0.051233120262623,2,&quot;y12++&quot;|675.40625,0.336008250713348,1,&quot;y5+&quot;|937.53729248046875,0.061362523585558,1,&quot;y7+&quot;|994.55938720703125,0.057263620197773,1,&quot;y8+&quot;|1051.580810546875,0.09991666674614,1,&quot;y9+&quot;|1138.6112060546875,0.048153448849916,1,&quot;y10+&quot;|1225.658935546875,7.874150760471821e-03,1,&quot;y11+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285716414452"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428596973419"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
+				<UserParam type="float" name="delta_score" value="13.195273399353027"/>
+				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -54,11 +56,13 @@
 				<UserParam type="string" name="fragment_annotation" value="147.112884521484375,0.073362722992897,1,&quot;y1+&quot;|149.436859130859375,0.012210736982524,2,&quot;b3++&quot;|185.128372192382813,0.304318636655808,1,&quot;b2+&quot;|294.18121337890625,0.199159145355225,1,&quot;y2+&quot;|298.212554931640625,0.030436070635915,1,&quot;b3+&quot;|426.25994873046875,0.053214963525534,2,&quot;b8++&quot;|604.2803955078125,0.367977857589722,1,&quot;y4+&quot;|638.34381103515625,0.023529993370175,1,&quot;b6+&quot;|675.31707763671875,0.364999026060104,1,&quot;y5+&quot;|681.91497802734375,0.018387651070952,2,&quot;b13++&quot;|746.35400390625,0.278303116559982,1,&quot;y6+&quot;|752.44500732421875,0.043161459267139,1,&quot;b7+&quot;|851.50775146484375,0.140275537967682,1,&quot;b8+&quot;|909.41217041015625,0.246380671858788,1,&quot;y7+&quot;|980.553148337916468,0.612667679786682,1,&quot;b9+&quot;|1079.6219482421875,1.0,1,&quot;b10+&quot;|1138.490478515625,0.284363687038422,1,&quot;y9+&quot;|1178.689378806666582,0.277622222900391,1,&quot;b11+&quot;|1221.7279052734375,0.205706641077995,2,&quot;b22++&quot;|1239.53515625,0.73640251159668,1,&quot;y10+&quot;|1249.726318359375,0.724085569381714,1,&quot;b12+&quot;|1292.7978515625,0.012267889454961,2,&quot;b24++&quot;|1352.6168212890625,0.234000310301781,1,&quot;y11+&quot;|1362.8125,0.279476225376129,1,&quot;b13+&quot;|1476.8531494140625,0.269533842802048,1,&quot;b14+&quot;|1499.689453125,0.080423474311829,1,&quot;y12+&quot;|1591.881591796875,0.727882027626038,1,&quot;b15+&quot;|1596.741455078125,0.219704270362854,1,&quot;y13+&quot;|1688.953905173854082,0.01809080503881,1,&quot;b16+&quot;|1711.765380859375,0.032515596598387,1,&quot;y14+&quot;|1825.8343505859375,0.032113555818796,1,&quot;y15+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.46428570151329"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.46428570151329"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
+				<UserParam type="float" name="delta_score" value="47.256179809570313"/>
+				<UserParam type="float" name="matched_ion_current" value="7.902573899365962"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -71,11 +75,13 @@
 				<UserParam type="string" name="fragment_annotation" value="175.118865966796875,0.150531977415085,1,&quot;y1+&quot;|254.148391723632813,0.206978902220726,1,&quot;b2+&quot;|322.18890380859375,0.049145385622978,1,&quot;y2+&quot;|379.209442138671875,0.17941327393055,1,&quot;y3+&quot;|382.223785400390625,0.022014291957021,1,&quot;b4+&quot;|435.20831298828125,0.068259246647358,2,&quot;b9++&quot;|450.24664306640625,0.259074866771698,1,&quot;y4+&quot;|463.720184326171875,0.089691311120987,2,&quot;b10++&quot;|497.24560546875,0.120945297181606,1,&quot;b5+&quot;|537.2552490234375,0.10333526879549,2,&quot;b11++&quot;|565.7642822265625,0.180150553584099,2,&quot;b12++&quot;|578.30462646484375,0.339738875627518,1,&quot;y5+&quot;|594.27630615234375,0.12102073431015,2,&quot;b13++&quot;|649.341552734375,0.642973005771637,1,&quot;y6+&quot;|650.82373046875,0.047898273915052,2,&quot;b14++&quot;|699.30572509765625,0.504444420337677,1,&quot;b7+&quot;|762.42547607421875,0.540082812309265,1,&quot;y7+&quot;|812.39007568359375,0.212916702032089,1,&quot;b8+&quot;|813.406494140625,0.049756519496441,2,&quot;y16++&quot;|869.41009521484375,0.156664118170738,1,&quot;b9+&quot;|877.45343017578125,0.795250296592712,1,&quot;y8+&quot;|926.434326171875,0.743671417236328,1,&quot;b10+&quot;|1007.50408935546875,0.035724259912968,2,&quot;y20++&quot;|1024.5223388671875,1.0,1,&quot;y9+&quot;|1073.5008544921875,0.200163260102272,1,&quot;b11+&quot;|1130.526123046875,0.135533377528191,1,&quot;b12+&quot;|1137.608154296875,0.113550938665867,1,&quot;y10+&quot;|1187.544189453125,0.804915189743042,1,&quot;b13+&quot;|1194.62841796875,0.170546039938927,1,&quot;y11+&quot;|1251.6474609375,0.285297006368637,1,&quot;y12+&quot;|1300.6290283203125,0.159593641757965,1,&quot;b14+&quot;|1562.7510986328125,0.039694063365459,1,&quot;b16+&quot;"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.52173912525177"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.52173912525177"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="delta_score" value="42.152938842773438"/>
+				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -40,8 +40,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
-				<UserParam type="int" name="matched_b_ions" value="3"/>
-				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="matched_prefix_ions" value="3"/>
+				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -57,8 +57,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
-				<UserParam type="int" name="matched_b_ions" value="13"/>
-				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="matched_prefix_ions" value="13"/>
+				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -74,8 +74,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
-				<UserParam type="int" name="matched_b_ions" value="12"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="12"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -40,8 +40,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857149243355"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428596973419"/>
 				<UserParam type="int" name="num_matched_peaks" value="10"/>
-				<UserParam type="int" name="matched_b_ions" value="2"/>
-				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="matched_prefix_ions" value="2"/>
+				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -57,8 +57,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857134342194"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.428571432828903"/>
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
-				<UserParam type="int" name="matched_b_ions" value="11"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="11"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -74,8 +74,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.47826087474823"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.52173912525177"/>
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
-				<UserParam type="int" name="matched_b_ions" value="11"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="11"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/Development/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>
@@ -18,7 +18,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-11T23:19:26" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-asymmetric-precursor-window-2026-04-11" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-17T14:55:16" search_engine="ProSE" search_engine_version="3.6.0-pre-feat-prose-percolator-features-2026-04-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -42,6 +42,8 @@
 				<UserParam type="int" name="num_matched_peaks" value="10"/>
 				<UserParam type="int" name="matched_prefix_ions" value="2"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
+				<UserParam type="float" name="delta_score" value="12.094764709472656"/>
+				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -59,6 +61,8 @@
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="delta_score" value="39.632766723632813"/>
+				<UserParam type="float" name="matched_ion_current" value="7.902573899365962"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -76,6 +80,8 @@
 				<UserParam type="int" name="num_matched_peaks" value="23"/>
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="delta_score" value="39.663528442382813"/>
+				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/SimpleSearchEngine_1_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_1_out.idXML
@@ -16,7 +16,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-09T11:18:57" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-17T14:55:15" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-prose-percolator-features-2026-04-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -36,11 +36,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.809573809163447"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285716414452"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428596973419"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
 				<UserParam type="int" name="matched_prefix_ions" value="3"/>
 				<UserParam type="int" name="matched_suffix_ions" value="8"/>
+				<UserParam type="float" name="matched_ion_current" value="1.781957282219082"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -53,11 +54,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.088843358789125"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.46428570151329"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.46428570151329"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
 				<UserParam type="int" name="matched_prefix_ions" value="13"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
+				<UserParam type="float" name="matched_ion_current" value="7.902573899365962"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -70,11 +72,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.52173912525177"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.52173912525177"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
 				<UserParam type="int" name="matched_prefix_ions" value="12"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/SimpleSearchEngine_1_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_1_out.idXML
@@ -39,8 +39,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.214285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.571428571428571"/>
 				<UserParam type="int" name="num_matched_peaks" value="11"/>
-				<UserParam type="int" name="matched_b_ions" value="3"/>
-				<UserParam type="int" name="matched_y_ions" value="8"/>
+				<UserParam type="int" name="matched_prefix_ions" value="3"/>
+				<UserParam type="int" name="matched_suffix_ions" value="8"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="10"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -56,8 +56,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="int" name="num_matched_peaks" value="26"/>
-				<UserParam type="int" name="matched_b_ions" value="13"/>
-				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="matched_prefix_ions" value="13"/>
+				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="11"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -73,8 +73,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
-				<UserParam type="int" name="matched_b_ions" value="12"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="12"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/SimpleSearchEngine_2_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_2_out.idXML
@@ -40,8 +40,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857142857143"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.714285714285714"/>
 				<UserParam type="int" name="num_matched_peaks" value="12"/>
-				<UserParam type="int" name="matched_b_ions" value="2"/>
-				<UserParam type="int" name="matched_y_ions" value="10"/>
+				<UserParam type="int" name="matched_prefix_ions" value="2"/>
+				<UserParam type="int" name="matched_suffix_ions" value="10"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -57,8 +57,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857142857143"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
-				<UserParam type="int" name="matched_b_ions" value="11"/>
-				<UserParam type="int" name="matched_y_ions" value="13"/>
+				<UserParam type="int" name="matched_prefix_ions" value="11"/>
+				<UserParam type="int" name="matched_suffix_ions" value="13"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -74,8 +74,8 @@
 				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.391304347826087"/>
 				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
 				<UserParam type="int" name="num_matched_peaks" value="21"/>
-				<UserParam type="int" name="matched_b_ions" value="9"/>
-				<UserParam type="int" name="matched_y_ions" value="12"/>
+				<UserParam type="int" name="matched_prefix_ions" value="9"/>
+				<UserParam type="int" name="matched_suffix_ions" value="12"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>

--- a/src/tests/topp/SimpleSearchEngine_2_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_2_out.idXML
@@ -17,7 +17,7 @@
 				<UserParam type="string" name="PeptideIndexer:missing_decoy_action" value="silent"/>
 				<UserParam name="EnzymeTermSpecificity" type="string" value="full" />
 	</SearchParameters>
-	<IdentificationRun date="2026-04-09T11:18:58" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-num-matched-peaks-2026-04-09" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2026-04-17T14:55:15" search_engine="SimpleSearchEngine" search_engine_version="3.6.0-pre-feat-prose-percolator-features-2026-04-17" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0.0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0.0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -37,11 +37,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.731785331544976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="-1.415652739967919"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857142857143"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.714285714285714"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.142857149243355"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.714285731315613"/>
 				<UserParam type="int" name="num_matched_peaks" value="12"/>
 				<UserParam type="int" name="matched_prefix_ions" value="2"/>
 				<UserParam type="int" name="matched_suffix_ions" value="10"/>
+				<UserParam type="float" name="matched_ion_current" value="2.41169178346172"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -54,11 +55,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.303180368382511"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="0.532776127422444"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857142857143"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.464285714285714"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.392857134342194"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.46428570151329"/>
 				<UserParam type="int" name="num_matched_peaks" value="24"/>
 				<UserParam type="int" name="matched_prefix_ions" value="11"/>
 				<UserParam type="int" name="matched_suffix_ions" value="13"/>
+				<UserParam type="float" name="matched_ion_current" value="9.078604371286929"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
@@ -71,11 +73,12 @@
 				<UserParam type="int" name="isotope_error" value="0"/>
 				<UserParam type="float" name="fragment_mz_error_median_ppm" value="1.389253520212976"/>
 				<UserParam type="float" name="precursor_mz_error_ppm" value="2.251259146760969"/>
-				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.391304347826087"/>
-				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.521739130434783"/>
+				<UserParam type="float" name="matched_prefix_ions_fraction" value="0.391304343938828"/>
+				<UserParam type="float" name="matched_suffix_ions_fraction" value="0.52173912525177"/>
 				<UserParam type="int" name="num_matched_peaks" value="21"/>
 				<UserParam type="int" name="matched_prefix_ions" value="9"/>
 				<UserParam type="int" name="matched_suffix_ions" value="12"/>
+				<UserParam type="float" name="matched_ion_current" value="8.528975328430533"/>
 				<UserParam type="int" name="longest_peptide_ion_sequence" value="12"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>


### PR DESCRIPTION
## Summary

Three tightly-related improvements to ProSE's Percolator feature set, bundled because they touch the same code paths (HyperScore, ProSEAlgorithm, SSE, Constants.h).

### 1. Rename `matched_b_ions` / `matched_y_ions` → `matched_prefix_ions` / `matched_suffix_ions`

With PR #9167 enabling a/b/c/x/y/z ion types, the old names were misleading — these counters track ALL prefix (a/b/c) and suffix (x/y/z) ions, not just b/y. Renamed across HyperScore, ProSE, SimpleSearchEngine, and Constants.h. MetaValue strings also renamed (`"matched_prefix_ions"` / `"matched_suffix_ions"`). No backward compatibility concern — ProSE is unreleased.

### 2. Fix HyperScore to count all prefix/suffix ion types

Previously `HyperScore::computeWithDetail()` only counted `'b'` and `'y'` ions in the factorial terms (lines 147-154). With c/z ions enabled, those ions contributed to the dot_product (intensity matching) but NOT to the ion-count factorial boost — silently penalizing ETD/EThcD searches.

Fixed: the fast path checks `a/b/c` (prefix) and `x/y/z` (suffix) via single-char comparison — O(1) per ion, zero regression for CID/HCD. XL-MS `$`-prefix fallback preserved for NuXL: falls through to `find('$')` only when first char doesn't match any ion letter.

### 3. Delta score (new Percolator feature)

Score difference between the best and second-best PSM for each spectrum. The single most discriminative Percolator feature after the primary score — used by Comet (deltaCN), Sage (delta_next), and MSFragger (delta_hyperscore).

**Implementation:** O(N) running-max pass over candidates BEFORE `partial_sort` — zero change to the existing sort (still `k=top_hits`). When only one candidate exists, delta = full score (same convention as Sage/MSFragger). Wired unconditionally into `extra_features` for Percolator.

Also wires `longest_peptide_ion_sequence` and `matched_prefix/suffix_ions` into `extra_features` — these were already computed by `postProcessHits_()` but previously not passed to Percolator.

## Files changed (7)

- `HyperScore.h` / `.cpp` — rename + all-ion-type counting
- `ProSEAlgorithm.h` / `.cpp` — rename + delta_score field + extra_features wiring
- `SimpleSearchEngineAlgorithm.h` / `.cpp` — rename (SSE shares the same struct/constants)
- `Constants.h` — rename MetaValue string constants

## Test Plan

- [x] ProSE + SimpleSearchEngine build cleanly
- [x] Default behavior unchanged for CID/HCD (b/y only → same scores)
- [ ] Regression: ProSE on existing test fixture produces identical idXML output at default settings (manual)
- [ ] ETD fixture: c/z ions now contribute to HyperScore factorial terms (no test fixture in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-PSM matched ion current and delta score; extra per-hit features (including longest peptide ion sequence) are now reported.

* **Refactor**
  * Replaced b/y matched-ion labels with prefix/suffix terminology (a/b/c and x/y/z) across annotations, scoring, normalization, and feature keys.

* **Tests**
  * Updated tests and reference outputs to validate prefix/suffix fields, matched ion current, and delta score.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->