### PR TITLE
fix(ProSE): resolve sibling PercolatorAdapter via File::findSiblingTOPPExecutable

### DIFF
--- a/src/topp/ProSE.cpp
+++ b/src/topp/ProSE.cpp
@@ -301,7 +301,24 @@ class ProSE :
                           << "Skipping rescoring." << endl;
         }
         else
-        for (Size i = 0; i < in_list.size(); ++i)
+        {
+          // Resolve the sibling PercolatorAdapter binary. runExternalProcess_ hands the
+          // executable to boost::process, which only searches PATH for bare names — in a
+          // dev build the OpenMS bin/ directory is typically not on PATH, so invoking
+          // "PercolatorAdapter" by name silently falls back to HyperScore. findSibling
+          // looks relative to the current (ProSE) executable.
+          String perc_adapter;
+          try
+          {
+            perc_adapter = File::findSiblingTOPPExecutable("PercolatorAdapter");
+          }
+          catch (const Exception::FileNotFound& e)
+          {
+            OPENMS_LOG_WARN << "Could not locate PercolatorAdapter (" << e.what()
+                            << "). Skipping Percolator rescoring — using original HyperScore results." << endl;
+          }
+          if (!perc_adapter.empty())
+          for (Size i = 0; i < in_list.size(); ++i)
         {
           auto& result = mfres.per_file[i];
           if (result.exit_code != ProSEAlgorithm::ExitCodes::EXECUTION_OK) continue;
@@ -329,7 +346,7 @@ class ProSE :
           };
 
           OPENMS_LOG_INFO << "[ProSE] Rescoring " << in_list[i] << " with Percolator..." << endl;
-          TOPPBase::ExitCodes perc_ec = runExternalProcess_(String("PercolatorAdapter"), perc_params);
+          TOPPBase::ExitCodes perc_ec = runExternalProcess_(perc_adapter, perc_params);
 
           if (perc_ec != EXECUTION_OK)
           {
@@ -349,6 +366,7 @@ class ProSE :
           File::remove(tmp_in);
           File::remove(tmp_out);
           File::remove(tmp_weights);
+        }
         }
 
         // Apply deferred PSM-level FDR filtering. For files rescored by Percolator,


### PR DESCRIPTION
## Summary

- ProSE called Percolator rescoring with `runExternalProcess_(String("PercolatorAdapter"), ...)` — a bare name.
- `runExternalProcess_` → `ExternalProcess::run` → boost::process only searches `$PATH`. In dev builds (or any install where the OpenMS `bin/` directory is not on `$PATH`) the adapter isn't found, and rescoring silently falls back to HyperScore with a one-line WARN.
- Resolve the sibling binary via `File::findSiblingTOPPExecutable("PercolatorAdapter")` once, before the per-file loop. If resolution throws `FileNotFound`, skip rescoring once with a clear warning instead of failing silently per file.

## Reproduction

Symptom in the run log (pre-fix):

    [ProSE] Rescoring DN17_Liver_classI_techRep2.mzML with Percolator...
    Standard error: Process 'PercolatorAdapter' failed to start. Does it exist? Is it executable?
    Percolator rescoring failed for DN17_Liver_classI_techRep2.mzML. Using original HyperScore results.

`PercolatorAdapter` lives at `<OpenMS-build>/bin/PercolatorAdapter` — invoking by absolute path works, but that directory is not on `$PATH` in a typical dev environment.

## E2E verification

Re-ran ProSE on `DN17_Liver_classI_techRep2.mzML` (SNES, 45M mothers, human SwissProt, 7 ppm / 20 ppm, 8 threads) with this fix applied:

- Log shows `[ProSE] Rescoring ... with Percolator...` directly followed by `ProSE took` — no "failed to start" error, no "Using original HyperScore" fallback.
- Wall: 1:22:45 (vs. 1:20:35 pre-fix where Percolator silently failed — the ~2 min delta is Percolator actually doing work).
- Matched spectra unchanged (28,235); unique peptides 23,417 after Percolator q-value filtering (vs. 23,422 when Percolator silently fell back to HyperScore).

## Notes

- The user-supplied `-percolator_executable` parameter is for the external **percolator** binary (correctly passed via `-percolator_executable` arg of PercolatorAdapter) — not for the adapter itself.
- `File::findSiblingTOPPExecutable` searches relative to the currently running executable path, so it works in dev builds, bin-installed setups, and macOS .app bundles alike.
- OpenNuXL has the same pattern at `src/topp/OpenNuXL.cpp:4788` and `:6410` — out of scope for this PR, worth a follow-up.

## Test plan

- [x] ProSE builds with the change
- [x] End-to-end ProSE run on immunopeptidomics mzML confirms `PercolatorAdapter` is found and rescoring succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)