### PR TITLE
feat(pyOpenMS): wrap FAIMSHelper

### DIFF
--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -1294,6 +1294,9 @@ chromatograms to be consumed and need to be informed about this
     nb::class_<OpenMS::FAIMSHelper>(m, "FAIMSHelper",
         "Helper functions for FAIMS data (compensation voltages, peptide ID filtering)")
         .def(nb::init<>())
+        .def(nb::init<const OpenMS::FAIMSHelper &>())
+        .def("__copy__", [](const OpenMS::FAIMSHelper& self) { return OpenMS::FAIMSHelper(self); })
+        .def("__deepcopy__", [](const OpenMS::FAIMSHelper& self, nb::dict) { return OpenMS::FAIMSHelper(self); }, "memo"_a)
         .def_static("getCompensationVoltages",
             [](const OpenMS::PeakMap& exp) { return OpenMS::FAIMSHelper::getCompensationVoltages(exp); },
             "exp"_a,

--- a/src/pyOpenMS/bindings/bind_misc.cpp
+++ b/src/pyOpenMS/bindings/bind_misc.cpp
@@ -146,6 +146,7 @@
 #include <OpenMS/FORMAT/XTandemXMLFile.h>
 #include <OpenMS/INTERFACES/DataStructures.h>
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
+#include <OpenMS/IONMOBILITY/FAIMSHelper.h>
 #include <OpenMS/IONMOBILITY/IMTypes.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
@@ -1285,6 +1286,24 @@ chromatograms to be consumed and need to be informed about this
         .def_static("imPeakTypeToString", [](OpenMS::IMPeakType value) {
             return OpenMS::imPeakTypeToString(value);
         }, "value"_a, "Convert IMPeakType to string")
+        ;
+
+    // -----------------------------------------------------------------------
+    // FAIMSHelper
+    // -----------------------------------------------------------------------
+    nb::class_<OpenMS::FAIMSHelper>(m, "FAIMSHelper",
+        "Helper functions for FAIMS data (compensation voltages, peptide ID filtering)")
+        .def(nb::init<>())
+        .def_static("getCompensationVoltages",
+            [](const OpenMS::PeakMap& exp) { return OpenMS::FAIMSHelper::getCompensationVoltages(exp); },
+            "exp"_a,
+            "Returns the unique FAIMS compensation voltages (CVs) found across spectra of `exp` whose drift time unit is FAIMS_COMPENSATION_VOLTAGE. Empty set if none.")
+        .def_static("filterPeptidesByFAIMSCV",
+            [](const OpenMS::PeptideIdentificationList& peptides, double target_cv, double cv_tolerance) {
+                return OpenMS::FAIMSHelper::filterPeptidesByFAIMSCV(peptides, target_cv, cv_tolerance);
+            },
+            "peptides"_a, "target_cv"_a, "cv_tolerance"_a = 0.01,
+            "Filters peptide identifications by FAIMS compensation voltage. IDs without FAIMS_CV annotation are kept for backward compatibility.")
         ;
 
     // -----------------------------------------------------------------------

--- a/src/pyOpenMS/tests/unittests/test_FAIMSHelper.py
+++ b/src/pyOpenMS/tests/unittests/test_FAIMSHelper.py
@@ -41,10 +41,14 @@ def test_get_compensation_voltages_ignores_non_faims():
 
 def _make_pid_list():
     pids = poms.PeptideIdentificationList()
-    a = poms.PeptideIdentification(); a.setMetaValue("FAIMS_CV", -45.0)
-    b = poms.PeptideIdentification(); b.setMetaValue("FAIMS_CV", -65.0)
+    a = poms.PeptideIdentification()
+    a.setMetaValue("FAIMS_CV", -45.0)
+    b = poms.PeptideIdentification()
+    b.setMetaValue("FAIMS_CV", -65.0)
     c = poms.PeptideIdentification()  # no FAIMS_CV — kept for backward compat
-    pids.append(a); pids.append(b); pids.append(c)
+    pids.append(a)
+    pids.append(b)
+    pids.append(c)
     return pids
 
 

--- a/src/pyOpenMS/tests/unittests/test_FAIMSHelper.py
+++ b/src/pyOpenMS/tests/unittests/test_FAIMSHelper.py
@@ -1,0 +1,69 @@
+"""Tests for the FAIMSHelper static helpers exposed via pyOpenMS."""
+
+import pyopenms as poms
+
+
+def _make_spec(cv: float) -> poms.MSSpectrum:
+    s = poms.MSSpectrum()
+    s.setDriftTime(cv)
+    s.setDriftTimeUnit(poms.DriftTimeUnit.FAIMS_COMPENSATION_VOLTAGE)
+    return s
+
+
+def test_class_exists_and_constructible():
+    h = poms.FAIMSHelper()
+    assert h is not None
+
+
+def test_get_compensation_voltages_empty():
+    exp = poms.MSExperiment()
+    assert poms.FAIMSHelper.getCompensationVoltages(exp) == set()
+
+
+def test_get_compensation_voltages_unique():
+    exp = poms.MSExperiment()
+    exp.addSpectrum(_make_spec(-45.0))
+    exp.addSpectrum(_make_spec(-65.0))
+    exp.addSpectrum(_make_spec(-45.0))
+    cvs = poms.FAIMSHelper.getCompensationVoltages(exp)
+    assert sorted(cvs) == [-65.0, -45.0]
+
+
+def test_get_compensation_voltages_ignores_non_faims():
+    exp = poms.MSExperiment()
+    s = poms.MSSpectrum()
+    s.setDriftTime(1.23)
+    s.setDriftTimeUnit(poms.DriftTimeUnit.MILLISECOND)
+    exp.addSpectrum(s)
+    exp.addSpectrum(_make_spec(-45.0))
+    assert poms.FAIMSHelper.getCompensationVoltages(exp) == {-45.0}
+
+
+def _make_pid_list():
+    pids = poms.PeptideIdentificationList()
+    a = poms.PeptideIdentification(); a.setMetaValue("FAIMS_CV", -45.0)
+    b = poms.PeptideIdentification(); b.setMetaValue("FAIMS_CV", -65.0)
+    c = poms.PeptideIdentification()  # no FAIMS_CV — kept for backward compat
+    pids.append(a); pids.append(b); pids.append(c)
+    return pids
+
+
+def test_filter_peptides_by_faims_cv_match():
+    pids = _make_pid_list()
+    out = poms.FAIMSHelper.filterPeptidesByFAIMSCV(pids, -45.0)
+    cvs = [p.getMetaValue("FAIMS_CV") for p in out if p.metaValueExists("FAIMS_CV")]
+    assert cvs == [-45.0]
+    # untagged ID is kept
+    assert sum(1 for p in out if not p.metaValueExists("FAIMS_CV")) == 1
+
+
+def test_filter_peptides_by_faims_cv_tolerance():
+    pids = _make_pid_list()
+    # within tolerance
+    out = poms.FAIMSHelper.filterPeptidesByFAIMSCV(pids, -45.005, 0.01)
+    cvs = [p.getMetaValue("FAIMS_CV") for p in out if p.metaValueExists("FAIMS_CV")]
+    assert cvs == [-45.0]
+    # outside tolerance — only untagged ID survives
+    out2 = poms.FAIMSHelper.filterPeptidesByFAIMSCV(pids, -50.0, 0.01)
+    assert all(not p.metaValueExists("FAIMS_CV") for p in out2)
+    assert len(out2) == 1


### PR DESCRIPTION
## Summary
- Exposes `FAIMSHelper` in pyOpenMS (`bind_misc.cpp`) with both static helpers:
  - `getCompensationVoltages(PeakMap) -> set[float]`
  - `filterPeptidesByFAIMSCV(PeptideIdentificationList, target_cv, cv_tolerance=0.01) -> PeptideIdentificationList`
- Adds `tests/unittests/test_FAIMSHelper.py` covering empty input, unique-CV collection, ignoring non-FAIMS drift units, exact match filtering, tolerance window, and the backward-compatibility behavior that keeps untagged peptide IDs.

Lets users do FAIMS-aware preprocessing (CV discovery and per-CV ID filtering) directly from Python without round-tripping through TOPP tools.

## Test plan
- [x] `cmake --build OpenMS-build --target pyopenms`
- [x] `pytest src/pyOpenMS/tests/unittests/test_FAIMSHelper.py` — 6/6 pass
- [x] Full pyOpenMS unittests — only the pre-existing `SpectrumRanges` docstring failure (`:meth:` role), unrelated to this change
- [x] `test_docstrings.py -k FAIMSHelper` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FAIMS helper to extract unique FAIMS compensation voltages from experiments and to filter peptide identifications by target compensation voltage with configurable tolerance (default 0.01), while preserving identifications lacking FAIMS annotations for backward compatibility.

* **Tests**
  * Added unit tests covering voltage extraction, deduplication, unit filtering, exact/tolerance-based peptide filtering, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->