### PR TITLE
feat(IDRipper): split merged .idparquet into per-run .idparquet outputs

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -188,6 +188,42 @@ add_test("TOPP_IDMerger_idparquet_diff"
     -whitelist "IdentificationRun date" "UserParam.*file_origin")
 set_tests_properties("TOPP_IDMerger_idparquet_diff" PROPERTIES DEPENDS "TOPP_IDMerger_idparquet_convert")
 
+# .idparquet rip: split the merged .idparquet from TOPP_IDMerger_idparquet back into
+# per-run .idparquet directories.  -numeric_filenames + -split_ident_runs make output
+# names deterministic (merged_<ident_run_idx>_<file_origin_idx>.idparquet) so the diff
+# also implicitly verifies that the per-run output ordering matches the input order.
+file(MAKE_DIRECTORY ${TESTS_TEMP_DIR}/IDRipper_idparquet_out)
+add_test("TOPP_IDRipper_idparquet"
+  ${TOPP_BIN_PATH}/IDRipper -test
+    -in ${TESTS_TEMP_DIR}/IDMerger_idparquet_output.tmp.idparquet
+    -out ${TESTS_TEMP_DIR}/IDRipper_idparquet_out
+    -split_ident_runs -numeric_filenames)
+set_tests_properties("TOPP_IDRipper_idparquet" PROPERTIES DEPENDS "TOPP_IDMerger_idparquet")
+
+add_test("TOPP_IDRipper_idparquet_convert_0"
+  ${TOPP_BIN_PATH}/IDFileConverter
+    -in ${TESTS_TEMP_DIR}/IDRipper_idparquet_out/IDMerger_idparquet_output.tmp_0_0.idparquet
+    -out ${TESTS_TEMP_DIR}/IDRipper_idparquet_out_0.tmp.idXML)
+set_tests_properties("TOPP_IDRipper_idparquet_convert_0" PROPERTIES DEPENDS "TOPP_IDRipper_idparquet")
+add_test("TOPP_IDRipper_idparquet_diff_0"
+  ${DIFF}
+    -in1 ${TESTS_TEMP_DIR}/IDRipper_idparquet_out_0.tmp.idXML
+    -in2 ${DATA_DIR_TOPP}/IDRipper_idparquet_0.idXML
+    -whitelist "IdentificationRun date")
+set_tests_properties("TOPP_IDRipper_idparquet_diff_0" PROPERTIES DEPENDS "TOPP_IDRipper_idparquet_convert_0")
+
+add_test("TOPP_IDRipper_idparquet_convert_1"
+  ${TOPP_BIN_PATH}/IDFileConverter
+    -in ${TESTS_TEMP_DIR}/IDRipper_idparquet_out/IDMerger_idparquet_output.tmp_1_1.idparquet
+    -out ${TESTS_TEMP_DIR}/IDRipper_idparquet_out_1.tmp.idXML)
+set_tests_properties("TOPP_IDRipper_idparquet_convert_1" PROPERTIES DEPENDS "TOPP_IDRipper_idparquet")
+add_test("TOPP_IDRipper_idparquet_diff_1"
+  ${DIFF}
+    -in1 ${TESTS_TEMP_DIR}/IDRipper_idparquet_out_1.tmp.idXML
+    -in2 ${DATA_DIR_TOPP}/IDRipper_idparquet_1.idXML
+    -whitelist "IdentificationRun date")
+set_tests_properties("TOPP_IDRipper_idparquet_diff_1" PROPERTIES DEPENDS "TOPP_IDRipper_idparquet_convert_1")
+
 #------------------------------------------------------------------------------
 # BaselineFilter tests
 add_test("TOPP_BaselineFilter_1" ${TOPP_BIN_PATH}/BaselineFilter -test -in ${DATA_DIR_TOPP}/BaselineFilter_input.mzML -out ${TESTS_TEMP_DIR}/BaselineFilter.tmp.mzML -struc_elem_length 1.5)

--- a/src/tests/topp/IDRipper_idparquet_0.idXML
+++ b/src/tests/topp/IDRipper_idparquet_0.idXML
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<IdentificationRun date="2006-10-07T06:30:59" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0.0" >
+			<ProteinHit id="PH_0" accession="APRT" score="40.0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="APRTT" score="40.0" sequence="" >
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0.0" MZ="623.580000000000041" RT="-1.0" >
+			<PeptideHit score="40.5" sequence="APRTPEPTIDER" charge="2" protein_refs="PH_0" >
+			</PeptideHit>
+			<PeptideHit score="40.5" sequence="APRTTPEPTIDER" charge="2" protein_refs="PH_1" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_0" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APEPTIDER" charge="2" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APEPTIDERR" charge="2" >
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/IDRipper_idparquet_1.idXML
+++ b/src/tests/topp/IDRipper_idparquet_1.idXML
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<IdentificationRun date="2006-10-07T06:31:08" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0.0" >
+			<ProteinHit id="PH_0" accession="BPRT" score="40.0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="BPRTT" score="40.0" sequence="" >
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0.0" MZ="623.580000000000041" RT="-1.0" >
+			<PeptideHit score="40.5" sequence="BPRTPEPTIDER" charge="2" protein_refs="PH_0" >
+			</PeptideHit>
+			<PeptideHit score="40.5" sequence="BPRTTPEPTIDER" charge="2" protein_refs="PH_1" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="BPRTTPEPTIDERR" charge="2" protein_refs="PH_1" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="BPEPTIDER" charge="2" >
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/topp/IDRipper.cpp
+++ b/src/topp/IDRipper.cpp
@@ -83,7 +83,7 @@ protected:
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input file, in which the protein/peptide identifications must be tagged with 'file_origin'");
-    setValidFormats_("in", ListUtils::create<String>("idXML"));
+    setValidFormats_("in", ListUtils::create<String>("idXML,idparquet"));
     registerOutputPrefix_("out", "<directory>", "", "Path to the output directory to write the ripped files to.", true, false);
     registerFlag_("numeric_filenames", "Do not infer output filenames from spectra_data or file_origin but use the input filename with numeric suffixes.");
     registerFlag_("split_ident_runs", "Split different identification runs into separate files.");
