### PR TITLE
cleanup(scoring): remove deprecated C-array overloads (#9252)

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
@@ -142,10 +142,8 @@ namespace OpenMS
       }
 
       // compute intensity distance:
-      OpenSwath::Scoring::normalize_sum(&feature_intensities[0],
-                                        boost::numeric_cast<int>(feature_intensities.size()));
-      OpenSwath::Scoring::normalize_sum(&assay_intensities[0],
-                                        boost::numeric_cast<int>(assay_intensities.size()));
+      OpenSwath::Scoring::normalize_sum(feature_intensities);
+      OpenSwath::Scoring::normalize_sum(assay_intensities);
       double dist_int = manhattanDist_(feature_intensities, 
                                            assay_intensities);
 

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/ALGO/Scoring.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/ALGO/Scoring.h
@@ -60,7 +60,7 @@ public:
 
     /** @name Helper functions */
     //@{
-    /** @brief Calculate the normalized Manhattan distance between two arrays
+    /** @brief Calculate the normalized Manhattan distance between two vectors
      *
      * Equivalent to the function "delta_ratio_sum" from mQuest to calculate
      * similarity between library intensity and experimental ones.
@@ -70,67 +70,46 @@ public:
        @f[
        d = \sqrt{\frac{1}{N}  \sum_{i=0}^N |\frac{x_i}{\mu_x} - \frac{y_i}{\mu_y}|) }
        @f]
-    */
-    [[deprecated("Use the std::vector& overload instead")]]
-    OPENSWATHALGO_DLLAPI double NormalizedManhattanDist(double x[], double y[], int n);
-
-    /** @brief Calculate the normalized Manhattan distance between two vectors
      *
      * @param[in,out] x First intensity vector; normalized in-place via normalize_sum
      * @param[in,out] y Second intensity vector; normalized in-place via normalize_sum
      */
     OPENSWATHALGO_DLLAPI double NormalizedManhattanDist(std::vector<double>& x, std::vector<double>& y);
 
-    /** @brief Calculate the RMSD (root means square deviation)
+    /** @brief Calculate the RMSD (root mean square deviation) between two vectors
      *
      * The RMSD is calculated as follows:
 
        @f[
        RMSD = \sqrt{\frac{1}{N}  \sum_{i=0}^N (x_i - y_i)^2 }
        @f]
-    */
-    [[deprecated("Use the std::vector& overload instead")]]
-    OPENSWATHALGO_DLLAPI double RootMeanSquareDeviation(double x[], double y[], int n);
-
-    /** @brief Calculate the RMSD between two vectors
      *
      * @param[in] x First data vector
      * @param[in] y Second data vector (must have same size as x)
      */
     OPENSWATHALGO_DLLAPI double RootMeanSquareDeviation(const std::vector<double>& x, const std::vector<double>& y);
 
-    /** @brief Calculate the Spectral angle (acosine of the normalized dotproduct)
+    /** @brief Calculate the spectral angle (acosine of the normalized dotproduct) between two vectors
      *
      * The spectral angle is calculated as follows:
 
        @f[
        \theta = acos \left( \frac{\sum_{i=0}^N (x_i * y_i))}{\sqrt{\sum_{i=0}^N (x_i * x_i) \sum_{i=0}^N (y_i * y_i)} }  \right)
        @f]
-    */
-    [[deprecated("Use the std::vector& overload instead")]]
-    OPENSWATHALGO_DLLAPI double SpectralAngle(double x[], double y[], int n);
-
-    /** @brief Calculate the Spectral angle between two vectors
      *
      * @param[in] x First intensity vector
      * @param[in] y Second intensity vector (must have same size as x)
      */
     OPENSWATHALGO_DLLAPI double SpectralAngle(const std::vector<double>& x, const std::vector<double>& y);
 
