### PR TITLE
fix(cmake): accept Arrow 24.x in pyOpenMS standalone build

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -303,7 +303,14 @@ else()
   # In standalone builds, OPENMS_ARROW_TARGET is not exported by OpenMSConfig.cmake.
   # Find Arrow ourselves so we can link the C++ bridge functions (ExportSchema, etc.).
   if(NOT OPENMS_ARROW_TARGET)
-    find_package(Arrow 23 CONFIG REQUIRED)
+    # Don't pin the version in find_package — Arrow's ConfigVersion uses
+    # SameMajorVersion compatibility, so requesting 23 rejects 24.x. Check the
+    # version manually after the call. Mirrors the main cmake path in
+    # cmake/cmake_findExternalLibs.cmake.
+    find_package(Arrow CONFIG REQUIRED)
+    if(Arrow_VERSION VERSION_LESS 23)
+      message(FATAL_ERROR "Apache Arrow >= 23 required (found ${Arrow_VERSION}).")
+    endif()
     if(ARROW_USE_STATIC AND TARGET Arrow::arrow_static)
       set(OPENMS_ARROW_TARGET Arrow::arrow_static)
     elseif(NOT ARROW_USE_STATIC AND TARGET Arrow::arrow_shared)


### PR DESCRIPTION
## Summary

- Fixes the macOS pyOpenMS wheel build (`build-wheels-macos` in `pyopenms-wheels-cibuildwheel.yml`), which currently fails at CMake configure because Homebrew now ships `apache-arrow` 24.0.0.
- Drops the `23` version pin from `find_package(Arrow CONFIG REQUIRED)` in `src/pyOpenMS/CMakeLists.txt` and checks the minimum manually afterwards — same pattern as #9196 already applied to `cmake/cmake_findExternalLibs.cmake`.

## Why

Arrow's `ArrowConfigVersion.cmake` uses `SameMajorVersion` compatibility, so `find_package(Arrow 23 ...)` rejects 24.x:

```
Could not find a configuration file for package "Arrow" that is compatible
with requested version "23".

  /opt/homebrew/lib/cmake/Arrow/ArrowConfig.cmake, version: 24.0.0
    The version found is not compatible with the version requested.
```

This was already fixed for the main OpenMS build in #9196, but the standalone pyOpenMS path (taken by `cibuildwheel` when building wheels with `NO_DEPENDENCIES=ON`) was missed. The full-OpenMS macOS CI job passes; only the standalone wheel job fails.

## Compatibility

Pure CMake version-discovery change. No effect on:
- `MACOSX_DEPLOYMENT_TARGET=14.0` (set in the wheels workflow)
- ABI / linkage — `ARROW_USE_STATIC=OFF` and `Arrow::arrow_shared` target selection unchanged
- `delocate-wheel` repair pipeline

## Test plan

- [ ] `pyopenms-wheels-cibuildwheel.yml` macOS arm64 job (`build-wheels-macos`) reaches the build step (no longer fails at CMake configure)
- [ ] Linux/Windows wheel jobs continue to pass
- [ ] Full OpenMS CI matrix unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve Arrow dependency handling with enhanced version compatibility verification during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->