### PR TITLE
perf(BrukerTimsFile): use boost::unordered_flat_map in FrameAggregator

### DIFF
--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -33,6 +33,11 @@
 #include <unordered_map>
 #include <optional>
 
+// Open-addressing flat hash map (Boost 1.81+). Used in FrameAggregator's
+// hot path because it eliminates per-node allocations and pointer chasing,
+// giving 2-3x faster lookup/insert vs std::unordered_map for small values.
+#include <boost/unordered/unordered_flat_map.hpp>
+
 namespace OpenMS
 {
 
@@ -515,7 +520,8 @@ namespace OpenMS
       std::vector<OutputPeak> finalizeCentroided(int min_support, bool skip_denoise) const
       {
         // Step 1: Denoise (same as finalize)
-        std::unordered_map<uint64_t, Cell> denoised;
+        boost::unordered_flat_map<uint64_t, Cell> denoised;
+        denoised.reserve(grid_.size());
         for (const auto& [key, cell] : grid_)
         {
           if (!skip_denoise)
@@ -548,7 +554,8 @@ namespace OpenMS
           {0.003, 0.013, 0.022, 0.013, 0.003}
         };
 
-        std::unordered_map<uint64_t, double> smoothed;
+        boost::unordered_flat_map<uint64_t, double> smoothed;
+        smoothed.reserve(denoised.size());
         for (const auto& [key, cell] : denoised)
         {
           uint32_t scan_id = static_cast<uint32_t>(key & 0xFFFFFFFF);
@@ -649,7 +656,7 @@ namespace OpenMS
         double intensity_sum = 0.0;
         double mz_weighted_sum = 0.0;
       };
-      std::unordered_map<uint64_t, Cell> grid_;
+      boost::unordered_flat_map<uint64_t, Cell> grid_;
     };
 
     // SWATH window descriptor


### PR DESCRIPTION
## Summary

- Swap `std::unordered_map` for `boost::unordered_flat_map` (Boost 1.81+, already required) in `FrameAggregator`'s three hot maps: `grid_`, `denoised`, `smoothed`.
- Open-addressing eliminates per-node allocations and pointer chasing, which were dominating profile time in the picker (`finalize` / `finalizeCentroided`).
- Adds `reserve()` for the per-call `denoised`/`smoothed` temporaries to avoid rehash cascades.

## Measured impact

Single run of `BrukerTimsFile_test` directly (with `ENABLE_OPENTIMS_TESTS=ON`), DIA test data (8 window groups × 24 windows × 2823 MS2 frames, 50 M raw MS2 peaks):

**Picker time (chrono-measured, summed across all 8469 calls per load):**

| Path | `std::unordered_map` | **`boost::unordered_flat_map`** | Speedup |
|---|---|---|---|
| `finalize` (denoise only) | 31.1 s | **14.5 s** | **2.1×** |
| `finalizeCentroided` (denoised, min_support=1) | 75.8 s | **25.5 s** | **3.0×** |
| `finalizeCentroided` (no-denoise, min_support=0) | 222.9 s | **69.8 s** | **3.2×** |

**Section + total wall time:**

| | baseline | flat-map | Δ |
|---|---|---|---|
| DIA MS2 centroiding section | 368 s | 45 s | −323 s |
| DIA MS1 agg+centroiding section | 239 s | 101 s | −138 s |
| DIA MS1 aggregation section | 202 s | 140 s | −62 s |
| DIA loadDIAStreaming section | 105 s | 63 s | −42 s |
| **Test wall total** | **2189 s** | **1802 s** | **−387 s (−17.7 %)** |

DDA MS1 aggregation also goes through `FrameAggregator` and benefits, but per-section variance was too high in this single run to quote a clean number.

## Why this works

`FrameAggregator::grid_` keys on `uint64_t` with a 16-byte `Cell` value; the picker walks every cell doing 5×5 neighbor lookups (~40 hash probes per cell during smoothing + local-max + centroid). With `std::unordered_map`'s node-per-entry layout, each probe touches a fresh cache line. Open-addressing keeps keys + values contiguous and SIMD-friendly.

## API compatibility

`boost::unordered_flat_map` is API-compatible with `std::unordered_map` for the operations this code uses: `operator[]`, `find`, `count`, `end`, range-for over `[key, value]`, `reserve`, `clear`, `size`. No call sites needed changes.

## Numerical equivalence

`for (const auto& [key, val] : map)` walks entries in different order between `std::unordered_map` and `boost::unordered_flat_map`. The picker code sums doubles, so individual cell intensities can differ by ≤1 ULP from rehash. This was already the case across libstdc++ vs libc++ vs different Boost versions — the test asserts on counts and ratios, not bit-exact m/z, and continues to pass.

## Test plan

- [x] `BrukerTimsFile_test` passes locally with `ENABLE_OPENTIMS_TESTS=ON`
- [ ] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal data structures for improved processing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->