### PR TITLE
refactor(ChromatogramExtractor): unify two prepare_coordinates overloads (issue #7284 follow-up)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -10,6 +10,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.h>
 
+#include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
@@ -388,12 +389,11 @@ private:
     {
       return comp.sequence;        // peptide path
     }
-    if (!comp.compound_name.empty())
-    {
-      return comp.compound_name;   // metabolite with human-readable CompoundName
-    }
-    return comp.id;                // fallback when compound_name is unset (matches the
-                                   // behavior of the now-removed heavyweight overload)
+    // Fall through to compound_name (may itself be empty — that is intentional
+    // for iRT calibration peptides, which carry empty sequence and no
+    // CompoundName user-param. Downstream consumers expect an empty
+    // peptide_sequence userParam in that case).
+    return comp.compound_name;
   }
 
   // Const-qualified template specialization for extract_id_.

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -128,7 +128,7 @@ public:
      * @param[out] coordinates An empty vector which will be filled with the
      *   appropriate extraction coordinates in m/z and rt and sorted by m/z (to
      *   be used as input to extractChromatograms)
-     * @param[in] transition_exp The transition experiment used as input (is constant)
+     * @param[in] transition_exp_used The transition experiment used as input
      * @param[in] rt_extraction_window If non-negative, full RT extraction window,
      *   centered on the first RT value (@p rt_end - @p rt_start will equal this
      *   window size). If negative, @p rt_end will be set to -1 and @p rt_start
@@ -269,10 +269,9 @@ private:
     /**
      * @brief Extracts id (peptide sequence or compound name) for a compound
      *
-     * @param[out] transition_exp_used The transition experiment used as input (is constant) and either of type LightTargetedExperiment or TargetedExperiment
-     * @param[in] id The identifier of the compound or peptide
-     * @param[in] prec_charge The charge state of the precursor
-     *
+     * @param[in]  transition_exp_used The transition experiment used as input (LightTargetedExperiment)
+     * @param[in]  id The identifier of the compound or peptide
+     * @param[out] prec_charge The charge state of the precursor (filled by this function)
      */
     template <typename TransitionExpT>
     static String extract_id_(TransitionExpT& transition_exp_used, const String& id, int& prec_charge);

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -386,12 +386,14 @@ private:
     prec_charge = comp.charge;
     if (!comp.sequence.empty())
     {
-      return comp.sequence;
+      return comp.sequence;        // peptide path
     }
-    else
+    if (!comp.compound_name.empty())
     {
-      return comp.compound_name;
+      return comp.compound_name;   // metabolite with human-readable CompoundName
     }
+    return comp.id;                // fallback when compound_name is unset (matches the
+                                   // behavior of the now-removed heavyweight overload)
   }
 
   // Const-qualified template specialization for extract_id_.

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -140,13 +140,6 @@ public:
     */
     static void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms,
                                     std::vector< ExtractionCoordinates > & coordinates,
-                                    const OpenMS::TargetedExperiment & transition_exp,
-                                    const double rt_extraction_window,
-                                    const bool ms1 = false,
-                                    const int ms1_isotopes = 0);
-
-    static void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms,
-                                    std::vector< ExtractionCoordinates > & coordinates,
                                     const OpenSwath::LightTargetedExperiment & transition_exp_used,
                                     const double rt_extraction_window,
                                     const bool ms1 = false,

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -14,13 +14,13 @@
 
 #include <unordered_map>
 
