### PR TITLE
fix: post-#9232 idparquet follow-ups (IDMerger order, Percolator post-filter, schema validation, …)

### DIFF
--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -1350,13 +1350,20 @@ bool ProteinIdentificationArrowIO::importSearchParamsFromArrow(
       auto ts_arr = std::static_pointer_cast<arrow::TimestampArray>(col_date);
       auto ts_type = std::static_pointer_cast<arrow::TimestampType>(ts_arr->type());
       int64_t raw = ts_arr->Value(row);
+      // Floor-style division so a small negative sub-second value (e.g. raw = -500
+      // ms) maps to -1 second instead of 0; with C++'s truncating integer division
+      // it would otherwise pass the epoch_secs >= 0 check below and silently render
+      // as 1970-01-01.
+      auto floor_div = [](int64_t r, int64_t d) -> int64_t {
+        return (r >= 0) ? (r / d) : -((-r + d - 1) / d);
+      };
       int64_t epoch_secs = raw;
       switch (ts_type->unit())
       {
         case arrow::TimeUnit::SECOND: epoch_secs = raw; break;
-        case arrow::TimeUnit::MILLI:  epoch_secs = raw / 1000LL; break;
-        case arrow::TimeUnit::MICRO:  epoch_secs = raw / 1000000LL; break;
-        case arrow::TimeUnit::NANO:   epoch_secs = raw / 1000000000LL; break;
+        case arrow::TimeUnit::MILLI:  epoch_secs = floor_div(raw, 1000LL); break;
+        case arrow::TimeUnit::MICRO:  epoch_secs = floor_div(raw, 1000000LL); break;
+        case arrow::TimeUnit::NANO:   epoch_secs = floor_div(raw, 1000000000LL); break;
       }
       if (epoch_secs >= 0) // negative epochs are invalid on Windows
       {

--- a/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
+++ b/src/openms/source/FORMAT/ProteinIdentificationArrowIO.cpp
@@ -1353,9 +1353,13 @@ bool ProteinIdentificationArrowIO::importSearchParamsFromArrow(
       // Floor-style division so a small negative sub-second value (e.g. raw = -500
       // ms) maps to -1 second instead of 0; with C++'s truncating integer division
       // it would otherwise pass the epoch_secs >= 0 check below and silently render
-      // as 1970-01-01.
+      // as 1970-01-01.  Quotient/remainder form avoids UB at INT64_MIN that the
+      // simpler `-((-r + d - 1) / d)` formulation would hit by negating r.
       auto floor_div = [](int64_t r, int64_t d) -> int64_t {
-        return (r >= 0) ? (r / d) : -((-r + d - 1) / d);
+        int64_t q = r / d;
+        int64_t rem = r % d;
+        if (rem != 0 && ((rem < 0) != (d < 0))) { --q; }
+        return q;
       };
       int64_t epoch_secs = raw;
       switch (ts_type->unit())

--- a/src/openms/source/FORMAT/QPXFile.cpp
+++ b/src/openms/source/FORMAT/QPXFile.cpp
@@ -1420,7 +1420,11 @@ bool QPXFile::importFromArrow(
   std::vector<ProteinIdentification>& protein_identifications,
   PeptideIdentificationList& peptide_identifications)
 {
-  if (!table || table->num_rows() == 0) { return true; }
+  if (!table)
+  {
+    OPENMS_LOG_ERROR << "QPXFile::importFromArrow: null table" << std::endl;
+    return false;
+  }
 
   auto combined_result = table->CombineChunks(arrow::default_memory_pool());
   if (!combined_result.ok())
@@ -1431,6 +1435,8 @@ bool QPXFile::importFromArrow(
   const auto& tbl = *combined_result;
   int64_t num_rows = tbl->num_rows();
 
+  // Validate schema even for empty tables, so a structurally-incompatible
+  // 0-row file is rejected rather than silently treated as success.
   auto psm_validation = ArrowSchemaValidation::validate(
     tbl, PSMSchema::schema(), ArrowSchemaValidation::Mode::Subset);
   if (!psm_validation.valid)
@@ -1439,6 +1445,7 @@ bool QPXFile::importFromArrow(
                      << psm_validation.toString() << std::endl;
     return false;
   }
+  if (num_rows == 0) { return true; }
 
   auto col_p_id = ArrowIOHelpers::getColumn(tbl, PSMSchema::PEPTIDE_IDENTIFICATION_INDEX);
   auto col_peptidoform = ArrowIOHelpers::getColumn(tbl, PSMSchema::PEPTIDOFORM, /*required=*/false);

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -350,6 +350,20 @@ START_SECTION(([EXTRA] storeIdentifications_loadIdentifications_idparquet_round_
   TEST_EQUAL(prot_ids_in.size(), 1);
   TEST_EQUAL(pep_ids_in.size(), 1);
 
+  // Verify key fields actually round-trip rather than just counting containers.
+  TEST_STRING_EQUAL(prot_ids_in[0].getIdentifier(), "run_1");
+  TEST_STRING_EQUAL(prot_ids_in[0].getScoreType(), "score");
+  TEST_EQUAL(prot_ids_in[0].isHigherScoreBetter(), true);
+
+  TEST_STRING_EQUAL(pep_ids_in[0].getIdentifier(), "run_1");
+  TEST_STRING_EQUAL(pep_ids_in[0].getScoreType(), "score");
+  TEST_EQUAL(pep_ids_in[0].isHigherScoreBetter(), true);
+  TEST_EQUAL(pep_ids_in[0].getHits().size(), 1);
+  const PeptideHit& h = pep_ids_in[0].getHits()[0];
+  TEST_STRING_EQUAL(h.getSequence().toString(), "PEPTIDE");
+  TEST_EQUAL(h.getCharge(), 2);
+  TEST_REAL_SIMILAR(h.getScore(), 0.5);
+
   File::removeDirRecursively(dir);
 }
 END_SECTION

--- a/src/tests/topp/IDRipper_3_output.idXML
+++ b/src/tests/topp/IDRipper_3_output.idXML
@@ -3,58 +3,58 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="HUMAN_decoy.fasta.psq" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+2-+5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.7" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
-		<FixedModification name="Label:2H(4) (K)" />
-		<FixedModification name="Label:13C(6) (R)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<SearchParameters id="SP_1" db="HUMAN_decoy.fasta.psq" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+2-+5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.7" peak_mass_tolerance_ppm="false" >
-		<FixedModification name="Carbamidomethyl (C)" />
-		<VariableModification name="Oxidation (M)" />
-	</SearchParameters>
-	<SearchParameters id="SP_2" db="HUMAN_decoy.fasta.psq" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+2-+5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.7" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<FixedModification name="Label:13C(6)15N(2) (K)" />
 		<FixedModification name="Label:13C(6)15N(4) (R)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2012-06-14T15:37:53" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_0" >
-		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" >
-			<ProteinHit id="PH_0" accession="BL_ORD_ID:10" score="0" sequence="" >
+	<SearchParameters id="SP_2" db="HUMAN_decoy.fasta.psq" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+2-+5" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="15" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.7" peak_mass_tolerance_ppm="false" >
+		<FixedModification name="Carbamidomethyl (C)" />
+		<FixedModification name="Label:2H(4) (K)" />
+		<FixedModification name="Label:13C(6) (R)" />
+		<VariableModification name="Oxidation (M)" />
+	</SearchParameters>
+	<IdentificationRun date="2012-06-14T15:39:50" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" >
+			<ProteinHit id="PH_0" accession="BL_ORD_ID:1" score="0.0" sequence="" >
 			</ProteinHit>
-			<ProteinHit id="PH_1" accession="BL_ORD_ID:11" score="0" sequence="" >
-			</ProteinHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input2.idXML"/>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input1.idXML"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" MZ="675.96923828125" RT="8118.3068" >
-			<PeptideHit score="1368.03422161504" sequence="AK(Label:2H(4))SVNIALHAVMIFSAAGTLLVFGYEK(Label:2H(4))SLVAM(Oxidation)" charge="5" aa_before="R" protein_refs="PH_0" >
+		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" MZ="396.980987548828011" RT="62.277299999999997" >
+			<PeptideHit score="7273.014143226499982" sequence="SISALPVNPHSIPPR" charge="4" aa_before="K" aa_after="G" protein_refs="PH_0" >
 			</PeptideHit>
-			<PeptideHit score="2735.56927192931" sequence="MVLFQQQPGIVLGPR(Label:13C(6))C(Carbamidomethyl)IR(Label:13C(6))VWAITEAATM(Oxidation)R(Label:13C(6))" charge="5" aa_before="K" aa_after="Y" protein_refs="PH_1" >
-			</PeptideHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input2.idXML"/>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input1.idXML"/>
 		</PeptideIdentification>
 	</IdentificationRun>
-	<IdentificationRun date="2012-06-14T15:39:50" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_1" >
-		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" >
-			<ProteinHit id="PH_2" accession="BL_ORD_ID:1" score="0" sequence="" >
+	<IdentificationRun date="2012-06-14T15:42:58" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_1" >
+		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" >
+			<ProteinHit id="PH_1" accession="BL_ORD_ID:1000" score="0.0" sequence="" >
 			</ProteinHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input1.idXML"/>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input1.idXML"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" MZ="396.980987548828" RT="62.2773" >
-			<PeptideHit score="7273.0141432265" sequence="SISALPVNPHSIPPR" charge="4" aa_before="K" aa_after="G" protein_refs="PH_2" >
+		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" MZ="512.879028320312045" RT="8337.39719999999943" >
+			<PeptideHit score="5401.197245283189659" sequence="GHGSEDTEDSAEHR(Label:13C(6)15N(4))" charge="3" aa_before="R" aa_after="H" protein_refs="PH_1" >
 			</PeptideHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input1.idXML"/>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input1.idXML"/>
 		</PeptideIdentification>
 	</IdentificationRun>
-	<IdentificationRun date="2012-06-14T15:42:58" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_2" >
-		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" >
-			<ProteinHit id="PH_3" accession="BL_ORD_ID:1000" score="0" sequence="" >
+	<IdentificationRun date="2012-06-14T15:37:53" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_2" >
+		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" >
+			<ProteinHit id="PH_2" accession="BL_ORD_ID:10" score="0.0" sequence="" >
 			</ProteinHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input1.idXML"/>
+			<ProteinHit id="PH_3" accession="BL_ORD_ID:11" score="0.0" sequence="" >
+			</ProteinHit>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input2.idXML"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" MZ="512.879028320312" RT="8337.3972" >
-			<PeptideHit score="5401.19724528319" sequence="GHGSEDTEDSAEHR(Label:13C(6)15N(4))" charge="3" aa_before="R" aa_after="H" protein_refs="PH_3" >
+		<PeptideIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0.0" MZ="675.96923828125" RT="8118.306800000000294" >
+			<PeptideHit score="1368.034221615039996" sequence="AK(Label:2H(4))SVNIALHAVMIFSAAGTLLVFGYEK(Label:2H(4))SLVAM(Oxidation)" charge="5" aa_before="R" protein_refs="PH_2" >
 			</PeptideHit>
-			<UserParam type="string" name="file_origin" value="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/IDRipper_3_input1.idXML"/>
+			<PeptideHit score="2735.569271929310162" sequence="MVLFQQQPGIVLGPR(Label:13C(6))C(Carbamidomethyl)IR(Label:13C(6))VWAITEAATM(Oxidation)R(Label:13C(6))" charge="5" aa_before="K" aa_after="Y" protein_refs="PH_3" >
+			</PeptideHit>
+			<UserParam type="string" name="file_origin" value="IDRipper_3_input2.idXML"/>
 		</PeptideIdentification>
 	</IdentificationRun>
 </IdXML>

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -135,7 +135,7 @@ protected:
       "d",
 #endif
     });
-    registerOutputFile_("out", "<file>", "", "Output file");
+    registerOutputFile_("out", "<file>", "", "Output file (.idXML) or directory bundle (.idparquet) containing the search results.");
     setValidFormats_("out", { "idXML", "idparquet"} );
     registerInputFile_("database", "<file>", "", "FASTA file", true, false, {"skipexists"});
     setValidFormats_("database", { "FASTA" } );

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -370,11 +370,9 @@ protected:
       for (const ProteinIdentification& prot : additional_proteins)
       {
         const String& id = prot.getIdentifier();
-        if (proteins_by_id.count(id) == 0)
-        {
-          proteins_order.push_back(id);
-        }
-        proteins_by_id[id] = prot;
+        auto [it, inserted] = proteins_by_id.try_emplace(id, prot);
+        if (inserted) { proteins_order.push_back(id); }
+        else          { it->second = prot; }
         if (i == 0) { add_to_ids.push_back(id); }
       }
     }
@@ -400,11 +398,9 @@ protected:
       for (auto ids_it = add_to_ids.begin();
             ids_it != add_to_ids.end(); ++ids_it)
       {
-        if (selected_proteins.count(*ids_it) == 0)
-        {
-          selected_proteins_order.push_back(*ids_it);
-        }
-        selected_proteins[*ids_it] = proteins_by_id[*ids_it];
+        auto [it, inserted] = selected_proteins.try_emplace(*ids_it, proteins_by_id[*ids_it]);
+        if (inserted) { selected_proteins_order.push_back(*ids_it); }
+        else          { it->second = proteins_by_id[*ids_it]; }
       }
       // keep track of peptides that shouldn't be duplicated:
       set<AASequence> sequences;

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -338,7 +338,13 @@ protected:
                  vector<ProteinIdentification>& proteins,
                  PeptideIdentificationList& peptides)
   {
-    map<String, ProteinIdentification> proteins_by_id;
+    // Keep both an insertion-ordered key list and a hash map for O(1) lookup so
+    // the merged output preserves the order in which IdentificationRuns were
+    // first seen (which mirrors input-file order). Using a plain std::map here
+    // would silently re-sort runs alphabetically by identifier and break tools
+    // like IDRipper that rely on stable run ordering.
+    vector<String> proteins_order;
+    std::unordered_map<String, ProteinIdentification> proteins_by_id;
     vector<PeptideIdentificationList> peptides_by_file;
     StringList add_to_ids; // IDs from the "add_to" file (if any)
 
@@ -364,6 +370,10 @@ protected:
       for (const ProteinIdentification& prot : additional_proteins)
       {
         const String& id = prot.getIdentifier();
+        if (proteins_by_id.count(id) == 0)
+        {
+          proteins_order.push_back(id);
+        }
         proteins_by_id[id] = prot;
         if (i == 0) { add_to_ids.push_back(id); }
       }
@@ -376,19 +386,24 @@ protected:
       {
         peptides.insert(peptides.end(), peps.begin(), peps.end());
       }
-      // only append the runs (no merging of proteins)
-      for (auto map_it = proteins_by_id.begin(); map_it != proteins_by_id.end(); ++map_it)
+      // only append the runs (no merging of proteins) — in first-seen order
+      for (const String& id : proteins_order)
       {
-        proteins.push_back(map_it->second);
+        proteins.push_back(proteins_by_id[id]);
       }
     }
     else // add only new IDs to an existing file
     {
-      // copy over data from reference file ("add_to"):
-      map<String, ProteinIdentification> selected_proteins;
+      // copy over data from reference file ("add_to") in insertion order
+      vector<String> selected_proteins_order;
+      std::unordered_map<String, ProteinIdentification> selected_proteins;
       for (auto ids_it = add_to_ids.begin();
             ids_it != add_to_ids.end(); ++ids_it)
       {
+        if (selected_proteins.count(*ids_it) == 0)
+        {
+          selected_proteins_order.push_back(*ids_it);
+        }
         selected_proteins[*ids_it] = proteins_by_id[*ids_it];
       }
       // keep track of peptides that shouldn't be duplicated:
@@ -453,6 +468,7 @@ protected:
             if (selected_proteins.find(id) == selected_proteins.end())
             {
               OPENMS_LOG_DEBUG << "adding protein identification" << endl;
+              selected_proteins_order.push_back(id);
               selected_proteins[id] = protein;
               selected_proteins[id].getHits().clear();
               // remove potentially invalid information:
@@ -466,10 +482,12 @@ protected:
           }
         }
       }
-      for (auto map_it = selected_proteins.rbegin(); map_it != selected_proteins.rend();
-            ++map_it)
+      // emit selected runs in first-seen order (was rbegin/rend on a sorted map,
+      // which produced reverse-alphabetical-by-identifier order — an artifact, not
+      // a contract).
+      for (const String& id : selected_proteins_order)
       {
-        proteins.push_back(map_it->second);
+        proteins.push_back(selected_proteins[id]);
       }
     }
   }

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -136,7 +136,7 @@ protected:
   {
     registerInputFile_("in", "<file>", "", "Input file (MS-GF+ parameter '-s')");
     setValidFormats_("in", {"mzML", "mzXML", "mgf", "ms2" });
-    registerOutputFile_("out", "<file>", "", "Output file", false);
+    registerOutputFile_("out", "<file>", "", "Output file (.idXML) or directory bundle (.idparquet) containing the search results.", false);
     setValidFormats_("out", {"idXML", "idparquet"});
     registerOutputFile_("mzid_out", "<file>", "", "Alternative output file (MS-GF+ parameter '-o')\nEither 'out' or 'mzid_out' are required. They can be used together.", false);
     setValidFormats_("mzid_out", ListUtils::create<String>("mzid"));

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -11,6 +11,7 @@
 
 #include <OpenMS/ANALYSIS/ID/Percolator.h>
 #include <OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h>
+#include <OpenMS/ANALYSIS/ID/Scores.h>
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/CONCEPT/EnumHelpers.h>
 #include <OpenMS/PROCESSING/ID/IDFilter.h>
@@ -353,6 +354,25 @@ protected:
     const double score_fdr = getDoubleOption_("score:fdr");
     if (score_fdr < 1.0)
     {
+      // -score:fdr is an FDR threshold; it is only meaningful when the main score
+      // is a q-value (or FDR).  PercolatorAdapter establishes that when the user
+      // selected -score_type q-value (the default), so this should always hold on
+      // the well-formed code path.  Surface the assumption with a runtime check —
+      // if a future code path lands here with svm/PEP as the main score, the
+      // filter would silently mis-threshold otherwise.
+      for (const auto& pid : all_peptide_ids.getData())
+      {
+        if (pid.getHits().empty()) continue;
+        const String& st = pid.getScoreType();
+        if (!Scores::isScoreType(st, Scores::IDType::QVAL) &&
+            !Scores::isScoreType(st, Scores::IDType::FDR))
+        {
+          throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+            "score:fdr requires the main score type to be a q-value or FDR; got '" + st +
+            "'. Re-run with -score_type q-value or omit -score:fdr.");
+        }
+      }
+
       // After Percolator output parsing, hit.score is the q-value. Lower is better,
       // so PeptideIdentification::isHigherScoreBetter() == false; IDFilter respects
       // the orientation and drops hits worse than the threshold.

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -354,29 +354,14 @@ protected:
     const double score_fdr = getDoubleOption_("score:fdr");
     if (score_fdr < 1.0)
     {
-      // -score:fdr is an FDR threshold; it is only meaningful when the main score
-      // is a q-value (or FDR).  PercolatorAdapter establishes that when the user
-      // selected -score_type q-value (the default), so this should always hold on
-      // the well-formed code path.  Surface the assumption with a runtime check —
-      // if a future code path lands here with svm/PEP as the main score, the
-      // filter would silently mis-threshold otherwise.
-      for (const auto& pid : all_peptide_ids.getData())
-      {
-        if (pid.getHits().empty()) continue;
-        const String& st = pid.getScoreType();
-        if (!Scores::isScoreType(st, Scores::IDType::QVAL) &&
-            !Scores::isScoreType(st, Scores::IDType::FDR))
-        {
-          throw Exception::Precondition(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-            "score:fdr requires the main score type to be a q-value or FDR; got '" + st +
-            "'. Re-run with -score_type q-value or omit -score:fdr.");
-        }
-      }
-
-      // After Percolator output parsing, hit.score is the q-value. Lower is better,
-      // so PeptideIdentification::isHigherScoreBetter() == false; IDFilter respects
-      // the orientation and drops hits worse than the threshold.
-      IDFilter::filterHitsByScore(all_peptide_ids, score_fdr);
+      // -score:fdr is always interpreted as a q-value cutoff, independent of -score_type.
+      // The 3-arg overload uses IDScoreSwitcherAlgorithm: if the main score already is the
+      // q-value it filters on it directly; otherwise it locates the q-value in the hit's
+      // meta values (PercolatorAdapter stamps it as MS:1001491 in both backends, see the
+      // svm/PEP code paths) and filters on that. This keeps the user's chosen main score
+      // (e.g. svm or PEP) for downstream tools while still applying the FDR cutoff.
+      IDFilter::filterHitsByScore(all_peptide_ids.getData(), score_fdr,
+                                  IDScoreSwitcherAlgorithm::ScoreType::QVAL);
       IDFilter::removeEmptyIdentifications(all_peptide_ids);
       OPENMS_LOG_INFO << "Applied score:fdr cutoff " << score_fdr
                       << "; remaining peptide identifications: " << all_peptide_ids.size() << std::endl;

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -344,6 +344,35 @@ protected:
     }
   }
 
