### PR TITLE
feat(FileHandler): add FEATUREPARQUET and CONSENSUSPARQUET file types

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FileTypes.h
+++ b/src/openms/include/OpenMS/FORMAT/FileTypes.h
@@ -96,6 +96,8 @@ namespace OpenMS
       ZIP,                ///< any ZIP compressed file
       PARQUET,            ///< Apache Parquet file format (.parquet, .pqt)
       IDPARQUET,          ///< OpenMS internal identification parquet bundle (directory: psms.parquet + proteins.parquet + protein_groups.parquet + search_params.parquet)
+      FEATUREPARQUET,     ///< OpenMS internal feature map parquet bundle (directory: features.parquet + psms.parquet + proteins.parquet + protein_groups.parquet + search_params.parquet)
+      CONSENSUSPARQUET,   ///< OpenMS internal consensus map parquet bundle (directory: consensus_features.parquet + psms.parquet + proteins.parquet + protein_groups.parquet + search_params.parquet)
       BRUKER_TDF,         ///< Bruker TimsTOF .d directory (TDF format)
       SIZE_OF_TYPE        ///< No file type. Simply stores the number of types
     };
@@ -131,7 +133,7 @@ namespace OpenMS
     /// Returns the mzML name (TODO: switch to accession since they are more stable!)
     static String typeToMZML(Type type);
 
-    /// Returns true if @p type represents a directory-shaped format (e.g. BRUKER_TDF, IDPARQUET).
+    /// Returns true if @p type represents a directory-shaped format (e.g. BRUKER_TDF, IDPARQUET, FEATUREPARQUET, CONSENSUSPARQUET).
     static bool isDirectoryType(Type type);
   };
 

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -42,6 +42,8 @@
 #include <OpenMS/METADATA/ID/IdentificationData.h>
 #include <OpenMS/METADATA/ID/IdentificationDataConverter.h>
 #include <OpenMS/FORMAT/PSMArrowIO.h>
+#include <OpenMS/FORMAT/FeatureMapArrowIO.h>
+#include <OpenMS/FORMAT/ConsensusMapArrowIO.h>
 
 #include <OpenMS/FORMAT/MsInspectFile.h>
 #include <OpenMS/FORMAT/SpecArrayFile.h>
@@ -1167,7 +1169,7 @@ namespace OpenMS
       }
       break;
 
-      case FileTypes::OMS: 
+      case FileTypes::OMS:
       {
         OMSFile f;
         f.setLogType(log);
@@ -1175,7 +1177,17 @@ namespace OpenMS
       }
       break;
 
-      default: 
+      case FileTypes::FEATUREPARQUET:
+      {
+        if (!FeatureMapArrowIO::importFromParquet(filename, map))
+        {
+          throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                      "FeatureMapArrowIO::importFromParquet failed");
+        }
+      }
+      break;
+
+      default:
       {
         throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,"type: " + FileTypes::typeToName(type) + " is not supported for loading features");
       }
@@ -1244,6 +1256,16 @@ namespace OpenMS
       }
       break;
 
+      case FileTypes::FEATUREPARQUET:
+      {
+        if (!FeatureMapArrowIO::exportToParquet(map, filename))
+        {
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                              "FeatureMapArrowIO::exportToParquet failed");
+        }
+      }
+      break;
+
       default:
       {
           throw Exception::InvalidFileType(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "type: " + FileTypes::typeToName(type) + " is not supported for storing features");
@@ -1283,11 +1305,21 @@ namespace OpenMS
       }
       break;
 
-      case FileTypes::OMS: 
+      case FileTypes::OMS:
       {
         OMSFile f;
         f.setLogType(log);
         f.load(filename, map);
+      }
+      break;
+
+      case FileTypes::CONSENSUSPARQUET:
+      {
+        if (!ConsensusMapArrowIO::importFromParquet(filename, map))
+        {
+          throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                      "ConsensusMapArrowIO::importFromParquet failed");
+        }
       }
       break;
 
@@ -1337,9 +1369,19 @@ namespace OpenMS
         f.store(filename, map);
       }
       break;
-      
+
+      case FileTypes::CONSENSUSPARQUET:
+      {
+        if (!ConsensusMapArrowIO::exportToParquet(map, filename))
+        {
+          throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename,
+                                              "ConsensusMapArrowIO::exportToParquet failed");
+        }
+      }
+      break;
+
       default:
-      {        
+      {
         throw Exception::InvalidFileType(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "type: " + FileTypes::typeToName(type) + " is not supported for storing consensus features");
       }
     }

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -108,6 +108,8 @@ namespace OpenMS
     TypeNameBinding(FileTypes::ZIP, "zip", "ZIP compressed file", {PROP::READABLE}),
     TypeNameBinding(FileTypes::PARQUET, "parquet", "Apache Parquet file", {PROP::READABLE, PROP::WRITEABLE}),
     TypeNameBinding(FileTypes::IDPARQUET, "idparquet", "OpenMS identification parquet bundle (directory)", {PROP::PROVIDES_IDENTIFICATIONS, PROP::READABLE, PROP::WRITEABLE}),