-    /// Calculate crosscorrelation on std::vector data - Deprecated!
-    /// Legacy code, this is a 1:1 port of the function from mQuest
-    [[deprecated("Use normalizedCrossCorrelation instead")]]
-    OPENSWATHALGO_DLLAPI XCorrArrayType calcxcorr_legacy_mquest_(std::vector<double>& data1,
-                                                  std::vector<double>& data2, bool normalize);
-
     /// Calculate crosscorrelation on std::vector data (which is first normalized)
-    /// NOTE: this replaces calcxcorr 
+    /// NOTE: this replaces calcxcorr
     OPENSWATHALGO_DLLAPI XCorrArrayType normalizedCrossCorrelation(std::vector<double>& data1,
                                                                    std::vector<double>& data2, const int maxdelay, const int lag);
 
     /// Calculate crosscorrelation on std::vector data that is already normalized
     OPENSWATHALGO_DLLAPI XCorrArrayType normalizedCrossCorrelationPost(std::vector<double>& normalized_data1,
-                                                                       std::vector<double>& normalized_data2, const int maxdelay, const int lag);                                                                   
+                                                                       std::vector<double>& normalized_data2, const int maxdelay, const int lag);
 
     /// Calculate crosscorrelation on std::vector data without normalization
     OPENSWATHALGO_DLLAPI XCorrArrayType calculateCrossCorrelation(const std::vector<double>& data1,
@@ -141,10 +120,6 @@ public:
 
     /// Standardize a vector (subtract mean, divide by standard deviation)
     OPENSWATHALGO_DLLAPI void standardize_data(std::vector<double>& data);
-
-    /// Divide each element of x by the sum of the vector
-    [[deprecated("Use the std::vector& overload instead")]]
-    OPENSWATHALGO_DLLAPI void normalize_sum(double x[], unsigned int n);
 
     /** @brief Divide each element of x by the sum of the vector
      *

--- a/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
+++ b/src/openswathalgo/source/OPENSWATHALGO/ALGO/Scoring.cpp
@@ -16,55 +16,21 @@
 
 namespace OpenSwath::Scoring
 {
-    namespace detail
-    {
-      // Internal helper to avoid deprecation warnings between our own functions
-      static void normalize_sum_impl(double* x, unsigned int n)
-      {
-        Eigen::Map<Eigen::VectorXd> v(x, n);
-        double s = v.sum();
-        if (s != 0.0) { v /= s; }
-      }
-    }
-
-    void normalize_sum(double x[], unsigned int n)
-    {
-      detail::normalize_sum_impl(x, n);
-    }
-
     void normalize_sum(std::vector<double>& x)
     {
-      detail::normalize_sum_impl(x.data(), static_cast<unsigned int>(x.size()));
-    }
-
-    double NormalizedManhattanDist(double x[], double y[], int n)
-    {
-      OPENSWATH_PRECONDITION(n > 0, "Need at least one element");
-
-      detail::normalize_sum_impl(x, n);
-      detail::normalize_sum_impl(y, n);
-      Eigen::Map<Eigen::VectorXd> vx(x, n);
-      Eigen::Map<Eigen::VectorXd> vy(y, n);
-      return (vx - vy).cwiseAbs().sum() / n;
+      Eigen::Map<Eigen::VectorXd> v(x.data(), x.size());
+      double s = v.sum();
+      if (s != 0.0) { v /= s; }
     }
 
     double NormalizedManhattanDist(std::vector<double>& x, std::vector<double>& y)
     {
       OPENSWATH_PRECONDITION(x.size() == y.size() && !x.empty(), "Both vectors need to have the same non-zero length");
-      detail::normalize_sum_impl(x.data(), static_cast<unsigned int>(x.size()));
-      detail::normalize_sum_impl(y.data(), static_cast<unsigned int>(y.size()));
+      normalize_sum(x);
+      normalize_sum(y);
       Eigen::Map<Eigen::VectorXd> vx(x.data(), x.size());
       Eigen::Map<Eigen::VectorXd> vy(y.data(), y.size());
       return (vx - vy).cwiseAbs().sum() / x.size();
-    }
-
-    double RootMeanSquareDeviation(double x[], double y[], int n)
-    {
-      OPENSWATH_PRECONDITION(n > 0, "Need at least one element");
-
-      Eigen::Map<const Eigen::VectorXd> vx(x, n);
-      Eigen::Map<const Eigen::VectorXd> vy(y, n);
-      return std::sqrt((vx - vy).squaredNorm() / n);
     }
 
     double RootMeanSquareDeviation(const std::vector<double>& x, const std::vector<double>& y)
@@ -73,26 +39,6 @@ namespace OpenSwath::Scoring
       Eigen::Map<const Eigen::VectorXd> vx(x.data(), x.size());
       Eigen::Map<const Eigen::VectorXd> vy(y.data(), y.size());
       return std::sqrt((vx - vy).squaredNorm() / x.size());
-    }
-
-    double SpectralAngle(double x[], double y[], int n)
-    {
-      OPENSWATH_PRECONDITION(n > 0, "Need at least one element");
-
-      Eigen::Map<const Eigen::VectorXd> vx(x, n);
-      Eigen::Map<const Eigen::VectorXd> vy(y, n);
-      double x_len = vx.norm();
-      double y_len = vy.norm();
-
-      // normalise, avoiding a divide by zero. See unit tests for what happens
-      // when one of the vectors has a length of zero.
-      double denominator = x_len * y_len;
-      double theta = (denominator == 0) ? 0.0 : vx.dot(vy) / denominator;
-
-      // clip to range [-1, 1] to save acos blowing up
-      theta = std::max(-1.0, std::min(1.0, theta));
-
-      return std::acos(theta);
     }
 
     double SpectralAngle(const std::vector<double>& x, const std::vector<double>& y)
@@ -195,67 +141,6 @@ namespace OpenSwath::Scoring
           sxy = sub1.dot(sub2);
         }
         result.data.push_back(std::make_pair(delay, sxy));
-      }
-      return result;
-    }
-
-    XCorrArrayType calcxcorr_legacy_mquest_(std::vector<double>& data1,
-                                            std::vector<double>& data2, bool normalize)
-    {
-      OPENSWATH_PRECONDITION(!data1.empty() && data1.size() == data2.size(), "Both data vectors need to have the same length");
-      int datasize = static_cast<int>(data1.size());
-      int maxdelay = datasize;
-      int lag = 1;
-
-      Eigen::Map<Eigen::VectorXd> map1(data1.data(), datasize);
-      Eigen::Map<Eigen::VectorXd> map2(data2.data(), datasize);
-
-      double mean1 = map1.mean();
-      double mean2 = map2.mean();
-      double denominator = 1.0;
-
-      if (normalize)
-      {
-        double sqsum1 = (map1.array() - mean1).square().sum();
-        double sqsum2 = (map2.array() - mean2).square().sum();
-        denominator = std::sqrt(sqsum1 * sqsum2);
-      }
-
-      denominator = (denominator > 0) ? (1.0 / denominator) : 0.0;
-
-      XCorrArrayType result;
-      result.data.reserve( (size_t)std::ceil((2*maxdelay + 1.0) / lag));
-
-      for (int delay = -maxdelay; delay <= maxdelay; delay += lag)
-      {
-        double sxy = 0.0;
-        int start = std::max(0, -delay);
-        int end = std::min(datasize, datasize - delay);
-        int len = end - start;
-
-        if (len > 0)
-        {
-          Eigen::Map<Eigen::VectorXd> sub1(data1.data() + start, len);
-          Eigen::Map<Eigen::VectorXd> sub2(data2.data() + start + delay, len);
-
-          if (normalize)
-          {
-            sxy = (sub1.array() - mean1).matrix().dot((sub2.array() - mean2).matrix());
-          }
-          else
-          {
-            sxy = sub1.dot(sub2);
-          }
-        }
-
-        if (denominator > 0)
-        {
-          result.data.emplace_back(delay, sxy * denominator);
-        }
-        else
-        {
-          result.data.emplace_back(delay, 0);
-        }
       }
       return result;
     }

--- a/src/tests/class_tests/openswathalgo/Scoring_test.cpp
+++ b/src/tests/class_tests/openswathalgo/Scoring_test.cpp
@@ -41,49 +41,6 @@ namespace
     return result;
   }
 
-  Scoring::XCorrArrayType calcxcorr_legacy_ref(
-    const std::vector<double>& data1, const std::vector<double>& data2, bool normalize)
-  {
-    int datasize = static_cast<int>(data1.size());
-    int maxdelay = datasize;
-    int lag = 1;
-
-    double mean1 = std::accumulate(data1.begin(), data1.end(), 0.0) / static_cast<double>(data1.size());
-    double mean2 = std::accumulate(data2.begin(), data2.end(), 0.0) / static_cast<double>(data2.size());
-    double denominator = 1.0;
-
-    if (normalize)
-    {
-      double sqsum1 = 0, sqsum2 = 0;
-      for (size_t i = 0; i < data1.size(); ++i)
-        sqsum1 += (data1[i] - mean1) * (data1[i] - mean1);
-      for (size_t i = 0; i < data2.size(); ++i)
-        sqsum2 += (data2[i] - mean2) * (data2[i] - mean2);
-      denominator = std::sqrt(sqsum1 * sqsum2);
-    }
-    denominator = (denominator > 0) ? (1.0 / denominator) : 0.0;
-
-    Scoring::XCorrArrayType result;
-    for (int delay = -maxdelay; delay <= maxdelay; delay += lag)
-    {
-      double sxy = 0;
-      for (int i = 0; i < datasize; ++i)
-      {
-        int j = i + delay;
-        if (j < 0 || j >= datasize) continue;
-        if (normalize)
-          sxy += (data1[i] - mean1) * (data2[j] - mean2);
-        else
-          sxy += data1[i] * data2[j];
-      }
-      if (denominator > 0)
-        result.data.emplace_back(delay, sxy * denominator);
-      else
-        result.data.emplace_back(delay, 0);
-    }
-    return result;
-  }
-
   std::vector<double> generate_test_signal(int n, double freq1 = 0.1, double freq2 = 0.3)
   {
     std::vector<double> data(n);
@@ -114,7 +71,7 @@ START_SECTION(double_NormalizedManhattanDist_test)
   static const double arr2[] = {1,3,5,2,0,0};
   std::vector<double> data1 (arr1, arr1 + sizeof(arr1) / sizeof(arr1[0]) );
   std::vector<double> data2 (arr2, arr2 + sizeof(arr2) / sizeof(arr2[0]) );
-  TEST_REAL_SIMILAR (Scoring::NormalizedManhattanDist(&data1[0], &data2[0], 6), 0.15151515)
+  TEST_REAL_SIMILAR (Scoring::NormalizedManhattanDist(data1, data2), 0.15151515)
 }
 END_SECTION
 
@@ -131,7 +88,7 @@ START_SECTION(double_RootMeanSquareDeviation_test)
   static const double arr2[] = {1,3,5,2,0,0};
   std::vector<double> data1 (arr1, arr1 + sizeof(arr1) / sizeof(arr1[0]) );
   std::vector<double> data2 (arr2, arr2 + sizeof(arr2) / sizeof(arr2[0]) );
-  TEST_REAL_SIMILAR (Scoring::RootMeanSquareDeviation(&data1[0], &data2[0], 6), 1.91485421551)
+  TEST_REAL_SIMILAR (Scoring::RootMeanSquareDeviation(data1, data2), 1.91485421551)
 }
 END_SECTION
 
@@ -204,7 +161,7 @@ START_SECTION(double_SpectralAngle_test)
     std::vector<double> d1,
     std::vector<double> d2
   ) -> double {
-    return Scoring::SpectralAngle(&d1[0], &d2[0], d1.size());
+    return Scoring::SpectralAngle(d1, d2);
   };
 
   // previous unit test
@@ -258,7 +215,6 @@ START_SECTION(double_SpectralAngle_test)
 END_SECTION
 
 START_SECTION(void_normalize_sum_test)
-// void normalize_sum(double x[], unsigned int n)
 {
   // arr1 = [ 0,1,3,5,2,0 ];
   // n_arr1 = (arr1 / (sum(arr1) *1.0) )
@@ -267,7 +223,7 @@ START_SECTION(void_normalize_sum_test)
   std::vector<double> data1 (arr1, arr1 + sizeof(arr1) / sizeof(arr1[0]) );
   std::vector<double> data2 (arr2, arr2 + sizeof(arr2) / sizeof(arr2[0]) );
 
-  Scoring::normalize_sum(&data1[0], 6);
+  Scoring::normalize_sum(data1);
   TEST_REAL_SIMILAR (data1[0], 0.0)
   TEST_REAL_SIMILAR (data1[1], 0.09090909)
   TEST_REAL_SIMILAR (data1[2], 0.27272727)
@@ -381,16 +337,16 @@ START_SECTION(test_MRMFeatureScoring_normalizedCrossCorrelation)
 }
 END_SECTION
 
-START_SECTION(test_MRMFeatureScoring_calcxcorr_legacy_mquest_)
-//START_SECTION((MRMFeatureScoring::XCorrArrayType MRMFeatureScoring::calcxcorr(std::vector<double>& data1, std::vector<double>& data2, bool normalize)))
+START_SECTION(test_MRMFeatureScoring_normalizedCrossCorrelation_full_range)
 {
-
+  // Full-range normalized cross-correlation (maxdelay = data.size(), lag = 1)
+  // produces 2*N+1 = 13 entries (-6..+6) for length-6 input vectors.
   static const double arr1[] = {0,1,3,5,2,0};
   static const double arr2[] = {1,3,5,2,0,0};
   std::vector<double> data1 (arr1, arr1 + sizeof(arr1) / sizeof(arr1[0]) );
   std::vector<double> data2 (arr2, arr2 + sizeof(arr2) / sizeof(arr2[0]) );
 
-  OpenSwath::Scoring::XCorrArrayType result = Scoring::calcxcorr_legacy_mquest_(data1, data2, true);
+  OpenSwath::Scoring::XCorrArrayType result = Scoring::normalizedCrossCorrelation(data1, data2, static_cast<int>(data1.size()), 1);
   TEST_EQUAL (result.data.size(), 13)
 
   TEST_REAL_SIMILAR (result.data[4+4].second, -0.7374631);    // .find( 2)
@@ -398,7 +354,7 @@ START_SECTION(test_MRMFeatureScoring_calcxcorr_legacy_mquest_)
   TEST_REAL_SIMILAR (result.data[2+4].second,  0.4159292);    // .find( 0)
   TEST_REAL_SIMILAR (result.data[1+4].second,  0.8215339);    // .find(-1)
   TEST_REAL_SIMILAR (result.data[0+4].second,  0.15634218);   // .find(-2)
-    
+
   TEST_EQUAL (result.data[4+4].first, 2)
   TEST_EQUAL (result.data[3+4].first, 1)
   TEST_EQUAL (result.data[2+4].first, 0)
@@ -457,65 +413,6 @@ START_SECTION(test_calculateCrossCorrelation_equivalence)
 
     auto result = Scoring::calculateCrossCorrelation(data1, data2, 20, 1);
     auto result_ref = calculateCrossCorrelation_ref(data1, data2, 20, 1);
-
-    TEST_EQUAL(result.data.size(), result_ref.data.size())
-    for (size_t i = 0; i < result.data.size(); ++i)
-    {
-      TEST_EQUAL(result.data[i].first, result_ref.data[i].first)
-      TEST_REAL_SIMILAR(result.data[i].second, result_ref.data[i].second)
-    }
-  }
-}
-END_SECTION
-
-START_SECTION(test_calcxcorr_legacy_equivalence)
-//START_SECTION(Eigen vs manual-loop reference for calcxcorr_legacy_mquest_)
-{
-  // Verify that Eigen-based calcxcorr_legacy_mquest_ matches the old
-  // manual-loop implementation in both normalized and unnormalized modes.
-
-  // Normalized mode - small array
-  {
-    std::vector<double> data1 = {0, 1, 3, 5, 2, 0};
-    std::vector<double> data2 = {1, 3, 5, 2, 0, 0};
-    std::vector<double> d1_copy = data1, d2_copy = data2;
-
-    auto result = Scoring::calcxcorr_legacy_mquest_(d1_copy, d2_copy, true);
-    auto result_ref = calcxcorr_legacy_ref(data1, data2, true);
-
-    TEST_EQUAL(result.data.size(), result_ref.data.size())
-    for (size_t i = 0; i < result.data.size(); ++i)
-    {
-      TEST_EQUAL(result.data[i].first, result_ref.data[i].first)
-      TEST_REAL_SIMILAR(result.data[i].second, result_ref.data[i].second)
-    }
-  }
-
-  // Unnormalized mode - small array
-  {
-    std::vector<double> data1 = {0, 1, 3, 5, 2, 0};
-    std::vector<double> data2 = {1, 3, 5, 2, 0, 0};
-    std::vector<double> d1_copy = data1, d2_copy = data2;
-
-    auto result = Scoring::calcxcorr_legacy_mquest_(d1_copy, d2_copy, false);
-    auto result_ref = calcxcorr_legacy_ref(data1, data2, false);
-
-    TEST_EQUAL(result.data.size(), result_ref.data.size())
-    for (size_t i = 0; i < result.data.size(); ++i)
-    {
-      TEST_EQUAL(result.data[i].first, result_ref.data[i].first)
-      TEST_REAL_SIMILAR(result.data[i].second, result_ref.data[i].second)
-    }
-  }
-
-  // Normalized mode - larger array (100 elements)
-  {
-    auto data1 = generate_test_signal(100, 0.1, 0.3);
-    auto data2 = generate_test_signal(100, 0.2, 0.5);
-    std::vector<double> d1_copy = data1, d2_copy = data2;
-
-    auto result = Scoring::calcxcorr_legacy_mquest_(d1_copy, d2_copy, true);
-    auto result_ref = calcxcorr_legacy_ref(data1, data2, true);
 
     TEST_EQUAL(result.data.size(), result_ref.data.size())
     for (size_t i = 0; i < result.data.size(); ++i)
@@ -600,7 +497,7 @@ START_SECTION(test_xcorr_edge_cases)
     std::vector<double> zeros(10, 0.0);
     std::vector<double> zeros2(10, 0.0);
 
-    auto result = Scoring::calcxcorr_legacy_mquest_(zeros, zeros2, true);
+    auto result = Scoring::normalizedCrossCorrelation(zeros, zeros2, 10, 1);
     for (auto it = result.begin(); it != result.end(); ++it)
     {
       TEST_REAL_SIMILAR(it->second, 0.0)
@@ -612,7 +509,7 @@ START_SECTION(test_xcorr_edge_cases)
     std::vector<double> const5(10, 5.0);
     std::vector<double> const5b(10, 5.0);
 
-    auto result = Scoring::calcxcorr_legacy_mquest_(const5, const5b, true);
+    auto result = Scoring::normalizedCrossCorrelation(const5, const5b, 10, 1);
     for (auto it = result.begin(); it != result.end(); ++it)
     {
       TEST_REAL_SIMILAR(it->second, 0.0)
@@ -644,34 +541,6 @@ START_SECTION(test_xcorr_edge_cases)
     TEST_EQUAL(result.data.size(), 1)
     TEST_EQUAL(result.data[0].first, 0)
     TEST_REAL_SIMILAR(result.data[0].second, 42.0 * 7.0)
-  }
-}
-END_SECTION
-
-START_SECTION(test_legacy_vs_normalized_consistency)
-//START_SECTION(calcxcorr_legacy_mquest_ agrees with normalizedCrossCorrelation)
-{
-  // The deprecated calcxcorr_legacy_mquest_(normalize=true) should produce
-  // the same results as normalizedCrossCorrelation at matching lags, since
-  // both compute Pearson cross-correlation with mean subtraction and
-  // variance normalization.
-
-  std::vector<double> d1_for_legacy = {0, 1, 3, 5, 2, 0};
-  std::vector<double> d2_for_legacy = {1, 3, 5, 2, 0, 0};
-  std::vector<double> d1_for_norm = d1_for_legacy;
-  std::vector<double> d2_for_norm = d2_for_legacy;
-
-  int maxdelay = static_cast<int>(d1_for_legacy.size());
-
-  auto result_legacy = Scoring::calcxcorr_legacy_mquest_(d1_for_legacy, d2_for_legacy, true);
-  auto result_normalized = Scoring::normalizedCrossCorrelation(d1_for_norm, d2_for_norm, maxdelay, 1);
-
-  TEST_EQUAL(result_legacy.data.size(), result_normalized.data.size())
-
-  for (size_t i = 0; i < result_legacy.data.size(); ++i)
-  {
-    TEST_EQUAL(result_legacy.data[i].first, result_normalized.data[i].first)
-    TEST_REAL_SIMILAR(result_legacy.data[i].second, result_normalized.data[i].second)
   }
 }
 END_SECTION


### PR DESCRIPTION
## Summary
- Removes the deprecated pointer-based `OpenSwath::Scoring` overloads (`NormalizedManhattanDist`, `RootMeanSquareDeviation`, `SpectralAngle`, `normalize_sum`) and `calcxcorr_legacy_mquest_`, which were the source of the 15 deprecation warnings reported in #9252.
- Ports the formula docstrings (Manhattan / RMSD / Spectral angle) from the deprecated declarations onto the surviving `std::vector&` overloads, as @singjc requested in the issue thread.
- Migrates the four pointer-based call sites in `Scoring_test.cpp` and the two in `ConfidenceScoring.cpp` to the vector overloads.
- Repurposes `test_MRMFeatureScoring_calcxcorr_legacy_mquest_` as `test_MRMFeatureScoring_normalizedCrossCorrelation_full_range` (per @jcharkow's suggestion to "rename to test the new function") — same reference values, full-range maxdelay coverage preserved.
- Deletes `test_calcxcorr_legacy_equivalence`, `test_legacy_vs_normalized_consistency`, and the unused `calcxcorr_legacy_ref` helper, which only validated the legacy function against itself or against the modern API and have no purpose once the legacy function is gone. Edge-case tests for zeros / constant-value inputs are migrated to `normalizedCrossCorrelation`.

Net change: +23 / −296 lines.

Closes #9252.

## Test plan
- [x] `cmake --build OpenMS-build --target Scoring_test` is clean of `-Wdeprecated-declarations` warnings from these symbols.
- [x] `Scoring_test` passes (all sections including the renamed full-range test).
- [x] `ctest -R "Scoring|ConfidenceScoring|MRMScoring|MRMFeatureFinderScoring"` — 20/20 pass.
- [ ] CI green on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated C-style array interfaces; vector-based APIs are now the standard approach for numerical scoring functions.
  * Eliminated a legacy cross-correlation function in favor of the modern implementation.
  * Updated all internal usage to use modern vector-based APIs consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->