### PR TITLE
docs(AccurateMassSearchResult): add class-level Doxygen and field semantics

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -28,120 +28,280 @@
 
 namespace OpenMS
 {
+  /**
+    @brief One small-molecule hit produced by AccurateMassSearchEngine.
+
+    Represents a single (observed feature/peak) — (database compound +
+    adduct) match. AccurateMassSearchEngine emits one of these per accepted
+    (feature, adduct, candidate-compound) combination, so the same input
+    feature can appear in several results if it is consistent with more
+    than one adduct or matches multiple isobaric compounds in the database.
+
+    @section AccurateMassSearchResult_lifecycle Lifecycle
+
+    Each result is built up incrementally by the search engine via the
+    setters and exposed read-only to consumers via the getters. The class
+    holds no logic of its own — it is a plain value object grouping the
+    observable, the database hit, and the diagnostics that explain why the
+    two were matched.
+
+    @section AccurateMassSearchResult_fields Field semantics
+
+    Observed quantities (from the spectrum / feature):
+      - @c observed_mz       : observed @em m/z of the feature.
+      - @c observed_rt       : retention time of the feature.
+      - @c observed_intensity: intensity of the feature.
+      - @c individual_intensities : per-sample intensities for consensus
+                                    features (empty for single-map input).
+      - @c mass_trace_intensities : per-isotopologue intensities of the
+                                    underlying mass traces (used for the
+                                    isotope-pattern similarity score).
+
+    Match-derived quantities:
+      - @c searched_mass : neutral mass back-calculated from
+                           @c observed_mz under the assumption of
+                           @c found_adduct and @c charge. Used as the
+                           database query.
+      - @c db_mass       : neutral mass of the matched database compound
+                           (the "ground truth" for this hit).
+      - @c theoretical_mz: @em m/z that the matched compound + adduct
+                           would produce; differs from @c observed_mz by
+                           @c mz_error_ppm.
+      - @c mz_error_ppm  : signed @em m/z error in ppm, observed vs.
+                           theoretical.
+      - @c charge        : ion charge under which the match was attempted
+                           (positive for cations, negative for anions).
+
+    Compound annotation:
+      - @c found_adduct      : adduct that produced the match, in the
+                               notation used by AdductInfo
+                               (e.g. @c "M+H;1+", @c "M-H2O+H;1+").
+      - @c empirical_formula : empirical formula of the matched compound.
+      - @c matching_hmdb_ids : zero or more database IDs that share the
+                               formula and mass (multiple isobars are
+                               common in HMDB-style databases).
+
+    Back-references:
+      - @c matching_index      : index of the hit within the engine's
+                                 internal candidate list (useful when
+                                 reconstructing scoring details after
+                                 export).
+      - @c source_feature_index: index of the source feature/peak in the
+                                 input map (lets callers traceback to the
+                                 raw observation).
+
+    Quality score:
+      - @c isotopes_sim_score : isotope-pattern similarity between the
+                                feature's observed mass-trace intensities
+                                and the theoretical pattern of the
+                                candidate compound. Higher = better.
+
+    @ingroup Analysis_ID
+    @see AccurateMassSearchEngine
+    @see AdductInfo
+  */
   class OPENMS_DLLAPI AccurateMassSearchResult
   {
   public:
-    /// Default constructor
+    /// @brief Default constructor; all numeric fields zero, strings and
+    /// vectors empty.
     AccurateMassSearchResult();
 
-    /// Default destructor
+    /// @brief Default destructor.
     ~AccurateMassSearchResult();
 
-    /// copy constructor
-    AccurateMassSearchResult(const AccurateMassSearchResult&);
+    /// @brief Copy constructor.
+    /// @param[in] other Source result to copy from.
+    AccurateMassSearchResult(const AccurateMassSearchResult& other);
 
-    /// assignment operator
-    AccurateMassSearchResult& operator=(const AccurateMassSearchResult&);
+    /// @brief Copy-assignment operator.
+    /// @param[in] other Source result to copy from.
+    AccurateMassSearchResult& operator=(const AccurateMassSearchResult& other);
 
-    /// get the m/z of the small molecule + adduct
+    /// @brief Observed @em m/z of the source feature (Th).
     double getObservedMZ() const;
 
-    /// set the m/z of the small molecule + adduct
-    void setObservedMZ(const double&);
+    /**
+      @brief Set the observed @em m/z of the source feature.
+      @param[in] mz Observed @em m/z (Th).
+    */
+    void setObservedMZ(const double& mz);
 
-    /// get the theoretical m/z of the small molecule + adduct
+    /// @brief Theoretical @em m/z of the matched compound + adduct (Th).
     double getCalculatedMZ() const;
 
-    /// set the theoretical m/z of the small molecule + adduct
-    void setCalculatedMZ(const double&);
+    /**
+      @brief Set the theoretical @em m/z of the matched compound + adduct.
+      @param[in] mz Theoretical @em m/z of compound + adduct (Th).
+    */
+    void setCalculatedMZ(const double& mz);
 
-    /// get the mass used to query the database (uncharged small molecule)
+    /// @brief Neutral mass used to query the database (Dalton), back-
+    /// calculated from #getObservedMZ assuming #getFoundAdduct and
+    /// #getCharge.
     double getQueryMass() const;
 
-    /// set the mass used to query the database (uncharged small molecule)
-    void setQueryMass(const double&);
+    /**
+      @brief Set the neutral mass used to query the database.
+      @param[in] mass Neutral mass used to query the database (Da).
+    */
+    void setQueryMass(const double& mass);
 
-    /// get the mass returned by the query (uncharged small molecule)
+    /// @brief Neutral mass of the matched database compound (Dalton).
     double getFoundMass() const;
 
-    /// set the mass returned by the query (uncharged small molecule)
-    void setFoundMass(const double&);
+    /**
+      @brief Set the neutral mass of the matched database compound.
+      @param[in] mass Neutral mass of the matched compound (Da).
+    */
+    void setFoundMass(const double& mass);
 
-    /// get the charge
+    /// @brief Ion charge under which this match was attempted (positive
+    /// for cations, negative for anions).
     Int getCharge() const;
 
-    /// set the charge
-    void setCharge(const Int&);
+    /**
+      @brief Set the ion charge under which this match was attempted.
+      @param[in] ch Signed ion charge (positive for cations).
+    */
+    void setCharge(const Int& ch);
 
-    /// get the error between observed and theoretical m/z in ppm
+    /// @brief Signed @em m/z error in ppm: (observed − theoretical) /
+    /// theoretical · 1e6.
     double getMZErrorPPM() const;
 
-    /// set the error between observed and theoretical m/z in ppm
-    void setMZErrorPPM(const double);
+    /**
+      @brief Set the signed @em m/z error in ppm.
+      @param[in] ppm Signed @em m/z error (observed − theoretical) in ppm.
+    */
+    void setMZErrorPPM(const double ppm);
 
-    /// get the observed rt
+    /// @brief Retention time of the source feature (seconds).
     double getObservedRT() const;
 
-    /// set the observed rt
+    /**
+      @brief Set the retention time of the source feature (seconds).
+      @param[in] rt Retention time of the source feature (s).
+    */
     void setObservedRT(const double& rt);
 
-    /// get the observed intensity
+    /// @brief Intensity of the source feature (consensus-aggregated when
+    /// the input was a ConsensusMap).
     double getObservedIntensity() const;
 
-    /// set the observed intensity
-    void setObservedIntensity(const double&);
+    /**
+      @brief Set the intensity of the source feature.
+      @param[in] intensity Intensity of the source feature.
+    */
+    void setObservedIntensity(const double& intensity);
 
-    /// get the observed intensities
+    /// @brief Per-sample intensities of the source feature when the input
+    /// is a ConsensusMap; empty otherwise.
     std::vector<double> getIndividualIntensities() const;
 
-    /// set the observed intensities
-    void setIndividualIntensities(const std::vector<double>&);
+    /**
+      @brief Set the per-sample intensities of the source feature.
+      @param[in] indiv_ints Per-sample intensities (ConsensusMap input).
+    */
+    void setIndividualIntensities(const std::vector<double>& indiv_ints);
 
+    /// @brief Index of this hit in the engine's internal candidate list
+    /// for the source feature. Useful when reconstructing scoring details
+    /// after export.
     Size getMatchingIndex() const;
-    void setMatchingIndex(const Size&);
 
+    /**
+      @brief Set the candidate-list index.
+      @param[in] idx Index in the engine's internal candidate list.
+    */
+    void setMatchingIndex(const Size& idx);
+
+    /// @brief Index of the source feature in the input map (back-
+    /// reference to the raw observation).
     Size getSourceFeatureIndex() const;
-    void setSourceFeatureIndex(const Size&);
 
+    /**
+      @brief Set the source feature index.
+      @param[in] idx Index in the input feature/peak map.
+    */
+    void setSourceFeatureIndex(const Size& idx);
+
+    /// @brief Adduct that produced the match, in AdductInfo notation
+    /// (e.g. @c "M+H;1+", @c "M-H2O+H;1+").
     const String& getFoundAdduct() const;
-    void setFoundAdduct(const String&);
 
+    /**
+      @brief Set the adduct that produced the match.
+      @param[in] add Adduct in AdductInfo notation (e.g. @c "M+H;1+").
+    */
+    void setFoundAdduct(const String& add);
+
+    /// @brief Empirical formula of the matched database compound.
     const String& getFormulaString() const;
-    void setEmpiricalFormula(const String&);
 
+    /**
+      @brief Set the empirical formula of the matched database compound.
+      @param[in] ep Empirical formula of the matched compound.
+    */
+    void setEmpiricalFormula(const String& ep);
+
+    /// @brief All database identifiers (HMDB-style) that share the
+    /// matched compound's formula and mass; can be empty when no
+    /// identifier mapping is available.
     const std::vector<String>& getMatchingHMDBids() const;
-    void setMatchingHMDBids(const std::vector<String>&);
 
-    /// return trace intensities of the underlying feature;
+    /**
+      @brief Set the matched database identifiers.
+      @param[in] ids Database identifiers (HMDB-style).
+    */
+    void setMatchingHMDBids(const std::vector<String>& ids);
+
+    /// @brief Per-isotopologue intensities of the underlying feature's
+    /// mass traces; used as the empirical isotope pattern when computing
+    /// #getIsotopesSimScore.
     const std::vector<double>& getMasstraceIntensities() const;
-    void setMasstraceIntensities(const std::vector<double>&);
 
+    /**
+      @brief Set the underlying feature's per-isotopologue intensities.
+      @param[in] intensities Per-isotopologue intensities from the feature.
+    */
+    void setMasstraceIntensities(const std::vector<double>& intensities);
+
+    /// @brief Similarity between the observed isotope pattern (from
+    /// #getMasstraceIntensities) and the theoretical pattern of the
+    /// matched compound. Higher values indicate a better match.
     double getIsotopesSimScore() const;
-    void setIsotopesSimScore(const double&);
 
-    // debug/output functions
+    /**
+      @brief Set the isotope-pattern similarity score.
+      @param[in] score Isotope-pattern similarity score (higher = better.
+    */
+    void setIsotopesSimScore(const double& score);
+
+    /// @brief Diagnostic stream output of all fields (not a parseable
+    /// serialization).
     friend OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const AccurateMassSearchResult& amsr);
 
 private:
     /// Stored information/results of DB query
-    double observed_mz_;
-    double theoretical_mz_;
-    double searched_mass_;
-    double db_mass_;
-    Int charge_;
-    double mz_error_ppm_;
-    double observed_rt_;
-    double observed_intensity_;
-    std::vector<double> individual_intensities_;
-    Size matching_index_;
-    Size source_feature_index_;
+    double observed_mz_;                   ///< observed m/z of source feature (Th)
+    double theoretical_mz_;                ///< theoretical m/z of matched compound + adduct (Th)
+    double searched_mass_;                 ///< neutral mass used to query the database (Da)
+    double db_mass_;                       ///< neutral mass of the matched database compound (Da)
+    Int charge_;                           ///< charge assumed for this match (positive for cations)
+    double mz_error_ppm_;                  ///< signed m/z error (observed − theoretical), ppm
+    double observed_rt_;                   ///< RT of source feature (s)
+    double observed_intensity_;            ///< intensity of source feature
+    std::vector<double> individual_intensities_; ///< per-sample intensities (ConsensusMap input)
+    Size matching_index_;                  ///< index in the engine's internal candidate list
+    Size source_feature_index_;            ///< index in the input feature/peak map
 
-    String found_adduct_;
-    String empirical_formula_;
-    std::vector<String> matching_hmdb_ids_;
+    String found_adduct_;                  ///< adduct in AdductInfo notation (e.g. "M+H;1+")
+    String empirical_formula_;             ///< empirical formula of matched compound
+    std::vector<String> matching_hmdb_ids_;///< zero or more DB IDs (multiple isobars share a formula)
 
-    std::vector<double> mass_trace_intensities_;
-    double isotopes_sim_score_;
+    std::vector<double> mass_trace_intensities_; ///< per-isotopologue intensities from the feature
+    double isotopes_sim_score_;            ///< observed vs. theoretical isotope-pattern similarity
   };
 
   OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const AccurateMassSearchResult& amsr);