+    TypeNameBinding(FileTypes::FEATUREPARQUET, "featureparquet", "OpenMS feature map parquet bundle (directory)", {PROP::PROVIDES_FEATURES, PROP::PROVIDES_IDENTIFICATIONS, PROP::READABLE, PROP::WRITEABLE}),
+    TypeNameBinding(FileTypes::CONSENSUSPARQUET, "consensusparquet", "OpenMS consensus map parquet bundle (directory)", {PROP::PROVIDES_CONSENSUSFEATURES, PROP::PROVIDES_IDENTIFICATIONS, PROP::READABLE, PROP::WRITEABLE}),
     TypeNameBinding(FileTypes::BRUKER_TDF, "d", "Bruker TDF", {PROP::PROVIDES_EXPERIMENT, PROP::READABLE}),
     TypeNameBinding(FileTypes::XML, "xml", "any XML file", {PROP::READABLE}),  // make sure this comes last, since the name is a suffix of other formats and should only be matched last
   };
@@ -244,7 +246,10 @@ namespace OpenMS
 
   bool FileTypes::isDirectoryType(Type type)
   {
-    return type == FileTypes::BRUKER_TDF || type == FileTypes::IDPARQUET;
+    return type == FileTypes::BRUKER_TDF
+        || type == FileTypes::IDPARQUET
+        || type == FileTypes::FEATUREPARQUET
+        || type == FileTypes::CONSENSUSPARQUET;
   }
 
 

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -24,9 +24,12 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentificationList.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CONCEPT/Constants.h>
 
 #include <filesystem>
 #include <fstream>
+#include <map>
+#include <set>
 
 START_TEST(FileHandler, "$Id$")
 
