### PR TITLE
fix(ChromatogramExtractor): honor ms1_isotopes on TargetedExperiment overload (closes #7284)

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -291,7 +291,7 @@ namespace OpenMS
       coord.ion_mobility = pep->getDriftTime();
       coordinates.push_back(coord);
 
-      if (ms1 && ms1_isotopes > 0 && false)
+      if (ms1 && ms1_isotopes > 0)
       {
         for (int k = 1; k <= ms1_isotopes; k++)
         {

--- a/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
@@ -10,6 +10,7 @@
 
 #include <OpenMS/test_config.h>
 #include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
@@ -105,6 +106,45 @@ START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr >
 
     TEST_EQUAL(OpenSwathHelper::computeTransitionGroupId(coordinates[0].id), "tr_gr1")
     TEST_EQUAL(OpenSwathHelper::computeTransitionGroupId(coordinates[1].id), "tr_gr2")
+  }
+
+  // Regression test for issue #7284: ms1_isotopes was previously ignored on
+  // the OpenMS::TargetedExperiment overload because of a literal `&& false`
+  // guard. Verify the parameter now produces (1 + ms1_isotopes) coordinates
+  // per peptide, with isotope IDs and m/z derived from C13C12_MASSDIFF_U.
+  {
+    std::vector< OpenSwath::ChromatogramPtr > output_chromatograms;
+    std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
+    ChromatogramExtractor extractor;
+    const int ms1_isotopes = 2;
+    extractor.prepare_coordinates(output_chromatograms, coordinates,
+                                  transitions, rt_extraction_window,
+                                  /*ms1*/ true, ms1_isotopes);
+
+    // 2 peptides * (1 monoisotopic + 2 isotopes) = 6 coordinates
+    TEST_EQUAL(output_chromatograms.size(), coordinates.size())
+    TEST_EQUAL(coordinates.size(), 6)
+
+    // After stable_sort by m/z the order is:
+    // 500.000  pep1 i0
+    // 501.000  pep2 i0
+    // 501.003  pep1 i1 = 500 + 1*C13C12_MASSDIFF_U
+    // 502.003  pep2 i1 = 501 + 1*C13C12_MASSDIFF_U
+    // 502.007  pep1 i2 = 500 + 2*C13C12_MASSDIFF_U
+    // 503.007  pep2 i2 = 501 + 2*C13C12_MASSDIFF_U
+    TEST_REAL_SIMILAR(coordinates[0].mz, 500.0)
+    TEST_REAL_SIMILAR(coordinates[1].mz, 501.0)
+    TEST_REAL_SIMILAR(coordinates[2].mz, 500.0 + 1 * Constants::C13C12_MASSDIFF_U)
+    TEST_REAL_SIMILAR(coordinates[3].mz, 501.0 + 1 * Constants::C13C12_MASSDIFF_U)
+    TEST_REAL_SIMILAR(coordinates[4].mz, 500.0 + 2 * Constants::C13C12_MASSDIFF_U)
+    TEST_REAL_SIMILAR(coordinates[5].mz, 501.0 + 2 * Constants::C13C12_MASSDIFF_U)
+
+    TEST_EQUAL(coordinates[0].id, "tr_gr1_Precursor_i0")
+    TEST_EQUAL(coordinates[1].id, "tr_gr2_Precursor_i0")
+    TEST_EQUAL(coordinates[2].id, "tr_gr1_Precursor_i1")
+    TEST_EQUAL(coordinates[3].id, "tr_gr2_Precursor_i1")
+    TEST_EQUAL(coordinates[4].id, "tr_gr1_Precursor_i2")
+    TEST_EQUAL(coordinates[5].id, "tr_gr2_Precursor_i2")
   }
 
 }


### PR DESCRIPTION
## Summary
The `OpenMS::TargetedExperiment` overload of `ChromatogramExtractor::prepare_coordinates` silently ignored its `ms1_isotopes` parameter because of a literal `&& false` guard introduced in 163696cde3 (2018) as part of a separate segfault fix. This PR removes the `&& false`.

## Why this is safe
- The block is structurally identical to the working `LightTargetedExperiment` overload — only differs in `pep->id` vs `pep.id` (pointer vs value access).
- The original 2018 segfault concern (precursor/transition ID collisions in pqp files) is addressed by routing IDs through `OpenSwathHelper::computePrecursorId`, which the disabled isotope block already used.
- The `pep` pointer is guaranteed non-null at the isotope block: it has already been dereferenced upstream in `populateMS1Transition` (line 249) and `pep->hasRetentionTime()` (line 266) without crashing.

## Caller analysis (TargetedExperiment overload only)
| Caller | `ms1` | `ms1_isotopes` | Triggered buggy block? |
|---|---|---|---|
| TOPP `OpenSwathChromatogramExtractor` | parameterized | not passed (default 0) | NO |
| `FeatureFinderIdentificationAlgorithm` | false | not passed | NO |
| `FeatureFinderAlgorithmMetaboIdent` | false | not passed | NO |
| `ChromatogramExtractor_test` | varies | not passed | NO |
| pyOpenMS `bind_misc.cpp` | parameterized | parameterized | **YES** if Python user passed `(ms1=True, ms1_isotopes>0)` |

`OpenSwathWorkflow` uses the `LightTargetedExperiment` overload (which has the isotope code enabled and working in production since 2018) and is unaffected by this PR.

## Test plan
- [x] New regression test in `ChromatogramExtractor_test.cpp` verifying `ms1_isotopes=2` produces `1 + 2 = 3` coordinates per peptide with isotope IDs `_i1`/`_i2` and m/z offsets from `Constants::C13C12_MASSDIFF_U`. Test passes locally.
- [ ] Full ctest run in CI to confirm no other test regressions (none expected — no in-tree caller previously exercised this path).

## Follow-up (separate PR)
A more invasive cleanup option (raised in the issue thread by @timosachsenberg in 2024) is to migrate the 5 callers of the `TargetedExperiment` overload to `LightTargetedExperiment` and delete the redundant overload entirely. That's deferred to a follow-up — the `convertTargetedExp` helper already exists, but the FeatureFinder migration needs ad-hoc per-call conversion since their `library_` member type cannot be changed without separate refactoring.

Closes #7284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enabled MS1 isotopes expansion in chromatogram extraction, now properly generating isotope coordinates when specified for mass spectrometry analysis.

* **Tests**
  * Added regression test validating MS1 isotopes handling in chromatogram extraction, including verification of mass-to-charge ratios and coordinate generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->