### PR TITLE
[FIX] TOPPView: prevent segfault on extreme zoom in 1D view (#9206)

### DIFF
--- a/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Plot1DCanvas.cpp
@@ -1473,6 +1473,11 @@ namespace OpenMS
         area.extend(getLayer(i).getRangeForArea(area));
       }
       auto& intensity = getGravityDim().map(area); // make sure y-axis spans [0, max * TOP_MARGIN]
+      if (intensity.isEmpty())
+      { // no peaks/data in the visible non-gravity range (e.g. extreme zoom). Fall back to the
+        // overall layer intensity range so the y-axis stays sane and dataToWidget_ doesn't divide by zero.
+        intensity = getGravityDim().map(overall_data_range_1d_);
+      }
       intensity.setMin(0); // make sure we start at 0
       intensity.extend(intensity.getMax() * TOP_MARGIN);
     }


### PR DESCRIPTION
## Summary
Fixes #9206 — TOPPView segfaults when zooming the 1D spectrum view to a very narrow m/z window (~<0.1 Da on M1/macOS).

## Root cause
In `Plot1DCanvas::correctGravityAxisOfVisibleArea_`, the SNAP intensity-mode branch rebuilds the y-axis range from peaks visible in the current x-window. When the window is zoomed in far enough that **no peaks fall inside it**, `LayerData1DPeak::getRangeForArea` returns an empty range; `RangeBase::extend(empty)` is a no-op, and the subsequent `intensity.setMin(0)` collapses the range to `[0, 0]` (because `setMin` snaps `max_` up to `min_` when `max_ < min_`).

The visible area then has zero height, and `Plot1DCanvas::dataToWidget_` does:

```cpp
point.setY(int((xy.maxY() - y) / xy.height() * h_px));  // xy.height() == 0
```

`int(NaN/inf)` is undefined behavior in C++ and produces wild QPoint coordinates that crash inside Qt's painter on Apple-silicon clang. Linux/Windows tolerate the same UB more gracefully, which matches the macOS-only report.

## Fix
If, after evaluating all layers in the visible non-gravity range, the intensity range is still empty, fall back to the layer's overall intensity range (`overall_data_range_1d_`). This keeps the y-axis valid even when no peaks are within the zoomed m/z window. SNAP behaves the same as before whenever there is at least one peak visible.

## Test plan
- [x] Builds (`cmake --build OpenMS-build --target OpenMS_GUI`)
- [ ] Open a spectrum in TOPPView (default SNAP mode), Cmd+left-click zoom until the visible m/z span is below the inter-peak distance — no crash; the panel renders empty until you zoom out
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash condition in the plot visualization that occurred when the intensity axis encountered an empty data range, ensuring proper axis scaling for all data configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->