### PR TITLE
docs(CrossLinksDB): add class-level Doxygen and per-method docs

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/CrossLinksDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/CrossLinksDB.h
@@ -13,19 +13,78 @@
 
 namespace OpenMS
 {
+  /**
+    @brief Process-wide singleton database of cross-linking modifications.
+
+    CrossLinksDB is a specialization of @ref ModificationsDB that loads
+    cross-linker definitions from the PSI XLMOD ontology
+    (@c CHEMISTRY/XLMOD.obo, shipped with OpenMS) instead of the
+    general-purpose UniMod/PSI-MOD modifications. It exposes the same
+    lookup, iteration, and matching interface as the base class but its
+    underlying pool contains @em only entries flagged as cross-links by
+    the OBO provider.
+
+    @section CrossLinksDB_singleton Singleton model
+
+    Like @ref ModificationsDB, CrossLinksDB is a singleton: there is at
+    most one instance per process. Obtain it via #getInstance — the
+    constructors, destructor, and assignment operator are intentionally
+    @c private so callers cannot create additional copies. Loading of the
+    XLMOD ontology happens once on the first call to #getInstance.
+
+    @section CrossLinksDB_typical_use Typical use
+
+    @code
+      auto* db = CrossLinksDB::getInstance();
+      // Use any ModificationsDB API to look up cross-linkers by name,
+      // origin, mass, or accession:
+      const ResidueModification* mod = db->getModification("DSS");
+
+      // Or enumerate the searchable subset for ID-search UIs:
+      std::vector<String> ids;
+      db->getAllSearchModifications(ids);
+    @endcode
+
+    Currently in OpenMS this database is used by @c MzIdentMLHandler
+    when serialising cross-link identifications, by the pyOpenMS chemistry
+    bindings, and by tests; new cross-link search algorithms should pull
+    their candidate modification list from here rather than from the
+    general ModificationsDB.
+
+    @ingroup Chemistry
+    @see ModificationsDB
+  */
   class OPENMS_DLLAPI CrossLinksDB :
       public ModificationsDB
   {
   public:
 
-    /// Returns a pointer to the modifications DB (singleton)
+    /**
+      @brief Returns the process-wide singleton instance.
+
+      First call lazily constructs the instance and populates it from
+      @c CHEMISTRY/XLMOD.obo. Subsequent calls return the same pointer.
+      The returned pointer is owned by the database and must @em not be
+      deleted by the caller.
+    */
     inline static CrossLinksDB* getInstance()
     {
       static CrossLinksDB* db_ = new CrossLinksDB;
       return db_;
     }
 
-    /// Collects all modifications that can be used for identification searches
+    /**
+      @brief Returns the IDs of all cross-linker modifications that are
+      usable for identification searches (i.e. carry a PSI-MOD accession).
+
+      The list is sorted ascending and contains @ref
+      ResidueModification::getFullId values, suitable for offering to the
+      user in a search-engine GUI dropdown or for passing to a
+      cross-link-aware search engine.
+
+      @param[out] modifications Sorted list of search-eligible modification
+                                full-IDs. Any previous contents are cleared.
+    */
     void getAllSearchModifications(std::vector<String>& modifications) const;
 
   private:
@@ -33,24 +92,31 @@ namespace OpenMS
       /** @name Constructors and Destructors
        */
       //@{
-      /// Default constructor
+      /// @brief Private default constructor: parses the XLMOD ontology
+      /// and forwards the resulting providers to @ref ModificationsDB.
+      /// Called once via #getInstance.
       CrossLinksDB();
 
-      /// Copy constructor
+      /// @brief Private copy constructor (singleton — copying is not
+      /// permitted).
       CrossLinksDB(const CrossLinksDB& residue_db);
 
-      /// Destructor
+      /// @brief Destructor. Never invoked in practice because the
+      /// singleton is allocated with @c new and outlives the process.
       ~CrossLinksDB() override;
       //@}
 
       /** @name Assignment
        */
       //@{
-      /// Assignment operator
+      /// @brief Private assignment operator (singleton — assignment is
+      /// not permitted).
       CrossLinksDB & operator=(const CrossLinksDB& aa);
       //@}
 
-      /// Creates the OBO provider for cross-linker loading
+      /// @brief Builds the OBO data provider list used by the base-class
+      /// constructor. Loads @c CHEMISTRY/XLMOD.obo with the
+      /// @c cross_links_only flag set.
       static std::vector<std::unique_ptr<ModificationDataProvider>> makeCrossLinkProviders_();
 
   };


### PR DESCRIPTION
## Summary

Adds proper Doxygen to `CrossLinksDB` — the singleton database of cross-linking modifications loaded from the PSI XLMOD ontology. The class previously had **no** class-level documentation and only `///` one-liners on its API, even though it is the canonical access point for cross-linker mods in OpenMS (used by `MzIdentMLHandler` when serialising cross-link IDs and by the pyOpenMS chemistry bindings). No behavioural change.

## What's in the docs

- **Class-level `@brief` + long description** explaining:
  - what `CrossLinksDB` is — a specialization of `ModificationsDB` restricted to PSI XLMOD entries (loaded from `CHEMISTRY/XLMOD.obo` with the `cross_links_only` flag),
  - how it differs from the general `ModificationsDB`,
  - that it is a process-wide singleton with lazy construction via `getInstance()`,
  - a code example showing both `ResidueModification` lookup and enumeration of the search-eligible subset,
  - who currently uses it, and that new cross-link-aware search algorithms should pull candidate modifications from here.
- **Per-public-method docs upgraded** to proper `@brief` + parameter docs:
  - `getInstance()` now spells out the singleton ownership convention (caller must not `delete` the returned pointer) and the lazy-load semantics.
  - `getAllSearchModifications()` now documents what "search-eligible" means (PSI-MOD accession present), sort order (ascending), and the `[out]`-clear semantics on the argument vector.
- **Private constructor/destructor/assignment** get short `@brief` notes explaining they are private (singleton — copying/assignment not permitted) and what the constructor actually does (parse the OBO, forward to the base class).

## Test plan

- [ ] Build passes (`cmake --build OpenMS-build --target OpenMS` — verified locally).
- [ ] Doxygen still parses the file (no broken cross-references; `@see ModificationsDB` resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and reorganized documentation for the cross-links database module, clarifying singleton initialization, ownership/lifetime notes, parameter behaviors, and data retrieval specifics (sorted identifiers matching residue-modification full IDs). Includes usage examples and guidance; documentation-only changes with no functional or public-interface modifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/OpenMS/pull/9292)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->