-#define IMPLIES(a, b) !(a) || (b)
-
 namespace OpenMS
 {
-  template <typename MapT, typename PepT>
-  bool populateMS1Transition(MapT & pep2tr,
-                             const PepT & pep,
+  // Populate the precursor (MS1) extraction coordinate for one compound.
+  // Returns false if the compound has no associated transitions, in which case
+  // the caller should record an empty coordinate and continue.
+  bool populateMS1Transition(const std::unordered_map<String, std::vector<const OpenSwath::LightTransition*>>& pep2tr,
+                             const OpenSwath::LightCompound & pep,
                              ChromatogramExtractor::ExtractionCoordinates & coord)
   {
     // default values for RT window (negative range)
@@ -28,32 +28,30 @@ namespace OpenMS
     coord.rt_start = 0;
 
     // Catch cases where a compound has no transitions
-    if (pep2tr.count(pep.id) == 0)
+    auto it = pep2tr.find(pep.id);
+    if (it == pep2tr.end())
     {
       OPENMS_LOG_INFO << "Warning: no transitions found for compound " << pep.id << std::endl;
       coord.id = OpenSwathHelper::computePrecursorId(pep.id, 0);
       return false;
     }
 
-    // This is slightly awkward but the m/z of the precursor is *not*
-    // stored in the precursor object but only in the transition object
-    // itself. So we have to get the first transition to look it up.
-    auto transition = (*pep2tr[pep.id][0]);
-    coord.mz = transition.getPrecursorMZ();
+    // The m/z of the precursor is *not* stored in the precursor object but only
+    // in the transition object itself. We get the first transition to look it up.
+    coord.mz = it->second[0]->getPrecursorMZ();
 
-    // Set chromatogram reference id: even though we use the peptide id
-    // here, it is possible that these ids overlap with the transition
-    // ids, leading to bad downstream consequences (e.g. ambiguity which
-    // chromatograms are precursor and which ones are fragment
-    // chromatograms). This is especially problematic with pqp files
-    // where peptide precursors and transitions are simply numbered and
-    // are guaranteed to overlap.
+    // Set chromatogram reference id: even though we use the peptide id here,
+    // it is possible that these ids overlap with the transition ids, leading
+    // to bad downstream consequences (e.g. ambiguity which chromatograms are
+    // precursor and which ones are fragment chromatograms). This is especially
+    // problematic with pqp files where peptide precursors and transitions are
+    // simply numbered and are guaranteed to overlap.
     coord.id = OpenSwathHelper::computePrecursorId(pep.id, 0);
     return true;
   }
 
-  template <typename TransitionT>
-  void populateMS2Transition(const TransitionT & transition,
+  // Populate the fragment (MS2) extraction coordinate from a single transition.
+  void populateMS2Transition(const OpenSwath::LightTransition & transition,
                              ChromatogramExtractor::ExtractionCoordinates & coord)
   {
     // default values for RT window (negative range)
@@ -63,41 +61,6 @@ namespace OpenMS
     coord.mz = transition.getProductMZ();
     coord.mz_precursor = transition.getPrecursorMZ();
     coord.id = transition.getNativeID();
-  }
-
-
-  const TargetedExperimentHelper::PeptideCompound* getPeptideHelperMS2_(const OpenMS::TargetedExperiment& transition_exp_used,
-                                                                        const OpenMS::ReactionMonitoringTransition& transition,
-                                                                        bool do_peptides)
-  {
-    OPENMS_PRECONDITION(IMPLIES(do_peptides, !transition.getPeptideRef().empty()), "PeptideRef cannot be empty for peptides")
-    OPENMS_PRECONDITION(IMPLIES(!do_peptides, !transition.getCompoundRef().empty()), "CompoundRef cannot be empty for compounds")
-
-    if (do_peptides)
-    {
-      return &transition_exp_used.getPeptideByRef(transition.getPeptideRef()); 
-    }
-    else
-    {
-      return &transition_exp_used.getCompoundByRef(transition.getCompoundRef()); 
-    }
-  }
-
-  const TargetedExperimentHelper::PeptideCompound* getPeptideHelperMS1_(const OpenMS::TargetedExperiment & transition_exp_used,
-                                                                        Size i,
-                                                                        bool do_peptides)
-  {
-    OPENMS_PRECONDITION(IMPLIES(do_peptides, i < transition_exp_used.getPeptides().size()), "Index i must be smaller than the number of peptides")
-    OPENMS_PRECONDITION(IMPLIES(!do_peptides, i < transition_exp_used.getCompounds().size()), "Index i must be smaller than the number of compounds")
-
-    if (do_peptides)
-    {
-      return &transition_exp_used.getPeptides()[i];
-    }
-    else
-    {
-      return &transition_exp_used.getCompounds()[i];
-    }
   }
 
   void ChromatogramExtractor::prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms,
@@ -163,10 +126,24 @@ namespace OpenMS
 
       if (rt_extraction_window >= 0)
       {
-        // if 'rt_extraction_window' is non-zero, just use the (first) RT value
+        // if 'rt_extraction_window' is non-negative, use the (first) RT value as window center
         double rt = pep.rt;
         coord.rt_start = rt - rt_extraction_window / 2.0;
         coord.rt_end = rt + rt_extraction_window / 2.0;
+      }
+      else if (std::isnan(rt_extraction_window))
+      {
+        // NaN means: use the per-compound RT range encoded on the LightCompound
+        // (populated from a heavyweight TargetedExperiment::Peptide whose `rts`
+        // vector had two entries — see OpenSwathDataAccessHelper::convertTargetedExp).
+        if (std::isnan(pep.rt_start) || std::isnan(pep.rt_end))
+        {
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+              "Error: rt_extraction_window=NaN requires the compound '" + pep.id +
+              "' to carry a retention-time range (rt_start, rt_end), but none is set.");
+        }
+        coord.rt_start = pep.rt_start;
+        coord.rt_end   = pep.rt_end;
       }
       coord.ion_mobility = pep.getDriftTime();
       coordinates.push_back(coord);
@@ -185,128 +162,7 @@ namespace OpenMS
       }
     }
 
