### PR TITLE
CI: Extract dependency handling to a custom action

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -1,0 +1,206 @@
+name: "Install OpenMS Dependencies"
+description: "Central action for all dependency management"
+inputs:
+  os:
+    description: "The operating system to install dependencies for"
+    required: true
+    default: "Linux"
+  compiler:
+    description: "The name of the compiler to use"
+    required: true
+  compiler_ver:
+    description: "The version number for the compiler"
+    required: true
+outputs:
+  cmake_prefix:
+    description: "Path to add to CMAKE_PREFIX"
+    value: ${{ steps.combine.outputs.cmake_prefix }}
+runs:
+  using: "composite"
+  steps:
+    - name: Identify contrib submodule revision for cache key
+      id: contrib-rev
+      if: inputs.os == 'Windows'
+      shell: bash
+      run: |
+        rev=$(git submodule status --cached -- contrib | sed -E 's/^-?//' | cut -d' ' -f1)
+        echo "rev=$rev" >> "$GITHUB_OUTPUT"
+
+    - name: Cache contrib
+      id: cache-contrib
+      if: inputs.os == 'Windows'
+      uses: actions/cache@v5
+      with:
+        path: contrib/build
+        key: ${{ inputs.os }}-${{ steps.contrib-rev.outputs.rev }}
+
+    - name: Fetch contrib if not in cache
+      if: inputs.os == 'Windows' && steps.cache-contrib.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        git submodule update --init -- contrib
+        mkdir -p contrib/build
+
+    - name: Build contrib if not in cache
+      if: inputs.os == 'Windows' && steps.cache-contrib.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $NPROC = $env:NUMBER_OF_PROCESSORS
+        if (-not $NPROC) { $NPROC = 4 }
+        $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
+        Set-Location "${{ github.workspace }}\contrib\build"
+        cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Add THIRDPARTY
+      shell: bash
+      run: |
+          # initialize THIRDPARTY
+          git submodule update --init THIRDPARTY
+
+          # add third-party binaries to PATH
+          # use flat THIRDPARTY structure
+          mkdir -p _thirdparty
+
+          tp_folder=${{ runner.os }}
+          if [ "$tp_folder" = "macOS" ]; then
+            tp_folder=MacOS
+          fi
+
+          # Copy the correct architecture
+          cp -R "THIRDPARTY/$tp_folder/$(uname -m)"/* _thirdparty/
+
+          # Copy architecture independent tools
+          cp -R THIRDPARTY/All/* _thirdparty/
+
+          # add third-party binaries to PATH
+          for thirdpartytool in '${{ github.workspace }}/_thirdparty'/*; do
+            if [ "${{ runner.os }}" = "Windows" ]; then
+              echo "${thirdpartytool//\//\\}" >> "$GITHUB_PATH"
+            else
+              echo "${thirdpartytool}" >> "$GITHUB_PATH"
+            fi
+          done
+
+    - name: Install Conda
+      if: inputs.os == 'Windows'
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+        activate-environment: "ci"
+        python-version: 3.11
+        use-mamba: true
+
+    - name: Install Dependencies via Conda
+      id: conda-setup
+      if: inputs.os == 'Windows'
+      # NOTE: This weird shell line is needed in order to activate
+      # conda (and put it in this shell's PATH) since the way it's
+      # installed requires a login shell :(
+      shell: bash -el {0}
+      run: |
+        # Dump out environment information for debugging:
+        conda info
+
+        # None of the other arrow sublibraries seemed necessary, but it's an easy addition.
+        conda install -c conda-forge libarrow libparquet libzip -y
+
+        # Set variables required for the following steps so they
+        # don't need a conda environment or login shell:
+        CONDA_ENV_PREFIX=$(
+          conda info --json |
+            jq --raw-output .active_prefix |
+            sed 's|\\|/|g'
+        )
+
+        echo "$CONDA_ENV_PREFIX/bin" >>"$GITHUB_PATH"
+        echo "$CONDA_ENV_PREFIX/Library/bin" >>"$GITHUB_PATH"
+        echo "cmake_prefix=$CONDA_ENV_PREFIX/Library" >>"$GITHUB_OUTPUT"
+
+        # Some output for debugging:
+        echo "CONDA_ENV_PREFIX=$CONDA_ENV_PREFIX"
+
+        # Disable conda auto-activation to prevent race conditions during parallel
+        # CMake builds. See https://github.com/conda/conda/issues/8733
+        # The paths are already added to GITHUB_PATH above, so conda activation
+        # is no longer needed for subsequent steps.
+        conda init --reverse bash
+
+    - name: Install Qt (Windows)
+      if: inputs.os == 'Windows'
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.8.3'    ## Note this version is build with win64_msvc2022_64 and should always match what we use
+        arch: 'win64_msvc2022_64'
+        cache: 'false'
+        archives: 'qtsvg qtimageformats qtbase'
+
+    - name: "Dependencies: Windows"
+      id: deps-windows
+      if: inputs.os == 'Windows'
+      shell: bash
+      run: |
+        choco install -y --no-progress \
+          ccache \
+          doxygen.portable \
+          ghostscript \
+          graphviz
+
+        # Use a custom NSIS, which provides 8-k string support and has
+        # UltraModernUI integrated already:
+        curl --no-progress-meter -L -o NSIS.tar.gz https://github.com/OpenMS/NSIS/raw/main/NSIS.tar.gz
+        7z x -so NSIS.tar.gz | 7z x -si -ttar -aoa -o"C:/Program Files (x86)/NSIS/"
+        echo "C:\Program Files (x86)\NSIS" >> $GITHUB_PATH
+
+        echo "cmake_prefix=" >>"$GITHUB_OUTPUT"
+
+    - name: "Dependencies: Linux"
+      id: deps-linux
+      if: inputs.os == 'Linux'
+      shell: bash
+      run: |
+        bash tools/ci/deps-ubuntu.sh
+
+        if [[ "${{ inputs.compiler }}" == clang* ]]; then
+          sudo apt-get -qq install -y libomp-${{ inputs.compiler_ver }}-dev
+        fi
+
+        echo "cmake_prefix=" >>$GITHUB_OUTPUT
+
+    - name: "Dependencies: macOS"
+      id: deps-macos
+      if: inputs.os == 'macOS'
+      env:
+        # We need to add this, otherwise brew "helpfully" updates all
+        # of the GitHub preinstalled packages, which can cause issues:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+      shell: bash
+      run: |
+        bash tools/ci/deps-macos.sh
+        brew install ccache
+
+        echo "$(brew --prefix)/bin" >>"$GITHUB_PATH"
+        echo "cmake_prefix=$(brew --prefix);$(brew --prefix libomp)" >>"$GITHUB_OUTPUT"
+
+    - name: Combine Outputs
+      id: combine
+      shell: bash
+      run: |
+        cmake_prefix_s=""
+        cmake_prefix_a=(
+          "${{ steps.conda-setup.outputs.cmake_prefix}}"
+          "${{ steps.deps-windows.outputs.cmake_prefix}}"
+          "${{ steps.deps-linux.outputs.cmake_prefix}}"
+          "${{ steps.deps-macos.outputs.cmake_prefix}}"
+        )
+
+        for path in "${cmake_prefix_a[@]}"; do
+          if [ -n "$path" ]; then
+            if [ -n "$cmake_prefix_s" ]; then
+              cmake_prefix_s="${cmake_prefix_s};"
+            fi
+            cmake_prefix_s="${cmake_prefix_s}${path}"
+          fi
+        done
+
+        echo "cmake_prefix=${cmake_prefix_s}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/openms_ci_matrix_full.yml
+++ b/.github/workflows/openms_ci_matrix_full.yml
@@ -1,5 +1,5 @@
 # This does the whole cmake build of OpenMS on github's runners. It is intended to replace our current Jenkins based jobs.
-# For Nightly and Release branches it builds the packages and submits them to our archive. 
+# For Nightly and Release branches it builds the packages and submits them to our archive.
 # NB: The actual upload is currently commented out so that this can get merged to develop. It will be re-added presently.
 name: openms-ci-full
 
@@ -38,60 +38,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # NOTE: This job is temporary until we get rid of contrib.
-  prepare-contrib-for-windows:
-    runs-on: windows-2025
-    steps:
-      - name: Clone OpenMS
-        uses: actions/checkout@v6
-      - name: Set up Visual Studio shell
-        uses: egor-tensin/vs-shell@v2
-        with: { arch: x64 }
-
-      - name: Identify contrib submodule revision for cache key
-        id: contrib-rev
-        shell: bash
-        run: |
-          rev=$(git submodule status --cached -- contrib | sed -E 's/^-?//' | cut -d' ' -f1)
-          echo "rev=$rev" >> "$GITHUB_OUTPUT"
-
-      - name: Cache contrib
-        id: cache-contrib
-        uses: actions/cache@v5
-        with:
-          path: contrib/build
-          key: ${{ runner.os }}-${{ steps.contrib-rev.outputs.rev }}
-
-      - name: Fetch contrib if not in cache
-        if: steps.cache-contrib.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git submodule update --init -- contrib
-          mkdir -p contrib/build
-
-      - name: Build contrib if not in cache
-        if: steps.cache-contrib.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $NPROC = $env:NUMBER_OF_PROCESSORS
-          if (-not $NPROC) { $NPROC = 4 }
-          $env:CMAKE_BUILD_PARALLEL_LEVEL = $NPROC
-          Set-Location "${{ github.workspace }}\contrib\build"
-          cmake -G"Visual Studio 17 2022" -Ax64 -DBUILD_TYPE=ALL "${{ github.workspace }}\contrib"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Upload Contrib
-        uses: actions/upload-artifact@v7
-        with:
-          name: contrib-${{ steps.contrib-rev.outputs.rev }}
-          path: |
-            contrib/build/lib/
-            contrib/build/bin/
-            contrib/build/include/
-          retention-days: 7
-
   build-and-test:
-    needs: prepare-contrib-for-windows
     strategy:
       fail-fast: false
       matrix:
@@ -121,7 +68,7 @@ jobs:
             compiler_ver: 13
           # Make sure the compilers are available in that version on the GH runners
           # We are not installing anything.
-          
+
           - os: ubuntu-24.04-arm
             compiler: g++
             compiler_ver: 13
@@ -133,19 +80,16 @@ jobs:
       version_number: ${{ steps.create_changelog.outputs.version_number }}
 
     runs-on: ${{ matrix.os }}
-    env: 
-      TERM: xterm-256color
-
     steps:
-    - uses: actions/checkout@v4
-      with:
-        path: OpenMS
+    - uses: actions/checkout@v6
 
     - id: extract_branch
       name: Extract branch/PR infos
       shell: bash
       run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_OUTPUT
 
+    # FIXME: We may need to remove this action since it is not being
+    # maintained and will stop working once GitHub upgrades nodejs.
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
@@ -161,7 +105,7 @@ jobs:
           echo "xvfb=xvfb-run -a" >> $GITHUB_OUTPUT
           echo "static_boost=OFF" >> $GITHUB_OUTPUT
           # always run doxygen on Ubuntu (because its fast), to detect Doxygen errors
-          echo "enable_docs=ON" >> $GITHUB_OUTPUT  
+          echo "enable_docs=ON" >> $GITHUB_OUTPUT
           if [ "$DO_PACKAGE" = true ]; then
             echo "pkg_type=deb" >> $GITHUB_OUTPUT
           else
@@ -169,7 +113,7 @@ jobs:
           fi
           echo "cxx_compiler=${{ matrix.compiler }}-${{ matrix.compiler_ver }}" >> $GITHUB_OUTPUT
         fi
-        
+
         if [[ "${{ matrix.os }}" == windows-* ]]; then
           echo "tp_folder=Windows" >> $GITHUB_OUTPUT
           echo "contrib_os=windows" >> $GITHUB_OUTPUT
@@ -228,13 +172,13 @@ jobs:
             VERSION_NUMBER=${VERSION_NUMBER%.*}
           fi
           echo "version_number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
-          grep -ne "----[[:space:]]*OpenMS" ${{ github.workspace }}/OpenMS/CHANGELOG > index_changelog.txt 
+          grep -ne "----[[:space:]]*OpenMS" ${{ github.workspace }}/CHANGELOG > index_changelog.txt
           START=$(cat index_changelog.txt | grep -A 1 -E " $VERSION_NUMBER(\.0)? " | cut -f1 -d: | head -1)
           END=$(cat index_changelog.txt | grep -A 1 -E " $VERSION_NUMBER(\.0)? " | cut -f1 -d: | tail -1)
           echo "Extracting between lines:"
           echo $START
           echo $END
-          awk "NR > $START && NR < $END" OpenMS/CHANGELOG > ${{ github.workspace }}/changelog.txt
+          awk "NR > $START && NR < $END" CHANGELOG > ${{ github.workspace }}/changelog.txt
         else
           echo "Branch name does not match the expected pattern."
           exit 1
@@ -269,137 +213,16 @@ jobs:
         # NOTE: x64 is hardcoded. No support for 32bit
         arch: x64
 
-    - name: Install Conda
-      if: startsWith(matrix.os, 'windows')
-      uses: conda-incubator/setup-miniconda@v3
+    - name: Install Dependencies
+      id: deps
+      uses: ./.github/actions/dependencies
       with:
-        auto-update-conda: true
-        activate-environment: "ci"
-        python-version: 3.11
-        use-mamba: true
-
-    - name: Install Dependencies via Conda
-      id: conda-setup
-      if: startsWith(matrix.os, 'windows')
-      # NOTE: This weird shell line is needed in order to activate
-      # conda (and put it in this shell's PATH) since the way it's
-      # installed requires a login shell :(
-      shell: bash -el {0}
-      run: |
-        # Dump out environment information for debugging:
-        conda info
-
-        # None of the other arrow sublibraries seemed necessary, but it's an easy addition.
-        conda install -c conda-forge libarrow libparquet libzip -y
-
-        # Set variables required for the following steps so they
-        # don't need a conda environment or login shell:
-        CONDA_ENV_PREFIX=$(
-          conda info --json |
-            jq --raw-output .active_prefix |
-            sed 's|\\|/|g'
-        )
-
-        echo "$CONDA_ENV_PREFIX/bin" >>"$GITHUB_PATH"
-        echo "$CONDA_ENV_PREFIX/Library/bin" >>"$GITHUB_PATH"
-        echo "cmake_prefix=$CONDA_ENV_PREFIX/Library" >>"$GITHUB_OUTPUT"
-
-        # Some output for debugging:
-        echo "CONDA_ENV_PREFIX=$CONDA_ENV_PREFIX"
-
-        # Disable conda auto-activation to prevent race conditions during parallel
-        # CMake builds. See https://github.com/conda/conda/issues/8733
-        # The paths are already added to GITHUB_PATH above, so conda activation
-        # is no longer needed for subsequent steps.
-        conda init --reverse bash
-
-    - name: Install Qt (Windows)
-      if: startsWith(matrix.os, 'windows')
-      uses: jurplel/install-qt-action@v4
-      with:
-        version: '6.8.3'    ## Note this version is build with win64_msvc2022_64 and should always match what we use
-        arch: 'win64_msvc2022_64'
-        cache: 'false'
-        archives: 'qtsvg qtimageformats qtbase'
-
-    - name: Set Up Build Tools
-      id: tools-prefix
-      shell: bash
-      env:
-        # We need to add this, otherwise brew "helpfully" updates all
-        # of the GitHub preinstalled packages, which can cause issues:
-        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-      run: |
-        if [[ "${{ matrix.os }}" == ubuntu-* ]]; then
-          # WARNING: Don't add any dependency install commands here.
-          # Instead edit the following script:
-          bash OpenMS/tools/ci/deps-ubuntu.sh
-          # Install libomp for clang compiler (needed for OpenMP support)
-          # Use version-specific package matching the clang version
-          if [[ "${{ matrix.compiler }}" == clang* ]]; then
-            sudo apt-get -qq install -y libomp-${{ matrix.compiler_ver }}-dev
-          fi
-          echo "Testing doxygen" && doxygen --version
-          echo "cmake_prefix=" >>$GITHUB_OUTPUT
-        fi
-
-        if [[ "${{ matrix.os }}" == windows-* ]]; then
-          choco install  -y --no-progress \
-                ccache \
-                cmake \
-                doxygen.portable \
-                eigen \
-                ghostscript \
-                graphviz \
-                ninja
-
-          if [[ "${{ steps.set-vars.outputs.pkg_type }}" != "none" ]]; then
-            # uses a custom NSIS, which provides 8-k string support and has UltraModernUI integrated already
-            curl --no-progress-meter -L -o NSIS.tar.gz https://github.com/OpenMS/NSIS/raw/main/NSIS.tar.gz
-            ## overwrite existing NSIS (which has only 1k-string support)
-            7z x -so NSIS.tar.gz | 7z x -si -ttar -aoa -o"C:/Program Files (x86)/NSIS/"
-            # Ensure makensis.exe is discoverable during CMake configuration
-            echo "C:\Program Files (x86)\NSIS" >> $GITHUB_PATH
-          fi
-
-          echo "cmake_prefix=" >>"$GITHUB_OUTPUT"
-          echo "eigen_choco=C:\ProgramData\chocolatey\lib\eigen\share\cmake" >> $GITHUB_OUTPUT
-
-          ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
-          # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
-          echo "C:\Program Files (x86)\GitHub CLI" >> $GITHUB_PATH
-        fi
-
-        if [[ "${{ matrix.os }}" == macos-* ]]; then
-          # WARNING: Don't add any brew install commands here, edit
-          # the following script instead:
-          bash OpenMS/tools/ci/deps-macos.sh
-          brew install ccache
-          echo "$(brew --prefix)/bin" >>"$GITHUB_PATH"
-          echo "cmake_prefix=$(brew --prefix);$(brew --prefix libomp)" >>"$GITHUB_OUTPUT"
-        fi
-
-    - name: Build libcurl from source (Windows)
-      if: startsWith(matrix.os, 'windows')
-      shell: bash
-      run: |
-          curl -L -o curl-src.tar.gz https://curl.se/download/curl-8.12.1.tar.gz
-          tar xzf curl-src.tar.gz
-          cd curl-8.12.1
-          cmake -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/OpenMS/contrib" \
-            -DBUILD_SHARED_LIBS=ON \
-            -DCURL_USE_SCHANNEL=ON \
-            -DBUILD_CURL_EXE=OFF \
-            -DBUILD_TESTING=OFF \
-            -DCURL_DISABLE_LDAP=ON \
-            -DCURL_USE_LIBPSL=OFF
-          cmake --build build
-          cmake --install build
+        os: ${{runner.os}}
+        compiler: ${{ matrix.compiler }}
+        compiler_ver: ${{ matrix.compiler_ver }}
 
     - name: Setup ccache cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .ccache
         key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-ccache-${{ steps.extract_branch.outputs.RUN_NAME }}-${{ github.run_number }}
@@ -409,51 +232,10 @@ jobs:
           ${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-ccache-develop
           ${{ runner.os }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-ccache-
 
-    - name: Identify contrib submodule revision for cache key
-      id: contrib-rev
-      shell: bash
-      run: |
-        cd OpenMS
-        rev=$(git submodule status --cached -- contrib | sed -E 's/^-?//' | cut -d' ' -f1)
-        echo "rev=$rev" >> "$GITHUB_OUTPUT"
-
-    - name: Download contrib artifact for Windows
-      if: runner.os == 'Windows'
-      uses: actions/download-artifact@v4
-      with:
-        name: contrib-${{ steps.contrib-rev.outputs.rev }}
-        path: OpenMS/contrib/build
-          
-    - name: Add THIRDPARTY
-      shell: bash
-      run: |
-          # initialize THIRDPARTY
-          cd OpenMS
-          git submodule update --init THIRDPARTY
-          cd ..
-          # add third-party binaries to PATH
-          # use flat THIRDPARTY structure
-          THIRDPARTY_DIR="OpenMS/THIRDPARTY"
-          mkdir -p _thirdparty
-          # Copy the correct architecture
-          cp -R "$THIRDPARTY_DIR/${{ steps.set-vars.outputs.tp_folder }}/$(uname -m)"/* _thirdparty/
-          # Copy architecture independent tools
-          cp -R OpenMS/THIRDPARTY/All/* _thirdparty/
-          # add third-party binaries to PATH
-          for thirdpartytool in '${{ github.workspace }}/_thirdparty'/*
-          do
-            if [[ "${{ matrix.os }}" == windows-* ]]; then
-              # substitute slashes
-              echo ${thirdpartytool//\//\\} >> $GITHUB_PATH
-            else
-              echo $thirdpartytool >> $GITHUB_PATH
-            fi
-          done
-
    # Upload the changelog to the same artifact that we will add the installers to.
     - name: Upload changelog as artifact
       if: steps.set-vars.outputs.pkg_type != 'none' && startsWith(steps.extract_branch.outputs.RUN_NAME,'release') && startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: changelog.txt
         path: |
@@ -473,22 +255,22 @@ jobs:
           CCACHE_DIR=${{ github.workspace }}/.ccache ccache -s || true
           echo "::endgroup::"
 
-          mkdir $GITHUB_WORKSPACE/OpenMS/bld/
-          bash OpenMS/tools/ci/capture-env.sh -v $GITHUB_WORKSPACE/OpenMS/bld/CMakeCache.txt
-          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cibuild.cmake
+          mkdir bld
+          bash tools/ci/capture-env.sh -v $GITHUB_WORKSPACE/bld/CMakeCache.txt
+          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/tools/ci/cibuild.cmake
           retVal=$?
-          
+
           # Display ccache statistics after build
           echo "::group::ccache statistics after build"
           CCACHE_DIR=${{ github.workspace }}/.ccache ccache -s || true
           echo "::endgroup::"
-          
+
           if [ $retVal -ne 0 ]; then
               echo -e "\033[0;31m Errors in build:"
               # TODO upload logs as artifact?
-              find $GITHUB_WORKSPACE/OpenMS/bld/ -name "LastBuild*" -type f -exec cat {} \;
+              find $GITHUB_WORKSPACE/bld/ -name "LastBuild*" -type f -exec cat {} \;
               # remove for next steps
-              find $GITHUB_WORKSPACE/OpenMS/bld/ -name "LastBuild*" -type f -exec rm {} \;
+              find $GITHUB_WORKSPACE/bld/ -name "LastBuild*" -type f -exec rm {} \;
           fi
           exit $retVal
       env:
@@ -498,11 +280,11 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ startsWith(matrix.os, 'macos') && '14.0' || '' }}
           PYOPENMS: "${{ startsWith(matrix.os, 'ubuntu') && matrix.compiler == 'g++' && 'ON' || 'OFF' }}"
           NO_DEPENDENCIES: "${{ startsWith(matrix.os, 'ubuntu') && matrix.compiler == 'g++' && 'OFF' || 'ON' }}"
-          CMAKE_PREFIX_PATH: "${{ steps.tools-prefix.outputs.cmake_prefix }};${{ steps.conda-setup.outputs.cmake_prefix }}"
-          OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/OpenMS/contrib/build"
+          CMAKE_PREFIX_PATH: "${{ steps.deps.outputs.cmake_prefix }}"
+          OPENMS_CONTRIB_LIBS: "${{ github.workspace }}/contrib/build"
           CI_PROVIDER: "GitHub-Actions"
           CMAKE_GENERATOR: "Ninja"
-          SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+          SOURCE_DIRECTORY: "${{ github.workspace }}"
           BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-class-topp-${{ github.run_number }}"
           ENABLE_STYLE_TESTING: "OFF"
           ENABLE_TOPP_TESTING: "ON"
@@ -529,18 +311,18 @@ jobs:
           CCACHE_SLOPPINESS: time_macros,include_file_ctime,include_file_mtime
           CCACHE_COMPILERCHECK: content
           WITH_THERMORAWFILEPARSER_TEST: "OFF"
-          Eigen3_DIR: "${{ steps.tools-prefix.outputs.eigen_choco }}" # Eigen is installed on windows using choco
+          #Eigen3_DIR: "${{ steps.tools-prefix.outputs.eigen_choco }}" # Eigen is installed on windows using choco
           USE_EXTERNAL_JSON: ${{ (startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'windows')) && 'OFF' || 'ON' }}
           USE_EXTERNAL_SQLITECPP: ${{ startsWith(matrix.os, 'ubuntu') && 'ON' || 'OFF' }}
           USE_EXTERNAL_SIMDE: ${{ startsWith(matrix.os, 'ubuntu') && 'ON' || 'OFF' }}
           # Note: USE_EXTERNAL_SQLITECPP and USE_EXTERNAL_SIMDE are set but not passed to CMake
-          # (not in capture-env.sh) because Ubuntu's packages don't provide CMake config files. 
+          # (not in capture-env.sh) because Ubuntu's packages don't provide CMake config files.
     - name: Test
       shell: bash
       run: |
-          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/OpenMS/tools/ci/citest.cmake
+          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -V -S $GITHUB_WORKSPACE/tools/ci/citest.cmake
       env:
-          SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+          SOURCE_DIRECTORY: "${{ github.workspace }}"
           CI_PROVIDER: "GitHub-Actions"
           BUILD_NAME: "${{ steps.extract_branch.outputs.RUN_NAME }}-${{ steps.set-vars.outputs.tp_folder }}-${{ runner.arch }}-${{ matrix.compiler }}-${{ matrix.compiler_ver }}-class-topp-${{ github.run_number }}"
           # The rest of the vars should be saved in the CMakeCache
@@ -570,7 +352,7 @@ jobs:
         security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild
         security import installer_certificate.p12 -k build.keychain -P "$INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/productbuild
         security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign:,productbuild: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-        
+
         echo "=== Available signing identities ==="
         security find-identity -v -p codesigning build.keychain
 
@@ -580,20 +362,20 @@ jobs:
       run: |
           # do not fail immediately
           set +e
-          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -VV -S $GITHUB_WORKSPACE/OpenMS/tools/ci/cipackage.cmake
+          ${{ steps.set-vars.outputs.xvfb }} ctest --output-on-failure -VV -S $GITHUB_WORKSPACE/tools/ci/cipackage.cmake
           retVal=$?
           if [ $retVal -ne 0 ]; then
               echo -e "\033[0;31m Errors in packaging:"
               # TODO upload logs as artifact?
-              find $GITHUB_WORKSPACE/OpenMS/bld/ -name "LastBuild*" -type f -exec cat {} \;
+              find $GITHUB_WORKSPACE/bld/ -name "LastBuild*" -type f -exec cat {} \;
               # remove for next steps
-              find $GITHUB_WORKSPACE/OpenMS/bld/ -name "LastBuild*" -type f -exec rm {} \;
+              find $GITHUB_WORKSPACE/bld/ -name "LastBuild*" -type f -exec rm {} \;
               # only on win
-              cat OpenMS/bld/_CPack_Packages/win64/NSIS/NSISOutput.log || true
+              cat bld/_CPack_Packages/win64/NSIS/NSISOutput.log || true
           fi
           exit $retVal
       env:
-          SOURCE_DIRECTORY: "${{ github.workspace }}/OpenMS"
+          SOURCE_DIRECTORY: "${{ github.workspace }}"
           PACKAGE_TYPE: ${{ steps.set-vars.outputs.pkg_type }}
           SEARCH_ENGINES_DIRECTORY: "${{ github.workspace }}/_thirdparty"
           CI_PROVIDER: "GitHub-Actions"
@@ -618,7 +400,7 @@ jobs:
         TEAM_ID: "C64UCGJ5PL"
       run: |
         echo "=== Starting macOS package notarization ==="
-        cd $GITHUB_WORKSPACE/OpenMS/bld/
+        cd $GITHUB_WORKSPACE/bld/
 
         # Find the generated .pkg file
         PKG_FILE=$(ls -1 *.pkg 2>/dev/null | head -1)
@@ -631,13 +413,13 @@ jobs:
         echo "Found package: $PKG_FILE"
 
         # Run notarization script
-        $GITHUB_WORKSPACE/OpenMS/cmake/MacOSX/notarize.sh \
+        $GITHUB_WORKSPACE/cmake/MacOSX/notarize.sh \
           "$PKG_FILE" \
           "de.openms" \
           "apple@openms.de" \
           "APPLE_APP_SPECIFIC_NOTARIZATION_PASSWORD" \
           "$TEAM_ID" \
-          "$GITHUB_WORKSPACE/OpenMS/bld/"
+          "$GITHUB_WORKSPACE/bld/"
 
         echo "=== Notarization complete ==="
 
@@ -649,13 +431,13 @@ jobs:
     # WARNING: Here you have to make sure that only one matrix configuration per OS produces packages. See set-vars steps.
     - name: Upload packages as artifacts
       if: steps.set-vars.outputs.pkg_type != 'none'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ format('installer-{0}{1}', steps.set-vars.outputs.tp_folder, runner.arch == 'arm64' && '-arm64' || '') }}
         path: |
-          ${{ github.workspace }}/OpenMS/bld/*.exe
-          ${{ github.workspace }}/OpenMS/bld/*.deb
-          ${{ github.workspace }}/OpenMS/bld/*.pkg
+          ${{ github.workspace }}/bld/*.exe
+          ${{ github.workspace }}/bld/*.deb
+          ${{ github.workspace }}/bld/*.pkg
 
     #Zip the documentation first, since there are :: which make the upload action choke.
     - name: Zip Documentation
@@ -663,26 +445,27 @@ jobs:
       uses: thedoctor0/zip-release@0.7.6
       with:
         type: 'zip'
-        directory: ${{ github.workspace }}/OpenMS/bld/doc
+        directory: ${{ github.workspace }}/bld/doc
         exclusions: '/CMakeFiles/* /doxygen/* /code_examples/*'
         filename: 'documentation.zip'
-    
+
    # Compress the source
     - name: Create tarball
       if: steps.set-vars.outputs.pkg_type != 'none' && startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64'
       run: |
         tar --exclude='bld/*' \
             --exclude='OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz' \
-            --exclude='OpenMS/THIRDPARTY/**' \
+            --exclude='THIRDPARTY/**' \
+            --exclude='contrib/**' \
             --exclude='.git/**' \
             --exclude='.github/**' \
             --exclude='vcpkg*/**' \
-            -czf OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz -C ${{ github.workspace }} OpenMS
-        
+            -czf OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz -C ${{ github.workspace }} .
+
    # Upload the source tar
     - name: Upload source tar as artifact
       if: steps.set-vars.outputs.pkg_type != 'none' && startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: OpenMS-${{ steps.create_changelog.outputs.version_number }}.tar.gz
         path: |
