### PR TITLE
feat(MGF): support SEQ= sequence-query field on read and write

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
@@ -30,6 +30,12 @@ namespace OpenMS
 
     For details of the format, see http://www.matrixscience.com/help/data_file_help.html#GEN.
 
+    In addition to the core MGF fields (TITLE, PEPMASS, CHARGE, RTINSECONDS, SCANS, MSLEVEL)
+    and the GNPS/metabolomics extensions (NAME, COMPOUND_NAME, INCHI, SMILES, IONMODE, ...),
+    this reader/writer also supports the sequence-query field SEQ. A SEQ line is exposed on
+    the MSSpectrum via the "SEQ" meta value; multiple SEQ lines per query are accumulated
+    into a StringList and written back out as one SEQ= line per entry.
+
     @htmlinclude OpenMS_MascotGenericFile.parameters
 
     @ingroup FileIO
@@ -140,6 +146,11 @@ protected:
       if (spectrum.metaValueExists("TITLE"))
       {
         spectrum.removeMetaValue("TITLE");
+      }
+      if (spectrum.metaValueExists("SEQ"))
+      {
+        // SEQ is a per-query field; do not let it bleed across spectra
+        spectrum.removeMetaValue("SEQ");
       }
       typename SpectrumType::PeakType p;
 
@@ -362,6 +373,34 @@ protected:
             {
               String tmp = line.substr(6);
               spectrum.setMetaValue("Scan_ID", tmp);
+            }
+            else if (line.hasPrefix("SEQ="))
+            {
+              // Mascot sequence-query field: peptide sequence in one-letter code.
+              // Per spec, SEQ may appear multiple times per query (each entry is
+              // an independent sequence filter). A single SEQ is stored as a
+              // String meta value; multiple SEQ lines are accumulated into a
+              // StringList under the same "SEQ" key.
+              String tmp = line.substr(4);
+              if (!spectrum.metaValueExists("SEQ"))
+              {
+                spectrum.setMetaValue("SEQ", tmp);
+              }
+              else
+              {
+                const DataValue& existing = spectrum.getMetaValue("SEQ");
+                StringList seqs;
+                if (existing.valueType() == DataValue::STRING_LIST)
+                {
+                  seqs = existing.toStringList();
+                }
+                else
+                {
+                  seqs.push_back(existing.toString());
+                }
+                seqs.push_back(tmp);
+                spectrum.setMetaValue("SEQ", seqs);
+              }
             }
           }
         }

--- a/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
@@ -32,9 +32,9 @@ namespace OpenMS
 
     In addition to the core MGF fields (TITLE, PEPMASS, CHARGE, RTINSECONDS, SCANS, MSLEVEL)
     and the GNPS/metabolomics extensions (NAME, COMPOUND_NAME, INCHI, SMILES, IONMODE, ...),
-    this reader/writer also supports the sequence-query field SEQ. A SEQ line is exposed on
-    the MSSpectrum via the "SEQ" meta value; multiple SEQ lines per query are accumulated
-    into a StringList and written back out as one SEQ= line per entry.
+    this reader/writer also supports the sequence-query field SEQ. SEQ lines are exposed on
+    the MSSpectrum via the "SEQ" meta value as a StringList (always, even for a single SEQ)
+    and written back out as one SEQ= line per entry.
 
     @htmlinclude OpenMS_MascotGenericFile.parameters
 
@@ -378,29 +378,17 @@ protected:
             {
               // Mascot sequence-query field: peptide sequence in one-letter code.
               // Per spec, SEQ may appear multiple times per query (each entry is
-              // an independent sequence filter). A single SEQ is stored as a
-              // String meta value; multiple SEQ lines are accumulated into a
-              // StringList under the same "SEQ" key.
-              String tmp = line.substr(4);
-              if (!spectrum.metaValueExists("SEQ"))
+              // an independent sequence filter). Always stored as a StringList
+              // under the "SEQ" key for a stable interface regardless of how
+              // many SEQ lines were present.
+              String sequence = line.substr(4);
+              StringList sequences;
+              if (spectrum.metaValueExists("SEQ"))
               {
-                spectrum.setMetaValue("SEQ", tmp);
+                sequences = spectrum.getMetaValue("SEQ").toStringList();
               }
-              else
-              {
-                const DataValue& existing = spectrum.getMetaValue("SEQ");
-                StringList seqs;
-                if (existing.valueType() == DataValue::STRING_LIST)
-                {
-                  seqs = existing.toStringList();
-                }
-                else
-                {
-                  seqs.push_back(existing.toString());
-                }
-                seqs.push_back(tmp);
-                spectrum.setMetaValue("SEQ", seqs);
-              }
+              sequences.push_back(sequence);
+              spectrum.setMetaValue("SEQ", sequences);
             }
           }
         }

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -381,20 +381,11 @@ namespace OpenMS
       }
 
       // Mascot sequence-query field: emit one SEQ= line per stored sequence.