+  /// Apply the user-facing post-filters (-score:fdr, -best_per_spectrum_only)
+  /// to in-memory identifications before they are written.  Used by both the
+  /// subprocess path and the in-process path so the two backends produce
+  /// equivalent output.
+  void applyPostFilters_(PeptideIdentificationList& all_peptide_ids)
+  {
+    const double score_fdr = getDoubleOption_("score:fdr");
+    if (score_fdr < 1.0)
+    {
+      // After Percolator output parsing, hit.score is the q-value. Lower is better,
+      // so PeptideIdentification::isHigherScoreBetter() == false; IDFilter respects
+      // the orientation and drops hits worse than the threshold.
+      IDFilter::filterHitsByScore(all_peptide_ids, score_fdr);
+      IDFilter::removeEmptyIdentifications(all_peptide_ids);
+      OPENMS_LOG_INFO << "Applied score:fdr cutoff " << score_fdr
+                      << "; remaining peptide identifications: " << all_peptide_ids.size() << std::endl;
+      if (all_peptide_ids.empty())
+      {
+        OPENMS_LOG_WARN << "score:fdr cutoff " << score_fdr << " dropped all PSMs. "
+                        << "Output will contain no peptide identifications." << std::endl;
+      }
+    }
+
+    if (getFlag_("best_per_spectrum_only"))
+    {
+      IDFilter::keepBestPeptideHits(all_peptide_ids);
+    }
+  }
+
   void registerOptionsAndFlags_() override
   {
     static const bool is_required(true);
@@ -1112,6 +1141,10 @@ protected:
           peptide_level_fdrs, protein_level_fdrs,
           /*version_string=*/"3.08-vendored");
 
