### PR TITLE
fix(File): fall back to copy+remove on cross-device rename (EXDEV)

### DIFF
--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -201,6 +201,27 @@ namespace OpenMS
     // move the file to the actual destination:
     std::error_code rename_ec;
     fs::rename(to_path(from), to_path(to), rename_ec);
+
+    // Cross-device rename fails with EXDEV on POSIX. Qt's QFile::rename silently
+    // copied and removed in that case; preserve that so TOPP tools can move files
+    // out of a tmp dir into a bind-mounted output (common in containers).
+    if (rename_ec == std::errc::cross_device_link)
+    {
+      std::error_code copy_ec;
+      fs::copy_file(to_path(from), to_path(to),
+                    fs::copy_options::overwrite_existing, copy_ec);
+      if (!copy_ec)
+      {
+        std::error_code remove_ec;
+        fs::remove(to_path(from), remove_ec); // best-effort source cleanup
+        rename_ec.clear();
+      }
+      else
+      {
+        rename_ec = copy_ec;
+      }
+    }
+
     if (rename_ec)
     {
       if (verbose)


### PR DESCRIPTION
## Summary

`File::rename()` now falls back to `std::filesystem::copy_file` + `std::filesystem::remove` when `std::filesystem::rename` fails with `EXDEV` (cross-device link). This restores the cross-filesystem semantics that `QFile::rename` provided before PR #8938 replaced Qt with `std::filesystem`.

## Why

`std::filesystem::rename` follows POSIX `rename(2)` and fails with `EXDEV` when source and destination are on different mounts. `QFile::rename` (the pre-#8938 implementation) silently copied + removed in that case. The regression surfaced as:

```
Error: Could not move '/tmp/.../result.pin' to 'HepG2_rep1_small_pin.tsv'
```

…when running OpenMS TOPP tools inside a container where `/tmp` is on an overlay FS and the output dir is a bind mount.

Affected TOPP tools (all move files from `tmp_dir.getPath()` to a user-specified output):
- `CometAdapter -pin_out`
- `MSGFPlusAdapter -mzid_out`
- `MSFraggerAdapter` (optional pepXML out, lower risk — source is typically next to the input mzML)

Since all three go through `File::rename`, fixing it once in `File.cpp` covers them all.

## Behavior

- Normal (same-FS) rename: unchanged — still an atomic `std::filesystem::rename`.
- EXDEV: copy + best-effort source remove (matches Qt's documented fallback).
- Any other rename error: unchanged — logged and returns `false`.

## Test plan

- [x] `File_test` still passes (same-FS path unchanged).
- [ ] **Not unit-tested for the EXDEV branch** — reproducing it requires two filesystems, which isn't available in the standard CI runner (`/tmp` and the build dir share a mount). The fix is narrow (the added `if (rename_ec == std::errc::cross_device_link)` block is ~17 lines) and relies on code review + downstream integration testing in the container environment that originally tripped the bug.
- [ ] Nightly integration runs inside a container should now complete `CometAdapter -pin_out` without the "Could not move" error.

If desired, a follow-up could add an env-gated test (e.g. `OPENMS_TEST_CROSSFS_DIR` pointing at a path on a different mount) that runs only where a second filesystem is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File rename and move operations now handle cross-filesystem scenarios, allowing successful transfers between different storage devices without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->