### PR TITLE
docs(Adduct): add class-level Doxygen and proper per-method tags

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
@@ -37,10 +37,10 @@ namespace OpenMS
                             formula triggers a warning at construction.
       - @c amount         : how many copies of @c formula contribute
                             (stoichiometric count; e.g. 2 in @c "M+2K-H").
-                            Negative amounts are rejected with a warning.
+                            Negative amounts are accepted but emit a warning.
       - @c singleMass     : monoisotopic mass of one entity (one copy of
-                            @c formula). The full contribution to the
-                            observed @em m/z is @c amount @c * @c singleMass.
+                            @c formula). The full mass contribution of this
+                            Adduct is @c amount @c * @c singleMass.
       - @c charge         : per-entity charge of the adduct (e.g. @c +1 for
                             Na+, @c -1 for a proton loss). The ion's total
                             charge is @c amount @c * @c charge.
@@ -100,8 +100,9 @@ public:
     /**
       @brief Construct with only the per-entity charge set.
 
-      All other fields are zero/empty and must be populated via setters
-      before the Adduct is used in scoring.
+      All other fields are zero/empty. @c amount, @c singleMass,
+      @c log_prob, and @c formula can be populated via setters; @c rt_shift
+      and @c label can only be set via the full constructor.
 
       @param[in] charge Per-entity charge (e.g. @c +1 for Na+).
     */
@@ -182,8 +183,7 @@ public:
 
     /**
       @brief Set the per-entity charge.
-      @param[in] charge Per-entity charge (zero is allowed here, unlike in
-                        the all-fields constructor).
+      @param[in] charge Per-entity charge.
     */
     void setCharge(const Int& charge);
 
@@ -264,7 +264,7 @@ public:
         ("Na1", +1, 1) -> "[M+Na]+"
         ("Na1", +1, 2) -> "[2M+Na]+"
         ("H1",  -1, 1) -> "[M-H]-"