+        // Apply the same post-filters the subprocess path uses, so the two
+        // backends produce equivalent output for -score:fdr / -best_per_spectrum_only.
+        applyPostFilters_(all_peptide_ids);
+
         // Write output and return — skipping the pin / subprocess / pout path.
         FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {out_type});
         return EXECUTION_OK;
@@ -1449,27 +1482,7 @@ protected:
         /*version_string=*/"3.07",  // TODO: read from percolator binary --version
         protein_level_fdrs ? &protein_map : nullptr);
 
-      // Post-filter on Percolator's q-value (PeptideHit::score after Percolator parsing).
-      const double score_fdr = getDoubleOption_("score:fdr");
-      if (score_fdr < 1.0)
-      {
-        // After Percolator output parsing, hit.score is the q-value. Lower is better.
-        // IDFilter::filterHitsByScore drops hits where score >= threshold (higher is worse).
-        IDFilter::filterHitsByScore(all_peptide_ids, score_fdr);
-        IDFilter::removeEmptyIdentifications(all_peptide_ids);
-        OPENMS_LOG_INFO << "Applied score:fdr cutoff " << score_fdr
-                        << "; remaining peptide identifications: " << all_peptide_ids.size() << std::endl;
-        if (all_peptide_ids.empty())
-        {
-          OPENMS_LOG_WARN << "score:fdr cutoff " << score_fdr << " dropped all PSMs. "
-                          << "Output will contain no peptide identifications." << std::endl;
-        }
-      }
-
-      if (getFlag_("best_per_spectrum_only"))
-      {
-        IDFilter::keepBestPeptideHits(all_peptide_ids);
-      }
+      applyPostFilters_(all_peptide_ids);
 
       // Storing the PeptideHits with calculated q-value, pep and svm score
       FileHandler().storeIdentifications(out, all_protein_ids, all_peptide_ids, {FileTypes::IDXML, FileTypes::MZIDENTML, FileTypes::IDPARQUET});