@@ -406,13 +409,27 @@ END_SECTION
 START_SECTION(([EXTRA] consensusparquet_round_trip_ProteomicsLFQ_real_output))
 {
   // Round-trip a real ProteomicsLFQ consensusXML through .consensusparquet
-  // (load → store as parquet bundle → load back) and verify that the
-  // structural counts that drive downstream tools (FeatureHandles, column
-  // headers, attached + unassigned IDs, ProteinIdentifications) all survive.
+  // (load -> store as parquet bundle -> load back) and verify the bits that
+  // matter for downstream consumers: map references (column headers <->
+  // FeatureHandle.map_index), run references (PeptideIdentification.identifier
+  // -> ProteinIdentification.identifier), id_merge_index linking PSMs to their
+  // original input file via spectra_data, inference info (indistinguishable
+  // proteins), and per-PSM hit content.
   ConsensusMap cmap_ref;
   FileHandler().loadConsensusFeatures(
     OPENMS_GET_TEST_DATA_PATH("ExperimentalDesign_ProteomicsLFQ_1_subset_out.consensusXML"),
     cmap_ref, {FileTypes::CONSENSUSXML});
+
+  // Sanity-anchor the reference: stable counts for this test fixture.
+  TEST_EQUAL(cmap_ref.size(), 39);
+  TEST_EQUAL(cmap_ref.getColumnHeaders().size(), 5);
+  TEST_EQUAL(cmap_ref.getProteinIdentifications().size(), 1);
+  TEST_EQUAL(cmap_ref.getUnassignedPeptideIdentifications().size(), 65);
+  TEST_EQUAL(cmap_ref.getProteinIdentifications()[0].getHits().size(), 25);
+  TEST_EQUAL(cmap_ref.getProteinIdentifications()[0].getIndistinguishableProteins().size(), 18);
+  // ConsensusXMLHandler rebuilds the run identifier as "<engine>_<date>_<hash>"
+  // on load — the file-level XML id="PI_0" is only an internal cross-reference.
+  TEST_EQUAL(cmap_ref.getProteinIdentifications()[0].getIdentifier().hasPrefix("OMSSA_"), true);
 
   String dir;
   NEW_TMP_FILE(dir)
@@ -423,36 +440,155 @@ START_SECTION(([EXTRA] consensusparquet_round_trip_ProteomicsLFQ_real_output))
   ConsensusMap cmap_in;
   FileHandler().loadConsensusFeatures(dir, cmap_in, {FileTypes::CONSENSUSPARQUET});
 
-  // Top-level structure
+  // ---- Top-level container counts ----
   TEST_EQUAL(cmap_in.size(), cmap_ref.size());
   TEST_EQUAL(cmap_in.getColumnHeaders().size(), cmap_ref.getColumnHeaders().size());
   TEST_EQUAL(cmap_in.getProteinIdentifications().size(), cmap_ref.getProteinIdentifications().size());
   TEST_EQUAL(cmap_in.getUnassignedPeptideIdentifications().size(), cmap_ref.getUnassignedPeptideIdentifications().size());
 
-  // Sum FeatureHandles and attached PeptideIdentifications across all features
-  Size handles_ref = 0, handles_in = 0;
-  Size feat_pids_ref = 0, feat_pids_in = 0;
-  for (Size i = 0; i < cmap_ref.size(); ++i)
+  // ---- ColumnHeaders (map references): filename, label, unique_id per map ----
+  for (const auto& [map_idx, header_ref] : cmap_ref.getColumnHeaders())
   {
-    handles_ref += cmap_ref[i].getFeatures().size();
-    feat_pids_ref += cmap_ref[i].getPeptideIdentifications().size();
+    auto it = cmap_in.getColumnHeaders().find(map_idx);
+    TEST_EQUAL(it != cmap_in.getColumnHeaders().end(), true);
+    if (it == cmap_in.getColumnHeaders().end()) continue;
+    TEST_STRING_EQUAL(it->second.filename, header_ref.filename);
+    TEST_STRING_EQUAL(it->second.label, header_ref.label);
+    TEST_EQUAL(it->second.unique_id, header_ref.unique_id);
   }
-  for (Size i = 0; i < cmap_in.size(); ++i)
-  {
-    handles_in += cmap_in[i].getFeatures().size();
-    feat_pids_in += cmap_in[i].getPeptideIdentifications().size();
-  }
-  TEST_EQUAL(handles_in, handles_ref);
-  TEST_EQUAL(feat_pids_in, feat_pids_ref);
 
-  // Spot-check a couple of features for numeric fidelity
-  if (!cmap_ref.empty() && !cmap_in.empty())
-  {
-    TEST_REAL_SIMILAR(cmap_in[0].getRT(), cmap_ref[0].getRT());
-    TEST_REAL_SIMILAR(cmap_in[0].getMZ(), cmap_ref[0].getMZ());
-    TEST_REAL_SIMILAR(cmap_in[0].getIntensity(), cmap_ref[0].getIntensity());
-    TEST_EQUAL(cmap_in[0].getCharge(), cmap_ref[0].getCharge());
-  }
+  // ---- FeatureHandle.map_index distribution ----
+  // Build per-map_index handle multisets keyed on (uid,map_idx) so any
+  // permutation of features still compares equal.
+  auto handle_keys = [](const ConsensusMap& m) {
+    std::multiset<std::pair<UInt64, UInt64>> keys;
+    for (const auto& cf : m)
+      for (const auto& fh : cf.getFeatures())
+        keys.emplace(fh.getUniqueId(), fh.getMapIndex());
+    return keys;
+  };
+  TEST_EQUAL(handle_keys(cmap_in) == handle_keys(cmap_ref), true);
+
+  // Per-map_index handle counts must match (covers the 5-map distribution).
+  auto handles_per_map = [](const ConsensusMap& m) {
+    std::map<UInt64, Size> counts;
+    for (const auto& cf : m)
+      for (const auto& fh : cf.getFeatures())
+        ++counts[fh.getMapIndex()];
+    return counts;
+  };
+  TEST_EQUAL(handles_per_map(cmap_in) == handles_per_map(cmap_ref), true);
+
+  // ---- Run references: every PeptideIdentification points to a known run ----
+  std::set<String> run_ids_ref, run_ids_in;
+  for (const auto& p : cmap_ref.getProteinIdentifications()) run_ids_ref.insert(p.getIdentifier());
+  for (const auto& p : cmap_in.getProteinIdentifications()) run_ids_in.insert(p.getIdentifier());
+  TEST_EQUAL(run_ids_in == run_ids_ref, true);
+
+  Size dangling_ref = 0, dangling_in = 0;
+  for (const auto& cf : cmap_ref)
+    for (const auto& pid : cf.getPeptideIdentifications())
+      if (!run_ids_ref.count(pid.getIdentifier())) ++dangling_ref;
+  for (const auto& pid : cmap_ref.getUnassignedPeptideIdentifications())
+    if (!run_ids_ref.count(pid.getIdentifier())) ++dangling_ref;
+  for (const auto& cf : cmap_in)
+    for (const auto& pid : cf.getPeptideIdentifications())
+      if (!run_ids_in.count(pid.getIdentifier())) ++dangling_in;
+  for (const auto& pid : cmap_in.getUnassignedPeptideIdentifications())
+    if (!run_ids_in.count(pid.getIdentifier())) ++dangling_in;
+  TEST_EQUAL(dangling_ref, 0);
+  TEST_EQUAL(dangling_in, 0);
+
+  // ---- ProteinIdentification (run-level) round-trip ----
+  const auto& prot_ref = cmap_ref.getProteinIdentifications()[0];
+  const auto& prot_in  = cmap_in.getProteinIdentifications()[0];
+  TEST_STRING_EQUAL(prot_in.getIdentifier(), prot_ref.getIdentifier());
+  TEST_STRING_EQUAL(prot_in.getSearchEngine(), prot_ref.getSearchEngine());
+  TEST_STRING_EQUAL(prot_in.getSearchEngineVersion(), prot_ref.getSearchEngineVersion());
+  TEST_STRING_EQUAL(prot_in.getScoreType(), prot_ref.getScoreType());
+  TEST_EQUAL(prot_in.isHigherScoreBetter(), prot_ref.isHigherScoreBetter());
+  TEST_EQUAL(prot_in.getHits().size(), prot_ref.getHits().size());
+
+  // spectra_data (the per-merge-index file list)
+  StringList spectra_ref, spectra_in;
+  prot_ref.getPrimaryMSRunPath(spectra_ref);
+  prot_in.getPrimaryMSRunPath(spectra_in);
+  TEST_EQUAL(spectra_in == spectra_ref, true);
+  TEST_EQUAL(spectra_ref.size(), 5);
+
+  // ProteinHit accession set must round-trip exactly.
+  auto accessions = [](const ProteinIdentification& p) {
+    std::set<String> acc;
+    for (const auto& h : p.getHits()) acc.insert(h.getAccession());
+    return acc;
+  };
+  TEST_EQUAL(accessions(prot_in) == accessions(prot_ref), true);
+
+  // ---- Inference info: IndistinguishableProteins groups ----
+  // Compare as a set of (probability, sorted-accession-list) tuples so group
+  // ordering doesn't matter.
+  auto group_signature = [](const std::vector<ProteinIdentification::ProteinGroup>& gs) {
+    std::set<std::pair<double, std::vector<String>>> sig;
+    for (const auto& g : gs) {
+      std::vector<String> accs(g.accessions.begin(), g.accessions.end());
+      std::sort(accs.begin(), accs.end());
+      sig.emplace(g.probability, std::move(accs));
+    }
+    return sig;
+  };
+  TEST_EQUAL(group_signature(prot_in.getIndistinguishableProteins())
+             == group_signature(prot_ref.getIndistinguishableProteins()), true);
+  TEST_EQUAL(group_signature(prot_in.getProteinGroups())
+             == group_signature(prot_ref.getProteinGroups()), true);
+
+  // ---- id_merge_index distribution (PSM -> original-run linkage) ----
+  auto merge_index_hist = [](const ConsensusMap& m) {
+    std::map<int, Size> hist;
+    auto count = [&](const PeptideIdentification& pid) {
+      if (pid.metaValueExists(Constants::UserParam::ID_MERGE_INDEX))
+        ++hist[(int)pid.getMetaValue(Constants::UserParam::ID_MERGE_INDEX)];
+      else
+        ++hist[-1];
+    };
+    for (const auto& cf : m)
+      for (const auto& pid : cf.getPeptideIdentifications()) count(pid);
+    for (const auto& pid : m.getUnassignedPeptideIdentifications()) count(pid);
+    return hist;
+  };
+  auto hist_ref = merge_index_hist(cmap_ref);
+  auto hist_in  = merge_index_hist(cmap_in);
+  TEST_EQUAL(hist_in == hist_ref, true);
+  TEST_EQUAL(hist_ref.count(-1), 0); // every PSM in this fixture must have id_merge_index
+  TEST_EQUAL(hist_ref.size(), 5);    // values 0..4 (one per spectra_data entry)
+
+  // ---- PSM hit content fidelity (sequence/charge/score) ----
+  // Build (run_id, id_merge_index, RT, MZ, sequence, charge, score) tuples for
+  // unassigned PSMs (best hit only). RT/MZ make the tuple stable across order.
+  using PSMSig = std::tuple<String, int, double, double, String, int, double>;
+  auto psm_sigs = [](const auto& pids) {
+    std::vector<PSMSig> sigs;
+    for (const auto& pid : pids) {
+      if (pid.getHits().empty()) continue;
+      const auto& h = pid.getHits()[0];
+      int mi = pid.metaValueExists(Constants::UserParam::ID_MERGE_INDEX)
+               ? (int)pid.getMetaValue(Constants::UserParam::ID_MERGE_INDEX) : -1;
+      sigs.emplace_back(pid.getIdentifier(), mi, pid.getRT(), pid.getMZ(),
+                        h.getSequence().toString(), h.getCharge(), h.getScore());
+    }
+    std::sort(sigs.begin(), sigs.end());
+    return sigs;
+  };
+  TEST_EQUAL(psm_sigs(cmap_in.getUnassignedPeptideIdentifications())
+             == psm_sigs(cmap_ref.getUnassignedPeptideIdentifications()), true);
+
+  // Same comparison for feature-attached PSMs, flattened across all features.
+  auto attached_sigs = [&](const ConsensusMap& m) {
+    std::vector<PeptideIdentification> all;
+    for (const auto& cf : m)
+      for (const auto& pid : cf.getPeptideIdentifications()) all.push_back(pid);
+    return psm_sigs(all);
+  };
+  TEST_EQUAL(attached_sigs(cmap_in) == attached_sigs(cmap_ref), true);
 
   File::removeDirRecursively(dir);
 }

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -383,6 +383,26 @@ START_SECTION(([EXTRA] storeFeatures_loadFeatures_featureparquet_round_trip))
   f.setIntensity(1000.0f);
   f.setCharge(2);
   f.setOverallQuality(0.9f);