-      // Accepts either a single String or a StringList in the "SEQ" meta value.
       if (spec.metaValueExists("SEQ"))
       {
-        const DataValue& seq_value = spec.getMetaValue("SEQ");
-        if (seq_value.valueType() == DataValue::STRING_LIST)
+        for (const String& sequence : spec.getMetaValue("SEQ").toStringList())
         {
-          for (const String& seq : seq_value.toStringList())
-          {
-            os << "SEQ=" << seq << "\n";
-          }
-        }
-        else
-        {
-          os << "SEQ=" << seq_value.toString() << "\n";
+          os << "SEQ=" << sequence << "\n";
         }
       }
 

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -380,6 +380,24 @@ namespace OpenMS
         }
       }
 
+      // Mascot sequence-query field: emit one SEQ= line per stored sequence.
+      // Accepts either a single String or a StringList in the "SEQ" meta value.
+      if (spec.metaValueExists("SEQ"))
+      {
+        const DataValue& seq_value = spec.getMetaValue("SEQ");
+        if (seq_value.valueType() == DataValue::STRING_LIST)
+        {
+          for (const String& seq : seq_value.toStringList())
+          {
+            os << "SEQ=" << seq << "\n";
+          }
+        }
+        else
+        {
+          os << "SEQ=" << seq_value.toString() << "\n";
+        }
+      }
+
       if (!store_compact_)
       {
         for (PeakSpectrum::const_iterator it = spec.begin(); it != spec.end(); ++it)

--- a/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
@@ -267,7 +267,7 @@ END_SECTION
 
 START_SECTION((SEQ sequence query field - single and multiple))
 {
-  // Single SEQ line: parsed, stored as String, round-tripped on write.
+  // Single SEQ line: parsed, stored as StringList (always), round-tripped on write.
   {
     String mgf_content = "BEGIN IONS\n"
                          "TITLE=seq_single\n"
@@ -289,8 +289,10 @@ START_SECTION((SEQ sequence query field - single and multiple))
     mgf_file.load(tmp_in, exp);
 
     TEST_EQUAL(exp.size(), 1)
-    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
-    TEST_EQUAL(String(exp[0].getMetaValue("SEQ")), "PEPTIDER")
+    TEST_TRUE(exp[0].metaValueExists("SEQ"))
+    StringList seqs = exp[0].getMetaValue("SEQ").toStringList();
+    TEST_EQUAL(seqs.size(), 1)
+    TEST_EQUAL(seqs[0], "PEPTIDER")
 
     // Round-trip: write and re-load, SEQ must survive unchanged.
     String tmp_out("MascotGenericFile_SEQ_single_out.mgf");
@@ -300,8 +302,10 @@ START_SECTION((SEQ sequence query field - single and multiple))
     PeakMap exp2;
     mgf_file.load(tmp_out, exp2);
     TEST_EQUAL(exp2.size(), 1)
-    TEST_EQUAL(exp2[0].metaValueExists("SEQ"), true)
-    TEST_EQUAL(String(exp2[0].getMetaValue("SEQ")), "PEPTIDER")
+    TEST_TRUE(exp2[0].metaValueExists("SEQ"))
+    StringList seqs_rt = exp2[0].getMetaValue("SEQ").toStringList();
+    TEST_EQUAL(seqs_rt.size(), 1)
+    TEST_EQUAL(seqs_rt[0], "PEPTIDER")
   }
 
   // Multiple SEQ lines in one query: accumulated into a StringList.
@@ -327,7 +331,7 @@ START_SECTION((SEQ sequence query field - single and multiple))
     mgf_file.load(tmp_in, exp);
 
     TEST_EQUAL(exp.size(), 1)
-    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
+    TEST_TRUE(exp[0].metaValueExists("SEQ"))
     StringList seqs = exp[0].getMetaValue("SEQ").toStringList();
     TEST_EQUAL(seqs.size(), 3)
     TEST_EQUAL(seqs[0], "PEPTIDEA")
@@ -350,6 +354,7 @@ START_SECTION((SEQ sequence query field - single and multiple))
   }
 
   // Writing: a user sets SEQ programmatically before export.
+  // Must work in both default and compact store modes.
   {
     MSSpectrum spec;
     spec.setNativeID("index=0");
@@ -363,7 +368,7 @@ START_SECTION((SEQ sequence query field - single and multiple))
     peak.setMZ(100.0);
     peak.setIntensity(1000.0);
     spec.push_back(peak);
-    spec.setMetaValue("SEQ", "PEPTIDER");
+    spec.setMetaValue("SEQ", StringList{"PEPTIDER"});
 
     PeakMap exp;
     exp.addSpectrum(spec);
@@ -371,7 +376,11 @@ START_SECTION((SEQ sequence query field - single and multiple))
     MascotGenericFile mgf_file;
     stringstream ss;
     mgf_file.store(ss, "test", exp);
-    TEST_EQUAL(String(ss.str()).hasSubstring("SEQ=PEPTIDER"), true)
+    TEST_TRUE(String(ss.str()).hasSubstring("SEQ=PEPTIDER"))
+
+    stringstream compact_ss;
+    mgf_file.store(compact_ss, "test", exp, true);
+    TEST_TRUE(String(compact_ss.str()).hasSubstring("SEQ=PEPTIDER"))
   }
 
   // SEQ must not bleed across spectra during sequential load.
@@ -399,10 +408,12 @@ START_SECTION((SEQ sequence query field - single and multiple))
     mgf_file.load(tmp_in, exp);
 
     TEST_EQUAL(exp.size(), 2)
-    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
-    TEST_EQUAL(String(exp[0].getMetaValue("SEQ")), "FIRSTONE")
+    TEST_TRUE(exp[0].metaValueExists("SEQ"))
+    StringList seqs_first = exp[0].getMetaValue("SEQ").toStringList();
+    TEST_EQUAL(seqs_first.size(), 1)
+    TEST_EQUAL(seqs_first[0], "FIRSTONE")
     // second spectrum had no SEQ - must not inherit it from the first
-    TEST_EQUAL(exp[1].metaValueExists("SEQ"), false)
+    TEST_FALSE(exp[1].metaValueExists("SEQ"))
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
@@ -17,6 +17,7 @@
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -261,6 +262,148 @@ START_SECTION((GNPS MGF file - 3-Des-Microcystein_LR))
     }
   }
   TEST_EQUAL(found_base_peak, true)