-        ("NH3", +1, 1) -> "[M+H+3N]+"   (canonical sort of NH3)
+        ("NH3", +1, 1) -> "[M+3H+N]+"   (canonical sort of NH3)
       @endverbatim
 
       @param[in] ion_string     EmpiricalFormula-parseable element string.

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
@@ -18,80 +18,286 @@
 namespace OpenMS
 {
 
+  /**
+    @brief One elementary adduct contribution to a feature's ionization state.
+
+    An Adduct describes a single chemical "piece" that can be added to (or
+    removed from) a neutral molecule during ionization — for example one
+    sodium cation, one ammonia adduct, or one lost proton. It is the
+    @em building-block used by feature/charge deconvolution algorithms
+    (FeatureDeconvolution, MetaboliteFeatureDeconvolution, Compomer,
+    QTClusterFinder); several Adducts combine to describe the complete
+    ion observed for one feature.
+
+    @section Adduct_fields Fields
+
+      - @c formula        : chemical formula of one entity, e.g. @c "Na",
+                            @c "H", @c "NH3", @c "C2H3N". Must parse as a
+                            neutral EmpiricalFormula; explicit charge in the
+                            formula triggers a warning at construction.
+      - @c amount         : how many copies of @c formula contribute
+                            (stoichiometric count; e.g. 2 in @c "M+2K-H").
+                            Negative amounts are rejected with a warning.
+      - @c singleMass     : monoisotopic mass of one entity (one copy of
+                            @c formula). The full contribution to the
+                            observed @em m/z is @c amount @c * @c singleMass.
+      - @c charge         : per-entity charge of the adduct (e.g. @c +1 for
+                            Na+, @c -1 for a proton loss). The ion's total
+                            charge is @c amount @c * @c charge.
+      - @c log_prob       : log-prior on observing this adduct, used by
+                            deconvolution algorithms when scoring competing
+                            hypotheses.
+      - @c rt_shift       : optional retention-time shift induced by one
+                            entity (non-zero for adducts attached @em prior
+                            to ESI, e.g. covalent labels; zero for
+                            in-source adducts like @c Na or @c K that do
+                            not affect chromatographic behavior).
+      - @c label          : free-form label, typically used to mark heavy
+                            isotopic labels.
+
+    @section Adduct_vs_adductinfo Relationship to AdductInfo
+
+    AdductInfo (in CHEMISTRY/) represents an entire @em adduct specification
+    — the parsed form of a string such as @c "[M+2K-H]+" with the molecular
+    entity @em M, an n-mer multiplier, and a net charge. Adduct represents
+    only a single piece of that specification (e.g. just the @c "2K" part
+    or the @c "-H" part). AdductInfo is used for matching observed @em m/z
+    against database compounds; Adduct is used to build up @em hypotheses
+    about which combinations of pieces might explain a feature.
+
+    @section Adduct_arithmetic Arithmetic
+
+    @c operator*(Int) scales the amount: @c a*3 returns a copy of @c a
+    with @c amount tripled. @c operator+ and @c operator+= merge two
+    Adducts that share the same @c formula, summing their amounts (used
+    when accumulating identical pieces of an ion's adduct composition).
+    Mixing adducts with different formulae throws.
+
+    @section Adduct_equality Equality and hashing
+
+    Equality compares @c charge, @c amount, @c singleMass, @c log_prob,
+    and @c formula. @c rt_shift and @c label are deliberately excluded so
+    that two Adducts describing the same physical entity but tagged with
+    different labels still compare equal — this matches the std::hash
+    specialization for Adduct (see bottom of this header).
+
+    @ingroup Datastructures
+  */
   class OPENMS_DLLAPI Adduct
   {
 public:
 
+    /// Convenience typedef for a list of Adducts (used by feature deconvolution).
     typedef std::vector<Adduct> AdductsType;
 
-    /// Default C'tor
+    /**
+      @brief Default constructor. All numeric fields zero-initialised; formula
+      and label empty. Use this only as a placeholder; populate fields via
+      setters before use.
+    */
     Adduct();
 
-    /// C'tor with initial charge
+    /**
+      @brief Construct with only the per-entity charge set.
+
+      All other fields are zero/empty and must be populated via setters
+      before the Adduct is used in scoring.
+
+      @param[in] charge Per-entity charge (e.g. @c +1 for Na+).
+    */
     Adduct(Int charge);
 
-    /// C'tor for all members
+    /**
+      @brief Construct with all fields populated.
+
+      @param[in] charge       Per-entity charge (e.g. @c +1 for Na+).
+      @param[in] amount       Stoichiometric count of this adduct in the ion
+                              (e.g. @c 2 for @c "2K" in @c "M+2K-H"). A
+                              negative value is accepted but emits a warning.
+      @param[in] singleMass   Monoisotopic mass of one entity in Dalton.
+      @param[in] formula      Chemical formula of one entity (e.g. @c "Na",
+                              @c "NH3"). Must parse as a neutral
+                              EmpiricalFormula; warnings are logged for
+                              empty, charged, or ambiguous single-element
+                              formulas (e.g. @c "C2" with no other element).
+      @param[in] log_prob     Log-prior on observing this adduct (default 0).
+      @param[in] rt_shift     RT shift contributed by one entity in seconds
+                              (default 0; non-zero for pre-ESI labels).
+      @param[in] label        Free-form label, typically heavy-isotope tag.
+    */
     Adduct(Int charge, Int amount, double singleMass, const String& formula, double log_prob, double rt_shift, const String& label = "");
 
-    /// Increase amount of this adduct by factor @param[in] m
+    /**
+      @brief Multiply the stoichiometric @c amount by an integer factor.
+
+      Returns a copy with @c amount scaled; other fields unchanged. Used
+      when expanding @c m*Adduct hypotheses (e.g. promoting one @c Na to
+      @c 3 @c Na).
+
+      @param[in] m Integer multiplier.
+      @return A new Adduct with the scaled amount.
+    */
     Adduct operator*(const Int m) const;
-    /// Add two adducts amount if they are equal (defined by equal formula)
+
+    /**
+      @brief Sum two Adducts that describe the same chemical entity.
+
+      Both operands must share the same @c formula; only the @c amount
+      fields are summed. Used when accumulating identical pieces of an
+      ion's adduct composition.
+
+      @param[in] rhs The other Adduct (must have identical @c formula).
+      @return A new Adduct with the summed amount.
+      @throws const char* C-string literal when @p rhs has a different
+              @c formula than @c *this.
+    */
     Adduct operator+(const Adduct& rhs);
-    /// Add other adducts amount to *this (equal formula required!)
+
+    /**
+      @brief In-place version of @c operator+. Same precondition
+      (matching formulas).
+
+      @param[in] rhs The other Adduct (must have identical @c formula).
+      @throws const char* C-string literal when @p rhs has a different
+              @c formula than @c *this.
+    */
     void operator+=(const Adduct& rhs);
 
 
-    /// Print the contents of an Adduct to a stream.
+    /// Print all fields except @c rt_shift and @c label to @p os
+    /// (for diagnostics; not a parseable serialization).
     friend OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const Adduct& a);
 
-    /// Comparator
+    /**
+      @brief Equality on @c charge, @c amount, @c singleMass, @c log_prob,
+      and @c formula. Deliberately ignores @c rt_shift and @c label so
+      that adducts differing only in labeling tag still compare equal.
+    */
     friend OPENMS_DLLAPI bool operator==(const Adduct& a, const Adduct& b);
 
     //@{ Accessors
+
+    /// @brief Per-entity charge; @c +1 for typical cation adducts (Na+, H+).
     const Int& getCharge() const;
 
+    /**
+      @brief Set the per-entity charge.
+      @param[in] charge Per-entity charge (zero is allowed here, unlike in
+                        the all-fields constructor).
+    */
     void setCharge(const Int& charge);
 
+    /// @brief Stoichiometric count of this adduct in the ion.
     const Int& getAmount() const;
+
+    /**
+      @brief Set the stoichiometric count. Logs a warning on negative
+      values but accepts them.
+      @param[in] amount Stoichiometric count (typically @c >= 0).
+    */
     void setAmount(const Int& amount);
 
+    /// @brief Monoisotopic mass of one entity (Dalton).
     const double& getSingleMass() const;
+
+    /**
+      @brief Set the monoisotopic mass of one entity.
+      @param[in] singleMass Monoisotopic mass of one entity in Dalton.
+    */
     void setSingleMass(const double& singleMass);
 
+    /// @brief Log-prior on observing this adduct.
     const double& getLogProb() const;
+
+    /**
+      @brief Set the log-prior on observing this adduct.
+      @param[in] log_prob Log-prior (negative for unlikely adducts; @c 0
+                          for no prior preference).
+    */
     void setLogProb(const double& log_prob);
 
+    /// @brief Chemical formula of one entity (canonicalised by
+    /// EmpiricalFormula, e.g. @c "H2O" — not @c "OH2").
     const String& getFormula() const;
+
+    /**
+      @brief Set the chemical formula of one entity. The input is parsed
+      as an EmpiricalFormula and re-emitted in canonical order; warnings
+      are logged for empty, explicitly charged, or ambiguous-single-
+      element formulas.
+      @param[in] formula EmpiricalFormula-parseable string (e.g. @c "Na",
+                         @c "NH3", @c "C2H3N").
+    */
     void setFormula(const String& formula);
 
+    /// @brief RT shift induced by one entity (seconds). Non-zero only for
+    /// adducts attached prior to ESI (e.g. covalent labels).
     const double& getRTShift() const;
+
+    /// @brief Free-form label (typically a heavy-isotope tag).
     const String& getLabel() const;
 
-    // convert a ion string to adduct string with charge information (eg. ion_string = "Na1", charge = "1" --> "[M+Na]+")
+    /**
+      @brief Render @p ion_string + @p charge as a canonical adduct string,
+      assuming a monomer (n=1).
+
+      Convenience overload that calls the three-argument version with
+      @c mol_multiplier = 1.
+
+      @param[in] ion_string Element/formula portion of the adduct,
+                            EmpiricalFormula-parseable (e.g. @c "Na1",
+                            @c "NH3").
+      @param[in] charge     Signed net charge of the resulting ion.
+      @return Adduct string in the form @c "[M+Na]+", @c "[M-H]-", etc.
+    */
     String toAdductString(const String& ion_string, const Int& charge);
 
-    /// Convert to adduct string with explicit multiplier (e.g., mol_multiplier=2 -> "[2M+H]+")
+    /**
+      @brief Render @p ion_string + @p charge as a canonical adduct string,
+      with an explicit n-mer multiplier.
+
+      Element/coefficient terms are sorted alphabetically by element symbol
+      so equivalent formulas always produce identical strings.
+
+      Examples:
+      @verbatim
+        ("Na1", +1, 1) -> "[M+Na]+"
+        ("Na1", +1, 2) -> "[2M+Na]+"
+        ("H1",  -1, 1) -> "[M-H]-"
+        ("NH3", +1, 1) -> "[M+H+3N]+"   (canonical sort of NH3)
+      @endverbatim
+
+      @param[in] ion_string     EmpiricalFormula-parseable element string.
+      @param[in] charge         Signed net charge of the resulting ion.
+      @param[in] mol_multiplier N-mer multiplier (@c 1 = monomer,
+                                @c 2 = dimer, ...).
+      @return Canonical adduct string.
+    */
     static String toAdductString(const String& ion_string, const Int& charge, Int mol_multiplier);
     //}
 
 private:
-    Int charge_; ///< usually +1
-    Int amount_; ///< number of entities
-    double singleMass_; ///< mass of a single entity
-    double log_prob_; ///< log probability of observing a single entity of this adduct
-    String formula_; ///< chemical formula (parsable by EmpiricalFormula)
-    double rt_shift_; ///< RT shift induced by a single entity of this adduct (this is for adducts attached prior to ESI, e.g. labeling)
-    String label_; ///< Label for this adduct (can be used to indicate heavy labels)
+    Int charge_;        ///< per-entity charge (e.g. +1 for Na+)
+    Int amount_;        ///< stoichiometric count of this entity
+    double singleMass_; ///< monoisotopic mass of one entity (Da)
+    double log_prob_;   ///< log-prior on observing this adduct
+    String formula_;    ///< chemical formula of one entity (EmpiricalFormula-parseable, canonicalised)
+    double rt_shift_;   ///< RT shift induced by one entity (s); non-zero only for pre-ESI labels
+    String label_;      ///< free-form tag (e.g. heavy-isotope label name)
 
+    /// Validate and canonicalise @p formula. Warns on empty, charged, or
+    /// ambiguous single-element inputs. Returns the canonical form.
     String checkFormula_(const String& formula);
 
   };
 
 } // namespace OpenMS
 