+
+  // Minimal ID sidecar: ProteinIdentification on the map, PeptideIdentification
+  // on the feature, linked via shared identifier.
+  ProteinIdentification prot;
+  prot.setIdentifier("run_1");
+  prot.setScoreType("score");
+  prot.setHigherScoreBetter(true);
+  fm.getProteinIdentifications().push_back(prot);
+
+  PeptideIdentification pid;
+  pid.setIdentifier("run_1");
+  pid.setScoreType("score");
+  pid.setHigherScoreBetter(true);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDE"));
+  hit.setCharge(2);
+  hit.setScore(0.8);
+  pid.getHits().push_back(hit);
+  f.getPeptideIdentifications().push_back(pid);
+
   fm.push_back(f);
 
   String dir;
@@ -401,6 +421,19 @@ START_SECTION(([EXTRA] storeFeatures_loadFeatures_featureparquet_round_trip))
   TEST_REAL_SIMILAR(fm_in[0].getIntensity(), 1000.0f);
   TEST_EQUAL(fm_in[0].getCharge(), 2);
   TEST_REAL_SIMILAR(fm_in[0].getOverallQuality(), 0.9f);
+
+  // ID sidecar round-trip
+  TEST_EQUAL(fm_in.getProteinIdentifications().size(), 1);
+  TEST_STRING_EQUAL(fm_in.getProteinIdentifications()[0].getIdentifier(), "run_1");
+  TEST_STRING_EQUAL(fm_in.getProteinIdentifications()[0].getScoreType(), "score");
+  TEST_EQUAL(fm_in.getProteinIdentifications()[0].isHigherScoreBetter(), true);
+  TEST_EQUAL(fm_in[0].getPeptideIdentifications().size(), 1);
+  TEST_STRING_EQUAL(fm_in[0].getPeptideIdentifications()[0].getIdentifier(), "run_1");
+  TEST_EQUAL(fm_in[0].getPeptideIdentifications()[0].getHits().size(), 1);
+  const PeptideHit& h_in = fm_in[0].getPeptideIdentifications()[0].getHits()[0];
+  TEST_STRING_EQUAL(h_in.getSequence().toString(), "PEPTIDE");
+  TEST_EQUAL(h_in.getCharge(), 2);
+  TEST_REAL_SIMILAR(h_in.getScore(), 0.8);
 
   File::removeDirRecursively(dir);
 }
