### PR TITLE
feat(ProSE): Orbitrap-aware isotope defaults + isotope_error Percolator feature

### DIFF
--- a/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
+++ b/src/openms/source/ANALYSIS/ID/FragmentIndex.cpp
@@ -1159,8 +1159,12 @@ init_hits.hits_.erase(it_zero, init_hits.hits_.end());
     //Search-related params
 
     defaults_.setValue("fragment:min_matched_ions", 5, "Minimal number of matched ions to report a PSM");
-    defaults_.setValue("precursor:isotope_error_min", -1, "Minimum allowed precursor isotope error");
-    defaults_.setValue("precursor:isotope_error_max", 1, "Maximum allowed precursor isotope error");
+    // Default iso range [0, +2]: Orbitrap/QExactive/tims monoisotopic peak picking
+    // fails predominantly *upward* (picks the +1 or +2 isotope instead of the true
+    // monoisotopic). Symmetric ranges like [-1, +1] waste a query slot on the
+    // rare downward mispick. Matches MetaMorpheus/MSFragger defaults.
+    defaults_.setValue("precursor:isotope_error_min", 0, "Minimum allowed precursor isotope error");
+    defaults_.setValue("precursor:isotope_error_max", 2, "Maximum allowed precursor isotope error");
     
     defaults_.setValue("fragment:max_charge", 2, "max fragment charge");
     defaults_.setValue("scoring:max_candidates_per_spectrum", 50, "The number of initial hits for which we calculate a score");

--- a/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ProSEAlgorithm.cpp
@@ -624,8 +624,8 @@ namespace OpenMS
             }
           }
 
-          // Add isotope error metavalue (always)
-          ph.setMetaValue("isotope_error", ah.isotope_error);
+          // Add isotope error metavalue (always; exposed as Percolator feature)
+          ph.setMetaValue(Constants::UserParam::ISOTOPE_ERROR, ah.isotope_error);
 
           // Add delta mass metavalue for open search
           if (isOpenSearchMode_())
@@ -655,7 +655,7 @@ namespace OpenMS
           OPENMS_LOG_DEBUG << "[ProSE] scan_index=" << scan_index
                            << " top_ln(hyperscore)=" << top_hit.getScore()
                            << " top_charge=" << top_hit.getCharge()
-                           << " top_isotope_error=" << (int)top_hit.getMetaValue("isotope_error")
+                           << " top_isotope_error=" << (int)top_hit.getMetaValue(Constants::UserParam::ISOTOPE_ERROR)
                            << std::endl;
         }
 #pragma omp critical (peptide_ids_access)
@@ -713,6 +713,7 @@ namespace OpenMS
     if (annotation_matched_suffix_ions) feature_set.push_back(Constants::UserParam::MATCHED_SUFFIX_IONS);
     if (annotation_matched_ion_current) feature_set.push_back(Constants::UserParam::MATCHED_ION_CURRENT);
     feature_set.push_back(Constants::UserParam::DELTA_SCORE);
+    feature_set.push_back(Constants::UserParam::ISOTOPE_ERROR);
     // note: precursor error is calculated by percolator itself
     search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));
     // record whether open-search mode was used

--- a/src/tests/topp/ProSE_1_out.idXML
+++ b/src/tests/topp/ProSE_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>

--- a/src/tests/topp/ProSE_2_out.idXML
+++ b/src/tests/topp/ProSE_2_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.1" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>

--- a/src/tests/topp/ProSE_4_out.idXML
+++ b/src/tests/topp/ProSE_4_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/home/sachsenb/dev/OpenMS/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.0177775416523218" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score"/>
+				<UserParam type="string" name="extra_features" value="score,fragment_mz_error_median_ppm,matched_prefix_ions_fraction,matched_suffix_ions_fraction,longest_peptide_ion_sequence,matched_prefix_ions,matched_suffix_ions,matched_ion_current,delta_score,isotope_error"/>
 				<UserParam type="string" name="open_search" value="false"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string" value="DECOY_"/>
 				<UserParam type="string" name="PeptideIndexer:decoy_string_position" value="prefix"/>


### PR DESCRIPTION
## Summary

Two small, independent improvements inspired by MetaMorpheus / MSFragger defaults:

- **Default isotope-error range** changed from `[-1, +1]` → `[0, +2]`. Orbitrap/QExactive/tims monoisotopic peak picking fails predominantly *upward*; symmetric ranges waste a query slot on the rare downward mispick. Same number of FI queries per spectrum, better coverage of the real failure mode.
- **`isotope_error` is now a Percolator feature**. The metavalue was already set on every PSM but was missing from `extra_features`. Lets the SVM/ML rescorer discount PSMs that only matched at non-zero iso offsets — free FDR gain.
- Drive-by cleanup: two string literals converted to `Constants::UserParam::ISOTOPE_ERROR`.

## Test plan

- [x] Class tests: `FragmentIndex_test`, `ProSEAlgorithm_test` — pass
- [x] TOPP tests: all 18 `TOPP_ProSE_*` (including the three long DDA integration tests) — pass
- [x] Reference idXML fixtures updated for the new `extra_features` string only; top PSM identities unchanged (all reference top hits were already at iso=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adjusted default precursor isotope error search bounds (0 to 2) for improved alignment with industry standards.
  * Standardized isotope error handling and added isotope error to Percolator feature output for enhanced MS/MS result analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->