### PR TITLE
add MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY constant 

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/Constants.h
+++ b/src/openms/include/OpenMS/CONCEPT/Constants.h
@@ -255,6 +255,13 @@ namespace OpenMS
        */
       inline const std::string INVERSE_REDUCED_ION_MOBILITY = "inverse reduced ion mobility";
 
+      /** Alternative MetaValue key for ion mobility data (inverse reduced ion mobility).
+       * Some files store ion mobility data with this prefix instead of "Ion Mobility".
+       * Unit is typically volt-seconds per square centimeter (Vs/cm^2) also known as 1/k0.
+       * CV Term MS:1003006
+       */
+      inline const std::string MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY = "mean inverse reduced ion mobility array";
+
       /** MetaValue key for centroided ion mobility data output by PeakPickerIM and MassTraceDetection.
        * PeakPickerIM outputs centroided peaks with this array name.
        * MassTraceDetection computes intensity-weighted ion mobility average of connected centroided peaks.

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -334,7 +334,7 @@ namespace OpenMS
         fda.getName().hasPrefix(Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY) ||
         fda.getName().hasPrefix(Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY))
     { // fallback for non-standard IM arrays (as created by Mobi-DIK, "Ion Mobility Centroid" from PeakPickerIM, "inverse reduced ion mobility" from MSConvert, or "mean inverse reduced ion mobility array" from Bruker)
-      if (fda.getName().hasSubstring("MS:1002815"))
+      if (fda.getName().hasSubstring("MS:1002815") || fda.getName().hasSubstring("MS:1003006"))
       {
         unit = DriftTimeUnit::VSSC;
       }

--- a/src/openms/source/IONMOBILITY/IMDataConverter.cpp
+++ b/src/openms/source/IONMOBILITY/IMDataConverter.cpp
@@ -331,8 +331,9 @@ namespace OpenMS
   {
     const auto& cv = ControlledVocabulary::getPSIMSCV();
     if (fda.getName().hasPrefix(Constants::UserParam::ION_MOBILITY) ||
-        fda.getName().hasPrefix(Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY))
-    { // fallback for non-standard IM arrays (as created by Mobi-DIK, "Ion Mobility Centroid" from PeakPickerIM, or "inverse reduced ion mobility" from MSConvert)
+        fda.getName().hasPrefix(Constants::UserParam::INVERSE_REDUCED_ION_MOBILITY) ||
+        fda.getName().hasPrefix(Constants::UserParam::MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY))
+    { // fallback for non-standard IM arrays (as created by Mobi-DIK, "Ion Mobility Centroid" from PeakPickerIM, "inverse reduced ion mobility" from MSConvert, or "mean inverse reduced ion mobility array" from Bruker)
       if (fda.getName().hasSubstring("MS:1002815"))
       {
         unit = DriftTimeUnit::VSSC;


### PR DESCRIPTION
Proteowizard msconvert is a popular tool to convert .d TimsTOF files to mzML. The algorithm output ion mobility array as 'MEAN_INVERSE_REDUCED_ION_MOBILITY_ARRAY' with the CV term MS:1003006. I updated the Constants.h file and IMDataConverter type to check for this term. 

Here is a snippet of mzML file from msconvert 

```
					</binaryDataArray>
					<binaryDataArray arrayLength="7625" encodedLength="40668" >
						<cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" unitAccession="MS:1002814" unitName="volt-second per square centimeter" unitCvRef="MS" />
						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
```

I double checked this controlled term using HUPO-PSI dictionary in this [link](https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo)

 IMDataConverter::getIMUnit should now be able to recognize this term among other CVs for ion mobility arrays. 

Forr the fallback block aiming to capture unconventional ion mobility array names, we should check for MS:1003006 in addition to MS:1002815. Feedback on this? if you agree, I will add a snippet code to check for this.

## Description

<!-- Please include a summary of the change and which issue is fixed here. -->

## Checklist
- [ ] Make sure that you are listed in the AUTHORS file
- [ ] Add relevant changes and new features to the CHANGELOG file
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Updated or added python bindings for changed or new classes (Tick if no updates were necessary.)

### How can I get additional information on failed tests during CI
<details>
  <summary>Click to expand</summary>
If your PR is failing you can check out

- The details of the action statuses at the end of the PR or the "Checks" tab.
- http://cdash.seqan.de/index.php?project=OpenMS and look for your PR. Use the "Show filters" capability on the top right to search for your PR number.
  If you click in the column that lists the failed tests you will get detailed error messages.

</details>

### Advanced commands (admins / reviewer only)
<details>
  <summary>Click to expand</summary>
  
- `/reformat` (experimental) applies the clang-format style changes as additional commit. Note: your branch must have a different name (e.g., yourrepo:feature/XYZ) than the receiving branch (e.g., OpenMS:develop). Otherwise, reformat fails to push.
- setting the label "NoJenkins" will skip tests for this PR on jenkins (saves resources e.g., on edits that do not affect tests)
- commenting with `rebuild jenkins` will retrigger Jenkins-based CI builds
  
</details>

---
:warning: Note: Once you opened a PR try to minimize the number of *pushes* to it as every push will trigger CI (automated builds and test) and is rather heavy on our infrastructure (e.g., if several pushes per day are performed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and properly classifying mean inverse reduced ion mobility array data types, improving compatibility with additional ion mobility data source formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->