-    // sort result, use stable_sort to ensure that ordering is preserved 
-    std::stable_sort(coordinates.begin(), coordinates.end(), ChromatogramExtractor::ExtractionCoordinates::SortExtractionCoordinatesByMZ);
-  }
-
-  void ChromatogramExtractor::prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms,
-                                                  std::vector< ExtractionCoordinates > & coordinates,
-                                                  const OpenMS::TargetedExperiment & transition_exp_used,
-                                                  const double rt_extraction_window,
-                                                  const bool ms1,
-                                                  const int ms1_isotopes)
-  {
-    typedef std::unordered_map<String, std::vector<const ReactionMonitoringTransition*> > PeptideTransitionMapType;
-    PeptideTransitionMapType pep2tr;
-    for (Size i = 0; i < transition_exp_used.getTransitions().size(); i++)
-    {
-      String ref = transition_exp_used.getTransitions()[i].getPeptideRef();
-      if (ref.empty()) ref = transition_exp_used.getTransitions()[i].getCompoundRef();
-      pep2tr[ref].push_back(&transition_exp_used.getTransitions()[i]);
-    }
-
-    // std::map<String, const TargetedExperimentHelper::PeptideCompound* > tr2pep;
-    // for (const auto & p : transition_exp_used.getPeptides()) {tr2pep[p.id] = &p;}
-    // for (const auto & c : transition_exp_used.getCompounds()) {tr2pep[c.id] = &c;}
-
-    bool have_peptides = (!transition_exp_used.getPeptides().empty());
-
-    // Determine iteration size (nr peptides or nr transitions)
-    Size itersize;
-    if (ms1)
-    {
-      if (have_peptides)
-      {
-        itersize = transition_exp_used.getPeptides().size();
-      }
-      else
-      {
-        itersize = transition_exp_used.getCompounds().size();
-      }
-    }
-    else
-    {
-      itersize = transition_exp_used.getTransitions().size();
-    }
-
-    // Pre-allocate vectors for better performance
-    Size expected_size = itersize * (1 + (ms1 && ms1_isotopes > 0 ? ms1_isotopes : 0));
-    output_chromatograms.reserve(output_chromatograms.size() + expected_size);
-    coordinates.reserve(coordinates.size() + expected_size);
-
-    for (Size i = 0; i < itersize; i++)
-    {
-      OpenSwath::ChromatogramPtr s(new OpenSwath::Chromatogram);
-      output_chromatograms.push_back(s);
-
-      ChromatogramExtractor::ExtractionCoordinates coord;
-      const TargetedExperimentHelper::PeptideCompound* pep;
-      OpenMS::ReactionMonitoringTransition transition;
-
-      if (ms1) 
-      {
-        pep = getPeptideHelperMS1_(transition_exp_used, i, have_peptides);
-        if (!populateMS1Transition(pep2tr, *pep, coord))
-        {
-          // Catch cases where a compound has no transitions
-          coordinates.push_back(coord);
-          continue;
-        }
-      }
-      else
-      {
-        transition = transition_exp_used.getTransitions()[i];
-        pep = getPeptideHelperMS2_(transition_exp_used, transition, have_peptides);
-        populateMS2Transition(transition, coord);
-      }
-
-      if (rt_extraction_window < 0) {} // construct for NAN (see below)
-      else
-      {
-        if (!pep->hasRetentionTime())
-        {
-          // we don't have retention times -> this is only a problem if we actually
-          // wanted to use the RT limit feature.
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                           "Error: Peptide " + pep->id + " does not have retention time information which is necessary to perform an RT-limited extraction");
-        }
-        else if (std::isnan(rt_extraction_window)) // if 'rt_extraction_window' is NAN, we assume that RT start/end is encoded in the data
-        {
-          // TODO: better use a single RT entry with start/end
-          if (pep->rts.size() != 2)
-          {
-            throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                "Error: Expected exactly two retention time entries for peptide '" + pep->id + "', found " + String(pep->rts.size()));
-          }
-          coord.rt_start = pep->rts[0].getRT();
-          coord.rt_end = pep->rts[1].getRT();
-        }
-        else // if 'rt_extraction_window' is non-zero, just use the (first) RT value
-        {
-          double rt = pep->getRetentionTime();
-          coord.rt_start = rt - rt_extraction_window / 2.0;
-          coord.rt_end = rt + rt_extraction_window / 2.0;
-        }
-      }
-      coord.ion_mobility = pep->getDriftTime();
-      coordinates.push_back(coord);
-
-      if (ms1 && ms1_isotopes > 0)
-      {
-        for (int k = 1; k <= ms1_isotopes; k++)
-        {
-          OpenSwath::ChromatogramPtr s(new OpenSwath::Chromatogram);
-          output_chromatograms.push_back(s);
-          ChromatogramExtractor::ExtractionCoordinates coord_new = coord;
-          coord_new.id = OpenSwathHelper::computePrecursorId(pep->id, k);
-          coord_new.mz = coord.mz + k * Constants::C13C12_MASSDIFF_U;
-          coordinates.push_back(coord_new);
-        }
-      }
-
-    }
-
-    // sort result, use stable_sort to ensure that ordering is preserved 
+    // sort result, use stable_sort to ensure that ordering is preserved
     std::stable_sort(coordinates.begin(), coordinates.end(), ChromatogramExtractor::ExtractionCoordinates::SortExtractionCoordinatesByMZ);
   }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -126,7 +126,16 @@ namespace OpenMS
 
       if (rt_extraction_window >= 0)
       {
-        // if 'rt_extraction_window' is non-negative, use the (first) RT value as window center
+        // Non-negative rt_extraction_window: use pep.rt as window center.
+        // pep.rt is NaN when the source library had no retention-time info;
+        // throw to match the pre-unification heavyweight overload's behavior
+        // (silently using NaN here would produce an empty extraction window).
+        if (std::isnan(pep.rt))
+        {
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+              "Error: Peptide " + pep.id +
+              " does not have retention time information which is necessary to perform an RT-limited extraction");
+        }
         double rt = pep.rt;
         coord.rt_start = rt - rt_extraction_window / 2.0;
         coord.rt_end = rt + rt_extraction_window / 2.0;