@@ -693,11 +476,11 @@ jobs:
 
     - name: Upload Documentation as artifacts
       if: steps.set-vars.outputs.pkg_type != 'none' && startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: documentation
         path: |
-          ${{ github.workspace }}/OpenMS/bld/doc/documentation.zip
+          ${{ github.workspace }}/bld/doc/documentation.zip
 
     - name: Generate KNIME descriptors and payloads
     # We never want to build the KNIME update site on our second Ubuntu + Clang matrix entry even if inputs.knime is true, so we check for that specific os + compiler combo
@@ -705,19 +488,19 @@ jobs:
       if: (steps.set-vars.outputs.pkg_type != 'none' && !(startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64')) || ( inputs.knime && !(startsWith(matrix.os, 'ubuntu') && (startsWith(matrix.compiler, 'clang++') || runner.arch == 'arm64') ) )
       shell: bash
       run: |
-        cd $GITHUB_WORKSPACE/OpenMS/bld/
+        cd $GITHUB_WORKSPACE/bld/
         # TODO use CTest or script to upload to CDash?
         cmake -DSEARCH_ENGINES_DIRECTORY="$GITHUB_WORKSPACE/_thirdparty" -DENABLE_PREPARE_KNIME_PACKAGE=ON .
         cmake --build . --target prepare_knime_package
-        
+
     - name: Upload KNIME payload and descriptors as artifacts
     # We never want to build the KNIME update site on our second Ubuntu + Clang matrix entry even if inputs.knime is true, so we check for that specific os + compiler combo
     # we also don't want it from both the arm and x86_64 builds
       if: (steps.set-vars.outputs.pkg_type != 'none' && !(startsWith(matrix.os, 'ubuntu') && runner.arch == 'arm64')) ||  ( inputs.knime && !(startsWith(matrix.os, 'ubuntu') && (startsWith(matrix.compiler, 'clang++') || runner.arch == 'arm64') ) )
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ format('knime-{0}{1}', steps.set-vars.outputs.tp_folder, runner.arch == 'arm64' && '-arm64' || '') }}
-        path: ${{ github.workspace }}/OpenMS/bld/knime/**/*
+        path: ${{ github.workspace }}/bld/knime/**/*
 
   deploy-installer:
     if: github.ref == 'refs/heads/nightly' || contains(github.ref, 'release/') || inputs.package