@@ -108,12 +108,13 @@ protected:
 
     vector<ProteinIdentification> proteins;
     PeptideIdentificationList peptides;
-    FileHandler().loadIdentifications(file_name, proteins, peptides, {FileTypes::IDXML});
+    const FileTypes::Type in_type = FileHandler::getTypeByFileName(file_name);
+    FileHandler().loadIdentifications(file_name, proteins, peptides, {FileTypes::IDXML, FileTypes::IDPARQUET});
 
     // ensure protein and peptide identifications are presented, otherwise we don't have to rip anything anyhow
     if (proteins.empty() || peptides.empty())
     {
-      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "idXML file has to store protein and peptide identifications!");
+      throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "input file has to store protein and peptide identifications!");
     }
 
     IDRipper::RipFileMap ripped;
@@ -126,6 +127,12 @@ protected:
     // writing output
     //-------------------------------------------------------------
 
+    // Output files preserve the input format: .idXML in -> .idXML out, .idparquet in -> .idparquet out.
+    // RipFileMap is sorted by (ident_run_idx, file_origin_idx), so iteration order matches the
+    // order in which IdentificationRuns appeared in the merged input.
+    const String out_ext = (in_type == FileTypes::IDPARQUET) ? ".idparquet" : ".idXML";
+    const FileTypes::Type out_type = (in_type == FileTypes::IDPARQUET) ? FileTypes::IDPARQUET : FileTypes::IDXML;
+
     for (IDRipper::RipFileMap::iterator it = ripped.begin(); it != ripped.end(); ++it)
     {
       const IDRipper::RipFileIdentifier& rfi = it->first;
@@ -136,17 +143,17 @@ protected:
       {
         String s_ident_run_idx = split_ident_runs ? '_' + String(rfi.ident_run_idx) : "";
         String s_file_origin_idx = '_' + String(rfi.file_origin_idx);
-        out_fname = to_path(file_name).stem().string() + s_ident_run_idx + s_file_origin_idx + ".idXML";
+        out_fname = to_path(file_name).stem().string() + s_ident_run_idx + s_file_origin_idx + out_ext;
       }
       else
       {
-        out_fname = to_path(rfi.out_basename).stem().string() + ".idXML";
+        out_fname = to_path(rfi.out_basename).stem().string() + out_ext;
       }
 
       String out = (to_path(output_directory) / to_path(out_fname)).make_preferred().string();
       OPENMS_LOG_INFO << "Storing file: '" << out << "'." << std::endl;
 
-      FileHandler().storeIdentifications(out, rfc.prot_idents, rfc.pep_idents, {FileTypes::IDXML});
+      FileHandler().storeIdentifications(out, rfc.prot_idents, rfc.pep_idents, {out_type});
     }
     return EXECUTION_OK;
   }


### PR DESCRIPTION
## Summary

- `IDRipper -in` now accepts `.idparquet` (in addition to `.idXML`).
- Output format follows input format: `.idXML` → `.idXML`, `.idparquet` → `.idparquet`.
- Output ordering is preserved end-to-end: the rip walks IdentificationRuns in the same order they were merged.

The order chain:

1. IDMerger writes `search_params.parquet` rows in input-file order.
2. The QPXFile / ProteinIdentificationArrowIO importer reads rows in storage order into `vector<ProteinIdentification>`.
3. `IDRipper::IdentificationRuns` assigns `ident_run_idx` 0,1,… in that vector's iteration order.
4. `RipFileMap` is a `std::map` keyed on `(ident_run_idx, file_origin_idx)`, so the output loop walks runs in the same order they were merged.

## Depends on

- #9232 (idparquet support)
- Compatible with #9236 (ProteomicsLFQ idparquet input) — independent.

## Test plan

- [x] `ctest -R TOPP_IDRipper` — 15/15 existing idXML tests pass.
- [x] End-to-end roundtrip: merge two distinct idparquet files → rip → verify output dirs match input by run_identifier and date, in the original merge order. Both `-numeric_filenames` and basename-derived naming verified.
- [ ] Add an idparquet rip ctest fixture (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IDRipper supports an additional identification input format and preserves the detected input format for outputs.

* **Bug Fixes**
  * Generalized precondition/error messaging to reference the input file generically.

* **Tests**
  * Added end-to-end tests and fixtures to validate splitting behavior and format conversion, with deterministic naming and output diffs against references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->