### PR TITLE
feat(IsobaricWorkflow): accept .idparquet (and .mzId) as ID input

### DIFF
--- a/src/topp/IsobaricWorkflow.cpp
+++ b/src/topp/IsobaricWorkflow.cpp
@@ -188,7 +188,7 @@ protected:
     registerInputFileList_("in", "<file>", {}, "input centroided spectrum files");
     setValidFormats_("in", {"mzML"});
     registerInputFileList_("in_id", "<file>", {}, "corresponding input PSMs");
-    setValidFormats_("in_id", {"idXML"});
+    setValidFormats_("in_id", {"idXML", "mzId", "idparquet"});
     registerInputFile_("exp_design", "<file>", "", "experimental design file (optional). If not given, the design is assumed to be unfractionated.", false);
     setValidFormats_("exp_design", {"tsv"});
     registerOutputFile_("out", "<file>", "", "output consensusXML file");
@@ -556,7 +556,8 @@ protected:
       // load idXML
       vector<ProteinIdentification> prot_ids;
       PeptideIdentificationList pep_ids;
-      FileHandler().loadIdentifications(id_file, prot_ids, pep_ids);
+      FileHandler().loadIdentifications(id_file, prot_ids, pep_ids,
+          {FileTypes::IDXML, FileTypes::MZIDENTML, FileTypes::IDPARQUET}, log_type_);
       // TODO filter by qvalue here?
       double pro_score = getDoubleOption_("protein_score");
       double psm_score = getDoubleOption_("psm_score");


### PR DESCRIPTION
## Summary
- Allow `IsobaricWorkflow -in_id` to take `.idparquet` directories and `.mzId` files alongside the existing `.idXML`, mirroring the ProteomicsLFQ change in #9236.
- Pass an explicit type list to `FileHandler::loadIdentifications` so the loader actually accepts the newly advertised formats rather than rejecting them at load time.

Per-file ID input only — multi-run merged `.idparquet` is not gated here (same behavior as today's merged `.idXML`).

Scope intentionally excludes `IsobaricAnalyzer`, which has no ID input.

## Test plan
- [x] `cmake --build OpenMS-build --target IsobaricWorkflow -j$(nproc)` — clean build
- [x] `ctest --test-dir OpenMS-build -R "IsobaricWorkflow|IsobaricAnalyzer"` — 14/14 pass
- [x] `IsobaricWorkflow --help` confirms `-in_id` valid formats list now shows `'idXML', 'mzId', 'idparquet'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IsobaricWorkflow now supports additional identification file formats (mzIdentML and idparquet) in addition to the previously supported idXML format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->