### PR TITLE
BrukerTimsFile: add 2D non-maximum suppression to centroiding and regression test

### DIFF
--- a/src/openms/source/FORMAT/BrukerTimsFile.cpp
+++ b/src/openms/source/FORMAT/BrukerTimsFile.cpp
@@ -578,7 +578,10 @@ namespace OpenMS
           smoothed[key] = weighted_sum;
         }
 
-        // Step 3: Find local maxima in smoothed grid
+        // Step 3: Find local maxima in the smoothed grid. Equal-valued
+        // plateaus are kept as candidates here and collapsed by the
+        // non-maximum suppression below, which prevents one broad 2D peak from
+        // producing several almost-identical centroid m/z values.
         std::vector<uint64_t> maxima;
         for (const auto& [key, val] : smoothed)
         {
@@ -599,6 +602,39 @@ namespace OpenMS
           }
           if (is_max) maxima.push_back(key);
         }
+
+        // Step 3b: Apply one-bin 2D non-maximum suppression. The centroiding
+        // window below intentionally overlaps neighboring cells (±2 bins), so
+        // adjacent maxima would otherwise reuse nearly the same support and can
+        // yield peaks that are indistinguishable in m/z and IM. Process the
+        // strongest candidates first and keep deterministic ordering for ties.
+        std::sort(maxima.begin(), maxima.end(), [&smoothed](uint64_t a, uint64_t b) {
+          double intensity_a = smoothed.at(a);
+          double intensity_b = smoothed.at(b);
+          if (intensity_a != intensity_b) return intensity_a > intensity_b;
+          return a < b;
+        });
+
+        std::vector<uint64_t> suppressed_maxima;
+        suppressed_maxima.reserve(maxima.size());
+        boost::unordered_flat_map<uint64_t, bool> suppressed;
+        suppressed.reserve(maxima.size() * 9);
+        for (uint64_t max_key : maxima)
+        {
+          if (suppressed.find(max_key) != suppressed.end()) continue;
+
+          suppressed_maxima.push_back(max_key);
+          uint32_t center_scan = static_cast<uint32_t>(max_key & 0xFFFFFFFF);
+          uint32_t center_mz_bin = static_cast<uint32_t>(max_key >> 32);
+          for (int dm = -1; dm <= 1; ++dm)
+          {
+            for (int ds = -1; ds <= 1; ++ds)
+            {
+              if (auto nkey = neighborKey(center_mz_bin, center_scan, dm, ds)) { suppressed[*nkey] = true; }
+            }
+          }
+        }
+        maxima.swap(suppressed_maxima);
 
         // Step 4: Centroid each maximum from original denoised cells within ±2 radius
         std::vector<OutputPeak> result;

--- a/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
+++ b/src/tests/class_tests/openms/source/BrukerTimsFile_test.cpp
@@ -20,6 +20,8 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h>
 
+#include <cmath>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -955,8 +957,24 @@ START_SECTION(DIA MS2 centroiding test)
     }
   }
 
-  STATUS("DIA centroiding: MS2 spectra=" << cent_ms2_count
-         << " peaks=" << cent_ms2_peaks);
+  // Regression guard: the 2D peak picker must not emit adjacent centroids that
+  // are indistinguishable in both m/z and ion mobility. Such peaks typically
+  // come from neighboring local maxima reusing the same centroid support.
+  Size ambiguous_2d_duplicates = 0;
+  for (const auto& spec : exp_cent)
+  {
+    if (spec.getMSLevel() != 2 || spec.empty() || ! spec.containsIMData()) continue;
+
+    const auto& im_array = spec.getFloatDataArrays()[0];
+    TEST_EQUAL(im_array.size(), spec.size());
+    for (Size i = 1; i < spec.size(); ++i)
+    {
+      if ((spec[i].getMZ() - spec[i - 1].getMZ()) < 1e-6 && std::fabs(im_array[i] - im_array[i - 1]) < 1e-6) { ++ambiguous_2d_duplicates; }
+    }
+  }
+  TEST_EQUAL(ambiguous_2d_duplicates, 0);
+
+  STATUS("DIA centroiding: MS2 spectra=" << cent_ms2_count << " peaks=" << cent_ms2_peaks);
 }
 END_SECTION
 


### PR DESCRIPTION
### Motivation

- Prevent neighboring local maxima from producing indistinguishable centroided peaks in m/z and ion mobility by collapsing adjacent candidates prior to centroiding.

### Description

- Apply a one-bin 2D non-maximum suppression pass after local-max detection in `BrukerTimsFile.cpp`, sorting candidates by smoothed intensity and using a deterministic tie-breaker (`a < b`).
- Mark suppressed neighbors in a `boost::unordered_flat_map` and retain only surviving maxima used for centroiding within the existing ±2 radius support.
- Add explanatory comments and keep plateaus as candidates to be resolved by the suppression step.
- Update the test `BrukerTimsFile_test.cpp` by including `<cmath>` and adding a regression check that scans centroided MS2 spectra for adjacent peaks indistinguishable in both m/z and IM (counts `ambiguous_2d_duplicates` and expects `0`).

### Testing

- Ran the modified unit test `BrukerTimsFile_test` which includes the new ambiguity regression check and it passed.
- Existing DIA centroiding tests were exercised as part of the same test and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7dfc708c8328a4bbfd2dab93d99a)