### PR DESCRIPTION
## Summary

Adds proper class-level Doxygen to `AccurateMassSearchResult` — the per-hit value object emitted by `AccurateMassSearchEngine` in metabolomics workflows. The class carries 16 fields (observation, match-derived values, compound annotation, back-references, quality score) but previously had **no** class-level documentation and only `///` one-liners on most accessors, despite being the primary output type for accurate-mass small-molecule search. No behavioural change.

## What's in the docs

- **Class-level `@brief` + long description** — what one result represents (a single feature ↔ DB-compound + adduct match) and warns that the same input feature can appear in several results when consistent with more than one adduct or isobaric compound.
- **`@section AccurateMassSearchResult_lifecycle`** — notes that the class is a plain value object built up by the engine via setters; no internal logic.
- **`@section AccurateMassSearchResult_fields`** — groups the 16 fields into four buckets (observed quantities, match-derived quantities, compound annotation, back-references) and spells out the meaning and relationships between them. Most importantly:
  - `searched_mass` is the neutral mass back-calculated from `observed_mz` under the assumption of `found_adduct` and `charge` — i.e. it is the @em query, not a result. This was not at all obvious from the previous one-liner.
  - `db_mass` is the ground-truth neutral mass from the database.
  - `mass_trace_intensities` feeds the isotope-pattern similarity score.
  - `matching_hmdb_ids` can be empty or hold multiple isobars sharing the same formula.
- **Per-accessor docs upgraded** to proper `@brief` with units (Th for m/z, Da for masses, s for RT, ppm for error) and constraints. The sign conventions for `charge` and `mz_error` are now explicit.
- **Private-field trailing comments** added so anyone reading the .cpp can map field names to their semantic group without bouncing back to the docs block.
- Cross-references to `AccurateMassSearchEngine` and `AdductInfo` for the adduct-string notation.

## Test plan

- [ ] Build passes (`cmake --build OpenMS-build --target OpenMS` — verified locally).
- [ ] Doxygen build still parses the file (balanced `@section` blocks, no broken cross-references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved user-facing documentation for mass search results: clearer result lifecycle, field semantics and units, and enhanced explanations of match annotations and quality/isotope scores.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9290)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->