### PR TITLE
fix(BrukerTimsFile): off-by-one in MS1 centroid cap (#9230)

### DIFF
--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -246,7 +246,7 @@ namespace OpenMS
                   size_t max_peaks = DEFAULT_CENTROID_MAX_PEAKS)
     {
       agg_buff.clear();
-      agg_buff.reserve(std::min(peaks.size(), max_peaks + 1));
+      agg_buff.reserve(std::min(peaks.size(), max_peaks));
       ++total_calls_;
 
       const float utol = mz_ppm / 1e6f;
@@ -257,7 +257,7 @@ namespace OpenMS
       {
         if (peaks[idx].intensity <= 0.0f) continue;  // already consumed
 
-        if (agg_buff.size() > max_peaks)
+        if (agg_buff.size() >= max_peaks)
         {
           // Only count as a "real" cap hit if the next dropped peak is above
           // the noise floor (~200 counts on timsTOF). Dropping noise-floor

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -516,6 +516,42 @@ START_SECTION(DDA MS1 centroiding test)
 }
 END_SECTION
 
+START_SECTION(DDA MS1 centroiding cap is exact (regression: issue #9230))
+{
+  // With ms1_centroid_max_peaks=N, no centroided MS1 spectrum should ever
+  // exceed N peaks. Prior to the fix, the cap was off-by-one and emitted
+  // N+1 peaks whenever it fired, producing defaultArrayLength="100001" in
+  // the resulting mzML on real timsTOF runs.
+  BrukerTimsFile f;
+  BrukerTimsFile::Config cfg;
+  cfg.ms1_centroid_mz_ppm = 5.0f;
+  cfg.ms1_centroid_im_pct = 3.0f;
+  cfg.ms1_centroid_max_peaks = 10; // small cap so it actually fires
+  MSExperiment exp;
+  f.load(OPENTIMS_DDA_TEST_DATA, exp, cfg);
+
+  Size capped_count = 0;
+  Size max_observed = 0;
+  for (const auto& spec : exp)
+  {
+    if (spec.getMSLevel() != 1) continue;
+    max_observed = std::max(max_observed, spec.size());
+    if (spec.size() == static_cast<Size>(cfg.ms1_centroid_max_peaks)) ++capped_count;
+    // IM array must stay aligned with peak count regardless of cap
+    if (!spec.empty())
+    {
+      TEST_EQUAL(spec.getFloatDataArrays().empty(), false);
+      TEST_EQUAL(spec.getFloatDataArrays()[0].size(), spec.size());
+    }
+  }
+
+  // Hard invariant: never exceed the cap
+  TEST_EQUAL(max_observed <= static_cast<Size>(cfg.ms1_centroid_max_peaks), true);
+  // Sanity: cap should actually have fired on this fixture
+  TEST_EQUAL(capped_count > 0, true);
+}
+END_SECTION
+
 START_SECTION(DDA partial centroiding config test)
 {
   // Setting only one tolerance should NOT enable centroiding


### PR DESCRIPTION
## Summary
- Closes #9230. The MS1 centroiding cap in `FrameCentroider::centroid` allowed one extra peak past `max_peaks`, so capped spectra emitted exactly `max_peaks + 1` entries — visible in the wild as `defaultArrayLength="100001"` on 93% of MS1 spectra in a Bruker timsTOF run, which downstream consumers (Comet via pwiz, MSFragger) trip over.
- Tightens the loop guard from `agg_buff.size() > max_peaks` to `>= max_peaks` and drops the matching `+ 1` from the buffer reserve. Capped output is now exactly bounded by the configured limit.
- Adds a regression test (`DDA MS1 centroiding cap is exact`) that lowers the cap to 10 to force it to fire on every MS1 spectrum, then asserts (a) no spectrum exceeds the cap, (b) the cap actually fires (sanity), and (c) the IM `FloatDataArray` length stays aligned with the peak count.

## Notes for the reviewer
A writer-side audit (`MzMLHandler` spectrum/binaryDataArray emit path) confirmed the OpenMS-emitted mzML was already internally length-consistent at 100001 — `defaultArrayLength`, m/z and intensity blob sizes (no per-array `arrayLength`, fall back to `defaultArrayLength`), and the IM array's explicit `arrayLength="..."` all matched. So this fix removes the surprising off-by-one but may not be sufficient to stop the downstream pwiz heap-corruption. Recommend the reporter re-run their pipeline against a build with this patch and confirm whether the Comet/MSFragger crash persists; if it does, the underlying bug is downstream of OpenMS at large array sizes.

## Test plan
- [x] `BrukerTimsFile_test` — new section `DDA MS1 centroiding cap is exact (regression: issue #9230)` passes; existing centroid/aggregation/round-trip sections continue to pass.
- [ ] Reporter to confirm patched build no longer emits `defaultArrayLength > 100000` and report whether downstream consumers still crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MS1 centroiding peak capping to strictly enforce the configured maximum limit instead of potentially exceeding it by one peak per frame.

* **Tests**
  * Added regression test validating peak cap enforcement and data alignment in MS1 centroiding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->