-// Hash function specialization for Adduct
-// Note: Only hash fields used in operator== (charge, amount, singleMass, log_prob, formula)
-// Do NOT hash rt_shift_ and label_ as they are not compared in operator==
+// Hash function specialization for Adduct.
+//
+// Note: only the fields compared by operator== (charge, amount, singleMass,
+// log_prob, formula) feed into the hash. rt_shift and label are deliberately
+// excluded so two Adducts that compare equal also hash equal.
 namespace std
 {
   template<>
@@ -108,5 +314,3 @@ namespace std
     }
   };
 } // namespace std
-
-


### PR DESCRIPTION
## Summary

Adds proper class-level Doxygen to `Adduct` — the value class used as a building block by `FeatureDeconvolution`, `MetaboliteFeatureDeconvolution`, `Compomer`, `QTClusterFinder`, `AccurateMassSearchEngine`, and `IdentificationData`. Previously had **zero** class-level documentation and only `///` one-liners on each setter/getter, despite carrying non-trivial semantics across seven different feature/charge-deconvolution call sites. No behavioural change.

## What's in the docs

- **Class-level `@brief` + long description** — what one `Adduct` represents (a single chemical piece, e.g. `Na`, `H`, `NH3`, in an ion's adduct composition) and how multiple `Adduct`s compose into a `Compomer`.
- **`@section Adduct_fields`** — full semantics, units, and constraints of every member: `formula` (canonicalised neutral EmpiricalFormula), `amount` (stoichiometric count, e.g. `2` in `M+2K-H`), `singleMass` (monoisotopic per-entity, Dalton), `charge` (per-entity), `log_prob` (deconvolution prior), `rt_shift` (non-zero only for pre-ESI labels, seconds), `label` (free-form tag).
- **`@section Adduct_vs_adductinfo`** — disambiguates the two similarly named classes: `AdductInfo` (CHEMISTRY/) represents the whole parsed adduct specification `[M+2K-H]+`, `Adduct` (DATASTRUCTURES/) represents one piece of that specification (`2K` or `-H`).
- **`@section Adduct_arithmetic`** — operator semantics for `*Int`, `+`, `+=`, including the matching-formula precondition and the throw-on-mismatch behavior.
- **`@section Adduct_equality`** — explicit rationale for why `operator==` (and the matching `std::hash` specialization) ignore `rt_shift` and `label`: so adducts differing only in labeling tag still compare and hash equal.
- **Per-method docs upgraded** to proper `@brief` / `@param[in]` / `@return`. Constructors now have parameter-level docs (they had none). The two static `toAdductString` overloads now show worked examples (`[M+Na]+`, `[2M+Na]+`, `[M-H]-`).
- **Units** stated where missing (Dalton for masses, seconds for `rt_shift`).

## Test plan

- [ ] Build passes (`cmake --build OpenMS-build --target OpenMS` — verified locally).
- [ ] Doxygen build still parses the file (balanced `@section`, `@verbatim`/`@endverbatim`, no broken cross-references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and rewritten Doxygen for the Adduct component: clarified each public field (formula, amount, single mass, charge, probability, RT shift, label), documented arithmetic operator behavior and equality semantics, and described hashing behavior and which fields are included—no public API or signatures were changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9289)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->