### PR TITLE
build(openms): suppress additional percolator warnings

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -71,7 +71,7 @@ if (MSVC)
 else()
   set_source_files_properties(${OpenMS_percolator_sources}
     PROPERTIES
-      COMPILE_FLAGS "-Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-declarations -Wno-unused-variable -Wno-overloaded-virtual")
+      COMPILE_FLAGS "-Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-declarations -Wno-unused-variable -Wno-overloaded-virtual -Wno-reorder -Wno-reorder-ctor -Wno-uninitialized -Wno-ignored-qualifiers -Wno-unused-but-set-variable")
   set_source_files_properties(${OpenMS_percolator_sources}
     PROPERTIES COMPILE_OPTIONS "-fvisibility=hidden")
 endif()


### PR DESCRIPTION
## Summary
- Extends the existing percolator warning suppression block in `src/openms/CMakeLists.txt` (GCC/Clang branch) with five additional `-Wno-*` flags so the vendored percolator sources compile cleanly:
  - `-Wno-reorder` — GCC member-initialization reorder warnings
  - `-Wno-reorder-ctor` — Clang constructor-specific reorder warnings
  - `-Wno-uninitialized` — self-initialization warning in `PackedMatrix.cpp`
  - `-Wno-ignored-qualifiers` — `const` return-type warning in `SetHandler`
  - `-Wno-unused-but-set-variable` — `hasRt` set but unused (distinct from the existing `-Wno-unused-variable`)
- Follows the established pattern of suppressing warnings on vendored upstream code rather than patching it.

Fixes #9248

## Test plan
- [ ] CI build on Linux/macOS (GCC + Clang) shows the previously reported percolator warnings are silenced
- [ ] CI build on Windows (MSVC) is unaffected (change is in the `else()` branch only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build configuration settings for third-party vendored code on non-Windows systems to reduce compiler warning messages during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->