### PR TITLE
fix(cmake): accept Arrow/Parquet 24.x and later

### DIFF
--- a/cmake/cmake_findExternalLibs.cmake
+++ b/cmake/cmake_findExternalLibs.cmake
@@ -187,10 +187,20 @@ endif()
 find_package(CURL REQUIRED)
 
 #------------------------------------------------------------------------------
-# Apache Arrow and Parquet (required dependency)
-# Arrow 23+ required for parquet file format compatibility
-find_package(Arrow 23 CONFIG REQUIRED)
-find_package(Parquet 23 CONFIG REQUIRED)
+# Apache Arrow and Parquet (required dependency).
+# Arrow 23+ required for parquet file format compatibility. We don't pin the
+# version in find_package because Arrow's ConfigVersion uses SameMajorVersion
+# compatibility, so `find_package(Arrow 23 ...)` rejects 24.x even though
+# 24.x remains API-compatible for our usage. Enforce the minimum with an
+# explicit VERSION_LESS check after the package is located.
+find_package(Arrow CONFIG REQUIRED)
+if(Arrow_VERSION VERSION_LESS 23)
+  message(FATAL_ERROR "Apache Arrow >= 23 required (found ${Arrow_VERSION}).")
+endif()
+find_package(Parquet CONFIG REQUIRED)
+if(Parquet_VERSION VERSION_LESS 23)
+  message(FATAL_ERROR "Apache Parquet >= 23 required (found ${Parquet_VERSION}).")
+endif()
 
 # Arrow's CMake config may import nlohmann_json as a transitive dependency.
 # If so, force the vendored extern to use the already-imported target instead

--- a/src/pyOpenMS/pyproject.toml
+++ b/src/pyOpenMS/pyproject.toml
@@ -72,8 +72,11 @@ Documentation = "https://pyopenms.readthedocs.io"
 
 [project.optional-dependencies]
 dataframes = ["pandas"]
-arrow = ["pyarrow"]
-all = ["pandas", "pyarrow"]
+# pyarrow 24.0.0 on PyPI only shipped cp310 wheels (no source distribution),
+# breaking uv sync on cp311/cp312/cp313 runners. Pin out of 24.0.0 until a
+# release with complete wheel coverage lands.
+arrow = ["pyarrow!=24.0.0"]
+all = ["pandas", "pyarrow!=24.0.0"]
 
 # Dependency groups (PEP 735) - installable with: uv sync --only-group <name>
 [dependency-groups]
@@ -90,7 +93,7 @@ test = [
     "pytest",
     "pytest-cov",
     "pandas",  # tests need pandas for DataFrame functionality
-    "pyarrow",  # tests need pyarrow for Arrow/Parquet export tests
+    "pyarrow!=24.0.0",  # see [project.optional-dependencies].arrow for the 24.0.0 exclusion rationale
 ]
 dev = [
     {include-group = "build"},
@@ -155,7 +158,7 @@ build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-win32 *-musllinux_* pp*"
 
 # Test the wheel after building
-test-requires = ["pytest", "numpy", "pandas", "pyarrow"]
+test-requires = ["pytest", "numpy", "pandas", "pyarrow!=24.0.0"]
 test-command = "pytest \"{package}/tests\" --import-mode=importlib"
 build-verbosity = 1
 


### PR DESCRIPTION
## Summary

Unblocks Linux CI. Ubuntu 24.04 GitHub-hosted runners shipped Arrow 24.0.0 as of 2026-04-21, which causes every PR's Linux build to fail at the CMake configure step:

\`\`\`
CMake Error at cmake/cmake_findExternalLibs.cmake:192 (find_package):
  Could not find a configuration file for package "Arrow" that is
  compatible with requested version "23".
    ArrowConfig.cmake, version: 24.0.0
\`\`\`

## Root cause

Arrow's ConfigVersion file uses \`SameMajorVersion\` compatibility, so \`find_package(Arrow 23 CONFIG REQUIRED)\` actively refuses 24.x even though 24.x is API-compatible with our usage (same for Parquet). The CMake version-range syntax doesn't help here — \`SameMajorVersion\` ignores the range and only checks exact major equality against \`PACKAGE_FIND_VERSION_MAJOR\`.

## Fix

Drop the version argument from \`find_package\` and enforce the ≥ 23 minimum with an explicit \`VERSION_LESS\` check post-detection. Applies to both \`Arrow\` and \`Parquet\`. No upper bound — we accept any newer major and rely on actual API compatibility (errors will surface at compile time if a future major breaks us; the previous hard pin only trapped the benign minor/major bump case).

## Test plan

- [x] Local CMake configure still resolves Arrow 23.0.1 cleanly.
- [x] \`cmake --build OpenMS-build --target OpenMS\` succeeds.
- [ ] CI confirms Ubuntu runners now configure against Arrow 24.0.0.

## Confirmed external breakage

- PR #9195 (3 Linux jobs failing with this exact error, 08:43 UTC 2026-04-21).
- \`add_bedrmod\` branch (3 Linux jobs failing with this exact error, 08:21 UTC 2026-04-21).
- Last \`develop\` CI run passing: 07:07 UTC 2026-04-21 (before the runner image update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Made Arrow/Parquet discovery more flexible while enforcing a minimum supported version at runtime.
  * Updated packaging to exclude a specific problematic pyarrow release from optional and test dependencies to improve build and test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->