@@ -604,6 +637,26 @@ START_SECTION(([EXTRA] storeConsensusFeatures_loadConsensusFeatures_consensuspar
   cf.setIntensity(2000.0f);
   cf.setCharge(3);
   cf.setQuality(0.8f);
+
+  // Minimal ID sidecar: ProteinIdentification on the map, PeptideIdentification
+  // on the consensus feature, linked via shared identifier.
+  ProteinIdentification prot;
+  prot.setIdentifier("run_1");
+  prot.setScoreType("score");
+  prot.setHigherScoreBetter(true);
+  cmap.getProteinIdentifications().push_back(prot);
+
+  PeptideIdentification pid;
+  pid.setIdentifier("run_1");
+  pid.setScoreType("score");
+  pid.setHigherScoreBetter(true);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("PEPTIDE"));
+  hit.setCharge(3);
+  hit.setScore(0.7);
+  pid.getHits().push_back(hit);
+  cf.getPeptideIdentifications().push_back(pid);
+
   cmap.push_back(cf);
 
   String dir;
@@ -622,6 +675,19 @@ START_SECTION(([EXTRA] storeConsensusFeatures_loadConsensusFeatures_consensuspar
   TEST_REAL_SIMILAR(cmap_in[0].getIntensity(), 2000.0f);
   TEST_EQUAL(cmap_in[0].getCharge(), 3);
   TEST_REAL_SIMILAR(cmap_in[0].getQuality(), 0.8f);
+
+  // ID sidecar round-trip
+  TEST_EQUAL(cmap_in.getProteinIdentifications().size(), 1);
+  TEST_STRING_EQUAL(cmap_in.getProteinIdentifications()[0].getIdentifier(), "run_1");
+  TEST_STRING_EQUAL(cmap_in.getProteinIdentifications()[0].getScoreType(), "score");
+  TEST_EQUAL(cmap_in.getProteinIdentifications()[0].isHigherScoreBetter(), true);
+  TEST_EQUAL(cmap_in[0].getPeptideIdentifications().size(), 1);
+  TEST_STRING_EQUAL(cmap_in[0].getPeptideIdentifications()[0].getIdentifier(), "run_1");
+  TEST_EQUAL(cmap_in[0].getPeptideIdentifications()[0].getHits().size(), 1);
+  const PeptideHit& h_in = cmap_in[0].getPeptideIdentifications()[0].getHits()[0];
+  TEST_STRING_EQUAL(h_in.getSequence().toString(), "PEPTIDE");
+  TEST_EQUAL(h_in.getCharge(), 3);
+  TEST_REAL_SIMILAR(h_in.getScore(), 0.7);
 
   File::removeDirRecursively(dir);
 }

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -15,6 +15,8 @@
 ///////////////////////////
 
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
+#include <OpenMS/KERNEL/ConsensusFeature.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/SYSTEM/File.h>
@@ -363,6 +365,72 @@ START_SECTION(([EXTRA] storeIdentifications_loadIdentifications_idparquet_round_
   TEST_STRING_EQUAL(h.getSequence().toString(), "PEPTIDE");
   TEST_EQUAL(h.getCharge(), 2);
   TEST_REAL_SIMILAR(h.getScore(), 0.5);
+
+  File::removeDirRecursively(dir);
+}
+END_SECTION
+
+START_SECTION(([EXTRA] storeFeatures_loadFeatures_featureparquet_round_trip))
+{
+  FeatureMap fm;
+  Feature f;
+  f.setUniqueId(42);
+  f.setRT(123.4);
+  f.setMZ(567.89);
+  f.setIntensity(1000.0f);
+  f.setCharge(2);
+  f.setOverallQuality(0.9f);
+  fm.push_back(f);
+
+  String dir;
+  NEW_TMP_FILE(dir)
+  dir += ".featureparquet";
+
+  FileHandler().storeFeatures(dir, fm, {FileTypes::FEATUREPARQUET});
+
+  FeatureMap fm_in;
+  FileHandler().loadFeatures(dir, fm_in, {FileTypes::FEATUREPARQUET});
+
+  TEST_EQUAL(fm_in.size(), 1);
+  TEST_EQUAL(fm_in[0].getUniqueId(), 42);
+  TEST_REAL_SIMILAR(fm_in[0].getRT(), 123.4);
+  TEST_REAL_SIMILAR(fm_in[0].getMZ(), 567.89);
+  TEST_REAL_SIMILAR(fm_in[0].getIntensity(), 1000.0f);
+  TEST_EQUAL(fm_in[0].getCharge(), 2);
+  TEST_REAL_SIMILAR(fm_in[0].getOverallQuality(), 0.9f);
+
+  File::removeDirRecursively(dir);
+}
+END_SECTION
+
+START_SECTION(([EXTRA] storeConsensusFeatures_loadConsensusFeatures_consensusparquet_round_trip))
+{
+  ConsensusMap cmap;
+  ConsensusFeature cf;
+  cf.setUniqueId(7);
+  cf.setRT(50.0);
+  cf.setMZ(300.5);
+  cf.setIntensity(2000.0f);
+  cf.setCharge(3);
+  cf.setQuality(0.8f);
+  cmap.push_back(cf);
+
+  String dir;
+  NEW_TMP_FILE(dir)
+  dir += ".consensusparquet";
+
+  FileHandler().storeConsensusFeatures(dir, cmap, {FileTypes::CONSENSUSPARQUET});
+
+  ConsensusMap cmap_in;
+  FileHandler().loadConsensusFeatures(dir, cmap_in, {FileTypes::CONSENSUSPARQUET});
+
+  TEST_EQUAL(cmap_in.size(), 1);
+  TEST_EQUAL(cmap_in[0].getUniqueId(), 7);
+  TEST_REAL_SIMILAR(cmap_in[0].getRT(), 50.0);
+  TEST_REAL_SIMILAR(cmap_in[0].getMZ(), 300.5);
+  TEST_REAL_SIMILAR(cmap_in[0].getIntensity(), 2000.0f);
+  TEST_EQUAL(cmap_in[0].getCharge(), 3);
+  TEST_REAL_SIMILAR(cmap_in[0].getQuality(), 0.8f);
 
   File::removeDirRecursively(dir);
 }

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -403,6 +403,61 @@ START_SECTION(([EXTRA] storeFeatures_loadFeatures_featureparquet_round_trip))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] consensusparquet_round_trip_ProteomicsLFQ_real_output))
+{
+  // Round-trip a real ProteomicsLFQ consensusXML through .consensusparquet
+  // (load → store as parquet bundle → load back) and verify that the
+  // structural counts that drive downstream tools (FeatureHandles, column
+  // headers, attached + unassigned IDs, ProteinIdentifications) all survive.
+  ConsensusMap cmap_ref;
+  FileHandler().loadConsensusFeatures(
+    OPENMS_GET_TEST_DATA_PATH("ExperimentalDesign_ProteomicsLFQ_1_subset_out.consensusXML"),
+    cmap_ref, {FileTypes::CONSENSUSXML});
+
+  String dir;
+  NEW_TMP_FILE(dir)
+  dir += ".consensusparquet";
+
+  FileHandler().storeConsensusFeatures(dir, cmap_ref, {FileTypes::CONSENSUSPARQUET});
+
+  ConsensusMap cmap_in;
+  FileHandler().loadConsensusFeatures(dir, cmap_in, {FileTypes::CONSENSUSPARQUET});
+
+  // Top-level structure
+  TEST_EQUAL(cmap_in.size(), cmap_ref.size());
+  TEST_EQUAL(cmap_in.getColumnHeaders().size(), cmap_ref.getColumnHeaders().size());
+  TEST_EQUAL(cmap_in.getProteinIdentifications().size(), cmap_ref.getProteinIdentifications().size());
+  TEST_EQUAL(cmap_in.getUnassignedPeptideIdentifications().size(), cmap_ref.getUnassignedPeptideIdentifications().size());
+
+  // Sum FeatureHandles and attached PeptideIdentifications across all features
+  Size handles_ref = 0, handles_in = 0;
+  Size feat_pids_ref = 0, feat_pids_in = 0;
+  for (Size i = 0; i < cmap_ref.size(); ++i)
+  {
+    handles_ref += cmap_ref[i].getFeatures().size();
+    feat_pids_ref += cmap_ref[i].getPeptideIdentifications().size();
+  }
+  for (Size i = 0; i < cmap_in.size(); ++i)
+  {
+    handles_in += cmap_in[i].getFeatures().size();
+    feat_pids_in += cmap_in[i].getPeptideIdentifications().size();
+  }
+  TEST_EQUAL(handles_in, handles_ref);
+  TEST_EQUAL(feat_pids_in, feat_pids_ref);
+
+  // Spot-check a couple of features for numeric fidelity
+  if (!cmap_ref.empty() && !cmap_in.empty())
+  {
+    TEST_REAL_SIMILAR(cmap_in[0].getRT(), cmap_ref[0].getRT());
+    TEST_REAL_SIMILAR(cmap_in[0].getMZ(), cmap_ref[0].getMZ());
+    TEST_REAL_SIMILAR(cmap_in[0].getIntensity(), cmap_ref[0].getIntensity());
+    TEST_EQUAL(cmap_in[0].getCharge(), cmap_ref[0].getCharge());
+  }
+
+  File::removeDirRecursively(dir);
+}
+END_SECTION
+
 START_SECTION(([EXTRA] storeConsensusFeatures_loadConsensusFeatures_consensusparquet_round_trip))
 {
   ConsensusMap cmap;

--- a/src/tests/class_tests/openms/source/FileTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/FileTypes_test.cpp
@@ -154,9 +154,7 @@ START_SECTION([EXTRA] FileTypes::FileTypeList)
     f.push_back(FileTypes::FileProperties::READABLE);
     FileTypeList g = FileTypeList::typesWithProperties(f);
     TEST_EQUAL(g.getTypes().size(), 47);
-    // Test that empty filter returns the full list
-    TEST_EQUAL(FileTypeList::typesWithProperties({}).size(), 70);
-    // Test that the full list is equal to the list of known file types
+    // Test that empty filter returns the full list, equal to the list of known file types
     TEST_EQUAL(FileTypeList::typesWithProperties({}).size(),static_cast<size_t>(FileTypes::Type::SIZE_OF_TYPE));
     // Check that we don't have duplicate Types in our type_with_annotation__
     vector<FileTypes::Type> vec = FileTypeList::typesWithProperties({});

--- a/src/tests/class_tests/openms/source/FileTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/FileTypes_test.cpp
@@ -97,6 +97,12 @@ START_SECTION((static Type nameToType(const String& name)))
   TEST_EQUAL(FileTypes::nameToType("idparquet"), FileTypes::IDPARQUET);
   TEST_EQUAL(FileTypes::nameToType("IDPARQUET"), FileTypes::IDPARQUET);
   TEST_STRING_EQUAL(FileTypes::typeToName(FileTypes::IDPARQUET), "idparquet");
+  TEST_EQUAL(FileTypes::nameToType("featureparquet"), FileTypes::FEATUREPARQUET);
+  TEST_EQUAL(FileTypes::nameToType("FEATUREPARQUET"), FileTypes::FEATUREPARQUET);
+  TEST_STRING_EQUAL(FileTypes::typeToName(FileTypes::FEATUREPARQUET), "featureparquet");
+  TEST_EQUAL(FileTypes::nameToType("consensusparquet"), FileTypes::CONSENSUSPARQUET);
+  TEST_EQUAL(FileTypes::nameToType("CONSENSUSPARQUET"), FileTypes::CONSENSUSPARQUET);
+  TEST_STRING_EQUAL(FileTypes::typeToName(FileTypes::CONSENSUSPARQUET), "consensusparquet");
   TEST_EQUAL(FileTypes::typeToName(FileTypes::BRUKER_TDF), "d");
   TEST_EQUAL(FileTypes::BRUKER_TDF, FileTypes::nameToType("d"));
 
@@ -107,6 +113,8 @@ END_SECTION
 START_SECTION(([EXTRA] isDirectoryType))
 {
   TEST_TRUE(FileTypes::isDirectoryType(FileTypes::IDPARQUET));
+  TEST_TRUE(FileTypes::isDirectoryType(FileTypes::FEATUREPARQUET));
+  TEST_TRUE(FileTypes::isDirectoryType(FileTypes::CONSENSUSPARQUET));
   TEST_TRUE(FileTypes::isDirectoryType(FileTypes::BRUKER_TDF));
   TEST_FALSE(FileTypes::isDirectoryType(FileTypes::IDXML));
   TEST_FALSE(FileTypes::isDirectoryType(FileTypes::PARQUET));
@@ -145,9 +153,9 @@ START_SECTION([EXTRA] FileTypes::FileTypeList)
     std::vector<FileTypes::FileProperties> f;
     f.push_back(FileTypes::FileProperties::READABLE);
     FileTypeList g = FileTypeList::typesWithProperties(f);
-    TEST_EQUAL(g.getTypes().size(), 45);
+    TEST_EQUAL(g.getTypes().size(), 47);
     // Test that empty filter returns the full list
-    TEST_EQUAL(FileTypeList::typesWithProperties({}).size(), 68);
+    TEST_EQUAL(FileTypeList::typesWithProperties({}).size(), 70);
     // Test that the full list is equal to the list of known file types
     TEST_EQUAL(FileTypeList::typesWithProperties({}).size(),static_cast<size_t>(FileTypes::Type::SIZE_OF_TYPE));
     // Check that we don't have duplicate Types in our type_with_annotation__


### PR DESCRIPTION
## Summary

- Register two new directory-shaped file types — `FEATUREPARQUET` (`.featureparquet`) and `CONSENSUSPARQUET` (`.consensusparquet`) — alongside the existing `IDPARQUET`, with `PROVIDES_FEATURES` / `PROVIDES_CONSENSUSFEATURES` (+ `PROVIDES_IDENTIFICATIONS`, `READABLE`, `WRITEABLE`) properties.
- Wire `FileHandler::loadFeatures` / `storeFeatures` and `loadConsensusFeatures` / `storeConsensusFeatures` to dispatch the new types to the existing `FeatureMapArrowIO::importFromParquet` / `exportToParquet` and `ConsensusMapArrowIO::importFromParquet` / `exportToParquet` (same pattern as `IDPARQUET` → `PSMArrowIO`: `ParseError` on read failure, `UnableToCreateFile` on write failure).
- Tools that already go through `FileHandler` (`FileInfo`, `FileConverter`, `ProteomicsLFQ`, etc.) now accept and emit feature/consensus parquet bundles based on the directory suffix; the on-disk bundle layout itself is unchanged.

The directory's outer extension is the FileType discriminator. Bundle contents stay as-is: `features.parquet`/`consensus_features.parquet` plus the four ID-side parquet files (`psms`, `proteins`, `protein_groups`, `search_params`).

## Test plan

- [x] `FileTypes_test` — name↔type round-trip and `isDirectoryType` for both new types; updated hardcoded type counts in `typesWithProperties` (45→47, 68→70).
- [x] `FileHandler_test` — added two round-trip sections that `storeFeatures`/`loadFeatures` against `*.featureparquet` and `storeConsensusFeatures`/`loadConsensusFeatures` against `*.consensusparquet`, verifying RT/MZ/intensity/charge/quality survive the trip.
- [x] `cmake --build OpenMS-build --target OpenMS` clean.
- [x] `ctest -R '^FileTypes_test\$|^FileHandler_test\$'` — 2/2 pass.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two Parquet-backed directory file formats for feature and consensus data and enabled their read/write support.
* **Tests**
  * Added comprehensive round-trip tests for Parquet feature and consensus persistence (real and synthetic), validating numeric fields, identifiers, sidecar links, and metadata consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->