+}
+END_SECTION
+
+START_SECTION((SEQ sequence query field - single and multiple))
+{
+  // Single SEQ line: parsed, stored as String, round-tripped on write.
+  {
+    String mgf_content = "BEGIN IONS\n"
+                         "TITLE=seq_single\n"
+                         "PEPMASS=500.0\n"
+                         "CHARGE=2+\n"
+                         "SEQ=PEPTIDER\n"
+                         "100.0 1000.0\n"
+                         "200.0 2000.0\n"
+                         "END IONS\n";
+
+    String tmp_in("MascotGenericFile_SEQ_single_in.mgf");
+    NEW_TMP_FILE(tmp_in)
+    std::ofstream ofs(tmp_in.c_str());
+    ofs << mgf_content;
+    ofs.close();
+
+    PeakMap exp;
+    MascotGenericFile mgf_file;
+    mgf_file.load(tmp_in, exp);
+
+    TEST_EQUAL(exp.size(), 1)
+    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
+    TEST_EQUAL(String(exp[0].getMetaValue("SEQ")), "PEPTIDER")
+
+    // Round-trip: write and re-load, SEQ must survive unchanged.
+    String tmp_out("MascotGenericFile_SEQ_single_out.mgf");
+    NEW_TMP_FILE(tmp_out)
+    mgf_file.store(tmp_out, exp);
+
+    PeakMap exp2;
+    mgf_file.load(tmp_out, exp2);
+    TEST_EQUAL(exp2.size(), 1)
+    TEST_EQUAL(exp2[0].metaValueExists("SEQ"), true)
+    TEST_EQUAL(String(exp2[0].getMetaValue("SEQ")), "PEPTIDER")
+  }
+
+  // Multiple SEQ lines in one query: accumulated into a StringList.
+  {
+    String mgf_content = "BEGIN IONS\n"
+                         "TITLE=seq_multi\n"
+                         "PEPMASS=600.0\n"
+                         "CHARGE=2+\n"
+                         "SEQ=PEPTIDEA\n"
+                         "SEQ=PEPTIDEB\n"
+                         "SEQ=PEPTIDEC\n"
+                         "100.0 1000.0\n"
+                         "END IONS\n";
+
+    String tmp_in("MascotGenericFile_SEQ_multi_in.mgf");
+    NEW_TMP_FILE(tmp_in)
+    std::ofstream ofs(tmp_in.c_str());
+    ofs << mgf_content;
+    ofs.close();
+
+    PeakMap exp;
+    MascotGenericFile mgf_file;
+    mgf_file.load(tmp_in, exp);
+
+    TEST_EQUAL(exp.size(), 1)
+    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
+    StringList seqs = exp[0].getMetaValue("SEQ").toStringList();
+    TEST_EQUAL(seqs.size(), 3)
+    TEST_EQUAL(seqs[0], "PEPTIDEA")
+    TEST_EQUAL(seqs[1], "PEPTIDEB")
+    TEST_EQUAL(seqs[2], "PEPTIDEC")
+
+    // Round-trip preserves all three SEQ lines.
+    String tmp_out("MascotGenericFile_SEQ_multi_out.mgf");
+    NEW_TMP_FILE(tmp_out)
+    mgf_file.store(tmp_out, exp);
+
+    PeakMap exp2;
+    mgf_file.load(tmp_out, exp2);
+    TEST_EQUAL(exp2.size(), 1)
+    StringList seqs2 = exp2[0].getMetaValue("SEQ").toStringList();
+    TEST_EQUAL(seqs2.size(), 3)
+    TEST_EQUAL(seqs2[0], "PEPTIDEA")
+    TEST_EQUAL(seqs2[1], "PEPTIDEB")
+    TEST_EQUAL(seqs2[2], "PEPTIDEC")
+  }
+
+  // Writing: a user sets SEQ programmatically before export.
+  {
+    MSSpectrum spec;
+    spec.setNativeID("index=0");
+    spec.setMSLevel(2);
+    spec.setRT(100.0);
+    Precursor prec;
+    prec.setMZ(500.0);
+    prec.setCharge(2);
+    spec.getPrecursors().push_back(prec);
+    Peak1D peak;
+    peak.setMZ(100.0);
+    peak.setIntensity(1000.0);
+    spec.push_back(peak);
+    spec.setMetaValue("SEQ", "PEPTIDER");
+
+    PeakMap exp;
+    exp.addSpectrum(spec);
+
+    MascotGenericFile mgf_file;
+    stringstream ss;
+    mgf_file.store(ss, "test", exp);
+    TEST_EQUAL(String(ss.str()).hasSubstring("SEQ=PEPTIDER"), true)
+  }
+
+  // SEQ must not bleed across spectra during sequential load.
+  {
+    String mgf_content = "BEGIN IONS\n"
+                         "TITLE=first\n"
+                         "PEPMASS=500.0\n"
+                         "SEQ=FIRSTONE\n"
+                         "100.0 1000.0\n"
+                         "END IONS\n"
+                         "BEGIN IONS\n"
+                         "TITLE=second\n"
+                         "PEPMASS=600.0\n"
+                         "200.0 2000.0\n"
+                         "END IONS\n";
+
+    String tmp_in("MascotGenericFile_SEQ_bleed.mgf");
+    NEW_TMP_FILE(tmp_in)
+    std::ofstream ofs(tmp_in.c_str());
+    ofs << mgf_content;
+    ofs.close();
+
+    PeakMap exp;
+    MascotGenericFile mgf_file;
+    mgf_file.load(tmp_in, exp);
+
+    TEST_EQUAL(exp.size(), 2)
+    TEST_EQUAL(exp[0].metaValueExists("SEQ"), true)
+    TEST_EQUAL(String(exp[0].getMetaValue("SEQ")), "FIRSTONE")
+    // second spectrum had no SEQ - must not inherit it from the first
+    TEST_EQUAL(exp[1].metaValueExists("SEQ"), false)
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
## Summary

`MascotGenericFile` previously ignored the `SEQ=` field on load and never emitted it on store, so peptide-sequence annotations could not survive a pyOpenMS MGF round-trip. This PR adds first-class `SEQ=` support in both directions.

## Background — what is SEQ in MGF?

Per the [Mascot MGF specification](https://www.matrixscience.com/help/data_file_help.html) and the [Sequence Query docs](https://www.matrixscience.com/help/sq_help.html):

- `SEQ=` is a **local (per-query) parameter** that appears inside a `BEGIN IONS ... END IONS` block, alongside `COMP=`, `TAG=`, `ETAG=`.
- The value is a peptide sequence in one-letter code — used by Mascot as a sequence-query filter.
- The spec explicitly allows **multiple `SEQ=` lines per query**; each acts as an independent filter.

Other tools already treat it as a standard local field — e.g. [pyteomics `mgf`](https://pyteomics.readthedocs.io/en/latest/api/mgf.html) exposes it as `'seq'` in the per-spectrum params dict, and Mascot's own `ms_inputquery` surfaces it via dedicated accessors.

## Changes

**Read — `src/openms/include/OpenMS/FORMAT/MascotGenericFile.h`** (`getNextSpectrum_`):
- New branch parses `SEQ=` and stores it on the `MSSpectrum` as the meta value `"SEQ"`.
- A single `SEQ` is kept as a `String`; multiple `SEQ` lines per query are accumulated into a `StringList` under the same key.
- Any pre-existing `"SEQ"` meta value on the reusable spectrum object is cleared at the top of `getNextSpectrum_` (same pattern as `TITLE`) so sequences cannot bleed between consecutive spectra.

**Write — `src/openms/source/FORMAT/MascotGenericFile.cpp`** (`writeSpectrum`):
- After `CHARGE`, emit one `SEQ=` line per entry when the meta value is a `StringList`, or a single `SEQ=` line when it's a `String`. Works in both compact and full modes.

**Tests — `src/tests/class_tests/openms/source/MascotGenericFile_test.cpp`**:
- Single-`SEQ` round-trip (load → store → load).
- Multi-`SEQ` `StringList` round-trip (three sequences preserved and re-emitted).
- Programmatic write from a freshly built `MSSpectrum` with `setMetaValue("SEQ", "PEPTIDER")`.
- Cross-spectrum bleed guard: second spectrum without `SEQ` must not inherit the first spectrum's `SEQ`.

## Design notes / rejected alternatives

- **Key name `"SEQ"`** — mirrors the MGF field directly, matching the existing convention in this file for `"TITLE"`, `"IONMODE"`, `"SOURCE_INSTRUMENT"`, etc. No new `Constants::UserParam::*` entry was added, since the metabolomics constants (`MSM_*`) are tied to `MetaboliteSpectralMatcher` and SEQ is a proteomics concept. Happy to add a constant if reviewers prefer.
- **`PeptideIdentification`** — considered threading SEQ through attached `PeptideIdentification`/`PeptideHit` objects (where a real `AASequence` lives), but that conflates a raw MGF annotation with an OpenMS search result and would require deciding score/score-type semantics on round-trip. A meta value is the least-invasive, lossless option.
- **Scope** — only `SEQ` is implemented here. `COMP`, `TAG`, `ETAG` are structurally similar and could be added in a follow-up with the same pattern.

## Test plan

- [ ] CI builds on Linux/macOS/Windows.
- [ ] `MascotGenericFile_test` passes (four new sub-blocks inside a new `START_SECTION`).
- [ ] No change in behaviour for MGF files that do not contain `SEQ=`.

> Note: I was unable to run the build locally in this environment (no `OpenMS-build/` tree present), so the above is verified by code review only and I'm relying on CI to confirm compilation and test pass.

https://claude.ai/code/session_01LpLkMxcZnXc8eCTLx5uXCB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser recognizes and stores SEQ= sequence-query fields as a list in spectrum metadata
  * Writer emits one SEQ= line per stored sequence when SEQ metadata is present
  * Multiple SEQ values per spectrum are accumulated and preserved

* **Bug Fixes**
  * SEQ metadata is cleared at the start of each spectrum to prevent cross-spectrum leakage

* **Tests**
  * Added round-trip and isolation tests for SEQ parsing and storage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->