### PR TITLE
feat(ProteomicsLFQ): accept .idparquet (and .mzId) as ID input

### DIFF
--- a/src/topp/ProteomicsLFQ.cpp
+++ b/src/topp/ProteomicsLFQ.cpp
@@ -173,7 +173,7 @@ protected:
       "3. IDFilter (pep:score = 0.05)\n"
       "To obtain well calibrated PEPs and an initial reduction of PSMs\n"
       "ID files must be provided in same order as spectra files.");
-    setValidFormats_("ids", ListUtils::create<String>("idXML,mzId"));
+    setValidFormats_("ids", ListUtils::create<String>("idXML,mzId,idparquet"));
 
     registerInputFile_("design", "<file>", "", "design file", false);
     setValidFormats_("design", ListUtils::create<String>("tsv"));
@@ -755,7 +755,8 @@ protected:
   {
 
     const String& mz_file_abs_path = File::absolutePath(mz_file);
-    FileHandler().loadIdentifications(id_file_abs_path, protein_ids, peptide_ids, {FileTypes::IDXML}, log_type_);
+    FileHandler().loadIdentifications(id_file_abs_path, protein_ids, peptide_ids,
+        {FileTypes::IDXML, FileTypes::MZIDENTML, FileTypes::IDPARQUET}, log_type_);
 
     ExitCodes e = checkSingleRunPerID_(protein_ids, id_file_abs_path);
     if (e != EXECUTION_OK) return e;


### PR DESCRIPTION
## Summary

- `ProteomicsLFQ -ids` now accepts `.idparquet` directories alongside the existing `.idXML`.
- Drive-by: also wires `MZIDENTML` into the `loadIdentifications` type list so `.mzId` — already advertised in `setValidFormats_` — is actually loadable rather than rejected at load time.

Three lines of change in `src/topp/ProteomicsLFQ.cpp`.

## Depends on

- #9232 (idparquet support) — this PR builds on the idparquet PSM/protein IO landed there.

## Test plan

- [x] `ctest -R TOPP_ProteomicsLFQ` — 66/66 pass with the existing idXML fixtures.
- [ ] CI / nightly with idparquet-input fixture (no fixture added in this PR; existing tests still cover the idXML path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for IDPARQUET and MZIDENTML file formats for identification data input, extending the accepted file types for the `-ids` parameter beyond the previously supported format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->