### PR TITLE
fix(FeatureFinderAlgorithmPicked): swap pattern/trace mz_tolerance assignments (#9247)

### DIFF
--- a/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
+++ b/src/openms/include/OpenMS/FEATUREFINDER/FeatureFinderAlgorithmPicked.h
@@ -156,8 +156,8 @@ protected:
 
     /// @name Members for parameters often needed in methods
     //@{
-    double pattern_tolerance_; ///< Stores mass_trace:mz_tolerance
-    double trace_tolerance_; ///< Stores isotopic_pattern:mz_tolerance
+    double pattern_tolerance_; ///< Stores isotopic_pattern:mz_tolerance
+    double trace_tolerance_; ///< Stores mass_trace:mz_tolerance
     UInt min_spectra_; ///< Number of spectra that have to show the same mass (for finding a mass trace)
     UInt max_missing_trace_peaks_; ///< Stores mass_trace:max_missing
     double slope_bound_; ///< Max slope of mass trace intensities

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -1109,8 +1109,8 @@ namespace OpenMS
 
   void FeatureFinderAlgorithmPicked::updateMembers_()
   {
-    pattern_tolerance_ = param_.getValue("mass_trace:mz_tolerance");
-    trace_tolerance_ = param_.getValue("isotopic_pattern:mz_tolerance");
+    pattern_tolerance_ = param_.getValue("isotopic_pattern:mz_tolerance");
+    trace_tolerance_ = param_.getValue("mass_trace:mz_tolerance");
     min_spectra_ = (UInt) std::floor((double)param_.getValue("mass_trace:min_spectra") * 0.5);
     max_missing_trace_peaks_ = param_.getValue("mass_trace:max_missing");
     slope_bound_ = param_.getValue("mass_trace:slope_bound");


### PR DESCRIPTION
## Summary
- Fixes #9247. `FeatureFinderAlgorithmPicked::updateMembers_()` was assigning `mass_trace:mz_tolerance` to `pattern_tolerance_` and `isotopic_pattern:mz_tolerance` to `trace_tolerance_` — the opposite of what the variable names and every call site expect.
- The variable semantics are clear from usage:
  - `pattern_tolerance_` is consumed by `findIsotope_()` (isotopic pattern position scoring at `FeatureFinderAlgorithmPicked.cpp:1623,1644,1665`).
  - `trace_tolerance_` is consumed by `feature_traces.isValid(seed_mz, trace_tolerance_)` for mass-trace validation (`:640, :2064`) and trace-extension position scores (`:323, :334, :1538`).
- Both parameters default to `0.03`, which is why the swap stayed latent — only users who tuned the two tolerances independently were affected, and silently.
- Also corrects the doxygen comments in `FeatureFinderAlgorithmPicked.h` that were documenting the buggy mapping.

## Test plan
- [ ] Build OpenMS (`cmake --build OpenMS-build -j$(nproc)`)
- [ ] `ctest --test-dir OpenMS-build -R FeatureFinder` — existing FFAP tests should still pass since defaults are unchanged.
- [ ] Manual sanity check with a featureXML where `isotopic_pattern:mz_tolerance` and `mass_trace:mz_tolerance` are deliberately set to different values: confirm the trace tolerance now drives mass-trace extension and the pattern tolerance now drives isotope matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected the assignment of mz tolerance parameters in feature detection to ensure proper tolerance application during mass-trace validation and isotope-pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->