@@ -134,8 +143,9 @@ namespace OpenMS
       else if (std::isnan(rt_extraction_window))
       {
         // NaN means: use the per-compound RT range encoded on the LightCompound
-        // (populated from a heavyweight TargetedExperiment::Peptide whose `rts`
-        // vector had two entries — see OpenSwathDataAccessHelper::convertTargetedExp).
+        // (populated from a heavyweight TargetedExperiment::Peptide/Compound whose
+        // `rts` vector had exactly two entries — see
+        // OpenSwathDataAccessHelper::convertTargetedExp).
         if (std::isnan(pep.rt_start) || std::isnan(pep.rt_end))
         {
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -199,6 +199,12 @@ namespace OpenMS
   {
     OpenSwath::LightModification light_mod;
 
+    // Reset RT-related fields up front so a reused LightCompound doesn't leak
+    // a stale rt/rt_start/rt_end when the new source has no RT info.
+    p.rt       = std::numeric_limits<double>::quiet_NaN();
+    p.rt_start = std::numeric_limits<double>::quiet_NaN();
+    p.rt_end   = std::numeric_limits<double>::quiet_NaN();
+
     p.id = pep.id;
     if (pep.hasRetentionTime())
     {
@@ -208,11 +214,14 @@ namespace OpenMS
         p.rt = 60 * pep.getRetentionTime();
       }
     }
-    // If the source library encodes a retention-time *range* via two RT entries
-    // (e.g. some pqp/TraML libraries), preserve it on the LightCompound so that
-    // ChromatogramExtractor::prepare_coordinates(..., rt_extraction_window=NaN)
-    // can use it. MINUTE→second conversion is applied per entry to match `p.rt`.
-    if (pep.rts.size() >= 2)
+    // If the source library encodes a retention-time *range* via exactly two
+    // RT entries (e.g. some pqp/TraML libraries), preserve it on the
+    // LightCompound so that ChromatogramExtractor::prepare_coordinates with
+    // rt_extraction_window=NaN can use it. We require exactly two entries
+    // (not >=2) to match the old heavyweight overload's contract; libraries
+    // with 3+ RT entries encode different semantics and should not be silently
+    // truncated.
+    if (pep.rts.size() == 2)
     {
       auto rt_in_seconds = [](const TargetedExperimentHelper::RetentionTime& r) {
         return r.retention_time_unit == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE
@@ -289,6 +298,12 @@ namespace OpenMS
 
   void OpenSwathDataAccessHelper::convertTargetedCompound(const TargetedExperiment::Compound& compound, OpenSwath::LightCompound & comp)
   {
+    // Reset RT-related fields up front so a reused LightCompound doesn't leak
+    // stale values when the new source has no RT info.
+    comp.rt       = std::numeric_limits<double>::quiet_NaN();
+    comp.rt_start = std::numeric_limits<double>::quiet_NaN();
+    comp.rt_end   = std::numeric_limits<double>::quiet_NaN();
+
     comp.id = compound.id;
     if (compound.hasRetentionTime())
     {
@@ -299,9 +314,11 @@ namespace OpenMS
       }
     }
     // Preserve a per-compound retention-time range (rt_start, rt_end) when the
-    // source library encodes one via two RT entries — used by
-    // ChromatogramExtractor::prepare_coordinates(..., rt_extraction_window=NaN).
-    if (compound.rts.size() >= 2)
+    // source library encodes one via exactly two RT entries — used by
+    // ChromatogramExtractor::prepare_coordinates with rt_extraction_window=NaN.
+    // We require exactly two entries to match the old heavyweight overload's
+    // contract.
+    if (compound.rts.size() == 2)
     {
       auto rt_in_seconds = [](const TargetedExperimentHelper::RetentionTime& r) {
         return r.retention_time_unit == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -208,6 +208,20 @@ namespace OpenMS
         p.rt = 60 * pep.getRetentionTime();
       }
     }
+    // If the source library encodes a retention-time *range* via two RT entries
+    // (e.g. some pqp/TraML libraries), preserve it on the LightCompound so that
+    // ChromatogramExtractor::prepare_coordinates(..., rt_extraction_window=NaN)
+    // can use it. MINUTE→second conversion is applied per entry to match `p.rt`.
+    if (pep.rts.size() >= 2)
+    {
+      auto rt_in_seconds = [](const TargetedExperimentHelper::RetentionTime& r) {
+        return r.retention_time_unit == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE
+                 ? 60.0 * r.getRT()
+                 : r.getRT();
+      };
+      p.rt_start = rt_in_seconds(pep.rts[0]);
+      p.rt_end   = rt_in_seconds(pep.rts[1]);
+    }
     p.setDriftTime(pep.getDriftTime());
 
     if (pep.hasCharge())
@@ -283,6 +297,19 @@ namespace OpenMS
       {
         comp.rt = 60 * compound.getRetentionTime();
       }
+    }
+    // Preserve a per-compound retention-time range (rt_start, rt_end) when the
+    // source library encodes one via two RT entries — used by
+    // ChromatogramExtractor::prepare_coordinates(..., rt_extraction_window=NaN).
+    if (compound.rts.size() >= 2)
+    {
+      auto rt_in_seconds = [](const TargetedExperimentHelper::RetentionTime& r) {
+        return r.retention_time_unit == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE
+                 ? 60.0 * r.getRT()
+                 : r.getRT();
+      };
+      comp.rt_start = rt_in_seconds(compound.rts[0]);
+      comp.rt_end   = rt_in_seconds(compound.rts[1]);
     }
     comp.setDriftTime(compound.getDriftTime());
 

--- a/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderAlgorithmMetaboIdent.cpp
@@ -14,6 +14,7 @@
 #include <OpenMS/FEATUREFINDER/TraceFitter.h>
 
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
 
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
@@ -358,7 +359,13 @@ namespace OpenMS
     // extractor.setLogType(ProgressLogger::NONE);
     vector<OpenSwath::ChromatogramPtr> chrom_temp;
     vector<ChromatogramExtractor::ExtractionCoordinates> coords;
-    extractor.prepare_coordinates(chrom_temp, coords, library_,
+    // ChromatogramExtractor::prepare_coordinates / return_chromatogram now
+    // take OpenSwath::LightTargetedExperiment (issue #7284 cleanup). The NaN
+    // window relies on rt_start/rt_end now carried on LightCompound, populated
+    // by convertTargetedExp from library_.peptides[*].rts.
+    OpenSwath::LightTargetedExperiment light_library;
+    OpenSwathDataAccessHelper::convertTargetedExp(library_, light_library);
+    extractor.prepare_coordinates(chrom_temp, coords, light_library,
                                   numeric_limits<double>::quiet_NaN(), false);
 
     std::shared_ptr<PeakMap> shared = std::make_shared<PeakMap>(ms_data_);
@@ -375,7 +382,7 @@ namespace OpenMS
       extractor.extractChromatograms(spec_temp, chrom_temp, coords, mz_window_,
                                      mz_window_ppm_, "tophat");
     }
-    extractor.return_chromatogram(chrom_temp, coords, library_, (*shared)[0],
+    extractor.return_chromatogram(chrom_temp, coords, light_library, (*shared)[0],
                                   chrom_data_.getChromatograms(), false);
 
     OPENMS_LOG_DEBUG << "Extracted " << chrom_data_.getNrChromatograms()

--- a/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -20,6 +20,7 @@
 #include <OpenMS/IONMOBILITY/IMDataConverter.h>
 #include <OpenMS/IONMOBILITY/FAIMSHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
 #include <OpenMS/ML/SVM/SimpleSVM.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h>
@@ -840,8 +841,14 @@ namespace OpenMS
       {
         vector<OpenSwath::ChromatogramPtr> chrom_temp;
         vector<ChromatogramExtractor::ExtractionCoordinates> coords;
-        // take entries in library_ and put to chrom_temp and coords
-        extractor.prepare_coordinates(chrom_temp, coords, library_,
+        // ChromatogramExtractor::prepare_coordinates / return_chromatogram now
+        // take OpenSwath::LightTargetedExperiment (issue #7284 cleanup). The
+        // NaN window relies on rt_start/rt_end now carried on LightCompound,
+        // populated by convertTargetedExp from library_.peptides[*].rts.
+        OpenSwath::LightTargetedExperiment light_library;
+        OpenSwathDataAccessHelper::convertTargetedExp(library_, light_library);
+        // take entries in light_library and put to chrom_temp and coords
+        extractor.prepare_coordinates(chrom_temp, coords, light_library,
                                       numeric_limits<double>::quiet_NaN(), false);
 
         if (has_IM && IM_window > 0.0)
@@ -855,7 +862,7 @@ namespace OpenMS
                                         mz_window_ppm_, "tophat");
         }
 
-        extractor.return_chromatogram(chrom_temp, coords, library_, (*shared)[0],
+        extractor.return_chromatogram(chrom_temp, coords, light_library, (*shared)[0],
                                       chrom_data_.getChromatograms(), false);
       }
 

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <cstdint>
 #include <functional>
+#include <limits>
 
 #include <OpenMS/OPENSWATHALGO/OpenSwathAlgoConfig.h>
 
@@ -269,12 +270,21 @@ namespace OpenSwath
 
     LightCompound() :
       drift_time(-1),
+      rt_start(std::numeric_limits<double>::quiet_NaN()),
+      rt_end(std::numeric_limits<double>::quiet_NaN()),
       charge(0)
     {
     }
 
     double drift_time;
     double rt;
+    /// Optional retention time range, used by ChromatogramExtractor::prepare_coordinates
+    /// when called with rt_extraction_window=NaN. Both NaN means "no range encoded";
+    /// otherwise rt_start..rt_end define the per-compound extraction window.
+    /// Populated by OpenSwathDataAccessHelper::convertTargetedExp from a heavyweight
+    /// TargetedExperiment::Peptide that has two retention-time entries.
+    double rt_start;
+    double rt_end;
     int charge;
     std::string sequence;
     std::vector<std::string> protein_refs;

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
@@ -270,6 +270,7 @@ namespace OpenSwath
 
     LightCompound() :
       drift_time(-1),
+      rt(std::numeric_limits<double>::quiet_NaN()),
       rt_start(std::numeric_limits<double>::quiet_NaN()),
       rt_end(std::numeric_limits<double>::quiet_NaN()),
       charge(0)
@@ -277,6 +278,8 @@ namespace OpenSwath
     }
 
     double drift_time;
+    /// Retention time (seconds). NaN if unset — `ChromatogramExtractor::prepare_coordinates`
+    /// throws if a non-negative `rt_extraction_window` is requested but `rt` is NaN.
     double rt;
     /// Optional retention time range, used by ChromatogramExtractor::prepare_coordinates
     /// when called with rt_extraction_window=NaN. Both NaN means "no range encoded";

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -48,6 +48,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMS.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMAssay.h>
@@ -2271,9 +2272,16 @@ ProgressLogger
                 double rt_extraction_window,
                 bool ms1,
                 int ms1_isotopes) {
+            // The TargetedExperiment overload of prepare_coordinates was
+            // removed in favor of the LightTargetedExperiment one (see issue
+            // #7284). Convert internally to keep this Python signature stable
+            // for existing callers; rt_extraction_window=NaN now uses the
+            // rt_start/rt_end fields populated by convertTargetedExp.
+            OpenSwath::LightTargetedExperiment light_exp;
+            OpenMS::OpenSwathDataAccessHelper::convertTargetedExp(targeted, light_exp);
             std::vector<std::shared_ptr<OpenSwath::OSChromatogram>> output_chromatograms;
             std::vector<OpenMS::ChromatogramExtractorAlgorithm::ExtractionCoordinates> extraction_coordinates;
-            OpenMS::ChromatogramExtractor::prepare_coordinates(output_chromatograms, extraction_coordinates, targeted, rt_extraction_window, ms1, ms1_isotopes);
+            OpenMS::ChromatogramExtractor::prepare_coordinates(output_chromatograms, extraction_coordinates, light_exp, rt_extraction_window, ms1, ms1_isotopes);
             // Update Python lists in-place
             while (nb::len(output_chromatograms_py) > 0) { output_chromatograms_py.attr("pop")(); }
             for (auto& c : output_chromatograms) { output_chromatograms_py.append(nb::cast(c)); }

--- a/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramExtractor_test.cpp
@@ -13,6 +13,7 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 
@@ -46,12 +47,17 @@ START_SECTION(void extractChromatograms(const OpenSwath::SpectrumAccessPtr input
 }
 END_SECTION
 
-START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms, std::vector< ExtractionCoordinates > & coordinates, OpenMS::TargetedExperiment & transition_exp, const double rt_extraction_window, const bool ms1) const)
+START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms, std::vector< ExtractionCoordinates > & coordinates, const OpenSwath::LightTargetedExperiment & transition_exp_used, const double rt_extraction_window, const bool ms1, const int ms1_isotopes))
 {
   TargetedExperiment transitions;
   TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.TraML"), transitions);
   TargetedExperiment transitions_;
   TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.TraML"), transitions_);
+  // The TargetedExperiment overload was removed (issue #7284); convert once
+  // and exercise the LightTargetedExperiment overload throughout. The NaN
+  // window relies on rt_start/rt_end now carried on LightCompound.
+  OpenSwath::LightTargetedExperiment light_transitions;
+  OpenSwathDataAccessHelper::convertTargetedExp(transitions, light_transitions);
   double rt_extraction_window = 1.0;
 
   // Test transitions
@@ -59,7 +65,7 @@ START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr >
     std::vector< OpenSwath::ChromatogramPtr > output_chromatograms;
     std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
     ChromatogramExtractor extractor;
-    extractor.prepare_coordinates(output_chromatograms, coordinates, transitions, rt_extraction_window, false);
+    extractor.prepare_coordinates(output_chromatograms, coordinates, light_transitions, rt_extraction_window, false);
 
     TEST_TRUE(transitions == transitions_)
     TEST_EQUAL(output_chromatograms.size(), coordinates.size())
@@ -87,7 +93,7 @@ START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr >
     std::vector< OpenSwath::ChromatogramPtr > output_chromatograms;
     std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
     ChromatogramExtractor extractor;
-    extractor.prepare_coordinates(output_chromatograms, coordinates, transitions, rt_extraction_window, true);
+    extractor.prepare_coordinates(output_chromatograms, coordinates, light_transitions, rt_extraction_window, true);
 
     TEST_TRUE(transitions == transitions_)
     TEST_EQUAL(output_chromatograms.size(), coordinates.size())
@@ -118,7 +124,7 @@ START_SECTION(void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr >
     ChromatogramExtractor extractor;
     const int ms1_isotopes = 2;
     extractor.prepare_coordinates(output_chromatograms, coordinates,
-                                  transitions, rt_extraction_window,
+                                  light_transitions, rt_extraction_window,
                                   /*ms1*/ true, ms1_isotopes);
 
     // 2 peptides * (1 monoisotopic + 2 isotopes) = 6 coordinates
@@ -159,6 +165,9 @@ START_SECTION((template < typename TransitionExpT > static void return_chromatog
 
   TargetedExperiment transitions;
   TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.TraML"), transitions);
+  // Convert once for both prepare_coordinates and return_chromatogram (issue #7284 cleanup).
+  OpenSwath::LightTargetedExperiment light_transitions;
+  OpenSwathDataAccessHelper::convertTargetedExp(transitions, light_transitions);
 
   std::shared_ptr<PeakMap > exp(new PeakMap);
   MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("ChromatogramExtractor_input.mzML"), *exp);
@@ -169,12 +178,12 @@ START_SECTION((template < typename TransitionExpT > static void return_chromatog
     std::vector< OpenSwath::ChromatogramPtr > output_chromatograms;
     std::vector< ChromatogramExtractor::ExtractionCoordinates > coordinates;
     ChromatogramExtractor extractor;
-    extractor.prepare_coordinates(output_chromatograms, coordinates, transitions, rt_extraction_window, false);
+    extractor.prepare_coordinates(output_chromatograms, coordinates, light_transitions, rt_extraction_window, false);
 
-    extractor.extractChromatograms(expptr, output_chromatograms, coordinates, 
+    extractor.extractChromatograms(expptr, output_chromatograms, coordinates,
         extract_window, ppm, extraction_function);
 
-    extractor.return_chromatogram(output_chromatograms, coordinates, transitions, (*exp)[0], chromatograms, false);
+    extractor.return_chromatogram(output_chromatograms, coordinates, light_transitions, (*exp)[0], chromatograms, false);
   }
 
   TEST_EQUAL(chromatograms.size(), 3)

--- a/src/tests/topp/OpenSwathChromatogramExtractor_5_output.mzML
+++ b/src/tests/topp/OpenSwathChromatogramExtractor_5_output.mzML
@@ -244,7 +244,7 @@
 						</selectedIonList>
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="tr_gr2"/>
+							<userParam name="peptide_sequence" type="xsd:string" value="comp2"/>
 						</activation>
 					</precursor>
 					<product>
@@ -280,7 +280,7 @@
 						</selectedIonList>
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
-							<userParam name="peptide_sequence" type="xsd:string" value="tr_gr1"/>
+							<userParam name="peptide_sequence" type="xsd:string" value="comp1"/>
 						</activation>
 					</precursor>
 					<product>
@@ -309,9 +309,9 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="tr_gr2_Precursor_i0">16981</offset>
-		<offset idRef="tr_gr1_Precursor_i0">19851</offset>
+		<offset idRef="tr_gr1_Precursor_i0">19850</offset>
 	</index>
 </indexList>
-<indexListOffset>22755</indexListOffset>
+<indexListOffset>22753</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/topp/OpenSwathChromatogramExtractor.cpp
+++ b/src/topp/OpenSwathChromatogramExtractor.cpp
@@ -7,6 +7,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SimpleOpenMSSpectraAccessFactory.h>
@@ -257,24 +258,29 @@ protected:
       // continue if the map is not empty
       if (do_continue)
       {
+        // ChromatogramExtractor::prepare_coordinates / return_chromatogram now
+        // operate exclusively on OpenSwath::LightTargetedExperiment (issue #7284
+        // cleanup; the heavyweight OpenMS::TargetedExperiment overload was removed).
+        OpenSwath::LightTargetedExperiment light_exp;
+        OpenSwathDataAccessHelper::convertTargetedExp(transition_exp_used, light_exp);
 
         // Prepare the coordinates (with or without rt extraction) and then extract the chromatograms
         ChromatogramExtractor extractor;
         if (rt_extraction_window < 0)
         {
-          extractor.prepare_coordinates(chromatogram_ptrs, coordinates, transition_exp_used, rt_extraction_window, extract_MS1);
+          extractor.prepare_coordinates(chromatogram_ptrs, coordinates, light_exp, rt_extraction_window, extract_MS1);
         }
         else
         {
           // Use an rt extraction window of 0.0 which will just write the retention time in start / end positions
-          extractor.prepare_coordinates(chromatogram_ptrs, coordinates, transition_exp_used, 0.0, extract_MS1);
+          extractor.prepare_coordinates(chromatogram_ptrs, coordinates, light_exp, 0.0, extract_MS1);
           for (ChromatogramExtractor::ExtractionCoordinates& chrom : coordinates)
           {
             chrom.rt_start = trafo_inverse.apply(chrom.rt_start) - rt_extraction_window / 2.0;
             chrom.rt_end = trafo_inverse.apply(chrom.rt_end) + rt_extraction_window / 2.0;
           }
         }
-        extractor.extractChromatograms(expptr, chromatogram_ptrs, coordinates, 
+        extractor.extractChromatograms(expptr, chromatogram_ptrs, coordinates,
             mz_extraction_window, ppm, im_window, extraction_function);
 
 #pragma omp critical (OpenSwathChromatogramExtractor_insertMS1)
@@ -288,7 +294,7 @@ protected:
               exp_settings.getDataProcessing()[j]->removeMetaValue("cached_data");
             }
           }
-          extractor.return_chromatogram(chromatogram_ptrs, coordinates, transition_exp_used, exp_settings, chromatograms, extract_MS1, im_window);
+          extractor.return_chromatogram(chromatogram_ptrs, coordinates, light_exp, exp_settings, chromatograms, extract_MS1, im_window);
         }
 
       } // end of do_continue


### PR DESCRIPTION
## Summary
Architectural follow-up to PR #9270 (which fixed the `&& false` bug in #7284). Removes the redundant `OpenMS::TargetedExperiment` overload of `ChromatogramExtractor::prepare_coordinates` by extending `OpenSwath::LightCompound` to carry the rt-range information that was the only structural reason the two overloads had to coexist.

3 commits, ~120 LOC removed net (~205 deletions / ~85 additions including comments).

## Why two overloads existed (until now)
`OpenMS::TargetedExperiment::Peptide` carries `std::vector<RetentionTime> rts`; `OpenSwath::LightCompound` only had a single `double rt`. The heavyweight overload supported `rt_extraction_window=NaN` → "use rts[0]/rts[1] as extraction window start/end" — semantics the lightweight overload structurally couldn't express. The two FeatureFinders (`FeatureFinderIdentificationAlgorithm`, `FeatureFinderAlgorithmMetaboIdent`) both pass NaN and depended on this behavior; that's why the previous removal attempt failed test regressions.

## What this PR does
**Commit 1**: Adds `double rt_start{NaN}; double rt_end{NaN};` to `LightCompound`. `OpenSwathDataAccessHelper::convertTargetedExp` now populates them from the source's `rts[0]/[1]` when present, with the same MINUTE→second conversion already applied to `rt`.

**Commit 2**: Adds the NaN branch to the LightTargetedExperiment overload of `prepare_coordinates`, replicating the (now removed) heavyweight overload's semantics. Removes the heavyweight overload (~120 LOC), the `getPeptideHelperMS1_/MS2_` helpers, the `IMPLIES` macro, and de-templates `populateMS1Transition` / `populateMS2Transition` to concrete `LightCompound` / `LightTransition` types.

**Commit 3**: Migrates the five callers of the removed overload — `OpenSwathChromatogramExtractor` TOPP tool, both FeatureFinders, `pyOpenMS/bindings/bind_misc.cpp` (preserves Python signature, converts internally), and `ChromatogramExtractor_test.cpp` — via `convertTargetedExp`.

## Test plan
- [x] **All affected suites pass locally**: 107/107 tests (ChromatogramExtractor, FeatureFinderIdentification, FeatureFinderMetaboIdent, OpenSwathChromatogramExtractor, OpenSwathWorkflow). FeatureFinder tests pass bit-identically — proving the rt-range NaN semantics are preserved through the conversion.
- [x] Synthetic regression test in `ChromatogramExtractor_test.cpp` for `ms1_isotopes>0` (added in PR #9270) still passes via the LightTargetedExperiment path.
- [ ] CI to verify cross-platform.

## Behavioral change worth calling out
The TOPP tool `OpenSwathChromatogramExtractor` previously emitted `peptide_sequence` user-params on metabolite chromatograms using `compound.id` (the TraML element id, e.g. `"tr_gr1"`); after unification it emits `compound.compound_name` (the human-readable CompoundName user-param, e.g. `"comp1"`).

This aligns the TOPP tool with `OpenSwathWorkflow`, which has been emitting `compound_name` for metabolites via the LightTargetedExperiment path since 2014. The two paths returning different values for the same input was a long-standing inconsistency between the two `extract_id_<TransitionExpT>` template specializations. Reference file `src/tests/topp/OpenSwathChromatogramExtractor_5_output.mzML` updated to reflect the now-consistent behavior.

If this is undesirable for any downstream consumer of `OpenSwathChromatogramExtractor`, please flag and we can either preserve the old TOPP-specific behavior or align `OpenSwathWorkflow` the other way (substantially more disruptive).

## Out of scope
- Reorganizing `LightCompound` into a `RetentionTimeRange` struct (mentioned as the structurally cleanest end state in the design discussion). Defer to a future cleanup if desired.
- TSV/PQP/parquet loader changes for multi-RT support — those formats don't currently encode RT ranges; this PR only ensures the `convertTargetedExp` path preserves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-compound/per-peptide retention-time range support for chromatogram extraction (explicit start/end RT).

* **Bug Fixes**
  * Improved handling of RT windows (numeric, NaN, disabled) and more robust precursor/RT lookup during extraction.

* **Refactor**
  * Extraction now uses a lightweight experiment representation internally for faster, clearer chromatogram preparation and extraction pathways.

* **Tests**
  * Updated tests to validate the lightweight pathway, RT-range behavior and isotope-aware MS1 extraction.

* **Documentation**
  * Minor docs/comments updated to reflect the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->