@@ -733,22 +516,22 @@ jobs:
         run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_ENV
 
       - name: Download installer artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: installer-*
           merge-multiple: true
 
       - name: Download source archive as artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: OpenMS-${{ needs.build-and-test.outputs.version_number }}.tar.gz
 
       - name: Download changelog as artifact
         if: inputs.do_release
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: changelog.txt
-      
+
       - name: Upload installer
         shell: bash
         env:
@@ -771,7 +554,7 @@ jobs:
           echo "$PASS" > ~/.ssh/private.key
           sudo chmod 600 ~/.ssh/private.key
           rsync --progress -avz -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/* "$USER@$HOST:/OpenMSInstaller/${folder}"
-        
+
       - name: Make installer latest
         if: inputs.mark_as_latest
         shell: bash
@@ -828,12 +611,12 @@ jobs:
             RELEASE_TEXT_ESCAPED_QUOTES="${RELEASE_TEXT//\"/\\\"}"
             cat releaseTextHeader.txt $GITHUB_WORKSPACE/changelog.txt releaseTextFooter.txt > RELEASE_TEXT_GH.md
             echo release_text_contents=`base64 -w0 RELEASE_TEXT_GH.md` >> $GITHUB_OUTPUT
-      
+
       - name: run GHA release action.
         id: create_release
         if: inputs.do_release
         uses: ncipollo/release-action@v1.16.0
-        with: 
+        with:
           bodyFile: RELEASE_TEXT_GH.md
           tag: ${{ github.ref_name }}
           draft: true
@@ -851,9 +634,9 @@ jobs:
       - name: Extract branch/PR infos
         shell: bash
         run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_ENV
-    
+
       - name: Download Documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: documentation
           path: docs
@@ -891,7 +674,7 @@ jobs:
           PASS: ${{ secrets.ARCHIVE_RRSYNC_SSH }}
           USER: ${{ secrets.ARCHIVE_RRSYNC_USER }}
           HOST: ${{ secrets.ARCHIVE_RRSYNC_HOST }}
-          PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}          
+          PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
@@ -907,11 +690,11 @@ jobs:
           sudo chmod 600 ~/.ssh/private.key
           ln -s ./$folder latest  #we can use the same link from above.
           rsync --progress -avz -e "ssh -i ~/.ssh/private.key -p $PORT -o StrictHostKeyChecking=no" latest "$USER@$HOST:/Documentation/release"
-      
+
         # TODO create softlinks to latest nightly
         # TODO create and upload file hashes, at least for release candidate
 
-        
+
   build-deploy-knime-updatesite:
     env:
       KNIME: 5.3
@@ -927,13 +710,13 @@ jobs:
         run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_ENV
 
       - name: Download KNIME artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: knime-*
           merge-multiple: true
           path: ${{ env.PLUGIN_SOURCE }}
-     
-      # Should be the default. 
+
+      # Should be the default.
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -983,7 +766,7 @@ jobs:
               CONTRIBUTING_DATE=$(git log -1 --format="%cd" --date="format:%Y%m%d%H%M")
               echo "Setting qualifier/SNAPSHOT for de.openms.knime contrib plugins to ${CONTRIBUTING_DATE}!"
               git log -1 --format="%cd" --date=iso
-              
+
               # TODO just iterate over all folders?
               replace_qualifier de.openms.knime.startupCheck ${CONTRIBUTING_DATE}
               replace_qualifier de.openms.knime.mzTab ${CONTRIBUTING_DATE}
@@ -997,7 +780,7 @@ jobs:
               replace_snapshot de.openms.knime.importers ${CONTRIBUTING_DATE}
               replace_snapshot de.openms.knime.qchandling ${CONTRIBUTING_DATE}
               replace_snapshot de.openms.thirdparty.knime.startupCheck ${CONTRIBUTING_DATE}
-              
+
               # move to thirdparty feature so they get installed together
               mv de.openms.thirdparty.knime.startupCheck ${PLUGIN_SOURCE_THIRDPARTY_CONTRIB_PLUGINS}/de.openms.thirdparty.knime.startupCheck
               rm -r .git
@@ -1060,7 +843,7 @@ jobs:
           USER: ${{ secrets.ARCHIVE_RRSYNC_USER }}
           HOST: ${{ secrets.ARCHIVE_RRSYNC_HOST }}
           PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}
-          
+
         run: |
           echo "Upload"
           if [[ "${{ github.ref_name }}" == "nightly" ]]; then
@@ -1076,7 +859,7 @@ jobs:
           chmod -R o+r $GITHUB_WORKSPACE/de.openms.update/target/repository/*
           chmod o+x $GITHUB_WORKSPACE/de.openms.update/target/repository/features
           chmod o+x $GITHUB_WORKSPACE/de.openms.update/target/repository/plugins
-          
+
           #Load private key into file
           mkdir -p ~/.ssh/
           echo "$PASS" > ~/.ssh/private.key
@@ -1090,7 +873,7 @@ jobs:
           PASS: ${{ secrets.ARCHIVE_RRSYNC_SSH }}
           USER: ${{ secrets.ARCHIVE_RRSYNC_USER }}
           HOST: ${{ secrets.ARCHIVE_RRSYNC_HOST }}
-          PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}          
+          PORT: ${{ secrets.ARCHIVE_RRSYNC_PORT }}
         run: |
           echo "Upload"
           if [[ "${{ github.ref_name }}" == release/* ]]; then
@@ -1112,7 +895,7 @@ jobs:
     needs: [build-deploy-knime-updatesite,deploy-installer, build-and-test]
     permissions: write-all
     steps:
-    
+
       - name: get a token so that we can update the tags
         uses: actions/create-github-app-token@v1
         id: app-token
@@ -1124,7 +907,7 @@ jobs:
       - name: Extract branch/PR infos
         shell: bash
         run: echo "RUN_NAME=${{ github.event.pull_request && github.event.number || github.ref_name }}" >> $GITHUB_ENV
-    
+
           # We created the draft release during deploy-installer step. Now we want to publish it.
       - name: Publish OpenMS release
         id: publish_release
@@ -1146,21 +929,21 @@ jobs:
       - id: bash_create_tags
         name: create tags for other repos
         shell: bash
-        env: 
+        env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           function handleGitTag() {
             REPO=$1
             SHA=$2
             TAG_NAME="${{ env.RUN_NAME }}"
-            
+
             # Check if the tag exists
             TAG_EXISTS=$(gh api \
               --method GET \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/${REPO}/git/refs/tags/${TAG_NAME} 2>/dev/null || echo "TAG_NOT_FOUND")
-            
+
             if [[ "$TAG_EXISTS" == "TAG_NOT_FOUND" ]]; then
               # Tag doesn't exist, create it
               echo "Creating tag ${TAG_NAME} in ${REPO} pointing to ${SHA}"
@@ -1174,7 +957,7 @@ jobs:
             else
               # Tag exists, check if it points to the same SHA
               EXISTING_SHA=$(echo $TAG_EXISTS | jq -r '.object.sha')
-              
+
               if [[ "$EXISTING_SHA" == "$SHA" ]]; then
                 # Tag already points to the correct SHA, do nothing
                 echo "Tag ${TAG_NAME} already exists in ${REPO} and points to the correct SHA: ${SHA}"
@@ -1190,9 +973,9 @@ jobs:
           JSViewer_SHA=$(curl -s -X GET https://api.github.com/repos/genericworkflownodes/de.openms.knime.dynamicJSViewers/git/ref/heads/master |jq -r '.object.sha')
           CONTRIB_SHA=$(curl -s -X GET https://api.github.com/repos/OpenMS/OpenMS/contents/contrib\?ref\=${{ github.sha }} | jq -r ".sha")
           THIRDPARTY_SHA=$(curl -s -X GET https://api.github.com/repos/OpenMS/OpenMS/contents/THIRDPARTY\?ref\=${{ github.sha }} | jq -r ".sha")
-          handleGitTag OpenMS/contrib $CONTRIB_SHA
-          handleGitTag OpenMS/THIRDPARTY $THIRDPARTY_SHA
-          handleGitTag OpenMS/de.openms.knime $DEOPENMS_SHA
+          handleGitTag contrib $CONTRIB_SHA
+          handleGitTag THIRDPARTY $THIRDPARTY_SHA
+          handleGitTag de.openms.knime $DEOPENMS_SHA
           # Uncomment when permissions are fixed
           # handleGitTag genericworkflownodes/de.openms.knime.dynamicJSViewers $JSViewer_SHA
 
@@ -1236,7 +1019,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: checkout website
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: OpenMS-website
           repository: OpenMS/OpenMS-website
@@ -1244,7 +1027,7 @@ jobs:
 
       - name: create text for website and update it.
         shell: bash
-        env: 
+        env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run:  |
             echo '${{ needs.deploy-installer.outputs.release_text_contents }}' | base64 -d >> OpenMS-website/content/en/news/release${{ needs.build-and-test.outputs.version_number }}.md


### PR DESCRIPTION
- All dependencies (including contrib) are dealt with in a separate action, perfect for the upcoming GSoC project

- Remove redundant installation of cURL on Windows (already in contrib)

- Remove redundant installation of Eigen on Windows (already in contrib)

- Removed weird cloning of the OpenMS repo into a sub-directory in the workspace that required each step to move into the correct directory

- Updated action versions to avoid pending nodejs issues on the GitHub runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized cross-platform dependency provisioning via a new CI composite action, emitting unified build-prefix outputs for downstream steps.
  * Simplified CI workflow and workspace layout by removing the separate contrib prep job, flattening top-level build outputs, and updating artifact handling and paths for more consistent cross-platform builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->