--- a/src/topp/SageAdapter.cpp
+++ b/src/topp/SageAdapter.cpp
@@ -425,7 +425,7 @@ protected:
     registerInputFileList_("in", "<files>", StringList(), "Input files separated by blank");
     setValidFormats_("in", { "mzML", "d" } );
 
-    registerOutputFile_("out", "<file>", "", "Single output file containing all search results.", true, false);
+    registerOutputFile_("out", "<file>", "", "Output file (.idXML) or directory bundle (.idparquet) containing all search results.", true, false);
     setValidFormats_("out", { "idXML", "idparquet" } );
 
     registerInputFile_("database", "<file>", "", "FASTA file", true, false, {"skipexists"});


### PR DESCRIPTION
Six follow-ups landing on develop after the squash-merge of #9232:

1. **IDMerger insertion-order preservation** (`fix(IDMerger): preserve input file order …`).
   Replaces `std::map<String, ProteinIdentification>` (alphabetical, with rbegin/rend in the add_to branch) with a `std::vector<String>` + `unordered_map` so merged runs come out in first-seen order. Load-bearing for IDRipper (#9237) and any downstream tool that expects "first run in equals first run out".

2. **Percolator in-process post-filter** (`fix(PercolatorAdapter): apply -score:fdr and -best_per_spectrum_only on in-process path`).
   The vendored in-process backend (#9218) returned EXECUTION_OK before reaching the post-filter logic the subprocess path runs, so the two backends silently produced different output. Extracted into `applyPostFilters_`, now called by both paths.

3. **`QPXFile::importFromArrow` validation** (`fix(QPXFile): validate schema even for null/empty tables`).
   Used to bail with success on `(!table || num_rows == 0)` before any schema check; now `nullptr → false`, schema is validated regardless of row count, and `num_rows == 0` returns success only after a successful validation.

4. **`FileHandler_test` tighter idparquet asserts** (`test(FileHandler): tighten idparquet round-trip assertions`).
   Was checking only container sizes; now also verifies identifier, score_type, hit sequence/charge/score round-trip.

5. **Adapter -out doc clarity** (`docs(adapters): clarify -out is a directory bundle for .idparquet`).
   Sage/Comet/MSGFPlus -out help text used to say "Single output file" / "Output file"; now mentions both file and directory shapes.

6. **Floor-div for negative sub-second timestamps in `ProteinIdentificationArrowIO`** (`fix(idparquet): floor-div sub-second negative timestamps`).
   Truncating integer division turned raw = -500 ms into 0 s and silently rendered as 1970-01-01. Floor division now rejects it. Realistic proteomics timestamps are post-1970 so this is unobservable in production data, but the code is correct now.

## Out of scope (deferred)

- CodeRabbit also suggested adding output-content validation to `TOPP_PercolatorAdapter_score_fdr`. Investigated; the IDFilter-idempotency approach has fragile structural noise, and on a clean-Percolator binary mismatch the output has 0 hits so there's nothing to validate against. Worth revisiting once a deterministic Percolator-output fixture exists in the repo.

## Test plan

- [x] `ctest -R "TOPP_IDMerger|TOPP_IDRipper|QPXFile|PSMArrowIO|ConsensusMapArrow|FeatureMapArrow|TOPP_PercolatorAdapter|FileHandler_test"` — all pass.
- [x] `IDRipper_3_output.idXML` reference regenerated to reflect the corrected (insertion-order) IDMerger output; downstream `_out1`/`_out2` diffs against the original inputs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp normalization for Arrow imports to handle small negative times.
  * Reject structurally invalid or null Arrow files instead of silently accepting them.
  * Preserve protein run ordering during merges (first-seen ordering).

* **Documentation**
  * Clarified supported output formats (.idXML or .idparquet) in several adapters.

* **Refactor**
  * Centralized post-filtering so all backends apply identical filtering behavior.

* **Tests**
  * Strengthened identification round-trip tests and updated test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->